### PR TITLE
test: refactor scrollable tabs tests to check for visible tabs

### DIFF
--- a/packages/tabs/test/not-animated-styles.js
+++ b/packages/tabs/test/not-animated-styles.js
@@ -1,0 +1,11 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-tabs',
+  css`
+    [part='forward-button'],
+    [part='back-button'] {
+      transition: none;
+    }
+  `,
+);

--- a/packages/tabs/test/scroll.test.js
+++ b/packages/tabs/test/scroll.test.js
@@ -1,11 +1,12 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, arrowLeft, arrowRight, arrowUp, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { arrowDown, arrowLeft, arrowRight, arrowUp, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
 import '../vaadin-tabs.js';
 
 describe('scrollable tabs', () => {
   let tabs, items, scroller;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tabs = fixtureSync(`
       <vaadin-tabs style="width: 400px; height: 150px;">
         <vaadin-tab>Foo</vaadin-tab>
@@ -26,14 +27,16 @@ describe('scrollable tabs', () => {
         <vaadin-tab>Baz4</vaadin-tab>
       </vaadin-tabs>
     `);
+    await nextRender();
     tabs._observer.flush();
     items = tabs.items;
     scroller = tabs.shadowRoot.querySelector('[part="tabs"]');
   });
 
   describe('horizontal', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       tabs.orientation = 'horizontal';
+      await nextFrame();
     });
 
     it('should show one extra item on the right edge of the viewport on "arrow-right" on last visible tab', () => {
@@ -75,36 +78,87 @@ describe('scrollable tabs', () => {
 
     ['ltr', 'rtl'].forEach((dir) => {
       describe(dir, () => {
+        let itemsInViewport;
+
+        function expectItemsInViewport(expected) {
+          const scrollerRect = scroller.getBoundingClientRect();
+
+          items.forEach((item) => {
+            const itemRect = item.getBoundingClientRect();
+
+            let left = scrollerRect.left;
+            const btnLeft = tabs.shadowRoot.querySelector(dir === 'ltr' ? '[part^="back"]' : '[part^="forward"]');
+            if (getComputedStyle(btnLeft).opacity === '1') {
+              left += btnLeft.clientWidth;
+            }
+
+            let right = scrollerRect.right;
+            const btnRight = tabs.shadowRoot.querySelector(dir === 'ltr' ? '[part^="forward"]' : '[part^="back"]');
+            if (getComputedStyle(btnRight).opacity === '1') {
+              right -= btnRight.clientWidth;
+            }
+
+            const inViewport = Math.round(itemRect.left) >= left && Math.round(itemRect.right) <= right;
+            if (inViewport) {
+              itemsInViewport.add(item);
+            } else if (itemsInViewport.has(item)) {
+              itemsInViewport.delete(item);
+            }
+          });
+          const actual = [...itemsInViewport].map((item) => item.textContent);
+          expect(actual.every((item) => expected.includes(item))).to.be.true;
+        }
+
         beforeEach(async () => {
+          itemsInViewport = new Set();
           tabs.setAttribute('dir', dir);
           await nextFrame();
         });
 
-        it('should have displayed all the items fully when scrolled forward to the end via button', () => {
+        it('should have displayed all the items fully when scrolled forward to the end via button', async () => {
           const forwardButton = tabs.shadowRoot.querySelector('[part="forward-button"]');
 
-          expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.equal(0);
+          expectItemsInViewport(['Foo', 'Bar', 'Baz', 'Foo1', 'Bar1']);
 
           forwardButton.click();
-          expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.be.approximately(310, 10);
+          await nextRender();
+
+          expectItemsInViewport(['Baz1', 'Foo2', 'Bar2', 'Baz2']);
 
           forwardButton.click();
-          expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.be.approximately(537, 10);
+          await nextRender();
+
+          expectItemsInViewport(['Foo3', 'Bar3', 'Baz3', 'Foo4']);
+
+          forwardButton.click();
+          await nextRender();
+
+          expectItemsInViewport(['Bar3', 'Baz3', 'Foo4', 'Bar4', 'Baz4']);
         });
 
-        it('should have displayed all the items fully when scrolled back to the start via button', () => {
+        it('should have displayed all the items fully when scrolled back to the start via button', async () => {
           // Initially scroll to the end
           tabs._scrollToItem(items.length - 1);
+          await nextRender();
+
+          expectItemsInViewport(['Bar3', 'Baz3', 'Foo4', 'Bar4', 'Baz4']);
 
           const backButton = tabs.shadowRoot.querySelector('[part="back-button"]');
 
-          expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.be.approximately(537, 10);
+          backButton.click();
+          await nextRender();
+
+          expectItemsInViewport(['Foo2', 'Bar2', 'Baz2', 'Foo3']);
 
           backButton.click();
-          expect(-tabs.__direction * tabs._scrollerElement.scrollLeft).to.be.approximately(228, 10);
+          await nextRender();
+
+          expectItemsInViewport(['Baz', 'Foo1', 'Bar1', 'Baz1']);
 
           backButton.click();
-          expect(tabs._scrollerElement.scrollLeft).to.equal(0);
+          await nextRender();
+
+          expectItemsInViewport(['Foo', 'Bar', 'Baz', 'Foo1', 'Bar1']);
         });
 
         it('should not get stuck with wide tabs when scrolled forward to the end via button', () => {


### PR DESCRIPTION
## Description

Fixes #6812

Updated scrollable tabs tests to actually check that every tab is visible at some point while scrolling using buttons.
The new assertion using `getBoundingClientRect()` is rather complicated but I was unable to find a better way 🤷‍♂️ 

## Type of change

- Tests