### PR TITLE
refactor: make PositionMixin properties sync, add Lit tests

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -41,6 +41,7 @@ export const PositionMixin = (superClass) =>
         positionTarget: {
           type: Object,
           value: null,
+          sync: true,
         },
 
         /**
@@ -56,6 +57,7 @@ export const PositionMixin = (superClass) =>
         horizontalAlign: {
           type: String,
           value: 'start',
+          sync: true,
         },
 
         /**
@@ -70,6 +72,7 @@ export const PositionMixin = (superClass) =>
         verticalAlign: {
           type: String,
           value: 'top',
+          sync: true,
         },
 
         /**
@@ -81,6 +84,7 @@ export const PositionMixin = (superClass) =>
         noHorizontalOverlap: {
           type: Boolean,
           value: false,
+          sync: true,
         },
 
         /**
@@ -92,6 +96,7 @@ export const PositionMixin = (superClass) =>
         noVerticalOverlap: {
           type: Boolean,
           value: false,
+          sync: true,
         },
 
         /**
@@ -105,6 +110,7 @@ export const PositionMixin = (superClass) =>
         requiredVerticalSpace: {
           type: Number,
           value: 0,
+          sync: true,
         },
       };
     }

--- a/packages/overlay/test/position-mixin-lit.js
+++ b/packages/overlay/test/position-mixin-lit.js
@@ -1,0 +1,10 @@
+import { Overlay } from '../src/vaadin-lit-overlay.js';
+import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
+
+class PositionedOverlay extends PositionMixin(Overlay) {
+  static get is() {
+    return 'vaadin-positioned-overlay';
+  }
+}
+
+customElements.define(PositionedOverlay.is, PositionedOverlay);

--- a/packages/overlay/test/position-mixin-lit.test.js
+++ b/packages/overlay/test/position-mixin-lit.test.js
@@ -1,0 +1,3 @@
+import './position-mixin-styles.js';
+import './position-mixin-lit.js';
+import './position-mixin.common.js';

--- a/packages/overlay/test/position-mixin-polymer.js
+++ b/packages/overlay/test/position-mixin-polymer.js
@@ -1,0 +1,10 @@
+import { Overlay } from '../src/vaadin-overlay.js';
+import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
+
+class PositionedOverlay extends PositionMixin(Overlay) {
+  static get is() {
+    return 'vaadin-positioned-overlay';
+  }
+}
+
+customElements.define(PositionedOverlay.is, PositionedOverlay);

--- a/packages/overlay/test/position-mixin-polymer.test.js
+++ b/packages/overlay/test/position-mixin-polymer.test.js
@@ -1,0 +1,3 @@
+import './position-mixin-styles.js';
+import './position-mixin-polymer.js';
+import './position-mixin.common.js';

--- a/packages/overlay/test/position-mixin-styles.js
+++ b/packages/overlay/test/position-mixin-styles.js
@@ -1,0 +1,17 @@
+import { css } from 'lit';
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
+
+registerStyles(
+  'vaadin-positioned-overlay',
+  css`
+    @keyframes slidein {
+      0% {
+        transform: translateY(10px);
+      }
+    }
+
+    :host(.animated) [part='overlay'] {
+      animation: slidein 0.2s;
+    }
+  `,
+);

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -1,33 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
-import { css } from 'lit';
-import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
-import { Overlay } from '../src/vaadin-overlay.js';
-import { PositionMixin } from '../src/vaadin-overlay-position-mixin.js';
-
-class PositionedOverlay extends PositionMixin(Overlay) {
-  static get is() {
-    return 'vaadin-positioned-overlay';
-  }
-}
-
-customElements.define(PositionedOverlay.is, PositionedOverlay);
-
-registerStyles(
-  'vaadin-positioned-overlay',
-  css`
-    @keyframes slidein {
-      0% {
-        transform: translateY(10px);
-      }
-    }
-
-    :host(.animated) [part='overlay'] {
-      animation: slidein 0.2s;
-    }
-  `,
-);
 
 describe('position mixin', () => {
   const TOP = 'top';
@@ -74,6 +47,7 @@ describe('position mixin', () => {
         root.appendChild(div);
       }
     };
+    await nextRender();
     overlayContent = overlay.$.overlay;
     overlay.positionTarget = target;
     overlay.opened = true;
@@ -93,11 +67,13 @@ describe('position mixin', () => {
     expectEdgesAligned(LEFT, LEFT);
   });
 
-  it('should update position on open', () => {
+  it('should update position on open', async () => {
     overlay.opened = false;
+    await nextUpdate(overlay);
     target.style.top = '5px';
     target.style.left = '10px';
     overlay.opened = true;
+    await nextUpdate(overlay);
     expectEdgesAligned(TOP, TOP);
     expectEdgesAligned(LEFT, LEFT);
   });
@@ -387,10 +363,12 @@ describe('position mixin', () => {
       expect(overlay.hasAttribute('end-aligned')).to.be.false;
     });
 
-    it('should align right edges with right-to-left', () => {
+    it('should align right edges with right-to-left', async () => {
       overlay.opened = false;
+      await nextUpdate(overlay);
       document.dir = 'rtl';
       overlay.opened = true;
+      await nextUpdate(overlay);
       expectEdgesAligned(RIGHT, RIGHT);
     });
 
@@ -492,10 +470,12 @@ describe('position mixin', () => {
       expect(overlay.hasAttribute('start-aligned')).to.be.false;
     });
 
-    it('should align left edges with right-to-left', () => {
+    it('should align left edges with right-to-left', async () => {
       overlay.opened = false;
+      await nextUpdate(overlay);
       document.dir = 'rtl';
       overlay.opened = true;
+      await nextUpdate(overlay);
       expectEdgesAligned(LEFT, LEFT);
     });
 


### PR DESCRIPTION
## Description

Extracted from #6467. 

This change is needed for `vaadin-context-menu-overlay` Lit based version to properly update position.

## Type of change

- Refactor