### PR TITLE
chore: exclude a11y-base package from web-types generation

### DIFF
--- a/scripts/buildWebtypes.js
+++ b/scripts/buildWebtypes.js
@@ -10,6 +10,7 @@ const API_DOCS_BASE_PATH = 'https://cdn.vaadin.com/vaadin-web-components';
 
 const blacklistedPackages = [
   /^vaadin-/u,
+  /^a11y-base/u,
   /^component-base/u,
   /^field-base/u,
   /^field-highlighter/u,


### PR DESCRIPTION
## Description

Just noticed that empty `web-types.json` and `web-types.lit.json` are created for this package. This PR fixes that.

## Type of change

- Internal change