### PR TITLE
feat: add --vaadin-app-layout-drawer-width CSS property

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -121,6 +121,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
           height: 100%;
           --vaadin-app-layout-transition: 200ms;
           transition: padding var(--vaadin-app-layout-transition);
+          --vaadin-app-layout-drawer-width: 16em;
           --vaadin-app-layout-touch-optimized: false;
           --vaadin-app-layout-navbar-offset-top: var(--_vaadin-app-layout-navbar-offset-size);
           --vaadin-app-layout-navbar-offset-bottom: var(--_vaadin-app-layout-navbar-offset-size-bottom);
@@ -196,7 +197,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
           transition: transform var(--vaadin-app-layout-transition), visibility var(--vaadin-app-layout-transition);
           transform: translateX(-100%);
           max-width: 90%;
-          width: 16em;
+          width: var(--vaadin-app-layout-drawer-width);
           box-sizing: border-box;
           padding: var(--safe-area-inset-top) 0 var(--safe-area-inset-bottom) var(--safe-area-inset-left);
           outline: none;
@@ -260,10 +261,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         @media (max-width: 800px), (max-height: 600px) {
           :host {
             --vaadin-app-layout-drawer-overlay: true;
-          }
-
-          [part='drawer'] {
-            width: 20em;
+            --vaadin-app-layout-drawer-width: 20em;
           }
         }
 

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -121,7 +121,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
           height: 100%;
           --vaadin-app-layout-transition: 200ms;
           transition: padding var(--vaadin-app-layout-transition);
-          --vaadin-app-layout-drawer-width: 16em;
+          --_vaadin-app-layout-drawer-width: var(--vaadin-app-layout-drawer-width, 16em);
           --vaadin-app-layout-touch-optimized: false;
           --vaadin-app-layout-navbar-offset-top: var(--_vaadin-app-layout-navbar-offset-size);
           --vaadin-app-layout-navbar-offset-bottom: var(--_vaadin-app-layout-navbar-offset-size-bottom);
@@ -197,7 +197,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
           transition: transform var(--vaadin-app-layout-transition), visibility var(--vaadin-app-layout-transition);
           transform: translateX(-100%);
           max-width: 90%;
-          width: var(--vaadin-app-layout-drawer-width);
+          width: var(--_vaadin-app-layout-drawer-width);
           box-sizing: border-box;
           padding: var(--safe-area-inset-top) 0 var(--safe-area-inset-bottom) var(--safe-area-inset-left);
           outline: none;
@@ -261,7 +261,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         @media (max-width: 800px), (max-height: 600px) {
           :host {
             --vaadin-app-layout-drawer-overlay: true;
-            --vaadin-app-layout-drawer-width: 20em;
+            --_vaadin-app-layout-drawer-width: var(--vaadin-app-layout-drawer-width, 20em);
           }
         }
 

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -139,7 +139,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         }
 
         :host([drawer-opened]) {
-          --vaadin-app-layout-drawer-offset-left: var(--_vaadin-app-layout-drawer-offset-size);
+          --vaadin-app-layout-drawer-offset-left: var(--_vaadin-app-layout-drawer-width);
         }
 
         :host([overlay]) {
@@ -589,11 +589,6 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
     this.style.setProperty('--_vaadin-app-layout-navbar-offset-size', `${navbarRect.height}px`);
     this.style.setProperty('--_vaadin-app-layout-navbar-offset-size-bottom', `${navbarBottomRect.height}px`);
-
-    const drawer = this.$.drawer;
-    const drawerRect = drawer.getBoundingClientRect();
-
-    this.style.setProperty('--_vaadin-app-layout-drawer-offset-size', `${drawerRect.width}px`);
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Adds the `--vaadin-app-layout-drawer-width` to be used as the value to be set as width to the drawer part of the App Layout. 

Fixes #950

## Type of change

- [ ] Bugfix
- [X] Feature
