### PR TITLE
fix: fire input event on input element on increment/decrement

### DIFF
--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
+import { arrowDown, arrowUp, fixtureSync, keyDownOn } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-integer-field.js';
 
@@ -12,6 +12,36 @@ describe('integer-field', () => {
   });
 
   describe('basic', () => {
+    it('should fire input event on input element when pressing ArrowUp', () => {
+      integerField.step = 3;
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      arrowUp(input);
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire input event on input element when pressing ArrowDown', () => {
+      integerField.step = 3;
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      arrowDown(input);
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire input event on input element when clicking decrease button', () => {
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      integerField.shadowRoot.querySelector('[part=decrease-button]').click();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire input event on input element when clicking increase button', () => {
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      integerField.shadowRoot.querySelector('[part=increase-button]').click();
+      expect(spy).to.be.calledOnce;
+    });
+
     it('should not prevent default for input wheel events when not focused', () => {
       const event = new CustomEvent('wheel', { cancelable: true });
       input.dispatchEvent(event);

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -270,9 +270,8 @@ export const NumberFieldMixin = (superClass) =>
 
       const newValue = this._getIncrement(incr, value);
       if (!this.value || incr === 0 || this._incrementIsInsideTheLimits(incr, value)) {
-        this.__keepCommittedValue = true;
-        this.value = this.inputElement.value = String(parseFloat(newValue));
-        this.__keepCommittedValue = false;
+        this.inputElement.value = String(parseFloat(newValue));
+        this.inputElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
         this.__commitValueChange();
       }
     }

--- a/packages/number-field/test/number-field.common.js
+++ b/packages/number-field/test/number-field.common.js
@@ -40,18 +40,36 @@ describe('number-field', () => {
       expect(numberField.value).equal('9.99');
     });
 
-    it('should increment value on arrow up', async () => {
+    it('should increment value on ArrowUp', async () => {
       numberField.step = 3;
       await nextUpdate(numberField);
       arrowUp(input);
       expect(numberField.value).equal('3');
     });
 
-    it('should decrement value on arrow down', async () => {
+    it('should fire input event on input element when pressing ArrowUp', async () => {
+      numberField.step = 3;
+      await nextUpdate(numberField);
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      arrowUp(input);
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should decrement value on ArrowDown', async () => {
       numberField.step = 3;
       await nextUpdate(numberField);
       arrowDown(input);
       expect(numberField.value).equal('-3');
+    });
+
+    it('should fire input event on input element when pressing ArrowDown', async () => {
+      numberField.step = 3;
+      await nextUpdate(numberField);
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      arrowDown(input);
+      expect(spy).to.be.calledOnce;
     });
 
     it('should not change value on arrow keys when readonly', async () => {

--- a/packages/number-field/test/value-control-buttons.common.js
+++ b/packages/number-field/test/value-control-buttons.common.js
@@ -14,6 +14,20 @@ describe('value control buttons', () => {
   });
 
   describe('basic', () => {
+    it('should fire input event on input element when clicking minus button', () => {
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      decreaseButton.click();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire input event on input element when clicking plus button', () => {
+      const spy = sinon.spy();
+      input.addEventListener('input', spy);
+      increaseButton.click();
+      expect(spy).to.be.calledOnce;
+    });
+
     it('should increase value by 1 on plus button click', async () => {
       numberField.value = 0;
       await nextUpdate(numberField);


### PR DESCRIPTION
## Description

The PR ensures that an `input` event is fired on number fields' input element when the user increments or decrements the value by clicking on a stepper button or pressing an arrow key. This aligns the web component's behavior with the native `input[type=number]` behavior that does fire `input` on stepper button click.

Fixes https://github.com/vaadin/flow-components/issues/5863

## Type of change

- [x] Bugfix
