### PR TITLE
fix: align check used to detect if the item is selected

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -178,7 +178,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     if (items && items.length && this.topGroup && this.topGroup.length) {
       // Filter out items included to the top group.
       const filteredItems = items.filter(
-        (item) => !this.topGroup.some((selectedItem) => this._getItemValue(item) === this._getItemValue(selectedItem)),
+        (item) => this._comboBox._findIndex(item, this.topGroup, this.itemIdPath) === -1,
       );
 
       this._dropdownItems = this.topGroup.concat(filteredItems);
@@ -205,6 +205,8 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    */
   _initScroller() {
     const comboBox = this.getRootNode().host;
+
+    this._comboBox = comboBox;
 
     super._initScroller(comboBox);
   }

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -165,6 +165,7 @@ describe('selecting items', () => {
   describe('selected items on top', () => {
     function expectItems(values) {
       const items = getAllItems(comboBox);
+      expect(items.length).to.equal(values.length);
       values.forEach((value, idx) => {
         expect(items[idx].textContent).to.equal(value);
       });
@@ -224,6 +225,27 @@ describe('selecting items', () => {
         comboBox.selectedItemsOnTop = false;
         comboBox.opened = true;
         expectItems(['apple', 'banana', 'lemon', 'orange']);
+      });
+    });
+
+    describe('object items', () => {
+      const items = [
+        { id: '0', label: 'apple' },
+        { id: '1', label: 'banana' },
+        { id: '2', label: 'lemon' },
+        { id: '3', label: 'orange' },
+        { id: '4', label: 'pear' },
+      ];
+
+      beforeEach(() => {
+        comboBox.itemIdPath = 'id';
+        comboBox.items = items;
+        comboBox.selectedItems = items.slice(1, 3);
+      });
+
+      it('should show selected items at the top of the overlay', () => {
+        comboBox.opened = true;
+        expectItems(['banana', 'lemon', 'apple', 'orange', 'pear']);
       });
     });
 


### PR DESCRIPTION
## Description

Fixes #6835

Updated to use the same logic as in `_isItemSelected` by `vaadin-multi-select-combo-box-scroller`:

https://github.com/vaadin/web-components/blob/04fe7d4adb3f6fec0563f90d47bc3b633ec833d1/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js#L75

This way we don't need to pass both `itemValuePath` and `itemIdPath`. Using `itemIdPath` is enough.

## Type of change

- Bugfix