### PR TITLE
refactor: remove protected method from combo-box typings

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -158,6 +158,4 @@ export declare class ComboBoxMixinClass<TItem> {
    * Closes the dropdown list.
    */
   close(): void;
-
-  protected _revertInputValue(): void;
 }


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/react-components/issues/162 - needed to hide method from IntelliJ completion:

<img width="598" alt="Screenshot 2023-12-07 at 12 31 00" src="https://github.com/vaadin/web-components/assets/10589913/450cef4f-3a79-4dd2-a986-f91cf59480db">

Removed `_revertInputValue()` from `ComboBoxMixin` typings. The only reason it's where is probably the fact that this method is called by `vaadin-combo-box-light`. All the other protected methods aren't present in typings anyway.

## Type of change

- Refactor