### PR TITLE
refactor: update Lit versions to use new input-container

### DIFF
--- a/packages/date-picker/src/vaadin-lit-date-picker.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/src/vaadin-input-container.js';
+import '@vaadin/input-container/src/vaadin-lit-input-container.js';
 import './vaadin-lit-date-picker-overlay.js';
 import './vaadin-lit-date-picker-overlay-content.js';
 import { html, LitElement } from 'lit';

--- a/packages/number-field/src/vaadin-lit-number-field.js
+++ b/packages/number-field/src/vaadin-lit-number-field.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/src/vaadin-input-container.js';
+import '@vaadin/input-container/src/vaadin-lit-input-container.js';
 import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';

--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/src/vaadin-input-container.js';
+import '@vaadin/input-container/src/vaadin-lit-input-container.js';
 import './vaadin-lit-select-item.js';
 import './vaadin-lit-select-list-box.js';
 import './vaadin-lit-select-overlay.js';

--- a/packages/text-area/src/vaadin-lit-text-area.js
+++ b/packages/text-area/src/vaadin-lit-text-area.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/src/vaadin-input-container.js';
+import '@vaadin/input-container/src/vaadin-lit-input-container.js';
 import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';

--- a/packages/text-field/src/vaadin-lit-text-field.js
+++ b/packages/text-field/src/vaadin-lit-text-field.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/src/vaadin-input-container.js';
+import '@vaadin/input-container/src/vaadin-lit-input-container.js';
 import { css, html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';


### PR DESCRIPTION
## Description

Follow-up to #6576

Updated LitElement based versions of field components to use Lit version of `vaadin-input-container`.

## Type of change

- Refactor