### PR TITLE
fix!: exclude hidden columns from sorting (24.4)

### DIFF
--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -105,17 +105,20 @@ export const SortMixin = (superClass) =>
       }
 
       this._sorters = this._sorters.filter((sorter) => sortersToRemove.indexOf(sorter) < 0);
-      if (this.multiSort) {
-        this.__updateSortOrders();
-      }
       this.__applySorters();
     }
 
     /** @private */
     __updateSortOrders() {
-      this._sorters.forEach((sorter, index) => {
-        sorter._order = this._sorters.length > 1 ? index : null;
+      this._sorters.forEach((sorter) => {
+        sorter._order = null;
       });
+
+      if (this._activeSorters.length > 1) {
+        this._activeSorters.forEach((sorter, index) => {
+          sorter._order = index;
+        });
+      }
     }
 
     /** @private */
@@ -125,8 +128,6 @@ export const SortMixin = (superClass) =>
       } else if (!this._sorters.includes(sorter)) {
         this._sorters.push(sorter);
       }
-
-      this.__updateSortOrders();
     }
 
     /** @private */
@@ -135,7 +136,6 @@ export const SortMixin = (superClass) =>
       if (sorter.direction) {
         this._sorters.unshift(sorter);
       }
-      this.__updateSortOrders();
     }
 
     /** @private */
@@ -176,9 +176,18 @@ export const SortMixin = (superClass) =>
         this.__debounceClearCache();
       }
 
+      this.__updateSortOrders();
       this._a11yUpdateSorters();
 
       this._previousSorters = this._mapSorters();
