### PR TITLE
fix: do not reset selected items when disabled set to false (#6822) (CP: 23.4)

### DIFF
--- a/packages/vaadin-list-mixin/test/list-mixin.test.js
+++ b/packages/vaadin-list-mixin/test/list-mixin.test.js
@@ -794,6 +794,16 @@ describe('vaadin-list-mixin', () => {
       list.multiple = false;
       expect(list.hasAttribute('aria-multiselectable')).to.be.false;
     });
+
+    it('should not reset selected state when setting disabled to false', () => {
+      list.multiple = true;
+      list.disabled = true;
+
+      list.selectedValues = [2];
+      list.disabled = false;
+
+      expect(list.items[2].selected).to.be.true;
+    });
   });
 
   describe('hidden items', () => {

--- a/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.js
+++ b/packages/vaadin-list-mixin/vaadin-multi-select-list-mixin.js
@@ -39,7 +39,7 @@ export const MultiSelectListMixin = (superClass) =>
     }
 
     static get observers() {
-      return [`_enhanceMultipleItems(items, multiple, selected, selectedValues, selectedValues.*)`];
+      return ['_enhanceMultipleItems(items, multiple, selected, disabled, selectedValues, selectedValues.*)'];
     }
 
     /** @protected */
@@ -51,7 +51,7 @@ export const MultiSelectListMixin = (superClass) =>
     }
 
     /** @private */
-    _enhanceMultipleItems(items, multiple, selected, selectedValues) {
+    _enhanceMultipleItems(items, multiple, selected, disabled, selectedValues) {
       if (!items || !multiple) {
         return;
       }


### PR DESCRIPTION
## Description

Manual cherry-pick of #6822 to `23.4` branch where we still have `vaadin-list-mixin` package.

## Type of change

- Cherry-pick