### PR TITLE
fix: define drawer width private prop based on child count

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -566,8 +566,10 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
 
     if (childCount === 0) {
       drawer.setAttribute('hidden', '');
+      this.style.setProperty('--_vaadin-app-layout-drawer-width', 0);
     } else {
       drawer.removeAttribute('hidden');
+      this.style.removeProperty('--_vaadin-app-layout-drawer-width');
     }
     this._updateOffsetSize();
   }

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -245,11 +245,20 @@ describe('vaadin-app-layout', () => {
         expect(spy.calledTwice).to.be.true;
       });
 
-      it('should hide drawer if corresponding slot has no content', async () => {
+      it('should hide/unhide drawer if corresponding slot depending on the number of content', async () => {
         const section = layout.querySelector('[slot="drawer"]');
+        const initialPadding = getComputedStyle(layout).paddingInlineStart;
         section.parentNode.removeChild(section);
         await nextFrame();
+
         expect(drawer.hasAttribute('hidden')).to.be.true;
+        expect(getComputedStyle(layout).paddingInlineStart).to.be.equal('0px');
+
+        layout.appendChild(section);
+        await nextFrame();
+
+        expect(drawer.hasAttribute('hidden')).to.be.false;
+        expect(getComputedStyle(layout).paddingInlineStart).to.be.equal(initialPadding);
       });
 
       it('should not close the drawer on navigation event', () => {


### PR DESCRIPTION
## Description

Set the value of the `--_vaadin-app-layout-drawer-width` CSS property to `0` if there's no child of the drawer slot attached.

Make sure to remove the property when the drawer has any children.

Fixes #6699

## Type of change

- [X] Bugfix
- [ ] Feature
