### PR TITLE
fix: fix typo in TextFieldMixinClass class name type definition

### DIFF
--- a/packages/text-field/src/vaadin-text-field-mixin.d.ts
+++ b/packages/text-field/src/vaadin-text-field-mixin.d.ts
@@ -39,11 +39,11 @@ export declare function TextFieldMixin<T extends Constructor<HTMLElement>>(
   Constructor<KeyboardMixinClass> &
   Constructor<LabelMixinClass> &
   Constructor<SlotStylesMixinClass> &
-  Constructor<TexFieldMixinClass> &
+  Constructor<TextFieldMixinClass> &
   Constructor<ValidateMixinClass> &
   T;
 
-export declare class TexFieldMixinClass {
+export declare class TextFieldMixinClass {
   /**
    * Maximum number of characters (in Unicode code points) that the user can enter.
    */


### PR DESCRIPTION
## Description

Changed `TexFieldMixinClass` to `TextFieldMixinClass` (missing `t` letter added).

As nobody noticed this since Vaadin 22, I hope this change is small enough to land in a minor 🙈 

## Type of change

- Bugfix