### PR TITLE
fix: fix opened-changed listener binding in confirm-dialog

### DIFF
--- a/packages/confirm-dialog/src/vaadin-lit-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-lit-confirm-dialog.js
@@ -54,7 +54,7 @@ class ConfirmDialog extends ConfirmDialogMixin(ElementMixin(ThemePropertyMixin(P
         .noCloseOnEsc="${this.noCloseOnEsc}"
         .contentHeight="${this._contentHeight}"
         .contentWidth="${this._contentWidth}"
-        @opened-changed=${this._onOpenedChanged}"
+        @opened-changed="${this._onOpenedChanged}"
       ></vaadin-confirm-dialog-dialog>
 
       <div hidden>


### PR DESCRIPTION
## Description

Fix opened-changed listener binding in confirm-dialog. 

Fixes the following error:
![Screenshot 2023-11-20 at 11 26 05](https://github.com/vaadin/web-components/assets/1222264/4edabeec-7d0c-44e2-aefe-244be325fb45)

## Type of change

Bugfix