### PR TITLE
test: split grid pro tests into common and import files

### DIFF
--- a/packages/grid-pro/test/edit-column-polymer.test.js
+++ b/packages/grid-pro/test/edit-column-polymer.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro-edit-column.js';
+import './edit-column.common.js';

--- a/packages/grid-pro/test/edit-column-renderer-polymer.test.js
+++ b/packages/grid-pro/test/edit-column-renderer-polymer.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro-edit-column.js';
+import './edit-column-renderer.common.js';

--- a/packages/grid-pro/test/edit-column-renderer.common.js
+++ b/packages/grid-pro/test/edit-column-renderer.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { enter, esc, fixtureSync, focusout, nextFrame, space } from '@vaadin/testing-helpers';
 import { sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   createItems,

--- a/packages/grid-pro/test/edit-column-type-polymer.test.js
+++ b/packages/grid-pro/test/edit-column-type-polymer.test.js
@@ -1,0 +1,4 @@
+import './not-animated-styles.js';
+import '../theme/lumo/vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro-edit-column.js';
+import './edit-column-type.common.js';

--- a/packages/grid-pro/test/edit-column-type.common.js
+++ b/packages/grid-pro/test/edit-column-type.common.js
@@ -11,9 +11,6 @@ import {
   space,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 import { Checkbox } from '@vaadin/checkbox/src/vaadin-checkbox.js';
 import { Select } from '@vaadin/select/src/vaadin-select.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync, focusin, focusout, isIOS, tab } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 import {
   createItems,
   dblclick,

--- a/packages/grid-pro/test/grid-pro-polymer.test.js
+++ b/packages/grid-pro/test/grid-pro-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-grid-pro.js';
+import './grid-pro.common.js';

--- a/packages/grid-pro/test/grid-pro-polymer.test.js
+++ b/packages/grid-pro/test/grid-pro-polymer.test.js
@@ -1,2 +1,2 @@
-import '../vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro.js';
 import './grid-pro.common.js';

--- a/packages/grid-pro/test/grid-pro.common.js
+++ b/packages/grid-pro/test/grid-pro.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid-pro.js';
 import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
 import { flushGrid, infiniteDataProvider } from './helpers.js';

--- a/packages/grid-pro/test/keyboard-navigation-polymer.test.js
+++ b/packages/grid-pro/test/keyboard-navigation-polymer.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro-edit-column.js';
+import './keyboard-navigation.common.js';

--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, esc, fixtureSync, tab } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 import { createItems, dblclick, dragAndDropOver, flushGrid, getCellEditor, getContainerCell } from './helpers.js';
 
 describe('keyboard navigation', () => {

--- a/packages/grid-pro/test/lit-polymer.test.js
+++ b/packages/grid-pro/test/lit-polymer.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro-edit-column.js';
+import './lit.common.js';

--- a/packages/grid-pro/test/lit-renderer-directives-polymer.test.js
+++ b/packages/grid-pro/test/lit-renderer-directives-polymer.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-grid-pro.js';
+import '../theme/lumo/vaadin-grid-pro-edit-column.js';
+import './lit-renderer-directives.common.js';

--- a/packages/grid-pro/test/lit-renderer-directives.common.js
+++ b/packages/grid-pro/test/lit-renderer-directives.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 import { html, render } from 'lit';
 import { columnHeaderRenderer } from '@vaadin/grid/lit.js';
 import { columnEditModeRenderer } from '../lit.js';

--- a/packages/grid-pro/test/lit.common.js
+++ b/packages/grid-pro/test/lit.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { enter, fixtureSync, nextFrame, tab } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid-pro.js';
-import '../vaadin-grid-pro-edit-column.js';
 import { html, render } from 'lit';
 import { until } from 'lit/directives/until.js';
 import { flushGrid, getCellEditor } from './helpers.js';


### PR DESCRIPTION
## Description

In preparation for implementing the Lit-based grid-pro, split the current test files into two parts. The common part is a copy of the old test file with the grid imports removed where the `-polymer.test.js` files include imports for the Polymer-based grid-pro.
Any timing changes required by the Lit migration are excluded from this PR.

## Type of change

Tests