### PR TITLE
Revert "fix: clean up listeners in quill editor when the rich-text-editor is detached (#6489) (#6498)"

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -526,13 +526,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
   }
 
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._editor.emitter.removeAllListeners();
-    this._editor.emitter.listeners = {};
-  }
-
   /** @private */
   __setDirection(dir) {
     // Needed for proper `ql-align` class to be set and activate the toolbar align button
@@ -554,14 +547,18 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
+  ready() {
+    super.ready();
 
     const editor = this.shadowRoot.querySelector('[part="content"]');
+    const toolbarConfig = this._prepareToolbar();
+    this._toolbar = toolbarConfig.container;
+
+    this._addToolbarListeners();
 
     this._editor = new Quill(editor, {
       modules: {
-        toolbar: this._toolbarConfig,
+        toolbar: toolbarConfig,
       },
     });
 
@@ -572,6 +569,10 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     if (isFirefox) {
       this.__patchFirefoxFocus();
     }
+
+    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
+      this.$.linkUrl.focus();
+    });
 
     const editorContent = editor.querySelector('.ql-editor');
 
@@ -601,20 +602,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     });
 
     this._editor.on('selection-change', this.__announceFormatting.bind(this));
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._toolbarConfig = this._prepareToolbar();
-    this._toolbar = this._toolbarConfig.container;
-
-    this._addToolbarListeners();
-
-    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
-      this.$.linkUrl.focus();
-    });
   }
 
   /** @private */

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -929,32 +929,4 @@ describe('rich text editor', () => {
       );
     });
   });
-
-  describe('listener clean up', () => {
-    it('should not have active listeners once detached', () => {
-      expect(editor.emitter).to.not.equal(null);
-      expect(editor.emitter._events).to.not.be.empty;
-      expect(editor.emitter._eventsCount).to.greaterThan(0);
-      expect(editor.emitter.listeners).to.not.be.empty;
-
-      rte.parentNode.removeChild(rte);
-
-      expect(editor.emitter._events).to.be.empty;
-      expect(editor.emitter._eventsCount).to.be.equal(0);
-      expect(editor.emitter.listeners).to.be.empty;
-    });
-
-    it('should have the listeners when removed and added back again', () => {
-      const parent = rte.parentNode;
-
-      parent.removeChild(rte);
-      parent.appendChild(rte);
-
-      // Previous `editor` reference is now stale as a new editor is created in the connectedCallback
-      expect(rte._editor.emitter).to.not.equal(null);
-      expect(rte._editor.emitter._events).to.not.be.empty;
-      expect(rte._editor.emitter._eventsCount).to.greaterThan(0);
-      expect(rte._editor.emitter.listeners).to.not.be.empty;
-    });
-  });
 });


### PR DESCRIPTION
This reverts commit 4dd6ee5ca5baa6123f2a96a723e58581a9f0b2cb.

## Description

Same as #6502 but for `23.3` branch.

## Type of change

- Revert