### PR TITLE
fix: ensure only selected items are shown when readonly

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -165,7 +165,12 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * @override
    */
   _setDropdownItems(items) {
-    if (this.filter || this.readonly || !this.selectedItemsOnTop) {
+    if (this.readonly) {
+      this._dropdownItems = this.selectedItems;
+      return;
+    }
+
+    if (this.filter || !this.selectedItemsOnTop) {
       this._dropdownItems = items;
       return;
     }

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -192,6 +192,17 @@ describe('readonly', () => {
       expect(items[2].textContent).to.equal('lemon');
       expect(items[3].textContent).to.equal('orange');
     });
+
+    it('should only render selected items in the dropdown when size is set', async () => {
+      inputElement.click();
+      // Wait for the async data provider timeout
+      await aTimeout(0);
+      comboBox.size = 5;
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.equal('apple');
+      expect(items[1].textContent).to.equal('orange');
+    });
   });
 
   describe('dataProvider is set after selectedItems', () => {

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -197,7 +197,7 @@ describe('readonly', () => {
       inputElement.click();
       // Wait for the async data provider timeout
       await aTimeout(0);
-      comboBox.size = 5;
+      comboBox.size = 4;
       const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('apple');

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -193,7 +193,7 @@ describe('readonly', () => {
       expect(items[3].textContent).to.equal('orange');
     });
 
-    it('should only render selected items in the dropdown when size is set', async () => {
+    it('should render selected items in the dropdown when size is set', async () => {
       inputElement.click();
       // Wait for the async data provider timeout
       await aTimeout(0);


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/4533

The issue with extra empty items shown in the dropdown was caused by filling `filteredItems` with placeholders:

https://github.com/vaadin/web-components/blob/85f5712eab50425d1eeaa161bc1d9611c60c0a00/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js#L243-L247

This wasn't caught as we didn't have a test for `size` property in the web component (Flow connector uses it).

## Type of change

- Bugfix

## Note

Backporting will likely require a different fix, as we I added `_dropdownItems` recently for 24.3 MSCB features.