### PR TITLE
feat: add new input field CSS custom properties, align naming

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -8,7 +8,7 @@ registerStyles(
   'vaadin-input-container',
   css`
     :host {
-      background-color: var(--lumo-contrast-10pct);
+      background: var(--_background);
       padding: 0 calc(0.375em + var(--_input-container-radius) / 4 - 1px);
       font-weight: 500;
       line-height: 1;
@@ -23,8 +23,14 @@ registerStyles(
         var(--vaadin-input-field-bottom-start-radius, var(--_input-container-radius));
       /* Fallback */
       --_input-container-radius: var(--vaadin-input-field-border-radius, var(--lumo-border-radius-m));
-      /* Default field border color */
+      /* Default values */
+      --_background: var(--vaadin-input-field-background, var(--lumo-contrast-10pct));
+      --_hover-highlight: var(--vaadin-input-field-hover-highlight, var(--lumo-contrast-50pct));
       --_input-border-color: var(--vaadin-input-field-border-color, var(--lumo-contrast-50pct));
+      --_icon-color: var(--vaadin-input-field-icon-color, var(--lumo-contrast-60pct));
+      --_icon-size: var(--vaadin-input-field-icon-size, var(--lumo-icon-size-m));
+      --_invalid-background: var(--vaadin-input-field-invalid-background, var(--lumo-error-color-10pct));
+      --_invalid-hover-highlight: var(--vaadin-input-field-invalid-hover-highlight, var(--lumo-error-color-50pct));
     }
 
     :host([dir='rtl']) {
@@ -43,7 +49,7 @@ registerStyles(
       inset: 0;
       border-radius: inherit;
       pointer-events: none;
-      background-color: var(--lumo-contrast-50pct);
+      background: var(--_hover-highlight);
       opacity: 0;
       transition: transform 0.15s, opacity 0.2s;
       transform-origin: 100% 0;
@@ -83,18 +89,18 @@ registerStyles(
 
     /* Invalid */
     :host([invalid]) {
-      background-color: var(--lumo-error-color-10pct);
+      background: var(--_invalid-background);
     }
 
     :host([invalid])::after {
-      background-color: var(--lumo-error-color-50pct);
+      background: var(--_invalid-hover-highlight);
     }
 
     /* Slotted icons */
     ::slotted(vaadin-icon) {
-      color: var(--lumo-contrast-60pct);
-      width: var(--lumo-icon-size-m);
-      height: var(--lumo-icon-size-m);
+      color: var(--_icon-color);
+      width: var(--_icon-size);
+      height: var(--_icon-size);
     }
 
     /* Vaadin icons are based on a 16x16 grid (unlike Lumo and Material icons with 24x24), so they look too big by default */

--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -74,7 +74,7 @@ registerStyles(
     :host([readonly])::after {
       background-color: transparent;
       opacity: 1;
-      border: var(--vaadin-text-input-field-readonly-border, 1px dashed var(--lumo-contrast-30pct));
+      border: var(--vaadin-input-field-readonly-border, 1px dashed var(--lumo-contrast-30pct));
     }
 
     /* Disabled */

--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -31,7 +31,7 @@ const select = css`
   }
 
   [part='input-field'] ::slotted([slot='value']:not([placeholder])) {
-    color: var(--vaadin-text-input-field-value-color, var(--lumo-body-text-color));
+    color: var(--vaadin-input-field-value-color, var(--lumo-body-text-color));
   }
 
   :host([readonly]) [part='input-field'] ::slotted([slot='value']:not([placeholder])) {
@@ -40,7 +40,7 @@ const select = css`
 
   /* placeholder styles */
   [part='input-field'] ::slotted([slot='value'][placeholder]) {
-    color: var(--vaadin-text-input-field-placeholder-color, var(--lumo-secondary-text-color));
+    color: var(--vaadin-input-field-placeholder-color, var(--lumo-secondary-text-color));
   }
 
   :host(:is([readonly], [disabled])) ::slotted([slot='value'][placeholder]) {
@@ -69,7 +69,7 @@ registerStyles(
   css`
     :host {
       font-family: var(--lumo-font-family);
-      font-size: var(--vaadin-text-input-field-value-font-size, var(--lumo-font-size-m));
+      font-size: var(--vaadin-input-field-value-font-size, var(--lumo-font-size-m));
       padding: 0 0.25em;
       --_lumo-selected-item-height: var(--lumo-size-m);
       --_lumo-selected-item-padding: 0.5em;

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -17,9 +17,9 @@ import { requiredField } from './required-field.js';
 const inputField = css`
   :host {
     --lumo-text-field-size: var(--lumo-size-m);
-    color: var(--vaadin-text-input-field-value-color, var(--lumo-body-text-color));
-    font-size: var(--vaadin-text-input-field-value-font-size, var(--lumo-font-size-m));
-    font-weight: var(--vaadin-text-input-field-value-font-weight, 400);
+    color: var(--vaadin-input-field-value-color, var(--lumo-body-text-color));
+    font-size: var(--vaadin-input-field-value-font-size, var(--lumo-font-size-m));
+    font-weight: var(--vaadin-input-field-value-font-weight, 400);
     font-family: var(--lumo-font-family);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -27,7 +27,7 @@ const inputField = css`
     padding: var(--lumo-space-xs) 0;
     --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
-    --_input-height: var(--vaadin-text-input-field-height, var(--lumo-text-field-size));
+    --_input-height: var(--vaadin-input-field-height, var(--lumo-text-field-size));
   }
 
   :host::before {
@@ -43,7 +43,7 @@ const inputField = css`
   }
 
   ::slotted(:is(input, textarea):placeholder-shown) {
-    color: var(--vaadin-text-input-field-placeholder-color, var(--lumo-secondary-text-color));
+    color: var(--vaadin-input-field-placeholder-color, var(--lumo-secondary-text-color));
   }
 
   /* Hover */

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -48,7 +48,7 @@ const inputField = css`
 
   /* Hover */
   :host(:hover:not([readonly]):not([focused])) [part='input-field']::after {
-    opacity: 0.1;
+    opacity: var(--vaadin-input-field-hover-highlight-opacity, 0.1);
   }
 
   /* Touch device adjustment */

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -95,18 +95,17 @@ const globals = css`
     --vaadin-input-field-error-font-weight: 400;
     /* Input field */
     --vaadin-input-field-background: var(--lumo-contrast-10pct);
-    --vaadin-input-field-hover-highlight: var(--lumo-contrast-50pct);
     --vaadin-input-field-icon-color: var(--lumo-contrast-60pct);
     --vaadin-input-field-icon-size: var(--lumo-icon-size-m);
     --vaadin-input-field-invalid-background: var(--lumo-error-color-10pct);
     --vaadin-input-field-invalid-hover-highlight: var(--lumo-error-color-50pct);
-    /* Text field */
-    --vaadin-text-input-field-height: var(--lumo-size-m);
-    --vaadin-text-input-field-placeholder-color: var(--lumo-secondary-text-color);
-    --vaadin-text-input-field-readonly-border: 1px dashed var(--lumo-contrast-30pct);
-    --vaadin-text-input-field-value-color: var(--lumo-body-text-color);
-    --vaadin-text-input-field-value-font-size: var(--lumo-font-size-m);
-    --vaadin-text-input-field-value-font-weight: 400;
+    --vaadin-input-field-height: var(--lumo-size-m);
+    --vaadin-input-field-hover-highlight: var(--lumo-contrast-50pct);
+    --vaadin-input-field-placeholder-color: var(--lumo-secondary-text-color);
+    --vaadin-input-field-readonly-border: 1px dashed var(--lumo-contrast-30pct);
+    --vaadin-input-field-value-color: var(--lumo-body-text-color);
+    --vaadin-input-field-value-font-size: var(--lumo-font-size-m);
+    --vaadin-input-field-value-font-weight: 400;
   }
 `;
 

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -93,6 +93,13 @@ const globals = css`
     --vaadin-input-field-error-color: var(--lumo-error-text-color);
     --vaadin-input-field-error-font-size: var(--lumo-font-size-xs);
     --vaadin-input-field-error-font-weight: 400;
+    /* Input field */
+    --vaadin-input-field-background: var(--lumo-contrast-10pct);
+    --vaadin-input-field-hover-highlight: var(--lumo-contrast-50pct);
+    --vaadin-input-field-icon-color: var(--lumo-contrast-60pct);
+    --vaadin-input-field-icon-size: var(--lumo-icon-size-m);
+    --vaadin-input-field-invalid-background: var(--lumo-error-color-10pct);
+    --vaadin-input-field-invalid-hover-highlight: var(--lumo-error-color-50pct);
     /* Text field */
     --vaadin-text-input-field-height: var(--lumo-size-m);
     --vaadin-text-input-field-placeholder-color: var(--lumo-secondary-text-color);


### PR DESCRIPTION
## Description

Part of #2954

## Type of change

- Feature

## CSS properties

The following custom CSS properties from the [spreadsheet](https://docs.google.com/spreadsheets/d/1Mzlbd8GzSZcEgYd-odagN3CBD0TSSTFCPmNCmP8rkLU/edit?usp=sharing) are added in this PR:

- `--vaadin-input-field-background`
- `--vaadin-input-field-invalid-background`
- `--vaadin-input-field-hover-highlight`
- `--vaadin-input-field-invalid-hover-highlight`
- `--vaadin-input-field-hover-highlight-opacity`
- `--vaadin-input-field-icon-color`
- `--vaadin-input-field-icon-size`