### PR TITLE
fix: do not lose focus on click in Safari (#6780) (CP: 24.1)

### DIFF
--- a/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
+++ b/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
@@ -19,6 +19,7 @@ snapshots["vaadin-checkbox-group host default"] =
     <input
       id="input-vaadin-checkbox-5"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="1"
     >
@@ -39,6 +40,7 @@ snapshots["vaadin-checkbox-group host default"] =
     <input
       id="input-vaadin-checkbox-6"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="2"
     >
@@ -178,6 +180,7 @@ snapshots["vaadin-checkbox-group host label"] =
     <input
       id="input-vaadin-checkbox-5"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="1"
     >
@@ -198,6 +201,7 @@ snapshots["vaadin-checkbox-group host label"] =
     <input
       id="input-vaadin-checkbox-6"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="2"
     >
@@ -240,6 +244,7 @@ snapshots["vaadin-checkbox-group host required"] =
     <input
       id="input-vaadin-checkbox-5"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="1"
     >
@@ -260,6 +265,7 @@ snapshots["vaadin-checkbox-group host required"] =
     <input
       id="input-vaadin-checkbox-6"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="2"
     >
@@ -301,6 +307,7 @@ snapshots["vaadin-checkbox-group host helper"] =
     <input
       id="input-vaadin-checkbox-5"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="1"
     >
@@ -321,6 +328,7 @@ snapshots["vaadin-checkbox-group host helper"] =
     <input
       id="input-vaadin-checkbox-6"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="2"
     >
@@ -369,6 +377,7 @@ snapshots["vaadin-checkbox-group host error"] =
     <input
       id="input-vaadin-checkbox-5"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="1"
     >
@@ -389,6 +398,7 @@ snapshots["vaadin-checkbox-group host error"] =
     <input
       id="input-vaadin-checkbox-6"
       slot="input"
+      tabindex="0"
       type="checkbox"
       value="2"
     >

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -48,6 +48,18 @@ export const CheckboxMixin = (superclass) =>
           type: String,
           value: '',
         },
+
+        /**
+         * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
+         *
+         * @override
+         * @protected
+         */
+        tabindex: {
+          type: Number,
+          value: 0,
+          reflectToAttribute: true,
+        },
       };
     }
 

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -151,7 +151,7 @@ describe('checkbox', () => {
         checkbox.addEventListener('focusout', spy);
         input.focus();
         await sendMouse({ type: 'click', position: [inputX, inputY] });
-        expect(spy).to.be.not.called;
+        expect(spy.called).to.be.false;
       });
     });
 

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -129,16 +129,29 @@ describe('checkbox', () => {
     });
 
     describe('focus', () => {
+      let inputX, inputY;
+
+      beforeEach(() => {
+        const rect = input.getBoundingClientRect();
+        inputX = Math.floor(rect.x + rect.width / 2);
+        inputY = Math.floor(rect.y + rect.height / 2);
+      });
+
       afterEach(async () => {
         await resetMouse();
       });
 
-      it('should focus on input click if not focused', async () => {
-        const rect = input.getBoundingClientRect();
-        const middleX = Math.floor(rect.x + rect.width / 2);
-        const middleY = Math.floor(rect.y + rect.height / 2);
-        await sendMouse({ type: 'click', position: [middleX, middleY] });
+      it('should focus on input click when not focused yet', async () => {
+        await sendMouse({ type: 'click', position: [inputX, inputY] });
         expect(checkbox.hasAttribute('focused')).to.be.true;
+      });
+
+      it('should keep focus on input click when already focused', async () => {
+        const spy = sinon.spy();
+        checkbox.addEventListener('focusout', spy);
+        input.focus();
+        await sendMouse({ type: 'click', position: [inputX, inputY] });
+        expect(spy).to.be.not.called;
       });
     });
 

--- a/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
+++ b/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
@@ -12,6 +12,7 @@ snapshots["vaadin-checkbox host default"] =
   <input
     id="input-vaadin-checkbox-1"
     slot="input"
+    tabindex="0"
     type="checkbox"
     value="on"
   >
@@ -72,6 +73,7 @@ snapshots["vaadin-checkbox host name"] =
     id="input-vaadin-checkbox-1"
     name="Name"
     slot="input"
+    tabindex="0"
     type="checkbox"
     value="on"
   >
@@ -94,6 +96,7 @@ snapshots["vaadin-checkbox host label"] =
   <input
     id="input-vaadin-checkbox-1"
     slot="input"
+    tabindex="0"
     type="checkbox"
     value="on"
   >

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -48,12 +48,6 @@ export const CheckedMixin = dedupingMixin(
         const input = event.target;
 
         this._toggleChecked(input.checked);
-
-        // Clicking the checkbox or radio-button in Safari
-        // does not make it focused, so we do it manually.
-        if (!isElementFocused(input)) {
-          input.focus();
-        }
       }
 
       /** @protected */

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -108,23 +108,4 @@ describe('checked-mixin', () => {
       });
     });
   });
