### PR TITLE
fix: allow switching between pickers with click when any is open

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -125,10 +125,6 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   static get template() {
     return html`
       <style>
-        :host([opened]) {
-          pointer-events: auto;
-        }
-
         .vaadin-date-time-picker-container {
           --vaadin-field-default-width: auto;
         }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -328,13 +328,6 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
         type: Boolean,
       },
 
-      opened: {
-        type: Boolean,
-        value: false,
-        notify: true,
-        reflectToAttribute: true,
-      },
-
       /**
        * The current selected date time.
        * @private
@@ -486,21 +479,6 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     }
   }
 
-  _shouldSetFocus(event) {
-    const target = event.relatedTarget;
-    const overlayContent = this.__datePicker._overlayContent;
-
-    if (
-      this.__datePicker.contains(target) ||
-      this.__timePicker.contains(target) ||
-      (overlayContent && overlayContent.contains(target))
-    ) {
-      return false;
-    }
-
-    return true;
-  }
-
   /**
    * Override method inherited from `FocusMixin` to not remove focused
    * state when focus moves between pickers or to the overlay.
@@ -546,7 +524,8 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   }
 
   __openedChangedEventHandler() {
-    this.opened = this.__datePicker.opened || this.__timePicker.opened;
+    const opened = this.__datePicker.opened || this.__timePicker.opened;
+    this.style.pointerEvents = opened ? 'auto' : '';
   }
 
   /** @private */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -125,6 +125,10 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   static get template() {
     return html`
       <style>
+        :host([opened]) {
+          pointer-events: auto;
+        }
+
         .vaadin-date-time-picker-container {
           --vaadin-field-default-width: auto;
         }
@@ -324,6 +328,13 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
         type: Boolean,
       },
 
+      opened: {
+        type: Boolean,
+        value: false,
+        notify: true,
+        reflectToAttribute: true,
+      },
+
       /**
        * The current selected date time.
        * @private
@@ -412,6 +423,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
 
     this.__changeEventHandler = this.__changeEventHandler.bind(this);
     this.__valueChangedEventHandler = this.__valueChangedEventHandler.bind(this);
+    this.__openedChangedEventHandler = this.__openedChangedEventHandler.bind(this);
   }
 
   /** @private */
@@ -474,6 +486,21 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     }
   }
 
+  _shouldSetFocus(event) {
+    const target = event.relatedTarget;
+    const overlayContent = this.__datePicker._overlayContent;
+
+    if (
+      this.__datePicker.contains(target) ||
+      this.__timePicker.contains(target) ||
+      (overlayContent && overlayContent.contains(target))
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
   /**
    * Override method inherited from `FocusMixin` to not remove focused
    * state when focus moves between pickers or to the overlay.
@@ -518,16 +545,22 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     this.__dispatchChangeForValue = undefined;
   }
 
+  __openedChangedEventHandler() {
+    this.opened = this.__datePicker.opened || this.__timePicker.opened;
+  }
+
   /** @private */
   __addInputListeners(node) {
     node.addEventListener('change', this.__changeEventHandler);
     node.addEventListener('value-changed', this.__valueChangedEventHandler);
+    node.addEventListener('opened-changed', this.__openedChangedEventHandler);
   }
 
   /** @private */
   __removeInputListeners(node) {
     node.removeEventListener('change', this.__changeEventHandler);
     node.removeEventListener('value-changed', this.__valueChangedEventHandler);
+    node.removeEventListener('opened-changed', this.__openedChangedEventHandler);
   }
 
   /** @private */


### PR DESCRIPTION
## Description

The PR allows switching between pickers of `date-time-picker` with click when any of them is open. 

Fixes #6407 

## Type of change

- [x] Bugfix
