### PR TITLE
refactor: mark _fields property in typings as protected

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -264,11 +264,6 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  */
 declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   /**
-   * A reference to all fields inside the [`_form`](#/elements/vaadin-crud#property-_form) element
-   */
-  readonly _fields: HTMLElement[];
-
-  /**
    * An array containing the items which will be stamped to the column template instances.
    */
   items: Item[] | null | undefined;
@@ -403,6 +398,11 @@ declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTML
    * ```
    */
   i18n: CrudI18n;
+
+  /**
+   * A reference to all fields inside the [`_form`](#/elements/vaadin-crud#property-_form) element
+   */
+  protected readonly _fields: HTMLElement[];
 
   addEventListener<K extends keyof CrudEventMap<Item>>(
     type: K,


### PR DESCRIPTION
## Description

Updated `_fields` property in `Crud` to be marked as protected. 
It actually has corresponding JSDoc, but is public in `.d.ts`.

https://github.com/vaadin/web-components/blob/d3c22c6003f3507e1c6ff4fa5487d5971191e65a/packages/crud/src/vaadin-crud.js#L677-L682

## Type of change

- Refactor