### PR TITLE
feat: add property to group selected overlay items at the top

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -234,6 +234,14 @@ export const ComboBoxMixin = (subclass) =>
           observer: '_toggleElementChanged',
         },
 
+        /**
+         * Set of items to be rendered in the dropdown.
+         * @protected
+         */
+        _dropdownItems: {
+          type: Array,
+        },
+
         /** @private */
         _closeOnBlurIsPrevented: Boolean,
 
@@ -251,8 +259,8 @@ export const ComboBoxMixin = (subclass) =>
     static get observers() {
       return [
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
-        '_openedOrItemsChanged(opened, filteredItems, loading)',
-        '_updateScroller(_scroller, filteredItems, opened, loading, selectedItem, itemIdPath, _focusedIndex, renderer, theme)',
+        '_openedOrItemsChanged(opened, _dropdownItems, loading)',
+        '_updateScroller(_scroller, _dropdownItems, opened, loading, selectedItem, itemIdPath, _focusedIndex, renderer, theme)',
       ];
     }
 
@@ -491,7 +499,7 @@ export const ComboBoxMixin = (subclass) =>
         this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-opened', { bubbles: true, composed: true }));
 
         this._onOpened();
-      } else if (wasOpened && this.filteredItems && this.filteredItems.length) {
+      } else if (wasOpened && this._dropdownItems && this._dropdownItems.length) {
         this.close();
 
         this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-closed', { bubbles: true, composed: true }));
@@ -681,7 +689,7 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _onArrowDown() {
       if (this.opened) {
-        const items = this.filteredItems;
+        const items = this._dropdownItems;
         if (items) {
           this._focusedIndex = Math.min(items.length - 1, this._focusedIndex + 1);
           this._prefillFocusedItemLabel();
@@ -697,7 +705,7 @@ export const ComboBoxMixin = (subclass) =>
         if (this._focusedIndex > -1) {
           this._focusedIndex = Math.max(0, this._focusedIndex - 1);
         } else {
-          const items = this.filteredItems;
+          const items = this._dropdownItems;
           if (items) {
             this._focusedIndex = items.length - 1;
           }
@@ -712,7 +720,7 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _prefillFocusedItemLabel() {
       if (this._focusedIndex > -1) {
-        const focusedItem = this.filteredItems[this._focusedIndex];
+        const focusedItem = this._dropdownItems[this._focusedIndex];
         this._inputElementValue = this._getItemLabel(focusedItem);
         this._markAllSelectionRange();
       }
@@ -885,7 +893,7 @@ export const ComboBoxMixin = (subclass) =>
     /** @private */
     _commitValue() {
       if (this._focusedIndex > -1) {
-        const focusedItem = this.filteredItems[this._focusedIndex];
+        const focusedItem = this._dropdownItems[this._focusedIndex];
         if (this.selectedItem !== focusedItem) {
           this.selectedItem = focusedItem;
         }
@@ -900,7 +908,7 @@ export const ComboBoxMixin = (subclass) =>
         }
       } else {
         // Try to find an item which label matches the input value.
-        const items = [...(this.filteredItems || []), this.selectedItem];
+        const items = [...(this._dropdownItems || []), this.selectedItem];
         const itemMatchingInputValue = items[this.__getItemIndexByLabel(items, this._inputElementValue)];
 
         if (
@@ -1115,6 +1123,8 @@ export const ComboBoxMixin = (subclass) =>
 
     /** @private */
     _filteredItemsChanged(filteredItems, oldFilteredItems) {
+      this._setDropdownItems(filteredItems);
+
       // Store the currently focused item if any. The focused index preserves
       // in the case when more filtered items are loading but it is reset
       // when the user types in a filter query.
@@ -1173,6 +1183,16 @@ export const ComboBoxMixin = (subclass) =>
       if (this.selectedItem === null && previouslySelectedItem === null) {
         this._selectedItemChanged(this.selectedItem);
       }
+    }
+
+    /**
+     * Provide items to be rendered in the dropdown.
+     * Override this method to show custom items.
+     *
+     * @protected
+     */
+    _setDropdownItems(items) {
+      this._dropdownItems = items;
     }
 
     /** @private */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -172,11 +172,11 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
     if (this.topGroup) {
       const filteredTopItems = this.topGroup.filter((selectedItem) => {
-        return items.some((item) => this._getItemLabel(item) === this._getItemLabel(selectedItem));
+        return items.some((item) => this._getItemValue(item) === this._getItemValue(selectedItem));
       });
 
       const filteredItems = (items || []).filter((item) => {
-        return !this.topGroup.some((selectedItem) => this._getItemLabel(item) === this._getItemLabel(selectedItem));
+        return !this.topGroup.some((selectedItem) => this._getItemValue(item) === this._getItemValue(selectedItem));
       });
 
       this._dropdownItems = [...filteredTopItems, ...filteredItems];

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -171,12 +171,15 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     }
 
     if (this.topGroup) {
-      const filteredTopItems = this.topGroup.filter((selectedItem) => {
-        return items.some((item) => this._getItemValue(item) === this._getItemValue(selectedItem));
-      });
+      const filteredTopItems = [];
+      const filteredItems = [];
 
-      const filteredItems = (items || []).filter((item) => {
-        return !this.topGroup.some((selectedItem) => this._getItemValue(item) === this._getItemValue(selectedItem));
+      (items || []).forEach((item) => {
+        if (this.topGroup.some((selectedItem) => this._getItemValue(item) === this._getItemValue(selectedItem))) {
+          filteredTopItems.push(item);
+        } else {
+          filteredItems.push(item);
+        }
       });
 
       this._dropdownItems = [...filteredTopItems, ...filteredItems];

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -61,6 +61,15 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
       },
 
       /**
+       * Set to true to group selected items at the top of the overlay.
+       * @attr {boolean} group-selected-items
+       */
+      groupSelectedItems: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
        * When set to `true`, "loading" attribute is set
        * on the host and the overlay element.
        * @type {boolean}
@@ -95,6 +104,14 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
       lastFilter: {
         type: String,
         notify: true,
+      },
+
+      /**
+       * A subset of items to be shown at the top of the overlay.
+       */
+      topGroup: {
+        type: Array,
+        observer: '_topGroupChanged',
       },
 
       _target: {
@@ -141,6 +158,39 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override combo-box method to group selected
+   * items at the top of the overlay.
+   *
+   * @protected
+   * @override
+   */
+  _setDropdownItems(items) {
+    if (this.readonly || !this.groupSelectedItems) {
+      this._dropdownItems = items;
+      return;
+    }
+
+    if (this.topGroup) {
+      const filteredTopItems = this.topGroup.filter((selectedItem) => {
+        return items.some((item) => this._getItemLabel(item) === this._getItemLabel(selectedItem));
+      });
+
+      const filteredItems = (items || []).filter((item) => {
+        return !this.topGroup.some((selectedItem) => this._getItemLabel(item) === this._getItemLabel(selectedItem));
+      });
+
+      this._dropdownItems = [...filteredTopItems, ...filteredItems];
+    }
+  }
+
+  /** @private */
+  _topGroupChanged(topGroup) {
+    if (topGroup) {
+      this._setDropdownItems(this.filteredItems);
+    }
+  }
+
+  /**
    * Override combo-box method to set correct owner for using by item renderers.
    * This needs to be done before the scroller gets added to the DOM to ensure
    * Lit directive works in case when combo-box is opened using attribute.
@@ -172,9 +222,9 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
         this.close();
       } else {
         // Keep selected item focused after committing on Enter.
-        const focusedItem = this.filteredItems[this._focusedIndex];
+        const focusedItem = this._dropdownItems[this._focusedIndex];
         this._commitValue();
-        this._focusedIndex = this.filteredItems.indexOf(focusedItem);
+        this._focusedIndex = this._dropdownItems.indexOf(focusedItem);
       }
 
       return;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -210,6 +210,12 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   filter: string;
 
   /**
+   * Set to true to group selected items at the top of the overlay.
+   * @attr {boolean} group-selected-items
+   */
+  groupSelectedItems: boolean;
+
+  /**
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -165,6 +165,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           size="{{size}}"
           filtered-items="[[__effectiveFilteredItems]]"
           selected-items="[[selectedItems]]"
+          group-selected-items="[[groupSelectedItems]]"
+          top-group="[[_topGroup]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
           theme$="[[_theme]]"
@@ -225,6 +227,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
         type: Boolean,
         reflectToAttribute: true,
         observer: '_clearButtonVisibleChanged',
+        value: false,
+      },
+
+      /**
+       * Set to true to group selected items at the top of the overlay.
+       * @attr {boolean} group-selected-items
+       */
+      groupSelectedItems: {
+        type: Boolean,
         value: false,
       },
 
@@ -464,6 +475,11 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       _lastFilter: {
         type: String,
       },
+
+      /** @private */
+      _topGroup: {
+        type: Array,
+      },
     };
   }
 
@@ -471,6 +487,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     return [
       '_selectedItemsChanged(selectedItems, selectedItems.*)',
       '__updateOverflowChip(_overflow, _overflowItems, disabled, readonly)',
+      '__updateTopGroup(selectedItems, opened)',
     ];
   }
 
@@ -821,6 +838,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     this.validate();
 
     this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+  }
+
+  /** @private */
+  __updateTopGroup(selectedItems, opened) {
+    if (!opened) {
+      this._topGroup = [...selectedItems];
+    }
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -487,7 +487,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     return [
       '_selectedItemsChanged(selectedItems, selectedItems.*)',
       '__updateOverflowChip(_overflow, _overflowItems, disabled, readonly)',
-      '__updateTopGroup(selectedItems, opened)',
+      '__updateTopGroup(groupSelectedItems, selectedItems, opened)',
     ];
   }
 
@@ -841,8 +841,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
-  __updateTopGroup(selectedItems, opened) {
-    if (!opened) {
+  __updateTopGroup(groupSelectedItems, selectedItems, opened) {
+    if (groupSelectedItems && !opened) {
       this._topGroup = [...selectedItems];
     }
   }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -842,7 +842,9 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
   /** @private */
   __updateTopGroup(groupSelectedItems, selectedItems, opened) {
-    if (groupSelectedItems && !opened) {
+    if (!groupSelectedItems) {
+      this._topGroup = [];
+    } else if (!opened) {
       this._topGroup = [...selectedItems];
     }
   }

--- a/packages/multi-select-combo-box/test/helpers.js
+++ b/packages/multi-select-combo-box/test/helpers.js
@@ -15,3 +15,21 @@ export const getAsyncDataProvider = (allItems) => {
     }, 0);
   };
 };
+
+/**
+ * Returns all the items of the combo box dropdown.
+ */
+export const getAllItems = (comboBox) => {
+  const internal = comboBox.$.comboBox;
+  return Array.from(internal._scroller.querySelectorAll('vaadin-multi-select-combo-box-item'))
+    .filter((item) => !item.hidden)
+    .sort((a, b) => a.index - b.index);
+};
+
+/**
+ * Returns first item of the combo box dropdown.
+ */
+export const getFirstItem = (comboBox) => {
+  const internal = comboBox.$.comboBox;
+  return internal._scroller.querySelector('vaadin-multi-select-combo-box-item');
+};

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -4,7 +4,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-multi-select-combo-box.js';
-import { getDataProvider } from './helpers.js';
+import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
 
 describe('selecting items', () => {
   let comboBox, internal, inputElement;
@@ -159,6 +159,80 @@ describe('selecting items', () => {
       comboBox.autoOpenDisabled = true;
       await sendKeys({ type: 'lime' });
       verifyEnterKeyPropagation(false);
+    });
+  });
+
+  describe('group selected items', () => {
+    function expectItems(values) {
+      getAllItems(comboBox).forEach((item, idx) => {
+        expect(item.textContent).to.equal(values[idx]);
+      });
+    }
+
+    beforeEach(() => {
+      comboBox.groupSelectedItems = true;
+    });
+
+    describe('items', () => {
+      beforeEach(() => {
+        comboBox.items = ['a', 'b', 'c', 'd', 'e'];
+        comboBox.selectedItems = ['c', 'd'];
+      });
+
+      it('should show selected items at the top of the overlay', () => {
+        comboBox.opened = true;
+        expectItems(['c', 'd', 'a', 'b', 'e']);
+      });
+
+      it('should update dropdown items after overlay is re-opened', () => {
+        comboBox.opened = true;
+        getFirstItem(comboBox).click();
+        expectItems(['c', 'd', 'a', 'b', 'e']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['d', 'a', 'b', 'c', 'e']);
+      });
+
+      it('should update dropdown items after clearing and re-opening', () => {
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        comboBox.$.clearButton.click();
+        expectItems(['c', 'd', 'a', 'b', 'e']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['a', 'b', 'c', 'd', 'e']);
+      });
+    });
+
+    describe('dataProvider', () => {
+      beforeEach(() => {
+        comboBox.dataProvider = getDataProvider(['a', 'b', 'c', 'd', 'e']);
+        comboBox.selectedItems = ['c', 'd'];
+      });
+
+      it('should show selected items at the top of the overlay', () => {
+        comboBox.opened = true;
+        expectItems(['c', 'd', 'a', 'b', 'e']);
+      });
+
+      it('should update dropdown items after overlay is re-opened', () => {
+        comboBox.opened = true;
+        getFirstItem(comboBox).click();
+        expectItems(['c', 'd', 'a', 'b', 'e']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['d', 'a', 'b', 'c', 'e']);
+      });
+
+      it('should update dropdown items after clearing and re-opening', () => {
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        comboBox.$.clearButton.click();
+        expectItems(['c', 'd', 'a', 'b', 'e']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['a', 'b', 'c', 'd', 'e']);
+      });
     });
   });
 });

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -216,6 +216,15 @@ describe('selecting items', () => {
         await sendKeys({ type: 'a' });
         expectItems(['orange', 'apple', 'banana']);
       });
+
+      it('should restore items when groupSelectedItems is set to false', () => {
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.groupSelectedItems = false;
+        comboBox.opened = true;
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
     });
 
     describe('dataProvider', () => {
@@ -259,6 +268,15 @@ describe('selecting items', () => {
         comboBox.inputElement.focus();
         await sendKeys({ type: 'a' });
         expectItems(['orange', 'apple', 'banana']);
+      });
+
+      it('should restore items when groupSelectedItems is set to false', () => {
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.groupSelectedItems = false;
+        comboBox.opened = true;
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
     });
   });

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -175,63 +175,89 @@ describe('selecting items', () => {
 
     describe('items', () => {
       beforeEach(() => {
-        comboBox.items = ['a', 'b', 'c', 'd', 'e'];
-        comboBox.selectedItems = ['c', 'd'];
+        comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+        comboBox.selectedItems = ['lemon', 'orange'];
       });
 
       it('should show selected items at the top of the overlay', () => {
         comboBox.opened = true;
-        expectItems(['c', 'd', 'a', 'b', 'e']);
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+      });
+
+      it('should only show selected items when readonly is true', () => {
+        comboBox.readonly = true;
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange']);
       });
 
       it('should update dropdown items after overlay is re-opened', () => {
         comboBox.opened = true;
         getFirstItem(comboBox).click();
-        expectItems(['c', 'd', 'a', 'b', 'e']);
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
         comboBox.opened = false;
         comboBox.opened = true;
-        expectItems(['d', 'a', 'b', 'c', 'e']);
+        expectItems(['orange', 'apple', 'banana', 'lemon']);
       });
 
       it('should update dropdown items after clearing and re-opening', () => {
         comboBox.clearButtonVisible = true;
         comboBox.opened = true;
         comboBox.$.clearButton.click();
-        expectItems(['c', 'd', 'a', 'b', 'e']);
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
         comboBox.opened = false;
         comboBox.opened = true;
-        expectItems(['a', 'b', 'c', 'd', 'e']);
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
+
+      it('should show correct items when internal filtering applied', async () => {
+        comboBox.opened = true;
+        comboBox.inputElement.focus();
+        await sendKeys({ type: 'a' });
+        expectItems(['orange', 'apple', 'banana']);
       });
     });
 
     describe('dataProvider', () => {
       beforeEach(() => {
-        comboBox.dataProvider = getDataProvider(['a', 'b', 'c', 'd', 'e']);
-        comboBox.selectedItems = ['c', 'd'];
+        comboBox.dataProvider = getDataProvider(['apple', 'banana', 'lemon', 'orange']);
+        comboBox.selectedItems = ['lemon', 'orange'];
       });
 
       it('should show selected items at the top of the overlay', () => {
         comboBox.opened = true;
-        expectItems(['c', 'd', 'a', 'b', 'e']);
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+      });
+
+      it('should only show selected items when readonly is true', () => {
+        comboBox.readonly = true;
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange']);
       });
 
       it('should update dropdown items after overlay is re-opened', () => {
         comboBox.opened = true;
         getFirstItem(comboBox).click();
-        expectItems(['c', 'd', 'a', 'b', 'e']);
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
         comboBox.opened = false;
         comboBox.opened = true;
-        expectItems(['d', 'a', 'b', 'c', 'e']);
+        expectItems(['orange', 'apple', 'banana', 'lemon']);
       });
 
       it('should update dropdown items after clearing and re-opening', () => {
         comboBox.clearButtonVisible = true;
         comboBox.opened = true;
         comboBox.$.clearButton.click();
-        expectItems(['c', 'd', 'a', 'b', 'e']);
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
         comboBox.opened = false;
         comboBox.opened = true;
-        expectItems(['a', 'b', 'c', 'd', 'e']);
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
+
+      it('should show correct items when internal filtering applied', async () => {
+        comboBox.opened = true;
+        comboBox.inputElement.focus();
+        await sendKeys({ type: 'a' });
+        expectItems(['orange', 'apple', 'banana']);
       });
     });
   });

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -164,8 +164,9 @@ describe('selecting items', () => {
 
   describe('group selected items', () => {
     function expectItems(values) {
-      getAllItems(comboBox).forEach((item, idx) => {
-        expect(item.textContent).to.equal(values[idx]);
+      const items = getAllItems(comboBox);
+      values.forEach((value, idx) => {
+        expect(items[idx].textContent).to.equal(value);
       });
     }
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -104,6 +104,7 @@ assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
 assertType<string>(narrowedComboBox.overlayClass);
+assertType<boolean>(narrowedComboBox.groupSelectedItems);
 
 // Mixins
 assertType<ControllerMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

Part of #4185

Added `groupSelectedItems` property that affects how `vaadin-multi-select-combo-box` overlay items are shown.

- Internal `_topGroup` property is used to store selected items. This property is only updated when the overlay is closed, so that selecting or deselecting an item doesn't move it in the overlay immediately.
- Re-introduced `_dropdownItems` property previously removed in #4019 to easily distinguish items that are actually shown in the dropdown vs `filteredItems` array, and prevent mutating it.

## Type of change

- Feature