### PR TITLE
fix: use correct mixins in context-menu overlay typings

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-overlay.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.d.ts
@@ -3,13 +3,15 @@
  * Copyright (c) 2016 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Overlay } from '@vaadin/overlay/src/vaadin-overlay.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
 
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  */
-declare class ContextMenuOverlay extends MenuOverlayMixin(Overlay) {}
+declare class ContextMenuOverlay extends MenuOverlayMixin(OverlayMixin(DirMixin(ThemableMixin(HTMLElement)))) {}
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
## Description

Follow-up to #6145 

I missed to update typings when updating `vaadin-context-menu-overlay` to not extend `Overlay`. This PR fixes that.

## Type of change

- Typings fix