### PR TITLE
refactor: restore and deprecate old grid cache API

### DIFF
--- a/packages/component-base/src/data-provider-controller/cache.d.ts
+++ b/packages/component-base/src/data-provider-controller/cache.d.ts
@@ -35,7 +35,7 @@ export class Cache<TItem> {
    * A map where the key is a requested page and the value is a callback
    * that will be called with data once the request is complete.
    */
-  pendingRequests: Map<number, DataProviderCallback<TItem>>;
+  pendingRequests: Record<number, DataProviderCallback<TItem>>;
 
   /**
    * An item in the parent cache that the current cache is associated with.
@@ -105,4 +105,34 @@ export class Cache<TItem> {
    * of an item in the `items` array.
    */
   getFlatIndex(index: number): number;
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  getItemForIndex(index: number): TItem | undefined;
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  getCacheAndIndex(index: number): { cache: Cache<TItem>; scaledIndex: number };
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  updateSize(): void;
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  ensureSubCacheForScaledIndex(scaledIndex: number): void;
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  get grid(): HTMLElement;
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  get itemCaches(): object;
 }

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -234,9 +234,7 @@ export class Cache {
    * @deprecated since 24.3 and will be removed in Vaadin 25.
    */
   updateSize() {
-    console.warn(
-      '<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25. Please, use `recalculateEffectiveSize()` instead.',
-    );
+    console.warn('<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25.');
     this.recalculateEffectiveSize();
   }
 
@@ -244,11 +242,13 @@ export class Cache {
    * @deprecated since 24.3 and will be removed in Vaadin 25.
    */
   ensureSubCacheForScaledIndex(scaledIndex) {
-    console.warn('<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25.');
+    console.warn(
+      '<vaadin-grid> The `ensureSubCacheForScaledIndex` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+    );
 
     if (!this.getSubCache(scaledIndex)) {
       const subCache = this.createSubCache(scaledIndex);
-      this.context.__controller.__loadPage(0, subCache);
+      this.context.__controller.__loadCachePage(subCache, 0);
     }
   }
 

--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { getFlatIndexContext } from './helpers.js';
 
 /**
  * A class that stores items with their associated sub-caches.
@@ -40,9 +41,9 @@ export class Cache {
    * A map where the key is a requested page and the value is a callback
    * that will be called with data once the request is complete.
    *
-   * @type {Map<number, Function>}
+   * @type {Record<number, Function>}
    */
-  pendingRequests = new Map();
+  pendingRequests = {};
 
   /**
    * A map where the key is the index of an item in the `items` array
@@ -106,7 +107,7 @@ export class Cache {
    * @return {boolean}
    */
   get isLoading() {
-    if (this.pendingRequests.size > 0) {
+    if (Object.keys(this.pendingRequests).length > 0) {
       return true;
     }
 
@@ -205,5 +206,67 @@ export class Cache {
       const index = subCache.parentCacheIndex;
       return clampedIndex > index ? prev + subCache.effectiveSize : prev;
     }, clampedIndex);
+  }
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  getItemForIndex(index) {
+    console.warn(
+      '<vaadin-grid> The `getItemForIndex` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+    );
+    const { item } = getFlatIndexContext(this, index);
+    return item;
+  }
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  getCacheAndIndex(index) {
+    console.warn(
+      '<vaadin-grid> The `getCacheAndIndex` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+    );
+    const { cache, index: scaledIndex } = getFlatIndexContext(this, index);
+    return { cache, scaledIndex };
+  }
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  updateSize() {
+    console.warn(
+      '<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25. Please, use `recalculateEffectiveSize()` instead.',
+    );
+    this.recalculateEffectiveSize();
+  }
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  ensureSubCacheForScaledIndex(scaledIndex) {
+    console.warn('<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25.');
+
+    if (!this.getSubCache(scaledIndex)) {
+      const subCache = this.createSubCache(scaledIndex);
+      this.context.__controller.__loadPage(0, subCache);
+    }
+  }
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  get grid() {
+    console.warn('<vaadin-grid> The `grid` property of ItemCache is deprecated and will be removed in Vaadin 25.');
+    return this.context.__controller.host;
+  }
+
+  /**
+   * @deprecated since 24.3 and will be removed in Vaadin 25.
+   */
+  get itemCaches() {
+    console.warn(
+      '<vaadin-grid> The `itemCaches` property of ItemCache is deprecated and will be removed in Vaadin 25.',
+    );
+    return this.__subCacheByIndex;
   }
 }

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -77,7 +77,11 @@ export class DataProviderController extends EventTarget {
 
   /** @private */
   get __cacheContext() {
-    return { isExpanded: this.isExpanded };
+    return {
+      isExpanded: this.isExpanded,
+      // The controller instance is needed to ensure deprecated cache methods work.
+      __controller: this,
+    };
   }
 
   /**
@@ -203,7 +207,7 @@ export class DataProviderController extends EventTarget {
 
   /** @private */
   __loadCachePage(cache, page) {
-    if (!this.dataProvider || cache.pendingRequests.has(page)) {
+    if (!this.dataProvider || cache.pendingRequests[page]) {
       return;
     }
 
@@ -227,12 +231,12 @@ export class DataProviderController extends EventTarget {
 
       this.dispatchEvent(new CustomEvent('page-received'));
 
-      cache.pendingRequests.delete(page);
+      delete cache.pendingRequests[page];
 
       this.dispatchEvent(new CustomEvent('page-loaded'));
     };
 
-    cache.pendingRequests.set(page, callback);
+    cache.pendingRequests[page] = callback;
 
     this.dispatchEvent(new CustomEvent('page-requested'));
 

--- a/packages/component-base/test/typings/data-provider-controller/cache.types.ts
+++ b/packages/component-base/test/typings/data-provider-controller/cache.types.ts
@@ -28,7 +28,7 @@ assertType<unknown[]>(cache.items);
 assertType<boolean>(cache.isLoading);
 assertType<unknown | undefined>(cache.parentItem);
 assertType<Array<Cache<TestItem>>>(cache.subCaches);
-assertType<Map<number, DataProviderCallback<TestItem>>>(cache.pendingRequests);
+assertType<Record<number, DataProviderCallback<TestItem>>>(cache.pendingRequests);
 
 // Methods
 assertType<(page: number, items: unknown[]) => void>(cache.setPage);

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -149,6 +149,15 @@ export const DataProviderMixin = (superClass) =>
       this._dataProviderController.addEventListener('page-loaded', this._onDataProviderPageLoaded.bind(this));
     }
 
+    /**
+     * @protected
+     * @deprecated since 24.3 and will be removed in Vaadin 25.
+     */
+    get _cache() {
+      console.warn('<vaadin-grid> The `_cache` property is deprecated and will be removed in Vaadin 25.');
+      return this._dataProviderController.rootCache;
+    }
+
     /** @private */
     _sizeChanged(size) {
       this._dataProviderController.setSize(size);
@@ -278,7 +287,7 @@ export const DataProviderMixin = (superClass) =>
      * @deprecated since 24.3 and will be removed in Vaadin 25.
      */
     _loadPage(page, cache) {
-      console.warn('<vaadin-grid> The `_loadPage` method is deprecated and will be removed in Vaadin 25');
+      console.warn('<vaadin-grid> The `_loadPage` method is deprecated and will be removed in Vaadin 25.');
       this._dataProviderController.__loadCachePage(cache, page);
     }
 

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -271,6 +271,17 @@ export const DataProviderMixin = (superClass) =>
       return level;
     }
 
+    /**
+     * @param {number} page
+     * @param {ItemCache} cache
+     * @protected
+     * @deprecated since 24.3 and will be removed in Vaadin 25.
+     */
+    _loadPage(page, cache) {
+      console.warn('<vaadin-grid> The `_loadPage` method is deprecated and will be removed in Vaadin 25');
+      this._dataProviderController.__loadCachePage(cache, page);
+    }
+
     /** @protected */
     _onDataProviderPageRequested() {
       this._setLoading(true);

--- a/packages/grid/test/deprecated-api.test.js
+++ b/packages/grid/test/deprecated-api.test.js
@@ -1,0 +1,155 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-grid.js';
+import { flushGrid } from './helpers.js';
+
+describe('deprecated API', () => {
+  let grid;
+
+  beforeEach(() => {
+    sinon.stub(console, 'warn');
+
+    grid = fixtureSync(`
+      <vaadin-grid size="2">
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    grid.dataProvider = ({ parentItem }, callback) => {
+      if (parentItem) {
+        callback([`${parentItem}-0`, `${parentItem}-1`], 2);
+      } else {
+        callback(['Item 0', 'Item 1'], 2);
+      }
+    };
+    grid.expandedItems = ['Item 0'];
+    flushGrid(grid);
+  });
+
+  afterEach(() => {
+    console.warn.restore();
+  });
+
+  describe('_loadPage', () => {
+    it('should delegate the call to dataProviderController', () => {
+      const spy = sinon.spy(grid._dataProviderController, '__loadCachePage');
+      grid._loadPage(0, grid._dataProviderController.rootCache);
+      expect(spy).to.be.calledOnce;
+      expect(spy).to.be.calledWith(grid._dataProviderController.rootCache, 0);
+    });
+
+    it('should warn about the property being deprecated', () => {
+      grid._loadPage(0, grid._dataProviderController.rootCache);
+      expect(console.warn).to.be.calledOnce;
+      expect(console.warn).to.be.calledWith(
+        '<vaadin-grid> The `_loadPage` method is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache', () => {
+    it('should return the root cache', () => {
+      expect(grid._cache).to.equal(grid._dataProviderController.rootCache);
+    });
+
+    it('should warn about the property being deprecated', () => {
+      const result = grid._cache;
+      expect(console.warn).to.be.calledOnce;
+      expect(console.warn).to.be.calledWith(
+        '<vaadin-grid> The `_cache` property is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache getItemForIndex', () => {
+    it('should return the item for the given index', () => {
+      expect(grid._cache.getItemForIndex(1)).to.equal('Item 0-0');
+    });
+
+    it('should warn about the method being deprecated', () => {
+      grid._cache.getItemForIndex(1);
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `getItemForIndex` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache updateSize', () => {
+    it('should call recalculateEffectiveSize', () => {
+      const spy = sinon.spy(grid._cache, 'recalculateEffectiveSize');
+      grid._cache.updateSize();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should warn about the method being deprecated', () => {
+      grid._cache.updateSize();
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `updateSize` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache getCacheAndIndex', () => {
+    it('should return the cache and scaled index for the given index', () => {
+      const { cache, scaledIndex } = grid._cache.getCacheAndIndex(1);
+      expect(cache).to.equal(grid._dataProviderController.rootCache.subCaches[0]);
+      expect(scaledIndex).to.equal(0);
+    });
+
+    it('should warn about the method being deprecated', () => {
+      grid._cache.getCacheAndIndex(1);
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `getCacheAndIndex` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache ensureSubCacheForScaledIndex', () => {
+    it('should create a sub-cache for the given index and request the first page', () => {
+      grid._cache.ensureSubCacheForScaledIndex(1);
+      const subCache = grid._dataProviderController.rootCache.getSubCache(1);
+      expect(subCache).to.exist;
+      expect(subCache.items).to.eql(['Item 1-0', 'Item 1-1']);
+    });
+
+    it('should warn about the method being deprecated', () => {
+      grid._cache.ensureSubCacheForScaledIndex(1);
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `ensureSubCacheForScaledIndex` method of ItemCache is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache grid', () => {
+    it('should return the grid instance', () => {
+      expect(grid._cache.grid).to.equal(grid);
+    });
+
+    it('should warn about the property being deprecated', () => {
+      const result = grid._cache.grid;
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `grid` property of ItemCache is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+
+  describe('_cache itemCaches', () => {
+    it('should return an object with sub-caches by index', () => {
+      const { itemCaches } = grid._cache;
+      expect(itemCaches[0]).to.equal(grid._dataProviderController.rootCache.getSubCache(0));
+    });
+
+    it('should warn about the property being deprecated', () => {
+      const result = grid._cache.itemCaches;
+      expect(console.warn).to.be.calledTwice;
+      expect(console.warn.lastCall).to.be.calledWith(
+        '<vaadin-grid> The `itemCaches` property of ItemCache is deprecated and will be removed in Vaadin 25.',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

The PR restores and deprecates the old grid cache API after it's been removed in #5961.

## Type of change

- [x] Refactor
