### PR TITLE
fix: make tabsheet type extend themable mixin

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -70,9 +69,7 @@ export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEve
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  */
-declare class TabSheet extends TabSheetMixin<Tab>(
-  ControllerMixin(DelegateStateMixin(ElementMixin(ThemableMixin(HTMLElement)))),
-) {
+declare class TabSheet extends ThemableMixin(TabSheetMixin<Tab>(ControllerMixin(ElementMixin(HTMLElement)))) {
   addEventListener<K extends keyof TabSheetEventMap>(
     type: K,
     listener: (this: TabSheet, ev: TabSheetEventMap[K]) => void,

--- a/packages/tabsheet/test/typings/tabsheet.types.ts
+++ b/packages/tabsheet/test/typings/tabsheet.types.ts
@@ -1,11 +1,16 @@
 import '../../vaadin-tabsheet.js';
+import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import type { Tab } from '@vaadin/tabs/src/vaadin-tab.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { TabSheetItemsChangedEvent, TabSheetSelectedChangedEvent } from '../../vaadin-tabsheet.js';
 
 const tabsheet = document.createElement('vaadin-tabsheet');
 
 const assertType = <TExpected>(actual: TExpected) => actual;
+
+assertType<ThemePropertyMixinClass>(tabsheet);
+assertType<DelegateStateMixinClass>(tabsheet);
 
 tabsheet.addEventListener('items-changed', (event) => {
   assertType<TabSheetItemsChangedEvent>(event);


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/react-components/issues/189

For some reason, the order of the mixins matters in this case and if `ThemableMixin` is not used as the very first one, the component type ends up not extending `ThemePropertyMixinClass`.

Also removed `DelegateStateMixin` from `TabSheet` because it gets inherited from `TabSheetMixin`

## Type of change

Bugfix