### PR TITLE
refactor: move Lumo font-size and font-weight styles to cells

### DIFF
--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -187,14 +187,14 @@ registerStyles(
 
     /* Headers and footers */
 
-    [part~='header-cell'] ::slotted(vaadin-grid-cell-content),
-    [part~='footer-cell'] ::slotted(vaadin-grid-cell-content),
+    [part~='header-cell'],
+    [part~='footer-cell'],
     [part~='reorder-ghost'] {
       font-size: var(--lumo-font-size-s);
       font-weight: 500;
     }
 
-    [part~='footer-cell'] ::slotted(vaadin-grid-cell-content) {
+    [part~='footer-cell'] {
       font-weight: 400;
     }
 


### PR DESCRIPTION
## Description

Part of #5636

## Type of change

- Refactor

## Note

This change aligns the approach with the one used by Material theme:

https://github.com/vaadin/web-components/blob/7db27ec8e087537e1b2d19a1cecf3906833eceac/packages/grid/theme/material/vaadin-grid-styles.js#L33-L39