### PR TITLE
Revert "fix: clean up Quill listeners on detach and re-create on reattach (#6489) (#6497)"

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -533,13 +533,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
   }
 
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._editor.emitter.removeAllListeners();
-    this._editor.emitter.listeners = {};
-  }
-
   /** @private */
   __setDirection(dir) {
     // Needed for proper `ql-align` class to be set and activate the toolbar align button
@@ -561,14 +554,18 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
+  ready() {
+    super.ready();
 
     const editor = this.shadowRoot.querySelector('[part="content"]');
+    const toolbarConfig = this._prepareToolbar();
+    this._toolbar = toolbarConfig.container;
+
+    this._addToolbarListeners();
 
     this._editor = new Quill(editor, {
       modules: {
-        toolbar: this._toolbarConfig,
+        toolbar: toolbarConfig,
       },
     });
 
@@ -579,6 +576,10 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     if (isFirefox) {
       this.__patchFirefoxFocus();
     }
+
+    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
+      this.$.linkUrl.focus();
+    });
 
     const editorContent = editor.querySelector('.ql-editor');
 
@@ -629,20 +630,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     });
 
     this._editor.on('selection-change', this.__announceFormatting.bind(this));
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._toolbarConfig = this._prepareToolbar();
-    this._toolbar = this._toolbarConfig.container;
-
-    this._addToolbarListeners();
-
-    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
-      this.$.linkUrl.focus();
-    });
   }
 
   /** @private */

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -928,32 +928,4 @@ describe('rich text editor', () => {
       );
     });
   });
-
-  describe('listener clean up', () => {
-    it('should not have active listeners once detached', () => {
-      expect(editor.emitter).to.not.equal(null);
-      expect(editor.emitter._events).to.not.be.empty;
-      expect(editor.emitter._eventsCount).to.greaterThan(0);
-      expect(editor.emitter.listeners).to.not.be.empty;
-
-      rte.parentNode.removeChild(rte);
-
-      expect(editor.emitter._events).to.be.empty;
-      expect(editor.emitter._eventsCount).to.be.equal(0);
-      expect(editor.emitter.listeners).to.be.empty;
-    });
-
-    it('should have the listeners when removed and added back again', () => {
-      const parent = rte.parentNode;
-
-      parent.removeChild(rte);
-      parent.appendChild(rte);
-
-      // previous `editor` reference is now stale as a new editor is created in the connectedCallback
-      expect(rte._editor.emitter).to.not.equal(null);
-      expect(rte._editor.emitter._events).to.not.be.empty;
-      expect(rte._editor.emitter._eventsCount).to.greaterThan(0);
-      expect(rte._editor.emitter.listeners).to.not.be.empty;
-    });
-  });
 });


### PR DESCRIPTION
This reverts commit 35f641d5860fdccbfbbf57fb1f9de60dac22a391.

## Description

Same as #6502 but for `24.1` branch.

## Type of change

- Revert