### PR TITLE
fix: make link focusable when path is an empty string

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -199,7 +199,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
         <a
           id="link"
           ?disabled="${this.disabled}"
-          tabindex="${this.disabled || !this.path ? '-1' : '0'}"
+          tabindex="${this.disabled || this.path == null ? '-1' : '0'}"
           href="${ifDefined(this.disabled ? null : this.path)}"
           part="link"
           aria-current="${this.current ? 'page' : 'false'}"

--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -263,7 +263,7 @@ snapshots["vaadin-side-nav-item shadow current"] =
     href=""
     id="link"
     part="link"
-    tabindex="-1"
+    tabindex="0"
   >
     <slot name="prefix">
     </slot>
@@ -338,6 +338,47 @@ snapshots["vaadin-side-nav-item shadow path"] =
 </div>
 `;
 /* end snapshot vaadin-side-nav-item shadow path */
+
+snapshots["vaadin-side-nav-item shadow null path"] = 
+`<div part="content">
+  <a
+    aria-current="false"
+    id="link"
+    part="link"
+    tabindex="-1"
+  >
+    <slot name="prefix">
+    </slot>
+    <slot>
+    </slot>
+    <slot name="suffix">
+    </slot>
+  </a>
+  <button
+    aria-controls="children"
+    aria-expanded="false"
+    aria-labelledby="link i18n"
+    part="toggle-button"
+  >
+  </button>
+</div>
+<ul
+  aria-hidden="true"
+  hidden=""
+  part="children"
+  role="list"
+>
+  <slot name="children">
+  </slot>
+</ul>
+<div
+  class="sr-only"
+  id="i18n"
+>
+  Toggle child items
+</div>
+`;
+/* end snapshot vaadin-side-nav-item shadow null path */
 
 snapshots["vaadin-side-nav-item shadow i18n"] = 
 `<div part="content">

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -75,6 +75,12 @@ describe('vaadin-side-nav-item', () => {
       await expect(sideNavItem).shadowDom.to.equalSnapshot();
     });
 
+    it('null path', async () => {
+      sideNavItem.path = null;
+      await nextRender(sideNavItem);
+      await expect(sideNavItem).shadowDom.to.equalSnapshot();
+    });
+
     it('i18n', async () => {
       sideNavItem.i18n = { toggle: 'Toggle children' };
       await nextRender();


### PR DESCRIPTION
## Description

Fixes #5667

As discussed internally, setting `path` to an empty string should be considered a non-empty path.
Updated the logic to only set `tabindex="-1"` when `path` contains `null` or `undefined` value.

## Type of change

- Bugfix