### PR TITLE
test: update rich-text-editor unit tests, add missing await

### DIFF
--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { down, fixtureSync, focusin, isFirefox, keyboardEventFor } from '@vaadin/testing-helpers';
+import {
+  down,
+  fixtureSync,
+  focusin,
+  isFirefox,
+  keyboardEventFor,
+  nextRender,
+  nextUpdate,
+} from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../vaadin-rich-text-editor.js';
@@ -15,8 +23,9 @@ describe('accessibility', () => {
 
   const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     rte = fixtureSync('<vaadin-rich-text-editor></vaadin-rich-text-editor>');
+    await nextRender();
     editor = rte._editor;
     buttons = Array.from(rte.shadowRoot.querySelectorAll(`[part=toolbar] button`));
     content = rte.shadowRoot.querySelector('[contenteditable]');
@@ -32,7 +41,7 @@ describe('accessibility', () => {
       });
     });
 
-    it('should localize tooltips for the buttons', () => {
+    it('should localize tooltips for the buttons', async () => {
       const defaultI18n = rte.i18n;
 
       const localized = {};
@@ -40,6 +49,7 @@ describe('accessibility', () => {
         localized[key] = `${defaultI18n[key]} localized`;
       });
       rte.i18n = localized;
+      await nextUpdate(rte);
 
       buttons.forEach((button, index) => {
         const expectedLabel = `${defaultI18n[Object.keys(defaultI18n)[index]]} localized`;
@@ -172,6 +182,7 @@ describe('accessibility', () => {
         <vaadin-rich-text-editor></vaadin-rich-text-editor>
         <button>button</button>
       </div>`);
+      await nextRender();
       const [rte, button] = wrapper.children;
       editor = rte._editor;
       editor.focus();
@@ -194,6 +205,7 @@ describe('accessibility', () => {
         <vaadin-rich-text-editor></vaadin-rich-text-editor>
         <button>button</button>
       </div>`);
+      await nextRender();
       const [rte, button] = wrapper.children;
       editor = rte._editor;
       editor.focus();

--- a/packages/rich-text-editor/test/auto-grow.test.js
+++ b/packages/rich-text-editor/test/auto-grow.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-rich-text-editor.js';
 
 describe('rich text editor', () => {
@@ -40,8 +40,9 @@ describe('rich text editor', () => {
   const conditionValues = ['equal', 'equal or greater than', 'below'];
   ['height', 'min-height', 'max-height'].forEach((definedValue, key) => {
     describe(`defined ${definedValue}`, () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         rte = fixtureSync(`<vaadin-rich-text-editor style="${definedValue}: 500px"></vaadin-rich-text-editor>`);
+        await nextRender();
         editorContainer = rte.shadowRoot.querySelector('.vaadin-rich-text-editor-container');
         editorContentContainer = rte.shadowRoot.querySelector('.ql-container');
         editorContent = rte.shadowRoot.querySelector('.ql-editor');


### PR DESCRIPTION
## Description

Updated `vaadin-rich-text-editor` unit tests to pass with the LitElement based version (to be added later).

## Type of change

- Test