### PR TITLE
chore: move Lit from dev dependencies to dependencies

### DIFF
--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -49,12 +49,12 @@
     "@vaadin/overlay": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.6.0",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -44,14 +44,14 @@
     "@vaadin/overlay": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/a11y-base": "24.4.0-alpha1",
     "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-area": "24.4.0-alpha1",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -47,12 +47,12 @@
     "@vaadin/text-field": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.6.0",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-grid-pro",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -53,12 +53,12 @@
     "@vaadin/text-field": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.6.0",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -40,12 +40,12 @@
     "@vaadin/component-base": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.6.0",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -50,12 +50,12 @@
     "@vaadin/overlay": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.6.0",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -45,12 +45,12 @@
     "@vaadin/lit-renderer": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",
     "@vaadin/vaadin-material-styles": "24.4.0-alpha1",
-    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1"
+    "@vaadin/vaadin-themable-mixin": "24.4.0-alpha1",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
     "@vaadin/testing-helpers": "^0.6.0",
-    "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [


### PR DESCRIPTION
## Description

Components that have Lit based versions should have Lit in `"dependencies"`, not `"devDependencies"`.

Note: some components in this PR aren't yet published to npm. Also, `lit` comes with `ThemableMixin`.
But IMO it's better to have a direct dependency for consistency with other component packages.

## Type of change

- Internal change