### PR TITLE
fix: update grid header and footer on column tree update

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -879,6 +879,7 @@ export const GridMixin = (superClass) =>
       this.__updateFooterPositioning();
       this.generateCellClassNames();
       this.generateCellPartNames();
+      this.__updateHeaderAndFooter();
     }
 
     /** @private */
@@ -1001,19 +1002,22 @@ export const GridMixin = (superClass) =>
      * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
      */
     requestContentUpdate() {
-      if (this._columnTree) {
-        // Header and footer renderers
-        this._columnTree.forEach((level) => {
-          level.forEach((column) => {
-            if (column._renderHeaderAndFooter) {
-              column._renderHeaderAndFooter();
-            }
-          });
-        });
+      // Header and footer renderers
+      this.__updateHeaderAndFooter();
 
-        // Body and row details renderers
-        this.__updateVisibleRows();
-      }
+      // Body and row details renderers
+      this.__updateVisibleRows();
+    }
+
+    /** @private */
+    __updateHeaderAndFooter() {
+      (this._columnTree || []).forEach((level) => {
+        level.forEach((column) => {
+          if (column._renderHeaderAndFooter) {
+            column._renderHeaderAndFooter();
+          }
+        });
+      });
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

Run header and footer renderers after grid column tree update. This ensures that header/footer content updates for a hidden column are applied when the column becomes visible again.

Fixes https://github.com/vaadin/flow-components/issues/5516

## Type of change

Bugfix