### PR TITLE
refactor: move input-container theme imports to styles modules

### DIFF
--- a/packages/combo-box/theme/lumo/vaadin-combo-box-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-styles.js
@@ -1,3 +1,4 @@
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/combo-box/theme/lumo/vaadin-combo-box.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box.js
@@ -1,4 +1,3 @@
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-combo-box-item-styles.js';
 import './vaadin-combo-box-overlay-styles.js';
 import './vaadin-combo-box-styles.js';

--- a/packages/combo-box/theme/material/vaadin-combo-box-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-styles.js
@@ -1,3 +1,4 @@
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';

--- a/packages/combo-box/theme/material/vaadin-combo-box.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box.js
@@ -1,4 +1,3 @@
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-combo-box-item-styles.js';
 import './vaadin-combo-box-overlay-styles.js';
 import './vaadin-combo-box-styles.js';

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-styles.js
@@ -1,3 +1,4 @@
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/date-picker/theme/lumo/vaadin-date-picker.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker.js
@@ -1,4 +1,3 @@
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-date-picker-overlay-styles.js';
 import './vaadin-date-picker-overlay-content-styles.js';
 import './vaadin-month-calendar-styles.js';

--- a/packages/date-picker/theme/material/vaadin-date-picker-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-styles.js
@@ -1,3 +1,4 @@
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';

--- a/packages/date-picker/theme/material/vaadin-date-picker.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker.js
@@ -1,4 +1,3 @@
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-date-picker-overlay-styles.js';
 import './vaadin-date-picker-overlay-content-styles.js';
 import './vaadin-month-calendar-styles.js';

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/style.js';

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-multi-select-combo-box-chip-styles.js';
 import './vaadin-multi-select-combo-box-styles.js';

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';

--- a/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-multi-select-combo-box-chip-styles.js';
 import './vaadin-multi-select-combo-box-styles.js';

--- a/packages/number-field/theme/lumo/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/lumo/vaadin-number-field-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import { fieldButton } from '@vaadin/vaadin-lumo-styles/mixins/field-button.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';

--- a/packages/number-field/theme/lumo/vaadin-number-field.js
+++ b/packages/number-field/theme/lumo/vaadin-number-field.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-number-field-styles.js';
 import '../../src/vaadin-number-field.js';

--- a/packages/number-field/theme/material/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/material/vaadin-number-field-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import { fieldButton } from '@vaadin/vaadin-material-styles/mixins/field-button.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/number-field/theme/material/vaadin-number-field.js
+++ b/packages/number-field/theme/material/vaadin-number-field.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-number-field-styles.js';
 import '../../src/vaadin-number-field.js';

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';

--- a/packages/select/theme/lumo/vaadin-select.js
+++ b/packages/select/theme/lumo/vaadin-select.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-select-styles.js';
 import '../../src/vaadin-select.js';

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { item } from '@vaadin/item/theme/material/vaadin-item-styles.js';
 import { listBox } from '@vaadin/list-box/theme/material/vaadin-list-box-styles.js';

--- a/packages/select/theme/material/vaadin-select.js
+++ b/packages/select/theme/material/vaadin-select.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-select-styles.js';
 import '../../src/vaadin-select.js';

--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';

--- a/packages/text-area/theme/lumo/vaadin-text-area.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-text-area-styles.js';
 import '../../src/vaadin-text-area.js';

--- a/packages/text-area/theme/material/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/material/vaadin-text-area-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/text-area/theme/material/vaadin-text-area.js
+++ b/packages/text-area/theme/material/vaadin-text-area.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-text-area-styles.js';
 import '../../src/vaadin-text-area.js';

--- a/packages/text-field/theme/lumo/vaadin-text-field-styles.js
+++ b/packages/text-field/theme/lumo/vaadin-text-field-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/text-field/theme/lumo/vaadin-text-field.js
+++ b/packages/text-field/theme/lumo/vaadin-text-field.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-text-field-styles.js';
 import '../../src/vaadin-text-field.js';

--- a/packages/text-field/theme/material/vaadin-text-field-styles.js
+++ b/packages/text-field/theme/material/vaadin-text-field-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/text-field/theme/material/vaadin-text-field.js
+++ b/packages/text-field/theme/material/vaadin-text-field.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2017 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-text-field-styles.js';
 import '../../src/vaadin-text-field.js';

--- a/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import { comboBoxItem } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-item-styles.js';
 import { comboBoxOverlay } from '@vaadin/combo-box/theme/lumo/vaadin-combo-box-overlay-styles.js';

--- a/packages/time-picker/theme/lumo/vaadin-time-picker.js
+++ b/packages/time-picker/theme/lumo/vaadin-time-picker.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/lumo/vaadin-input-container.js';
 import './vaadin-time-picker-styles.js';
 import '../../src/vaadin-time-picker.js';

--- a/packages/time-picker/theme/material/vaadin-time-picker-styles.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import { comboBoxItem } from '@vaadin/combo-box/theme/material/vaadin-combo-box-item-styles.js';
 import { comboBoxOverlay } from '@vaadin/combo-box/theme/material/vaadin-combo-box-overlay-styles.js';

--- a/packages/time-picker/theme/material/vaadin-time-picker.js
+++ b/packages/time-picker/theme/material/vaadin-time-picker.js
@@ -3,6 +3,5 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/input-container/theme/material/vaadin-input-container.js';
 import './vaadin-time-picker-styles.js';
 import '../../src/vaadin-time-picker.js';


### PR DESCRIPTION
## Description

As reported in https://github.com/vaadin/web-components/pull/6578#discussion_r1341382242, we need to move `-styles` modules to be placed in corresponding theme files so they can be used with Lit versions. Otherwise, we would have to import these manually for each component in addition to its own theme entrypoint.

## Type of change

- Refactor