### PR TITLE
refactor: make cell content inherit cursor from the cell

### DIFF
--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -44,12 +44,13 @@ registerStyles(
     [part~='cell'] {
       min-height: var(--lumo-size-m);
       background-color: var(--lumo-base-color);
+      cursor: default;
       --_cell-padding: var(--vaadin-grid-cell-padding, var(--_cell-default-padding));
       --_cell-default-padding: var(--lumo-space-xs) var(--lumo-space-m);
     }
 
     [part~='cell'] ::slotted(vaadin-grid-cell-content) {
-      cursor: default;
+      cursor: inherit;
       padding: var(--_cell-padding);
     }
 


### PR DESCRIPTION
## Description

Part of #5636

This change makes it possible to customize `cursor` property e.g. like this:

```css
vaadin-grid::part(header-cell) {
  cursor: pointer;
}
```

## Type of change

- Refactor