### PR TITLE
fix: use correct moduleId for login overlay Lumo styles (24.1)

### DIFF
--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -173,7 +173,7 @@ const loginOverlayWrapper = css`
 `;
 
 registerStyles('vaadin-login-overlay-wrapper', [color, typography, loginOverlayWrapper], {
-  moduleId: 'vaadin-login-overlay-wrapper-lumo-styles',
+  moduleId: 'lumo-login-overlay-wrapper',
 });
 
 const loginFormWrapper = css`


### PR DESCRIPTION
## Description

Fixes #6647

## Type of change

- Bugfix

## Note

The issue is fixed since 24.2 as part of https://github.com/vaadin/web-components/pull/6204.