### PR TITLE
fix: add missing export for DetailsSummary component class

### DIFF
--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -83,3 +83,5 @@ class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolymerElement))
 }
 
 defineCustomElement(DetailsSummary);
+
+export { DetailsSummary };

--- a/packages/details/src/vaadin-lit-details-summary.js
+++ b/packages/details/src/vaadin-lit-details-summary.js
@@ -67,3 +67,5 @@ class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(Lit
 }
 
 defineCustomElement(DetailsSummary);
+
+export { DetailsSummary };


### PR DESCRIPTION
## Description

We missed to add `export` for the JS class in `vaadin-details-summary` which breaks the React wrapper:

```
Uncaught SyntaxError: The requested module '/@fs/Users/serhii/vaadin/react-components/node_modules/.vite/deps/@vaadin_details_vaadin-details-summary__js.js?v=9c5ddbf1' does not provide an export named 'DetailsSummary' (at DetailsSummary.ts:2:10)
```

## Type of change

- Bugfix