### PR TITLE
refactor!: update drawer-toggle to not extend button

### DIFF
--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -41,7 +41,8 @@
     "@vaadin/component-base": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",

--- a/packages/app-layout/src/vaadin-drawer-toggle-styles.d.ts
+++ b/packages/app-layout/src/vaadin-drawer-toggle-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const drawerToggle: CSSResult;

--- a/packages/app-layout/src/vaadin-drawer-toggle-styles.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle-styles.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const drawerToggle = css`
+  :host {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: default;
+    position: relative;
+    outline: none;
+    height: 24px;
+    width: 24px;
+    padding: 4px;
+  }
+
+  [part='icon'],
+  [part='icon']::after,
+  [part='icon']::before {
+    position: absolute;
+    top: 8px;
+    height: 3px;
+    width: 24px;
+    background-color: #000;
+  }
+
+  [part='icon']::after,
+  [part='icon']::before {
+    content: '';
+  }
+
+  [part='icon']::after {
+    top: 6px;
+  }
+
+  [part='icon']::before {
+    top: 12px;
+  }
+`;

--- a/packages/app-layout/src/vaadin-drawer-toggle.d.ts
+++ b/packages/app-layout/src/vaadin-drawer-toggle.d.ts
@@ -3,7 +3,9 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Button } from '@vaadin/button/src/vaadin-button.js';
+import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
  * The Drawer Toggle component controls the drawer in App Layout component.
@@ -14,7 +16,7 @@ import { Button } from '@vaadin/button/src/vaadin-button.js';
  * </vaadin-app-layout>
  * ```
  */
-declare class DrawerToggle extends Button {
+declare class DrawerToggle extends ButtonMixin(DirMixin(ThemableMixin(HTMLElement))) {
   ariaLabel: string;
 }
 

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -3,56 +3,16 @@
  * Copyright (c) 2018 - 2023 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { Button } from '@vaadin/button/src/vaadin-button.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { buttonStyles } from '@vaadin/button/src/vaadin-button-base.js';
+import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { isEmptyTextNode } from '@vaadin/component-base/src/dom-utils.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { drawerToggle } from './vaadin-drawer-toggle-styles.js';
 
-/**
- * Use registerStyles instead of the `<style>` tag to make sure
- * that this CSS will override core styles of `vaadin-button`.
- */
-registerStyles(
-  'vaadin-drawer-toggle',
-  css`
-    :host {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      cursor: default;
-      position: relative;
-      outline: none;
-      height: 24px;
-      width: 24px;
-      padding: 4px;
-    }
-
-    [part='icon'],
-    [part='icon']::after,
-    [part='icon']::before {
-      position: absolute;
-      top: 8px;
-      height: 3px;
-      width: 24px;
-      background-color: #000;
-    }
-
-    [part='icon']::after,
-    [part='icon']::before {
-      content: '';
-    }
-
-    [part='icon']::after {
-      top: 6px;
-    }
-
-    [part='icon']::before {
-      top: 12px;
-    }
-  `,
-  { moduleId: 'vaadin-drawer-toggle-styles' },
-);
+registerStyles('vaadin-drawer-toggle', [buttonStyles, drawerToggle], { moduleId: 'vaadin-drawer-toggle-styles' });
 
 /**
  * The Drawer Toggle component controls the drawer in App Layout component.
@@ -64,16 +24,18 @@ registerStyles(
  * ```
  *
  * @customElement
- * @extends Button
+ * @extends HTMLElement
+ * @mixes ButtonMixin
+ * @mixes DirMixin
+ * @mixes ThemableMixin
  */
-class DrawerToggle extends Button {
+class DrawerToggle extends ButtonMixin(DirMixin(ThemableMixin(PolymerElement))) {
   static get template() {
     return html`
       <slot id="slot">
         <div part="icon"></div>
       </slot>
       <div part="icon" hidden$="[[!_showFallbackIcon]]"></div>
-      <slot name="tooltip"></slot>
     `;
   }
 

--- a/packages/app-layout/test/dom/__snapshots__/drawer-toggle.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/drawer-toggle.test.snap.js
@@ -11,8 +11,6 @@ snapshots["vaadin-app-layout default"] =
   part="icon"
 >
 </div>
-<slot name="tooltip">
-</slot>
 `;
 /* end snapshot vaadin-app-layout default */
 


### PR DESCRIPTION
## Description

Same as #7004 but for `vaadin-drawer-toggle` component.

Changed to use `ButtonMixin` and `buttonStyles` CSS literal instead of extending `Button` class.

This eliminates the need for having `<slot name="tooltip">` which was there just to prevent throwing an error.
Also, from now on custom CSS applied to `vaadin-button` won't accidentally affect `vaadin-drawer-toggle`.

## Type of change

- Refactor / behavior altering change.
