### PR TITLE
refactor: extract vaadin-virtual-list-mixin and split tests

### DIFF
--- a/dev/virtual-list.html
+++ b/dev/virtual-list.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Virtual list</title>
+    <script type="module" src="./common.js"></script>
+
+    <script type="module">
+      import '@vaadin/virtual-list';
+
+      const items = Array.from({ length: 100000 }).map((_, i) => {
+        return { label: `Item ${i}` };
+      });
+
+      const renderer = (root, _, { item }) => {
+        root.innerHTML = `<div>${item.label}</div>`;
+      };
+
+      const list = document.querySelector('vaadin-virtual-list');
+      list.items = items;
+      list.renderer = renderer;
+    </script>
+  </head>
+
+  <body>
+    <vaadin-virtual-list style="height: 400px"></vaadin-virtual-list>
+  </body>
+</html>

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -37,6 +37,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "24.3.0-alpha10",
     "@vaadin/lit-renderer": "24.3.0-alpha10",

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.d.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { VirtualList } from './vaadin-virtual-list.js';
+
+export type VirtualListDefaultItem = any;
+
+export interface VirtualListItemModel<TItem> {
+  index: number;
+  item: TItem;
+}
+
+export type VirtualListRenderer<TItem> = (
+  root: HTMLElement,
+  virtualList: VirtualList<TItem>,
+  model: VirtualListItemModel<TItem>,
+) => void;
+
+export declare function VirtualListMixin<TItem, T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ControllerMixinClass> & Constructor<VirtualListMixinClass<TItem>> & T;
+
+export declare class VirtualListMixinClass<TItem = VirtualListDefaultItem> {
+  /**
+   * Gets the index of the first visible item in the viewport.
+   */
+  readonly firstVisibleIndex: number;
+
+  /**
+   * Gets the index of the last visible item in the viewport.
+   */
+  readonly lastVisibleIndex: number;
+
+  /**
+   * Custom function for rendering the content of every item.
+   * Receives three arguments:
+   *
+   * - `root` The render target element representing one item at a time.
+   * - `virtualList` The reference to the `<vaadin-virtual-list>` element.
+   * - `model` The object with the properties related with the rendered
+   *   item, contains:
+   *   - `model.index` The index of the rendered item.
+   *   - `model.item` The item.
+   */
+  renderer: VirtualListRenderer<TItem> | undefined;
+
+  /**
+   * An array containing items determining how many instances to render.
+   */
+  items: TItem[] | undefined;
+
+  /**
+   * Scroll to a specific index in the virtual list.
+   */
+  scrollToIndex(index: number): void;
+
+  /**
+   * Requests an update for the content of the rows.
+   * While performing the update, it invokes the renderer passed in the `renderer` property for each visible row.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   */
+  requestContentUpdate(): void;
+}

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
+import { processTemplates } from '@vaadin/component-base/src/templates.js';
+import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
+
+/**
+ * @polymerMixin
+ * @mixes ControllerMixin
+ */
+export const VirtualListMixin = (superClass) =>
+  class VirtualListMixinClass extends ControllerMixin(superClass) {
+    static get properties() {
+      return {
+        /**
+         * An array containing items determining how many instances to render.
+         * @type {Array<!VirtualListItem> | undefined}
+         */
+        items: { type: Array },
+
+        /**
+         * Custom function for rendering the content of every item.
+         * Receives three arguments:
+         *
+         * - `root` The render target element representing one item at a time.
+         * - `virtualList` The reference to the `<vaadin-virtual-list>` element.
+         * - `model` The object with the properties related with the rendered
+         *   item, contains:
+         *   - `model.index` The index of the rendered item.
+         *   - `model.item` The item.
+         * @type {VirtualListRenderer | undefined}
+         */
+        renderer: Function,
+
+        /** @private */
+        __virtualizer: Object,
+      };
+    }
+
+    static get observers() {
+      return ['__itemsOrRendererChanged(items, renderer, __virtualizer)'];
+    }
+
+    /**
+     * Gets the index of the first visible item in the viewport.
+     *
+     * @return {number}
+     */
+    get firstVisibleIndex() {
+      return this.__virtualizer.firstVisibleIndex;
+    }
+
+    /**
+     * Gets the index of the last visible item in the viewport.
+     *
+     * @return {number}
+     */
+    get lastVisibleIndex() {
+      return this.__virtualizer.lastVisibleIndex;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this.__virtualizer = new Virtualizer({
+        createElements: this.__createElements,
+        updateElement: this.__updateElement.bind(this),
+        elementsContainer: this,
+        scrollTarget: this,
+        scrollContainer: this.shadowRoot.querySelector('#items'),
+      });
+
+      this.__overflowController = new OverflowController(this);
+      this.addController(this.__overflowController);
+
+      processTemplates(this);
+    }
+
+    /**
+     * Scroll to a specific index in the virtual list.
+     *
+     * @param {number} index Index to scroll to
+     */
+    scrollToIndex(index) {
+      this.__virtualizer.scrollToIndex(index);
+    }
+
+    /** @private */
+    __createElements(count) {
+      return [...Array(count)].map(() => document.createElement('div'));
+    }
+
+    /** @private */
+    __updateElement(el, index) {
+      if (el.__renderer !== this.renderer) {
+        el.__renderer = this.renderer;
+        this.__clearRenderTargetContent(el);
+      }
+
+      if (this.renderer) {
+        this.renderer(el, this, { item: this.items[index], index });
+      }
+    }
+
+    /**
+     * Clears the content of a render target.
+     * @private
+     */
+    __clearRenderTargetContent(element) {
+      element.innerHTML = '';
+      // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
+      // When clearing the rendered content, this part needs to be manually disposed of.
+      // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
+      delete element._$litPart$;
+    }
+
+    /** @private */
+    __itemsOrRendererChanged(items, renderer, virtualizer) {
+      // If the renderer is removed but there are elements created by
+      // a previous renderer, we need to request an update from the virtualizer
+      // to get the already existing elements properly cleared.
+      const hasRenderedItems = this.childElementCount > 0;
+
+      if ((renderer || hasRenderedItems) && virtualizer) {
+        virtualizer.size = (items || []).length;
+        virtualizer.update();
+      }
+    }
+
+    /**
+     * Requests an update for the content of the rows.
+     * While performing the update, it invokes the renderer passed in the `renderer` property for each visible row.
+     *
+     * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+     */
+    requestContentUpdate() {
+      if (this.__virtualizer) {
+        this.__virtualizer.update();
+      }
+    }
+  };

