### PR TITLE
refactor: extract panel and heading styles to css literals

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading-styles.d.ts
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const accordionHeading: CSSResult;

--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const accordionHeading = css`
+  :host {
+    display: block;
+    outline: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: inherit;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    background-color: initial;
+    color: inherit;
+    border: initial;
+    outline: none;
+    font: inherit;
+    text-align: inherit;
+  }
+`;

--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -7,7 +7,10 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ActiveMixin } from '@vaadin/a11y-base/src/active-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { accordionHeading } from './vaadin-accordion-heading-styles.js';
+
+registerStyles('vaadin-accordion-heading', accordionHeading, { moduleId: 'vaadin-accordion-heading-styles' });
 
 /**
  * The accordion heading element.
@@ -55,34 +58,6 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolymerElement
 
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-          outline: none;
-          -webkit-user-select: none;
-          -moz-user-select: none;
-          user-select: none;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        button {
-          display: flex;
-          align-items: center;
-          justify-content: inherit;
-          width: 100%;
-          margin: 0;
-          padding: 0;
-          background-color: initial;
-          color: inherit;
-          border: initial;
-          outline: none;
-          font: inherit;
-          text-align: inherit;
-        }
-      </style>
       <button id="button" part="content" disabled$="[[disabled]]" aria-expanded$="[[__updateAriaExpanded(opened)]]">
         <span part="toggle" aria-hidden="true"></span>
         <slot></slot>

--- a/packages/accordion/src/vaadin-accordion-panel-styles.d.ts
+++ b/packages/accordion/src/vaadin-accordion-panel-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const accordionPanel: CSSResult;

--- a/packages/accordion/src/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/src/vaadin-accordion-panel-styles.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const accordionPanel = css`
+  :host {
+    display: block;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  [part='content'] {
+    display: none;
+    overflow: hidden;
+  }
+
+  :host([opened]) [part='content'] {
+    display: block;
+    overflow: visible;
+  }
+`;

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -12,7 +12,10 @@ import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mi
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { CollapsibleMixin } from '@vaadin/details/src/collapsible-mixin.js';
 import { SummaryController } from '@vaadin/details/src/summary-controller.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { accordionPanel } from './vaadin-accordion-panel-styles.js';
+
+registerStyles('vaadin-accordion-panel', accordionPanel, { moduleId: 'vaadin-accordion-panel-styles' });
 
 /**
  * The accordion panel element.
@@ -55,26 +58,6 @@ class AccordionPanel extends CollapsibleMixin(
 
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        [part='content'] {
-          display: none;
-          overflow: hidden;
-        }
-
-        :host([opened]) [part='content'] {
-          display: block;
-          overflow: visible;
-        }
-      </style>
-
       <slot name="summary"></slot>
 
       <div part="content">


### PR DESCRIPTION
## Description

Extracted CSS to reusable tagged literals for using by the LitElement version of `vaadin-accordion`.

## Type of change

- Refactor