### PR TITLE
fix: stop propagation of click events on overlay (#6987)

### DIFF
--- a/integration/tests/context-menu-date-picker.test.js
+++ b/integration/tests/context-menu-date-picker.test.js
@@ -1,0 +1,50 @@
+import { expect } from '@esm-bundle/chai';
+import { fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/context-menu';
+import '@vaadin/date-picker';
+import { isTouch } from '@vaadin/component-base/src/browser-utils';
+import { getFocusedCell, open } from '@vaadin/date-picker/test/helpers';
+
+async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
+  const menu = target.closest('vaadin-context-menu');
+  if (menu) {
+    menu.__openListenerActive = true;
+  }
+  const { right, bottom } = target.getBoundingClientRect();
+  fire(target, event, { x: right, y: bottom });
+  await nextRender();
+}
+
+function getMenuItems(menu) {
+  return [...menu._overlayElement.querySelectorAll('[role="menu"] > :not([role="separator]"')];
+}
+
+describe('date picker in context menu', () => {
+  let menu;
+
+  beforeEach(async () => {
+    menu = fixtureSync(`
+      <vaadin-context-menu>
+        <button id="target"></button>
+      </vaadin-context-menu>
+    `);
+    menu.openOn = isTouch ? 'click' : 'mouseover';
+    const datePicker = document.createElement('vaadin-date-picker');
+    menu.items = [{ component: datePicker }];
+    await nextRender();
+    const target = menu.firstElementChild;
+    await openMenu(target);
+  });
+
+  it('should not close context menu on date click', async () => {
+    const datePicker = getMenuItems(menu)[0];
+    await open(datePicker);
+
+    const date = getFocusedCell(datePicker._overlayContent);
+    date.click();
+    await nextFrame();
+
+    expect(datePicker.opened).to.be.false;
+    expect(menu.opened).to.be.true;
+  });
+});

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -518,6 +518,8 @@ export const DatePickerMixin = (subclass) =>
         }
       });
 
+      this._overlayContent.addEventListener('click', (e) => e.stopPropagation());
+
       this.addEventListener('mousedown', () => this.__bringToFront());
       this.addEventListener('touchstart', () => this.__bringToFront());
     }


### PR DESCRIPTION
## Description

Back-port of #6987 to v23.4 and v23.3.

The test has 2 extra functions since the helper class does not exist in v23.

Fixes #6986 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.