### PR TITLE
fix: use correct hidden attribute syntax in Lit version

### DIFF
--- a/packages/login/src/vaadin-lit-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-lit-login-overlay-wrapper.js
@@ -48,7 +48,7 @@ class LoginOverlayWrapper extends OverlayMixin(DirMixin(ThemableMixin(PolylitMix
   /** @protected */
   render() {
     return html`
-      <div id="backdrop" part="backdrop" ?hidden$="${!this.withBackdrop}"></div>
+      <div id="backdrop" part="backdrop" ?hidden="${!this.withBackdrop}"></div>
       <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">
           <section part="card">


### PR DESCRIPTION
## Description

The issue was found when bumping `lit` to 3.0, see #6630 

## Type of change

- Bugfix