### PR TITLE
chore: add missing dedupe-mixin dependency used in typings (#7037) (CP: 24.3)

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -38,6 +38,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "~24.3.2",
     "@vaadin/component-base": "~24.3.2",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "~24.3.2",
     "@vaadin/vaadin-lumo-styles": "~24.3.2",

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/a11y-base": "~24.3.2",
     "@vaadin/component-base": "~24.3.2",
     "@vaadin/vaadin-lumo-styles": "~24.3.2",


### PR DESCRIPTION
## Description

Manual cherry-pick of #7037 to `24.3` branch.

## Type of change

- Cherry-pick