### PR TITLE
fix: make sure unhidden combo-box items get re-rendered

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.js
@@ -63,6 +63,21 @@ export const ComboBoxItemMixin = (superClass) =>
       return ['__rendererOrItemChanged(renderer, index, item.*, selected, focused)', '__updateLabel(label, renderer)'];
     }
 
+    static get observedAttributes() {
+      return [...super.observedAttributes, 'hidden'];
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+      if (name === 'hidden' && newValue !== null) {
+        // The element is being hidden (by virtualizer). Mark one of the __rendererOrItemChanged
+        // dependencies as undefined to make sure it's called when the element is shown again
+        // and assigned properties with possibly identical values as before hiding.
+        this.index = undefined;
+      } else {
+        super.attributeChangedCallback(name, oldValue, newValue);
+      }
+    }
+
     /** @protected */
     connectedCallback() {
       super.connectedCallback();

--- a/packages/combo-box/test/item-renderer.test.js
+++ b/packages/combo-box/test/item-renderer.test.js
@@ -3,7 +3,7 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-combo-box.js';
-import { getFirstItem } from './helpers.js';
+import { getAllItems, getFirstItem, setInputValue } from './helpers.js';
 
 describe('item renderer', () => {
   let comboBox;
@@ -95,5 +95,19 @@ describe('item renderer', () => {
     comboBox.opened = true;
     comboBox.renderer = () => {};
     expect(getFirstItem(comboBox).textContent).to.equal('');
+  });
+
+  it('should restore filtered item content', () => {
+    const contentNodes = comboBox.items.map((item) => document.createTextNode(item));
+
+    comboBox.renderer = (root, _, { item }) => {
+      root.textContent = '';
+      root.append(contentNodes[comboBox.items.indexOf(item)]);
+    };
+
+    comboBox.opened = true;
+    setInputValue(comboBox, 'r');
+    setInputValue(comboBox, '');
+    expect(getAllItems(comboBox)[1].textContent).to.equal('bar');
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/1304

When the Virtualizer's size gets reduced to a value smaller than the number of elements it currently manages, it simply hides the excess elements instead of removing them from the DOM. When this happens, it's possible that an element that represents some item gets hidden, while another element continues representing the same item.

This can happen, for example, with a combo box when you filter the list of options. Consider the following scenario:

1. Initial combo-box dropdown content with three elements representing three items:

| ComboBox | 
|----|
| AA |
| BB |
| CC |

2. Filter the combo box with "B". Now we are left with just 1 visible element that represents item BB. The other elements are hidden and not updated.

| ComboBox | 
|----|
| BB |
| BB [hidden] |
| CC [hidden] |

3. Remove the filter. The first element is updated and the hidden elements become visible again.

| ComboBox | 
|----|
| AA |
| BB |
| CC |

In phase 3, the second element, which was hidden in phase 2 still represents the same item (BB) in the same index (1) it did before it was hidden. In `<vaadin-combo-box-item>`'s case, this would mean that none of the [dependencies](https://github.com/vaadin/web-components/blob/55cd88822471efc4b561ecc13ac7440aea5f2b93/packages/combo-box/src/vaadin-combo-box-item-mixin.js#L63) of the `__rendererOrItemChanged` observer [function](https://github.com/vaadin/web-components/blob/55cd88822471efc4b561ecc13ac7440aea5f2b93/packages/combo-box/src/vaadin-combo-box-item-mixin.js#L100) got changed between hiding and unhiding the element, so it would not trigger a [re-render](https://github.com/vaadin/web-components/blob/55cd88822471efc4b561ecc13ac7440aea5f2b93/packages/combo-box/src/vaadin-combo-box-item-mixin.js#L115) while becoming visible again either.

In most cases, this wouldn't be a problem. However, the `ComponentRenderer` works in the way that it obtains a reference to a node by a node ID it receives and then appends that node inside the content root. In the above scenario, if a `ComponentRenderer` is used and the items are actual elements instead of text:

- 1:  There are 3 `ComponentRenderer`s at play, each receiving different node IDs (1, 2, and 3), and they append the corresponding nodes to the DOM.
- 2 (filter): The node ID of the first element's `ComponentRenderer` is changed to 2. Based on the updated ID, it gets the node "BB", which is still attached to the (hidden) second element, and replaces its previous content "AA" with it. As a result, "BB" gets removed from the second (hidden) element, because a DOM node can't exist in two places simultaneously.
- 3 (clear filter): The node ID of the first element's `ComponentRenderer` is changed back to 1 so its content is changed back to "AA". The second element becomes visible again, but since it still has the same index and item it had before getting hidden, no re-renders are triggered and the content remains empty. The third element also becomes visible again, but its content was never taken by another element so it's fine.

https://github.com/vaadin/web-components/assets/1222264/ebc00b88-169f-49da-8655-607a8f369070

This PR fixes the issue by making `<vaadin-combo-box-item>` observe the `hidden` attribute and based on that, when the Virtualizer hides it, it clears one of the `__rendererOrItemChanged` dependencies. This guarantees that a re-render gets triggered when the element becomes visible again and its properties are updated.

## Type of change

Bugfix