### PR TITLE
refactor: move items-outside-click listener to the constructor

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -71,18 +71,8 @@ export const ItemsMixin = (superClass) =>
       };
     }
 
-    /**
-     * Tag name prefix used by overlay, list-box and items.
-     * @protected
-     * @return {string}
-     */
-    get _tagNamePrefix() {
-      return 'vaadin-context-menu';
-    }
-
-    /** @protected */
-    ready() {
-      super.ready();
+    constructor() {
+      super();
 
       // Overlay's outside click listener doesn't work with modeless
       // overlays (submenus) so we need additional logic for it
@@ -91,7 +81,18 @@ export const ItemsMixin = (superClass) =>
           this.dispatchEvent(new CustomEvent('items-outside-click'));
         }
       };
-      this.addEventListener('items-outside-click', () => this.items && this.close());
+      this.addEventListener('items-outside-click', () => {
+        this.items && this.close();
+      });
+    }
+
+    /**
+     * Tag name prefix used by overlay, list-box and items.
+     * @protected
+     * @return {string}
+     */
+    get _tagNamePrefix() {
+      return 'vaadin-context-menu';
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

This is a finding from `vaadin-context-menu` Lit conversion. 

Using `ready()` means adding the listener after initial render which breaks some tests due to timings change.
Also, it's a general practie to initialize event listeners in the `constructor()` so let's follow it here.

## Type of change

- Refactor