### PR TITLE
refactor: use KeyboardMixin to handle select keydown events

### DIFF
--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { DelegateFocusMixin } from '@vaadin/field-base/src/delegate-focus-mixin.js';
 import { DelegateStateMixin } from '@vaadin/field-base/src/delegate-state-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
@@ -173,7 +174,7 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class Select extends DelegateFocusMixin(
-  DelegateStateMixin(FieldMixin(ElementMixin(ThemableMixin(HTMLElement)))),
+  DelegateStateMixin(FieldMixin(KeyboardMixin(ElementMixin(ThemableMixin(HTMLElement))))),
 ) {
   /**
    * An array containing items that will be rendered as the options of the select.

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -11,6 +11,7 @@ import './vaadin-select-value-button.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { addValueToAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { KeyboardMixin } from '@vaadin/component-base/src/keyboard-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
@@ -134,10 +135,13 @@ registerStyles('vaadin-select', [fieldShared, inputFieldContainer], { moduleId: 
  * @mixes ElementMixin
  * @mixes ThemableMixin
  * @mixes FieldMixin
+ * @mixes KeyboardMixin
  * @mixes DelegateFocusMixin
  * @mixes DelegateStateMixin
  */
-class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMixin(ThemableMixin(PolymerElement))))) {
+class Select extends DelegateFocusMixin(
+  DelegateStateMixin(KeyboardMixin(FieldMixin(ElementMixin(ThemableMixin(PolymerElement))))),
+) {
   static get is() {
     return 'vaadin-select';
   }
@@ -330,8 +334,6 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
     super();
 
     this._fieldId = `${this.localName}-${generateUniqueId()}`;
-
-    this._boundOnKeyDown = this._onKeyDown.bind(this);
   }
 
   /** @protected */
@@ -362,8 +364,6 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
         addValueToAttribute(btn, 'aria-labelledby', this._fieldId);
 
         this._updateAriaExpanded(host.opened);
-
-        btn.addEventListener('keydown', this._boundOnKeyDown);
       },
     );
     this.addController(this._valueButtonController);
@@ -515,7 +515,7 @@ class Select extends DelegateFocusMixin(DelegateStateMixin(FieldMixin(ElementMix
    * @protected
    */
   _onKeyDown(e) {
-    if (!this.readonly && !this.opened) {
+    if (e.target === this._valueButton && !this.readonly && !this.opened) {
       if (/^(Enter|SpaceBar|\s|ArrowDown|Down|ArrowUp|Up)$/.test(e.key)) {
         e.preventDefault();
         this.opened = true;


### PR DESCRIPTION
## Description

> ⚠️  This PR is targeting `23.3` branch.

We got a request to override `keydown` listener in `vaadin-select` to not open on <kbd>Enter</kbd>.
Currently, it isn't possible because of the fact that corresponding event listener uses `.bind(this)`

This PR updates the component to use `KeyboardMixin` instead, as we generally do in other components.
It's already done in Vaadin 24 as part of the bigger `vaadin-select-value-button` refactoring in https://github.com/vaadin/web-components/pull/5215

See the internal Slack discussion: https://vaadin.slack.com/archives/C3TGRP4HY/p1696848138596359

## Type of change

- Refactor