### PR TITLE
refactor: remove unused internal mixin detection property

### DIFF
--- a/packages/a11y-base/src/list-mixin.d.ts
+++ b/packages/a11y-base/src/list-mixin.d.ts
@@ -16,11 +16,6 @@ export declare function ListMixin<T extends Constructor<HTMLElement>>(
 
 export declare class ListMixinClass {
   /**
-   * Used for mixin detection because `instanceof` does not work with mixins.
-   */
-  _hasVaadinListMixin: boolean;
-
-  /**
    * If true, the user cannot interact with this element.
    * When the element is disabled, the selected item is
    * not updated when `selected` property is changed.

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -21,14 +21,6 @@ export const ListMixin = (superClass) =>
     static get properties() {
       return {
         /**
-         * Used for mixin detection because `instanceof` does not work with mixins.
-         * @type {boolean}
-         */
-        _hasVaadinListMixin: {
-          value: true,
-        },
-
-        /**
          * If true, the user cannot interact with this element.
          * When the element is disabled, the selected item is
          * not updated when `selected` property is changed.

--- a/packages/list-box/test/list-box.test.js
+++ b/packages/list-box/test/list-box.test.js
@@ -4,7 +4,7 @@ import '@vaadin/item/vaadin-item.js';
 import '../vaadin-list-box.js';
 
 describe('vaadin-list-box', () => {
-  let listBox;
+  let listBox, tagName;
 
   beforeEach(() => {
     listBox = fixtureSync(`
@@ -13,9 +13,14 @@ describe('vaadin-list-box', () => {
         <vaadin-item>Bar</vaadin-item>
       </vaadin-list-box>
     `);
+    tagName = listBox.tagName.toLowerCase();
   });
 
-  it('should extend list-mixin', () => {
-    expect(listBox._hasVaadinListMixin).to.be.true;
+  it('should be defined in custom element registry', () => {
+    expect(customElements.get(tagName)).to.be.ok;
+  });
+
+  it('should have a valid static "is" getter', () => {
+    expect(customElements.get(tagName).is).to.equal(tagName);
   });
 });


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/react-components/issues/162 - needed to hide property from IntelliJ completion:

<img width="220" alt="Screenshot 2023-12-07 at 14 23 48" src="https://github.com/vaadin/web-components/assets/10589913/955feee5-54a2-4ad4-acec-05aa5d739dd7">

This was added in https://github.com/vaadin/vaadin-list-mixin/pull/15 but I was unable to figure out if we ever used it. 

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
