### PR TITLE
refactor: extract rich-text-editor styles to css literal

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-styles.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-styles.js
@@ -12,6 +12,35 @@ import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { contentStyles } from './vaadin-rich-text-editor-content-styles.js';
 import { toolbarStyles } from './vaadin-rich-text-editor-toolbar-styles.js';
 
+export const baseStyles = css`
+  :host {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  .announcer {
+    position: fixed;
+    clip: rect(0, 0, 0, 0);
+  }
+
+  input[type='file'] {
+    display: none;
+  }
+
+  .vaadin-rich-text-editor-container {
+    display: flex;
+    flex-direction: column;
+    min-height: inherit;
+    max-height: inherit;
+    flex: auto;
+  }
+`;
+
 export const statesStyles = css`
   :host([readonly]) [part='toolbar'] {
     display: none;
@@ -30,4 +59,4 @@ export const statesStyles = css`
   }
 `;
 
-export const richTextEditorStyles = [contentStyles, toolbarStyles, statesStyles];
+export const richTextEditorStyles = [baseStyles, contentStyles, toolbarStyles, statesStyles];

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -159,35 +159,6 @@ const TAB_KEY = 9;
 class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
     return html`
-      <style>
-        :host {
-          display: flex;
-          flex-direction: column;
-          box-sizing: border-box;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        .announcer {
-          position: fixed;
-          clip: rect(0, 0, 0, 0);
-        }
-
-        input[type='file'] {
-          display: none;
-        }
-
-        .vaadin-rich-text-editor-container {
-          display: flex;
-          flex-direction: column;
-          min-height: inherit;
-          max-height: inherit;
-          flex: auto;
-        }
-      </style>
-
       <div class="vaadin-rich-text-editor-container">
         <!-- Create toolbar container -->
         <div part="toolbar" role="toolbar">


### PR DESCRIPTION
## Description

While most of `vaadin-rich-text-editor` styles already use `css` literals, there is still a `<style>` tag in the template.
This PR makes it aligned to use `css` literal consistently in preparation for LitElement based version.

## Type of change

- Refactor