### PR TITLE
fix: support non-latin chars in list-mixin keyboard search

### DIFF
--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -253,7 +253,7 @@ export const ListMixin = (superClass) =>
       const key = event.key;
 
       const currentIdx = this.items.indexOf(this.focused);
-      if (/[a-zA-Z0-9]/u.test(key) && key.length === 1) {
+      if (/[\p{L}\p{Nd}]/u.test(key) && key.length === 1) {
         const idx = this._searchKey(currentIdx, key);
         if (idx >= 0) {
           this._focus(idx);

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -515,6 +515,25 @@ const runTests = (defineHelper, baseMixin) => {
         keyDownChar(list, 'b');
         expect(list.items[1].focused).to.be.true;
       });
+
+      describe('non-latin keys', () => {
+        const LARGE = 'ใหญ่';
+        const SMALL = 'เล็ก';
+
+        beforeEach(() => {
+          list.items[0].textContent = LARGE;
+          list.items[1].textContent = SMALL;
+          list.items[1].removeAttribute('label');
+        });
+
+        it('should select items when non-latin keys are pressed', () => {
+          keyDownChar(list, SMALL.charAt(0));
+          expect(list.items[1].focused).to.be.true;
+
+          keyDownChar(list, LARGE.charAt(0));
+          expect(list.items[0].focused).to.be.true;
+        });
+      });
     });
 
     describe('empty items', () => {


### PR DESCRIPTION
## Description

Fixes #6581

Same as #2815 but for `ListMixin` (which also applies to opened `vaadin-select`).

## Type of change

- Bugfix