### PR TITLE
chore: config tests to retry on failure

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -247,7 +247,7 @@ const createUnitTestsConfig = (config) => {
       config: {
         ui: 'bdd',
         timeout: '10000',
-        retries: 2,
+        retries: process.env.GITHUB_REF ? 2 : 0,
       },
     },
     coverage: hasCoverageParam,

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -247,6 +247,7 @@ const createUnitTestsConfig = (config) => {
       config: {
         ui: 'bdd',
         timeout: '10000',
+        retries: 2,
       },
     },
     coverage: hasCoverageParam,


### PR DESCRIPTION
## Description

Configure Mocha to retry failed tests 2 more times by using the `retries` setting in the web-test-runner configuration object.

Not closing https://github.com/vaadin/components-team-tasks/issues/613 because we may want to use the rerun option in GitHub actions if this change is not enough.

Part of https://github.com/vaadin/components-team-tasks/issues/613