### PR TITLE
fix: debounce grid sorter changes to avoid extra requests

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { timeOut } from '@vaadin/component-base/src/async.js';
+import { microTask, timeOut } from '@vaadin/component-base/src/async.js';
 import { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
@@ -357,6 +357,11 @@ export const DataProviderMixin = (superClass) =>
       if (!this._dataProviderController.isLoading()) {
         this._debouncerApplyCachedData.flush();
       }
+    }
+
+    /** @private */
+    __debounceClearCache() {
+      this.__clearCacheDebouncer = Debouncer.debounce(this.__clearCacheDebouncer, microTask, () => this.clearCache());
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -173,7 +173,7 @@ export const SortMixin = (superClass) =>
         this.isAttached &&
         JSON.stringify(this._previousSorters) !== JSON.stringify(this._mapSorters())
       ) {
-        this.clearCache();
+        this.__debounceClearCache();
       }
 
       this._a11yUpdateSorters();

--- a/packages/grid/test/array-data-provider.common.js
+++ b/packages/grid/test/array-data-provider.common.js
@@ -156,25 +156,28 @@ describe('invalid paths', () => {
       sorter = grid.querySelector('vaadin-grid-sorter');
     });
 
-    it('should warn about invalid path with undefined parent property', () => {
+    it('should warn about invalid path with undefined parent property', async () => {
       sorter.path = 'foo.bar';
       click(sorter);
+      await nextFrame();
       expect(console.warn.called).to.be.true;
     });
 
-    it('should not warn about undefined values with defined parent property', () => {
+    it('should not warn about undefined values with defined parent property', async () => {
       sorter.path = 'name.foo';
       click(sorter);
+      await nextFrame();
       expect(console.warn.called).to.be.false;
     });
 
-    it('should not warn about invalid path without dots', () => {
+    it('should not warn about invalid path without dots', async () => {
       sorter.path = 'foobar';
       click(sorter);
+      await nextFrame();
       expect(console.warn.called).to.be.false;
     });
 
-    it('should not warn about undefined values with defined parent property (long path)', () => {
+    it('should not warn about undefined values with defined parent property (long path)', async () => {
       grid.items = [
         {
           name: {
@@ -187,6 +190,7 @@ describe('invalid paths', () => {
 
       sorter.path = 'name.last.foo';
       click(sorter);
+      await nextFrame();
       expect(console.warn.called).to.be.false;
     });
   });

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -338,6 +338,7 @@ describe('array data provider', () => {
     grid._filters[1].value = 'r';
     await nextFrame();
     grid.querySelector('vaadin-grid-sorter').direction = 'asc';
+    await nextFrame();
     expect(grid.size).to.equal(2);
     expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('bar');
     expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('foo');

--- a/packages/grid/test/sorting.common.js
+++ b/packages/grid/test/sorting.common.js
@@ -368,8 +368,9 @@ describe('sorting', () => {
         expect(getBodyCellContent(grid, 2, 1).innerText).to.equal('bar');
       });
 
-      it('should sort automatically on sort', () => {
+      it('should sort automatically on sort', async () => {
         sorterFirst.direction = null;
+        await nextFrame();
         expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('foo');
         expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('foo');
         expect(getBodyCellContent(grid, 2, 0).innerText).to.equal('bar');
@@ -439,7 +440,7 @@ describe('sorting', () => {
         expect(getBodyCellContent(grid, 2, 0).innerText).to.equal('11');
       });
 
-      it('should sort dates correctly', () => {
+      it('should sort dates correctly', async () => {
         grid.items = [
           { first: 1, last: new Date(2000, 1, 2) },
           { first: 2, last: new Date(2000, 1, 3) },
@@ -449,6 +450,7 @@ describe('sorting', () => {
         sorterFirst.direction = '';
         sorterLast.direction = 'asc';
 
+        await nextFrame();
         expect(getBodyCellContent(grid, 0, 0).innerText).to.equal('3');
         expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('1');
         expect(getBodyCellContent(grid, 2, 0).innerText).to.equal('2');
@@ -470,8 +472,9 @@ describe('sorting', () => {
         ]);
       });
 
-      it('should request new data on sort', () => {
+      it('should request new data on sort', async () => {
         sorterFirst.direction = 'desc';
+        await nextFrame();
         const lastCall = grid.dataProvider.lastCall;
         const params = lastCall.args[0];
         expect(params.sortOrders).to.eql([
@@ -480,9 +483,10 @@ describe('sorting', () => {
         ]);
       });
 
-      it('should request new data on change in existing sorters', () => {
+      it('should request new data on change in existing sorters', async () => {
         grid.dataProvider.resetHistory();
         sorterLast.direction = 'asc';
+        await nextFrame();
         expect(grid.dataProvider.called).to.be.true;
       });
     });
@@ -557,10 +561,11 @@ describe('sorting', () => {
         grid.dataProvider = sinon.spy(grid.dataProvider);
       });
 
-      it('should only using single sorter', () => {
+      it('should only using single sorter', async () => {
         grid.dataProvider.resetHistory();
         sorterFirst.direction = 'desc';
 
+        await nextFrame();
         expect(grid.dataProvider.args[0][0].sortOrders.length).to.eql(1);
       });
 
@@ -595,10 +600,11 @@ describe('sorting', () => {
         expect(getSorterCell(sorterLast).getAttribute('aria-sort')).to.equal('descending');
       });
 
-      it('should update aria-sort on sorter change', () => {
+      it('should update aria-sort on sorter change', async () => {
         sorterFirst.direction = 'desc';
         sorterLast.direction = null;
 
+        await nextFrame();
         expect(getSorterCell(sorterFirst).getAttribute('aria-sort')).to.equal('descending');
         expect(getSorterCell(sorterLast).getAttribute('aria-sort')).to.equal('none');
       });


### PR DESCRIPTION
## Description

This PR makes grid sort mixin debounce its invocations to `clearCache()` in order to avoid excess data requests caused by multiple simultaneous sorter changes.

Fixes the regression described at https://github.com/vaadin/web-components/pull/6851#issuecomment-1825592737 and https://github.com/vaadin/web-components/pull/6851#issuecomment-1825632111

## Type of change

Bugfix