### PR TITLE
fix: use correct indeterminate checkmark property name

### DIFF
--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -79,7 +79,7 @@ registerStyles(
 
     /* Indeterminate checkmark */
     :host([indeterminate]) [part='checkbox']::after {
-      content: var(--vaadin-checkbox-checkmark-char-intermediate, '');
+      content: var(--vaadin-checkbox-checkmark-char-indeterminate, '');
       opacity: 1;
       top: 45%;
       height: 10%;

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -56,7 +56,7 @@ const globals = css`
     --vaadin-checkbox-background-hover: var(--lumo-contrast-30pct);
     --vaadin-checkbox-border-radius: var(--lumo-border-radius-s);
     --vaadin-checkbox-checkmark-char: var(--lumo-icons-checkmark);
-    --vaadin-checkbox-checkmark-char-intermediate: '';
+    --vaadin-checkbox-checkmark-char-indeterminate: '';
     --vaadin-checkbox-checkmark-color: var(--lumo-primary-contrast-color);
     --vaadin-checkbox-checkmark-size: calc(var(--vaadin-checkbox-size) + 2px);
     --vaadin-checkbox-label-color: var(--lumo-body-text-color);


### PR DESCRIPTION
## Description

Fixed a typo in the recently added custom CSS property: `intermediate` -> `indeterminate`.

## Type of change

- Bugfix