### PR TITLE
chore: add missing Lit direct dependency

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -41,7 +41,8 @@
     "@vaadin/details": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -44,7 +44,8 @@
     "@vaadin/tooltip": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -43,7 +43,8 @@
     "@vaadin/overlay": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -43,7 +43,8 @@
     "@vaadin/field-base": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -44,7 +44,8 @@
     "@vaadin/overlay": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -46,7 +46,8 @@
     "@vaadin/component-base": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -35,7 +35,8 @@
     "@vaadin/component-base": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -50,7 +50,8 @@
     "@vaadin/text-field": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -48,7 +48,8 @@
     "@vaadin/field-base": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -48,7 +48,8 @@
     "@vaadin/tooltip": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -42,7 +42,8 @@
     "@vaadin/item": "24.3.0-rc2",
     "@vaadin/vaadin-lumo-styles": "24.3.0-rc2",
     "@vaadin/vaadin-material-styles": "24.3.0-rc2",
-    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2"
+    "@vaadin/vaadin-themable-mixin": "24.3.0-rc2",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",


### PR DESCRIPTION
## Description

Some packages with Lit based version are missing the `lit` direct dependency.

While it's available through `@vaadin/vaadin-themable-mixin`, there are errors when using Skypack CDN:

<img width="893" alt="Screenshot 2023-12-11 at 11 41 28" src="https://github.com/vaadin/web-components/assets/10589913/c90f3e12-4b01-47c6-ba3c-8ee8130a9ce9">

## Type of change

- Internal change