### PR TITLE
fix: remove hardcoded aria-labels from the `learn more` and `dismiss` links

### DIFF
--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -178,7 +178,8 @@ class CookieConsent extends ElementMixin(PolymerElement) {
       },
       position: this.position,
       elements: {
-        messagelink: `<span id="cookieconsent:desc" class="cc-message">${this.message} <a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,
+        messagelink: `<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,
+        dismiss: `<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`,
       },
     });
 

--- a/packages/cookie-consent/test/cookie-consent.test.js
+++ b/packages/cookie-consent/test/cookie-consent.test.js
@@ -33,7 +33,7 @@ describe('vaadin-cookie-consent', () => {
     });
   });
 
-  describe('cooke consent window', () => {
+  describe('cookie consent window', () => {
     let consent, ccWindow;
 
     beforeEach(async () => {
@@ -89,11 +89,6 @@ describe('vaadin-cookie-consent', () => {
       expect(link.textContent).to.be.equal('Learn more');
       expect(link.href).to.be.equal('https://cookiesandyou.com/');
     });
-
-    it('learn more link should not have role', () => {
-      const link = ccWindow.querySelector('.cc-link');
-      expect(link.hasAttribute('role')).to.be.false;
-    });
   });
 
   describe('custom texts', () => {
@@ -129,6 +124,38 @@ describe('vaadin-cookie-consent', () => {
       expect(dismiss.textContent).to.be.equal('custom-dismiss');
       expect(link.textContent).to.be.equal('custom-learn-more');
       expect(link.href).to.be.equal('https://example.com/');
+    });
+  });
+
+  describe('accessibility', () => {
+    let consent, ccWindow;
+
+    beforeEach(async () => {
+      consent = fixtureSync('<vaadin-cookie-consent></vaadin-cookie-consent>');
+
+      // Force cookie consent to appear.
+      consent._show();
+
+      // By default the cookie consent dialog has a 20 ms delay after it
+      // is initialized and before it starts the fade-in animation.
+      await aTimeout(50);
+
+      ccWindow = document.querySelector('.cc-window');
+    });
+
+    it('learn more link should not have role', () => {
+      const link = ccWindow.querySelector('.cc-link');
+      expect(link.hasAttribute('role')).to.be.false;
+    });
+
+    it('learn more link should not have aria-label', () => {
+      const link = ccWindow.querySelector('.cc-link');
+      expect(link.hasAttribute('aria-label')).to.be.false;
+    });
+
+    it('dismiss link should not have aria-label', () => {
+      const link = ccWindow.querySelector('.cc-dismiss');
+      expect(link.hasAttribute('aria-label')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description
Fixes #6307

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
