### PR TITLE
fix: apply border radius to default rich-text-editor variant

### DIFF
--- a/packages/rich-text-editor/theme/lumo/vaadin-rich-text-editor-styles.js
+++ b/packages/rich-text-editor/theme/lumo/vaadin-rich-text-editor-styles.js
@@ -173,6 +173,8 @@ const richTextEditor = css`
   /* No border */
   :host(:not([theme~='no-border'])) {
     border: 1px solid var(--lumo-contrast-20pct);
+    border-radius: var(--lumo-border-radius-l);
+    overflow: hidden;
   }
 
   :host(:not([theme~='no-border']):not([readonly])) [part='content'] {


### PR DESCRIPTION
## Description

TODO need to update visual tests.

Define a border radius on the default Rich Text Editor variant.

Part of #6522 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.
