### PR TITLE
fix: add missing export for DetailsSummary component class (#6929) (CP: 24.1)

### DIFF
--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -81,3 +81,5 @@ class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolymerElement))
 }
 
 customElements.define(DetailsSummary.is, DetailsSummary);
+
+export { DetailsSummary };


### PR DESCRIPTION
## Description

Manual cherry-pick of #6929 to `24.1` branch which doesn't have a LitElement based version yet.

## Type of change

- Cherry-pick