### PR TITLE
refactor!: use separate element for tooltip announcements

### DIFF
--- a/integration/tests/checkbox-group-tooltip.test.js
+++ b/integration/tests/checkbox-group-tooltip.test.js
@@ -4,7 +4,7 @@ import '@vaadin/checkbox-group';
 import '@vaadin/tooltip';
 
 describe('checkbox-group with tooltip', () => {
-  let group, tooltip, checkbox1, checkbox2, overlay;
+  let group, tooltip, checkbox1, checkbox2, label;
 
   beforeEach(async () => {
     group = document.createElement('vaadin-checkbox-group');
@@ -27,7 +27,7 @@ describe('checkbox-group with tooltip', () => {
     group.appendChild(tooltip);
 
     await nextRender();
-    overlay = tooltip._overlayElement;
+    label = tooltip.querySelector('[slot="sr-label"]');
   });
 
   afterEach(() => {
@@ -35,8 +35,8 @@ describe('checkbox-group with tooltip', () => {
   });
 
   it('should link tooltip with input elements using aria-describedby', () => {
-    expect(checkbox1.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
-    expect(checkbox2.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+    expect(checkbox1.inputElement.getAttribute('aria-describedby')).to.equal(label.id);
+    expect(checkbox2.inputElement.getAttribute('aria-describedby')).to.equal(label.id);
   });
 
   it('should set aria-describedby on the newly added checkbox input', async () => {
@@ -44,7 +44,7 @@ describe('checkbox-group with tooltip', () => {
     checkbox.value = 'de';
     group.appendChild(checkbox);
     await nextRender();
-    expect(checkbox.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+    expect(checkbox.inputElement.getAttribute('aria-describedby')).to.equal(label.id);
   });
 
   it('should remove aria-describedby from the removed checkbox input', async () => {

--- a/integration/tests/radio-group-tooltip.test.js
+++ b/integration/tests/radio-group-tooltip.test.js
@@ -4,7 +4,7 @@ import '@vaadin/radio-group';
 import '@vaadin/tooltip';
 
 describe('radio-group with tooltip', () => {
-  let group, tooltip, radio1, radio2, overlay;
+  let group, tooltip, radio1, radio2, label;
 
   beforeEach(async () => {
     group = document.createElement('vaadin-radio-group');
@@ -27,7 +27,7 @@ describe('radio-group with tooltip', () => {
     group.appendChild(tooltip);
 
     await nextRender();
-    overlay = tooltip._overlayElement;
+    label = tooltip.querySelector('[slot="sr-label"]');
   });
 
   afterEach(() => {
@@ -35,8 +35,8 @@ describe('radio-group with tooltip', () => {
   });
 
   it('should link tooltip with input elements using aria-describedby', () => {
-    expect(radio1.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
-    expect(radio2.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+    expect(radio1.inputElement.getAttribute('aria-describedby')).to.equal(label.id);
+    expect(radio2.inputElement.getAttribute('aria-describedby')).to.equal(label.id);
   });
 
   it('should set aria-describedby on the newly added radio button input', async () => {
@@ -44,7 +44,7 @@ describe('radio-group with tooltip', () => {
     radio.value = 'xl';
     group.appendChild(radio);
     await nextRender();
-    expect(radio.inputElement.getAttribute('aria-describedby')).to.equal(overlay.id);
+    expect(radio.inputElement.getAttribute('aria-describedby')).to.equal(label.id);
   });
 
   it('should remove aria-describedby from the removed radio button input', async () => {

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2022 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
@@ -59,7 +60,7 @@ export type TooltipPosition =
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
-declare class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement))) {
+declare class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ControllerMixin(ElementMixin(HTMLElement)))) {
   /**
    * Sets the default focus delay to be used by all tooltip instances,
    * except for those that have focus delay configured using property.

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -570,6 +570,7 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Controll
     this._srLabelController = new SlotController(this, 'sr-label', 'div', {
       initializer: (element) => {
         element.id = this._uniqueId;
+        element.setAttribute('role', 'tooltip');
         this._srLabel = element;
       },
     });

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -7,10 +7,12 @@ import './vaadin-tooltip-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
@@ -253,11 +255,12 @@ class TooltipStateController {
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @extends HTMLElement
+ * @mixes ControllerMixin
  * @mixes ElementMixin
  * @mixes OverlayClassMixin
  * @mixes ThemePropertyMixin
  */
-class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerElement))) {
+class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(ControllerMixin(PolymerElement)))) {
   static get is() {
     return 'vaadin-tooltip';
   }
@@ -270,8 +273,6 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
         }
       </style>
       <vaadin-tooltip-overlay
-        id="[[_uniqueId]]"
-        role="tooltip"
         renderer="[[_renderer]]"
         theme$="[[_theme]]"
         opened="[[__computeOpened(manual, opened, _autoOpened, _isConnected)]]"
@@ -285,6 +286,8 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
         on-mouseleave="__onOverlayMouseLeave"
         modeless
       ></vaadin-tooltip-overlay>
+
+      <slot name="sr-label"></slot>
     `;
   }
 
@@ -465,11 +468,24 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
       _isConnected: {
         type: Boolean,
       },
+
+      /** @private */
+      _srLabel: {
+        type: Object,
+      },
+
+      /** @private */
+      _overlayContent: {
+        type: String,
+      },
     };
   }
 
   static get observers() {
-    return ['__generatorChanged(_overlayElement, generator, context)'];
+    return [
+      '__generatorChanged(_overlayElement, generator, context)',
+      '__updateSrLabelText(_srLabel, _overlayContent)',
+    ];
   }
 
   /**
@@ -547,6 +563,19 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
     document.body.removeEventListener('vaadin-overlay-open', this.__onOverlayOpen);
   }
 
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._srLabelController = new SlotController(this, 'sr-label', 'div', {
+      initializer: (element) => {
+        element.id = this._uniqueId;
+        this._srLabel = element;
+      },
+    });
+    this.addController(this._srLabelController);
+  }
+
   /** @private */
   __computeAriaTarget(ariaTarget, target) {
     const isElementNode = (el) => el && el.nodeType === Node.ELEMENT_NODE;
@@ -587,6 +616,9 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
   /** @private */
   __tooltipRenderer(root) {
     root.textContent = typeof this.generator === 'function' ? this.generator(this.context) : this.text;
+
+    // Update the sr-only label text content
+    this._overlayContent = root.textContent;
   }
 
   /** @private */
@@ -835,6 +867,13 @@ class Tooltip extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolymerE
 
       this.__oldTextGenerator = generator;
       this.__oldContext = context;
+    }
+  }
+
+  /** @private */
+  __updateSrLabelText(srLabel, textContent) {
+    if (srLabel) {
+      srLabel.textContent = textContent;
     }
   }
 }

--- a/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
+++ b/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
@@ -1,6 +1,18 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
+snapshots["vaadin-tooltip host"] = 
+`<vaadin-tooltip>
+  <div
+    id="vaadin-tooltip-0"
+    role="tooltip"
+    slot="sr-label"
+  >
+  </div>
+</vaadin-tooltip>
+`;
+/* end snapshot vaadin-tooltip host */
+
 snapshots["vaadin-tooltip default"] = 
 `<vaadin-tooltip-overlay
   hidden=""

--- a/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
+++ b/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
@@ -4,169 +4,169 @@ export const snapshots = {};
 snapshots["vaadin-tooltip default"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="bottom"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip default */
 
 snapshots["vaadin-tooltip top-start"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="top-start"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip top-start */
 
 snapshots["vaadin-tooltip top"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="top"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip top */
 
 snapshots["vaadin-tooltip top-end"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="top-end"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip top-end */
 
 snapshots["vaadin-tooltip bottom-start"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="bottom-start"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip bottom-start */
 
 snapshots["vaadin-tooltip bottom"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="bottom"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip bottom */
 
 snapshots["vaadin-tooltip bottom-end"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   position="bottom-end"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip bottom-end */
 
 snapshots["vaadin-tooltip start-top"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-horizontal-overlap=""
   position="start-top"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip start-top */
 
 snapshots["vaadin-tooltip start"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-horizontal-overlap=""
   position="start"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip start */
 
 snapshots["vaadin-tooltip start-bottom"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-horizontal-overlap=""
   position="start-bottom"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip start-bottom */
 
 snapshots["vaadin-tooltip end-top"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-horizontal-overlap=""
   position="end-top"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip end-top */
 
 snapshots["vaadin-tooltip end"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-horizontal-overlap=""
   position="end"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip end */
 
 snapshots["vaadin-tooltip end-bottom"] = 
 `<vaadin-tooltip-overlay
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-horizontal-overlap=""
   position="end-bottom"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
+<slot name="sr-label">
+</slot>
 `;
 /* end snapshot vaadin-tooltip end-bottom */
 
@@ -174,12 +174,10 @@ snapshots["vaadin-tooltip opened overlay"] =
 `<vaadin-tooltip-overlay
   dir="ltr"
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   opened=""
   position="bottom"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
 `;
@@ -190,12 +188,10 @@ snapshots["vaadin-tooltip opened overlay class"] =
   class="custom tooltip-overlay"
   dir="ltr"
   hidden=""
-  id="vaadin-tooltip-0"
   modeless=""
   no-vertical-overlap=""
   opened=""
   position="bottom"
-  role="tooltip"
 >
 </vaadin-tooltip-overlay>
 `;

--- a/packages/tooltip/test/dom/tooltip.test.js
+++ b/packages/tooltip/test/dom/tooltip.test.js
@@ -11,6 +11,10 @@ describe('vaadin-tooltip', () => {
     tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
   });
 
+  it('host', async () => {
+    await expect(tooltip).dom.to.equalSnapshot();
+  });
+
   it('default', async () => {
     await expect(tooltip).shadowDom.to.equalSnapshot();
   });

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -119,12 +119,14 @@ describe('vaadin-tooltip', () => {
   });
 
   describe('target', () => {
-    let target;
+    let target, srLabel;
 
     beforeEach(() => {
       target = document.createElement('div');
       target.textContent = 'Target';
       document.body.appendChild(target);
+
+      srLabel = tooltip.querySelector('[slot="sr-label"]');
     });
 
     afterEach(() => {
@@ -138,7 +140,7 @@ describe('vaadin-tooltip', () => {
 
     it('should set aria-describedby on the target element', () => {
       tooltip.target = target;
-      expect(target.getAttribute('aria-describedby')).to.equal(overlay.id);
+      expect(target.getAttribute('aria-describedby')).to.equal(srLabel.id);
     });
 
     it('should retain existing aria-describedby attribute', () => {
@@ -146,7 +148,7 @@ describe('vaadin-tooltip', () => {
       tooltip.target = target;
 
       expect(target.getAttribute('aria-describedby')).to.contain('foo');
-      expect(target.getAttribute('aria-describedby')).to.contain(overlay.id);
+      expect(target.getAttribute('aria-describedby')).to.contain(srLabel.id);
     });
 
     it('should restore aria-describedby when clearing target', () => {
@@ -159,7 +161,7 @@ describe('vaadin-tooltip', () => {
   });
 
   describe('ariaTarget', () => {
-    let target, ariaTarget;
+    let target, ariaTarget, srLabel;
 
     beforeEach(() => {
       target = document.createElement('div');
@@ -168,6 +170,8 @@ describe('vaadin-tooltip', () => {
 
       ariaTarget = document.createElement('input');
       target.appendChild(ariaTarget);
+
+      srLabel = tooltip.querySelector('[slot="sr-label"]');
     });
 
     afterEach(() => {
@@ -178,7 +182,7 @@ describe('vaadin-tooltip', () => {
       tooltip.target = target;
       tooltip.ariaTarget = ariaTarget;
 
-      expect(ariaTarget.getAttribute('aria-describedby')).to.equal(overlay.id);
+      expect(ariaTarget.getAttribute('aria-describedby')).to.equal(srLabel.id);
     });
 
     it('should remove aria-describedby when the ariaTarget is cleared', () => {
@@ -188,7 +192,7 @@ describe('vaadin-tooltip', () => {
       tooltip.ariaTarget = null;
 
       expect(ariaTarget.hasAttribute('aria-describedby')).to.be.false;
-      expect(target.getAttribute('aria-describedby')).to.equal(overlay.id);
+      expect(target.getAttribute('aria-describedby')).to.equal(srLabel.id);
     });
 
     it('should set aria-describedby when providing multiple elements', () => {
@@ -198,8 +202,8 @@ describe('vaadin-tooltip', () => {
       tooltip.target = target;
       tooltip.ariaTarget = [ariaTarget, ariaTarget2];
 
-      expect(ariaTarget.getAttribute('aria-describedby')).to.equal(overlay.id);
-      expect(ariaTarget2.getAttribute('aria-describedby')).to.equal(overlay.id);
+      expect(ariaTarget.getAttribute('aria-describedby')).to.equal(srLabel.id);
+      expect(ariaTarget2.getAttribute('aria-describedby')).to.equal(srLabel.id);
     });
 
     it('should clear aria-describedby when providing empty array', () => {
@@ -213,7 +217,7 @@ describe('vaadin-tooltip', () => {
 
       expect(ariaTarget.hasAttribute('aria-describedby')).to.be.false;
       expect(ariaTarget2.hasAttribute('aria-describedby')).to.be.false;
-      expect(target.getAttribute('aria-describedby')).to.equal(overlay.id);
+      expect(target.getAttribute('aria-describedby')).to.equal(srLabel.id);
     });
   });
 

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -24,11 +24,12 @@ describe('vaadin-tooltip', () => {
     Tooltip.setDefaultHideDelay(0);
   });
 
-  let tooltip, overlay;
+  let tooltip, overlay, srLabel;
 
   beforeEach(() => {
     tooltip = fixtureSync('<vaadin-tooltip></vaadin-tooltip>');
     overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+    srLabel = tooltip.querySelector('[slot="sr-label"]');
   });
 
   describe('custom element definition', () => {
@@ -68,6 +69,11 @@ describe('vaadin-tooltip', () => {
       expect(overlay.textContent.trim()).to.equal('Foo');
     });
 
+    it('should use text property as screen reader label content', () => {
+      tooltip.text = 'Foo';
+      expect(srLabel.textContent.trim()).to.equal('Foo');
+    });
+
     it('should clear overlay content when text is set to null', () => {
       tooltip.text = 'Foo';
       tooltip.text = null;
@@ -87,6 +93,11 @@ describe('vaadin-tooltip', () => {
     it('should use generator property to generate text content', () => {
       tooltip.generator = () => 'Foo';
       expect(overlay.textContent.trim()).to.equal('Foo');
+    });
+
+    it('should set screen reader label content using generator', () => {
+      tooltip.generator = () => 'Foo';
+      expect(srLabel.textContent.trim()).to.equal('Foo');
     });
 
     it('should override text property when generator is set', () => {
@@ -119,14 +130,12 @@ describe('vaadin-tooltip', () => {
   });
 
   describe('target', () => {
-    let target, srLabel;
+    let target;
 
     beforeEach(() => {
       target = document.createElement('div');
       target.textContent = 'Target';
       document.body.appendChild(target);
-
-      srLabel = tooltip.querySelector('[slot="sr-label"]');
     });
 
     afterEach(() => {
@@ -161,7 +170,7 @@ describe('vaadin-tooltip', () => {
   });
 
   describe('ariaTarget', () => {
-    let target, ariaTarget, srLabel;
+    let target, ariaTarget;
 
     beforeEach(() => {
       target = document.createElement('div');
@@ -170,8 +179,6 @@ describe('vaadin-tooltip', () => {
 
       ariaTarget = document.createElement('input');
       target.appendChild(ariaTarget);
-
-      srLabel = tooltip.querySelector('[slot="sr-label"]');
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Description

Fixes #6380

Updated `vaadin-tooltip` to create a nested hidden element instead of using the `vaadin-tooltip-overlay` for screen reader announcement. This ensures the target and its accessible label element are in the same DOM scope.

## Type of change

- Behavior altering change

## Note

The new element is implicitly hidden due to the fact that `vaadin-tooltip` uses `display: none` but it [still works](https://www.tpgi.com/short-note-on-aria-labelledby-and-aria-describedby/):

> It is important to note that by design, hiding the content (using CSS display:none or visibility:hidden or the HTML [hidden attribute](https://www.w3.org/TR/html51/editing.html#the-hidden-attribute)) of the element(s) referenced by these attributes does not stop the content from being used to provide the name/description.