### PR TITLE
fix: add missing export for CrudEdit component class

### DIFF
--- a/packages/crud/src/vaadin-crud-edit.js
+++ b/packages/crud/src/vaadin-crud-edit.js
@@ -76,3 +76,5 @@ class CrudEdit extends Button {
 }
 
 defineCustomElement(CrudEdit);
+
+export { CrudEdit };


### PR DESCRIPTION
## Description

Same as #6929 but for `vaadin-crud-edit` component.

We missed to add `export` for the JS class in `vaadin-details-summary` which breaks the React wrapper:

```
Uncaught SyntaxError: The requested module '/@fs/Users/serhii/vaadin/react-components/node_modules/.vite/deps/@vaadin_crud_vaadin-crud-edit__js.js?v=561c48f7' does not provide an export named 'CrudEdit' (at CrudEdit.ts:2:10)
```

## Type of change

- Bugfix