### PR TITLE
fix: stop propagation of click events on overlay

### DIFF
--- a/integration/tests/context-menu-date-picker.test.js
+++ b/integration/tests/context-menu-date-picker.test.js
@@ -1,0 +1,37 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/context-menu';
+import '@vaadin/date-picker';
+import { isTouch } from '@vaadin/component-base/src/browser-utils';
+import { getMenuItems, openMenu } from '@vaadin/context-menu/test/helpers';
+import { getFocusedCell, open } from '@vaadin/date-picker/test/helpers';
+
+describe('date picker in context menu', () => {
+  let menu;
+
+  beforeEach(async () => {
+    menu = fixtureSync(`
+      <vaadin-context-menu>
+        <button id="target"></button>
+      </vaadin-context-menu>
+    `);
+    menu.openOn = isTouch ? 'click' : 'mouseover';
+    const datePicker = document.createElement('vaadin-date-picker');
+    menu.items = [{ component: datePicker }];
+    await nextRender();
+    const target = menu.firstElementChild;
+    await openMenu(target);
+  });
+
+  it('should not close context menu on date click', async () => {
+    const datePicker = getMenuItems(menu)[0];
+    await open(datePicker);
+
+    const date = getFocusedCell(datePicker._overlayContent);
+    date.click();
+    await nextFrame();
+
+    expect(datePicker.opened).to.be.false;
+    expect(menu.opened).to.be.true;
+  });
+});

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -559,6 +559,8 @@ export const DatePickerMixin = (subclass) =>
       content.addEventListener('focused-date-changed', (e) => {
         this._focusedDate = e.detail.value;
       });
+
+      content.addEventListener('click', (e) => e.stopPropagation());
     }
 
     /**

--- a/packages/date-picker/test/dropdown.common.js
+++ b/packages/date-picker/test/dropdown.common.js
@@ -282,20 +282,6 @@ describe('dropdown', () => {
 
       expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
-
-    it('should stop click events from bubbling outside the overlay', async () => {
-      const clickSpy = sinon.spy();
-      document.addEventListener('click', clickSpy);
-
-      input.focus();
-      await open(datePicker);
-
-      dateTap();
-      await aTimeout(0);
-
-      document.removeEventListener('click', clickSpy);
-      expect(clickSpy.notCalled).to.be.true;
-    });
   });
 
   describe('virtual keyboard', () => {

--- a/packages/date-picker/test/dropdown.common.js
+++ b/packages/date-picker/test/dropdown.common.js
@@ -282,6 +282,20 @@ describe('dropdown', () => {
 
       expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
+
+    it('should stop click events from bubbling outside the overlay', async () => {
+      const clickSpy = sinon.spy();
+      document.addEventListener('click', clickSpy);
+
+      input.focus();
+      await open(datePicker);
+
+      dateTap();
+      await aTimeout(0);
+
+      document.removeEventListener('click', clickSpy);
+      expect(clickSpy.notCalled).to.be.true;
+    });
   });
 
   describe('virtual keyboard', () => {


### PR DESCRIPTION
## Description

Currently, the event is propagated on date picker overlay click. This leads to problems as a possible context menu or popup that contains the date picker is also closed. A similar problem in combo box is [handled](https://github.com/vaadin/web-components/blob/main/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js#L132) by stopping click event propagation on the scroller. This PR applies the same logic to the overlay content. Note that this also fixes the issue with the date time picker.

NOTE: It should be back-ported to the relevant versions for the BFP request.

Fixes #6986 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.