### PR TITLE
fix: use drawer actual size in the offset

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -139,7 +139,7 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
         }
 
         :host([drawer-opened]) {
-          --vaadin-app-layout-drawer-offset-left: var(--_vaadin-app-layout-drawer-width);
+          --vaadin-app-layout-drawer-offset-left: var(--_vaadin-app-layout-drawer-offset-size);
         }
 
         :host([overlay]) {
@@ -589,8 +589,12 @@ class AppLayout extends ElementMixin(ThemableMixin(ControllerMixin(PolymerElemen
     const navbarBottom = this.$.navbarBottom;
     const navbarBottomRect = navbarBottom.getBoundingClientRect();
 
+    const drawer = this.$.drawer;
+    const drawerRect = drawer.getBoundingClientRect();
+
     this.style.setProperty('--_vaadin-app-layout-navbar-offset-size', `${navbarRect.height}px`);
     this.style.setProperty('--_vaadin-app-layout-navbar-offset-size-bottom', `${navbarBottomRect.height}px`);
+    this.style.setProperty('--_vaadin-app-layout-drawer-offset-size', `${drawerRect.width}px`);
   }
 
   /** @protected */

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -307,10 +307,13 @@ describe('vaadin-app-layout', () => {
       });
 
       it('should use the drawer width as offset width', async () => {
-        const style = document.createElement('style');
-        document.documentElement.append(style);
-        const css = style.sheet;
-        css.insertRule('vaadin-app-layout::part(drawer) { width: 100px; }');
+        fixtureSync(`
+          <style>
+            vaadin-app-layout::part(drawer) {
+              width: 100px;
+            }
+          </style>
+        `);
 
         await nextRender();
         const { width } = layout.$.drawer.getBoundingClientRect();

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -318,7 +318,6 @@ describe('vaadin-app-layout', () => {
         await nextRender();
         const { width } = layout.$.drawer.getBoundingClientRect();
 
-        style.remove();
         expect(width).to.be.equal(100);
       });
     });

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -204,6 +204,7 @@ describe('vaadin-app-layout', () => {
 
     describe('desktop layout', () => {
       beforeEach(async () => {
+        document.adoptedStyleSheets = [];
         await fixtureLayout('desktop');
       });
 
@@ -304,6 +305,17 @@ describe('vaadin-app-layout', () => {
         await nextFrame();
 
         expect(spy.callCount).to.be.equal(1);
+      });
+
+      it('should use the drawer width as offset width', async () => {
+        const css = new CSSStyleSheet();
+        css.insertRule('vaadin-app-layout::part(drawer) { width: 100px; }');
+        document.adoptedStyleSheets = [css];
+
+        await nextRender();
+        const { width } = layout.$.drawer.getBoundingClientRect();
+
+        expect(width).to.be.equal(100);
       });
     });
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -204,7 +204,6 @@ describe('vaadin-app-layout', () => {
 
     describe('desktop layout', () => {
       beforeEach(async () => {
-        document.adoptedStyleSheets = [];
         await fixtureLayout('desktop');
       });
 
@@ -308,13 +307,15 @@ describe('vaadin-app-layout', () => {
       });
 
       it('should use the drawer width as offset width', async () => {
-        const css = new CSSStyleSheet();
+        const style = document.createElement('style');
+        document.documentElement.append(style);
+        const css = style.sheet;
         css.insertRule('vaadin-app-layout::part(drawer) { width: 100px; }');
-        document.adoptedStyleSheets = [css];
 
         await nextRender();
         const { width } = layout.$.drawer.getBoundingClientRect();
 
+        style.remove();
         expect(width).to.be.equal(100);
       });
     });


### PR DESCRIPTION
## Description

Use the drawer actual size to define the offset size used for the content area in the app-layout.

This change brings back the functionality that was removed as part of the new drawer width CSS variable. As the drawer width can be defined in different ways (eg. `vaadin-app-layout::part(drawer) {width: 100px;}`), we can't rely only on the CSS variable to define the offset value.

- fix: use drawer effecive size for content offset
- test: add test checking that offset uses the right size

## Type of change

- [x] Bugfix
