### PR TITLE
fix: add missing change event type to vaadin-checkbox

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -130,4 +130,10 @@ export const CheckboxMixin = (superclass) =>
 
       super._toggleChecked(checked);
     }
+
+    /**
+     * Fired when the checkbox is checked or unchecked by the user.
+     *
+     * @event change
+     */
   };

--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -12,6 +12,13 @@ import { LabelMixin } from '@vaadin/field-base/src/label-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
+ * Fired when the checkbox is checked or unchecked by the user.
+ */
+export type CheckboxChangeEvent = Event & {
+  target: Checkbox;
+};
+
+/**
  * Fired when the `checked` property changes.
  */
 export type CheckboxCheckedChangedEvent = CustomEvent<{ value: boolean }>;
@@ -27,7 +34,9 @@ export interface CheckboxCustomEventMap {
   'indeterminate-changed': CheckboxIndeterminateChangedEvent;
 }
 
-export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEventMap {}
+export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEventMap {
+  change: CheckboxChangeEvent;
+}
 
 /**
  * `<vaadin-checkbox>` is an input field representing a binary choice.
@@ -58,6 +67,7 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @fires {Event} change - Fired when the checkbox is checked or unchecked by the user.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
  */

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -42,6 +42,7 @@ registerStyles('vaadin-checkbox', checkboxStyles, { moduleId: 'vaadin-checkbox-s
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @fires {Event} change - Fired when the checkbox is checked or unchecked by the user.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
  *

--- a/packages/checkbox/test/typings/checkbox.types.ts
+++ b/packages/checkbox/test/typings/checkbox.types.ts
@@ -9,7 +9,12 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { CheckedMixinClass } from '@vaadin/field-base/src/checked-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { CheckboxCheckedChangedEvent, CheckboxIndeterminateChangedEvent } from '../../vaadin-checkbox.js';
+import type {
+  Checkbox,
+  CheckboxChangeEvent,
+  CheckboxCheckedChangedEvent,
+  CheckboxIndeterminateChangedEvent,
+} from '../../vaadin-checkbox.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
@@ -45,4 +50,9 @@ checkbox.addEventListener('checked-changed', (event) => {
 checkbox.addEventListener('indeterminate-changed', (event) => {
   assertType<CheckboxIndeterminateChangedEvent>(event);
   assertType<boolean>(event.detail.value);
+});
+
+checkbox.addEventListener('change', (event) => {
+  assertType<CheckboxChangeEvent>(event);
+  assertType<Checkbox>(event.target);
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/react-components/issues/133

While `vaadin-checkbox` allows to use `change` event bubbling from the `<input>`, it doesn't expose proper type.
Also, this event isn't documented, which causes corresponding `onChange` to not be generated for React usage.

As discussed internally, this small feature can be also considered a bugfix (in terms of React wrapper API).

## Type of change

- Bugfix