### PR TITLE
test: use relative imports in SlotStylesMixin tests

### DIFF
--- a/packages/component-base/test/slot-styles-mixin.test.js
+++ b/packages/component-base/test/slot-styles-mixin.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+import { ControllerMixin } from '../src/controller-mixin.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
+import { SlotController } from '../src/slot-controller.js';
 import { SlotStylesMixin } from '../src/slot-styles-mixin.js';
 
 const runTests = (defineHelper, baseMixin) => {


### PR DESCRIPTION
## Description

This mixin was moved from `@vaadin/field-base` in #6393 and the imports in tests weren't updated.

## Type of change

- Test