### PR TITLE
fix: measure grid column auto-width from column cell

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -418,8 +418,19 @@ export const GridMixin = (superClass) =>
         })
         .forEach((cell) => {
           cell.__measuringAutoWidth = autoWidth;
-          cell.style.width = autoWidth ? 'auto' : '';
-          cell.style.position = autoWidth ? 'absolute' : '';
+
+          if (cell.__measuringAutoWidth) {
+            // Store the original inline width of the cell to restore it later
+            cell.__originalWidth = cell.style.width;
+            // Prepare the cell for having its intrinsic width measured
+            cell.style.width = 'auto';
+            cell.style.position = 'absolute';
+          } else {
+            // Restore the original width
+            cell.style.width = cell.__originalWidth || '';
+            delete cell.__originalWidth;
+            cell.style.position = '';
+          }
         });
     }
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -427,7 +427,7 @@ export const GridMixin = (superClass) =>
             cell.style.position = 'absolute';
           } else {
             // Restore the original width
-            cell.style.width = cell.__originalWidth || '';
+            cell.style.width = cell.__originalWidth;
             delete cell.__originalWidth;
             cell.style.position = '';
           }

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -418,8 +418,8 @@ export const GridMixin = (superClass) =>
         })
         .forEach((cell) => {
           cell.__measuringAutoWidth = autoWidth;
-          cell._content.style.width = autoWidth ? 'auto' : '';
-          cell._content.style.position = autoWidth ? 'absolute' : '';
+          cell.style.width = autoWidth ? 'auto' : '';
+          cell.style.position = autoWidth ? 'absolute' : '';
         });
     }
 
@@ -433,7 +433,7 @@ export const GridMixin = (superClass) =>
       // Note: _allCells only contains cells which are currently rendered in DOM
       return col._allCells.reduce((width, cell) => {
         // Add 1px buffer to the offset width to avoid too narrow columns (sub-pixel rendering)
-        return cell.__measuringAutoWidth ? Math.max(width, cell._content.offsetWidth + 1) : width;
+        return cell.__measuringAutoWidth ? Math.max(width, cell.offsetWidth + 1) : width;
       }, 0);
     }
 

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { flushGrid } from './helpers.js';
+import { flushGrid, getContainerCell } from './helpers.js';
 
 describe('column auto-width', () => {
   let grid;
@@ -208,6 +208,13 @@ describe('column auto-width', () => {
 
     await recalculateWidths();
     expectColumnWidthsToBeOk(columns, [63]);
+  });
+
+  it('should have correct cell width after re-measuring', async () => {
+    grid.recalculateColumnWidths();
+    await recalculateWidths();
+
+    expect(getContainerCell(grid.$.header, 0, 0).getBoundingClientRect().width).to.be.closeTo(43, 5);
   });
 });
 

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -196,10 +196,12 @@ describe('column auto-width', () => {
   });
 
   it('should take cell styling into account', async () => {
+    const firstColumnWidth = columns[0].width;
+
     fixtureSync(`
       <style>
         vaadin-grid::part(cell) {
-          padding: 10px;
+          padding-right: 20px;
         }
       </style>
     `);
@@ -207,7 +209,7 @@ describe('column auto-width', () => {
     grid.recalculateColumnWidths();
 
     await recalculateWidths();
-    expectColumnWidthsToBeOk(columns, [63]);
+    expectColumnWidthsToBeOk(columns, [parseInt(firstColumnWidth) + 20]);
   });
 
   it('should have correct cell width after re-measuring', async () => {

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -196,7 +196,7 @@ describe('column auto-width', () => {
   });
 
   it('should take cell styling into account', async () => {
-    const firstColumnWidth = columns[0].width;
+    const firstColumnWidth = parseInt(columns[0].width);
 
     fixtureSync(`
       <style>
@@ -207,9 +207,9 @@ describe('column auto-width', () => {
     `);
 
     grid.recalculateColumnWidths();
-
     await recalculateWidths();
-    expectColumnWidthsToBeOk(columns, [parseInt(firstColumnWidth) + 20]);
+
+    expectColumnWidthsToBeOk(columns, [firstColumnWidth + 20]);
   });
 
   it('should have correct cell width after re-measuring', async () => {

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -194,6 +194,21 @@ describe('column auto-width', () => {
     await recalculateWidths();
     expectColumnWidthsToBeOk(columns, [74]);
   });
+
+  it('should take cell styling into account', async () => {
+    fixtureSync(`
+      <style>
+        vaadin-grid::part(cell) {
+          padding: 10px;
+        }
+      </style>
+    `);
+
+    grid.recalculateColumnWidths();
+
+    await recalculateWidths();
+    expectColumnWidthsToBeOk(columns, [63]);
+  });
 });
 
 describe('tree column', () => {

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -211,10 +211,13 @@ describe('column auto-width', () => {
   });
 
   it('should have correct cell width after re-measuring', async () => {
+    const headerCell = getContainerCell(grid.$.header, 0, 0);
+    const headerCellWidth = headerCell.getBoundingClientRect().width;
+
     grid.recalculateColumnWidths();
     await recalculateWidths();
 
-    expect(getContainerCell(grid.$.header, 0, 0).getBoundingClientRect().width).to.be.closeTo(43, 5);
+    expect(headerCell.getBoundingClientRect().width).to.be.closeTo(headerCellWidth, 5);
   });
 });
 


### PR DESCRIPTION
## Description

The width for a grid column using `autoWidth` is currently measured from the cell content element (regression from https://github.com/vaadin/web-components/pull/5623). This is problematic since it doesn't take into account styling applied to the column cells, which could affect the total column width.

This PR fixes the issue by having auto-width measured from the cell element instead of the cell content element.

Fixes https://github.com/vaadin/flow-components/issues/5599

## Type of change

Bugfix