### PR TITLE
refactor: extract vaadin-grid-filter logic into a reusable mixin

### DIFF
--- a/packages/grid/src/vaadin-grid-filter-element-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.d.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+
+/**
+ * Fired when the `value` property changes.
+ */
+export type GridFilterValueChangedEvent = CustomEvent<{ value: string }>;
+
+export interface GridFilterCustomEventMap {
+  'value-changed': GridFilterValueChangedEvent;
+}
+
+export interface GridFilterEventMap extends HTMLElementEventMap, GridFilterCustomEventMap {}
+
+export declare function GridFilterElementMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ControllerMixinClass> & Constructor<GridFilterElementMixinClass> & T;
+
+declare class GridFilterElementMixinClass {
+  /**
+   * JS Path of the property in the item used for filtering the data.
+   */
+  path: string | null | undefined;
+
+  /**
+   * Current filter value.
+   */
+  value: string | null | undefined;
+}

--- a/packages/grid/src/vaadin-grid-filter-element-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.js
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { timeOut } from '@vaadin/component-base/src/async.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin';
+
+registerStyles(
+  'vaadin-grid-filter',
+  css`
+    :host {
+      display: inline-flex;
+      max-width: 100%;
+    }
+
+    ::slotted(*) {
+      width: 100%;
+      box-sizing: border-box;
+    }
+  `,
+  { moduleId: 'vaadin-grid-filter-styles' },
+);
+
+/**
+ * @polymerMixin
+ *
+ * @mixes ControllerMixin
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ */
+export const GridFilterElementMixin = (superClass) =>
+  class extends ControllerMixin(superClass) {
+    static get properties() {
+      return {
+        /**
+         * JS Path of the property in the item used for filtering the data.
+         */
+        path: String,
+
+        /**
+         * Current filter value.
+         */
+        value: {
+          type: String,
+          notify: true,
+        },
+
+        /** @private */
+        _textField: {
+          type: Object,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['_filterChanged(path, value, _textField)'];
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._filterController = new SlotController(this, '', 'vaadin-text-field', {
+        initializer: (field) => {
+          field.addEventListener('value-changed', (e) => {
+            this.value = e.detail.value;
+          });
+
+          this._textField = field;
+        },
+      });
+      this.addController(this._filterController);
+    }
+
+    /** @private */
+    _filterChanged(path, value, textField) {
+      if (path === undefined || value === undefined || !textField) {
+        return;
+      }
+      if (this._previousValue === undefined && value === '') {
+        return;
+      }
+
+      textField.value = value;
+      this._previousValue = value;
+
+      this._debouncerFilterChanged = Debouncer.debounce(this._debouncerFilterChanged, timeOut.after(200), () => {
+        this.dispatchEvent(new CustomEvent('filter-changed', { bubbles: true }));
+      });
+    }
+
+    focus() {
+      if (this._textField) {
+        this._textField.focus();
+      }
+    }
+  };

--- a/packages/grid/src/vaadin-grid-filter-element-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.js
@@ -29,7 +29,6 @@ registerStyles(
  * @polymerMixin
  *
  * @mixes ControllerMixin
- * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 export const GridFilterElementMixin = (superClass) =>
   class extends ControllerMixin(superClass) {

--- a/packages/grid/src/vaadin-grid-filter.d.ts
+++ b/packages/grid/src/vaadin-grid-filter.d.ts
@@ -3,18 +3,11 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 
-/**
- * Fired when the `value` property changes.
- */
-export type GridFilterValueChangedEvent = CustomEvent<{ value: string }>;
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { GridFilterElementMixin, type GridFilterEventMap } from './vaadin-grid-filter-element-mixin.js';
 
-export interface GridFilterCustomEventMap {
-  'value-changed': GridFilterValueChangedEvent;
-}
-
-export interface GridFilterEventMap extends HTMLElementEventMap, GridFilterCustomEventMap {}
+export * from './vaadin-grid-filter-element-mixin.js';
 
 /**
  * `<vaadin-grid-filter>` is a helper element for the `<vaadin-grid>` that provides out-of-the-box UI controls,
@@ -41,17 +34,7 @@ export interface GridFilterEventMap extends HTMLElementEventMap, GridFilterCusto
  *
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class GridFilter extends ControllerMixin(HTMLElement) {
-  /**
-   * JS Path of the property in the item used for filtering the data.
-   */
-  path: string | null | undefined;
-
-  /**
-   * Current filter value.
-   */
-  value: string | null | undefined;
-
+declare class GridFilter extends GridFilterElementMixin(ThemableMixin(HTMLElement)) {
   addEventListener<K extends keyof GridFilterEventMap>(
     type: K,
     listener: (this: GridFilter, ev: GridFilterEventMap[K]) => void,

--- a/packages/grid/src/vaadin-grid-filter.js
+++ b/packages/grid/src/vaadin-grid-filter.js
@@ -32,6 +32,8 @@ import { GridFilterElementMixin } from './vaadin-grid-filter-element-mixin.js';
  * };
  * ```
  *
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ *
  * @customElement
  * @extends HTMLElement
  * @mixes GridFilterElementMixin

--- a/packages/grid/src/vaadin-grid-filter.js
+++ b/packages/grid/src/vaadin-grid-filter.js
@@ -5,11 +5,9 @@
  */
 import '@vaadin/text-field/src/vaadin-text-field.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { timeOut } from '@vaadin/component-base/src/async.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { GridFilterElementMixin } from './vaadin-grid-filter-element-mixin.js';
 
 /**
  * `<vaadin-grid-filter>` is a helper element for the `<vaadin-grid>` that provides out-of-the-box UI controls,
@@ -34,96 +32,17 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  * };
  * ```
  *
- * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
- *
  * @customElement
  * @extends HTMLElement
+ * @mixes GridFilterElementMixin
  */
-class GridFilter extends ControllerMixin(PolymerElement) {
+class GridFilter extends GridFilterElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: inline-flex;
-          max-width: 100%;
-        }
-
-        ::slotted(*) {
-          width: 100%;
-          box-sizing: border-box;
-        }
-      </style>
-      <slot></slot>
-    `;
+    return html`<slot></slot>`;
   }
 
   static get is() {
     return 'vaadin-grid-filter';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * JS Path of the property in the item used for filtering the data.
-       */
-      path: String,
-
-      /**
-       * Current filter value.
-       */
-      value: {
-        type: String,
-        notify: true,
-      },
-
-      /** @private */
-      _textField: {
-        type: Object,
-      },
-    };
-  }
-
-  static get observers() {
-    return ['_filterChanged(path, value, _textField)'];
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._filterController = new SlotController(this, '', 'vaadin-text-field', {
-      initializer: (field) => {
-        field.addEventListener('value-changed', (e) => {
-          this.value = e.detail.value;
-        });
-
-        this._textField = field;
-      },
-    });
-    this.addController(this._filterController);
-  }
-
-  /** @private */
-  _filterChanged(path, value, textField) {
-    if (path === undefined || value === undefined || !textField) {
-      return;
-    }
-    if (this._previousValue === undefined && value === '') {
-      return;
-    }
-
-    textField.value = value;
-    this._previousValue = value;
-
-    this._debouncerFilterChanged = Debouncer.debounce(this._debouncerFilterChanged, timeOut.after(200), () => {
-      this.dispatchEvent(new CustomEvent('filter-changed', { bubbles: true }));
-    });
-  }
-
-  focus() {
-    if (this._textField) {
-      this._textField.focus();
-    }
   }
 }
 


### PR DESCRIPTION
## Description

Extracted grid filter element mixin to be used by the LitElement version to be added later.

The new mixin file is named `vaadin-grid-filter-element-mixin.js` because `vaadin-grid-filter-mixin.js` already exists.

## Type of change

Refactor