### PR TITLE
fix: manually load first page if grid virtualizer is empty

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -369,7 +369,7 @@ export const DataProviderMixin = (superClass) =>
       this._hasData = false;
       this.__updateVisibleRows();
 
-      if (!this._flatSize || !this.__virtualizer.size) {
+      if (!this.__virtualizer.size) {
         this._dataProviderController.loadFirstPage();
       }
     }

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -369,7 +369,7 @@ export const DataProviderMixin = (superClass) =>
       this._hasData = false;
       this.__updateVisibleRows();
 
-      if (!this._flatSize) {
+      if (!this._flatSize || !this.__virtualizer.size) {
         this._dataProviderController.loadFirstPage();
       }
     }

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -203,6 +203,25 @@ describe('data provider', () => {
     it('should set itemHasChildren path by default', () => {
       expect(grid.itemHasChildrenPath).to.equal('children');
     });
+
+    it('should request items when sorting is applied initially', () => {
+      // Initialize a fresh grid
+      grid.remove();
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-sort-column path="value" direction="asc"></vaadin-grid-sort-column>
+        </vaadin-grid>
+      `);
+
+      // Set data provider
+      grid.dataProvider = (params, callback) => {
+        infiniteDataProvider(params, (items) => callback(items, 1));
+      };
+
+      // Expect the grid to have a body row
+      flushGrid(grid);
+      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('foo0');
+    });
   });
 
   describe('tree', () => {

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -214,13 +214,11 @@ describe('data provider', () => {
       `);
 
       // Set data provider
-      grid.dataProvider = (params, callback) => {
-        infiniteDataProvider(params, (items) => callback(items, 1));
-      };
+      grid.dataProvider = (params, callback) => callback([{ value: 'foo' }], 1);
 
       // Expect the grid to have a body row
       flushGrid(grid);
-      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('foo0');
+      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('foo');
     });
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/6849

If the grid has physical row elements and its cache gets cleared, updating the physical rows would automatically result in a new data request being made for the pages in the current viewport. If the grid has no rows (yet) however, a data request needs to be made manually. There is a [check](https://github.com/vaadin/web-components/blob/a197041861e1bbf8d3e966d893648f5dd462b036/packages/grid/src/vaadin-grid-data-provider-mixin.js#L372-L374) for this condition in the `clearCache` function.

It's possible for the grid to end up in a state where its flat size doesn't equal the virtualizer's size. This can happen if `clearCache` is called after flat size is set but before the value gets [synchronized](https://github.com/vaadin/web-components/blob/a197041861e1bbf8d3e966d893648f5dd462b036/packages/grid/src/vaadin-grid-mixin.js#L300) as the virtualizer's size.

In this condition, `clearCache()` would never result in a new data request because there are no physical row elements yet and the flat size is > 0 so the above check wouldn't create one manually either.

This PR fixes the issue by improving the above condition to check if the virtualizer has no size.

## Type of change

Bugfix