### PR TITLE
fix: add missing a11y-base dependency to side-nav (24.2)

### DIFF
--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@vaadin/a11y-base": "~24.2.5",
     "@vaadin/component-base": "~24.2.5",
     "@vaadin/vaadin-lumo-styles": "~24.2.5",
     "@vaadin/vaadin-material-styles": "~24.2.5",


### PR DESCRIPTION
## Description

Same as #6944 but for `24.2` where `vaadin-side-nav` was first introduced as stable.

## Type of change

- Bugfix