### PR TITLE
refactor: remove no longer needed overlay imports from dialog

### DIFF
--- a/packages/dialog/theme/lumo/vaadin-dialog.js
+++ b/packages/dialog/theme/lumo/vaadin-dialog.js
@@ -1,3 +1,2 @@
-import '@vaadin/overlay/theme/lumo/vaadin-overlay.js';
 import './vaadin-dialog-styles.js';
 import '../../src/vaadin-dialog.js';

--- a/packages/dialog/theme/lumo/vaadin-lit-dialog.js
+++ b/packages/dialog/theme/lumo/vaadin-lit-dialog.js
@@ -1,3 +1,2 @@
-import '@vaadin/overlay/theme/lumo/vaadin-overlay-styles.js';
 import './vaadin-dialog-styles.js';
 import '../../src/vaadin-lit-dialog.js';

--- a/packages/dialog/theme/material/vaadin-dialog.js
+++ b/packages/dialog/theme/material/vaadin-dialog.js
@@ -1,3 +1,2 @@
-import '@vaadin/overlay/theme/material/vaadin-overlay.js';
 import './vaadin-dialog-styles.js';
 import '../../src/vaadin-dialog.js';

--- a/packages/dialog/theme/material/vaadin-lit-dialog.js
+++ b/packages/dialog/theme/material/vaadin-lit-dialog.js
@@ -1,3 +1,2 @@
-import '@vaadin/overlay/theme/material/vaadin-overlay-styles.js';
 import './vaadin-dialog-styles.js';
 import '../../src/vaadin-lit-dialog.js';


### PR DESCRIPTION
## Description

Follow-up to #6184

These theme imports were added in #3888 but they are no longer needed as we now updated individual components to no longer extend `vaadin-overlay` (in fact, this generic component will become unused once #7002 is merged).

## Type of change

- Refactor