### PR TITLE
docs: add missing mixes annotations to ItemMixin JSDoc

### DIFF
--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -10,7 +10,10 @@ import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
  * A mixin providing `focused`, `focus-ring`, `active`, `disabled` and `selected`.
  *
  * `focused`, `active` and `focus-ring` are set as only as attributes.
+ *
  * @polymerMixin
+ * @mixes ActiveMixin
+ * @mixes FocusMixin
  */
 export const ItemMixin = (superClass) =>
   class VaadinItemMixin extends ActiveMixin(FocusMixin(superClass)) {


### PR DESCRIPTION
## Description

Currently, `ItemMixin` applies `DisabledMixin` but is lacking `@mixes` annotation. This PR fixes that.

## Type of change

- Documentation