### PR TITLE
docs: remove unused InputFieldMixin import from typings

### DIFF
--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
 


### PR DESCRIPTION
## Description

This mixin import is unused since #5522 where the `NumberFieldMixin` was introduced.

## Type of change

- Documentation