### PR TITLE
fix: re-initialize Quill on detach and re-attach and keep htmlValue

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -533,6 +533,13 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     }
   }
 
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._editor.emitter.removeAllListeners();
+    this._editor.emitter.listeners = {};
+  }
+
   /** @private */
   __setDirection(dir) {
     // Needed for proper `ql-align` class to be set and activate the toolbar align button
@@ -554,18 +561,14 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @protected */
-  ready() {
-    super.ready();
+  connectedCallback() {
+    super.connectedCallback();
 
     const editor = this.shadowRoot.querySelector('[part="content"]');
-    const toolbarConfig = this._prepareToolbar();
-    this._toolbar = toolbarConfig.container;
-
-    this._addToolbarListeners();
 
     this._editor = new Quill(editor, {
       modules: {
-        toolbar: toolbarConfig,
+        toolbar: this._toolbarConfig,
       },
     });
 
@@ -576,10 +579,6 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     if (isFirefox) {
       this.__patchFirefoxFocus();
     }
-
-    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
-      this.$.linkUrl.focus();
-    });
 
     const editorContent = editor.querySelector('.ql-editor');
 
@@ -630,6 +629,20 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     });
 
     this._editor.on('selection-change', this.__announceFormatting.bind(this));
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._toolbarConfig = this._prepareToolbar();
+    this._toolbar = this._toolbarConfig.container;
+
+    this._addToolbarListeners();
+
+    this.$.linkDialog.$.dialog.$.overlay.addEventListener('vaadin-overlay-open', () => {
+      this.$.linkUrl.focus();
+    });
   }
 
   /** @private */

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -536,6 +536,13 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
+
+    // Ensure that htmlValue property set before attach
+    // gets applied in case of detach and re-attach.
+    if (this.__debounceSetValue && this.__debounceSetValue.isActive()) {
+      this.__debounceSetValue.flush();
+    }
+
     this._editor.emitter.removeAllListeners();
     this._editor.emitter.listeners = {};
   }

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -928,4 +928,32 @@ describe('rich text editor', () => {
       );
     });
   });
+
+  describe('listener clean up', () => {
+    it('should not have active listeners once detached', () => {
+      expect(editor.emitter).to.not.equal(null);
+      expect(editor.emitter._events).to.not.be.empty;
+      expect(editor.emitter._eventsCount).to.greaterThan(0);
+      expect(editor.emitter.listeners).to.not.be.empty;
+
+      rte.parentNode.removeChild(rte);
+
+      expect(editor.emitter._events).to.be.empty;
+      expect(editor.emitter._eventsCount).to.be.equal(0);
+      expect(editor.emitter.listeners).to.be.empty;
+    });
+
+    it('should have the listeners when removed and added back again', () => {
+      const parent = rte.parentNode;
+
+      parent.removeChild(rte);
+      parent.appendChild(rte);
+
+      // previous `editor` reference is now stale as a new editor is created in the connectedCallback
+      expect(rte._editor.emitter).to.not.equal(null);
+      expect(rte._editor.emitter._events).to.not.be.empty;
+      expect(rte._editor.emitter._eventsCount).to.greaterThan(0);
+      expect(rte._editor.emitter.listeners).to.not.be.empty;
+    });
+  });
 });

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -929,7 +929,7 @@ describe('rich text editor', () => {
     });
   });
 
-  describe('listener clean up', () => {
+  describe('detach and re-attach', () => {
     it('should not have active listeners once detached', () => {
       expect(editor.emitter).to.not.equal(null);
       expect(editor.emitter._events).to.not.be.empty;
@@ -954,6 +954,16 @@ describe('rich text editor', () => {
       expect(rte._editor.emitter._events).to.not.be.empty;
       expect(rte._editor.emitter._eventsCount).to.greaterThan(0);
       expect(rte._editor.emitter.listeners).to.not.be.empty;
+    });
+
+    it('should keep htmlValue when detached and immediately re-attached', () => {
+      rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
+
+      const parent = rte.parentNode;
+      parent.removeChild(rte);
+      parent.appendChild(rte);
+
+      expect(rte.htmlValue).to.equal('<h1>Foo</h1>');
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/6480

Same as #6489 but with a fix to flush the value debouncer in `disconnectedCallback()`.

## Type of change

- Bugfix