### PR TITLE
fix: unset input width/height to avoid issue with UA styles

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -57,6 +57,8 @@ export const checkboxStyles = css`
     margin: 0;
     align-self: stretch;
     -webkit-appearance: none;
+    width: initial;
+    height: initial;
   }
 
   @media (forced-colors: active) {


### PR DESCRIPTION
## Description

In iOS Safari, the user agent styles define width and height to the input of type checkbox which makes it not take the whole size of the visual checkbox area. In this case, it becomes hard to touch on the checkbox because the misalignment.

#### Before 

![image](https://github.com/vaadin/web-components/assets/262432/bc8127a2-2615-460b-9dff-dabd53d7dcbb)

#### After

![image](https://github.com/vaadin/web-components/assets/262432/12948f2b-c330-4700-add0-52bd305af214)


Fixes https://github.com/vaadin/flow-components/issues/5190


## Type of change

- [X] Bugfix
- [ ] Feature
