### PR TITLE
feat(time-picker): add unparsable-change event

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -112,6 +112,22 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * ### Change events
+ *
+ * Depending on the nature of the value change that the user attempts to commit e.g. by pressing Enter,
+ * the component can fire either a `change` event or an `unparsable-change` event:
+ *
+ * Value change             | Event
+ * :------------------------|:------------------
+ * empty => parsable        | change
+ * empty => unparsable      | unparsable-change
+ * parsable => empty        | change
+ * parsable => parsable     | change
+ * parsable => unparsable   | change
+ * unparsable => empty      | unparsable-change
+ * unparsable => parsable   | change
+ * unparsable => unparsable | unparsable-change
+ *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -540,16 +540,18 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
    * @private
    */
   __commitValueChange() {
+    const unparsableValue = this.__unparsableValue;
+
     if (this.__committedValue !== this.value) {
       this.validate();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-    } else if (this.__committedUnparsableValue !== this.__unparsableValue) {
+    } else if (this.__committedUnparsableValue !== unparsableValue) {
       this.validate();
       this.dispatchEvent(new CustomEvent('unparsable-change'));
     }
 
     this.__committedValue = this.value;
-    this.__committedUnparsableValue = this.__unparsableValue;
+    this.__committedUnparsableValue = unparsableValue;
   }
 
   /**

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -72,6 +72,22 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * ### Change events
+ *
+ * Depending on the nature of the value change that the user attempts to commit e.g. by pressing Enter,
+ * the component can fire either a `change` event or an `unparsable-change` event:
+ *
+ * Value change             | Event
+ * :------------------------|:------------------
+ * empty => parsable        | change
+ * empty => unparsable      | unparsable-change
+ * parsable => empty        | change
+ * parsable => parsable     | change
+ * parsable => unparsable   | change
+ * unparsable => empty      | unparsable-change
+ * unparsable => parsable   | change
+ * unparsable => unparsable | unparsable-change
+ *
  * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
@@ -507,23 +523,19 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /**
-   * Depending on the type of value change that has occurred since
+   * Depending on the nature of the value change that has occurred since
    * the last commit attempt, triggers validation and fires an event:
    *
-   * ```text
-   * +--------------------------+-------------------+
-   * | Type of value change     | Event             |
-   * +--------------------------+-------------------+
-   * | empty => parsable        | change            |
-   * | empty => unparsable      | unparsable-change |
-   * | parsable => empty        | change            |
-   * | parsable => parsable     | change            |
-   * | parsable => unparsable   | change            |
-   * | unparsable => empty      | unparsable-change |
-   * | unparsable => parsable   | change            |
-   * | unparsable => unparsable | unparsable-change |
-   * +--------------------------+-------------------+
-   * ```
+   * Value change             | Event
+   * -------------------------|-------------------
+   * empty => parsable        | change
+   * empty => unparsable      | unparsable-change
+   * parsable => empty        | change
+   * parsable => parsable     | change
+   * parsable => unparsable   | change
+   * unparsable => empty      | unparsable-change
+   * unparsable => parsable   | change
+   * unparsable => unparsable | unparsable-change
    *
    * @private
    */

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -173,6 +173,23 @@ describe('value commit', () => {
         expect(timePicker.inputElement.value).to.equal('12:00');
       });
     });
+
+    describe('value set programmatically', () => {
+      beforeEach(() => {
+        timePicker.value = '00:00';
+        valueChangedSpy.resetHistory();
+      });
+
+      it('should not commit but validate on blur', () => {
+        timePicker.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectNoValueCommit();
+      });
+    });
   });
 
   describe('unparsable input entered', () => {
@@ -273,6 +290,23 @@ describe('value commit', () => {
         await sendKeys({ press: 'Escape' });
         expectNoValueCommit();
         expect(timePicker.inputElement.value).to.equal('foo');
+      });
+    });
+
+    describe('value set programmatically', () => {
+      beforeEach(() => {
+        timePicker.value = '00:00';
+        valueChangedSpy.resetHistory();
+      });
+
+      it('should not commit but validate on blur', () => {
+        timePicker.blur();
+        expectValidationOnly();
+      });
+
+      it('should not commit on Enter', async () => {
+        await sendKeys({ press: 'Enter' });
+        expectNoValueCommit();
       });
     });
   });


### PR DESCRIPTION
## Description

The PR introduces a new event `unparsable-change` to `time-picker`. This event is fired when the user attempts to commit or clear input that the component has failed to parse as a time. This event is intended as a supplement to the change event, which means it will be fired only when there is no change event.

Here is a table that illustrates which event is fired based on the nature of the value change:

| Value change                | Event             | Note
|:-----------------------|:------------------|:-------|
| empty => parsable      | change            | |
| empty => unparsable    | unparsable-change | |
| parsable => empty      | change            | |
| parsable => parsable   | change            | |
| parsable => unparsable | change            | The value property changes to an empty string |
| unparsable => empty    | unparsable-change |
| unparsable => parsable | change | The value property changes to a non-empty string |
| unparsable => unparsable | unparsable-change |

Also, the PR removes undesired validation on <kbd>Escape</kbd> for `time-picker` (https://github.com/vaadin/web-components/issues/5436)

Part of https://github.com/vaadin/flow-components/issues/5537

## Type of change

- [x] Feature