### PR TITLE
fix: add missing a11y-base dependency to side-nav

### DIFF
--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@vaadin/a11y-base": "24.3.0-rc1",
     "@vaadin/component-base": "24.3.0-rc1",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc1",
     "@vaadin/vaadin-material-styles": "24.3.0-rc1",


### PR DESCRIPTION
## Description

Trying to use `@vaadin/side-nav` package in a Vite app currently throws an error due to missing dependency:

```
✘ [ERROR] Could not resolve "@vaadin/a11y-base/src/disabled-mixin.js"

    node_modules/@vaadin/side-nav/src/vaadin-side-nav-item.js:8:30:
      8 │ import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
        ╵                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

✘ [ERROR] Could not resolve "@vaadin/a11y-base/src/styles/sr-only-styles.js"

    node_modules/@vaadin/side-nav/src/vaadin-side-nav-item.js:9:33:
      9 │ import { screenReaderOnly } from '@vaadin/a11y-base/src/styles/sr-only-styles.js';
        ╵                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Type of change

- Bugfix