### PR TITLE
refactor: use items api in grid-pro edit select

### DIFF
--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -42,8 +42,6 @@
     "@vaadin/checkbox": "24.3.0-alpha9",
     "@vaadin/component-base": "24.3.0-alpha9",
     "@vaadin/grid": "24.3.0-alpha9",
-    "@vaadin/item": "24.3.0-alpha9",
-    "@vaadin/list-box": "24.3.0-alpha9",
     "@vaadin/lit-renderer": "24.3.0-alpha9",
     "@vaadin/select": "24.3.0-alpha9",
     "@vaadin/text-field": "24.3.0-alpha9",

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -8,8 +8,6 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import '@vaadin/item/src/vaadin-item.js';
-import '@vaadin/list-box/src/vaadin-list-box.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { Select } from '@vaadin/select/src/vaadin-select.js';
 
@@ -108,20 +106,10 @@ class GridProEditSelect extends Select {
 
   _optionsChanged(options) {
     if (options && options.length) {
-      this.renderer = (root) => {
-        if (root.firstChild) {
-          return;
-        }
-        const listBox = document.createElement('vaadin-list-box');
-        listBox.selected = options.indexOf(this.value);
-        options.forEach((option) => {
-          const item = document.createElement('vaadin-item');
-          item.textContent = option;
-          listBox.appendChild(item);
-        });
-
-        root.appendChild(listBox);
-      };
+      this.items = options.map((option) => ({
+        label: option,
+        value: option,
+      }));
 
       this._overlayElement.addEventListener('vaadin-overlay-outside-click', () => {
         this._grid._stopEdit();

--- a/packages/grid-pro/test/edit-column-type.test.js
+++ b/packages/grid-pro/test/edit-column-type.test.js
@@ -172,7 +172,7 @@ describe('edit column editor type', () => {
         editor.opened = false;
         editor.focusElement.click();
         focusout(editor);
-        focusin(editor._overlayElement.querySelector('vaadin-item'));
+        focusin(editor._overlayElement.querySelector('vaadin-select-item'));
         grid._flushStopEdit();
         await nextRender(editor._menuElement);
         expect(editor.opened).to.equal(true);
@@ -206,7 +206,7 @@ describe('edit column editor type', () => {
 
       it('should update value and exit edit mode when item is selected', () => {
         grid.singleCellEdit = true;
-        const item = editor._overlayElement.querySelector('vaadin-item');
+        const item = editor._overlayElement.querySelector('vaadin-select-item');
         const value = item.textContent;
         const spy = sinon.spy(cell, 'focus');
         item.click();
@@ -217,7 +217,7 @@ describe('edit column editor type', () => {
 
       it('should work with `enterNextRow`', () => {
         grid.enterNextRow = true;
-        const item = editor._overlayElement.querySelector('vaadin-item');
+        const item = editor._overlayElement.querySelector('vaadin-select-item');
         enter(item);
         expect(column._getEditorComponent(cell)).to.not.be.ok;
         const secondCell = getContainerCell(grid.$.items, 1, 1);


### PR DESCRIPTION
## Description

Make `<vaadin-grid-pro>`'s built-in select editor use the `items` API instead of `renderer`.

This change simplifies the implementation and fixes the select overlay to use the correct tag names: `<vaadin-item>` -> `<vaadin-select-item>`, `<vaadin-list-box>` -> `<vaadin-select-list-box>`, 

## Type of change

Refactor