### PR TITLE
fix: focus overlay on mouseup when focus moves to body

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -118,6 +118,14 @@ export const OverlayMixin = (superClass) =>
       // and <vaadin-context-menu>).
       this.addEventListener('click', () => {});
       this.$.backdrop.addEventListener('click', () => {});
+
+      this.addEventListener('mouseup', () => {
+        // In Chrome, focus moves to body on overlay content mousedown
+        // See https://github.com/vaadin/flow-components/issues/5507
+        if (document.activeElement === document.body && this.$.overlay.getAttribute('tabindex') === '0') {
+          this.$.overlay.focus();
+        }
+      });
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/flow-components/issues/5507

This is an alternative solution to the underlying problem of unwanted `focusout` event in Chrome.
As `focusout` fires before `mouseup`, at that point we can check which element has focus.

## Type of change

- Bugfix