### PR TITLE
fix: move tooltip static methods types back to the class

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
@@ -29,24 +29,6 @@ export declare function TooltipMixin<T extends Constructor<HTMLElement>>(
 
 export declare class TooltipMixinClass {
   /**
-   * Sets the default focus delay to be used by all tooltip instances,
-   * except for those that have focus delay configured using property.
-   */
-  static setDefaultFocusDelay(focusDelay: number): void;
-
-  /**
-   * Sets the default hide delay to be used by all tooltip instances,
-   * except for those that have hide delay configured using property.
-   */
-  static setDefaultHideDelay(hideDelay: number): void;
-
-  /**
-   * Sets the default hover delay to be used by all tooltip instances,
-   * except for those that have hover delay configured using property.
-   */
-  static setDefaultHoverDelay(delay: number): void;
-
-  /**
    * Element used to link with the `aria-describedby`
    * attribute. Supports array of multiple elements.
    * When not set, defaults to `target`.

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -48,7 +48,25 @@ export { TooltipPosition } from './vaadin-tooltip-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
-declare class Tooltip extends TooltipMixin(ThemePropertyMixin(ControllerMixin(ElementMixin(HTMLElement)))) {}
+declare class Tooltip extends TooltipMixin(ThemePropertyMixin(ControllerMixin(ElementMixin(HTMLElement)))) {
+  /**
+   * Sets the default focus delay to be used by all tooltip instances,
+   * except for those that have focus delay configured using property.
+   */
+  static setDefaultFocusDelay(focusDelay: number): void;
+
+  /**
+   * Sets the default hide delay to be used by all tooltip instances,
+   * except for those that have hide delay configured using property.
+   */
+  static setDefaultHideDelay(hideDelay: number): void;
+
+  /**
+   * Sets the default hover delay to be used by all tooltip instances,
+   * except for those that have hover delay configured using property.
+   */
+  static setDefaultHoverDelay(delay: number): void;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/tooltip/test/typings/tooltip.types.ts
+++ b/packages/tooltip/test/typings/tooltip.types.ts
@@ -2,7 +2,7 @@ import '../../vaadin-tooltip.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
-import type { TooltipPosition } from '../../vaadin-tooltip.js';
+import { Tooltip, type TooltipPosition } from '../../vaadin-tooltip.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -28,3 +28,7 @@ assertType<number>(tooltip.hoverDelay);
 assertType<TooltipPosition>(tooltip.position);
 assertType<string>(tooltip.overlayClass);
 assertType<(target: HTMLElement, context?: Record<string, unknown>) => boolean>(tooltip.shouldShow);
+
+Tooltip.setDefaultFocusDelay(1);
+Tooltip.setDefaultHideDelay(1);
+Tooltip.setDefaultHoverDelay(1);


### PR DESCRIPTION
## Description

This PR fixes a regression introduced in #6532 when extracting `vaadin-tooltip` code into mixin.

Apparently the approach that we use for typing mixins with `Constructor` helper type only allows us to type instances of the class, but not the class itself. So in case of `Tooltip` we have to specify static class methods on the class.

## Type of change

- Bugfix