### PR TITLE
chore: fix wrong directory paths in package.json files

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",
-    "directory": "packages/vaadin-overlay"
+    "directory": "packages/overlay"
   },
   "author": "Vaadin Ltd",
   "homepage": "https://vaadin.com/components",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",
-    "directory": "packages/vaadin-tabs"
+    "directory": "packages/tabs"
   },
   "author": "Vaadin Ltd",
   "homepage": "https://vaadin.com/components",

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -9,7 +9,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/vaadin/web-components.git",
-    "directory": "packages/vaadin-tabsheet"
+    "directory": "packages/tabsheet"
   },
   "author": "Vaadin Ltd",
   "homepage": "https://vaadin.com/components",


### PR DESCRIPTION
## Description

Some `package.json` entries were not updated when moving packages. This PR fixes that.

## Type of change

- Internal change