### PR TITLE
fix: do not reset selected items when disabled set to false

### DIFF
--- a/packages/list-box/src/vaadin-multi-select-list-mixin.js
+++ b/packages/list-box/src/vaadin-multi-select-list-mixin.js
@@ -39,7 +39,7 @@ export const MultiSelectListMixin = (superClass) =>
     }
 
     static get observers() {
-      return [`_enhanceMultipleItems(items, multiple, selected, selectedValues, selectedValues.*)`];
+      return ['_enhanceMultipleItems(items, multiple, selected, disabled, selectedValues, selectedValues.*)'];
     }
 
     /** @protected */
@@ -51,8 +51,8 @@ export const MultiSelectListMixin = (superClass) =>
     }
 
     /** @private */
-    _enhanceMultipleItems(items, multiple, selected, selectedValues) {
-      if (!items || !multiple) {
+    _enhanceMultipleItems(items, multiple, selected, disabled, selectedValues) {
+      if (!items || !multiple || disabled) {
         return;
       }
 

--- a/packages/list-box/src/vaadin-multi-select-list-mixin.js
+++ b/packages/list-box/src/vaadin-multi-select-list-mixin.js
@@ -52,7 +52,7 @@ export const MultiSelectListMixin = (superClass) =>
 
     /** @private */
     _enhanceMultipleItems(items, multiple, selected, disabled, selectedValues) {
-      if (!items || !multiple || disabled) {
+      if (!items || !multiple) {
         return;
       }
 

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -172,4 +172,14 @@ describe('MultiSelectListMixin', () => {
     list.multiple = false;
     expect(list.hasAttribute('aria-multiselectable')).to.be.false;
   });
+
+  it('should not reset selected state when setting disabled to false', () => {
+    list.multiple = true;
+    list.disabled = true;
+
+    list.selectedValues = [2];
+    list.disabled = false;
+
+    expect(list.items[2].selected).to.be.true;
+  });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5056

This PR aligns two observers in mixins used by `vaadin-list-box` so that they both use `disabled`:

https://github.com/vaadin/web-components/blob/bda453714f5ed8a4ad72efe168efb6a208116c88/packages/a11y-base/src/list-mixin.js#L94

https://github.com/vaadin/web-components/blob/bda453714f5ed8a4ad72efe168efb6a208116c88/packages/list-box/src/vaadin-multi-select-list-mixin.js#L42

When trying the original issue in the Flow counterpart, I noticed that `selected` is first set to `true` on the `vaadin-item` in `MultiSelectListMixin`, and then it is reset back to `false` by [`ListMixin`](https://github.com/vaadin/web-components/blob/bda453714f5ed8a4ad72efe168efb6a208116c88/packages/a11y-base/src/list-mixin.js#L171-L174), as `selected` property is `undefined`. 

Adding `disabled` to the second observer makes it run in the right order. I believe it also needs to be there for general reasons related to `setEnabled()` purpose on the Flow side, to postpone state change until enabled is `true`.

## Type of change

- Bugfix