### PR TITLE
chore: add missing dedupe-mixin dependency used in typings

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -38,6 +38,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "24.4.0-alpha1",
     "@vaadin/component-base": "24.4.0-alpha1",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/a11y-base": "24.4.0-alpha1",
     "@vaadin/component-base": "24.4.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "24.4.0-alpha1",


### PR DESCRIPTION
## Description

Added missing `@open-wc/dedupe-mixin` dependency to some components that import `Constructor` type from there.

## Type of change

- Internal change