### PR TITLE
docs: fix vaadin-grid-selection-column JSDoc annotations

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
@@ -19,8 +19,6 @@ export declare function GridSelectionColumnBaseMixin<TItem, T extends Constructo
  * Web component-specific selection state updates must be implemented in the
  * `<vaadin-grid-selection-column>` itself, by overriding the protected methods
  * provided by this mixin.
- *
- * @polymerMixin
  */
 export declare class GridSelectionColumnBaseMixinClass<TItem> {
   /**

--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -7,6 +7,7 @@ import { GridSelectionColumnBaseMixin } from './vaadin-grid-selection-column-bas
 
 /**
  * @polymerMixin
+ * @mixes GridSelectionColumnBaseMixin
  */
 export const GridSelectionColumnMixin = (superClass) =>
   class extends GridSelectionColumnBaseMixin(superClass) {


### PR DESCRIPTION
## Description

Follow-up to #6610 

- Added missing `@mixes` annotation to make `GridSelectionColumnBaseMixin` properties such as `autoSelect`, `selectAll` etc correctly shown in [API docs](https://cdn.vaadin.com/vaadin-web-components/24.3.2/#/elements/vaadin-grid-selection-column) of `vaadin-grid-selection-column` web component,
- Removed incorrect `@polymerMixin` annotation from `.d.ts` file (these are only needed in `.js` files).

## Type of change

- Documentation