### PR TITLE
feat: add property to group selected overlay items at the top (#6685) (CP: 23.4)

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -168,20 +168,17 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
       return;
     }
 
-    if (this.topGroup) {
-      const filteredTopItems = [];
-      const filteredItems = [];
+    if (items && items.length && this.topGroup && this.topGroup.length) {
+      // Filter out items included to the top group.
+      const filteredItems = items.filter(
+        (item) => !this.topGroup.some((selectedItem) => this._getItemValue(item) === this._getItemValue(selectedItem)),
+      );
 
-      (items || []).forEach((item) => {
-        if (this.topGroup.some((selectedItem) => this._getItemValue(item) === this._getItemValue(selectedItem))) {
-          filteredTopItems.push(item);
-        } else {
-          filteredItems.push(item);
-        }
-      });
-
-      this._dropdownItems = [...filteredTopItems, ...filteredItems];
+      this._dropdownItems = this.topGroup.concat(filteredItems);
+      return;
     }
+
+    this._dropdownItems = items;
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -163,7 +163,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * @override
    */
   _setDropdownItems(items) {
-    if (this.readonly || !this.groupSelectedItems) {
+    if (this.filter || this.readonly || !this.groupSelectedItems) {
       this._dropdownItems = items;
       return;
     }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -59,15 +59,6 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
       },
 
       /**
-       * Set to true to group selected items at the top of the overlay.
-       * @attr {boolean} group-selected-items
-       */
-      groupSelectedItems: {
-        type: Boolean,
-        value: false,
-      },
-
-      /**
        * When set to `true`, "loading" attribute is set
        * on the host and the overlay element.
        * @type {boolean}
@@ -93,6 +84,15 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
       selectedItems: {
         type: Array,
         value: () => [],
+      },
+
+      /**
+       * Set to true to group selected items at the top of the overlay.
+       * @attr {boolean} selected-items-on-top
+       */
+      selectedItemsOnTop: {
+        type: Boolean,
+        value: false,
       },
 
       /**
@@ -163,7 +163,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * @override
    */
   _setDropdownItems(items) {
-    if (this.filter || this.readonly || !this.groupSelectedItems) {
+    if (this.filter || this.readonly || !this.selectedItemsOnTop) {
       this._dropdownItems = items;
       return;
     }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -205,6 +205,12 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   filter: string;
 
   /**
+   * Set to true to group selected items at the top of the overlay.
+   * @attr {boolean} group-selected-items
+   */
+  groupSelectedItems: boolean;
+
+  /**
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -205,12 +205,6 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   filter: string;
 
   /**
-   * Set to true to group selected items at the top of the overlay.
-   * @attr {boolean} group-selected-items
-   */
-  groupSelectedItems: boolean;
-
-  /**
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */
@@ -300,6 +294,12 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
    * Note: modifying the selected items creates a new array each time.
    */
   selectedItems: TItem[];
+
+  /**
+   * Set to true to group selected items at the top of the overlay.
+   * @attr {boolean} selected-items-on-top
+   */
+  selectedItemsOnTop: boolean;
 
   /**
    * Total number of items.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -167,7 +167,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           size="{{size}}"
           filtered-items="[[__effectiveFilteredItems]]"
           selected-items="[[selectedItems]]"
-          group-selected-items="[[groupSelectedItems]]"
+          selected-items-on-top="[[selectedItemsOnTop]]"
           top-group="[[_topGroup]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
@@ -237,15 +237,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
         type: Boolean,
         reflectToAttribute: true,
         observer: '_clearButtonVisibleChanged',
-        value: false,
-      },
-
-      /**
-       * Set to true to group selected items at the top of the overlay.
-       * @attr {boolean} group-selected-items
-       */
-      groupSelectedItems: {
-        type: Boolean,
         value: false,
       },
 
@@ -442,6 +433,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       filteredItems: Array,
 
+      /**
+       * Set to true to group selected items at the top of the overlay.
+       * @attr {boolean} selected-items-on-top
+       */
+      selectedItemsOnTop: {
+        type: Boolean,
+        value: false,
+      },
+
       /** @private */
       value: {
         type: String,
@@ -487,7 +487,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   static get observers() {
     return [
       '_selectedItemsChanged(selectedItems, selectedItems.*)',
-      '__updateTopGroup(groupSelectedItems, selectedItems, opened)',
+      '__updateTopGroup(selectedItemsOnTop, selectedItems, opened)',
     ];
   }
 
@@ -845,8 +845,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   }
 
   /** @private */
-  __updateTopGroup(groupSelectedItems, selectedItems, opened) {
-    if (!groupSelectedItems) {
+  __updateTopGroup(selectedItemsOnTop, selectedItems, opened) {
+    if (!selectedItemsOnTop) {
       this._topGroup = [];
     } else if (!opened) {
       this._topGroup = [...selectedItems];

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -167,6 +167,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           size="{{size}}"
           filtered-items="[[__effectiveFilteredItems]]"
           selected-items="[[selectedItems]]"
+          group-selected-items="[[groupSelectedItems]]"
+          top-group="[[_topGroup]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
           theme$="[[_theme]]"
@@ -235,6 +237,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
         type: Boolean,
         reflectToAttribute: true,
         observer: '_clearButtonVisibleChanged',
+        value: false,
+      },
+
+      /**
+       * Set to true to group selected items at the top of the overlay.
+       * @attr {boolean} group-selected-items
+       */
+      groupSelectedItems: {
+        type: Boolean,
         value: false,
       },
 
@@ -465,11 +476,19 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       _lastFilter: {
         type: String,
       },
+
+      /** @private */
+      _topGroup: {
+        type: Array,
+      },
     };
   }
 
   static get observers() {
-    return ['_selectedItemsChanged(selectedItems, selectedItems.*)'];
+    return [
+      '_selectedItemsChanged(selectedItems, selectedItems.*)',
+      '__updateTopGroup(groupSelectedItems, selectedItems, opened)',
+    ];
   }
 
   /** @protected */
@@ -823,6 +842,15 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     this.validate();
 
     this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
+  }
+
+  /** @private */
+  __updateTopGroup(groupSelectedItems, selectedItems, opened) {
+    if (!groupSelectedItems) {
+      this._topGroup = [];
+    } else if (!opened) {
+      this._topGroup = [...selectedItems];
+    }
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/helpers.js
+++ b/packages/multi-select-combo-box/test/helpers.js
@@ -15,3 +15,21 @@ export const getAsyncDataProvider = (allItems) => {
     }, 0);
   };
 };
+
+/**
+ * Returns all the items of the combo box dropdown.
+ */
+export const getAllItems = (comboBox) => {
+  const internal = comboBox.$.comboBox;
+  return Array.from(internal._scroller.querySelectorAll('vaadin-multi-select-combo-box-item'))
+    .filter((item) => !item.hidden)
+    .sort((a, b) => a.index - b.index);
+};
+
+/**
+ * Returns first item of the combo box dropdown.
+ */
+export const getFirstItem = (comboBox) => {
+  const internal = comboBox.$.comboBox;
+  return internal._scroller.querySelector('vaadin-multi-select-combo-box-item');
+};

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -4,7 +4,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-multi-select-combo-box.js';
-import { getDataProvider } from './helpers.js';
+import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
 
 describe('selecting items', () => {
   let comboBox, internal, inputElement;
@@ -123,6 +123,125 @@ describe('selecting items', () => {
       await sendKeys({ type: 'orange' });
       await sendKeys({ down: 'Enter' });
       expect(comboBox.selectedItems).to.deep.equal(['orange']);
+    });
+  });
+
+  describe('group selected items', () => {
+    function expectItems(values) {
+      const items = getAllItems(comboBox);
+      values.forEach((value, idx) => {
+        expect(items[idx].textContent).to.equal(value);
+      });
+    }
+
+    beforeEach(() => {
+      comboBox.groupSelectedItems = true;
+    });
+
+    describe('items', () => {
+      beforeEach(() => {
+        comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+        comboBox.selectedItems = ['lemon', 'orange'];
+      });
+
+      it('should show selected items at the top of the overlay', () => {
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+      });
+
+      it('should only show selected items when readonly is true', () => {
+        comboBox.readonly = true;
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange']);
+      });
+
+      it('should update dropdown items after overlay is re-opened', () => {
+        comboBox.opened = true;
+        getFirstItem(comboBox).click();
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['orange', 'apple', 'banana', 'lemon']);
+      });
+
+      it('should update dropdown items after clearing and re-opening', () => {
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        comboBox.$.clearButton.click();
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
+
+      it('should show correct items when internal filtering applied', async () => {
+        comboBox.opened = true;
+        comboBox.inputElement.focus();
+        await sendKeys({ type: 'a' });
+        expectItems(['orange', 'apple', 'banana']);
+      });
+
+      it('should restore items when groupSelectedItems is set to false', () => {
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.groupSelectedItems = false;
+        comboBox.opened = true;
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
+    });
+
+    describe('dataProvider', () => {
+      beforeEach(() => {
+        comboBox.dataProvider = getDataProvider(['apple', 'banana', 'lemon', 'orange']);
+        comboBox.selectedItems = ['lemon', 'orange'];
+      });
+
+      it('should show selected items at the top of the overlay', () => {
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+      });
+
+      it('should only show selected items when readonly is true', () => {
+        comboBox.readonly = true;
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange']);
+      });
+
+      it('should update dropdown items after overlay is re-opened', () => {
+        comboBox.opened = true;
+        getFirstItem(comboBox).click();
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['orange', 'apple', 'banana', 'lemon']);
+      });
+
+      it('should update dropdown items after clearing and re-opening', () => {
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        comboBox.$.clearButton.click();
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.opened = true;
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
+
+      it('should show correct items when internal filtering applied', async () => {
+        comboBox.opened = true;
+        comboBox.inputElement.focus();
+        await sendKeys({ type: 'a' });
+        expectItems(['orange', 'apple', 'banana']);
+      });
+
+      it('should restore items when groupSelectedItems is set to false', () => {
+        comboBox.opened = true;
+        expectItems(['lemon', 'orange', 'apple', 'banana']);
+        comboBox.opened = false;
+        comboBox.groupSelectedItems = false;
+        comboBox.opened = true;
+        expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
     });
   });
 });

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -243,5 +243,48 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
     });
+
+    describe('lazy loading', () => {
+      let allItems;
+
+      beforeEach(() => {
+        allItems = Array.from({ length: 100 }, (_, i) => `item ${i}`);
+        comboBox.dataProvider = getDataProvider(allItems);
+        comboBox.groupSelectedItems = true;
+        comboBox.opened = true;
+      });
+
+      it('should show selected item on top when its page is not loaded yet', async () => {
+        comboBox.inputElement.focus();
+        await sendKeys({ type: '55' });
+
+        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'Enter' });
+
+        comboBox.opened = false;
+        comboBox.opened = true;
+
+        const item = getFirstItem(comboBox);
+        expect(item.label).to.equal('item 55');
+        expect(item.hasAttribute('selected')).to.be.true;
+      });
+
+      it('should not show selected item on top when filter is applied', async () => {
+        comboBox.inputElement.focus();
+        await sendKeys({ type: '55' });
+
+        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'Enter' });
+
+        comboBox.opened = false;
+        comboBox.opened = true;
+
+        await sendKeys({ type: '5' });
+
+        const item = getFirstItem(comboBox);
+        expect(item.label).to.equal('item 5');
+        expect(item.hasAttribute('selected')).to.be.false;
+      });
+    });
   });
 });

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -174,11 +174,11 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
 
