### PR TITLE
refactor: remove vaadin-menu-bar-overlay from template

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -35,17 +35,6 @@ class MenuBarSubmenu extends ContextMenu {
       </style>
 
       <slot id="slot"></slot>
-
-      <vaadin-menu-bar-overlay
-        id="overlay"
-        on-opened-changed="_onOverlayOpened"
-        on-vaadin-overlay-open="_onVaadinOverlayOpen"
-        modeless="[[_modeless]]"
-        with-backdrop="[[_phone]]"
-        phone$="[[_phone]]"
-        model="[[_context]]"
-        theme$="[[_theme]]"
-      ></vaadin-menu-bar-overlay>
     `;
   }
 


### PR DESCRIPTION
## Description

Follow-up to #6870

In the above PR the logic was changed to create overlay in the constructor, but I missed to update this template.

## Type of change

- Refactor