### PR TITLE
fix: add missing export for CrudEdit component class (#6930) (CP: 23.3)

### DIFF
--- a/packages/crud/src/vaadin-crud-edit.js
+++ b/packages/crud/src/vaadin-crud-edit.js
@@ -64,3 +64,5 @@ class CrudEdit extends Button {
 }
 
 customElements.define(CrudEdit.is, CrudEdit);
+
+export { CrudEdit };


### PR DESCRIPTION
## Description

Manual cherry-pick of #6930 to `23.3` branch. The merge conflict was caused by `defineCustomElement` on `main`.

## Type of change

- Cherry-pick