### PR TITLE
fix: unset radio button input width and height to fix UA styles relat…

### DIFF
--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -121,6 +121,8 @@ class RadioButton extends LabelMixin(
           margin: 0;
           align-self: stretch;
           -webkit-appearance: none;
+          width: initial;
+          height: initial;
         }
 
         @media (forced-colors: active) {


### PR DESCRIPTION
## Description

This PR applies the Checkbox [fix](https://github.com/vaadin/web-components/pull/6550) regarding input misalignment to RadioButton.

Follow up from the related checkbox [issue](https://github.com/vaadin/flow-components/issues/5190).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.