### PR TITLE
refactor: decrease array data provider calls when filtering or sorting

### DIFF
--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -37,6 +37,18 @@ export const ArrayDataProviderMixin = (superClass) =>
       this.dataProvider = arrayDataProvider;
     }
 
+    /**
+     * @override
+     * @protected
+     */
+    _onDataProviderPageReceived() {
+      super._onDataProviderPageReceived();
+
+      if (this._arrayDataProvider) {
+        this.size = this._flatSize;
+      }
+    }
+
     /** @private */
     __dataProviderOrItemsChanged(dataProvider, items, isAttached) {
       if (!isAttached) {
@@ -59,7 +71,6 @@ export const ArrayDataProviderMixin = (superClass) =>
         } else if (this._arrayDataProvider.__items === items) {
           // The items array was modified
           this.clearCache();
-          this.size = this._flatSize;
         } else {
           // The items array was replaced
           this.__setArrayDataProvider(items);

--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -25,7 +25,7 @@ export const ArrayDataProviderMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__dataProviderOrItemsChanged(dataProvider, items, isAttached, _filters, _sorters, items.*)'];
+      return ['__dataProviderOrItemsChanged(dataProvider, items, isAttached, items.*)'];
     }
 
     /** @private */

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -318,6 +318,18 @@ describe('array data provider', () => {
     expect(getVisibleItems(grid).length).to.equal(3);
   });
 
+  it('should invoke data provider only once when removing a column with filter', () => {
+    const spy = sinon.spy(grid.dataProvider);
+    grid._arrayDataProvider = spy;
+    grid.dataProvider = spy;
+    spy.resetHistory();
+
+    grid.removeChild(grid.firstElementChild);
+    flushGrid(grid);
+
+    expect(spy).to.be.calledOnce;
+  });
+
   it('should not filter items before grid is re-attached', () => {
     filterFirst.value = 'bar';
     flushFilters(grid);

--- a/packages/grid/test/sorting.common.js
+++ b/packages/grid/test/sorting.common.js
@@ -502,6 +502,18 @@ describe('sorting', () => {
         expect(getBodyCellContent(grid, 1, 0).innerText).to.equal('1');
         expect(getBodyCellContent(grid, 2, 0).innerText).to.equal('2');
       });
+
+      it('should invoke data provider only once when removing a column with sorter', () => {
+        const spy = sinon.spy(grid.dataProvider);
+        grid._arrayDataProvider = spy;
+        grid.dataProvider = spy;
+        spy.resetHistory();
+
+        grid.removeChild(columns[0]);
+        flushGrid(grid);
+
+        expect(spy).to.be.calledOnce;
+      });
     });
 
     describe('data provider', () => {


### PR DESCRIPTION
## Description

The PR decreases the number of array data provider calls to one for filtering and sorting operations. This is achieved by removing `_filters` and `_sorters` from dependencies of `ArrayDataProviderMixin`'s observer.

A follow-up to https://github.com/vaadin/web-components/pull/6981#discussion_r1430074919

## Type of change

- [x] Performance
