### PR TITLE
[WIP] refactor!: update to use input type text instead of number

### DIFF
--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -41,6 +41,10 @@ export class IntegerField extends NumberField {
     return 'vaadin-integer-field';
   }
 
+  static get observers() {
+    return ['_stepChanged(step)'];
+  }
+
   constructor() {
     super();
 
@@ -65,23 +69,16 @@ export class IntegerField extends NumberField {
   }
 
   /**
-   * Override an observer from `NumberField` to reset the step
-   * property when an invalid step is set.
    * @param {number} newVal
-   * @param {HTMLElement | undefined} inputElement
    * @protected
-   * @override
    */
-  _stepChanged(step, inputElement) {
+  _stepChanged(step) {
     if (step != null && !this.__hasOnlyDigits(step)) {
       console.warn(
         `<vaadin-integer-field> The \`step\` property must be a positive integer but \`${step}\` was provided, so the property was reset to \`null\`.`,
       );
       this.step = null;
-      return;
     }
-
-    super._stepChanged(step, inputElement);
   }
 
   /** @private */

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -11,28 +11,6 @@ describe('integer-field', () => {
     input = integerField.inputElement;
   });
 
-  describe('basic', () => {
-    it('should not prevent default for input wheel events when not focused', () => {
-      const event = new CustomEvent('wheel', { cancelable: true });
-      input.dispatchEvent(event);
-      expect(event.defaultPrevented).to.be.false;
-    });
-
-    it('should prevent default for input wheel events when focused', () => {
-      const event = new CustomEvent('wheel', { cancelable: true });
-      input.focus();
-      input.dispatchEvent(event);
-      expect(event.defaultPrevented).to.be.true;
-    });
-
-    it('should not prevent default for host wheel events when focused', () => {
-      const event = new CustomEvent('wheel', { cancelable: true });
-      input.focus();
-      integerField.dispatchEvent(event);
-      expect(event.defaultPrevented).to.be.false;
-    });
-  });
-
   describe('keyboard input', () => {
     let keydownSpy;
 

--- a/packages/integer-field/test/value-commit.test.js
+++ b/packages/integer-field/test/value-commit.test.js
@@ -115,14 +115,13 @@ describe('value commit', () => {
     it('should not commit but validate on blur', () => {
       integerField.blur();
       expectValidationOnly();
-      expect(integerField.inputElement.validity.badInput).to.be.true;
+      expect(integerField._validity.badInput).to.be.true;
     });
 
-    // FIXME: https://github.com/vaadin/web-components/issues/5113
-    it.skip('should not commit but validate on Enter', async () => {
+    it('should not commit but validate on Enter', async () => {
       await sendKeys({ press: 'Enter' });
       expectValidationOnly();
-      expect(integerField.inputElement.validity.badInput).to.be.true;
+      expect(integerField._validity.badInput).to.be.true;
     });
   });
 
@@ -204,13 +203,13 @@ describe('value commit', () => {
       it('should commit an empty value on blur', () => {
         integerField.blur();
         expectValueCommit('');
-        expect(integerField.inputElement.validity.badInput).to.be.true;
+        expect(integerField._validity.badInput).to.be.true;
       });
 
       it('should commit an empty value on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         expectValueCommit('');
-        expect(integerField.inputElement.validity.badInput).to.be.true;
+        expect(integerField._validity.badInput).to.be.true;
       });
     });
   });

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -36,6 +36,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@internationalized/number": "3.2.1",
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "24.3.0-alpha1",

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -60,8 +60,6 @@ export const NumberFieldMixin = (superClass) =>
     constructor() {
       super();
 
-      this.__onWheel = this.__onWheel.bind(this);
-
       this._lastCommittedValue = '';
 
       this._validity = {
@@ -164,32 +162,6 @@ export const NumberFieldMixin = (superClass) =>
       this.__skipForwarding = false;
     }
 
-    /**
-     * Override the method from `InputMixin` to add
-     * a wheel event listener to the input element.
-     *
-     * @param {HTMLElement} input
-     * @override
-     * @protected
-     */
-    _addInputListeners(input) {
-      super._addInputListeners(input);
-      input.addEventListener('wheel', this.__onWheel);
-    }
-
-    /**
-     * Override the method from `InputMixin` to remove
-     * the wheel event listener from the input element.
-     *
-     * @param {HTMLElement} input
-     * @override
-     * @protected
-     */
-    _removeInputListeners(input) {
-      super._removeInputListeners(input);
-      input.removeEventListener('wheel', this.__onWheel);
-    }
-
     /** @private */
     _checkInputValidity() {
       const inputValue = this._inputElementValue;
@@ -228,24 +200,6 @@ export const NumberFieldMixin = (superClass) =>
       };
 
       return valid;
-    }
-
-    /**
-     * Prevents default browser behavior for wheel events on the input element
-     * when it's focused. More precisely, this prevents the browser from attempting
-     * to increment or decrement the value when the mouse wheel is used within
-     * the input element.
-     *
-     * CAVEAT: As a side-effect, this also prevents page scrolling when
-     * the pointer is positioned over the field and the field is focused.
-     *
-     * @param {WheelEvent} event
-     * @private
-     */
-    __onWheel(event) {
-      if (this.hasAttribute('focused')) {
-        event.preventDefault();
-      }
     }
 
     /** @protected */

--- a/packages/number-field/test/number-field.common.js
+++ b/packages/number-field/test/number-field.common.js
@@ -65,26 +65,6 @@ describe('number-field', () => {
       arrowDown(input);
       expect(numberField.value).to.be.equal('0');
     });
-
-    it('should not prevent default for input wheel events when not focused', () => {
-      const event = new CustomEvent('wheel', { cancelable: true });
-      input.dispatchEvent(event);
-      expect(event.defaultPrevented).to.be.false;
-    });
-
-    it('should prevent default for input wheel events when focused', () => {
-      const event = new CustomEvent('wheel', { cancelable: true });
-      input.focus();
-      input.dispatchEvent(event);
-      expect(event.defaultPrevented).to.be.true;
-    });
-
-    it('should not prevent default for host wheel events when focused', () => {
-      const event = new CustomEvent('wheel', { cancelable: true });
-      input.focus();
-      numberField.dispatchEvent(event);
-      expect(event.defaultPrevented).to.be.false;
-    });
   });
 
   describe('has-input-value-changed event', () => {

--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -55,14 +55,6 @@ describe('validation', () => {
       expect(field.validate()).to.be.true;
     });
 
-    it('should align checkValidity with the native input element', async () => {
-      field.value = -1;
-      field.min = 0;
-      await nextUpdate(field);
-
-      expect(field.checkValidity()).to.equal(input.checkValidity());
-    });
-
     it('should allow setting decimals', async () => {
       field.value = 7.6;
       await nextUpdate(field);

--- a/packages/number-field/test/value-commit.common.js
+++ b/packages/number-field/test/value-commit.common.js
@@ -127,15 +127,14 @@ describe('value commit', () => {
       numberField.blur();
       await nextUpdate(numberField);
       expectValidationOnly();
-      expect(numberField.inputElement.validity.badInput).to.be.true;
+      expect(numberField._validity.badInput).to.be.true;
     });
 
-    // FIXME: https://github.com/vaadin/web-components/issues/5113
-    it.skip('should not commit but validate on Enter', async () => {
+    it('should not commit but validate on Enter', async () => {
       await sendKeys({ press: 'Enter' });
       await nextUpdate(numberField);
       expectValidationOnly();
-      expect(numberField.inputElement.validity.badInput).to.be.true;
+      expect(numberField._validity.badInput).to.be.true;
     });
   });
 
@@ -162,8 +161,7 @@ describe('value commit', () => {
         expectValidationOnly();
       });
 
-      // FIXME: https://github.com/vaadin/web-components/issues/5113
-      it.skip('should not commit but validate on Enter', async () => {
+      it('should not commit but validate on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         await nextUpdate(numberField);
         expectValidationOnly();
@@ -230,14 +228,14 @@ describe('value commit', () => {
         numberField.blur();
         await nextUpdate(numberField);
         expectValueCommit('');
-        expect(numberField.inputElement.validity.badInput).to.be.true;
+        expect(numberField._validity.badInput).to.be.true;
       });
 
       it('should commit an empty value on Enter', async () => {
         await sendKeys({ press: 'Enter' });
         await nextUpdate(numberField);
         expectValueCommit('');
-        expect(numberField.inputElement.validity.badInput).to.be.true;
+        expect(numberField._validity.badInput).to.be.true;
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,13 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@internationalized/number@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.2.1.tgz#570e4010544a84a8225e65b34a689a36187caaa8"
+  integrity sha512-hK30sfBlmB1aIe3/OwAPg9Ey0DjjXvHEiGVhNaOiBJl31G0B6wMaX8BN3ibzdlpyRNE9p7X+3EBONmxtJO9Yfg==
+  dependencies:
+    "@swc/helpers" "^0.5.0"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1644,6 +1651,13 @@
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
+"@swc/helpers@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.2.tgz#85ea0c76450b61ad7d10a37050289eded783c27d"
+  integrity sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==
+  dependencies:
+    tslib "^2.4.0"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -12106,7 +12120,7 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.5.0, tslib@^2.6.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
## Description

Related to #3102

This PR updates `vaadin-number-field` to not use `<input type="number">` in favor of `<input type="text">`.

Some things from the ticket above that are not implemented yet:

- [ ] Configurable representation number formats, i.e. how should a number entered by the user be formatted and displayed in the input (groups separator, decimal separator, number of decimals, prefix / suffix)
- [ ] Configurable parsing number formats, i.e. how should the number entered by the user be parsed and provided through the value property - expose configuration for the `NumberParser` from `@internationalized/number`
- [ ] Enforce preventing entering invalid characters consistently in all browsers

## Type of change

- Prototype