### PR TITLE
fix: make vaadin-icon respect fill and stroke from source icon

### DIFF
--- a/dev/assets/circle-check.svg
+++ b/dev/assets/circle-check.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-circle-check" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-  <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path d="M9 12l2 2l4 -4" />
-</svg>
-
-

--- a/dev/assets/circle-check.svg
+++ b/dev/assets/circle-check.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-circle-check" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+  <path d="M9 12l2 2l4 -4" />
+</svg>
+
+

--- a/dev/assets/info-circle.svg
+++ b/dev/assets/info-circle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-info-circle" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />
+  <path d="M12 9h.01" />
+  <path d="M11 12h1v4h1" />
+</svg>

--- a/dev/icon.html
+++ b/dev/icon.html
@@ -61,6 +61,9 @@
     <h6>SVG Standalone</h6>
     <vaadin-icon src="assets/code-branch.svg"></vaadin-icon>
 
+    <h6>SVG Standalone with fill and stroke attributes</h6>
+    <vaadin-icon src="assets/circle-check.svg"></vaadin-icon>
+
     <h6>SVG Sprite</h6>
     <vaadin-icon src="assets/solid.svg#code-branch"></vaadin-icon>
 

--- a/dev/icon.html
+++ b/dev/icon.html
@@ -62,7 +62,7 @@
     <vaadin-icon src="assets/code-branch.svg"></vaadin-icon>
 
     <h6>SVG Standalone with fill and stroke attributes</h6>
-    <vaadin-icon src="assets/circle-check.svg"></vaadin-icon>
+    <vaadin-icon src="assets/info-circle.svg"></vaadin-icon>
 
     <h6>SVG Sprite</h6>
     <vaadin-icon src="assets/solid.svg#code-branch"></vaadin-icon>

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -112,6 +112,9 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         xmlns:xlink="http://www.w3.org/1999/xlink"
         viewBox="[[__computeViewBox(size, __viewBox)]]"
         preserveAspectRatio="[[__computePAR(__defaultPAR, __preserveAspectRatio)]]"
+        fill$="[[__fill]]"
+        stroke$="[[__stroke]]"
+        stroke-width$="[[__strokeWidth]]"
         aria-hidden="true"
       >
         <g id="svg-group"></g>
@@ -250,6 +253,15 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
 
       /** @private */
       __viewBox: String,
+
+      /** @private */
+      __fill: String,
+
+      /** @private */
+      __stroke: String,
+
+      /** @private */
+      __strokeWidth: String,
     };
   }
 
@@ -383,6 +395,9 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         }
 
         this.__viewBox = svgElement.getAttribute('viewBox');
+        this.__fill = svgElement.getAttribute('fill');
+        this.__stroke = svgElement.getAttribute('stroke');
+        this.__strokeWidth = svgElement.getAttribute('stroke-width');
       } catch (e) {
         console.error(e);
         this.svg = null;

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -115,6 +115,8 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         fill$="[[__fill]]"
         stroke$="[[__stroke]]"
         stroke-width$="[[__strokeWidth]]"
+        stroke-linecap$="[[__strokeLinecap]]"
+        stroke-linejoin$="[[__strokeLinejoin]]"
         aria-hidden="true"
       >
         <g id="svg-group"></g>
@@ -262,6 +264,12 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
 
       /** @private */
       __strokeWidth: String,
+
+      /** @private */
+      __strokeLinecap: String,
+
+      /** @private */
+      __strokeLinejoin: String,
     };
   }
 
@@ -398,6 +406,8 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
         this.__fill = svgElement.getAttribute('fill');
         this.__stroke = svgElement.getAttribute('stroke');
         this.__strokeWidth = svgElement.getAttribute('stroke-width');
