### PR TITLE
feat: add Lumo selection colors custom CSS properties

### DIFF
--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -25,6 +25,7 @@ registerStyles(
       --_checkbox-size: var(--vaadin-checkbox-size, calc(var(--lumo-size-m) / 2));
       --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
       --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
+      --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     }
 
     :host([has-label]) ::slotted(label) {
@@ -52,7 +53,7 @@ registerStyles(
 
     :host([indeterminate]) [part='checkbox'],
     :host([checked]) [part='checkbox'] {
-      background-color: var(--lumo-primary-color);
+      background-color: var(--_selection-color);
     }
 
     /* Checkmark */

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -19,6 +19,8 @@ registerStyles(
       padding: 0 var(--lumo-space-xs);
       --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
       --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
+      --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
+      --_selection-color-text: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
     }
 
     /* Month header */
@@ -78,7 +80,7 @@ registerStyles(
     /* Today date */
 
     [part~='date'][part~='today'] {
-      color: var(--lumo-primary-text-color);
+      color: var(--_selection-color-text);
     }
 
     /* Focused date */
@@ -122,7 +124,7 @@ registerStyles(
     }
 
     [part~='date'][part~='selected']::before {
-      background-color: var(--lumo-primary-color);
+      background-color: var(--_selection-color);
     }
 
     [part~='date'][part~='disabled'] {

--- a/packages/grid/theme/lumo/vaadin-grid-sorter-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-sorter-styles.js
@@ -34,7 +34,7 @@ registerStyles(
     }
 
     :host([direction]) {
-      color: var(--lumo-primary-text-color);
+      color: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
     }
 
     [part='order'] {

--- a/packages/item/theme/lumo/vaadin-item-styles.js
+++ b/packages/item/theme/lumo/vaadin-item-styles.js
@@ -24,6 +24,7 @@ const item = css`
     -webkit-tap-highlight-color: var(--lumo-primary-color-10pct);
     --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
+    --_selection-color-text: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
   }
 
   /* Checkmark */
@@ -37,7 +38,7 @@ const item = css`
     width: 1em;
     height: 1em;
     margin: calc((1 - var(--lumo-line-height-xs)) * var(--lumo-font-size-m) / 2) 0;
-    color: var(--lumo-primary-text-color);
+    color: var(--_selection-color-text);
     flex: none;
     opacity: 0;
     transition: transform 0.2s cubic-bezier(0.12, 0.32, 0.54, 2), opacity 0.1s;

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -77,7 +77,7 @@ const multiSelectComboBox = css`
   }
 
   ::slotted([slot='chip'][focused]) {
-    background-color: var(--lumo-primary-color);
+    background-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     color: var(--lumo-primary-contrast-color);
   }
 

--- a/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
@@ -24,6 +24,7 @@ registerStyles(
       --_radio-button-size: var(--vaadin-radio-button-size, calc(var(--lumo-size-m) / 2));
       --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
       --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
+      --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     }
 
     :host([has-label]) ::slotted(label) {
@@ -82,7 +83,7 @@ registerStyles(
     }
 
     :host([checked]) [part='radio'] {
-      background-color: var(--lumo-primary-color);
+      background-color: var(--_selection-color);
     }
 
     :host([checked]) [part='radio']::after {

--- a/packages/rich-text-editor/theme/lumo/vaadin-rich-text-editor-styles.js
+++ b/packages/rich-text-editor/theme/lumo/vaadin-rich-text-editor-styles.js
@@ -50,7 +50,7 @@ const richTextEditor = css`
   }
 
   [part~='toolbar-button'][on] {
-    background-color: var(--lumo-primary-color);
+    background-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     color: var(--lumo-primary-contrast-color);
   }
 

--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -115,7 +115,7 @@ export const sideNavItemStyles = css`
 
   :host([current]) [part='content'] {
     background-color: var(--lumo-primary-color-10pct);
-    color: var(--lumo-primary-text-color);
+    color: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
     border-radius: var(--lumo-border-radius-m);
   }
 `;

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -33,6 +33,8 @@ registerStyles(
       user-select: none;
       --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
       --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
+      --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
+      --_selection-color-text: var(--vaadin-selection-color-text, var(--lumo-primary-text-color));
     }
 
     :host(:not([orientation='vertical'])) {
@@ -64,12 +66,12 @@ registerStyles(
     }
 
     :host([selected]) {
-      color: var(--lumo-primary-text-color);
+      color: var(--_selection-color-text);
       transition: 0.6s color;
     }
 
     :host([active]:not([selected])) {
-      color: var(--lumo-primary-text-color);
+      color: var(--_selection-color-text);
       transition-duration: 0.1s;
     }
 
@@ -92,7 +94,7 @@ registerStyles(
 
     :host([selected])::before,
     :host([selected])::after {
-      background-color: var(--lumo-primary-color);
+      background-color: var(--_selection-color);
     }
 
     :host([orientation='vertical'])::before,
@@ -107,7 +109,7 @@ registerStyles(
     }
 
     :host::after {
-      box-shadow: 0 0 0 4px var(--lumo-primary-color);
+      box-shadow: 0 0 0 4px var(--_selection-color);
       opacity: 0.15;
       transition: 0.15s 0.02s transform, 0.8s 0.17s opacity;
     }

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -33,6 +33,8 @@ const globals = css`
   html {
     --vaadin-checkbox-size: calc(var(--lumo-size-m) / 2);
     --vaadin-radio-button-size: calc(var(--lumo-size-m) / 2);
+    --vaadin-selection-color: var(--lumo-primary-color);
+    --vaadin-selection-color-text: var(--lumo-primary-text-color);
     --vaadin-input-field-border-radius: var(--lumo-border-radius-m);
     --vaadin-focus-ring-color: var(--lumo-primary-color-50pct);
     --vaadin-focus-ring-width: 2px;


### PR DESCRIPTION
## Description

Part of #2954

## Type of change

- Feature

## CSS properties

The following custom CSS properties from the [spreadsheet](https://docs.google.com/spreadsheets/d/1Mzlbd8GzSZcEgYd-odagN3CBD0TSSTFCPmNCmP8rkLU/edit?usp=sharing) are added in this PR:

- `--vaadin-selection-color` 
- `--vaadin-selection-color-text`