### PR TITLE
test: mitigate timezone related date-picker test issues

### DIFF
--- a/packages/date-picker/test/keyboard-input.common.js
+++ b/packages/date-picker/test/keyboard-input.common.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { aTimeout, enter, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { getAdjustedYear } from '../src/vaadin-date-picker-helper.js';
+import { getAdjustedYear, parseDate } from '../src/vaadin-date-picker-helper.js';
 import { close, getFocusedCell, idleCallback, open, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
 describe('keyboard', () => {
@@ -347,7 +347,7 @@ describe('keyboard', () => {
 
     async function checkMonthAndDayOffset(monthOffsetToAdd, dayOffsetToAdd, expectedYearOffset) {
       input.value = '';
-      const referenceDate = new Date(datePicker.i18n.referenceDate);
+      const referenceDate = parseDate(datePicker.i18n.referenceDate);
       const yearToTest = referenceDate.getFullYear() + 50;
       await sendKeys({
         type: `${referenceDate.getMonth() + 1 + monthOffsetToAdd}/${referenceDate.getDate() + dayOffsetToAdd}/${

--- a/packages/date-picker/test/validation.common.js
+++ b/packages/date-picker/test/validation.common.js
@@ -342,12 +342,12 @@ describe('validation', () => {
 
     it('should validate correctly with custom validator', () => {
       // Try invalid value.
-      datePicker.value = '2014-01-01';
+      datePicker.value = '2014-06-01';
       expect(datePicker.validate()).to.be.false;
       expect(datePicker.invalid).to.be.true;
 
       // Try valid value.
-      datePicker.value = '2016-01-01';
+      datePicker.value = '2016-06-01';
       expect(datePicker.validate()).to.be.true;
       expect(datePicker.invalid).to.be.false;
     });


### PR DESCRIPTION
## Description

Avoid date-picker test cases using a `Date` breaking on different time zones. See https://github.com/vaadin/web-components/pull/6603#discussion_r1389464356

## Type of change

Tests