### PR TITLE
fix: prevent rte from trimming whitespace on delta conversion (#6651)

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -1015,11 +1015,11 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
   dangerouslySetHtmlValue(htmlValue) {
     const whitespaceCharacters = {
       '\t': '__VAADIN_RICH_TEXT_EDITOR_TAB',
-      ' ': '__VAADIN_RICH_TEXT_EDITOR_SPACE',
+      '  ': '__VAADIN_RICH_TEXT_EDITOR_DOUBLE_SPACE',
     };
     // Replace whitespace characters with placeholders before the Delta conversion to prevent Quill from trimming them
     Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
-      htmlValue = htmlValue.replace(new RegExp(character, 'gu'), replacement);
+      htmlValue = htmlValue.replaceAll(character, replacement);
     });
 
     const deltaFromHtml = this._editor.clipboard.convert(htmlValue);
@@ -1028,7 +1028,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
       deltaFromHtml.ops.forEach((op) => {
         if (typeof op.insert === 'string') {
-          op.insert = op.insert.replace(new RegExp(replacement, 'gu'), character);
+          op.insert = op.insert.replaceAll(replacement, character);
         }
       });
     });

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -1013,7 +1013,26 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
    * @param {string} htmlValue
    */
   dangerouslySetHtmlValue(htmlValue) {
+    const whitespaceCharacters = {
+      '\t': '__VAADIN_RICH_TEXT_EDITOR_TAB',
+      ' ': '__VAADIN_RICH_TEXT_EDITOR_SPACE',
+    };
+    // Replace whitespace characters with placeholders before the Delta conversion to prevent Quill from trimming them
+    Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
+      htmlValue = htmlValue.replace(new RegExp(character, 'gu'), replacement);
+    });
+
     const deltaFromHtml = this._editor.clipboard.convert(htmlValue);
+
+    // Restore whitespace characters after the conversion
+    Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
+      deltaFromHtml.ops.forEach((op) => {
+        if (typeof op.insert === 'string') {
+          op.insert = op.insert.replace(new RegExp(replacement, 'gu'), character);
+        }
+      });
+    });
+
     this._editor.setContents(deltaFromHtml, SOURCE.API);
   }
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -1019,7 +1019,7 @@ class RichTextEditor extends ElementMixin(ThemableMixin(PolymerElement)) {
     };
     // Replace whitespace characters with placeholders before the Delta conversion to prevent Quill from trimming them
     Object.entries(whitespaceCharacters).forEach(([character, replacement]) => {
-      htmlValue = htmlValue.replaceAll(character, replacement);
+      htmlValue = htmlValue.replaceAll(/>[^<]*</gu, (match) => match.replaceAll(character, replacement)); // NOSONAR
     });
 
     const deltaFromHtml = this._editor.clipboard.convert(htmlValue);

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -697,11 +697,18 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal(htmlWithLeadingTab);
     });
 
-    it('should not lose extra stpace characters from the resulting htmlValue', () => {
+    it('should not lose extra space characters from the resulting htmlValue', () => {
       const htmlWithExtraSpaces = '<p>Extra   spaces</p>';
       rte.dangerouslySetHtmlValue(htmlWithExtraSpaces);
       flushValueDebouncer();
       expect(rte.htmlValue).to.equal(htmlWithExtraSpaces);
+    });
+
+    it('should not break code block attributes', () => {
+      const htmlWithCodeBlock = `<pre spellcheck="false">code\n</pre>`;
+      rte.dangerouslySetHtmlValue(htmlWithCodeBlock);
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal(htmlWithCodeBlock);
     });
 
     it('should return the quill editor innerHTML', () => {

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -690,6 +690,20 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal('<p><strong>Hello </strong></p><p><strong>world</strong></p>');
     });
 
+    it('should not lose leading tab characters from the resulting htmlValue', () => {
+      const htmlWithLeadingTab = '<p>\tTab</p>';
+      rte.dangerouslySetHtmlValue(htmlWithLeadingTab);
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal(htmlWithLeadingTab);
+    });
+
+    it('should not lose extra stpace characters from the resulting htmlValue', () => {
+      const htmlWithExtraSpaces = '<p>Extra   spaces</p>';
+      rte.dangerouslySetHtmlValue(htmlWithExtraSpaces);
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal(htmlWithExtraSpaces);
+    });
+
     it('should return the quill editor innerHTML', () => {
       expect(rte.htmlValue).to.equal('<p><br></p>');
     });

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -711,6 +711,20 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal(htmlWithCodeBlock);
     });
 
+    it('should support double spaces inside html tags', () => {
+      const htmlWithCodeBlock = `<pre  spellcheck="false">code\n</pre>`;
+      rte.dangerouslySetHtmlValue(htmlWithCodeBlock);
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal(`<pre spellcheck="false">code\n</pre>`);
+    });
+
+    it('should support tabs inside html tags', () => {
+      const htmlWithCodeBlock = `<pre\tspellcheck="false">code\n</pre>`;
+      rte.dangerouslySetHtmlValue(htmlWithCodeBlock);
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal(`<pre spellcheck="false">code\n</pre>`);
+    });
+
     it('should return the quill editor innerHTML', () => {
       expect(rte.htmlValue).to.equal('<p><br></p>');
     });


### PR DESCRIPTION
## Description

Cherry-pick #6651 to `24.2`

Also includes fixes: #6652 and #6661