### PR TITLE
feat: grid column header and footer part names

### DIFF
--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -93,6 +93,16 @@ export declare class ColumnBaseMixinClass<TItem, Column extends ColumnBaseMixinC
    * - `column` The `<vaadin-grid-column>` element.
    */
   footerRenderer: GridHeaderFooterRenderer<TItem, Column> | null | undefined;
+
+  /**
+   * Custom part name for the column header cell.
+   */
+  headerPartName: string | null | undefined;
+
+  /**
+   * Custom part name for the column footer cell.
+   */
+  footerPartName: string | null | undefined;
 }
 
 export interface GridColumnMixin<TItem, Column extends GridColumnMixinClass<TItem, Column>>

--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -96,11 +96,15 @@ export declare class ColumnBaseMixinClass<TItem, Column extends ColumnBaseMixinC
 
   /**
    * Custom part name for the header cell.
+   *
+   * @attr {string} header-part-name
    */
   headerPartName: string | null | undefined;
 
   /**
    * Custom part name for the footer cell.
+   *
+   * @attr {string} footer-part-name
    */
   footerPartName: string | null | undefined;
 }

--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -95,12 +95,12 @@ export declare class ColumnBaseMixinClass<TItem, Column extends ColumnBaseMixinC
   footerRenderer: GridHeaderFooterRenderer<TItem, Column> | null | undefined;
 
   /**
-   * Custom part name for the column header cell.
+   * Custom part name for the header cell.
    */
   headerPartName: string | null | undefined;
 
   /**
-   * Custom part name for the column footer cell.
+   * Custom part name for the footer cell.
    */
   footerPartName: string | null | undefined;
 }

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -102,14 +102,14 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * Custom part name for the column header cell.
+         * Custom part name for the header cell.
          */
         headerPartName: {
           type: String,
         },
 
         /**
-         * Custom part name for the column footer cell.
+         * Custom part name for the footer cell.
          */
         footerPartName: {
           type: String,

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -103,6 +103,8 @@ export const ColumnBaseMixin = (superClass) =>
 
         /**
          * Custom part name for the header cell.
+         *
+         * @attr {string} header-part-name
          */
         headerPartName: {
           type: String,
@@ -110,6 +112,8 @@ export const ColumnBaseMixin = (superClass) =>
 
         /**
          * Custom part name for the footer cell.
+         *
+         * @attr {string} footer-part-name
          */
         footerPartName: {
           type: String,

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -102,6 +102,20 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
+         * Custom part name for the column header cell.
+         */
+        headerPartName: {
+          type: String,
+        },
+
+        /**
+         * Custom part name for the column footer cell.
+         */
+        footerPartName: {
+          type: String,
+        },
+
+        /**
          * @type {boolean}
          * @protected
          */
@@ -238,6 +252,7 @@ export const ColumnBaseMixin = (superClass) =>
         '_reorderStatusChanged(_reorderStatus, _headerCell, _footerCell, _cells.*)',
         '_hiddenChanged(hidden, _headerCell, _footerCell, _cells.*)',
         '_rowHeaderChanged(rowHeader, _cells.*)',
+        '__headerFooterPartNameChanged(_headerCell, _footerCell, headerPartName, footerPartName)',
       ];
     }
 
@@ -629,6 +644,22 @@ export const ColumnBaseMixin = (superClass) =>
     /** @protected */
     _onHeaderRendererOrBindingChanged(headerRenderer, headerCell, ..._bindings) {
       this._renderHeaderCellContent(headerRenderer, headerCell);
+    }
+
+    /** @private */
+    __headerFooterPartNameChanged(headerCell, footerCell, headerPartName, footerPartName) {
+      [
+        { cell: headerCell, partName: headerPartName, currentName: '__currentHeaderPartName' },
+        { cell: footerCell, partName: footerPartName, currentName: '__currentFooterPartName' },
+      ].forEach(({ cell, partName, currentName }) => {
+        if (cell) {
+          const currentPartNames = cell[currentName] || [];
+          cell.part.remove(...currentPartNames);
+
+          cell[currentName] = partName ? partName.trim().split(' ') : [];
+          cell.part.add(...cell[currentName]);
+        }
+      });
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -657,12 +657,11 @@ export const ColumnBaseMixin = (superClass) =>
         { cell: footerCell, partName: footerPartName },
       ].forEach(({ cell, partName }) => {
         if (cell) {
-          const currentName = '__currentPartName';
-          const currentPartNames = cell[currentName] || [];
-          cell.part.remove(...currentPartNames);
+          const customParts = cell.__customParts || [];
+          cell.part.remove(...customParts);
 
-          cell[currentName] = partName ? partName.trim().split(' ') : [];
-          cell.part.add(...cell[currentName]);
+          cell.__customParts = partName ? partName.trim().split(' ') : [];
+          cell.part.add(...cell.__customParts);
         }
       });
     }

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -653,10 +653,11 @@ export const ColumnBaseMixin = (superClass) =>
     /** @private */
     __headerFooterPartNameChanged(headerCell, footerCell, headerPartName, footerPartName) {
       [
-        { cell: headerCell, partName: headerPartName, currentName: '__currentHeaderPartName' },
-        { cell: footerCell, partName: footerPartName, currentName: '__currentFooterPartName' },
-      ].forEach(({ cell, partName, currentName }) => {
+        { cell: headerCell, partName: headerPartName },
+        { cell: footerCell, partName: footerPartName },
+      ].forEach(({ cell, partName }) => {
         if (cell) {
+          const currentName = '__currentPartName';
           const currentPartNames = cell[currentName] || [];
           cell.part.remove(...currentPartNames);
 

--- a/packages/grid/test/styling.common.js
+++ b/packages/grid/test/styling.common.js
@@ -197,4 +197,91 @@ describe('styling', () => {
 
     runStylingTest('parts', 'cellPartNameGenerator', 'generateCellPartNames', assertPartNames);
   });
+
+  describe('header and footer part name', () => {
+    let column;
+    let headerCell;
+    let footerCell;
+
+    beforeEach(() => {
+      column = grid.querySelector('vaadin-grid-column');
+      column.footerRenderer = (root) => {
+        root.textContent = 'footer';
+      };
+      headerCell = getContainerCell(grid.$.header, 0, 0);
+      footerCell = getContainerCell(grid.$.footer, 0, 0);
+    });
+
+    it('should add a header and footer part name', () => {
+      column.headerPartName = 'foobar';
+      column.footerPartName = 'bazqux';
+
+      expect(headerCell.getAttribute('part')).to.contain('foobar');
+      expect(footerCell.getAttribute('part')).to.contain('bazqux');
+    });
+
+    it('should clear the header and footer part name', () => {
+      column.headerPartName = 'foobar';
+      column.footerPartName = 'bazqux';
+
+      column.headerPartName = '';
+      column.footerPartName = '';
+
+      expect(headerCell.getAttribute('part')).to.not.contain('foobar');
+      expect(footerCell.getAttribute('part')).to.not.contain('bazqux');
+    });
+
+    it('should add multiple header and footer part names', () => {
+      column.headerPartName = 'foobar bazqux';
+      column.footerPartName = 'bazqux foobar';
+
+      expect(headerCell.getAttribute('part')).to.contain('foobar');
+      expect(headerCell.getAttribute('part')).to.contain('bazqux');
+      expect(footerCell.getAttribute('part')).to.contain('foobar');
+      expect(footerCell.getAttribute('part')).to.contain('bazqux');
+    });
+
+    it('should remove one header and footer part name', () => {
+      column.headerPartName = 'foobar bazqux';
+      column.footerPartName = 'bazqux foobar';
+
+      column.headerPartName = 'foobar';
+      column.footerPartName = 'bazqux';
+
+      expect(headerCell.getAttribute('part')).to.contain('foobar');
+      expect(headerCell.getAttribute('part')).to.not.contain('bazqux');
+      expect(footerCell.getAttribute('part')).to.contain('bazqux');
+      expect(footerCell.getAttribute('part')).to.not.contain('foobar');
+    });
+
+    it('should add a header and footer part name with trailing whitespace', () => {
+      column.headerPartName = 'foobar ';
+      column.footerPartName = ' bazqux';
+
+      expect(headerCell.getAttribute('part')).to.contain('foobar');
+      expect(footerCell.getAttribute('part')).to.contain('bazqux');
+    });
+
+    it('should clear the header and footer part name with null', () => {
+      column.headerPartName = 'foobar';
+      column.footerPartName = 'bazqux';
+
+      column.headerPartName = null;
+      column.footerPartName = null;
+
+      expect(headerCell.getAttribute('part')).to.not.contain('foobar');
+      expect(footerCell.getAttribute('part')).to.not.contain('bazqux');
+    });
+
+    it('should clear the header and footer part name with undefined', () => {
+      column.headerPartName = 'foobar';
+      column.footerPartName = 'bazqux';
+
+      column.headerPartName = undefined;
+      column.footerPartName = undefined;
+
+      expect(headerCell.getAttribute('part')).to.not.contain('foobar');
+      expect(footerCell.getAttribute('part')).to.not.contain('bazqux');
+    });
+  });
 });

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -250,6 +250,8 @@ assertType<string | null | undefined>(narrowedColumn.header);
 assertType<GridColumnTextAlign | null | undefined>(narrowedColumn.textAlign);
 assertType<string | null | undefined>(narrowedColumn.path);
 assertType<boolean>(narrowedColumn.autoWidth);
+assertType<string | null | undefined>(narrowedColumn.headerPartName);
+assertType<string | null | undefined>(narrowedColumn.footerPartName);
 
 /* GridColumnGroup */
 const genericColumnGroup = document.createElement('vaadin-grid-column-group');
@@ -258,6 +260,8 @@ assertType<GridColumnGroup>(genericColumnGroup);
 const narrowedColumnGroup = genericColumnGroup as GridColumnGroup<TestGridItem>;
 assertType<HTMLElement>(narrowedColumnGroup);
 assertType<ColumnBaseMixinClass<TestGridItem, GridColumnGroup>>(narrowedColumnGroup);
+assertType<string | null | undefined>(narrowedColumnGroup.headerPartName);
+assertType<string | null | undefined>(narrowedColumnGroup.footerPartName);
 
 narrowedColumnGroup.headerRenderer = (root, column) => {
   assertType<HTMLElement>(root);


### PR DESCRIPTION
## Description

Add `headerPartName` and  `footerPartName` properties to `ColumnBaseMixinClass`.

Part of https://github.com/vaadin/web-components/issues/1434

## Type of change

Feature