### PR TITLE
refactor: prevent duplicate custom element definition errors

### DIFF
--- a/integration/tests/define.test.js
+++ b/integration/tests/define.test.js
@@ -30,7 +30,7 @@ describe('define', () => {
       console.error.restore();
     });
 
-    it('should log an error when component with same version is loaded twice', () => {
+    it('should log an error when two components with different versions are loaded', () => {
       defineCustomElement({ is: 'vaadin-button', version: '0.0.1' });
       expect(console.error.calledOnce).to.be.true;
       expect(console.error.firstCall.args[0]).to.equal(

--- a/integration/tests/define.test.js
+++ b/integration/tests/define.test.js
@@ -1,30 +1,41 @@
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import '@vaadin/button';
 import { Button } from '@vaadin/button';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 
-it('should warn when component with same version is loaded twice', () => {
-  const oldWarn = console.warn;
-  const warningMessages = [];
-  console.warn = (message, ...args) => {
-    warningMessages.push(message);
-  };
-  defineCustomElement({ is: 'vaadin-button', version: Button.version });
-  expect(warningMessages.length).to.equal(1);
-  expect(warningMessages[0]).to.equal('The component vaadin-button has been loaded twice');
-  console.warn = oldWarn;
-});
+describe('define', () => {
+  describe('same version', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+    });
 
-it('should print an error when a component with different version is loaded twice', () => {
-  const oldError = console.error;
-  const errorMessages = [];
-  console.error = (message, ...args) => {
-    errorMessages.push(message);
-  };
-  defineCustomElement({ is: 'vaadin-button', version: '0.0.1' });
-  expect(errorMessages.length).to.equal(1);
-  expect(errorMessages[0]).to.equal(
-    'Tried to define vaadin-button version 0.0.1 when version 24.2.0-alpha16 is already in use. Something will probably break.',
-  );
-  console.error = oldError;
+    afterEach(() => {
+      console.warn.restore();
+    });
+
+    it('should warn when component with same version is loaded twice', () => {
+      defineCustomElement({ is: 'vaadin-button', version: Button.version });
+      expect(console.warn.calledOnce).to.be.true;
+      expect(console.warn.firstCall.args[0]).to.equal('The component vaadin-button has been loaded twice');
+    });
+  });
+
+  describe('different version', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'error');
+    });
+
+    afterEach(() => {
+      console.error.restore();
+    });
+
+    it('should log an error when component with same version is loaded twice', () => {
+      defineCustomElement({ is: 'vaadin-button', version: '0.0.1' });
+      expect(console.error.calledOnce).to.be.true;
+      expect(console.error.firstCall.args[0]).to.equal(
+        `Tried to define vaadin-button version 0.0.1 when version ${Button.version} is already in use. Something will probably break.`,
+      );
+    });
+  });
 });

--- a/integration/tests/define.test.js
+++ b/integration/tests/define.test.js
@@ -1,0 +1,30 @@
+import { expect } from '@esm-bundle/chai';
+import '@vaadin/button';
+import { Button } from '@vaadin/button';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+
+it('should warn when component with same version is loaded twice', () => {
+  const oldWarn = console.warn;
+  const warningMessages = [];
+  console.warn = (message, ...args) => {
+    warningMessages.push(message);
+  };
+  defineCustomElement({ is: 'vaadin-button', version: Button.version });
+  expect(warningMessages.length).to.equal(1);
+  expect(warningMessages[0]).to.equal('The component vaadin-button has been loaded twice');
+  console.warn = oldWarn;
+});
+
+it('should print an error when a component with different version is loaded twice', () => {
+  const oldError = console.error;
+  const errorMessages = [];
+  console.error = (message, ...args) => {
+    errorMessages.push(message);
+  };
+  defineCustomElement({ is: 'vaadin-button', version: '0.0.1' });
+  expect(errorMessages.length).to.equal(1);
+  expect(errorMessages[0]).to.equal(
+    'Tried to define vaadin-button version 0.0.1 when version 24.2.0-alpha16 is already in use. Something will probably break.',
+  );
+  console.error = oldError;
+});

--- a/packages/component-base/src/define.js
+++ b/packages/component-base/src/define.js
@@ -4,5 +4,18 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 export function defineCustomElement(CustomElement) {
-  customElements.define(CustomElement.is, CustomElement);
+  const defined = customElements.get(CustomElement.is);
+  if (!defined) {
+    customElements.define(CustomElement.is, CustomElement);
+  } else {
+    const definedVersion = defined.version;
+    if (definedVersion && CustomElement.version && definedVersion === CustomElement.version) {
+      // Just loading the same thing again
+      console.warn(`The component ${CustomElement.is} has been loaded twice`);
+    } else {
+      console.error(
+        `Tried to define ${CustomElement.is} version ${CustomElement.version} when version ${defined.version} is already in use. Something will probably break.`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Description

Log a warning when components are loaded twice and an error if different versions of the component is loaded
    
Fixes #6508

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have done all of the above

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
