### PR TITLE
fix: make virtualizer with placeholders retry scroll to index

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -92,7 +92,7 @@ export class IronListAdapter {
     }
     delete this.__pendingScrollToIndex;
 
-    if (this._physicalCount === 3 /* iron-list-core.DEFAULT_PHYSICAL_COUNT */) {
+    if (this._physicalCount <= 3 /* iron-list-core.DEFAULT_PHYSICAL_COUNT */) {
       // The condition here is a performance improvement to avoid an unnecessary
       // re-render when the physical item pool is already covered.
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -93,7 +93,7 @@ export class IronListAdapter {
     delete this.__pendingScrollToIndex;
 
     if (this._physicalCount === 3 /* iron-list-core.DEFAULT_PHYSICAL_COUNT */) {
-      // The condition here is a perfoemance improvement to avoid an unnecessary
+      // The condition here is a performance improvement to avoid an unnecessary
       // re-render when the physical item pool is already covered.
 
       // Finish rendering at the current scroll position before scrolling

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -92,6 +92,14 @@ export class IronListAdapter {
     }
     delete this.__pendingScrollToIndex;
 
+    if (this._physicalCount === 3 /* iron-list-core.DEFAULT_PHYSICAL_COUNT */) {
+      // The condition here is a perfoemance improvement to avoid an unnecessary
+      // re-render when the physical item pool is already covered.
+
+      // Finish rendering at the current scroll position before scrolling
+      this.flush();
+    }
+
     index = this._clamp(index, 0, this.size - 1);
 
     const visibleElementCount = this.__getVisibleElements().length;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -83,7 +83,7 @@ export class IronListAdapter {
   }
 
   __hasPlaceholders() {
-    return this.__getVisibleElements().some((el) => el.__placeholder);
+    return this.__getVisibleElements().some((el) => el.__virtualizerPlaceholder);
   }
 
   scrollToIndex(index) {
@@ -219,9 +219,9 @@ export class IronListAdapter {
 
   __updateElement(el, index, forceSameIndexUpdates) {
     // Clean up temporary placeholder sizing
-    if (el.__placeholder) {
+    if (el.__virtualizerPlaceholder) {
       el.style.paddingTop = '';
-      el.__placeholder = false;
+      el.__virtualizerPlaceholder = false;
     }
 
     if (!this.__preventElementUpdates && (el.__lastUpdatedIndex !== index || forceSameIndexUpdates)) {
@@ -245,7 +245,7 @@ export class IronListAdapter {
         // Assign a temporary placeholder sizing to elements that would otherwise end up having
         // no height.
         el.style.paddingTop = `${this.__placeholderHeight}px`;
-        el.__placeholder = true;
+        el.__virtualizerPlaceholder = true;
 
         // Manually schedule the resize handler to make sure the placeholder padding is
         // cleared in case the resize observer never triggers.

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -82,10 +82,16 @@ export class IronListAdapter {
     return this.lastVisibleIndex + this._vidxOffset;
   }
 
+  __hasPlaceholders() {
+    return this.__getVisibleElements().some((el) => el.__placeholder);
+  }
+
   scrollToIndex(index) {
     if (typeof index !== 'number' || isNaN(index) || this.size === 0 || !this.scrollTarget.offsetHeight) {
       return;
     }
+    delete this.__pendingScrollToIndex;
+
     index = this._clamp(index, 0, this.size - 1);
 
     const visibleElementCount = this.__getVisibleElements().length;
@@ -113,6 +119,12 @@ export class IronListAdapter {
       this._scrollTop -= this.__getIndexScrollOffset(index) || 0;
     }
     this._scrollHandler();
+
+    if (this.__hasPlaceholders()) {
+      // After rendering synchronously, there are still placeholders in the DOM.
+      // Try again after the next elements update.
+      this.__pendingScrollToIndex = index;
+    }
   }
 
   flush() {
@@ -199,8 +211,9 @@ export class IronListAdapter {
 
   __updateElement(el, index, forceSameIndexUpdates) {
     // Clean up temporary placeholder sizing
-    if (el.style.paddingTop) {
+    if (el.__placeholder) {
       el.style.paddingTop = '';
+      el.__placeholder = false;
     }
 
     if (!this.__preventElementUpdates && (el.__lastUpdatedIndex !== index || forceSameIndexUpdates)) {
@@ -224,6 +237,7 @@ export class IronListAdapter {
         // Assign a temporary placeholder sizing to elements that would otherwise end up having
         // no height.
         el.style.paddingTop = `${this.__placeholderHeight}px`;
+        el.__placeholder = true;
 
         // Manually schedule the resize handler to make sure the placeholder padding is
         // cleared in case the resize observer never triggers.
@@ -241,6 +255,10 @@ export class IronListAdapter {
         this.__placeholderHeight = Math.round(filteredHeights.reduce((a, b) => a + b, 0) / filteredHeights.length);
       }
     });
+
+    if (this.__pendingScrollToIndex !== undefined && !this.__hasPlaceholders()) {
+      this.scrollToIndex(this.__pendingScrollToIndex);
+    }
   }
 
   __getIndexScrollOffset(index) {

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -260,6 +260,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
     virtualizer = new Virtualizer({
       createElements: (count) => Array.from({ length: count }, () => document.createElement('div')),
       updateElement: (el, index) => {
+        el.dataset.index = index;
         el.style.width = '100%';
         el.textContent = renderPlaceholders ? '' : `Item ${index}`;
       },
@@ -361,6 +362,27 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
         // Expect the scroll position to be the same as before
         expect(scrollTarget.scrollTop).to.equal(scrollTop);
       });
+    });
+
+    it('should scroll to end', async () => {
+      renderPlaceholders = false;
+      virtualizer.update();
+      virtualizer.scrollToIndex(Infinity);
+      await aTimeout(200);
+
+      expect(virtualizer.lastVisibleIndex).to.equal(999);
+
+      const { top, bottom, left } = scrollTarget.getBoundingClientRect();
+
+      // Expect the first visible item to be at the top of the viewport
+      const topMostItem = document.elementFromPoint(left, top);
+      const firstVisibleItem = document.querySelector(`[data-index="${virtualizer.firstVisibleIndex}"]`);
+      expect(topMostItem).to.equal(firstVisibleItem);
+
+      // Expect the last visible item to be at the bottom of the viewport
+      const bottomMostItem = document.elementFromPoint(left, bottom - 1);
+      const lastVisibleItem = document.querySelector(`[data-index="${virtualizer.lastVisibleIndex}"]`);
+      expect(bottomMostItem).to.equal(lastVisibleItem);
     });
   });
 });

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -3,6 +3,11 @@ import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';
 
+async function contentUpdate() {
+  // Wait for the content to update (and resize observer to fire)
+  await aTimeout(200);
+}
+
 describe('virtualizer - item height', () => {
   let elementsContainer;
   let virtualizer;
@@ -57,13 +62,13 @@ describe('virtualizer - item height', () => {
   it('should resize the elements once the content updates', async () => {
     const firstItem = elementsContainer.querySelector(`#item-0`);
     // Wait for the content to update
-    await aTimeout(100);
+    await contentUpdate();
     expect(firstItem.offsetHeight).to.equal(EVEN_ITEM_HEIGHT);
   });
 
   it('should adjust the placeholder height', async () => {
     // Wait for the content to update
-    await aTimeout(100);
+    await contentUpdate();
     // Scroll down
     virtualizer.scrollToIndex(100);
 
@@ -76,7 +81,7 @@ describe('virtualizer - item height', () => {
 
   it('should clear the temporary placeholder padding from the item', async () => {
     // Wait for the content to update (and resize observer to fire)
-    await aTimeout(200);
+    await contentUpdate();
 
     // Cache the height of the first item
     const firstItem = elementsContainer.querySelector(`#item-0`);
@@ -91,7 +96,7 @@ describe('virtualizer - item height', () => {
     firstItem.style.height = `${firstItemHeight}px`;
 
     // Give some time for the resize observer to fire
-    await aTimeout(100);
+    await contentUpdate();
 
     // The padding should have been be cleared and the item should have its original height.
     expect(firstItem.offsetHeight).to.equal(firstItemHeight);
@@ -278,7 +283,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
           // Setup where the virtualizer has initially rendered all the items once
           renderPlaceholders = false;
           virtualizer.update();
-          await aTimeout(200);
+          await contentUpdate();
           renderPlaceholders = true;
         }
       });
@@ -292,7 +297,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
         renderPlaceholders = false;
         virtualizer.update();
         // Wait for the content to update (and resize observer to fire)
-        await aTimeout(200);
+        await contentUpdate();
 
         // The first visible index should be correct
         expect(virtualizer.firstVisibleIndex).to.equal(500);
@@ -304,7 +309,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
 
         renderPlaceholders = false;
         virtualizer.update();
-        await aTimeout(200);
+        await contentUpdate();
 
         expect(virtualizer.firstVisibleIndex).to.equal(600);
       });
@@ -314,7 +319,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
 
         renderPlaceholders = false;
         virtualizer.scrollToIndex(0);
-        await aTimeout(200);
+        await contentUpdate();
 
         expect(virtualizer.firstVisibleIndex).to.equal(0);
       });
@@ -326,7 +331,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
         virtualizer.scrollToIndex(0);
 
         const scrollToIndexSpy = sinon.spy(virtualizer.__adapter, 'scrollToIndex');
-        await aTimeout(200);
+        await contentUpdate();
 
         // Expect spy to not have been called
         expect(scrollToIndexSpy).to.not.have.been.called;
@@ -334,12 +339,12 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
 
       it('should not scroll away from manually scrolled position', async () => {
         virtualizer.scrollToIndex(500);
-        await aTimeout(200);
+        await contentUpdate();
         renderPlaceholders = false;
         virtualizer.update();
-        await aTimeout(200);
+        await contentUpdate();
         scrollTarget.scrollTop += 500;
-        await aTimeout(200);
+        await contentUpdate();
 
         expect(virtualizer.firstVisibleIndex).not.to.equal(500);
       });
@@ -347,7 +352,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
       it('should not change scroll position after item height change', async () => {
         renderPlaceholders = false;
         virtualizer.scrollToIndex(1);
-        await aTimeout(200);
+        await contentUpdate();
         const scrollTop = scrollTarget.scrollTop;
 
         // Increase item height
@@ -358,7 +363,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
             }
           </style>
         `);
-        await aTimeout(200);
+        await contentUpdate();
 
         // Expect the scroll position to be the same as before
         expect(scrollTarget.scrollTop).to.equal(scrollTop);
@@ -369,7 +374,7 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
       renderPlaceholders = false;
       virtualizer.update();
       virtualizer.scrollToIndex(Infinity);
-      await aTimeout(200);
+      await contentUpdate();
 
       expect(virtualizer.lastVisibleIndex).to.equal(999);
 

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -319,16 +319,17 @@ describe('virtualizer - item height - lazy rendering - scroll to index', () => {
         expect(virtualizer.firstVisibleIndex).to.equal(0);
       });
 
-      it('should not try to scroll to undefined', async () => {
-        const scrollToIndexSpy = sinon.spy(virtualizer.__adapter, 'scrollToIndex');
+      it('should not scroll to pending index when there are no placeholders', async () => {
         virtualizer.scrollToIndex(500);
 
         renderPlaceholders = false;
         virtualizer.scrollToIndex(0);
+
+        const scrollToIndexSpy = sinon.spy(virtualizer.__adapter, 'scrollToIndex');
         await aTimeout(200);
 
-        // Expect spy to not have been called with undefined
-        expect(scrollToIndexSpy.args.every((args) => args[0] !== undefined)).to.be.true;
+        // Expect spy to not have been called
+        expect(scrollToIndexSpy).to.not.have.been.called;
       });
 
       it('should not scroll away from manually scrolled position', async () => {

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -62,13 +62,13 @@ describe('virtualizer - item height', () => {
   it('should resize the elements once the content updates', async () => {
     const firstItem = elementsContainer.querySelector(`#item-0`);
     // Wait for the content to update
-    await contentUpdate();
+    await aTimeout(100);
     expect(firstItem.offsetHeight).to.equal(EVEN_ITEM_HEIGHT);
   });
 
   it('should adjust the placeholder height', async () => {
     // Wait for the content to update
-    await contentUpdate();
+    await aTimeout(100);
     // Scroll down
     virtualizer.scrollToIndex(100);
 
@@ -96,7 +96,7 @@ describe('virtualizer - item height', () => {
     firstItem.style.height = `${firstItemHeight}px`;
 
     // Give some time for the resize observer to fire
-    await contentUpdate();
+    await aTimeout(100);
 
     // The padding should have been be cleared and the item should have its original height.
     expect(firstItem.offsetHeight).to.equal(firstItemHeight);


### PR DESCRIPTION
## Description

Make the virtualizer retry scrolling to an index on the next round of element updates in case there are placeholder items in the DOM after scrollToIndex.

This change is a prerequisite to finishing https://github.com/vaadin/flow-components/pull/5037 without having to work around the issue in the connector.

## Type of change

Bugfix