### PR TITLE
refactor: maintain root size only at the cache level

### DIFF
--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -68,13 +68,12 @@ export class DataProviderController extends EventTarget {
   constructor(host, { size, pageSize, isExpanded, getItemId, dataProvider, dataProviderParams }) {
     super();
     this.host = host;
-    this.size = size;
     this.pageSize = pageSize;
     this.getItemId = getItemId;
     this.isExpanded = isExpanded;
     this.dataProvider = dataProvider;
     this.dataProviderParams = dataProviderParams;
-    this.rootCache = this.__createRootCache();
+    this.rootCache = this.__createRootCache(size);
   }
 
   /**
@@ -100,17 +99,6 @@ export class DataProviderController extends EventTarget {
    */
   isLoading() {
     return this.rootCache.isLoading;
-  }
-
-  /**
-   * Sets the size for the root cache and recalculates the flattened size.
-   *
-   * @param {number} size
-   */
-  setSize(size) {
-    this.size = size;
-    this.rootCache.size = size;
-    this.recalculateFlatSize();
   }
 
   /**
@@ -144,7 +132,7 @@ export class DataProviderController extends EventTarget {
    * Clears the cache.
    */
   clearCache() {
-    this.rootCache = this.__createRootCache();
+    this.rootCache = this.__createRootCache(this.rootCache.size);
   }
 
   /**
@@ -228,8 +216,8 @@ export class DataProviderController extends EventTarget {
   }
 
   /** @private */
-  __createRootCache() {
-    return new Cache(this.__cacheContext, this.pageSize, this.size);
+  __createRootCache(size) {
+    return new Cache(this.__cacheContext, this.pageSize, size);
   }
 
   /** @private */

--- a/packages/component-base/test/data-provider-controller.test.js
+++ b/packages/component-base/test/data-provider-controller.test.js
@@ -82,10 +82,6 @@ describe('DataProviderController', () => {
       });
     });
 
-    it('should have size', () => {
-      expect(controller.size).to.equal(500);
-    });
-
     it('should have rootCache size', () => {
       expect(controller.rootCache.size).to.equal(500);
     });
@@ -141,31 +137,6 @@ describe('DataProviderController', () => {
     it('should set pageSize for the new cache', () => {
       controller.clearCache();
       expect(controller.rootCache.pageSize).to.equal(50);
-    });
-  });
-
-  describe('changing size', () => {
-    beforeEach(() => {
-      controller = new DataProviderController(host, {
-        pageSize: 50,
-        isExpanded,
-        dataProvider: (_params, callback) => callback([], 0),
-      });
-    });
-
-    it('should set the new size', () => {
-      controller.setSize(100);
-      expect(controller.size).to.equal(100);
-    });
-
-    it('should set the new rootCache size', () => {
-      controller.setSize(100);
-      expect(controller.rootCache.size).to.equal(100);
-    });
-
-    it('should recalculate flatSize', () => {
-      controller.setSize(100);
-      expect(controller.flatSize).to.equal(100);
     });
   });
 

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -365,6 +365,7 @@ export const DataProviderMixin = (superClass) =>
     clearCache() {
       this._dataProviderController.clearCache();
       this._dataProviderController.rootCache.size = this.size;
+      this._dataProviderController.recalculateFlatSize();
       this._hasData = false;
       this.__updateVisibleRows();
 

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -186,7 +186,8 @@ export const DataProviderMixin = (superClass) =>
 
     /** @private */
     _sizeChanged(size) {
-      this._dataProviderController.setSize(size);
+      this._dataProviderController.rootCache.size = size;
+      this._dataProviderController.recalculateFlatSize();
       this._flatSize = this._dataProviderController.flatSize;
     }
 
@@ -363,6 +364,7 @@ export const DataProviderMixin = (superClass) =>
      */
     clearCache() {
       this._dataProviderController.clearCache();
+      this._dataProviderController.rootCache.size = this.size;
       this._hasData = false;
       this.__updateVisibleRows();
 


### PR DESCRIPTION
## Description

DataProviderController currently maintains the root size in two different places at the same time: controller instance and root cache instance. This approach was chosen because `grid` requires the root cache to be always initialized with the last size that was set by the developer via the grid's `size` property rather than the last size that was received from the data provider, see https://github.com/vaadin/web-components/pull/5961#discussion_r1305666570. However, as I recently discovered, `combo-box` requires completely opposite.

So, to lighten the controller's functionality, this PR proposes: 
- dropping the controller's own size property and making the controller always initialize the root cache with the last size received from the data provider (default behavior)
- considering it the grid's responsibility to keep the cache size in sync with the grid's `size` property (custom behavior).

Note, there is even a [proposal](https://github.com/vaadin/web-components/issues/6585) to deprecate and drop the `size` property from `grid` and `combo-box`, leaving only the ability to control the size via the data provider callback.

## Type of change

- [x] Refactor
