### PR TITLE
fix: clean up listeners in quill editor when the rich-text-editor is detached

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -1122,6 +1122,13 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
   }
 
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._editor.emitter.removeAllListeners();
+    this._editor.emitter.listeners = {};
+  }
+
   /**
    * Fired when the user commits a value change.
    *

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -533,6 +533,13 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
   }
 
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._editor.emitter.removeAllListeners();
+    this._editor.emitter.listeners = {};
+  }
+
   /** @private */
   __setDirection(dir) {
     // Needed for proper `ql-align` class to be set and activate the toolbar align button
@@ -1120,13 +1127,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
       // Value changed from outside
       this.__lastCommittedChange = this.value;
     }
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._editor.emitter.removeAllListeners();
-    this._editor.emitter.listeners = {};
   }
 
   /**

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -561,8 +561,8 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @protected */
-  ready() {
-    super.ready();
+  connectedCallback() {
+    super.connectedCallback();
 
     const editor = this.shadowRoot.querySelector('[part="content"]');
     const toolbarConfig = this._prepareToolbar();

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -565,14 +565,10 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     super.connectedCallback();
 
     const editor = this.shadowRoot.querySelector('[part="content"]');
-    const toolbarConfig = this._prepareToolbar();
-    this._toolbar = toolbarConfig.container;
-
-    this._addToolbarListeners();
 
     this._editor = new Quill(editor, {
       modules: {
-        toolbar: toolbarConfig,
+        toolbar: this._toolbarConfig,
       },
     });
 
@@ -583,10 +579,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     if (isFirefox) {
       this.__patchFirefoxFocus();
     }
-
-    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
-      this.$.linkUrl.focus();
-    });
 
     const editorContent = editor.querySelector('.ql-editor');
 
@@ -637,6 +629,20 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     });
 
     this._editor.on('selection-change', this.__announceFormatting.bind(this));
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._toolbarConfig = this._prepareToolbar();
+    this._toolbar = this._toolbarConfig.container;
+
+    this._addToolbarListeners();
+
+    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
+      this.$.linkUrl.focus();
+    });
   }
 
   /** @private */

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -928,4 +928,19 @@ describe('rich text editor', () => {
       );
     });
   });
+
+  describe('listener clean up', () => {
+    it('should not have active listeners once detached', () => {
+      expect(editor.emitter).to.not.equal(null);
+      expect(editor.emitter._events).to.not.be.empty;
+      expect(editor.emitter._eventsCount).to.greaterThan(0);
+      expect(editor.emitter.listeners).to.not.be.empty;
+
+      rte.parentNode.removeChild(rte);
+
+      expect(editor.emitter._events).to.be.empty;
+      expect(editor.emitter._eventsCount).to.be.equal(0);
+      expect(editor.emitter.listeners).to.be.empty;
+    });
+  });
 });

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -949,13 +949,11 @@ describe('rich text editor', () => {
       parent.removeChild(rte);
       parent.appendChild(rte);
 
-      const __rte = document.querySelector('vaadin-rich-text-editor');
-      const __editor = __rte._editor;
-
-      expect(__editor.emitter).to.not.equal(null);
-      expect(__editor.emitter._events).to.not.be.empty;
-      expect(__editor.emitter._eventsCount).to.greaterThan(0);
-      expect(__editor.emitter.listeners).to.not.be.empty;
+      // previous `editor` reference is now stale as a new editor is created in the connectedCallback
+      expect(rte._editor.emitter).to.not.equal(null);
+      expect(rte._editor.emitter._events).to.not.be.empty;
+      expect(rte._editor.emitter._eventsCount).to.greaterThan(0);
+      expect(rte._editor.emitter.listeners).to.not.be.empty;
     });
   });
 });

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -942,5 +942,20 @@ describe('rich text editor', () => {
       expect(editor.emitter._eventsCount).to.be.equal(0);
       expect(editor.emitter.listeners).to.be.empty;
     });
+
+    it('should have the listeners when removed and added back again', () => {
+      const parent = rte.parentNode;
+
+      parent.removeChild(rte);
+      parent.appendChild(rte);
+
+      const __rte = document.querySelector('vaadin-rich-text-editor');
+      const __editor = __rte._editor;
+
+      expect(__editor.emitter).to.not.equal(null);
+      expect(__editor.emitter._events).to.not.be.empty;
+      expect(__editor.emitter._eventsCount).to.greaterThan(0);
+      expect(__editor.emitter.listeners).to.not.be.empty;
+    });
   });
 });


### PR DESCRIPTION
## Description
Quill uses `eventemitter3` internally which has a `removeAllListeners()` method, however, there are still some listeners present in the Quill's `Emitter` class that needs to be cleaned up.

Fixes #6480

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.