### PR TITLE
fix: prevent selected item checkmark icon from flashing (24.1)

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -214,10 +214,12 @@ export const ItemsMixin = (superClass) =>
         const { value } = event.detail;
         if (typeof value === 'number') {
           const item = listBox.items[value]._item;
+          // Reset selected before dispatching the event to prevent
+          // checkmark icon flashing before the overlay is closed.
+          listBox.selected = null;
           if (!item.children) {
             this.dispatchEvent(new CustomEvent('item-selected', { detail: { value: item } }));
           }
-          listBox.selected = null;
         }
       });
 


### PR DESCRIPTION
## Description

Backported the change that was included in #6241 together with adding `keepOpen` (24.2) to the `24.1` branch.

## Type of change

- UX improvement / bugfix

## Comparison

### Before

https://github.com/vaadin/web-components/assets/10589913/71ae0130-11e4-498d-bdb7-9e273707c59a

### After

https://github.com/vaadin/web-components/assets/10589913/b1a3a980-4a79-4975-af32-3b5db9cf25e7

