### PR TITLE
refactor: move item and list-box imports to the context-menu

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -4,6 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-contextmenu-event.js';
+import './vaadin-context-menu-item.js';
+import './vaadin-context-menu-list-box.js';
 import './vaadin-context-menu-overlay.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -3,8 +3,6 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import './vaadin-context-menu-item.js';
-import './vaadin-context-menu-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
 /**


### PR DESCRIPTION
## Description

This change is needed in preparation for `vaadin-context-menu` Lit conversion.

There will be separate Lit based versions of item and list-box elements, and they shouldn't be imported by the mixin.

## Type of change

- Refactor