### PR TITLE
fix: flush virtualizer until physical count stabilizes

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -136,6 +136,7 @@ export class IronListAdapter {
   }
 
   flush() {
+    const startPhysicalCount = this._physicalCount;
     // The scroll target is hidden.
     if (this.scrollTarget.offsetHeight === 0) {
       return;
@@ -152,6 +153,11 @@ export class IronListAdapter {
     }
     if (this.__debouncerWheelAnimationFrame) {
       this.__debouncerWheelAnimationFrame.flush();
+    }
+
+    if (this._physicalCount !== startPhysicalCount) {
+      // Flushing again until physical count stabilizes fixes https://github.com/vaadin/flow-components/issues/5595#issuecomment-1770278913
+      this.flush();
     }
   }
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/5595

This change fixes the issue described in https://github.com/vaadin/flow-components/issues/5595#issuecomment-1770278913

Despite numerous attempts, I couldn't produce a test case for the change in `web-components`. It's possible that the issue only occurs in `flow-components` due to the grid functionality overrides in the connector, but not sure.

Before:
![Screenshot 2023-10-23 at 13 30 19](https://github.com/vaadin/web-components/assets/1222264/42fee0b6-7cb7-4853-8061-2358411de801)

After:
![Screenshot 2023-10-23 at 13 31 05](https://github.com/vaadin/web-components/assets/1222264/ecb63ec6-c0ff-40c5-bb77-d6f8f001709c)

## Type of change

Bugfix