### PR TITLE
chore: remove incorrect license note from Lit grid-pro JSDoc

### DIFF
--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-checkbox.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-checkbox.js
@@ -18,7 +18,6 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
  *
  * This component is an experiment not intended for publishing to npm.
  * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class GridProEditCheckbox extends Checkbox {
   static get is() {

--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-column.js
@@ -22,7 +22,6 @@ import { GridProEditColumnMixin } from './vaadin-grid-pro-edit-column-mixin.js';
  *
  * This component is an experiment not intended for publishing to npm.
  * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class GridProEditColumn extends GridProEditColumnMixin(GridColumn) {
   static get is() {

--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-select.js
@@ -19,7 +19,6 @@ import { GridProEditSelectMixin } from './vaadin-grid-pro-edit-select-mixin.js';
  *
  * This component is an experiment not intended for publishing to npm.
  * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class GridProEditSelect extends GridProEditSelectMixin(Select) {
   static get is() {

--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-text-field.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-text-field.js
@@ -18,7 +18,6 @@ import { TextField } from '@vaadin/text-field/src/vaadin-lit-text-field.js';
  *
  * This component is an experiment not intended for publishing to npm.
  * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class GridProEditText extends TextField {
   static get is() {

--- a/packages/grid-pro/src/vaadin-lit-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro.js
@@ -19,7 +19,6 @@ import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
  *
  * This component is an experiment not intended for publishing to npm.
  * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class GridPro extends InlineEditingMixin(Grid) {
   static get is() {


### PR DESCRIPTION
## Description

This note is a copy-paste from elsewhere but in case of `vaadin-grid-pro` it refers to the wrong license.

## Type of change

- Internal change