### PR TITLE
chore: remove item and list box style imports from grid pro

### DIFF
--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-edit-select.js
@@ -1,5 +1,3 @@
-import '@vaadin/item/theme/lumo/vaadin-item.js';
-import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '@vaadin/select/theme/lumo/vaadin-select.js';
 import './vaadin-grid-pro-edit-select-styles.js';
 import '../../src/vaadin-grid-pro-edit-select.js';

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-edit-select.js
@@ -1,5 +1,3 @@
-import '@vaadin/item/theme/material/vaadin-item.js';
-import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '@vaadin/select/theme/material/vaadin-select.js';
 import './vaadin-grid-pro-edit-select-styles.js';
 import '../../src/vaadin-grid-pro-edit-select.js';


### PR DESCRIPTION
## Description

Follow up for https://github.com/vaadin/web-components/pull/6747

Remove no longer necessary style imports for `vaadin-item` and `vaadin-list-box`