### PR TITLE
docs: use mixins in multi-select-combo-box-overlay JSDoc

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -34,7 +34,11 @@ registerStyles('vaadin-multi-select-combo-box-overlay', [overlayStyles, multiSel
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
  *
  * @customElement
- * @extends ComboBoxOverlay
+ * @extends HTMLElement
+ * @mixes ComboBoxOverlayMixin
+ * @mixes DirMixin
+ * @mixes OverlayMixin
+ * @mixes ThemableMixin
  * @private
  */
 class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(OverlayMixin(DirMixin(ThemableMixin(PolymerElement)))) {


### PR DESCRIPTION
## Description

Follow-up to #7002 

I missed to update JSDoc for this element. This PR fixes that.

## Type of change

- Documentation