### PR TITLE
fix: update virtualizer scroller size before size change

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -310,6 +310,7 @@ export class IronListAdapter {
       this.__preventElementUpdates = false;
     } else {
       // Already initialized, just update _virtualCount
+      this._updateScrollerSize();
       this._virtualCount = this.items.length;
     }
 

--- a/packages/grid/test/resizing.common.js
+++ b/packages/grid/test/resizing.common.js
@@ -288,4 +288,39 @@ describe('all rows visible', () => {
       expect(grid.contains(belowGrid)).to.be.false;
     });
   });
+
+  describe('tree grid', () => {
+    beforeEach(() => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-tree-column path="value"></vaadin-grid-tree-column>
+        </vaadin-grid>
+      `);
+      grid.allRowsVisible = true;
+      grid.itemIdPath = 'value';
+      grid.dataProvider = ({ parentItem }, cb) => {
+        const item = {
+          value: `${parentItem ? `${parentItem.value}-` : ''}0`,
+          children: true,
+        };
+        cb([item], 1);
+      };
+      flushGrid(grid);
+    });
+
+    it('should have all rows visible on deep expand', () => {
+      grid.expandedItems = [
+        { value: '0' },
+        { value: '0-0' },
+        { value: '0-0-0' },
+        { value: '0-0-0-0' },
+        { value: '0-0-0-0-0' },
+        { value: '0-0-0-0-0-0' },
+        { value: '0-0-0-0-0-0-0' },
+        { value: '0-0-0-0-0-0-0-0' },
+      ];
+      expect(grid._firstVisibleIndex).to.equal(0);
+      expect(grid._lastVisibleIndex).to.equal(8);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes a regression originating from https://github.com/vaadin/web-components/pull/5650 that manifests as a pre-expanded tree grid with allRowsVisible not displaying all rows until scrolling the content:

https://github.com/vaadin/web-components/assets/1222264/2f93b246-75d9-453d-8812-5a01a807d5f0

## Type of change

Bugfix