### PR TITLE
docs: fix incorrect type name in deprecation notice

### DIFF
--- a/packages/grid/src/vaadin-grid-styling-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-styling-mixin.d.ts
@@ -10,7 +10,7 @@ import type { GridColumn } from './vaadin-grid-column.js';
 export type GridCellPartNameGenerator<TItem> = (column: GridColumn<TItem>, model: GridItemModel<TItem>) => string;
 
 /**
- * @deprecated Use `GridPartCellGenerator` type and `cellPartNameGenerator` API instead.
+ * @deprecated Use `GridCellPartNameGenerator` type and `cellPartNameGenerator` API instead.
  */
 export type GridCellClassNameGenerator<TItem> = GridCellPartNameGenerator<TItem>;
 


### PR DESCRIPTION
## Description

There is no `GridPartCellGenerator` type, the correct one is `GridCellPartNameGenerator`.

## Type of change

- Documentation