### PR TITLE
fix: check if grid focus target is in viewport (#6731)

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -662,7 +662,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       // If the target focusable is tied to a column that is not visible,
       // find the first visible column and update the target in order to
       // prevent scrolling to the start of the row.
-      if (focusStepTarget && focusStepTarget._column && !this.__isColumnInViewport(focusStepTarget._column)) {
+      if (focusStepTarget && !this.__isHorizontallyInViewport(focusStepTarget)) {
         const firstVisibleColumn = this._getColumnsInOrder().find((column) => this.__isColumnInViewport(column));
         if (firstVisibleColumn) {
           if (focusStepTarget === this._headerFocusable) {
@@ -688,9 +688,14 @@ export const KeyboardNavigationMixin = (superClass) =>
         // Assume frozen columns to always be inside the viewport
         return true;
       }
+      return this.__isHorizontallyInViewport(column._sizerCell);
+    }
+
+    /** @private */
+    __isHorizontallyInViewport(element) {
       return (
-        column._sizerCell.offsetLeft + column._sizerCell.offsetWidth >= this._scrollLeft &&
-        column._sizerCell.offsetLeft <= this._scrollLeft + this.clientWidth
+        element.offsetLeft + element.offsetWidth >= this._scrollLeft &&
+        element.offsetLeft <= this._scrollLeft + this.clientWidth
       );
     }
 

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1156,6 +1156,26 @@ describe('keyboard navigation', () => {
         shiftTab();
         expect(grid.$.table.scrollLeft).to.be.at.least(100);
       });
+
+      it('should not throw when focusing a group header cell', () => {
+        // Wrap the columns in a group
+        const group = document.createElement('vaadin-grid-column-group');
+        group.append(...grid.querySelectorAll('vaadin-grid-column'));
+        group.header = 'group';
+        grid.appendChild(group);
+        flushGrid(grid);
+
+        // Move focused header cell to the group header row
+        tabToBody();
+        shiftTab();
+        up();
+
+        // Tab to body
+        tab();
+
+        // Tab back to header
+        shiftTab();
+      });
     });
 
     describe('vertical scrolling', () => {


### PR DESCRIPTION
## Description

Manually cherry-pick https://github.com/vaadin/web-components/pull/6731 to `23.4`