### PR TITLE
refactor: remove private property from avatar-group typings

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -72,8 +72,6 @@ export interface AvatarGroupItem {
 declare class AvatarGroup extends ResizeMixin(
   OverlayClassMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))),
 ) {
-  readonly _avatars: HTMLElement[];
-
   /**
    * An array containing the items which will be stamped as avatars.
    *


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/react-components/issues/162 - needed to hide property from IntelliJ completion:

<img width="241" alt="Screenshot 2023-12-07 at 13 35 42" src="https://github.com/vaadin/web-components/assets/10589913/18b93276-3bff-48db-911c-5c92396e5938">

The `_avatars` property in the JS file is marked as private and is not supposed to be used from outside the component.

## Type of change

- Refactor