### PR TITLE
feat: add helper text and error message CSS properties

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/helper.js
+++ b/packages/vaadin-lumo-styles/mixins/helper.js
@@ -10,17 +10,25 @@ import '../typography.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const helper = css`
+  :host {
+    --_helper-color: var(--vaadin-input-field-helper-color, var(--lumo-secondary-text-color));
+    --_helper-font-size: var(--vaadin-input-field-helper-font-size, var(--lumo-font-size-xs));
+    --_helper-font-weight: var(--vaadin-input-field-helper-font-weight, 400);
+    --_helper-spacing: var(--vaadin-input-field-helper-spacing, 0.4em);
+  }
+
   :host([has-helper]) [part='helper-text']::before {
     content: '';
     display: block;
-    height: 0.4em;
+    height: var(--_helper-spacing);
   }
 
   [part='helper-text'] {
     display: block;
-    color: var(--lumo-secondary-text-color);
-    font-size: var(--lumo-font-size-xs);
+    color: var(--_helper-color);
+    font-size: var(--_helper-font-size);
     line-height: var(--lumo-line-height-xs);
+    font-weight: var(--_helper-font-weight);
     margin-left: calc(var(--lumo-border-radius-m) / 4);
     transition: color 0.2s;
   }
@@ -41,12 +49,12 @@ export const helper = css`
   :host([has-helper][theme~='helper-above-field']) [part='helper-text']::after {
     content: '';
     display: block;
-    height: 0.4em;
+    height: var(--_helper-spacing);
   }
 
   :host([has-helper][theme~='helper-above-field']) [part='label'] {
     order: 0;
-    padding-bottom: 0.4em;
+    padding-bottom: var(--_helper-spacing);
   }
 
   :host([has-helper][theme~='helper-above-field']) [part='helper-text'] {

--- a/packages/vaadin-lumo-styles/mixins/helper.js
+++ b/packages/vaadin-lumo-styles/mixins/helper.js
@@ -11,9 +11,6 @@ import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const helper = css`
   :host {
-    --_helper-color: var(--vaadin-input-field-helper-color, var(--lumo-secondary-text-color));
-    --_helper-font-size: var(--vaadin-input-field-helper-font-size, var(--lumo-font-size-xs));
-    --_helper-font-weight: var(--vaadin-input-field-helper-font-weight, 400);
     --_helper-spacing: var(--vaadin-input-field-helper-spacing, 0.4em);
   }
 
@@ -25,10 +22,10 @@ export const helper = css`
 
   [part='helper-text'] {
     display: block;
-    color: var(--_helper-color);
-    font-size: var(--_helper-font-size);
+    color: var(--vaadin-input-field-helper-color, var(--lumo-secondary-text-color));
+    font-size: var(--vaadin-input-field-helper-font-size, var(--lumo-font-size-xs));
     line-height: var(--lumo-line-height-xs);
-    font-weight: var(--_helper-font-weight);
+    font-weight: var(--vaadin-input-field-helper-font-weight, 400);
     margin-left: calc(var(--lumo-border-radius-m) / 4);
     transition: color 0.2s;
   }

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -10,12 +10,6 @@ import '../typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const requiredField = css`
-  :host {
-    --_error-color: var(--vaadin-input-field-error-color, var(--lumo-error-text-color));
-    --_error-font-size: var(--vaadin-input-field-error-font-size, var(--lumo-font-size-xs));
-    --_error-font-weight: var(--vaadin-input-field-error-font-weight, 400);
-  }
-
   [part='label'] {
     align-self: flex-start;
     color: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
@@ -85,10 +79,10 @@ const requiredField = css`
 
   [part='error-message'] {
     margin-left: calc(var(--lumo-border-radius-m) / 4);
-    font-size: var(--_error-font-size);
+    font-size: var(--vaadin-input-field-error-font-size, var(--lumo-font-size-xs));
     line-height: var(--lumo-line-height-xs);
-    font-weight: var(--_error-font-weight);
-    color: var(--_error-color);
+    font-weight: var(--vaadin-input-field-error-font-weight, 400);
+    color: var(--vaadin-input-field-error-color, var(--lumo-error-text-color));
     will-change: max-height;
     transition: 0.4s max-height;
     max-height: 5em;

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -10,6 +10,12 @@ import '../typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const requiredField = css`
+  :host {
+    --_error-color: var(--vaadin-input-field-error-color, var(--lumo-error-text-color));
+    --_error-font-size: var(--vaadin-input-field-error-font-size, var(--lumo-font-size-xs));
+    --_error-font-weight: var(--vaadin-input-field-error-font-weight, 400);
+  }
+
   [part='label'] {
     align-self: flex-start;
     color: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
@@ -79,9 +85,10 @@ const requiredField = css`
 
   [part='error-message'] {
     margin-left: calc(var(--lumo-border-radius-m) / 4);
-    font-size: var(--lumo-font-size-xs);
+    font-size: var(--_error-font-size);
     line-height: var(--lumo-line-height-xs);
-    color: var(--lumo-error-text-color);
+    font-weight: var(--_error-font-weight);
+    color: var(--_error-color);
     will-change: max-height;
     transition: 0.4s max-height;
     max-height: 5em;

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -78,11 +78,22 @@ const globals = css`
     --vaadin-input-field-border-radius: var(--lumo-border-radius-m);
     --vaadin-focus-ring-color: var(--lumo-primary-color-50pct);
     --vaadin-focus-ring-width: 2px;
+    /* Label */
     --vaadin-input-field-label-color: var(--lumo-secondary-text-color);
     --vaadin-input-field-focused-label-color: var(--lumo-primary-text-color);
     --vaadin-input-field-hovered-label-color: var(--lumo-body-text-color);
     --vaadin-input-field-label-font-size: var(--lumo-font-size-s);
     --vaadin-input-field-label-font-weight: 500;
+    /* Helper */
+    --vaadin-input-field-helper-color: var(--lumo-secondary-text-color);
+    --vaadin-input-field-helper-font-size: var(--lumo-font-size-xs);
+    --vaadin-input-field-helper-font-weight: 400;
+    --vaadin-input-field-helper-spacing: 0.4em;
+    /* Error message */
+    --vaadin-input-field-error-color: var(--lumo-error-text-color);
+    --vaadin-input-field-error-font-size: var(--lumo-font-size-xs);
+    --vaadin-input-field-error-font-weight: 400;
+    /* Text field */
     --vaadin-text-input-field-height: var(--lumo-size-m);
     --vaadin-text-input-field-placeholder-color: var(--lumo-secondary-text-color);
     --vaadin-text-input-field-readonly-border: 1px dashed var(--lumo-contrast-30pct);


### PR DESCRIPTION
## Description

Part of #2954

## Type of change

- Feature

## CSS properties

The following custom CSS properties from the [spreadsheet](https://docs.google.com/spreadsheets/d/1Mzlbd8GzSZcEgYd-odagN3CBD0TSSTFCPmNCmP8rkLU/edit?usp=sharing) are added in this PR:

- `--vaadin-input-field-helper-color`
- `--vaadin-input-field-helper-font-size`
- `--vaadin-input-field-helper-font-weight`
- `--vaadin-input-field-helper-spacing`
- `--vaadin-input-field-error-color`
- `--vaadin-input-field-error-font-size`
- `--vaadin-input-field-error-font-weight`