### PR TITLE
feat: always show at least last selected item as a chip

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -146,6 +146,7 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * `--vaadin-field-default-width`                       | Default width of the field | `12em`
  * `--vaadin-multi-select-combo-box-overlay-width`      | Width of the overlay       | `auto`
  * `--vaadin-multi-select-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
+ * `--vaadin-multi-select-combo-box-chip-min-width`     | Min width of the chip      | `50px`
  * `--vaadin-multi-select-combo-box-input-min-width`    | Min width of the input     | `4em`
  *
  * ### Internal components

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -944,7 +944,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       remainingWidth -= this.__getOverflowWidth();
     }
 
-    const chipMinWidth = parseInt(getComputedStyle(this).getPropertyValue('--chip-min-width'));
+    const chipMinWidth = parseInt(getComputedStyle(this).getPropertyValue('--_chip-min-width'));
 
     // Add chips until remaining width is exceeded
     for (let i = items.length - 1, refNode = null; i >= 0; i--) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -23,6 +23,7 @@ import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixi
 const multiSelectComboBox = css`
   :host {
     --input-min-width: var(--vaadin-multi-select-combo-box-input-min-width, 4em);
+    --chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, 50px);
   }
 
   #chips {
@@ -111,6 +112,7 @@ registerStyles('vaadin-multi-select-combo-box', [inputFieldShared, multiSelectCo
  * `--vaadin-field-default-width`                       | Default width of the field | `12em`
  * `--vaadin-multi-select-combo-box-overlay-width`      | Width of the overlay       | `auto`
  * `--vaadin-multi-select-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
+ * `--vaadin-multi-select-combo-box-chip-min-width`     | Min width of the chip      | `50px`
  * `--vaadin-multi-select-combo-box-input-min-width`    | Min width of the input     | `4em`
  *
  * ### Internal components
@@ -942,6 +944,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       remainingWidth -= this.__getOverflowWidth();
     }
 
+    const chipMinWidth = parseInt(getComputedStyle(this).getPropertyValue('--chip-min-width'));
+
     // Add chips until remaining width is exceeded
     for (let i = items.length - 1, refNode = null; i >= 0; i--) {
       const chip = this.__createChip(items[i]);
@@ -949,8 +953,13 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
       // If all the chips are visible, no need to measure remaining width
       if (!this.allChipsVisible && this.$.chips.clientWidth > remainingWidth) {
-        chip.remove();
-        break;
+        // Always show at least last selected item as a chip
+        if (refNode === null) {
+          chip.style.maxWidth = `${Math.max(chipMinWidth, remainingWidth)}px`;
+        } else {
+          chip.remove();
+          break;
+        }
       }
 
       items.pop();

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -23,7 +23,7 @@ import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixi
 const multiSelectComboBox = css`
   :host {
     --input-min-width: var(--vaadin-multi-select-combo-box-input-min-width, 4em);
-    --chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, 50px);
+    --_chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, 50px);
   }
 
   #chips {

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -200,6 +200,31 @@ describe('chips', () => {
         await nextRender();
         expect(overflow.hasAttribute('hidden')).to.be.true;
       });
+
+      it('should always show at least one chip in addition to overflow', async () => {
+        comboBox.style.width = 'auto';
+        await nextResize(comboBox);
+
+        comboBox.selectedItems = ['apple', 'orange'];
+        await nextRender();
+
+        const chips = getChips(comboBox);
+        expect(chips.length).to.equal(2);
+        expect(getChipContent(chips[1])).to.equal('orange');
+      });
+
+      it('should set show max width on the chip based on CSS property', async () => {
+        comboBox.style.width = 'auto';
+        comboBox.clearButtonVisible = true;
+        await nextResize(comboBox);
+
+        comboBox.selectedItems = ['apple', 'orange'];
+        await nextRender();
+
+        const chips = getChips(comboBox);
+        const minWidth = getComputedStyle(comboBox).getPropertyValue('--chip-min-width');
+        expect(chips[1].style.maxWidth).to.equal(minWidth);
+      });
     });
   });
 

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -222,7 +222,7 @@ describe('chips', () => {
         await nextRender();
 
         const chips = getChips(comboBox);
-        const minWidth = getComputedStyle(comboBox).getPropertyValue('--chip-min-width');
+        const minWidth = getComputedStyle(comboBox).getPropertyValue('--_chip-min-width');
         expect(chips[1].style.maxWidth).to.equal(minWidth);
       });
     });


### PR DESCRIPTION
## Description

Fixes #4821

Added `--vaadin-multi-select-combo-box-chip-min-width` custom CSS property with the default value of 50px, which allows to fit one letter plus ellipsis, while also keeping enough space for the `<input>` element and clear button.

## Type of change

- Feature

## Before

<img width="216" alt="Screenshot 2023-10-26 at 15 44 51" src="https://github.com/vaadin/web-components/assets/10589913/a58049b5-5e98-4872-8220-636e489821c0">

## After

<img width="219" alt="Screenshot 2023-10-26 at 15 44 28" src="https://github.com/vaadin/web-components/assets/10589913/90e59818-cdc2-42ef-bff0-e3b374880a72">

