### PR TITLE
refactor: align Crud generic type with Grid and GridPro

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -10,7 +10,7 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import type { GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
+import type { GridDefaultItem, GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export type CrudDataProviderCallback<T> = (items: T[], size?: number) => void;
@@ -262,7 +262,7 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item.
  * @fires {CustomEvent} cancel - Fired when user discards edition.
  */
-declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTMLElement))) {
+declare class Crud<Item = GridDefaultItem> extends ControllerMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   /**
    * An array containing the items which will be stamped to the column template instances.
    */
@@ -419,7 +419,7 @@ declare class Crud<Item> extends ControllerMixin(ElementMixin(ThemableMixin(HTML
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-crud': Crud<any>;
+    'vaadin-crud': Crud<GridDefaultItem>;
   }
 }
 

--- a/packages/crud/test/typings/crud.types.ts
+++ b/packages/crud/test/typings/crud.types.ts
@@ -23,7 +23,10 @@ type User = {
   };
 };
 
-const crud: Crud<User> = document.createElement('vaadin-crud');
+const genericCrud = document.createElement('vaadin-crud');
+assertType<Crud>(genericCrud);
+
+const crud = genericCrud as Crud<User>;
 
 crud.addEventListener('editor-opened-changed', (event) => {
   assertType<CrudEditorOpenedChangedEvent>(event);


### PR DESCRIPTION
## Description

Currently, when using `Constructor<CrudElement>` there is a TS compilation error:

```
error TS2314: Generic type 'Crud<Item>' requires 1 type argument(s).
```

This PR makes `Crud` class aligned with `Grid` and `GridPro` to mitigate this.
In general, nothing changes since `GridDefaultItem` is just an alias to `any`.

Note: this PR is needed for my ongoing lazy React components prototype.

## Type of change

- Refactor