### PR TITLE
refactor: extract virtual-list styles to reusable css literals

### DIFF
--- a/packages/virtual-list/src/vaadin-virtual-list-styles.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const virtualListStyles: CSSResult;

--- a/packages/virtual-list/src/vaadin-virtual-list-styles.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-styles.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const virtualListStyles = css`
+  :host {
+    display: block;
+    height: 400px;
+    overflow: auto;
+    flex: auto;
+    align-self: stretch;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  :host(:not([grid])) #items > ::slotted(*) {
+    width: 100%;
+  }
+
+  #items {
+    position: relative;
+  }
+`;

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -10,7 +10,10 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { virtualListStyles } from './vaadin-virtual-list-styles.js';
+
+registerStyles('vaadin-virtual-list', virtualListStyles, { moduleId: 'vaadin-virtual-list-styles' });
 
 /**
  * `<vaadin-virtual-list>` is a Web Component for displaying a virtual/infinite list of items.
@@ -44,28 +47,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 class VirtualList extends ElementMixin(ControllerMixin(ThemableMixin(PolymerElement))) {
   static get template() {
     return html`
-      <style>
-        :host {
-          display: block;
-          height: 400px;
-          overflow: auto;
-          flex: auto;
-          align-self: stretch;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        :host(:not([grid])) #items > ::slotted(*) {
-          width: 100%;
-        }
-
-        #items {
-          position: relative;
-        }
-      </style>
-
       <div id="items">
         <slot></slot>
       </div>


### PR DESCRIPTION
## Description

Extracted `vaadin-virtual-list` styles to `css` literals for reusing by LitElement based version.

## Type of change

- Refactor