### PR TITLE
refactor: mark ariaTarget property in typings as protected

### DIFF
--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -21,11 +21,6 @@ export declare function FieldMixin<T extends Constructor<HTMLElement>>(
 
 export declare class FieldMixinClass {
   /**
-   * A target element to which ARIA attributes are set.
-   */
-  ariaTarget: HTMLElement;
-
-  /**
    * String used for the helper text.
    *
    * @attr {string} helper-text
@@ -50,6 +45,11 @@ export declare class FieldMixinClass {
    * @attr {string} accessible-name-ref
    */
   accessibleNameRef: string | null | undefined;
+
+  /**
+   * A target element to which ARIA attributes are set.
+   */
+  protected ariaTarget: HTMLElement;
 
   protected readonly _errorNode: HTMLElement;
 


### PR DESCRIPTION
## Description

Updated `ariaTarget` property in `FieldMixin` to be marked as protected. 
It actually has corresponding JSDoc, but is marked as public in `.d.ts`.

This change is needed to hide this property from VSCode autocomplete.

## Type of change

- Refactor