### PR TITLE
feat: add setProperties() method to PolylitMixin

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -93,6 +93,9 @@ const PolylitMixinImplementation = (superclass) => {
 
       let result = defaultDescriptor;
 
+      // Set the key for this property
+      this.getOrCreateMap('__propKeys').set(name, key);
+
       if (options.sync) {
         result = {
           get: defaultDescriptor.get,
@@ -230,6 +233,24 @@ const PolylitMixinImplementation = (superclass) => {
         this.__isReadyInvoked = true;
         this.ready();
       }
+    }
+
+    /**
+     * Set several properties at once and perform synchronous update.
+     * @protected
+     */
+    setProperties(props) {
+      Object.entries(props).forEach(([name, value]) => {
+        // Use private key and not setter to not trigger
+        // update for properties marked as `sync: true`.
+        const key = this.constructor.__propKeys.get(name);
+        const oldValue = this[name];
+        this[key] = value;
+        this.requestUpdate(name, oldValue);
+      });
+
+      // Perform sync update
+      this.performUpdate();
     }
 
     /** @protected */

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -250,7 +250,9 @@ const PolylitMixinImplementation = (superclass) => {
       });
 
       // Perform sync update
-      this.performUpdate();
+      if (this.hasUpdated) {
+        this.performUpdate();
+      }
     }
 
     /** @protected */

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -244,7 +244,7 @@ const PolylitMixinImplementation = (superclass) => {
         // Use private key and not setter to not trigger
         // update for properties marked as `sync: true`.
         const key = this.constructor.__propKeys.get(name);
-        const oldValue = this[name];
+        const oldValue = this[key];
         this[key] = value;
         this.requestUpdate(name, oldValue);
       });

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -1003,4 +1003,50 @@ describe('PolylitMixin', () => {
       expect(element.count).to.equal(1);
     });
   });
+
+  describe('setProperties()', () => {
+    let element;
+
+    const tag = defineCE(
+      class extends PolylitMixin(LitElement) {
+        static get properties() {
+          return {
+            disabled: {
+              type: Boolean,
+              sync: true,
+            },
+
+            value: {
+              type: String,
+            },
+          };
+        }
+      },
+    );
+
+    beforeEach(async () => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      await element.updateComplete;
+    });
+
+    it('should set property values on the element', () => {
+      element.setProperties({ value: 'foo', disabled: true });
+      expect(element.value).to.equal('foo');
+      expect(element.disabled).to.be.true;
+    });
+
+    it('should request update for each passed property', () => {
+      const spy = sinon.spy(element, 'requestUpdate');
+      element.setProperties({ value: 'foo', disabled: true });
+      expect(spy).to.be.calledTwice;
+      expect(spy.firstCall.args[0]).to.equal('value');
+      expect(spy.secondCall.args[0]).to.equal('disabled');
+    });
+
+    it('should only call performUpdate() method once', () => {
+      const spy = sinon.spy(element, 'performUpdate');
+      element.setProperties({ value: 'foo', disabled: true });
+      expect(spy).to.be.calledOnce;
+    });
+  });
 });

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -1048,5 +1048,11 @@ describe('PolylitMixin', () => {
       element.setProperties({ value: 'foo', disabled: true });
       expect(spy).to.be.calledOnce;
     });
+
+    it('should not throw when calling before first render', () => {
+      expect(() => {
+        document.createElement(tag).setProperties({ disabled: true });
+      }).to.not.throw(Error);
+    });
   });
 });


### PR DESCRIPTION
## Description

Added a simplified version of the [`setProperties()`](https://github.com/Polymer/polymer/blob/1e8b246d01ea99adba305ea04c45d26da31f68f1/lib/mixins/property-effects.js#L1846-L1857) method available in `PolymerElement` for batching updates.
This is a pre-requisite for converting `vaadin-combo-box` to Lit, as this component relies on this method logic.

Note: I didn't bother to implement `setReadOnly` flag as we don't use it, and to keep the code cleaner.

## Type of change

- Internal feature