### PR TITLE
refactor: remove use of setProperties in grid items

### DIFF
--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -29,11 +29,9 @@ export const ArrayDataProviderMixin = (superClass) =>
     __setArrayDataProvider(items) {
       const arrayDataProvider = createArrayDataProvider(this.items, {});
       arrayDataProvider.__items = items;
-      this.setProperties({
-        _arrayDataProvider: arrayDataProvider,
-        size: items.length,
-        dataProvider: arrayDataProvider,
-      });
+      this._arrayDataProvider = arrayDataProvider;
+      this.size = items.length;
+      this.dataProvider = arrayDataProvider;
     }
 
     /** @private */
@@ -47,17 +45,13 @@ export const ArrayDataProviderMixin = (superClass) =>
 
         if (dataProvider !== this._arrayDataProvider) {
           // A custom data provider was set externally
-          this.setProperties({
-            _arrayDataProvider: undefined,
-            items: undefined,
-          });
+          this._arrayDataProvider = undefined;
+          this.items = undefined;
         } else if (!items) {
           // The items array was unset
-          this.setProperties({
-            _arrayDataProvider: undefined,
-            dataProvider: undefined,
-            size: 0,
-          });
+          this._arrayDataProvider = undefined;
+          this.dataProvider = undefined;
+          this.size = 0;
           this.clearCache();
         } else if (this._arrayDataProvider.__items === items) {
           // The items array was modified


### PR DESCRIPTION
## Description

Remove the use of Polymer-specific `this.setProperties` in `vaadin-grid-array-data-provider-mixin.js`.
This is a prerequisite for the vaadin-grid LitElement migration.