### PR TITLE
fix: add missing held property to UploadFile type

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-mixin.d.ts
@@ -20,6 +20,7 @@ export interface UploadFile extends File {
   error: string;
   abort?: boolean;
   complete?: boolean;
+  held?: boolean;
   uploading?: boolean;
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/react-components/issues/73

The `held` property is set on the `file` instance but missing from the corresponding type. This PR adds it.

https://github.com/vaadin/web-components/blob/1f34ad0c959f91ceb505b4264c0f9cb67d50d566/packages/upload/src/vaadin-upload-mixin.js#L819

## Type of change

- Bugfix