### PR TITLE
refactor: extract grid tree column logic to a separate mixin

### DIFF
--- a/packages/grid/src/vaadin-grid-tree-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-column-mixin.d.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { GridColumn } from './vaadin-grid-column';
+
+export declare function GridTreeColumnMixin<TItem, T extends Constructor<GridColumn>>(
+  superclass: T,
+): Constructor<GridTreeColumnMixinClass<TItem>> & T;
+
+export declare class GridTreeColumnMixinClass<TItem> {
+  /**
+   * JS Path of the property in the item used as text content for the tree toggle.
+   */
+  path: string | null | undefined;
+}

--- a/packages/grid/src/vaadin-grid-tree-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-tree-column-mixin.js
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { get } from '@vaadin/component-base/src/path-utils.js';
+
+/**
+ * @polymerMixin
+ */
+export const GridTreeColumnMixin = (superClass) =>
+  class extends superClass {
+    static get properties() {
+      return {
+        /**
+         * JS Path of the property in the item used as text content for the tree toggle.
+         */
+        path: String,
+      };
+    }
+
+    static get observers() {
+      return ['_onRendererOrBindingChanged(_renderer, _cells, _bodyContentHidden, _cells.*, path)'];
+    }
+
+    constructor() {
+      super();
+
+      this.__boundOnExpandedChanged = this.__onExpandedChanged.bind(this);
+    }
+
+    /**
+     * Renders the grid tree toggle to the body cell
+     *
+     * @private
+     */
+    __defaultRenderer(root, _column, { item, expanded, level }) {
+      let toggle = root.firstElementChild;
+      if (!toggle) {
+        toggle = document.createElement('vaadin-grid-tree-toggle');
+        toggle.addEventListener('expanded-changed', this.__boundOnExpandedChanged);
+        root.appendChild(toggle);
+      }
+
+      toggle.__item = item;
+      toggle.__rendererExpanded = expanded;
+      toggle.expanded = expanded;
+      toggle.leaf = this.__isLeafItem(item, this._grid.itemHasChildrenPath);
+      toggle.textContent = this.__getToggleContent(this.path, item);
+      toggle.level = level;
+    }
+
+    /**
+     * The tree column doesn't allow to use a custom renderer
+     * to override the content of body cells.
+     * It always renders the grid tree toggle to body cells.
+     *
+     * @override
+     */
+    _computeRenderer() {
+      return this.__defaultRenderer;
+    }
+
+    /**
+     * Expands or collapses the row once the tree toggle is switched.
+     * The listener handles only user-fired events.
+     *
+     * @private
+     */
+    __onExpandedChanged(e) {
+      // Skip if the state is changed by the renderer.
+      if (e.detail.value === e.target.__rendererExpanded) {
+        return;
+      }
+
+      if (e.detail.value) {
+        this._grid.expandItem(e.target.__item);
+      } else {
+        this._grid.collapseItem(e.target.__item);
+      }
+    }
+
+    /** @private */
+    __isLeafItem(item, itemHasChildrenPath) {
+      return !item || !item[itemHasChildrenPath];
+    }
+
+    /** @private */
+    __getToggleContent(path, item) {
+      return path && get(path, item);
+    }
+  };

--- a/packages/grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-column.d.ts
@@ -4,7 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { GridDefaultItem } from './vaadin-grid.js';
-import { GridColumn } from './vaadin-grid-column.js';
+import type { GridColumn, GridColumnMixin } from './vaadin-grid-column.js';
+import type { GridTreeColumnMixinClass } from './vaadin-grid-tree-column-mixin.js';
 
 /**
  * `<vaadin-grid-tree-column>` is a helper element for the `<vaadin-grid>`
@@ -19,12 +20,13 @@ import { GridColumn } from './vaadin-grid-column.js';
  *    ...
  * ```
  */
-declare class GridTreeColumn<TItem = GridDefaultItem> extends GridColumn<TItem> {
-  /**
-   * JS Path of the property in the item used as text content for the tree toggle.
-   */
-  path: string | null | undefined;
-}
+
+declare class GridTreeColumn<TItem = GridDefaultItem> extends HTMLElement {}
+
+interface GridTreeColumn<TItem = GridDefaultItem>
+  extends GridTreeColumnMixinClass<TItem>,
+    GridColumnMixin<TItem, GridTreeColumn<TItem>>,
+    GridColumn<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/grid/src/vaadin-grid-tree-column.js
+++ b/packages/grid/src/vaadin-grid-tree-column.js
@@ -5,8 +5,8 @@
  */
 import './vaadin-grid-tree-toggle.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
-import { get } from '@vaadin/component-base/src/path-utils.js';
 import { GridColumn } from './vaadin-grid-column.js';
+import { GridTreeColumnMixin } from './vaadin-grid-tree-column-mixin.js';
 
 /**
  * `<vaadin-grid-tree-column>` is a helper element for the `<vaadin-grid>`
@@ -22,90 +22,11 @@ import { GridColumn } from './vaadin-grid-column.js';
  * ```
  * @customElement
  * @extends GridColumn
+ * @mixes GridTreeColumnMixin
  */
-class GridTreeColumn extends GridColumn {
+class GridTreeColumn extends GridTreeColumnMixin(GridColumn) {
   static get is() {
     return 'vaadin-grid-tree-column';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * JS Path of the property in the item used as text content for the tree toggle.
-       */
-      path: String,
-    };
-  }
-
-  static get observers() {
-    return ['_onRendererOrBindingChanged(_renderer, _cells, _bodyContentHidden, _cells.*, path)'];
-  }
-
-  constructor() {
-    super();
-
-    this.__boundOnExpandedChanged = this.__onExpandedChanged.bind(this);
-  }
-
-  /**
-   * Renders the grid tree toggle to the body cell
-   *
-   * @private
-   */
-  __defaultRenderer(root, _column, { item, expanded, level }) {
-    let toggle = root.firstElementChild;
-    if (!toggle) {
-      toggle = document.createElement('vaadin-grid-tree-toggle');
-      toggle.addEventListener('expanded-changed', this.__boundOnExpandedChanged);
-      root.appendChild(toggle);
-    }
-
-    toggle.__item = item;
-    toggle.__rendererExpanded = expanded;
-    toggle.expanded = expanded;
-    toggle.leaf = this.__isLeafItem(item, this._grid.itemHasChildrenPath);
-    toggle.textContent = this.__getToggleContent(this.path, item);
-    toggle.level = level;
-  }
-
-  /**
-   * The tree column doesn't allow to use a custom renderer
-   * to override the content of body cells.
-   * It always renders the grid tree toggle to body cells.
-   *
-   * @override
-   */
-  _computeRenderer() {
-    return this.__defaultRenderer;
-  }
-
-  /**
-   * Expands or collapses the row once the tree toggle is switched.
-   * The listener handles only user-fired events.
-   *
-   * @private
-   */
-  __onExpandedChanged(e) {
-    // Skip if the state is changed by the renderer.
-    if (e.detail.value === e.target.__rendererExpanded) {
-      return;
-    }
-
-    if (e.detail.value) {
-      this._grid.expandItem(e.target.__item);
-    } else {
-      this._grid.collapseItem(e.target.__item);
-    }
-  }
-
-  /** @private */
-  __isLeafItem(item, itemHasChildrenPath) {
-    return !item || !item[itemHasChildrenPath];
-  }
-
-  /** @private */
-  __getToggleContent(path, item) {
-    return path && get(path, item);
   }
 }
 


### PR DESCRIPTION
## Description

Extracted grid tree column logic to a mixin to be used by the LitElement version to be added later.

## Type of change

Refactor