### PR TITLE
fix: add vaadin-button src import to the unstyled confirm-dialog

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/button/src/vaadin-button.js';
 import './vaadin-confirm-dialog-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { setAriaIDReference } from '@vaadin/a11y-base/src/aria-id-reference.js';

--- a/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
+++ b/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
@@ -22,20 +22,27 @@ snapshots["vaadin-confirm-dialog overlay"] =
   </div>
   <vaadin-button
     hidden=""
+    role="button"
     slot="cancel-button"
+    tabindex="0"
     theme="tertiary"
   >
     Cancel
   </vaadin-button>
   <vaadin-button
+    focused=""
+    role="button"
     slot="confirm-button"
+    tabindex="0"
     theme="primary"
   >
     Confirm
   </vaadin-button>
   <vaadin-button
     hidden=""
+    role="button"
     slot="reject-button"
+    tabindex="0"
     theme="error tertiary"
   >
     Reject
@@ -66,20 +73,27 @@ snapshots["vaadin-confirm-dialog overlay theme"] =
   </div>
   <vaadin-button
     hidden=""
+    role="button"
     slot="cancel-button"
+    tabindex="0"
     theme="tertiary"
   >
     Cancel
   </vaadin-button>
   <vaadin-button
+    focused=""
+    role="button"
     slot="confirm-button"
+    tabindex="0"
     theme="primary"
   >
     Confirm
   </vaadin-button>
   <vaadin-button
     hidden=""
+    role="button"
     slot="reject-button"
+    tabindex="0"
     theme="error tertiary"
   >
     Reject
@@ -110,20 +124,27 @@ snapshots["vaadin-confirm-dialog overlay class"] =
   </div>
   <vaadin-button
     hidden=""
+    role="button"
     slot="cancel-button"
+    tabindex="0"
     theme="tertiary"
   >
     Cancel
   </vaadin-button>
   <vaadin-button
+    focused=""
+    role="button"
     slot="confirm-button"
+    tabindex="0"
     theme="primary"
   >
     Confirm
   </vaadin-button>
   <vaadin-button
     hidden=""
+    role="button"
     slot="reject-button"
+    tabindex="0"
     theme="error tertiary"
   >
     Reject


### PR DESCRIPTION
## Description

The `vaadin-confirm-dialog` element uses `vaadin-button` element for its action buttons by default:

https://github.com/vaadin/web-components/blob/8f6b33df93fac22ca8a268c064dddec82920d711/packages/confirm-dialog/src/vaadin-confirm-dialog.js#L373

https://github.com/vaadin/web-components/blob/8f6b33df93fac22ca8a268c064dddec82920d711/packages/confirm-dialog/src/vaadin-confirm-dialog.js#L380

https://github.com/vaadin/web-components/blob/8f6b33df93fac22ca8a268c064dddec82920d711/packages/confirm-dialog/src/vaadin-confirm-dialog.js#L387

However, the unstyled `src` version of the confirm-dialog does not include the `vaadin-button` import.
This wasn't noticed as we import Lumo version in tests, but it might be a problem for custom themes.

## Type of change

- Bugfix