### PR TITLE
docs: add missing mixes annotations to ActiveMixin JSDoc

### DIFF
--- a/packages/a11y-base/src/active-mixin.js
+++ b/packages/a11y-base/src/active-mixin.js
@@ -17,6 +17,8 @@ import { KeyboardMixin } from './keyboard-mixin.js';
  * by the pointer or by releasing the activation key.
  *
  * @polymerMixin
+ * @mixes DisabledMixin
+ * @mixes KeyboardMixin
  */
 export const ActiveMixin = (superclass) =>
   class ActiveMixinClass extends DisabledMixin(KeyboardMixin(superclass)) {


### PR DESCRIPTION
## Description

Currently, `ActiveMixin` applies `DirMixin` but is lacking `@mixes` annotation. As a result, components using `ActiveMixin` such as `vaadin-accordion-heading` don't have `disabled` property in [API docs](https://cdn.vaadin.com/vaadin-web-components/24.3.2/#/elements/AccordionHeading#properties). This PR fixes that.

## Type of change

- Documentation