### PR TITLE
chore: add missing type: module entry to package.json

### DIFF
--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -18,6 +18,7 @@
   },
   "main": "vaadin-multi-select-combo-box.js",
   "module": "vaadin-multi-select-combo-box.js",
+  "type": "module",
   "files": [
     "lit.d.ts",
     "lit.js",


### PR DESCRIPTION
## Description

The `@vaadin/multi-select-combo-box` package is missing `"type": "module"` entry added in #3280. Let's fix this.

## Type of change

- Internal change