### PR TITLE
fix: allow defining slots in split-layout

### DIFF
--- a/packages/split-layout/src/vaadin-split-layout-mixin.js
+++ b/packages/split-layout/src/vaadin-split-layout-mixin.js
@@ -63,17 +63,34 @@ export const SplitLayoutMixin = (superClass) =>
 
     /** @private */
     _processChildren() {
-      [...this.children].forEach((child, i) => {
-        if (i === 0) {
-          this._primaryChild = child;
-          child.setAttribute('slot', 'primary');
-        } else if (i === 1) {
-          this._secondaryChild = child;
-          child.setAttribute('slot', 'secondary');
-        } else {
+      this.querySelectorAll('[slot]').forEach((child) => {
+        const slot = child.getAttribute('slot');
+        if (child.__autoSlotted) {
+          this[`_${slot}Child`] = null;
           child.removeAttribute('slot');
+        } else {
+          this[`_${slot}Child`] = child;
         }
       });
+      [...this.children]
+        .filter((child) => !child.hasAttribute('slot'))
+        .forEach((child, i) => {
+          if (this._primaryChild && this._secondaryChild) {
+            child.removeAttribute('slot');
+            return;
+          }
+
+          let slotName;
+          if (this._primaryChild || this._secondaryChild) {
+            slotName = this._primaryChild ? 'secondary' : 'primary';
+          } else {
+            slotName = i === 0 ? 'primary' : 'secondary';
+          }
+
+          this[`_${slotName}Child`] = child;
+          child.setAttribute('slot', slotName);
+          child.__autoSlotted = true;
+        });
     }
 
     /** @private */

--- a/packages/split-layout/test/split-layout.common.js
+++ b/packages/split-layout/test/split-layout.common.js
@@ -73,6 +73,78 @@ describe('split layout', () => {
       expect(getComputedStyle(first).pointerEvents).to.equal('visible');
       expect(getComputedStyle(second).pointerEvents).to.equal('visible');
     });
+
+    describe('elements with slot pre-defined', () => {
+      it('should respect pre-defined slot values in both elements', async () => {
+        const layout = fixtureSync(`
+          <vaadin-split-layout>
+            <div id="second" slot="secondary">secondary</div>
+            <div id="first" slot="primary">primary</div>
+          </vaadin-split-layout>
+        `);
+        await nextRender();
+        expect(layout.querySelector('#first').getAttribute('slot')).to.be.equal('primary');
+        expect(layout.querySelector('#second').getAttribute('slot')).to.be.equal('secondary');
+      });
+
+      it('should assign a slot if one element has "secondary" slot pre-defined', async () => {
+        const layout = fixtureSync(`
+          <vaadin-split-layout>
+            <div id="second" slot="secondary">secondary</div>
+            <div id="first">primary</div>
+          </vaadin-split-layout>
+        `);
+        await nextRender();
+        expect(layout.querySelector('#first').getAttribute('slot')).to.be.equal('primary');
+        expect(layout.querySelector('#second').getAttribute('slot')).to.be.equal('secondary');
+      });
+
+      it('should assign a slot if only element has "primary" slot pre-defined', async () => {
+        const layout = fixtureSync(`
+          <vaadin-split-layout>
+            <div id="second">secondary</div>
+            <div id="first" slot="primary">primary</div>
+          </vaadin-split-layout>
+        `);
+        await nextRender();
+        expect(layout.querySelector('#first').getAttribute('slot')).to.be.equal('primary');
+        expect(layout.querySelector('#second').getAttribute('slot')).to.be.equal('secondary');
+      });
+
+      it('should respect assigned slot if only one element has slot pre-defined after order is inverted', async () => {
+        const layout = fixtureSync(`
+          <vaadin-split-layout>
+            <div id="second">secondary</div>
+            <div id="first" slot="primary">primary</div>
+          </vaadin-split-layout>
+        `);
+        await nextRender();
+
+        const first = layout.querySelector('#first');
+        layout.prepend(first);
+        await nextRender();
+
+        expect(layout.querySelector('#first').getAttribute('slot')).to.be.equal('primary');
+        expect(layout.querySelector('#second').getAttribute('slot')).to.be.equal('secondary');
+      });
+
+      it('should swap slots if children without pre-defined slots invert order', async () => {
+        const layout = fixtureSync(`
+          <vaadin-split-layout>
+            <div id="second">secondary</div>
+            <div id="first">primary</div>
+          </vaadin-split-layout>
+        `);
+        await nextRender();
+
+        const second = layout.querySelector('#second');
+        layout.prepend(second);
+        await nextRender();
+
+        expect(layout.querySelector('#first').getAttribute('slot')).to.be.equal('secondary');
+        expect(layout.querySelector('#second').getAttribute('slot')).to.be.equal('primary');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Description

`split-layout` has a method called `_processChildren` that loops over the children and assigns the `primary`/`secondary` slots based on their indexes. The current behavior prevents the user from trying to assign the slots themselves because it always overwrites them as stated previously. The `SplitLayout` Flow component assigns the slots for each child added, but that is currently ignored by the `_processChildren` method. Since https://github.com/vaadin/flow-components/pull/5750, the FC no longer removes all children when `addToPrimary`/`addToSecondary` are called, which caused a regression when `addToSecondary` is called before `addToPrimary` method, making the component set as the secondary to be added on the `primary` slot due to it being the first child.

This change:
- Keeps the current behavior if the child doesn't have any slot assigned to it
  - If slots are auto-assigned, and the order of children is inverted, then the slots are re-assigned again based on the same behavior	
- Adds the ability to assign the slots to each child individually, so that their order doesn't matter
- Make it possible to assign just one of the slots and make the other one to be auto-assigned with the missing slot


Fixes vaadin/flow-components#5799

## Type of change

- [X] Bugfix
- [ ] Feature
