### PR TITLE
refactor: deprecate effectiveSize in favor of flatSize

### DIFF
--- a/packages/component-base/src/data-provider-controller/cache.d.ts
+++ b/packages/component-base/src/data-provider-controller/cache.d.ts
@@ -58,6 +58,14 @@ export class Cache<TItem> {
    */
   get flatSize(): number;
 
+  /**
+   * The total number of items, including items from expanded sub-caches.
+   *
+   * @protected
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  get effectiveSize(): number;
+
   constructor(
     context: CacheContext<TItem>,
     pageSize: number,

--- a/packages/component-base/src/data-provider-controller/cache.d.ts
+++ b/packages/component-base/src/data-provider-controller/cache.d.ts
@@ -56,7 +56,7 @@ export class Cache<TItem> {
   /**
    * The total number of items, including items from expanded sub-caches.
    */
-  get effectiveSize(): number;
+  get flatSize(): number;
 
   constructor(
     context: CacheContext<TItem>,
@@ -67,9 +67,9 @@ export class Cache<TItem> {
   );
 
   /**
-   * Recalculates the effective size for the cache and its descendant caches recursively.
+   * Recalculates the flat size for the cache and its descendant caches recursively.
    */
-  recalculateEffectiveSize(): void;
+  recalculateFlatSize(): void;
 
   /**
    * Adds an array of items corresponding to the given page

--- a/packages/component-base/src/data-provider-controller/cache.d.ts
+++ b/packages/component-base/src/data-provider-controller/cache.d.ts
@@ -75,7 +75,7 @@ export class Cache<TItem> {
   );
 
   /**
-   * Recalculates the flat size for the cache and its descendant caches recursively.
+   * Recalculates the flattened size for the cache and its descendant caches recursively.
    */
   recalculateFlatSize(): void;
 

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -137,7 +137,7 @@ export class Cache {
   }
 
   /**
-   * Recalculates the flat size for the cache and its descendant caches recursively.
+   * Recalculates the flattened size for the cache and its descendant caches recursively.
    */
   recalculateFlatSize() {
     this.__flatSize =

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -64,7 +64,7 @@ export class Cache {
    * @type {number}
    * @private
    */
-  __effectiveSize = 0;
+  __flatSize = 0;
 
   /**
    * @param {Cache['context']} context
@@ -79,7 +79,7 @@ export class Cache {
     this.size = size || 0;
     this.parentCache = parentCache;
     this.parentCacheIndex = parentCacheIndex;
-    this.__effectiveSize = size || 0;
+    this.__flatSize = size || 0;
   }
 
   /**
@@ -119,20 +119,20 @@ export class Cache {
    *
    * @return {number}
    */
-  get effectiveSize() {
-    return this.__effectiveSize;
+  get flatSize() {
+    return this.__flatSize;
   }
 
   /**
-   * Recalculates the effective size for the cache and its descendant caches recursively.
+   * Recalculates the flat size for the cache and its descendant caches recursively.
    */
-  recalculateEffectiveSize() {
-    this.__effectiveSize =
+  recalculateFlatSize() {
+    this.__flatSize =
       !this.parentItem || this.context.isExpanded(this.parentItem)
         ? this.size +
           this.subCaches.reduce((total, subCache) => {
-            subCache.recalculateEffectiveSize();
-            return total + subCache.effectiveSize;
+            subCache.recalculateFlatSize();
+            return total + subCache.flatSize;
           }, 0)
         : 0;
   }
@@ -204,7 +204,7 @@ export class Cache {
 
     return this.subCaches.reduce((prev, subCache) => {
       const index = subCache.parentCacheIndex;
-      return clampedIndex > index ? prev + subCache.effectiveSize : prev;
+      return clampedIndex > index ? prev + subCache.flatSize : prev;
     }, clampedIndex);
   }
 

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -124,6 +124,17 @@ export class Cache {
   }
 
   /**
+   * @protected
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  get effectiveSize() {
+    console.warn(
+      '<vaadin-grid> The `effectiveSize` property of ItemCache is deprecated and will be removed in Vaadin 25.',
+    );
+    return this.flatSize;
+  }
+
+  /**
    * Recalculates the flat size for the cache and its descendant caches recursively.
    */
   recalculateFlatSize() {
@@ -235,7 +246,7 @@ export class Cache {
    */
   updateSize() {
     console.warn('<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25.');
-    this.recalculateEffectiveSize();
+    this.recalculateFlatSize();
   }
 
   /**

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -124,6 +124,8 @@ export class Cache {
   }
 
   /**
+   * The total number of items, including items from expanded sub-caches.
+   *
    * @protected
    * @deprecated since 24.3 and will be removed in Vaadin 25.
    */

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
@@ -76,7 +76,7 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
   /**
    * The total number of items, including items from expanded sub-caches.
    */
-  get effectiveSize(): number;
+  get flatSize(): number;
 
   hostConnected(): void;
 
@@ -88,7 +88,7 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
   isLoading(): boolean;
 
   /**
-   * Sets the size for the root cache and recalculates the effective size.
+   * Sets the size for the root cache and recalculates the flat size.
    */
   setSize(size: number): void;
 
@@ -103,9 +103,9 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
   setDataProvider(dataProvider: DataProvider<TItem, TDataProviderParams>): void;
 
   /**
-   * Recalculates the effective size.
+   * Recalculates the flat size.
    */
-  recalculateEffectiveSize(): void;
+  recalculateFlatSize(): void;
 
   /**
    * Clears the cache.

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
@@ -88,7 +88,7 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
   isLoading(): boolean;
 
   /**
-   * Sets the size for the root cache and recalculates the flat size.
+   * Sets the size for the root cache and recalculates the flattened size.
    */
   setSize(size: number): void;
 
@@ -103,7 +103,7 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
   setDataProvider(dataProvider: DataProvider<TItem, TDataProviderParams>): void;
 
   /**
-   * Recalculates the flat size.
+   * Recalculates the flattened size.
    */
   recalculateFlatSize(): void;
 

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -71,8 +71,8 @@ export class DataProviderController extends EventTarget {
   /**
    * The total number of items, including items from expanded sub-caches.
    */
-  get effectiveSize() {
-    return this.rootCache.effectiveSize;
+  get flatSize() {
+    return this.rootCache.flatSize;
   }
 
   /** @private */
@@ -94,14 +94,14 @@ export class DataProviderController extends EventTarget {
   }
 
   /**
-   * Sets the size for the root cache and recalculates the effective size.
+   * Sets the size for the root cache and recalculates the flat size.
    *
    * @param {number} size
    */
   setSize(size) {
     this.size = size;
     this.rootCache.size = size;
-    this.recalculateEffectiveSize();
+    this.recalculateFlatSize();
   }
 
   /**
@@ -125,10 +125,10 @@ export class DataProviderController extends EventTarget {
   }
 
   /**
-   * Recalculates the effective size.
+   * Recalculates the flat size.
    */
-  recalculateEffectiveSize() {
-    this.rootCache.recalculateEffectiveSize();
+  recalculateFlatSize() {
+    this.rootCache.recalculateFlatSize();
   }
 
   /**
@@ -227,7 +227,7 @@ export class DataProviderController extends EventTarget {
 
       cache.setPage(page, items);
 
-      this.recalculateEffectiveSize();
+      this.recalculateFlatSize();
 
       this.dispatchEvent(new CustomEvent('page-received'));
 

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -94,7 +94,7 @@ export class DataProviderController extends EventTarget {
   }
 
   /**
-   * Sets the size for the root cache and recalculates the flat size.
+   * Sets the size for the root cache and recalculates the flattened size.
    *
    * @param {number} size
    */
@@ -125,7 +125,7 @@ export class DataProviderController extends EventTarget {
   }
 
   /**
-   * Recalculates the flat size.
+   * Recalculates the flattened size.
    */
   recalculateFlatSize() {
     this.rootCache.recalculateFlatSize();

--- a/packages/component-base/src/data-provider-controller/helpers.js
+++ b/packages/component-base/src/data-provider-controller/helpers.js
@@ -23,10 +23,10 @@ export function getFlatIndexContext(cache, flatIndex, level = 0) {
     const index = subCache.parentCacheIndex;
     if (levelIndex <= index) {
       break;
-    } else if (levelIndex <= index + subCache.effectiveSize) {
+    } else if (levelIndex <= index + subCache.flatSize) {
       return getFlatIndexContext(subCache, levelIndex - index - 1, level + 1);
     }
-    levelIndex -= subCache.effectiveSize;
+    levelIndex -= subCache.flatSize;
   }
 
   return {
@@ -56,7 +56,7 @@ export function getFlatIndexByPath(cache, [levelIndex, ...subIndexes], flatIndex
 
   const flatIndexOnLevel = cache.getFlatIndex(levelIndex);
   const subCache = cache.getSubCache(levelIndex);
-  if (subCache && subCache.effectiveSize > 0 && subIndexes.length) {
+  if (subCache && subCache.flatSize > 0 && subIndexes.length) {
     return getFlatIndexByPath(subCache, subIndexes, flatIndex + flatIndexOnLevel + 1);
   }
   return flatIndex + flatIndexOnLevel;

--- a/packages/component-base/test/typings/data-provider-controller/cache.types.ts
+++ b/packages/component-base/test/typings/data-provider-controller/cache.types.ts
@@ -32,7 +32,7 @@ assertType<Record<number, DataProviderCallback<TestItem>>>(cache.pendingRequests
 
 // Methods
 assertType<(page: number, items: unknown[]) => void>(cache.setPage);
-assertType<() => void>(cache.recalculateEffectiveSize);
+assertType<() => void>(cache.recalculateFlatSize);
 assertType<(index: number) => number>(cache.getFlatIndex);
 assertType<(index: number) => Cache<TestItem> | undefined>(cache.getSubCache);
 assertType<(index: number) => void>(cache.removeSubCache);

--- a/packages/component-base/test/typings/data-provider-controller/data-provider-controller.types.ts
+++ b/packages/component-base/test/typings/data-provider-controller/data-provider-controller.types.ts
@@ -55,11 +55,11 @@ assertType<number>(dataProviderController.pageSize);
 assertType<(item: TestItem) => boolean>(dataProviderController.isExpanded);
 assertType<() => TestDataProviderParams>(dataProviderController.dataProviderParams);
 assertType<DataProvider<TestItem, TestDataProviderParams>>(dataProviderController.dataProvider);
-assertType<number>(dataProviderController.effectiveSize);
+assertType<number>(dataProviderController.flatSize);
 
 // Methods
 assertType<() => void>(dataProviderController.clearCache);
-assertType<() => void>(dataProviderController.recalculateEffectiveSize);
+assertType<() => void>(dataProviderController.recalculateFlatSize);
 assertType<(flatIndex: number) => void>(dataProviderController.ensureFlatIndexLoaded);
 assertType<(flatIndex: number) => void>(dataProviderController.ensureFlatIndexHierarchy);
 assertType<

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1223,7 +1223,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
 
   /** @private */
   __restoreFocusOnDelete() {
-    if (this._grid._effectiveSize === 1) {
+    if (this._grid._flatSize === 1) {
       this._newButton.focus();
     } else {
       this._grid._focusFirstVisibleRow();

--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -62,7 +62,7 @@ export const ArrayDataProviderMixin = (superClass) =>
         } else if (this._arrayDataProvider.__items === items) {
           // The items array was modified
           this.clearCache();
-          this.size = this._effectiveSize;
+          this.size = this._flatSize;
         } else {
           // The items array was replaced
           this.__setArrayDataProvider(items);

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -161,7 +161,7 @@ export const DataProviderMixin = (superClass) =>
     /** @private */
     _sizeChanged(size) {
       this._dataProviderController.setSize(size);
-      this._effectiveSize = this._dataProviderController.effectiveSize;
+      this._flatSize = this._dataProviderController.flatSize;
     }
 
     /** @private */
@@ -179,7 +179,7 @@ export const DataProviderMixin = (superClass) =>
      * @protected
      */
     _getItem(index, el) {
-      if (index >= this._effectiveSize) {
+      if (index >= this._flatSize) {
         return;
       }
 
@@ -234,8 +234,8 @@ export const DataProviderMixin = (superClass) =>
 
     /** @private */
     _expandedItemsChanged() {
-      this._dataProviderController.recalculateEffectiveSize();
-      this._effectiveSize = this._dataProviderController.effectiveSize;
+      this._dataProviderController.recalculateFlatSize();
+      this._flatSize = this._dataProviderController.flatSize;
       this.__updateVisibleRows();
     }
 
@@ -299,7 +299,7 @@ export const DataProviderMixin = (superClass) =>
     /** @protected */
     _onDataProviderPageReceived() {
       // With the new items added, update the cache size and the grid's effective size
-      this._effectiveSize = this._dataProviderController.effectiveSize;
+      this._flatSize = this._dataProviderController.flatSize;
 
       // After updating the cache, check if some of the expanded items should have sub-caches loaded
       this._getRenderedRows().forEach((row) => {
@@ -339,7 +339,7 @@ export const DataProviderMixin = (superClass) =>
       this._hasData = false;
       this.__updateVisibleRows();
 
-      if (!this._effectiveSize) {
+      if (!this._flatSize) {
         this._dataProviderController.loadFirstPage();
       }
     }
@@ -355,7 +355,7 @@ export const DataProviderMixin = (superClass) =>
 
     /** @protected */
     _checkSize() {
-      if (this.size === undefined && this._effectiveSize === 0) {
+      if (this.size === undefined && this._flatSize === 0) {
         console.warn(
           'The <vaadin-grid> needs the total number of items in' +
             ' order to display rows, which you can specify either by setting' +

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -158,6 +158,15 @@ export const DataProviderMixin = (superClass) =>
       return this._dataProviderController.rootCache;
     }
 
+    /**
+     * @protected
+     * @deprecated since 24.3 and will be removed in Vaadin 25.
+     */
+    get _effectiveSize() {
+      console.warn('<vaadin-grid> The `_effectiveSize` property is deprecated and will be removed in Vaadin 25.');
+      return this._flatSize;
+    }
+
     /** @private */
     _sizeChanged(size) {
       this._dataProviderController.setSize(size);

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -211,7 +211,7 @@ export const DragAndDropMixin = (superClass) =>
 
         let row = e.composedPath().find((node) => node.localName === 'tr');
 
-        if (!this._effectiveSize || this.dropMode === DropMode.ON_GRID) {
+        if (!this._flatSize || this.dropMode === DropMode.ON_GRID) {
           // The grid is empty or "on-grid" drop mode was used, always default to "empty"
           this._dropLocation = DropLocation.EMPTY;
         } else if (!row || row.parentNode !== this.$.items) {

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -443,7 +443,7 @@ export const KeyboardNavigationMixin = (superClass) =>
     __navigateRows(dy, activeRow, activeCell) {
       const currentRowIndex = this.__getIndexInGroup(activeRow, this._focusedItemIndex);
       const activeRowGroup = activeRow.parentNode;
-      const maxRowIndex = (activeRowGroup === this.$.items ? this._effectiveSize : activeRowGroup.children.length) - 1;
+      const maxRowIndex = (activeRowGroup === this.$.items ? this._flatSize : activeRowGroup.children.length) - 1;
 
       // Index of the destination row
       let dstRowIndex = Math.max(0, Math.min(currentRowIndex + dy, maxRowIndex));

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -88,7 +88,7 @@ export const GridMixin = (superClass) =>
     static get observers() {
       return [
         '_columnTreeChanged(_columnTree, _columnTree.*)',
-        '_effectiveSizeChanged(_effectiveSize, __virtualizer, _hasData, _columnTree)',
+        '_flatSizeChanged(_flatSize, __virtualizer, _hasData, _columnTree)',
       ];
     }
 
@@ -294,20 +294,20 @@ export const GridMixin = (superClass) =>
     }
 
     /** @private */
-    _effectiveSizeChanged(effectiveSize, virtualizer, hasData, columnTree) {
+    _flatSizeChanged(flatSize, virtualizer, hasData, columnTree) {
       if (virtualizer && hasData && columnTree) {
         // Changing the virtualizer size may result in the row with focus getting hidden
         const cell = this.shadowRoot.activeElement;
         const cellCoordinates = this.__getBodyCellCoordinates(cell);
 
         const previousSize = virtualizer.size || 0;
-        virtualizer.size = effectiveSize;
+        virtualizer.size = flatSize;
 
         // Request an update for the previous last row to have the "last" state removed
         virtualizer.update(previousSize - 1, previousSize - 1);
-        if (effectiveSize < previousSize) {
+        if (flatSize < previousSize) {
           // Size was decreased, so the new last row requires an explicit update
-          virtualizer.update(effectiveSize - 1, effectiveSize - 1);
+          virtualizer.update(flatSize - 1, flatSize - 1);
         }
 
         // If the focused cell's parent row got hidden by the size change, focus the corresponding new cell
@@ -801,7 +801,7 @@ export const GridMixin = (superClass) =>
     _updateRowOrderParts(row, index = row.index) {
       updateBooleanRowStates(row, {
         first: index === 0,
-        last: index === this._effectiveSize - 1,
+        last: index === this._flatSize - 1,
         odd: index % 2 !== 0,
         even: index % 2 === 0,
       });

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -160,7 +160,7 @@ export const ScrollMixin = (superClass) =>
      * @protected
      */
     _scrollToFlatIndex(index) {
-      index = Math.min(this._effectiveSize - 1, Math.max(0, index));
+      index = Math.min(this._flatSize - 1, Math.max(0, index));
       this.__virtualizer.scrollToIndex(index);
       this.__scrollIntoViewport(index);
     }

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -257,7 +257,7 @@ describe('data provider', () => {
 
     describe('first level', () => {
       it('should have collapsed items by default', () => {
-        for (let i = 0; i < grid._effectiveSize; i++) {
+        for (let i = 0; i < grid._flatSize; i++) {
           expect(isIndexExpanded(grid, i)).to.be.false;
         }
       });
@@ -285,11 +285,11 @@ describe('data provider', () => {
       });
 
       it('should have full size set to first level size provided by data provider', () => {
-        expect(grid._effectiveSize).to.equal(10);
+        expect(grid._flatSize).to.equal(10);
       });
 
       it('should have first level items in cache', () => {
-        for (let i = 0; i < grid._effectiveSize; i++) {
+        for (let i = 0; i < grid._flatSize; i++) {
           expect(getItemForIndex(i)).to.deep.equal({ level: 0, value: `foo${i}` });
         }
       });
@@ -319,7 +319,7 @@ describe('data provider', () => {
         expandIndex(grid, 0);
 
         grid.dataProvider.resetHistory();
-        const renderSpy = sinon.spy(grid, '_effectiveSizeChanged');
+        const renderSpy = sinon.spy(grid, '_flatSizeChanged');
         const updateItemSpy = sinon.spy(grid, '_updateItem');
         grid.clearCache();
 
@@ -430,12 +430,12 @@ describe('data provider', () => {
 
         it('should not increase size', () => {
           expandIndex(grid, 7);
-          expect(grid._effectiveSize).to.equal(10);
+          expect(grid._flatSize).to.equal(10);
         });
 
         it('should have first level items in cache', () => {
           expandIndex(grid, 7);
-          for (let i = 0; i < grid._effectiveSize; i++) {
+          for (let i = 0; i < grid._flatSize; i++) {
             expect(getItemForIndex(i)).to.deep.equal({ level: 0, value: `foo${i}` });
           }
         });
@@ -480,7 +480,7 @@ describe('data provider', () => {
                 // The root-level items (10) and the first child item children (10), 20 in total,
                 // should be rendered at this point even though the data request for the second expanded
                 // item hasn't still been resolved
-                expect(grid._effectiveSize).to.equal(20);
+                expect(grid._flatSize).to.equal(20);
                 done();
               }, 0);
             }
@@ -493,7 +493,7 @@ describe('data provider', () => {
 
       it('should increase full size', () => {
         expandIndex(grid, 0);
-        expect(grid._effectiveSize).to.equal(20);
+        expect(grid._flatSize).to.equal(20);
       });
 
       it('should have first and second level items in cache', () => {
@@ -522,7 +522,7 @@ describe('data provider', () => {
 
       it('should decrease full size', () => {
         collapseIndex(grid, 7);
-        expect(grid._effectiveSize).to.equal(10);
+        expect(grid._flatSize).to.equal(10);
       });
 
       it('should have first level items in cache', () => {
@@ -546,7 +546,7 @@ describe('data provider', () => {
 
       it('should increase full size', () => {
         expandIndex(grid, 7);
-        expect(grid._effectiveSize).to.equal(20);
+        expect(grid._flatSize).to.equal(20);
       });
 
       it('should have first and second level items in cache', () => {

--- a/packages/grid/test/deprecated-api.test.js
+++ b/packages/grid/test/deprecated-api.test.js
@@ -47,6 +47,20 @@ describe('deprecated API', () => {
     });
   });
 
+  describe('_effectiveSize', () => {
+    it('should return the flattened size', () => {
+      expect(grid._effectiveSize).to.equal(4);
+    });
+
+    it('should warn about the property being deprecated', () => {
+      const result = grid._effectiveSize;
+      expect(console.warn).to.be.calledOnce;
+      expect(console.warn).to.be.calledWith(
+        '<vaadin-grid> The `_effectiveSize` property is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
   describe('_cache', () => {
     it('should return the root cache', () => {
       expect(grid._cache).to.equal(grid._dataProviderController.rootCache);
@@ -57,6 +71,20 @@ describe('deprecated API', () => {
       expect(console.warn).to.be.calledOnce;
       expect(console.warn).to.be.calledWith(
         '<vaadin-grid> The `_cache` property is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache effectiveSize', () => {
+    it('should return the flattened size', () => {
+      expect(grid._cache.effectiveSize).to.equal(4);
+    });
+
+    it('should warn about the property being deprecated', () => {
+      const result = grid._cache.effectiveSize;
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `effectiveSize` property of ItemCache is deprecated and will be removed in Vaadin 25.',
       );
     });
   });
@@ -76,8 +104,8 @@ describe('deprecated API', () => {
   });
 
   describe('_cache updateSize', () => {
-    it('should call recalculateEffectiveSize', () => {
-      const spy = sinon.spy(grid._cache, 'recalculateEffectiveSize');
+    it('should call recalculateFlatSize', () => {
+      const spy = sinon.spy(grid._cache, 'recalculateFlatSize');
       grid._cache.updateSize();
       expect(spy).to.be.calledOnce;
     });


### PR DESCRIPTION
## Description

The PR deprecates `effectiveSize` and introduces `flatSize` as a replacement in Grid and DataProviderController.

Follow-up to #5961 

## Type of change

- [x] Internal
