### PR TITLE
experiment: add imports for lit grid-pro

### DIFF
--- a/dev/grid-pro.html
+++ b/dev/grid-pro.html
@@ -25,8 +25,8 @@
       import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 
       // LitElement based imports
-      // import '@vaadin/grid-pro/theme/lumo/vaadin-lit-grid-pro.js';
-      // import '@vaadin/grid-pro/theme/lumo/vaadin-lit-grid-pro-edit-column.js';
+      // import '@vaadin/grid-pro/vaadin-lit-grid-pro.js';
+      // import '@vaadin/grid-pro/vaadin-lit-grid-pro-edit-column.js';
 
       import { users } from '../packages/grid-pro/test/visual/users.js';
 

--- a/packages/grid-pro/test/typings/lit-grid-pro.types.ts
+++ b/packages/grid-pro/test/typings/lit-grid-pro.types.ts
@@ -1,0 +1,109 @@
+import type {
+  Grid,
+  GridActiveItemChangedEvent,
+  GridCellActivateEvent,
+  GridColumnReorderEvent,
+  GridColumnResizeEvent,
+  GridDragStartEvent,
+  GridDropEvent,
+  GridDropLocation,
+  GridExpandedItemsChangedEvent,
+  GridItemModel,
+  GridLoadingChangedEvent,
+  GridSelectedItemsChangedEvent,
+} from '@vaadin/grid/vaadin-lit-grid.js';
+import type { GridColumn } from '@vaadin/grid/vaadin-lit-grid-column.js';
+import type { InlineEditingMixinClass } from '../../src/vaadin-grid-pro-inline-editing-mixin.js';
+import type { GridPro, GridProEditorType } from '../../vaadin-lit-grid-pro.js';
+import type { GridProEditColumn } from '../../vaadin-lit-grid-pro-edit-column.js';
+
+interface TestGridItem {
+  testProperty: string;
+}
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+/* GridPro */
+const genericGrid = document.createElement('vaadin-grid-pro');
+assertType<GridPro>(genericGrid);
+
+const narrowedGrid = genericGrid as GridPro<TestGridItem>;
+assertType<Grid<TestGridItem>>(narrowedGrid);
+assertType<InlineEditingMixinClass>(narrowedGrid);
+
+narrowedGrid.addEventListener('cell-edit-started', (event) => {
+  assertType<string>(event.detail.path);
+  assertType<number>(event.detail.index);
+  assertType<TestGridItem>(event.detail.item);
+});
+
+narrowedGrid.addEventListener('item-property-changed', (event) => {
+  assertType<string>(event.detail.path);
+  assertType<number>(event.detail.index);
+  assertType<TestGridItem>(event.detail.item);
+  assertType<boolean | string>(event.detail.value);
+});
+
+narrowedGrid.addEventListener('active-item-changed', (event) => {
+  assertType<GridActiveItemChangedEvent<TestGridItem>>(event);
+  assertType<TestGridItem | null | undefined>(event.detail.value);
+});
+
+narrowedGrid.addEventListener('cell-activate', (event) => {
+  assertType<GridCellActivateEvent<TestGridItem>>(event);
+  assertType<GridItemModel<TestGridItem>>(event.detail.model);
+});
+
+narrowedGrid.addEventListener('column-reorder', (event) => {
+  assertType<GridColumnReorderEvent<TestGridItem>>(event);
+  assertType<Array<GridColumn<TestGridItem>>>(event.detail.columns);
+});
+
+narrowedGrid.addEventListener('column-resize', (event) => {
+  assertType<GridColumnResizeEvent<TestGridItem>>(event);
+  assertType<GridColumn<TestGridItem>>(event.detail.resizedColumn);
+});
+
+narrowedGrid.addEventListener('loading-changed', (event) => {
+  assertType<GridLoadingChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+narrowedGrid.addEventListener('expanded-items-changed', (event) => {
+  assertType<GridExpandedItemsChangedEvent<TestGridItem>>(event);
+  assertType<TestGridItem[]>(event.detail.value);
+});
+
+narrowedGrid.addEventListener('selected-items-changed', (event) => {
+  assertType<GridSelectedItemsChangedEvent<TestGridItem>>(event);
+  assertType<TestGridItem[]>(event.detail.value);
+});
+
+narrowedGrid.addEventListener('grid-dragstart', (event) => {
+  assertType<GridDragStartEvent<TestGridItem>>(event);
+  assertType<TestGridItem[]>(event.detail.draggedItems);
+});
+
+narrowedGrid.addEventListener('grid-drop', (event) => {
+  assertType<GridDropEvent<TestGridItem>>(event);
+  assertType<TestGridItem>(event.detail.dropTargetItem);
+  assertType<GridDropLocation>(event.detail.dropLocation);
+});
+
+/* GridProEditColumn */
+const genericEditColumn = document.createElement('vaadin-grid-pro-edit-column');
+assertType<GridProEditColumn>(genericEditColumn);
+
+const narrowedEditColumn = genericEditColumn as GridProEditColumn<TestGridItem>;
+assertType<GridColumn<TestGridItem>>(narrowedEditColumn);
+
+assertType<string | null | undefined>(narrowedEditColumn.path);
+assertType<string[]>(narrowedEditColumn.editorOptions);
+assertType<GridProEditorType>(narrowedEditColumn.editorType);
+assertType<string>(narrowedEditColumn.editorValuePath);
+
+narrowedEditColumn.editModeRenderer = (root, column, model) => {
+  assertType<HTMLElement>(root);
+  assertType<GridColumn<TestGridItem>>(column);
+  assertType<GridItemModel<TestGridItem>>(model);
+};

--- a/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-checkbox.js
+++ b/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-checkbox.js
@@ -1,0 +1,2 @@
+import '@vaadin/checkbox/theme/material/vaadin-checkbox-styles.js';
+import '../../src/vaadin-lit-grid-pro-edit-checkbox.js';

--- a/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-column.js
+++ b/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-column.js
@@ -1,0 +1,4 @@
+import './vaadin-lit-grid-pro-edit-checkbox.js';
+import './vaadin-lit-grid-pro-edit-select.js';
+import './vaadin-lit-grid-pro-edit-text-field.js';
+import '../../src/vaadin-lit-grid-pro-edit-column.js';

--- a/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-select.js
+++ b/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-select.js
@@ -1,0 +1,3 @@
+import '@vaadin/select/theme/material/vaadin-select-styles.js';
+import './vaadin-grid-pro-edit-select-styles.js';
+import '../../src/vaadin-lit-grid-pro-edit-select.js';

--- a/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-text-field.js
+++ b/packages/grid-pro/theme/material/vaadin-lit-grid-pro-edit-text-field.js
@@ -1,0 +1,3 @@
+import '@vaadin/text-field/theme/material/vaadin-text-field-styles.js';
+import './vaadin-grid-pro-edit-text-field-styles.js';
+import '../../src/vaadin-lit-grid-pro-edit-text-field.js';

--- a/packages/grid-pro/theme/material/vaadin-lit-grid-pro.js
+++ b/packages/grid-pro/theme/material/vaadin-lit-grid-pro.js
@@ -1,0 +1,3 @@
+import '@vaadin/grid/theme/material/vaadin-grid-styles.js';
+import './vaadin-grid-pro-styles.js';
+import '../../src/vaadin-lit-grid-pro.js';

--- a/packages/grid-pro/vaadin-lit-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/vaadin-lit-grid-pro-edit-column.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-grid-pro-edit-column.js';

--- a/packages/grid-pro/vaadin-lit-grid-pro-edit-column.js
+++ b/packages/grid-pro/vaadin-lit-grid-pro-edit-column.js
@@ -1,0 +1,3 @@
+import './theme/lumo/vaadin-lit-grid-pro-edit-column.js';
+
+export * from './src/vaadin-lit-grid-pro-edit-column.js';

--- a/packages/grid-pro/vaadin-lit-grid-pro.d.ts
+++ b/packages/grid-pro/vaadin-lit-grid-pro.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-grid-pro.js';

--- a/packages/grid-pro/vaadin-lit-grid-pro.js
+++ b/packages/grid-pro/vaadin-lit-grid-pro.js
@@ -1,0 +1,3 @@
+import './theme/lumo/vaadin-lit-grid-pro.js';
+
+export * from './src/vaadin-lit-grid-pro.js';


### PR DESCRIPTION
## Description

Add files to import the LitElement-based grid-pro
- root level
  - example: `import '@vaadin/grid-pro/vaadin-lit-grid-pro.js';`
- lumo
  - example: `import '@vaadin/grid-pro/theme/lumo/vaadin-lit-grid-pro.js';`
- material
  - example: `import '@vaadin/grid-pro/theme/material/vaadin-lit-grid-pro.js';`

Also, add `lit-grid-pro.types.ts` to make sure the types are aligned with those of the PolymerElement-based grid-pro.