### PR TITLE
fix: ignore data from re-invoked callbacks

### DIFF
--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -237,6 +237,10 @@ export class DataProviderController extends EventTarget {
     }
 
     const callback = (items, size) => {
+      if (cache.pendingRequests[page] !== callback) {
+        return;
+      }
+
       if (size !== undefined) {
         cache.size = size;
       } else if (params.parentItem) {

--- a/packages/component-base/test/data-provider-controller-data-callbacks.test.js
+++ b/packages/component-base/test/data-provider-controller-data-callbacks.test.js
@@ -1,0 +1,34 @@
+import { expect } from '@esm-bundle/chai';
+import '@vaadin/testing-helpers';
+import { DataProviderController } from '../src/data-provider-controller/data-provider-controller.js';
+
+describe('DataProviderController - data callbacks', () => {
+  let host, controller, dataProviderCallback;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+
+    controller = new DataProviderController(host, {
+      pageSize: 2,
+      dataProvider: (_params, callback) => {
+        dataProviderCallback = callback;
+      },
+    });
+  });
+
+  it('should ignore already invoked once callbacks', () => {
+    controller.loadFirstPage();
+    dataProviderCallback(['Item-0', 'Item-1'], 2);
+    dataProviderCallback(['Item-2'], 1);
+    expect(controller.rootCache.size).to.equal(2);
+    expect(controller.rootCache.items).to.eql(['Item-0', 'Item-1']);
+  });
+
+  it('should ignore old pending callbacks after clearing cache', () => {
+    controller.loadFirstPage();
+    controller.clearCache();
+    dataProviderCallback(['Item-0', 'Item-1'], 2);
+    expect(controller.rootCache.size).to.equal(0);
+    expect(controller.rootCache.items).to.have.lengthOf(0);
+  });
+});

--- a/packages/component-base/test/data-provider-controller-data-callbacks.test.js
+++ b/packages/component-base/test/data-provider-controller-data-callbacks.test.js
@@ -16,7 +16,7 @@ describe('DataProviderController - data callbacks', () => {
     });
   });
 
-  it('should ignore already invoked once callbacks', () => {
+  it('should ignore data from re-invoked callbacks', () => {
     controller.loadFirstPage();
     dataProviderCallback(['Item-0', 'Item-1'], 2);
     dataProviderCallback(['Item-2'], 1);
@@ -24,7 +24,7 @@ describe('DataProviderController - data callbacks', () => {
     expect(controller.rootCache.items).to.eql(['Item-0', 'Item-1']);
   });
 
-  it('should ignore old pending callbacks after clearing cache', () => {
+  it('should ignore data from callbacks created before cache clear', () => {
     controller.loadFirstPage();
     controller.clearCache();
     dataProviderCallback(['Item-0', 'Item-1'], 2);

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -872,6 +872,8 @@ describe('drag and drop', () => {
 
       it('should enable row drag once items are available', () => {
         finishLoadingItems([getTestItems()[0], undefined]);
+        // Manually trigger a content update to re-request the first page.
+        grid.requestContentUpdate();
         finishLoadingItems();
         expect(getDraggable(grid, 1)).to.be.ok;
         expect(grid.$.items.children[1].hasAttribute('drag-disabled')).to.be.false;
@@ -988,6 +990,8 @@ describe('drag and drop', () => {
 
       it('should enable drop on row once items are available', () => {
         finishLoadingItems([getTestItems()[0], undefined]);
+        // Manually trigger a content update to re-request the first page.
+        grid.requestContentUpdate();
         finishLoadingItems();
         const row = grid.$.items.children[1];
         fireDragOver(row, 'above');


### PR DESCRIPTION
## Description

The PR adds a check to DataProviderController to ignore data from callbacks that have been already invoked once before.

Fixes https://github.com/vaadin/web-components/issues/6584

## Type of change

- [x] Bugfix
