### PR TITLE
fix: update overlay width when selected items change

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -46,19 +46,24 @@ export const ComboBoxOverlayMixin = (superClass) =>
       return !eventPath.includes(this.positionTarget) && !eventPath.includes(this);
     }
 
+    /** @protected */
+    _updateOverlayWidth() {
+      const propPrefix = this.localName;
+      this.style.setProperty(`--_${propPrefix}-default-width`, `${this.positionTarget.clientWidth}px`);
+
+      const customWidth = getComputedStyle(this._comboBox).getPropertyValue(`--${propPrefix}-width`);
+
+      if (customWidth === '') {
+        this.style.removeProperty(`--${propPrefix}-width`);
+      } else {
+        this.style.setProperty(`--${propPrefix}-width`, customWidth);
+      }
+    }
+
     /** @private */
     _setOverlayWidth(positionTarget, opened) {
       if (positionTarget && opened) {
-        const propPrefix = this.localName;
-        this.style.setProperty(`--_${propPrefix}-default-width`, `${positionTarget.clientWidth}px`);
-
-        const customWidth = getComputedStyle(this._comboBox).getPropertyValue(`--${propPrefix}-width`);
-
-        if (customWidth === '') {
-          this.style.removeProperty(`--${propPrefix}-width`);
-        } else {
-          this.style.setProperty(`--${propPrefix}-width`, customWidth);
-        }
+        this._updateOverlayWidth();
 
         this._updatePosition();
       }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -783,6 +783,10 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     // Update selected for dropdown items
     this.requestContentUpdate();
+
+    if (this.opened) {
+      this.$.comboBox.$.overlay._updateOverlayWidth();
+    }
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -485,5 +485,24 @@ describe('chips', () => {
       await nextRender();
       expect(inputField.clientHeight).to.be.greaterThan(height);
     });
+
+    it('should adapt overlay width to the input field width while opened', async () => {
+      comboBox.allChipsVisible = true;
+      comboBox.style.width = 'auto';
+      comboBox.selectedItems = ['apple', 'banana', 'lemon', 'orange'];
+
+      await nextRender();
+      comboBox.opened = true;
+
+      const overlay = document.querySelector('vaadin-multi-select-combo-box-overlay');
+      const overlayPart = overlay.$.overlay;
+      const width = overlayPart.clientWidth;
+      expect(width).to.equal(comboBox.clientWidth);
+
+      comboBox.selectedItems = ['apple', 'banana'];
+      await nextRender();
+      expect(overlayPart.clientWidth).to.be.lessThan(width);
+      expect(overlayPart.clientWidth).to.be.equal(comboBox.clientWidth);
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #6755

Note: this issue is only reproducible when `allChipsVisible` is `true`, so we don't have to backport this fix.

## Type of change

- Bugfix