### PR TITLE
fix: remove hardcoded aria-label attributes from links (#6492) (CP: 24.1)

### DIFF
--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -177,6 +177,10 @@ class CookieConsent extends ElementMixin(PolymerElement) {
         name: this.cookieName,
       },
       position: this.position,
+      elements: {
+        messagelink: `<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,
+        dismiss: `<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`,
+      },
     });
 
     const popup = this._getPopup();

--- a/packages/cookie-consent/test/cookie-consent.test.js
+++ b/packages/cookie-consent/test/cookie-consent.test.js
@@ -33,7 +33,7 @@ describe('vaadin-cookie-consent', () => {
     });
   });
 
-  describe('cooke consent window', () => {
+  describe('cookie consent window', () => {
     let consent, ccWindow;
 
     beforeEach(async () => {
@@ -124,6 +124,38 @@ describe('vaadin-cookie-consent', () => {
       expect(dismiss.textContent).to.be.equal('custom-dismiss');
       expect(link.textContent).to.be.equal('custom-learn-more');
       expect(link.href).to.be.equal('https://example.com/');
+    });
+  });
+
+  describe('accessibility', () => {
+    let consent, ccWindow;
+
+    beforeEach(async () => {
+      consent = fixtureSync('<vaadin-cookie-consent></vaadin-cookie-consent>');
+
+      // Force cookie consent to appear.
+      consent._show();
+
+      // By default the cookie consent dialog has a 20 ms delay after it
+      // is initialized and before it starts the fade-in animation.
+      await aTimeout(50);
+
+      ccWindow = document.querySelector('.cc-window');
+    });
+
+    it('learn more link should not have role', () => {
+      const link = ccWindow.querySelector('.cc-link');
+      expect(link.hasAttribute('role')).to.be.false;
+    });
+
+    it('learn more link should not have aria-label', () => {
+      const link = ccWindow.querySelector('.cc-link');
+      expect(link.hasAttribute('aria-label')).to.be.false;
+    });
+
+    it('dismiss link should not have aria-label', () => {
+      const link = ccWindow.querySelector('.cc-dismiss');
+      expect(link.hasAttribute('aria-label')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Cherry-pick of #6492 