### PR TITLE
docs: use correct mixins in vaadin-login-overlay JSDoc

### DIFF
--- a/packages/login/src/vaadin-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-login-overlay-wrapper.js
@@ -18,7 +18,10 @@ registerStyles('vaadin-login-overlay-wrapper', [overlayStyles, loginOverlayWrapp
 /**
  * An element used internally by `<vaadin-login-overlay>`. Not intended to be used separately.
  *
- * @extends Overlay
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes OverlayMixin
+ * @mixes ThemableMixin
  * @private
  */
 class LoginOverlayWrapper extends OverlayMixin(DirMixin(ThemableMixin(PolymerElement))) {


### PR DESCRIPTION
## Description

Follow-up to #6204

I missed to update JSDoc for this element when changing to not extend `vaadin-overlay`. This PR fixes that.

## Type of change

- Documentation