### PR TITLE
fix: do not show selected items on top when filter applied

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -165,7 +165,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * @override
    */
   _setDropdownItems(items) {
-    if (this.readonly || !this.groupSelectedItems) {
+    if (this.filter || this.readonly || !this.groupSelectedItems) {
       this._dropdownItems = items;
       return;
     }

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -210,11 +210,11 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
 
-      it('should show correct items when internal filtering applied', async () => {
+      it('should not show selected items on top when internal filtering applied', async () => {
         comboBox.opened = true;
         comboBox.inputElement.focus();
         await sendKeys({ type: 'a' });
-        expectItems(['orange', 'apple', 'banana']);
+        expectItems(['apple', 'banana', 'orange']);
       });
 
       it('should restore items when groupSelectedItems is set to false', () => {
@@ -263,11 +263,11 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
 
-      it('should show correct items when internal filtering applied', async () => {
+      it('should not show selected items on top when internal filtering applied', async () => {
         comboBox.opened = true;
         comboBox.inputElement.focus();
         await sendKeys({ type: 'a' });
-        expectItems(['orange', 'apple', 'banana']);
+        expectItems(['apple', 'banana', 'orange']);
       });
 
       it('should restore items when groupSelectedItems is set to false', () => {


### PR DESCRIPTION
## Description

Implemented this requirement from the original issue: https://github.com/vaadin/web-components/issues/4185

> When filtering is active (i.e. the filter field is non-empty), this top-grouping of selected items should not be used.

Previously, top group was shown also with `filter` set, but with selected items not on the first page it wouldn't work. 

This problem was originally discussed in #6717 but I decided to extract it into separate PR.

## Type of change

- Bugfix