### PR TITLE
refactor: remove Polymer splice support for menu items

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -158,11 +158,10 @@ export const MenuBarMixin = (superClass) =>
 
     static get observers() {
       return [
-        '_itemsChanged(items, items.splices)',
         '_themeChanged(_theme, _overflow, _container)',
         '__hasOverflowChanged(_hasOverflow, _overflow)',
         '__i18nChanged(i18n, _overflow)',
-        '_menuItemsChanged(items, _overflow, _container, items.splices)',
+        '_menuItemsChanged(items, _overflow, _container)',
       ];
     }
 
@@ -337,6 +336,11 @@ export const MenuBarMixin = (superClass) =>
       if (items !== this._oldItems) {
         this._oldItems = items;
         this.__renderButtons(items);
+      }
+
+      const subMenu = this._subMenu;
+      if (subMenu && subMenu.opened) {
+        subMenu.close();
       }
     }
 
@@ -740,14 +744,6 @@ export const MenuBarMixin = (superClass) =>
         default:
           super._onKeyDown(event);
           break;
-      }
-    }
-
-    /** @private */
-    _itemsChanged() {
-      const subMenu = this._subMenu;
-      if (subMenu && subMenu.opened) {
-        subMenu.close();
       }
     }
 

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -370,7 +370,7 @@ describe('sub-menu', () => {
     buttons[0].click();
     await nextRender(subMenu);
 
-    menu.splice('items', 0, 1, { text: 'Menu Item 1' });
+    menu.items = [...menu.items, { text: 'Menu Item 1' }];
     await nextRender(subMenu);
     expect(subMenu.opened).to.be.false;
   });


### PR DESCRIPTION
## Description

Updated `MenuBarMixin` to not use Polymer-specific `items.splices`. Also, combined two observers into one.

## Type of change

- Behavior altering change