### PR TITLE
docs: add label property JSDoc annotation to vaadin-item

### DIFF
--- a/packages/item/src/vaadin-item.d.ts
+++ b/packages/item/src/vaadin-item.d.ts
@@ -50,6 +50,11 @@ declare class Item extends ItemMixin(ThemableMixin(DirMixin(HTMLElement))) {
    * Submittable string value. The default value is the trimmed text content of the element.
    */
   value: string;
+
+  /**
+   * String that can be set to visually represent the selected item in `vaadin-select`.
+   */
+  label: string | undefined;
 }
 
 declare global {

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -83,8 +83,13 @@ class Item extends ItemMixin(ThemableMixin(DirMixin(PolymerElement))) {
      * Submittable string value. The default value is the trimmed text content of the element.
      * @type {string}
      */
-    // eslint-disable-next-line no-unused-expressions
     this.value;
+
+    /**
+     * String that can be set to visually represent the selected item in `vaadin-select`.
+     * @type {string}
+     */
+    this.label;
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/react-components/issues/147

We are using the `label` attribute in `vaadin-select` to get the item label, but it's currently not documented:

https://github.com/vaadin/web-components/blob/25bb2617a12ecdfcacc188fe3d4c16c62a5f0033/packages/select/src/vaadin-select-base-mixin.js#L408

This change adds the `label` property to `vaadin-item` API docs (and also `web-types.json`):

<img width="582" alt="Screenshot 2023-12-07 at 10 30 07" src="https://github.com/vaadin/web-components/assets/10589913/e39d44b2-0988-4f7f-9379-7d3414c44b1c">

## Type of change

- Documentation 