### PR TITLE
test: split context-menu tests into common and import files

### DIFF
--- a/packages/context-menu/test/a11y-polymer.test.js
+++ b/packages/context-menu/test/a11y-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './a11y.common.js';

--- a/packages/context-menu/test/a11y.common.js
+++ b/packages/context-menu/test/a11y.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { getMenuItems } from './helpers.js';
 

--- a/packages/context-menu/test/context-polymer.test.js
+++ b/packages/context-menu/test/context-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './context.common.js';

--- a/packages/context-menu/test/context.common.js
+++ b/packages/context-menu/test/context.common.js
@@ -3,8 +3,6 @@ import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XFoo extends PolymerElement {

--- a/packages/context-menu/test/integration-polymer.test.js
+++ b/packages/context-menu/test/integration-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './integration.common.js';

--- a/packages/context-menu/test/integration.common.js
+++ b/packages/context-menu/test/integration.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MenuWrapper extends PolymerElement {

--- a/packages/context-menu/test/items-polymer.test.js
+++ b/packages/context-menu/test/items-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './items.common.js';

--- a/packages/context-menu/test/items-theme-polymer.test.js
+++ b/packages/context-menu/test/items-theme-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './items-theme.common.js';

--- a/packages/context-menu/test/items-theme.common.js
+++ b/packages/context-menu/test/items-theme.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
 

--- a/packages/context-menu/test/items.common.js
+++ b/packages/context-menu/test/items.common.js
@@ -16,8 +16,6 @@ import {
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
 

--- a/packages/context-menu/test/lit-renderer-directive-polymer.test.js
+++ b/packages/context-menu/test/lit-renderer-directive-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './lit-renderer-directives.common.js';

--- a/packages/context-menu/test/lit-renderer-directives.common.js
+++ b/packages/context-menu/test/lit-renderer-directives.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, nothing, render } from 'lit';
 import { contextMenuRenderer } from '../lit.js';
 

--- a/packages/context-menu/test/overlay-polymer.test.js
+++ b/packages/context-menu/test/overlay-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './overlay.common.js';

--- a/packages/context-menu/test/overlay.common.js
+++ b/packages/context-menu/test/overlay.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync, isIOS, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 
 describe('overlay', () => {
   let menu, overlay, content, viewHeight, viewWidth;

--- a/packages/context-menu/test/properties-polymer.test.js
+++ b/packages/context-menu/test/properties-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './properties.common.js';

--- a/packages/context-menu/test/properties.common.js
+++ b/packages/context-menu/test/properties.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 
 describe('properties', () => {
   let menu;

--- a/packages/context-menu/test/renderer-polymer.test.js
+++ b/packages/context-menu/test/renderer-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './renderer.common.js';

--- a/packages/context-menu/test/renderer.common.js
+++ b/packages/context-menu/test/renderer.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 
 describe('renderer', () => {
   let menu, target, overlay;

--- a/packages/context-menu/test/selection-polymer.test.js
+++ b/packages/context-menu/test/selection-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './selection.common.js';

--- a/packages/context-menu/test/selection.common.js
+++ b/packages/context-menu/test/selection.common.js
@@ -3,8 +3,6 @@ import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@v
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 
 describe('selection', () => {
   let menu, overlay;

--- a/packages/context-menu/test/touch-polymer.test.js
+++ b/packages/context-menu/test/touch-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-context-menu.js';
+import './touch.common.js';

--- a/packages/context-menu/test/touch.common.js
+++ b/packages/context-menu/test/touch.common.js
@@ -10,8 +10,6 @@ import {
   touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { gestures } from '@vaadin/component-base/src/gestures.js';
 


### PR DESCRIPTION
## Description

Same as #6564 but for `vaadin-context-menu`.

In preparation for implementing the Lit-based context-menu, split the current test files into two parts. The common part is a copy of the old test file with the component imports removed where the `-polymer.test.js` files include imports for the Polymer-based component. Any timing changes required by the Lit migration are excluded from this PR.

## Type of change

- Tests