--- a/packages/virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list.d.ts
@@ -3,22 +3,16 @@
  * Copyright (c) 2021 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type {
+  VirtualListDefaultItem,
+  VirtualListItemModel,
+  VirtualListMixinClass,
+  VirtualListRenderer,
+} from './vaadin-virtual-list-mixin.js';
 
-export type VirtualListDefaultItem = any;
-
-export interface VirtualListItemModel<TItem> {
-  index: number;
-  item: TItem;
-}
-
-export type VirtualListRenderer<TItem> = (
-  root: HTMLElement,
-  virtualList: VirtualList<TItem>,
-  model: VirtualListItemModel<TItem>,
-) => void;
+export { VirtualListDefaultItem, VirtualListItemModel, VirtualListRenderer };
 
 /**
  * `<vaadin-virtual-list>` is a Web Component for displaying a virtual/infinite list of items.
@@ -46,51 +40,11 @@ export type VirtualListRenderer<TItem> = (
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin
+ * @mixes VirtualListMixin
  */
-declare class VirtualList<TItem = VirtualListDefaultItem> extends ElementMixin(
-  ControllerMixin(ThemableMixin(HTMLElement)),
-) {
-  /**
-   * Gets the index of the first visible item in the viewport.
-   */
-  readonly firstVisibleIndex: number;
+declare class VirtualList<TItem = VirtualListDefaultItem> extends ThemableMixin(ElementMixin(HTMLElement)) {}
 
-  /**
-   * Gets the index of the last visible item in the viewport.
-   */
-  readonly lastVisibleIndex: number;
-
-  /**
-   * Custom function for rendering the content of every item.
-   * Receives three arguments:
-   *
-   * - `root` The render target element representing one item at a time.
-   * - `virtualList` The reference to the `<vaadin-virtual-list>` element.
-   * - `model` The object with the properties related with the rendered
-   *   item, contains:
-   *   - `model.index` The index of the rendered item.
-   *   - `model.item` The item.
-   */
-  renderer: VirtualListRenderer<TItem> | undefined;
-
-  /**
-   * An array containing items determining how many instances to render.
-   */
-  items: TItem[] | undefined;
-
-  /**
-   * Scroll to a specific index in the virtual list.
-   */
-  scrollToIndex(index: number): void;
-
-  /**
-   * Requests an update for the content of the rows.
-   * While performing the update, it invokes the renderer passed in the `renderer` property for each visible row.
-   *
-   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
-   */
-  requestContentUpdate(): void;
-}
+interface VirtualList<TItem = VirtualListDefaultItem> extends VirtualListMixinClass<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -4,13 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
-import { processTemplates } from '@vaadin/component-base/src/templates.js';
-import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { VirtualListMixin } from './vaadin-virtual-list-mixin.js';
 import { virtualListStyles } from './vaadin-virtual-list-styles.js';
 
 registerStyles('vaadin-virtual-list', virtualListStyles, { moduleId: 'vaadin-virtual-list-styles' });
