### PR TITLE
docs: add toolbar-button-pressed entry in parts list

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -64,6 +64,7 @@ export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEdi
  * `toolbar-group-block`                | The group for preformatted block controls
  * `toolbar-group-format`               | The group for format controls
  * `toolbar-button`                     | The toolbar button (applies to all buttons)
+ * `toolbar-button-pressed`             | The toolbar button in pressed state (applies to all buttons)
  * `toolbar-button-undo`                | The "undo" button
  * `toolbar-button-redo`                | The "redo" button
  * `toolbar-button-bold`                | The "bold" button

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -62,6 +62,7 @@ registerStyles('vaadin-rich-text-editor', richTextEditorStyles, { moduleId: 'vaa
  * `toolbar-group-block`                | The group for preformatted block controls
  * `toolbar-group-format`               | The group for format controls
  * `toolbar-button`                     | The toolbar button (applies to all buttons)
+ * `toolbar-button-pressed`             | The toolbar button in pressed state (applies to all buttons)
  * `toolbar-button-undo`                | The "undo" button
  * `toolbar-button-redo`                | The "redo" button
  * `toolbar-button-bold`                | The "bold" button


### PR DESCRIPTION
## Description

Add missing entries for the `toolbar-button-pressed` part name to the part listing in docs.