### PR TITLE
fix: align controller-mixin TS API visibility

### DIFF
--- a/packages/component-base/src/controller-mixin.d.ts
+++ b/packages/component-base/src/controller-mixin.d.ts
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { ReactiveController } from 'lit';
 
 /**
  * A mixin for connecting controllers to the element.
@@ -13,16 +13,14 @@ export declare function ControllerMixin<T extends Constructor<HTMLElement>>(
   superclass: T,
 ): Constructor<ControllerMixinClass> & T;
 
-export declare class ControllerMixinClass
-  implements Pick<ReactiveControllerHost, 'addController' | 'removeController'>
-{
+export declare class ControllerMixinClass {
   /**
    * Registers a controller to participate in the element update cycle.
    */
-  addController(controller: ReactiveController): void;
+  protected addController(controller: ReactiveController): void;
 
   /**
    * Removes a controller from the element.
    */
-  removeController(controller: ReactiveController): void;
+  protected removeController(controller: ReactiveController): void;
 }


### PR DESCRIPTION
## Description

This pull request addresses an inconsistency in the `ControllerMixin` API. The `addController` and `removeController` functions are currently [labeled as protected in JSDoc](https://github.com/vaadin/web-components/blob/713c37a239d9230774eddc10436c7587a1de09d1/packages/component-base/src/controller-mixin.js#L61), which makes them appear as protected on the API [documentation generated with Polymer Analyzer](https://cdn.vaadin.com/vaadin-web-components/24.3.0-rc1/#/elements/vaadin-avatar-group#method-addController).

However, in the TypeScript definition, they are [not marked as protected](https://github.com/vaadin/web-components/blob/713c37a239d9230774eddc10436c7587a1de09d1/packages/component-base/src/controller-mixin.d.ts#L22), which makes them public properties for the generated React components / TypeScript users in general.

These functions are mainly intended for internal purposes, so they should be excluded from the public interface the same as other PolymerElement/LitElement-specific API.

To resolve this issue, this pull request aligns the TypeScript definitions with the JSDoc by marking the `addController` and `removeController` functions as protected.

Related to https://github.com/vaadin/react-components/issues/161

## Type of change

Documentation/refactor