### PR TITLE
fix: check if grid focus target is in viewport

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -691,7 +691,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       // If the target focusable is tied to a column that is not visible,
       // find the first visible column and update the target in order to
       // prevent scrolling to the start of the row.
-      if (focusStepTarget && focusStepTarget._column && !this.__isColumnInViewport(focusStepTarget._column)) {
+      if (focusStepTarget && !this.__isHorizontallyInViewport(focusStepTarget)) {
         const firstVisibleColumn = this._getColumnsInOrder().find((column) => this.__isColumnInViewport(column));
         if (firstVisibleColumn) {
           if (focusStepTarget === this._headerFocusable) {

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -321,9 +321,14 @@ export const ScrollMixin = (superClass) =>
       }
 
       // Check if the column's sizer cell is inside the viewport
+      return this.__isHorizontallyInViewport(column._sizerCell);
+    }
+
+    /** @private */
+    __isHorizontallyInViewport(element) {
       return (
-        column._sizerCell.offsetLeft + column._sizerCell.offsetWidth >= this._scrollLeft &&
-        column._sizerCell.offsetLeft <= this._scrollLeft + this.clientWidth
+        element.offsetLeft + element.offsetWidth >= this._scrollLeft &&
+        element.offsetLeft <= this._scrollLeft + this.clientWidth
       );
     }
 

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -1147,6 +1147,26 @@ describe('keyboard navigation', () => {
         shiftTab();
         expect(grid.$.table.scrollLeft).to.be.at.least(100);
       });
+
+      it('should not throw when focusing a group header cell', () => {
+        // Wrap the columns in a group
+        const group = document.createElement('vaadin-grid-column-group');
+        group.append(...grid.querySelectorAll('vaadin-grid-column'));
+        group.header = 'group';
+        grid.appendChild(group);
+        flushGrid(grid);
+
+        // Move focused header cell to the group header row
+        tabToBody();
+        shiftTab();
+        up();
+
+        // Tab to body
+        tab();
+
+        // Tab back to header
+        shiftTab();
+      });
     });
 
     describe('vertical scrolling', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/6724

Fixes https://github.com/vaadin/hilla/issues/1641

The issue was caused by keyboard navigation mixin [calling](https://github.com/vaadin/web-components/blob/9691021289293b040a850d2b3bbca5ea4cabcc4e/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js#L694) `__isColumnInViewport` without taking into account that the focus target could be a header/footer cell of a column group whereas the helper function only supports columns.

This PR adds a new helper `__isHorizontallyInViewport` to check if the given element is horizontally inside the viewport and updates the logic in keyboard navigation mixin to use it instead.

## Type of change

Bugfix