-
-  describe('focus', () => {
-    beforeEach(() => {
-      element = fixtureSync(`<checked-mixin-element checked></checked-mixin-element>`);
-      input = element.querySelector('[slot=input]');
-    });
-
-    afterEach(async () => {
-      await resetMouse();
-    });
-
-    it('should focus on input click if not focused', async () => {
-      const rect = input.getBoundingClientRect();
-      const middleX = Math.floor(rect.x + rect.width / 2);
-      const middleY = Math.floor(rect.y + rect.height / 2);
-      await sendMouse({ type: 'click', position: [middleX, middleY] });
-      expect(document.activeElement).to.eql(input);
-    });
-  });
 });

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -154,6 +154,18 @@ class RadioButton extends LabelMixin(
         type: String,
         value: '',
       },
+
+      /**
+       * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
+       *
+       * @override
+       * @protected
+       */
+      tabindex: {
+        type: Number,
+        value: 0,
+        reflectToAttribute: true,
+      },
     };
   }
 

--- a/packages/radio-group/test/dom/__snapshots__/radio-button.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-button.test.snap.js
@@ -17,6 +17,7 @@ snapshots["vaadin-radio-button host default"] =
   <input
     id="input-vaadin-radio-button-1"
     slot="input"
+    tabindex="0"
     type="radio"
     value="on"
   >

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -19,6 +19,7 @@ snapshots["vaadin-radio-group host default"] =
     <input
       id="input-vaadin-radio-button-6"
       slot="input"
+      tabindex="0"
       type="radio"
       value="1"
     >
@@ -39,6 +40,7 @@ snapshots["vaadin-radio-group host default"] =
     <input
       id="input-vaadin-radio-button-7"
       slot="input"
+      tabindex="0"
       type="radio"
       value="2"
     >
@@ -80,6 +82,7 @@ snapshots["vaadin-radio-group host label"] =
     <input
       id="input-vaadin-radio-button-6"
       slot="input"
+      tabindex="0"
       type="radio"
       value="1"
     >
@@ -100,6 +103,7 @@ snapshots["vaadin-radio-group host label"] =
     <input
       id="input-vaadin-radio-button-7"
       slot="input"
+      tabindex="0"
       type="radio"
       value="2"
     >
@@ -211,6 +215,7 @@ snapshots["vaadin-radio-group host required"] =
     <input
       id="input-vaadin-radio-button-6"
       slot="input"
+      tabindex="0"
       type="radio"
       value="1"
     >
@@ -231,6 +236,7 @@ snapshots["vaadin-radio-group host required"] =
     <input
       id="input-vaadin-radio-button-7"
       slot="input"
+      tabindex="0"
       type="radio"
       value="2"
     >
@@ -272,6 +278,7 @@ snapshots["vaadin-radio-group host helper"] =
     <input
       id="input-vaadin-radio-button-6"
       slot="input"
+      tabindex="0"
       type="radio"
       value="1"
     >
@@ -292,6 +299,7 @@ snapshots["vaadin-radio-group host helper"] =
     <input
       id="input-vaadin-radio-button-7"
       slot="input"
+      tabindex="0"
       type="radio"
       value="2"
     >
@@ -342,6 +350,7 @@ snapshots["vaadin-radio-group host error"] =
       id="input-vaadin-radio-button-6"
       name="vaadin-radio-group-5"
       slot="input"
+      tabindex="0"
       type="radio"
       value="1"
     >
@@ -363,6 +372,7 @@ snapshots["vaadin-radio-group host error"] =
       id="input-vaadin-radio-button-7"
       name="vaadin-radio-group-5"
       slot="input"
+      tabindex="0"
       type="radio"
       value="2"
     >

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -259,4 +259,33 @@ describe('radio-button', () => {
       expect(radio.hasAttribute('has-label')).to.be.true;
     });
   });
+
+  describe('focus', () => {
+    let inputX, inputY;
+
+    beforeEach(() => {
+      radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
+      input = radio.querySelector('[slot=input]');
+      const rect = input.getBoundingClientRect();
+      inputX = Math.floor(rect.x + rect.width / 2);
+      inputY = Math.floor(rect.y + rect.height / 2);
+    });
+
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should focus on input click when not focused yet', async () => {
+      await sendMouse({ type: 'click', position: [inputX, inputY] });
+      expect(radio.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should keep focus on input click when already focused', async () => {
+      const spy = sinon.spy();
+      radio.addEventListener('focusout', spy);
+      input.focus();
+      await sendMouse({ type: 'click', position: [inputX, inputY] });
+      expect(spy).to.be.not.called;
+    });
+  });
 });

--- a/packages/radio-group/test/radio-button.test.js
+++ b/packages/radio-group/test/radio-button.test.js
@@ -285,7 +285,7 @@ describe('radio-button', () => {
       radio.addEventListener('focusout', spy);
       input.focus();
       await sendMouse({ type: 'click', position: [inputX, inputY] });
-      expect(spy).to.be.not.called;
+      expect(spy.called).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

A cherry-pick of the following fix to `24.1`:

- #6780

The automatic cherry-pick failed because there is no `vaadin-radio-button-mixin.js` on `24.1`.

Fixes https://github.com/vaadin/web-components/issues/6756

## Type of change

- [x] Bugfix