@@ -40,11 +37,11 @@ registerStyles('vaadin-virtual-list', virtualListStyles, { moduleId: 'vaadin-vir
  *
  * @customElement
  * @extends HTMLElement
- * @mixes ControllerMixin
  * @mixes ElementMixin
  * @mixes ThemableMixin
+ * @mixes VirtualListMixin
  */
-class VirtualList extends ElementMixin(ControllerMixin(ThemableMixin(PolymerElement))) {
+class VirtualList extends ElementMixin(ThemableMixin(VirtualListMixin(PolymerElement))) {
   static get template() {
     return html`
       <div id="items">
@@ -55,136 +52,6 @@ class VirtualList extends ElementMixin(ControllerMixin(ThemableMixin(PolymerElem
 
   static get is() {
     return 'vaadin-virtual-list';
-  }
-
-  static get properties() {
-    return {
-      /**
-       * An array containing items determining how many instances to render.
-       * @type {Array<!VirtualListItem> | undefined}
-       */
-      items: { type: Array },
-
-      /**
-       * Custom function for rendering the content of every item.
-       * Receives three arguments:
-       *
-       * - `root` The render target element representing one item at a time.
-       * - `virtualList` The reference to the `<vaadin-virtual-list>` element.
-       * - `model` The object with the properties related with the rendered
-       *   item, contains:
-       *   - `model.index` The index of the rendered item.
-       *   - `model.item` The item.
-       * @type {VirtualListRenderer | undefined}
-       */
-      renderer: Function,
-
-      /** @private */
-      __virtualizer: Object,
-    };
-  }
-
-  static get observers() {
-    return ['__itemsOrRendererChanged(items, renderer, __virtualizer)'];
-  }
-
-  /**
-   * Gets the index of the first visible item in the viewport.
-   *
-   * @return {number}
-   */
-  get firstVisibleIndex() {
-    return this.__virtualizer.firstVisibleIndex;
-  }
-
-  /**
-   * Gets the index of the last visible item in the viewport.
-   *
-   * @return {number}
-   */
-  get lastVisibleIndex() {
-    return this.__virtualizer.lastVisibleIndex;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this.__virtualizer = new Virtualizer({
-      createElements: this.__createElements,
-      updateElement: this.__updateElement.bind(this),
-      elementsContainer: this,
-      scrollTarget: this,
-      scrollContainer: this.shadowRoot.querySelector('#items'),
-    });
-
-    this.__overflowController = new OverflowController(this);
-    this.addController(this.__overflowController);
-
-    processTemplates(this);
-  }
-
-  /**
-   * Scroll to a specific index in the virtual list.
-   *
-   * @param {number} index Index to scroll to
-   */
-  scrollToIndex(index) {
-    this.__virtualizer.scrollToIndex(index);
-  }
-
-  /** @private */
-  __createElements(count) {
-    return [...Array(count)].map(() => document.createElement('div'));
-  }
-
-  /** @private */
-  __updateElement(el, index) {
-    if (el.__renderer !== this.renderer) {
-      el.__renderer = this.renderer;
-      this.__clearRenderTargetContent(el);
-    }
-
-    if (this.renderer) {
-      this.renderer(el, this, { item: this.items[index], index });
-    }
-  }
-
-  /**
-   * Clears the content of a render target.
-   * @private
-   */
-  __clearRenderTargetContent(element) {
-    element.innerHTML = '';
-    // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
-    // When clearing the rendered content, this part needs to be manually disposed of.
-    // Otherwise, using a Lit-based renderer on the same node will throw an exception or render nothing afterward.
-    delete element._$litPart$;
-  }
-
-  /** @private */
-  __itemsOrRendererChanged(items, renderer, virtualizer) {
-    // If the renderer is removed but there are elements created by
-    // a previous renderer, we need to request an update from the virtualizer
-    // to get the already existing elements properly cleared.
-    const hasRenderedItems = this.childElementCount > 0;
-
-    if ((renderer || hasRenderedItems) && virtualizer) {
-      virtualizer.size = (items || []).length;
-      virtualizer.update();
-    }
-  }
-
-  /**
-   * Requests an update for the content of the rows.
-   * While performing the update, it invokes the renderer passed in the `renderer` property for each visible row.
-   *
-   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
-   */
-  requestContentUpdate() {
-    if (this.__virtualizer) {
-      this.__virtualizer.update();
-    }
   }
 }
 

--- a/packages/virtual-list/test/lit-polymer.test.js
+++ b/packages/virtual-list/test/lit-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-virtual-list.js';
+import './lit.common.js';

--- a/packages/virtual-list/test/lit-renderer-directives-polymer.test.js
+++ b/packages/virtual-list/test/lit-renderer-directives-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-virtual-list.js';
+import './lit-renderer-directives.common.js';

--- a/packages/virtual-list/test/lit-renderer-directives.common.js
+++ b/packages/virtual-list/test/lit-renderer-directives.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-virtual-list.js';
 import { html, render } from 'lit';
 import { virtualListRenderer } from '../lit.js';
 

--- a/packages/virtual-list/test/lit.common.js
+++ b/packages/virtual-list/test/lit.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-virtual-list.js';
 import { html, render } from 'lit';
 
 describe('lit', () => {

--- a/packages/virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/virtual-list/test/typings/virtual-list.types.ts
@@ -1,4 +1,6 @@
 import '../../vaadin-virtual-list.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import type { VirtualList, VirtualListItemModel, VirtualListRenderer } from '../../vaadin-virtual-list.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
@@ -6,6 +8,9 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 const genericVirtualList = document.createElement('vaadin-virtual-list');
 
 assertType<VirtualList>(genericVirtualList);
+
+assertType<ThemableMixinClass>(genericVirtualList);
+assertType<ElementMixinClass>(genericVirtualList);
 
 genericVirtualList.items = [1, 2, 3];
 

--- a/packages/virtual-list/test/virtual-list-polymer.test.js
+++ b/packages/virtual-list/test/virtual-list-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-virtual-list.js';
+import './virtual-list.common.js';

--- a/packages/virtual-list/test/virtual-list.common.js
+++ b/packages/virtual-list/test/virtual-list.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-virtual-list.js';
 
 describe('virtual-list', () => {
   let list;


### PR DESCRIPTION
## Description

- Extracted `vaadin-virtual-list` logic into a mixin for reusing by LitElement version.
- Split the test cases into `.common.js` and `-polymer.test.js` files

## Type of change

- Refactor