### PR TITLE
test: add timeout to stabilize a flaky combo-box test

### DIFF
--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -467,14 +467,12 @@ describe('lazy loading', () => {
           expect(getFocusedItemIndex(comboBox)).to.equal(0);
 
           comboBox._scrollIntoView(50);
+          await nextFrame();
           // Wait for the async data provider to respond
-          await aTimeout(0);
-          // Wait for the __loadingChanged observer
           await aTimeout(0);
 
           comboBox._scrollIntoView(0);
-          // Wait for the async data provider to respond
-          await aTimeout(100);
+          await nextFrame();
           expect(getFocusedItemIndex(comboBox)).to.equal(0);
         });
 

--- a/packages/combo-box/test/lazy-loading.test.js
+++ b/packages/combo-box/test/lazy-loading.test.js
@@ -473,6 +473,8 @@ describe('lazy loading', () => {
           await aTimeout(0);
 
           comboBox._scrollIntoView(0);
+          // Wait for the async data provider to respond
+          await aTimeout(100);
           expect(getFocusedItemIndex(comboBox)).to.equal(0);
         });
 


### PR DESCRIPTION
## Description

Try to stabilize a test that randomly fails on Firefox (CI + locally)