### PR TITLE
feat: add part  in custom-field

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -72,7 +72,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
- * `input-field`        | The slotted input elements wrapper
+ * `input-fields`        | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -72,7 +72,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
- * `input-fields`        | The slotted input elements wrapper
+ * `input-fields`       | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -72,6 +72,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
+ * `input-wrapper`      | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -72,7 +72,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
- * `input`              | The slotted input elements wrapper
+ * `input-field`        | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -72,7 +72,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
- * `input-wrapper`      | The slotted input elements wrapper
+ * `input`              | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -32,7 +32,7 @@ registerStyles('vaadin-custom-field', customFieldStyles, { moduleId: 'vaadin-cus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
- * `input-wrapper`      | The slotted input elements wrapper
+ * `input`              | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *
@@ -75,7 +75,7 @@ class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolymerEle
           <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
-        <div class="inputs-wrapper" part="input-wrapper" on-change="_onInputChange">
+        <div class="inputs-wrapper" part="input" on-change="_onInputChange">
           <slot id="slot"></slot>
         </div>
 

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -32,7 +32,7 @@ registerStyles('vaadin-custom-field', customFieldStyles, { moduleId: 'vaadin-cus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
- * `input`              | The slotted input elements wrapper
+ * `input-fields`       | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *
@@ -75,7 +75,7 @@ class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolymerEle
           <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
-        <div class="inputs-wrapper" part="input" on-change="_onInputChange">
+        <div class="inputs-wrapper" part="input-fields" on-change="_onInputChange">
           <slot id="slot"></slot>
         </div>
 

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -32,6 +32,7 @@ registerStyles('vaadin-custom-field', customFieldStyles, { moduleId: 'vaadin-cus
  * `helper-text`        | The slotted helper text element wrapper
  * `error-message`      | The slotted error message element wrapper
  * `required-indicator` | The `required` state indicator element
+ * `input-wrapper`      | The slotted input elements wrapper
  *
  * The following state attributes are available for styling:
  *
@@ -74,7 +75,7 @@ class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolymerEle
           <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
-        <div class="inputs-wrapper" on-change="_onInputChange">
+        <div class="inputs-wrapper" part="input-wrapper" on-change="_onInputChange">
           <slot id="slot"></slot>
         </div>
 

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -124,7 +124,7 @@ snapshots["vaadin-custom-field shadow default"] =
   </div>
   <div
     class="inputs-wrapper"
-    part="input-wrapper"
+    part="input"
   >
     <slot id="slot">
     </slot>

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -124,7 +124,7 @@ snapshots["vaadin-custom-field shadow default"] =
   </div>
   <div
     class="inputs-wrapper"
-    part="input"
+    part="input-fields"
   >
     <slot id="slot">
     </slot>

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -122,7 +122,10 @@ snapshots["vaadin-custom-field shadow default"] =
     >
     </span>
   </div>
-  <div class="inputs-wrapper">
+  <div
+    class="inputs-wrapper"
+    part="input-wrapper"
+  >
     <slot id="slot">
     </slot>
   </div>


### PR DESCRIPTION
## Description

Add `input-wrapper` part name to the input wrapper elements in `<vaadin-custom-field>`

Fixes #4263

## Type of change

- [ ] Bugfix
- [X] Feature
