### PR TITLE
fix: support non-latin chars in list-mixin keyboard search (#6798) (CP: 23.4)

### DIFF
--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -494,6 +494,24 @@ describe('vaadin-list-mixin', () => {
       const listElement = document.createElement('test-list-element');
       expect(() => listElement.focus()).not.to.throw(Error);
     });
+
+    describe('non-latin keys', () => {
+      const LARGE = 'ใหญ่';
+      const SMALL = 'เล็ก';
+
+      beforeEach(() => {
+        list.items[0].textContent = LARGE;
+        list.items[1].textContent = SMALL;
+      });
+
+      it('should select items when non-latin keys are pressed', () => {
+        keyDownChar(list, SMALL.charAt(0));
+        expect(list.items[1].focused).to.be.true;
+
+        keyDownChar(list, LARGE.charAt(0));
+        expect(list.items[0].focused).to.be.true;
+      });
+    });
   });
 
   describe('orientation', () => {

--- a/packages/vaadin-list-mixin/vaadin-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-list-mixin.js
@@ -213,7 +213,7 @@ export const ListMixin = (superClass) =>
       const key = event.key;
 
       const currentIdx = this.items.indexOf(this.focused);
-      if (/[a-zA-Z0-9]/.test(key) && key.length === 1) {
+      if (/[\p{L}\p{Nd}]/u.test(key) && key.length === 1) {
         const idx = this._searchKey(currentIdx, key);
         if (idx >= 0) {
           this._focus(idx);


### PR DESCRIPTION
## Description

Manual cherry-pick of #6798 to 23.4 branch.

## Type of change

- Cherry-pick