### PR TITLE
docs: remove customElement JSDoc from Lit based tooltip

### DIFF
--- a/packages/tooltip/src/vaadin-lit-tooltip.js
+++ b/packages/tooltip/src/vaadin-lit-tooltip.js
@@ -21,7 +21,6 @@ import { TooltipMixin } from './vaadin-tooltip-mixin.js';
  * There is no ETA regarding specific Vaadin version where it'll land.
  * Feel free to try this code in your apps as per Apache 2.0 license.
  *
- * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemePropertyMixin


### PR DESCRIPTION
## Description

Using `@customElement` in Lit based component JSDoc makes `vaadin-tooltip` show up in [API docs](https://cdn.vaadin.com/vaadin-web-components/24.3.2/) navigation twice:

<img width="124" alt="Screenshot 2023-12-28 at 10 10 05" src="https://github.com/vaadin/web-components/assets/10589913/6dc98edc-1231-485e-8dbe-7e7d6894f234">

Removed this annotation to only have Polymer based version shown in the navigation.

## Type of change

- Documentation