### PR TITLE
fix: announce file reject correctly

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -884,7 +884,7 @@ export const UploadMixin = (superClass) =>
 
     /** @private */
     _onFileReject(event) {
-      announce(`${event.detail.file.name}: ${event.detail.file.error}`, { mode: 'alert' });
+      announce(`${event.detail.file.name}: ${event.detail.error}`, { mode: 'alert' });
     }
 
     /** @private */

--- a/packages/upload/test/a11y.common.js
+++ b/packages/upload/test/a11y.common.js
@@ -100,7 +100,7 @@ describe('a11y', () => {
 
     it('should announce file reject', () => {
       upload.dispatchEvent(
-        new CustomEvent('file-reject', { detail: { file: { name: 'file.js', error: 'rejected' } } }),
+        new CustomEvent('file-reject', { detail: { file: { name: 'file.js' }, error: 'rejected' } }),
       );
       clock.tick(200);
       expect(announceRegion.textContent).to.equal('file.js: rejected');


### PR DESCRIPTION
## Description

The way `file-reject` event is [defined](https://github.com/vaadin/web-components/blob/main/packages/upload/src/vaadin-upload.d.ts#L17) is not aligned with how it is announced. The corresponding test also is a false negative since it creates the event with the structure used in announcing.

This PR fixes the announcement and the test based on the actual event structure.

One thing to note is the extra error in the event is unnecessary as `UploadFile` already contains a property for error. This is also not aligned with how the other events are structured. Updating `UploadFileRejectEvent` would be a breaking change, therefore can be considered for the future.

No related issue.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.