### PR TITLE
refactor: add __shouldValidateOnProgrammaticValueChange method

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -333,11 +333,6 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
     }
   }
 
-  /** @private */
-  __onCheckboxChange() {
-    this.dirty = true;
-  }
-
   /**
    * @param {!CustomEvent} event
    * @private
@@ -350,6 +345,29 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
     } else {
       this.__removeCheckboxFromValue(checkbox.value);
     }
+  }
+
+  /** @private */
+  __onCheckboxChange() {
+    this.dirty = true;
+
+    // Normally, the validation is triggered on `checked-changed` (in the value property observer).
+    // However, it can be disabled, in which case we need to trigger it manually here.
+    if (!this.__shouldValidateOnProgrammaticValueChange()) {
+      this.validate();
+    }
+  }
+
+  /**
+   * Override this method to define whether the component should validate on
+   * programmatic value property change.
+   *
+   * WARNING: Do not rely on this method because it will be removed later.
+   *
+   * @private
+   */
+  __shouldValidateOnProgrammaticValueChange() {
+    return true;
   }
 
   /**
@@ -369,7 +387,7 @@ class CheckboxGroup extends FieldMixin(FocusMixin(DisabledMixin(ElementMixin(The
       checkbox.checked = value.includes(checkbox.value);
     });
 
-    if (oldValue !== undefined) {
+    if (oldValue !== undefined && this.__shouldValidateOnProgrammaticValueChange()) {
       this.validate();
     }
   }

--- a/packages/checkbox-group/test/validation.test.js
+++ b/packages/checkbox-group/test/validation.test.js
@@ -56,12 +56,12 @@ describe('validation', () => {
       expect(group.checkValidity()).to.be.true;
     });
 
-    it('should validate when adding a value', () => {
+    it('should validate when adding a value programmatically', () => {
       group.value = ['en', 'fr'];
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate when removing a value', () => {
+    it('should validate when removing a value programmatically', () => {
       group.value = ['en', 'fr'];
       validateSpy.resetHistory();
       group.value = ['en'];
@@ -128,6 +128,22 @@ describe('validation', () => {
         await sendKeys({ up: 'Shift' });
 
         expect(validateSpy.called).to.be.false;
+      });
+    });
+
+    describe('validation on programmatic value change is disabled', () => {
+      beforeEach(() => {
+        group.__shouldValidateOnProgrammaticValueChange = () => false;
+      });
+
+      it('should not validate on programmatic value change', () => {
+        group.value = '1';
+        expect(validateSpy).to.be.not.called;
+      });
+
+      it('should validate on checkbox click', () => {
+        group.querySelector('vaadin-checkbox').click();
+        expect(validateSpy).to.be.calledOnce;
       });
     });
   });

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -381,11 +381,6 @@ class RadioGroup extends FieldMixin(
     }
   }
 
-  /** @private */
-  __onRadioButtonChange() {
-    this.dirty = true;
-  }
-
   /**
    * @param {!CustomEvent} event
    * @private
@@ -394,6 +389,29 @@ class RadioGroup extends FieldMixin(
     if (event.target.checked) {
       this.__selectRadioButton(event.target);
     }
+  }
+
+  /** @private */
+  __onRadioButtonChange() {
+    this.dirty = true;
+
+    // Normally, the validation is triggered on `checked-changed` (in the value property observer).
+    // However, it can be disabled, in which case we need to trigger it manually here.
+    if (!this.__shouldValidateOnProgrammaticValueChange()) {
+      this.validate();
+    }
+  }
+
+  /**
+   * Override this method to define whether the component should validate on
+   * programmatic value property change.
+   *
+   * WARNING: Do not rely on this method because it will be removed later.
+   *
+   * @private
+   */
+  __shouldValidateOnProgrammaticValueChange() {
+    return true;
   }
 
   /**
@@ -428,7 +446,7 @@ class RadioGroup extends FieldMixin(
       this.removeAttribute('has-value');
     }
 
-    if (oldValue !== undefined) {
+    if (oldValue !== undefined && this.__shouldValidateOnProgrammaticValueChange()) {
       this.validate();
     }
   }

--- a/packages/radio-group/test/validation.test.js
+++ b/packages/radio-group/test/validation.test.js
@@ -65,7 +65,7 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on value change', () => {
+    it('should validate on programmatic value change', () => {
       group.value = '1';
       expect(validateSpy.calledOnce).to.be.true;
     });
@@ -122,6 +122,22 @@ describe('validation', () => {
         await sendKeys({ up: 'Shift' });
 
         expect(validateSpy.called).to.be.false;
+      });
+    });
+
+    describe('validation on programmatic value change is disabled', () => {
+      beforeEach(() => {
+        group.__shouldValidateOnProgrammaticValueChange = () => false;
+      });
+
+      it('should not validate on programmatic value change', () => {
+        group.value = '1';
+        expect(validateSpy).to.be.not.called;
+      });
+
+      it('should validate on radio button click', () => {
+        group.querySelector('vaadin-radio-button').click();
+        expect(validateSpy).to.be.calledOnce;
       });
     });
   });

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -290,6 +290,18 @@ export const SelectBaseMixin = (superClass) =>
       }
     }
 
+    /**
+     * Override this method to define whether the component should validate on
+     * programmatic value property change.
+     *
+     * WARNING: Do not rely on this method because it will be removed later.
+     *
+     * @private
+     */
+    __shouldValidateOnProgrammaticValueChange() {
+      return true;
+    }
+
     /** @private */
     _valueChanged(value, oldValue) {
       this.toggleAttribute('has-value', Boolean(value));
@@ -297,7 +309,7 @@ export const SelectBaseMixin = (superClass) =>
       // Skip validation during initialization and when
       // a change event is scheduled, as validation will be
       // triggered by `__dispatchChange()` in that case.
-      if (oldValue !== undefined && !this.__dispatchChangePending) {
+      if (oldValue !== undefined && !this.__dispatchChangePending && this.__shouldValidateOnProgrammaticValueChange()) {
         this.validate();
       }
     }

--- a/packages/select/test/validation.common.js
+++ b/packages/select/test/validation.common.js
@@ -79,7 +79,7 @@ describe('validation', () => {
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
-    it('should validate on value change', async () => {
+    it('should validate on programmatic value change', async () => {
       select.value = 'option-2';
       await nextUpdate(select);
       expect(validateSpy.callCount).to.be.equal(1);
@@ -133,6 +133,28 @@ describe('validation', () => {
       it('should not validate on blur when document does not have focus', () => {
         select.blur();
         expect(validateSpy.called).to.be.false;
+      });
+    });
+
+    describe('validation on programmatic value change is disabled', () => {
+      beforeEach(() => {
+        select.__shouldValidateOnProgrammaticValueChange = () => false;
+      });
+
+      it('should not validate on programmatic value change', async () => {
+        select.value = 'option-2';
+        await nextUpdate(select);
+        expect(validateSpy).to.be.not.called;
+      });
+
+      it('should validate on Enter', async () => {
+        select.focus();
+        select.click();
+        await nextRender();
+
+        await sendKeys({ press: 'Enter' });
+        await nextUpdate(select);
+        expect(validateSpy).to.be.calledOnce;
       });
     });
   });


### PR DESCRIPTION
## Description

The PR introduces a `__shouldValidateOnProgrammaticValueChange` method to certain components. This method controls whether the component's validation should be triggered on programmatic value changes. 

> **Warning**
> This method is a temporary solution until we get away from the `validated` event. 

> **Warning**
> This method is only intended to be overridden by the Flow counterparts.

## Type of change

- [x] Refactor