+        this.__strokeLinecap = svgElement.getAttribute('stroke-linecap');
+        this.__strokeLinejoin = svgElement.getAttribute('stroke-linejoin');
       } catch (e) {
         console.error(e);
         this.svg = null;

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -131,7 +131,7 @@ describe('vaadin-icon', () => {
       icon.__fetch.restore();
     });
 
-    it('should use cors mode on fecth', () => {
+    it('should use cors mode on fetch', () => {
       sinon.stub(icon, '__fetch').resolves({ ok: true, text: () => Promise.resolve('<svg></svg>') });
 
       icon.src = `data:image/svg+xml,${encodeURIComponent('<svg></svg')}`;
@@ -162,6 +162,34 @@ describe('vaadin-icon', () => {
       await nextRender();
 
       expect(svgElement.getAttribute('viewBox')).to.be.equal('0 0 100 100');
+
+      icon.__fetch.restore();
+    });
+
+    it('should set fill, stroke and stroke-color attributes if they are defined source SVG', async () => {
+      const svgSrc = `<svg fill="none" stroke="currentColor" stroke-width="2">${ANGLE_DOWN}</svg>`;
+      sinon.stub(icon, '__fetch').resolves({ ok: true, text: () => Promise.resolve(svgSrc) });
+
+      icon.src = `data:image/svg+xml,${encodeURIComponent(svgSrc)}`;
+      await nextRender();
+
+      expect(svgElement.getAttribute('fill')).to.be.equal('none');
+      expect(svgElement.getAttribute('stroke')).to.be.equal('currentColor');
+      expect(svgElement.getAttribute('stroke-width')).to.be.equal('2');
+
+      icon.__fetch.restore();
+    });
+
+    it('should not set fill, stroke and stroke-color attributes if they are not defined in the source SVG', async () => {
+      const svgSrc = `<svg>${ANGLE_DOWN}</svg>`;
+      sinon.stub(icon, '__fetch').resolves({ ok: true, text: () => Promise.resolve(svgSrc) });
+
+      icon.src = `data:image/svg+xml,${encodeURIComponent(svgSrc)}`;
+      await nextRender();
+
+      expect(svgElement.hasAttribute('fill')).to.be.false;
+      expect(svgElement.hasAttribute('stroke')).to.be.false;
+      expect(svgElement.hasAttribute('stroke-width')).to.be.false;
 
       icon.__fetch.restore();
     });

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -166,8 +166,8 @@ describe('vaadin-icon', () => {
       icon.__fetch.restore();
     });
 
-    it('should set fill, stroke and stroke-color attributes if they are defined source SVG', async () => {
-      const svgSrc = `<svg fill="none" stroke="currentColor" stroke-width="2">${ANGLE_DOWN}</svg>`;
+    it('should set fill and stroke attributes if they are defined source SVG', async () => {
+      const svgSrc = `<svg fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="bevel">${ANGLE_DOWN}</svg>`;
       sinon.stub(icon, '__fetch').resolves({ ok: true, text: () => Promise.resolve(svgSrc) });
 
       icon.src = `data:image/svg+xml,${encodeURIComponent(svgSrc)}`;
@@ -176,6 +176,8 @@ describe('vaadin-icon', () => {
       expect(svgElement.getAttribute('fill')).to.be.equal('none');
       expect(svgElement.getAttribute('stroke')).to.be.equal('currentColor');
       expect(svgElement.getAttribute('stroke-width')).to.be.equal('2');
+      expect(svgElement.getAttribute('stroke-linecap')).to.be.equal('round');
+      expect(svgElement.getAttribute('stroke-linejoin')).to.be.equal('bevel');
 
       icon.__fetch.restore();
     });
@@ -190,6 +192,8 @@ describe('vaadin-icon', () => {
       expect(svgElement.hasAttribute('fill')).to.be.false;
       expect(svgElement.hasAttribute('stroke')).to.be.false;
       expect(svgElement.hasAttribute('stroke-width')).to.be.false;
+      expect(svgElement.hasAttribute('stroke-linecap')).to.be.false;
+      expect(svgElement.hasAttribute('stroke-linejoin')).to.be.false;
 
       icon.__fetch.restore();
     });


### PR DESCRIPTION
Several icon libraries configure the fill and stroke on the root SVG element, which is currently not respected by vaadin-icon. This change copies the `fill`, `stroke`, `stroke-width`, `stroke-linecap` and `stroke-linejoin` attributes from the source SVG to the one used internally by vaadin-icon.

Fixes https://github.com/vaadin/web-components/issues/6644