### PR TITLE
refactor!: do not set ID attribute on the menu overlay

### DIFF
--- a/integration/tests/context-menu-template.test.js
+++ b/integration/tests/context-menu-template.test.js
@@ -5,7 +5,7 @@ import '@vaadin/context-menu';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 
 describe('template', () => {
-  let menu, target;
+  let menu, target, overlay;
 
   beforeEach(() => {
     menu = fixtureSync(`
@@ -15,23 +15,24 @@ describe('template', () => {
       </vaadin-context-menu>
     `);
     target = document.querySelector('#target');
+    overlay = menu._overlayElement;
   });
 
   it('should stamp template on open', () => {
     menu._setOpened(true);
 
-    expect(menu.$.overlay.textContent).to.contain('FOOBAR');
+    expect(overlay.textContent).to.contain('FOOBAR');
   });
 
   it('should bind target property', () => {
     fire(target, 'vaadin-contextmenu');
 
-    expect(menu.$.overlay.textContent).to.contain('target');
+    expect(overlay.textContent).to.contain('target');
   });
 
   it('should bind detail property', () => {
     fire(target, 'vaadin-contextmenu', { foo: 'bar' });
 
-    expect(menu.$.overlay.textContent).to.contain('bar');
+    expect(overlay.textContent).to.contain('bar');
   });
 });

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -222,17 +222,6 @@ class ContextMenu extends ContextMenuMixin(
       </style>
 
       <slot id="slot"></slot>
-
-      <vaadin-context-menu-overlay
-        id="overlay"
-        on-opened-changed="_onOverlayOpened"
-        on-vaadin-overlay-open="_onVaadinOverlayOpen"
-        modeless="[[_modeless]]"
-        with-backdrop="[[_phone]]"
-        phone$="[[_phone]]"
-        model="[[_context]]"
-        theme$="[[_theme]]"
-      ></vaadin-context-menu-overlay>
     `;
   }
 
@@ -245,6 +234,19 @@ class ContextMenu extends ContextMenuMixin(
     super.ready();
 
     processTemplates(this);
+  }
+
+  /**
+   * @param {DocumentFragment} dom
+   * @return {null}
+   * @protected
+   * @override
+   */
+  _attachDom(dom) {
+    const root = this.attachShadow({ mode: 'open' });
+    root.appendChild(dom);
+    root.appendChild(this._overlayElement);
+    return root;
   }
 
   /**

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -110,7 +110,7 @@ export const ItemsMixin = (superClass) =>
 
     /** @protected */
     __forwardFocus() {
-      const overlay = this.$.overlay;
+      const overlay = this._overlayElement;
       const child = overlay.getFirstChild();
       // If parent item is not focused, do not focus submenu
       if (overlay.parentOverlay) {
@@ -131,9 +131,9 @@ export const ItemsMixin = (superClass) =>
       subMenu.listenOn = itemElement;
       subMenu.overlayClass = overlayClass;
 
-      const parent = this.$.overlay;
+      const parent = this._overlayElement;
 
-      const subMenuOverlay = subMenu.$.overlay;
+      const subMenuOverlay = subMenu._overlayElement;
       subMenuOverlay.positionTarget = itemElement;
       subMenuOverlay.noHorizontalOverlap = true;
       // Store the reference parent overlay
@@ -146,7 +146,7 @@ export const ItemsMixin = (superClass) =>
         subMenu.removeAttribute('theme');
       }
 
-      const content = subMenu.$.overlay.$.content;
+      const content = subMenuOverlay.$.content;
       content.style.minWidth = '';
 
       itemElement.dispatchEvent(
@@ -233,7 +233,7 @@ export const ItemsMixin = (superClass) =>
 
     /** @private */
     __initOverlay() {
-      const overlay = this.$.overlay;
+      const overlay = this._overlayElement;
 
       overlay.$.backdrop.addEventListener('click', () => {
         this.close();
@@ -342,7 +342,7 @@ export const ItemsMixin = (superClass) =>
       }
 
       // Don't open sub-menus while the menu is still opening
-      if (this.$.overlay.hasAttribute('opening')) {
+      if (this._overlayElement.hasAttribute('opening')) {
         requestAnimationFrame(() => {
           this.__showSubMenu(event, item);
         });

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -4,7 +4,6 @@ export const snapshots = {};
 snapshots["context-menu items"] = 
 `<vaadin-context-menu-overlay
   dir="ltr"
-  id="overlay"
   opened=""
 >
   <vaadin-context-menu-list-box
@@ -64,7 +63,6 @@ snapshots["context-menu items"] =
 snapshots["context-menu items nested"] = 
 `<vaadin-context-menu-overlay
   dir="ltr"
-  id="overlay"
   modeless=""
   opened=""
   right-aligned=""
@@ -106,7 +104,6 @@ snapshots["context-menu items overlay class"] =
 `<vaadin-context-menu-overlay
   class="context-menu-overlay custom"
   dir="ltr"
-  id="overlay"
   opened=""
 >
   <vaadin-context-menu-list-box
@@ -167,7 +164,6 @@ snapshots["context-menu items overlay class nested"] =
 `<vaadin-context-menu-overlay
   class="context-menu-overlay custom"
   dir="ltr"
-  id="overlay"
   modeless=""
   opened=""
   right-aligned=""

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -138,7 +138,7 @@ export const MenuBarMixin = (superClass) =>
       this._subMenu.addEventListener('item-selected', this.__onItemSelected.bind(this));
       this._subMenu.addEventListener('close-all-menus', this.__onEscapeClose.bind(this));
 
-      const overlay = this._subMenu.$.overlay;
+      const overlay = this._subMenu._overlayElement;
       overlay.addEventListener('keydown', this.__boundOnContextMenuKeydown);
 
       const container = this.shadowRoot.querySelector('[part="container"]');
@@ -675,7 +675,7 @@ export const MenuBarMixin = (superClass) =>
 
       subMenu.items = items;
       subMenu.listenOn = button;
-      const overlay = subMenu.$.overlay;
+      const overlay = subMenu._overlayElement;
       overlay.positionTarget = button;
       overlay.noVerticalOverlap = true;
 
@@ -720,13 +720,13 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     _focusFirstItem() {
-      const list = this._subMenu.$.overlay.firstElementChild;
+      const list = this._subMenu._overlayElement.firstElementChild;
       list.focus();
     }
 
     /** @private */
     _focusLastItem() {
-      const list = this._subMenu.$.overlay.firstElementChild;
+      const list = this._subMenu._overlayElement.firstElementChild;
       const item = list.items[list.items.length - 1];
       if (item) {
         item.focus();

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -68,7 +68,7 @@ class MenuBarSubmenu extends ContextMenu {
    * Overriding the observer to not add global "contextmenu" listener.
    */
   _openedChanged(opened) {
-    this.$.overlay.opened = opened;
+    this._overlayElement.opened = opened;
   }
 
   /**

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -57,7 +57,6 @@ snapshots["menu-bar basic"] =
 snapshots["menu-bar overlay"] = 
 `<vaadin-menu-bar-overlay
   dir="ltr"
-  id="overlay"
   opened=""
   right-aligned=""
   start-aligned=""
@@ -95,7 +94,6 @@ snapshots["menu-bar overlay class"] =
 `<vaadin-menu-bar-overlay
   class="custom menu-bar-overlay"
   dir="ltr"
-  id="overlay"
   opened=""
   right-aligned=""
   start-aligned=""

--- a/packages/menu-bar/test/visual/material/menu-bar.test.js
+++ b/packages/menu-bar/test/visual/material/menu-bar.test.js
@@ -96,7 +96,7 @@ describe('menu-bar', () => {
             },
             { text: 'Help' },
           ];
-          overlay = element._subMenu.$.overlay;
+          overlay = element._subMenu._overlayElement;
         });
 
         it('outlined', async () => {


### PR DESCRIPTION
## Description

Fixes #5990

Changed to create `vaadin-context-menu-overlay` in the `constructor()` instead of using the template.
This way we ensure `_overlayElement` is available before `ready()` to make observers work properly. 

## Type of change

- Refactor