+    }
+
+    /**
+     * @type {GridSorterDefinition[]}
+     * @protected
+     */
+    get _activeSorters() {
+      return this._sorters.filter((sorter) => sorter.direction && sorter.isConnected);
     }
 
     /**
@@ -186,7 +195,7 @@ export const SortMixin = (superClass) =>
      * @protected
      */
     _mapSorters() {
-      return this._sorters.map((sorter) => {
+      return this._activeSorters.map((sorter) => {
         return {
           path: sorter.path,
           direction: sorter.direction,

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -168,6 +168,8 @@ export const SortMixin = (superClass) =>
 
     /** @private */
     __applySorters() {
+      this.__updateSortOrders();
+
       if (
         this.dataProvider &&
         // No need to clear cache if sorters didn't change and grid is attached
@@ -177,7 +179,6 @@ export const SortMixin = (superClass) =>
         this.__debounceClearCache();
       }
 
-      this.__updateSortOrders();
       this._a11yUpdateSorters();
 
       this._previousSorters = this._mapSorters();

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -114,8 +114,9 @@ export const SortMixin = (superClass) =>
         sorter._order = null;
       });
 
-      if (this._activeSorters.length > 1) {
-        this._activeSorters.forEach((sorter, index) => {
+      const activeSorters = this._getActiveSorters();
+      if (activeSorters.length > 1) {
+        activeSorters.forEach((sorter, index) => {
           sorter._order = index;
         });
       }
@@ -186,7 +187,7 @@ export const SortMixin = (superClass) =>
      * @type {GridSorterDefinition[]}
      * @protected
      */
-    get _activeSorters() {
+    _getActiveSorters() {
       return this._sorters.filter((sorter) => sorter.direction && sorter.isConnected);
     }
 
@@ -195,7 +196,7 @@ export const SortMixin = (superClass) =>
      * @protected
      */
     _mapSorters() {
-      return this._activeSorters.map((sorter) => {
+      return this._getActiveSorters().map((sorter) => {
         return {
           path: sorter.path,
           direction: sorter.direction,

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -95,7 +95,7 @@ export const SortMixin = (superClass) =>
       e.stopPropagation();
       sorter._grid = this;
       this.__updateSorter(sorter, e.detail.shiftClick, e.detail.fromSorterClick);
-      this._applySorters();
+      this.__applySorters();
     }
 
     /** @private */
@@ -105,7 +105,7 @@ export const SortMixin = (superClass) =>
       }
 
       this._sorters = this._sorters.filter((sorter) => sortersToRemove.indexOf(sorter) < 0);
-      this._applySorters();
+      this.__applySorters();
     }
 
     /** @private */
@@ -166,8 +166,8 @@ export const SortMixin = (superClass) =>
       }
     }
 
-    /** @protected */
-    _applySorters() {
+    /** @private */
+    __applySorters() {
       if (
         this.dataProvider &&
         // No need to clear cache if sorters didn't change and grid is attached

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -95,7 +95,7 @@ export const SortMixin = (superClass) =>
       e.stopPropagation();
       sorter._grid = this;
       this.__updateSorter(sorter, e.detail.shiftClick, e.detail.fromSorterClick);
-      this.__applySorters();
+      this._applySorters();
     }
 
     /** @private */
@@ -105,7 +105,7 @@ export const SortMixin = (superClass) =>
       }
 
       this._sorters = this._sorters.filter((sorter) => sortersToRemove.indexOf(sorter) < 0);
-      this.__applySorters();
+      this._applySorters();
     }
 
     /** @private */
@@ -166,8 +166,8 @@ export const SortMixin = (superClass) =>
       }
     }
 
-    /** @private */
-    __applySorters() {
+    /** @protected */
+    _applySorters() {
       if (
         this.dataProvider &&
         // No need to clear cache if sorters didn't change and grid is attached

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -118,7 +118,7 @@ export const GridSorterMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       if (this._grid) {
-        this._grid.__applySorters();
+        this._grid._applySorters();
       } else {
         this.__dispatchSorterChangedEvenIfPossible();
       }
@@ -131,7 +131,7 @@ export const GridSorterMixin = (superClass) =>
       if (!this.parentNode && this._grid) {
         this._grid.__removeSorters([this]);
       } else if (this._grid) {
-        this._grid.__applySorters();
+        this._grid._applySorters();
       }
     }
 

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -118,7 +118,7 @@ export const GridSorterMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       if (this._grid) {
-        this._grid._applySorters();
+        this._grid.__applySorters();
       } else {
         this.__dispatchSorterChangedEvenIfPossible();
       }
@@ -131,7 +131,7 @@ export const GridSorterMixin = (superClass) =>
       if (!this.parentNode && this._grid) {
         this._grid.__removeSorters([this]);
       } else if (this._grid) {
-        this._grid._applySorters();
+        this._grid.__applySorters();
       }
     }
 

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -101,12 +101,6 @@ export const GridSorterMixin = (superClass) =>
           value: null,
           sync: true,
         },
-
-        /** @private */
-        _isConnected: {
-          type: Boolean,
-          observer: '__isConnectedChanged',
-        },
       };
     }
 
@@ -123,16 +117,21 @@ export const GridSorterMixin = (superClass) =>
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
-      this._isConnected = true;
+      if (this._grid) {
+        this._grid.__applySorters();
+      } else {
+        this.__dispatchSorterChangedEvenIfPossible();
+      }
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      this._isConnected = false;
 
       if (!this.parentNode && this._grid) {
         this._grid.__removeSorters([this]);
+      } else if (this._grid) {
+        this._grid.__applySorters();
       }
     }
 
@@ -142,17 +141,8 @@ export const GridSorterMixin = (superClass) =>
     }
 
     /** @private */
-    __isConnectedChanged(newValue, oldValue) {
-      if (oldValue === false) {
-        return;
-      }
-
-      this.__dispatchSorterChangedEvenIfPossible();
-    }
-
-    /** @private */
     __dispatchSorterChangedEvenIfPossible() {
-      if (this.path === undefined || this.direction === undefined || !this._isConnected) {
+      if (this.path === undefined || this.direction === undefined || !this.isConnected) {
         return;
       }
 

--- a/packages/grid/test/sorting.common.js
+++ b/packages/grid/test/sorting.common.js
@@ -233,7 +233,7 @@ describe('sorting', () => {
   });
 
   describe('grid', () => {
-    let grid, sorters;
+    let grid, columns, sorters;
 
     beforeEach(async () => {
       grid = fixtureSync(`
@@ -243,7 +243,7 @@ describe('sorting', () => {
           <vaadin-grid-sort-column></vaadin-grid-sort-column>
         </vaadin-grid>
       `);
-      const columns = [...grid.querySelectorAll('vaadin-grid-column')];
+      columns = [...grid.querySelectorAll('vaadin-grid-column')];
       columns[0].headerRenderer = (root) => {
         if (!root.firstChild) {
           root.innerHTML = `
@@ -535,6 +535,26 @@ describe('sorting', () => {
         sorters[1].direction = 'asc';
         flushGrid(grid);
         expect(grid.dataProvider.called).to.be.true;
+      });
+
+      it('should request new data when showing a column whose direction was changed', async () => {
+        columns[0].hidden = true;
+        await nextFrame();
+        grid.dataProvider.resetHistory();
+        sorters[0].direction = 'desc';
+        columns[0].hidden = false;
+        await nextFrame();
+        expect(grid.dataProvider.calledOnce).to.be.true;
+      });
+
+      it('should not request new data when showing a column whose direction was reset', async () => {
+        columns[0].hidden = true;
+        await nextFrame();
+        grid.dataProvider.resetHistory();
+        sorters[0].direction = null;
+        columns[0].hidden = false;
+        await nextFrame();
+        expect(grid.dataProvider.called).to.be.false;
       });
     });
 

--- a/packages/grid/test/sorting.common.js
+++ b/packages/grid/test/sorting.common.js
@@ -135,7 +135,7 @@ describe('sorting', () => {
       flushGrid(grid);
     });
 
-    it('should preserve sorter order when grid is re-attached', () => {
+    it('should preserve sorters order when grid is re-attached', () => {
       click(sorters[1]);
       const parentNode = grid.parentNode;
       parentNode.removeChild(grid);
@@ -156,7 +156,7 @@ describe('sorting', () => {
       assertColumnCellOrder(columns[1], ['1', '2', '3']);
     });
 
-    it('should update sorter order when removing column', () => {
+    it('should update sorters order when removing column', () => {
       grid.removeChild(columns[2]);
       flushGrid(grid);
       expect(sorters.map((sorter) => sorter._order)).to.eql([1, 0, 0]);
@@ -217,13 +217,13 @@ describe('sorting', () => {
       assertColumnCellOrder(columns[1], ['1', '2', '3']);
     });
 
-    it('should update sorter order when column gets hidden', async () => {
+    it('should update sorters order when column gets hidden', async () => {
       columns[2].hidden = true;
       await nextFrame();
       expect(sorters.map((sorter) => sorter._order)).to.eql([1, 0, null]);
     });
 
-    it('should update sorter order when column gets shown again', async () => {
+    it('should update sorters order when column gets shown again', async () => {
       columns[2].hidden = true;
       await nextFrame();
       columns[2].hidden = false;

--- a/packages/grid/test/sorting.common.js
+++ b/packages/grid/test/sorting.common.js
@@ -144,7 +144,7 @@ describe('sorting', () => {
       expect(sorters.map((sorter) => sorter._order)).to.eql([2, 0, 1]);
     });
 
-    it('should remove sorter reference when removing column', () => {
+    it('should remove sorter reference when removing a column', () => {
       grid.removeChild(columns[0]);
       flushGrid(grid);
       expect(grid._sorters).to.not.contain(sorters[0]);
@@ -156,7 +156,7 @@ describe('sorting', () => {
       assertColumnCellOrder(columns[1], ['1', '2', '3']);
     });
 
-    it('should update sorters order when removing column', () => {
+    it('should update sorters order when removing a column', () => {
       grid.removeChild(columns[2]);
       flushGrid(grid);
       expect(sorters.map((sorter) => sorter._order)).to.eql([1, 0, 0]);
@@ -217,13 +217,13 @@ describe('sorting', () => {
       assertColumnCellOrder(columns[1], ['1', '2', '3']);
     });
 
-    it('should update sorters order when column gets hidden', async () => {
+    it('should update sorters order when a column gets hidden', async () => {
       columns[2].hidden = true;
       await nextFrame();
       expect(sorters.map((sorter) => sorter._order)).to.eql([1, 0, null]);
     });
 
-    it('should update sorters order when column gets shown again', async () => {
+    it('should update sorters order when a column gets shown again', async () => {
       columns[2].hidden = true;
       await nextFrame();
       columns[2].hidden = false;


### PR DESCRIPTION
## Description

The PR updates the grid sorting logic so that it excludes hidden columns from sorting and includes them when they are shown again.

Precedes:
- https://github.com/vaadin/flow-components/pull/5817

Part of https://github.com/vaadin/flow-components/issues/5513

## Type of change

- [x] Bugfix
