### PR TITLE
fix: validate on Enter only if there was an actual value commit

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -458,11 +458,11 @@ export const DatePickerMixin = (subclass) =>
       super._onBlur(event);
 
       if (!this.opened) {
-        const valueCommitResult = this.__commitParsedOrFocusedDate();
+        const didValueCommitOccur = this.__commitParsedOrFocusedDate();
 
         // Do not validate when focusout is caused by document
         // losing focus, which happens on browser tab switch.
-        if (!valueCommitResult && document.hasFocus()) {
+        if (!didValueCommitOccur && document.hasFocus()) {
           this.validate();
         }
       }
@@ -681,7 +681,7 @@ export const DatePickerMixin = (subclass) =>
      * @private
      * @return {boolean} whether a change has been detected and committed.
      */
-    __commitValueChangeIfPending() {
+    __commitValueChange() {
       let result = false;
 
       if (this.__committedValue !== this.value) {
@@ -714,7 +714,7 @@ export const DatePickerMixin = (subclass) =>
       this.__keepCommittedValue = true;
       this._selectedDate = date;
       this.__keepCommittedValue = false;
-      return this.__commitValueChangeIfPending();
+      return this.__commitValueChange();
     }
 
     /** @private */
@@ -947,7 +947,8 @@ export const DatePickerMixin = (subclass) =>
 
     /**
      * Tries to parse the input element's value as a date. When succeeds,
-     * sets the resulting date as the value and tries to commit it.
+     * sets the resulting date as the value and tries to commit it. When fails,
+     * resets the value to an empty string and tries to commit it.
      * If no i18n parser is provided, sets the focused date as the value.
      *
      * @private
@@ -986,7 +987,7 @@ export const DatePickerMixin = (subclass) =>
       }
       window.removeEventListener('scroll', this._boundOnScroll, true);
 
-      const valueCommitResult = this.__commitParsedOrFocusedDate();
+      const didValueCommitOccur = this.__commitParsedOrFocusedDate();
 
       if (this._nativeInput && this._nativeInput.selectionStart) {
         this._nativeInput.selectionStart = this._nativeInput.selectionEnd;
@@ -994,7 +995,7 @@ export const DatePickerMixin = (subclass) =>
       // No need to revalidate the value after it has been just committed.
       // Needed in case the value was not changed: open and close dropdown,
       // especially on outside click. On Esc key press, do not validate.
-      if (!valueCommitResult && !this.value && !this._keyboardActive) {
+      if (!didValueCommitOccur && !this.value && !this._keyboardActive) {
         this.validate();
       }
     }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -657,17 +657,29 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /**
-     * Executes one of the following branches depending on the first match:
+     * Depending on the type of value change that has taken place
+     * since the last commit attempt, triggers validation and fires
+     * an event:
      *
-     * 1. If the parsable value has changed since the last commit attempt,
-     *    triggers validation and fires a change event.
-     * 2. If the unparsable value has changed since the last commit attempt,
-     *    triggers validation.
+     * ```text
+     * +------------------------+--------+
+     * | Type of change         | Event  |
+     * +------------------------+--------+
+     * | empty => parsable      | change |
+     * | empty => unparsable    |        |
+     * | parsable => empty      | change |
+     * | parsable => unparsable | change |
+     * | unparsable => empty    |        |
+     * | unparsable => parsable |        |
+     * +------------------------+--------+
+     * ```
      *
-     * Finally, updates the last committed parsable and unparsable values.
+     * If no value change is detected, the method returns false.
+     *
+     * (the above table has been generated with ChatGPT)
      *
      * @private
-     * @return {boolean} whether an actual commit occurred.
+     * @return {boolean} whether a change has been detected and committed.
      */
     __commitValueChangeIfPending() {
       let result = false;

--- a/packages/date-picker/test/value-commit-auto-open-disabled.common.js
+++ b/packages/date-picker/test/value-commit-auto-open-disabled.common.js
@@ -50,9 +50,9 @@ describe('value commit - autoOpenDisabled', () => {
       expectValidationOnly();
     });
 
-    it('should not commit but validate on Enter', async () => {
+    it('should not commit on Enter', async () => {
       await sendKeys({ press: 'Enter' });
-      expectValidationOnly();
+      expectNoValueCommit();
     });
 
     it('should not commit but validate on outside click', () => {
@@ -201,9 +201,9 @@ describe('value commit - autoOpenDisabled', () => {
         expectValidationOnly();
       });
 
-      it('should not commit but validate on Enter', async () => {
+      it('should not commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
-        expectValidationOnly();
+        expectNoValueCommit();
       });
 
       it('should not commit on Escape', async () => {

--- a/packages/date-picker/test/value-commit.common.js
+++ b/packages/date-picker/test/value-commit.common.js
@@ -57,9 +57,9 @@ describe('value commit', () => {
       expectValidationOnly();
     });
 
-    it('should not commit but validate on Enter', async () => {
+    it('should not commit on Enter', async () => {
       await sendKeys({ press: 'Enter' });
-      expectValidationOnly();
+      expectNoValueCommit();
     });
 
     it('should not commit on Escape', async () => {
@@ -300,9 +300,9 @@ describe('value commit', () => {
         expectValidationOnly();
       });
 
-      it('should not commit but validate on Enter', async () => {
+      it('should not commit on Enter', async () => {
         await sendKeys({ press: 'Enter' });
-        expectValidationOnly();
+        expectNoValueCommit();
       });
 
       it('should not commit on Escape', async () => {


### PR DESCRIPTION
## Description

The PR makes `date-picker` validate on Enter only if there was an actual value commit [^1] to align that with the native browser behavior.

Part of https://github.com/vaadin/flow-components/issues/5537

## Type of change

- [x] Bugfix

[^1]: Note, there can be parsable and unparsable value commits.