### PR TITLE
fix: ensure only selected items are shown when readonly (#6814) (CP: 24.1)

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -139,6 +139,22 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override combo-box method to group selected
+   * items at the top of the overlay.
+   *
+   * @protected
+   * @override
+   */
+  _setDropdownItems(items) {
+    if (this.readonly) {
+      this._dropdownItems = this.selectedItems;
+      return;
+    }
+
+    this._dropdownItems = items;
+  }
+
+  /**
    * Override combo-box method to set correct owner for using by item renderers.
    * This needs to be done before the scroller gets added to the DOM to ensure
    * Lit directive works in case when combo-box is opened using attribute.

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -192,6 +192,17 @@ describe('readonly', () => {
       expect(items[2].textContent).to.equal('lemon');
       expect(items[3].textContent).to.equal('orange');
     });
+
+    it('should render selected items in the dropdown when size is set', async () => {
+      inputElement.click();
+      // Wait for the async data provider timeout
+      await aTimeout(0);
+      comboBox.size = 4;
+      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      expect(items.length).to.equal(2);
+      expect(items[0].textContent).to.equal('apple');
+      expect(items[1].textContent).to.equal('orange');
+    });
   });
 
   describe('dataProvider is set after selectedItems', () => {


### PR DESCRIPTION
## Description

Manual cherry-pick of #6814 to `24.1` branch. 

This also partially reverts #4019 and restores `_dropdownItems`.

## Type of change

- Cherry-pick