### PR TITLE
refactor: make combo-box use DataProviderController

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -193,10 +193,13 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       }
     }
 
-    /** @private */
+    /**
+     * When the size change originates externally, synchronizes the new size with
+     * the controller and request a content update to re-render the scroller.
+     *
+     * @private
+     */
     _sizeChanged(size) {
-      // When the size update originates externally, sync the new size with
-      // the controller and request a content update to re-render the scroller.
       const { rootCache } = this.__dataProviderController;
       if (rootCache.size !== size) {
         rootCache.size = size;
@@ -208,6 +211,9 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     }
 
     /**
+     * When the items change originates externally, synchronizes the new items with
+     * the controller and requests a content update to re-render the scroller.
+     *
      * @private
      * @override
      */
@@ -215,8 +221,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       super._filteredItemsChanged(items);
 
       if (this.dataProvider && items) {
-        // When the items update originates externally, sync the new items with
-        // the controller and request a content update to re-render the scroller.
         const { rootCache } = this.__dataProviderController;
         if (rootCache.items !== items) {
           rootCache.items = items;

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -220,11 +220,10 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     /** @override */
     requestContentUpdate() {
       if (this.dataProvider) {
-        const { rootCache } = this.__dataProviderController;
-
         // Sync the controller's state with the component. It can be of sync
         // after the controller receives new data from the data provider or
         // if the state in the controller is directly manipulated.
+        const { rootCache } = this.__dataProviderController;
         this.size = rootCache.size;
         this.filteredItems = rootCache.items;
         this.loading = this.__dataProviderController.isLoading();

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
@@ -69,11 +69,23 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
    */
   rootCache: Cache<TItem>;
 
+  /**
+   * A placeholder item that is used to indicate that the item is not loaded yet.
+   */
+  placeholder?: unknown;
+
+  /**
+   * A callback that returns whether the given item is a placeholder.
+   */
+  isPlaceholder?: (item: unknown) => boolean;
+
   constructor(
     host: HTMLElement,
     config: {
       size?: number;
       pageSize: number;
+      placeholder?: unknown;
+      isPlaceholder?(item: unknown): boolean;
       getItemId(item: TItem): unknown;
       isExpanded(item: TItem): boolean;
       dataProvider: DataProvider<TItem, TDataProviderParams>;

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -68,7 +68,7 @@ export class DataProviderController extends EventTarget {
   /**
    * A placeholder item that is used to indicate that the item is not loaded yet.
    *
-   * @type {undefined | object}
+   * @type {unknown}
    */
   placeholder;
 

--- a/packages/component-base/test/data-provider-controller-data-callbacks.test.js
+++ b/packages/component-base/test/data-provider-controller-data-callbacks.test.js
@@ -28,7 +28,7 @@ describe('DataProviderController - data callbacks', () => {
     controller.loadFirstPage();
     controller.clearCache();
     dataProviderCallback(['Item-0', 'Item-1'], 2);
-    expect(controller.rootCache.size).to.equal(0);
+    expect(controller.rootCache.size).to.be.undefined;
     expect(controller.rootCache.items).to.have.lengthOf(0);
   });
 });

--- a/packages/component-base/test/data-provider-controller.test.js
+++ b/packages/component-base/test/data-provider-controller.test.js
@@ -51,8 +51,8 @@ describe('DataProviderController', () => {
       expect(controller.rootCache).to.be.instanceOf(Cache);
     });
 
-    it('should have rootCache size', () => {
-      expect(controller.rootCache.size).to.equal(0);
+    it('should not have rootCache size', () => {
+      expect(controller.rootCache.size).to.be.undefined;
     });
 
     it('should have rootCache pageSize', () => {

--- a/packages/component-base/test/typings/data-provider-controller/data-provider-controller.types.ts
+++ b/packages/component-base/test/typings/data-provider-controller/data-provider-controller.types.ts
@@ -30,6 +30,8 @@ const dataProviderController = new DataProviderController<TestItem, TestDataProv
   pageSize: 50,
   getItemId: (item) => item,
   isExpanded: (_item) => true,
+  placeholder: 'placeholder',
+  isPlaceholder: (item) => item === 'placeholder',
   dataProvider,
   dataProviderParams: () => ({ bar: 'bar' }),
 });
@@ -41,6 +43,8 @@ assertType<
     config: {
       size: number | undefined;
       pageSize: number;
+      placeholder?: unknown;
+      isPlaceholder?(item: unknown): boolean;
       getItemId(item: TestItem): unknown;
       isExpanded(item: TestItem): boolean;
       dataProvider: DataProvider<TestItem, DataProviderParams>;
@@ -54,6 +58,8 @@ assertType<HTMLElement>(dataProviderController.host);
 assertType<Cache<TestItem>>(dataProviderController.rootCache);
 assertType<number | undefined>(dataProviderController.size);
 assertType<number>(dataProviderController.pageSize);
+assertType<unknown>(dataProviderController.placeholder);
+assertType<((item: unknown) => boolean) | undefined>(dataProviderController.isPlaceholder);
 assertType<(item: TestItem) => unknown>(dataProviderController.getItemId);
 assertType<(item: TestItem) => boolean>(dataProviderController.isExpanded);
 assertType<() => TestDataProviderParams>(dataProviderController.dataProviderParams);

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -148,7 +148,7 @@ export const DataProviderMixin = (superClass) =>
 
       /** @type {DataProviderController} */
       this._dataProviderController = new DataProviderController(this, {
-        size: this.size,
+        size: this.size || 0,
         pageSize: this.pageSize,
         getItemId: this.getItemId.bind(this),
         isExpanded: this._isExpanded.bind(this),


### PR DESCRIPTION
## Description

This PR refactors the combo-box to use DataProviderController. The refactoring is expected to be non-breaking and fully compatible with the existing ComboBox Flow connector, which is verified by successfully passing all the Flow integration tests.

Depends on 
- https://github.com/vaadin/web-components/pull/6968
- https://github.com/vaadin/web-components/pull/7205
- https://github.com/vaadin/web-components/pull/6979
- https://github.com/vaadin/web-components/pull/7257
- https://github.com/vaadin/web-components/pull/7266
- https://github.com/vaadin/web-components/pull/7262
- https://github.com/vaadin/web-components/pull/7350
- https://github.com/vaadin/web-components/pull/7426
- https://github.com/vaadin/web-components/pull/7349
- https://github.com/vaadin/web-components/pull/7353
- https://github.com/vaadin/web-components/pull/7425
- https://github.com/vaadin/web-components/pull/7463
- https://github.com/vaadin/web-components/pull/7465


## Type of change

- [x] Refactor
