### PR TITLE
fix: focus the closest focusable on overlay mousedown

### DIFF
--- a/packages/a11y-base/src/focus-utils.d.ts
+++ b/packages/a11y-base/src/focus-utils.d.ts
@@ -55,3 +55,11 @@ export declare function isElementFocused(element: HTMLElement): boolean;
  * The method traverses nodes in shadow DOM trees too if any.
  */
 export declare function getFocusableElements(element: HTMLElement): HTMLElement[];
+
+/**
+ * Returns a closest focusable ancestor of an element,
+ * or an element itself in case if it's focusable.
+ *
+ * The method traverses nodes in shadow DOM trees too if any.
+ */
+export declare function getClosestFocusable(element: HTMLElement): HTMLElement | undefined;

--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -274,3 +274,43 @@ export function getFocusableElements(element) {
   }
   return focusableElements;
 }
+
+/**
+ * Returns an ancestor for the given node.
+ *
+ * @param {Node} node
+ * @return {Node}
+ * @private
+ */
+function getAncestor(node) {
+  if (node.nodeType === Node.ELEMENT_NODE && node.assignedSlot) {
+    return node.assignedSlot;
+  }
+
+  if (node instanceof ShadowRoot) {
+    return node.host;
+  }
+
+  return node.parentNode;
+}
+
+/**
+ * Returns a closest focusable ancestor of an element,
+ * or an element itself in case if it's focusable.
+ *
+ * The method traverses nodes in shadow DOM trees too if any.
+ *
+ * @param {HTMLElement} element
+ * @return {HTMLElement | undefined}
+ */
+export function getClosestFocusable(element) {
+  let current = element;
+
+  while (current !== document.body) {
+    if (current.nodeType === Node.ELEMENT_NODE && isElementFocusable(current)) {
+      return current;
+    }
+
+    current = getAncestor(current);
+  }
+}

--- a/packages/a11y-base/test/focus-utils.test.js
+++ b/packages/a11y-base/test/focus-utils.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { defineCE, fixtureSync, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
 import {
+  getClosestFocusable,
   getDeepActiveElement,
   getFocusableElements,
   isElementFocusable,
@@ -298,6 +299,67 @@ describe('focus-utils', () => {
           expect(getDeepActiveElement()).to.eql(el);
         });
       });
+    });
+  });
+
+  describe('getClosestFocusable', () => {
+    let element, host;
+
+    const hostTag = defineCE(
+      class extends HTMLElement {
+        constructor() {
+          super();
+          this.attachShadow({ mode: 'open' });
+          this.shadowRoot.innerHTML = `
+            <div tabindex="0">
+              <slot></slot>
+              <input id="inner" />
+            </div>
+            <slot name="footer"></slot>
+          `;
+        }
+      },
+    );
+
+    beforeEach(() => {
+      element = fixtureSync(`
+        <div>
+          <div tabindex="0">
+            <${hostTag}>
+              <input id="outer" />
+              <div id="content">Content</div>
+              <div slot="footer">Footer</footer>
+            </${hostTag}>
+          </div>
+        </div>
+      `);
+      host = element.querySelector(`${hostTag}`);
+    });
+
+    it('should return element itself in case if it is focusable', () => {
+      const outerInput = element.querySelector('#outer');
+      expect(getClosestFocusable(outerInput)).to.equal(outerInput);
+
+      const innerInput = host.shadowRoot.querySelector('#inner');
+      expect(getClosestFocusable(innerInput)).to.equal(innerInput);
+    });
+
+    it('should return parent element in case if it is focusable', () => {
+      expect(getClosestFocusable(host)).to.equal(host.parentElement);
+    });
+
+    it('should return element in shadow DOM for a slotted element', () => {
+      const content = element.querySelector('#content');
+      const focusable = host.shadowRoot.querySelector('[tabindex="0"]');
+      expect(getClosestFocusable(content)).to.equal(focusable);
+    });
+
+    it('should return element outside shadow DOM for a shadow root', () => {
+      expect(getClosestFocusable(host.shadowRoot)).to.equal(host.parentElement);
+    });
+
+    it('should return undefined if no focusable ancestor is found', () => {
+      expect(getClosestFocusable(element)).to.be.undefined;
     });
   });
 });

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { getClosestFocusable } from '@vaadin/a11y-base/src/focus-utils.js';
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
@@ -118,6 +119,10 @@ export const OverlayMixin = (superClass) =>
       // and <vaadin-context-menu>).
       this.addEventListener('click', () => {});
       this.$.backdrop.addEventListener('click', () => {});
+
+      this.addEventListener('mousedown', (e) => {
+        this._onMouseDown(e);
+      });
     }
 
     /** @protected */
@@ -467,6 +472,15 @@ export const OverlayMixin = (superClass) =>
         if (this.opened && !evt.defaultPrevented) {
           this.close(event);
         }
+      }
+    }
+
+    /** @private */
+    _onMouseDown(event) {
+      const focusable = getClosestFocusable(event.target);
+      if (focusable) {
+        event.preventDefault();
+        focusable.focus();
       }
     }
   };

--- a/packages/overlay/test/interactions.common.js
+++ b/packages/overlay/test/interactions.common.js
@@ -4,6 +4,8 @@ import {
   enterKeyDown,
   escKeyDown,
   fixtureSync,
+  makeMouseEvent,
+  middleOfNode,
   mousedown,
   mouseup,
   nextRender,
@@ -67,7 +69,15 @@ describe('interactions', () => {
       parent = document.createElement('div');
       overlay = fixtureSync('<vaadin-overlay></vaadin-overlay>', parent);
       overlay.renderer = (root) => {
-        root.textContent = 'overlay content';
+        if (!root.firstChild) {
+          const div = document.createElement('div');
+          div.textContent = 'overlay content';
+          root.appendChild(div);
+
+          const btn = document.createElement('button');
+          btn.textContent = 'Button';
+          root.appendChild(btn);
+        }
       };
       await nextRender();
       overlayPart = overlay.$.overlay;
@@ -291,6 +301,28 @@ describe('interactions', () => {
         click(overlayPart);
 
         expect(overlay.opened).to.be.true;
+      });
+    });
+
+    describe('mousedown on content', () => {
+      it('should prevent default on content mousedown', () => {
+        const div = overlay.querySelector('div');
+        const event = makeMouseEvent('mousedown', middleOfNode(div), div);
+        expect(event.defaultPrevented).to.be.true;
+      });
+
+      it('should focus an overlay part on content mousedown', () => {
+        const div = overlay.querySelector('div');
+        const spy = sinon.spy(overlayPart, 'focus');
+        mousedown(div);
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should focus a focusable content element, if any', () => {
+        const button = overlay.querySelector('button');
+        const spy = sinon.spy(button, 'focus');
+        mousedown(button);
+        expect(spy.calledOnce).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5507

This PR adapts the solution from Elix library mentioned at https://github.com/vaadin/flow-components/issues/5507#issuecomment-1798601476.

The actual issue was happening when clicking an element in any of the `vaadin-dialog-overlay` slots (including header content and footer). In this scenario, in Chrome there was a `focusout` event fired, with focus moving to `<body>`. By calling `preventDefault()` we make sure there is no `focusout`, and then we focus correct element manually.

## Type of change

- Bugfix