### PR TITLE
fix: render virtualizer after size change

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -312,6 +312,7 @@ export class IronListAdapter {
       // Already initialized, just update _virtualCount
       this._updateScrollerSize();
       this._virtualCount = this.items.length;
+      this._render();
     }
 
     // When reducing size while invisible, iron-list does not update items, so

--- a/packages/grid/test/resizing.common.js
+++ b/packages/grid/test/resizing.common.js
@@ -305,7 +305,6 @@ describe('all rows visible', () => {
         };
         cb([item], 1);
       };
-      flushGrid(grid);
     });
 
     it('should have all rows visible on deep expand', () => {
@@ -319,6 +318,28 @@ describe('all rows visible', () => {
         { value: '0-0-0-0-0-0-0' },
         { value: '0-0-0-0-0-0-0-0' },
       ];
+
+      flushGrid(grid);
+      expect(grid._firstVisibleIndex).to.equal(0);
+      expect(grid._lastVisibleIndex).to.equal(8);
+    });
+
+    it('should have all rows visible on deep expand with no header', () => {
+      grid.expandedItems = [
+        { value: '0' },
+        { value: '0-0' },
+        { value: '0-0-0' },
+        { value: '0-0-0-0' },
+        { value: '0-0-0-0-0' },
+        { value: '0-0-0-0-0-0' },
+        { value: '0-0-0-0-0-0-0' },
+        { value: '0-0-0-0-0-0-0-0' },
+      ];
+
+      const column = grid.querySelector('vaadin-grid-tree-column');
+      column.header = null;
+
+      flushGrid(grid);
       expect(grid._firstVisibleIndex).to.equal(0);
       expect(grid._lastVisibleIndex).to.equal(8);
     });


### PR DESCRIPTION
## Description

Follow-up for https://github.com/vaadin/web-components/pull/6795

The previous fix failed to cover a case where the pre-expanded grid has no header. This PR fixes the issue.

https://github.com/vaadin/web-components/assets/1222264/89de9558-4fb9-4b9b-b7d5-094738205c3f


## Type of change

Bugfix