### PR TITLE
fix: update vaadin-tabsheet type to extend HTMLElement

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2022 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -70,7 +69,7 @@ export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEve
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  */
-declare class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
+declare class TabSheet extends ControllerMixin(DelegateStateMixin(ElementMixin(ThemableMixin(HTMLElement)))) {
   /**
    * The index of the selected tab.
    */


### PR DESCRIPTION
## Description

Currently, `vaadin-tabsheet` uses `PolymerElement` in type definitions causing the code completion to look like this:

<img width="604" alt="Screenshot 2023-12-08 at 11 56 30" src="https://github.com/vaadin/web-components/assets/10589913/b82bd3b1-eb3d-4da3-9450-8fd34cfa9847">

Updated to use `HTMLElement` instead, same as it's done in all the other web components type definitions.

## Type of change

- Bugfix