### PR TITLE
refactor: make stateTarget property in typings as protected

### DIFF
--- a/packages/component-base/src/delegate-state-mixin.d.ts
+++ b/packages/component-base/src/delegate-state-mixin.d.ts
@@ -16,5 +16,5 @@ export declare class DelegateStateMixinClass {
   /**
    * A target element to which attributes and properties are delegated.
    */
-  stateTarget: HTMLElement | null;
+  protected stateTarget: HTMLElement | null;
 }


### PR DESCRIPTION
## Description

Similar to #6917

Updated `stateTarget` property in `DelegateStateMixin` to be marked as protected. 
It actually has corresponding JSDoc, but is marked as public in `.d.ts`.

This change is needed to hide this property from VSCode / IntelliJ autocomplete:

<img width="537" alt="Screenshot 2023-12-14 at 14 29 52" src="https://github.com/vaadin/web-components/assets/10589913/fd730b45-33b3-499f-9486-dcfff4b58479">

## Type of change

- Refactor