-      it('should show correct items when internal filtering applied', async () => {
+      it('should not show selected items on top when internal filtering applied', async () => {
         comboBox.opened = true;
         comboBox.inputElement.focus();
         await sendKeys({ type: 'a' });
-        expectItems(['orange', 'apple', 'banana']);
+        expectItems(['apple', 'banana', 'orange']);
       });
 
       it('should restore items when groupSelectedItems is set to false', () => {
@@ -227,11 +227,11 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
 
-      it('should show correct items when internal filtering applied', async () => {
+      it('should not show selected items on top when internal filtering applied', async () => {
         comboBox.opened = true;
         comboBox.inputElement.focus();
         await sendKeys({ type: 'a' });
-        expectItems(['orange', 'apple', 'banana']);
+        expectItems(['apple', 'banana', 'orange']);
       });
 
       it('should restore items when groupSelectedItems is set to false', () => {

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -126,7 +126,7 @@ describe('selecting items', () => {
     });
   });
 
-  describe('group selected items', () => {
+  describe('selected items on top', () => {
     function expectItems(values) {
       const items = getAllItems(comboBox);
       values.forEach((value, idx) => {
@@ -135,7 +135,7 @@ describe('selecting items', () => {
     }
 
     beforeEach(() => {
-      comboBox.groupSelectedItems = true;
+      comboBox.selectedItemsOnTop = true;
     });
 
     describe('items', () => {
@@ -181,11 +181,11 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'orange']);
       });
 
-      it('should restore items when groupSelectedItems is set to false', () => {
+      it('should restore items when selectedItemsOnTop is set to false', () => {
         comboBox.opened = true;
         expectItems(['lemon', 'orange', 'apple', 'banana']);
         comboBox.opened = false;
-        comboBox.groupSelectedItems = false;
+        comboBox.selectedItemsOnTop = false;
         comboBox.opened = true;
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
@@ -234,11 +234,11 @@ describe('selecting items', () => {
         expectItems(['apple', 'banana', 'orange']);
       });
 
-      it('should restore items when groupSelectedItems is set to false', () => {
+      it('should restore items when selectedItemsOnTop is set to false', () => {
         comboBox.opened = true;
         expectItems(['lemon', 'orange', 'apple', 'banana']);
         comboBox.opened = false;
-        comboBox.groupSelectedItems = false;
+        comboBox.selectedItemsOnTop = false;
         comboBox.opened = true;
         expectItems(['apple', 'banana', 'lemon', 'orange']);
       });
@@ -250,7 +250,7 @@ describe('selecting items', () => {
       beforeEach(() => {
         allItems = Array.from({ length: 100 }, (_, i) => `item ${i}`);
         comboBox.dataProvider = getDataProvider(allItems);
-        comboBox.groupSelectedItems = true;
+        comboBox.selectedItemsOnTop = true;
         comboBox.opened = true;
       });
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -91,7 +91,7 @@ assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
 assertType<string | null | undefined>(narrowedComboBox.theme);
-assertType<boolean>(narrowedComboBox.groupSelectedItems);
+assertType<boolean>(narrowedComboBox.selectedItemsOnTop);
 
 // Mixins
 assertType<ControllerMixinClass>(narrowedComboBox);

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -91,6 +91,7 @@ assertType<boolean>(narrowedComboBox.readonly);
 assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
 assertType<string | null | undefined>(narrowedComboBox.theme);
+assertType<boolean>(narrowedComboBox.groupSelectedItems);
 
 // Mixins
 assertType<ControllerMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

This is a PR to backport `groupSelectedItems` property to `23.4` branch. It includes the following PRs:

- #6685
- #6717
- #6723
- #6754

## Type of change

- Featrue cherry-pick