### PR TITLE
fix: only replace double spaces on rte delta conversion

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -695,11 +695,11 @@ export const RichTextEditorMixin = (superClass) =>
     dangerouslySetHtmlValue(htmlValue) {
       const whitespaceCharacters = {
         '\t': '__VAADIN_RICH_TEXT_EDITOR_TAB',
-        ' ': '__VAADIN_RICH_TEXT_EDITOR_SPACE',
+        '  ': '__VAADIN_RICH_TEXT_EDITOR_DOUBLE_SPACE',
       };
       // Replace whitespace characters with placeholders before the Delta conversion to prevent Quill from trimming them
       Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
-        htmlValue = htmlValue.replace(new RegExp(character, 'gu'), replacement);
+        htmlValue = htmlValue.replaceAll(character, replacement);
       });
 
       const deltaFromHtml = this._editor.clipboard.convert(htmlValue);
@@ -708,7 +708,7 @@ export const RichTextEditorMixin = (superClass) =>
       Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
         deltaFromHtml.ops.forEach((op) => {
           if (typeof op.insert === 'string') {
-            op.insert = op.insert.replace(new RegExp(replacement, 'gu'), character);
+            op.insert = op.insert.replaceAll(replacement, character);
           }
         });
       });

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -713,11 +713,18 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal(htmlWithLeadingTab);
     });
 
-    it('should not lose extra stpace characters from the resulting htmlValue', () => {
+    it('should not lose extra space characters from the resulting htmlValue', () => {
       const htmlWithExtraSpaces = '<p>Extra   spaces</p>';
       rte.dangerouslySetHtmlValue(htmlWithExtraSpaces);
       flushValueDebouncer();
       expect(rte.htmlValue).to.equal(htmlWithExtraSpaces);
+    });
+
+    it('should not break code block attributes', () => {
+      const htmlWithCodeBlock = `<pre spellcheck="false">code\n</pre>`;
+      rte.dangerouslySetHtmlValue(htmlWithCodeBlock);
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal(htmlWithCodeBlock);
     });
 
     it('should return the quill editor innerHTML', () => {


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/vaadin/web-components/pull/6651 where temporarily replacing all space characters in the HTML before delta conversion might change the semantics of the original HTML:

Example:
```html
<pre spellcheck="false">code\n</pre>
```
would become invalid in case the space between the tag name and the attribute was replaced.
```html
<pre__VAADIN_RICH_TEXT_EDITOR_SPACEspellcheck="false">code\n</pre>
```

This PR fixes the issue by making the logic not replace all space characters (` `) in the HTML but only double-spaces (`  `).

## Type of change

Bugfix