### PR TITLE
feat!: bump Lit to 3.0.0, update testing-helpers

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -37,7 +37,7 @@
     "@vaadin/radio-group": "24.3.0-alpha4",
     "@vaadin/select": "24.3.0-alpha4",
     "@vaadin/tabs": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-area": "24.3.0-alpha4",
     "@vaadin/text-field": "24.3.0-alpha4",
     "@vaadin/time-picker": "24.3.0-alpha4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@fontsource/roboto": "^4.5.1",
     "@polymer/iron-component-page": "^4.0.1",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@web/dev-server": "^0.2.1",
     "@web/rollup-plugin-html": "^2.0.0",
     "@web/test-runner": "^0.16.1",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -33,11 +33,11 @@
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/tabs": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -46,11 +46,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-board",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -43,12 +43,12 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/icon": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-chart",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -45,11 +45,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -51,9 +51,9 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-field": "24.3.0-alpha4",
-    "lit": "^2.0.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -35,11 +35,11 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
     "@vaadin/vaadin-usage-statistics": "^2.1.0",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/a11y-base": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -51,8 +51,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0"
+    "@vaadin/testing-helpers": "^0.6.0"
   },
   "cvdlName": "vaadin-cookie-consent",
   "web-types": [

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-crud",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -54,7 +54,7 @@
     "@vaadin/number-field": "24.3.0-alpha4",
     "@vaadin/password-field": "24.3.0-alpha4",
     "@vaadin/select": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-area": "24.3.0-alpha4",
     "@vaadin/text-field": "24.3.0-alpha4",
     "@vaadin/time-picker": "24.3.0-alpha4",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -23,8 +23,8 @@
     "src",
     "!src/vaadin-lit-date-picker-overlay-content.js",
     "!src/vaadin-lit-date-picker-overlay.js",
-    "!src/vaadin-lit-month-calendar.js",
     "!src/vaadin-lit-date-picker.js",
+    "!src/vaadin-lit-month-calendar.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -53,9 +53,9 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/a11y-base": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-area": "24.3.0-alpha4",
-    "lit": "^2.0.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -42,11 +42,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -34,11 +34,11 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "24.3.0-alpha4",
     "@vaadin/component-base": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -39,7 +39,7 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
@@ -53,7 +53,7 @@
     "@vaadin/list-box": "24.3.0-alpha4",
     "@vaadin/radio-group": "24.3.0-alpha4",
     "@vaadin/select": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-area": "24.3.0-alpha4",
     "@vaadin/text-field": "24.3.0-alpha4",
     "@vaadin/time-picker": "24.3.0-alpha4",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/custom-field": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-field": "24.3.0-alpha4",
     "sinon": "^13.0.2"
   },

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -53,8 +53,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-grid-pro",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -57,8 +57,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0"
+    "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -38,11 +38,11 @@
     "@vaadin/component-base": "24.3.0-alpha4",
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -42,7 +42,7 @@
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/icon": "24.3.0-alpha4",
     "@vaadin/icons": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -30,11 +30,11 @@
     "lit"
   ],
   "dependencies": {
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-map",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/icon": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -44,11 +44,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -51,8 +51,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -43,12 +43,12 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/button": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -45,11 +45,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -33,14 +33,14 @@
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/checkbox": "24.3.0-alpha4",
     "@vaadin/grid": "24.3.0-alpha4",
     "@vaadin/grid-pro": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -44,11 +44,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0"
+    "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/a11y-base": "24.3.0-alpha4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "gulp-iconfont": "^11.0.0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0"
+    "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -62,8 +62,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -38,12 +38,12 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -45,11 +45,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -45,11 +45,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -49,11 +49,11 @@
     "@vaadin/vaadin-lumo-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-material-styles": "24.3.0-alpha4",
     "@vaadin/vaadin-themable-mixin": "24.3.0-alpha4",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -32,12 +32,12 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "lit": "^2.0.0"
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@polymer/polymer": "^3.0.0",
-    "@vaadin/testing-helpers": "^0.5.0",
+    "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0"
+    "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.5.0",
-    "lit": "^2.0.0",
+    "@vaadin/testing-helpers": "^0.6.0",
+    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,17 +1027,17 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@lit-labs/ssr-dom-shim@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz#427e19a2765681fd83411cd72c55ba80a01e0523"
-  integrity sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==
+"@lit-labs/ssr-dom-shim@^1.1.2-pre.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz#d693d972974a354034454ec1317eb6afd0b00312"
+  integrity sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==
 
-"@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.6.1.tgz#0d958b6d479d0e3db5fc1132ecc4fa84be3f0b93"
-  integrity sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==
+"@lit/reactive-element@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-2.0.0.tgz#da14a256ac5533873b935840f306d572bac4a2ab"
+  integrity sha512-wn+2+uDcs62ROBmVAwssO4x5xue/uKD3MGGZOXL2sMxReTRIT0JXKyMXeu7gh0aJ4IJNEIG/3aOnUaQvM7BMzQ==
   dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.0.0"
+    "@lit-labs/ssr-dom-shim" "^1.1.2-pre.0"
 
 "@mapbox/jsonlint-lines-primitives@~2.0.2":
   version "2.0.2"
@@ -2072,15 +2072,15 @@
     "@typescript-eslint/types" "6.7.0"
     eslint-visitor-keys "^3.4.1"
 
-"@vaadin/testing-helpers@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.5.0.tgz#3fd0413fff63c6b79c3bbfab857c3189c31cfac1"
-  integrity sha512-JJlqWzMhH6tEwEpEBhzJgdS1Eujqg5Yt3ZRrTPVKLQqRR+EtnKFiYC4MoyAejQASUjBtbQgOE5KLi7ajbCWFzA==
+"@vaadin/testing-helpers@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.6.0.tgz#895f21394b8ee2cd078ca68645d1551346e650ef"
+  integrity sha512-yyA+JULu3/ZM98wrkioZPPEK6+jl4nOr2gGTq7GsqGWMO2Mdo22yk3S6Pa4Bu+nZuYORKZCPbz7a+l3xxuSKzA==
   dependencies:
     "@esm-bundle/chai" "^4.3.1"
     "@open-wc/semantic-dom-diff" "^0.19.7"
     "@polymer/polymer" "^3.5.1"
-    lit "^2.6.1"
+    lit "^3.0.0"
     sinon-chai "3.7.0"
 
 "@vaadin/vaadin-development-mode-detector@^2.0.0":
@@ -7932,29 +7932,30 @@ listr2@^5.0.7:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-element@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.2.2.tgz#d148ab6bf4c53a33f707a5168e087725499e5f2b"
-  integrity sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==
+lit-element@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-4.0.0.tgz#8343891bc9159a5fcb7f534914b37f2c0161e036"
+  integrity sha512-N6+f7XgusURHl69DUZU6sTBGlIN+9Ixfs3ykkNDfgfTkDYGGOWwHAYBhDqVswnFGyWgQYR2KiSpu4J76Kccs/A==
   dependencies:
-    "@lit/reactive-element" "^1.3.0"
-    lit-html "^2.2.0"
+    "@lit-labs/ssr-dom-shim" "^1.1.2-pre.0"
+    "@lit/reactive-element" "^2.0.0"
+    lit-html "^3.0.0"
 
-lit-html@^2.2.0, lit-html@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.6.1.tgz#eb29f0b0c2ab54ea77379db11fc011b0c71f1cda"
-  integrity sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==
+lit-html@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-3.0.0.tgz#77d6776ee488642c74c5575315ef81aa09d24ea9"
+  integrity sha512-DNJIE8dNY0dQF2Gs0sdMNUppMQT2/CvV4OVnSdg7BXAsGqkVwsE5bqQ04POfkYH5dBIuGnJYdFz5fYYyNnOxiA==
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@^2.0.0, lit@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.6.1.tgz#5951a2098b9bde5b328c73b55c15fdc0eefd96d7"
-  integrity sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==
+lit@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-3.0.0.tgz#204bd65935892a73670471e893ee8ca55d2f9a3b"
+  integrity sha512-nQ0teRzU1Kdj++VdmttS2WvIen8M79wChJ6guRKIIym2M3Ansg3Adj9O6yuQh2IpjxiUXlNuS81WKlQ4iL3BmA==
   dependencies:
-    "@lit/reactive-element" "^1.6.0"
-    lit-element "^3.2.0"
-    lit-html "^2.6.0"
+    "@lit/reactive-element" "^2.0.0"
+    lit-element "^4.0.0"
+    lit-html "^3.0.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Description

Updated `lit` dependency to 3.0.0 to align with the Flow version.

## Type of change

- Breaking change (major dependency bump)