### PR TITLE
experiment: prepare LitElement based date-picker for publishing

### DIFF
--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -21,10 +21,6 @@
   "type": "module",
   "files": [
     "src",
-    "!src/vaadin-lit-date-picker-overlay-content.js",
-    "!src/vaadin-lit-date-picker-overlay.js",
-    "!src/vaadin-lit-date-picker.js",
-    "!src/vaadin-lit-month-calendar.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/date-picker/src/vaadin-date-picker-year-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-mixin.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * @polymerMixin
+ */
+export const DatePickerYearMixin = (superClass) =>
+  class DatePickerYearMixin extends superClass {
+    static get properties() {
+      return {
+        year: {
+          type: String,
+          sync: true,
+        },
+
+        selectedDate: {
+          type: Object,
+          sync: true,
+        },
+      };
+    }
+
+    static get observers() {
+      return ['__updateSelected(year, selectedDate)'];
+    }
+
+    /** @private */
+    __updateSelected(year, selectedDate) {
+      this.toggleAttribute('selected', selectedDate && selectedDate.getFullYear() === year);
+      this.toggleAttribute('current', year === new Date().getFullYear());
+    }
+  };

--- a/packages/date-picker/src/vaadin-lit-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker-overlay-content.js
@@ -3,10 +3,10 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/button/src/vaadin-button.js';
+import '@vaadin/button/src/vaadin-lit-button.js';
 import './vaadin-date-picker-month-scroller.js';
 import './vaadin-date-picker-year-scroller.js';
-import './vaadin-date-picker-year.js';
+import './vaadin-lit-date-picker-year.js';
 import './vaadin-lit-month-calendar.js';
 import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';

--- a/packages/date-picker/src/vaadin-lit-date-picker-year.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker-year.js
@@ -3,34 +3,36 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { css, html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DatePickerYearMixin } from './vaadin-date-picker-year-mixin.js';
 
 /**
- * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
- *
- * @customElement
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DatePickerYearMixin
  * @private
  */
-export class DatePickerYear extends ThemableMixin(DatePickerYearMixin(PolymerElement)) {
+export class DatePickerYear extends ThemableMixin(DatePickerYearMixin(PolylitMixin(LitElement))) {
   static get is() {
     return 'vaadin-date-picker-year';
   }
 
-  static get template() {
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+        height: 100%;
+      }
+    `;
+  }
+
+  /** @protected */
+  render() {
     return html`
-      <style>
-        :host {
-          display: block;
-          height: 100%;
-        }
-      </style>
-      <div part="year-number">[[year]]</div>
+      <div part="year-number">${this.year}</div>
       <div part="year-separator" aria-hidden="true"></div>
     `;
   }

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import '@vaadin/button/theme/lumo/vaadin-button.js';
+import '@vaadin/button/theme/lumo/vaadin-button-styles.js';
 import './vaadin-date-picker-year-styles.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/date-picker/theme/lumo/vaadin-lit-date-picker.js
+++ b/packages/date-picker/theme/lumo/vaadin-lit-date-picker.js
@@ -1,0 +1,5 @@
+import './vaadin-date-picker-overlay-styles.js';
+import './vaadin-date-picker-overlay-content-styles.js';
+import './vaadin-month-calendar-styles.js';
+import './vaadin-date-picker-styles.js';
+import '../../src/vaadin-lit-date-picker.js';

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -2,7 +2,7 @@ import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
-import '@vaadin/button/theme/material/vaadin-button.js';
+import '@vaadin/button/theme/material/vaadin-button-styles.js';
 import './vaadin-date-picker-year-styles.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/date-picker/theme/material/vaadin-lit-date-picker.js
+++ b/packages/date-picker/theme/material/vaadin-lit-date-picker.js
@@ -1,0 +1,5 @@
+import './vaadin-date-picker-overlay-styles.js';
+import './vaadin-date-picker-overlay-content-styles.js';
+import './vaadin-month-calendar-styles.js';
+import './vaadin-date-picker-styles.js';
+import '../../src/vaadin-lit-date-picker.js';

--- a/packages/date-picker/vaadin-lit-date-picker-light.d.ts
+++ b/packages/date-picker/vaadin-lit-date-picker-light.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-date-picker-light.js';

--- a/packages/date-picker/vaadin-lit-date-picker-light.js
+++ b/packages/date-picker/vaadin-lit-date-picker-light.js
@@ -1,0 +1,2 @@
+import './theme/lumo/vaadin-lit-date-picker-light.js';
+export * from './src/vaadin-lit-date-picker-light.js';

--- a/packages/date-picker/vaadin-lit-date-picker.d.ts
+++ b/packages/date-picker/vaadin-lit-date-picker.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-date-picker.js';

--- a/packages/date-picker/vaadin-lit-date-picker.js
+++ b/packages/date-picker/vaadin-lit-date-picker.js
@@ -1,0 +1,2 @@
+import './theme/lumo/vaadin-lit-date-picker.js';
+export * from './src/vaadin-lit-date-picker.js';


### PR DESCRIPTION
## Description

Prepare LitElement-based date-picker for release:
- Add the import files
- Remove "vaadin-lit-" excludes from package.json
- Split `vaadin-date-picker-year.js` into a shared mixin and add the LitElement-counterpart