### PR TITLE
refactor: cache icon src fetch results

### DIFF
--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-icon.js';
 import { unsafeSvgLiteral } from '../src/vaadin-icon-svg.js';
@@ -256,6 +256,18 @@ describe('vaadin-icon', () => {
       expect(svgElement.querySelector('#use-group').getAttribute('visibility')).to.be.equal('hidden');
 
       icon.__fetch.restore();
+    });
+
+    it('should fetch the same src only once', async () => {
+      icon.src = `data:image/svg+xml,${encodeURIComponent('<svg></svg')}`;
+
+      const icon2 = fixtureSync('<vaadin-icon></vaadin-icon>');
+      sinon.stub(icon2, '__fetch').resolves({ ok: true, text: () => Promise.resolve('<svg></svg>') });
+      icon2.src = icon.src;
+
+      await nextFrame();
+
+      expect(icon2.__fetch.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

This PR updates `<vaadin-icon>` to cache the fetch to a URL provided as `src`. This is to prevent making multiple requests to the same URL unnecessarily.

Before:
![Screenshot 2023-09-18 at 12 12 11](https://github.com/vaadin/web-components/assets/1222264/35daec19-b526-46b5-9e69-2e49ffa6e283)

After:
![Screenshot 2023-09-18 at 12 12 25](https://github.com/vaadin/web-components/assets/1222264/3881e500-932c-4827-82ca-819245fa87b4)


## Type of change

Refactor