### PR TITLE
feat: add Lumo custom properties for input field label

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -37,10 +37,6 @@ const inputField = css`
     align-items: center;
   }
 
-  :host([focused]:not([readonly])) [part='label'] {
-    color: var(--lumo-primary-text-color);
-  }
-
   :host([focused]) [part='input-field'] ::slotted(:is(input, textarea)) {
     -webkit-mask-image: none;
     mask-image: none;
@@ -51,20 +47,12 @@ const inputField = css`
   }
 
   /* Hover */
-  :host(:hover:not([readonly]):not([focused])) [part='label'] {
-    color: var(--lumo-body-text-color);
-  }
-
   :host(:hover:not([readonly]):not([focused])) [part='input-field']::after {
     opacity: 0.1;
   }
 
   /* Touch device adjustment */
   @media (pointer: coarse) {
-    :host(:hover:not([readonly]):not([focused])) [part='label'] {
-      color: var(--lumo-secondary-text-color);
-    }
-
     :host(:hover:not([readonly]):not([focused])) [part='input-field']::after {
       opacity: 0;
     }

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -12,15 +12,15 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 const requiredField = css`
   [part='label'] {
     align-self: flex-start;
-    color: var(--lumo-secondary-text-color);
-    font-weight: 500;
-    font-size: var(--lumo-font-size-s);
+    color: var(--_label-color-default);
+    font-weight: var(--_label-font-weight);
+    font-size: var(--_label-font-size);
     margin-left: calc(var(--lumo-border-radius-m) / 4);
     transition: color 0.2s;
     line-height: 1;
     padding-right: 1em;
     padding-bottom: 0.5em;
-    /* As a workaround for diacritics being cut off, add a top padding and a 
+    /* As a workaround for diacritics being cut off, add a top padding and a
     negative margin to compensate */
     padding-top: 0.25em;
     margin-top: -0.25em;
@@ -30,6 +30,27 @@ const requiredField = css`
     position: relative;
     max-width: 100%;
     box-sizing: border-box;
+    /* Label properties */
+    --_label-color-default: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
+    --_label-color-focused: var(--vaadin-input-field-focused-label-color, var(--lumo-primary-text-color));
+    --_label-color-hovered: var(--vaadin-input-field-hovered-label-color, var(--lumo-body-text-color));
+    --_label-font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
+    --_label-font-weight: var(--vaadin-input-field-label-font-weight, 500);
+  }
+
+  :host([focused]:not([readonly])) [part='label'] {
+    color: var(--_label-color-focused);
+  }
+
+  :host(:hover:not([readonly]):not([focused])) [part='label'] {
+    color: var(--_label-color-hovered);
+  }
+
+  /* Touch device adjustment */
+  @media (pointer: coarse) {
+    :host(:hover:not([readonly]):not([focused])) [part='label'] {
+      color: var(--_label-color-default);
+    }
   }
 
   :host([has-label])::before {

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -10,20 +10,11 @@ import '../typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const requiredField = css`
-  :host {
-    /* Label properties */
-    --_label-color-default: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
-    --_label-color-focused: var(--vaadin-input-field-focused-label-color, var(--lumo-primary-text-color));
-    --_label-color-hovered: var(--vaadin-input-field-hovered-label-color, var(--lumo-body-text-color));
-    --_label-font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
-    --_label-font-weight: var(--vaadin-input-field-label-font-weight, 500);
-  }
-
   [part='label'] {
     align-self: flex-start;
-    color: var(--_label-color-default);
-    font-weight: var(--_label-font-weight);
-    font-size: var(--_label-font-size);
+    color: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
+    font-weight: var(--vaadin-input-field-label-font-weight, 500);
+    font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
     margin-left: calc(var(--lumo-border-radius-m) / 4);
     transition: color 0.2s;
     line-height: 1;
@@ -42,17 +33,17 @@ const requiredField = css`
   }
 
   :host([focused]:not([readonly])) [part='label'] {
-    color: var(--_label-color-focused);
+    color: var(--vaadin-input-field-focused-label-color, var(--lumo-primary-text-color));
   }
 
   :host(:hover:not([readonly]):not([focused])) [part='label'] {
-    color: var(--_label-color-hovered);
+    color: var(--vaadin-input-field-hovered-label-color, var(--lumo-body-text-color));
   }
 
   /* Touch device adjustment */
   @media (pointer: coarse) {
     :host(:hover:not([readonly]):not([focused])) [part='label'] {
-      color: var(--_label-color-default);
+      color: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
     }
   }
 

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -10,6 +10,15 @@ import '../typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const requiredField = css`
+  :host {
+    /* Label properties */
+    --_label-color-default: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
+    --_label-color-focused: var(--vaadin-input-field-focused-label-color, var(--lumo-primary-text-color));
+    --_label-color-hovered: var(--vaadin-input-field-hovered-label-color, var(--lumo-body-text-color));
+    --_label-font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
+    --_label-font-weight: var(--vaadin-input-field-label-font-weight, 500);
+  }
+
   [part='label'] {
     align-self: flex-start;
     color: var(--_label-color-default);
@@ -30,12 +39,6 @@ const requiredField = css`
     position: relative;
     max-width: 100%;
     box-sizing: border-box;
-    /* Label properties */
-    --_label-color-default: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
-    --_label-color-focused: var(--vaadin-input-field-focused-label-color, var(--lumo-primary-text-color));
-    --_label-color-hovered: var(--vaadin-input-field-hovered-label-color, var(--lumo-body-text-color));
-    --_label-font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
-    --_label-font-weight: var(--vaadin-input-field-label-font-weight, 500);
   }
 
   :host([focused]:not([readonly])) [part='label'] {

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -36,6 +36,11 @@ const globals = css`
     --vaadin-input-field-border-radius: var(--lumo-border-radius-m);
     --vaadin-focus-ring-color: var(--lumo-primary-color-50pct);
     --vaadin-focus-ring-width: 2px;
+    --vaadin-input-field-label-color: var(--lumo-secondary-text-color);
+    --vaadin-input-field-focused-label-color: var(--lumo-primary-text-color);
+    --vaadin-input-field-hovered-label-color: var(--lumo-body-text-color);
+    --vaadin-input-field-label-font-size: var(--lumo-font-size-s);
+    --vaadin-input-field-label-font-weight: 500;
     --vaadin-text-input-field-height: var(--lumo-size-m);
     --vaadin-text-input-field-placeholder-color: var(--lumo-secondary-text-color);
     --vaadin-text-input-field-readonly-border: 1px dashed var(--lumo-contrast-30pct);


### PR DESCRIPTION
## Description

Part of #2954

## Type of change

- Feature

## CSS properties

The following custom CSS properties from the [spreadsheet](https://docs.google.com/spreadsheets/d/1Mzlbd8GzSZcEgYd-odagN3CBD0TSSTFCPmNCmP8rkLU/edit?usp=sharing) are added in this PR:

- `--vaadin-input-field-label-color`
- `--vaadin-input-field-focused-label-color`
- `--vaadin-input-field-hovered-label-color`
- `--vaadin-input-field-label-font-size`
- `--vaadin-input-field-label-font-weight`