### PR TITLE
refactor: remove dialog imports from confirm-dialog and crud

### DIFF
--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog.js
@@ -1,4 +1,3 @@
-import '@vaadin/dialog/theme/lumo/vaadin-dialog.js';
 import '@vaadin/button/theme/lumo/vaadin-button.js';
 import './vaadin-confirm-dialog-styles.js';
 import '../../src/vaadin-confirm-dialog.js';

--- a/packages/confirm-dialog/theme/lumo/vaadin-lit-confirm-dialog.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-lit-confirm-dialog.js
@@ -1,4 +1,3 @@
-import '@vaadin/dialog/theme/lumo/vaadin-dialog-styles.js';
 import '@vaadin/button/theme/lumo/vaadin-button-styles.js';
 import './vaadin-confirm-dialog-styles.js';
 import '../../src/vaadin-lit-confirm-dialog.js';

--- a/packages/confirm-dialog/theme/material/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/theme/material/vaadin-confirm-dialog.js
@@ -1,4 +1,3 @@
-import '@vaadin/dialog/theme/material/vaadin-dialog.js';
 import '@vaadin/button/theme/material/vaadin-button.js';
 import './vaadin-confirm-dialog-styles.js';
 import '../../src/vaadin-confirm-dialog.js';

--- a/packages/confirm-dialog/theme/material/vaadin-lit-confirm-dialog.js
+++ b/packages/confirm-dialog/theme/material/vaadin-lit-confirm-dialog.js
@@ -1,4 +1,3 @@
-import '@vaadin/dialog/theme/material/vaadin-dialog-styles.js';
 import '@vaadin/button/theme/material/vaadin-button-styles.js';
 import './vaadin-confirm-dialog-styles.js';
 import '../../src/vaadin-lit-confirm-dialog.js';

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -9,7 +9,6 @@
  * license.
  */
 import '@vaadin/button/src/vaadin-button.js';
-import '@vaadin/dialog/src/vaadin-dialog.js';
 import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
 import './vaadin-crud-dialog.js';
 import './vaadin-crud-grid.js';

--- a/packages/crud/theme/lumo/vaadin-crud.js
+++ b/packages/crud/theme/lumo/vaadin-crud.js
@@ -1,6 +1,5 @@
 import '@vaadin/button/theme/lumo/vaadin-button.js';
 import '@vaadin/confirm-dialog/theme/lumo/vaadin-confirm-dialog.js';
-import '@vaadin/dialog/theme/lumo/vaadin-dialog.js';
 import '@vaadin/form-layout/theme/lumo/vaadin-form-layout.js';
 import '@vaadin/grid/theme/lumo/vaadin-grid.js';
 import '@vaadin/grid/theme/lumo/vaadin-grid-sorter.js';

--- a/packages/crud/theme/material/vaadin-crud.js
+++ b/packages/crud/theme/material/vaadin-crud.js
@@ -1,6 +1,5 @@
 import '@vaadin/button/theme/material/vaadin-button.js';
 import '@vaadin/confirm-dialog/theme/material/vaadin-confirm-dialog.js';
-import '@vaadin/dialog/theme/material/vaadin-dialog.js';
 import '@vaadin/form-layout/theme/material/vaadin-form-layout.js';
 import '@vaadin/grid/theme/material/vaadin-grid.js';
 import '@vaadin/grid/theme/material/vaadin-grid-sorter.js';


### PR DESCRIPTION
## Description

This is a follow-up to the following PRs:

- #6166
- #6167

There is no need to define `vaadin-dialog` as a side-effect of importing `vaadin-confirm-dialog` or `vaadin-crud`.

## Type of change

- Refactor