### PR TITLE
fix: check for margins object when trying to set overlay position

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -117,8 +117,8 @@ export const PositionMixin = (superClass) =>
 
     static get observers() {
       return [
-        '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap, requiredVerticalSpace)',
         '__overlayOpenedChanged(opened, positionTarget)',
+        '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap, requiredVerticalSpace)',
       ];
     }
 

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -117,8 +117,8 @@ export const PositionMixin = (superClass) =>
 
     static get observers() {
       return [
-        '__overlayOpenedChanged(opened, positionTarget)',
         '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap, requiredVerticalSpace)',
+        '__overlayOpenedChanged(opened, positionTarget)',
       ];
     }
 
@@ -210,7 +210,7 @@ export const PositionMixin = (superClass) =>
     }
 
     _updatePosition() {
-      if (!this.positionTarget || !this.opened) {
+      if (!this.positionTarget || !this.opened || !this.__margins) {
         return;
       }
 

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 
 describe('position mixin', () => {
@@ -575,5 +575,30 @@ describe('position mixin', () => {
         expectEdgesAligned(RIGHT, LEFT);
       });
     });
+  });
+});
+
+describe('opened before attach', () => {
+  let parent, overlay, target;
+
+  beforeEach(() => {
+    parent = fixtureSync(`
+      <div>
+        <div id="target"></div>
+      </div>
+    `);
+    target = parent.firstElementChild;
+  });
+
+  it('should not throw when adding pre-opened overlay to the DOM', async () => {
+    overlay = document.createElement('vaadin-positioned-overlay');
+
+    overlay.positionTarget = target;
+    overlay.opened = true;
+
+    parent.appendChild(overlay);
+    await oneEvent(overlay, 'vaadin-overlay-open');
+
+    expect(overlay.hasAttribute('start-aligned')).to.be.true;
   });
 });

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 
 describe('position mixin', () => {


### PR DESCRIPTION
## Description

Currently, when using `PositionMixin` with Lit, there is an issue related to the order of observers. As they are run by `PolylitMixin` in the same order in which they are provided in the array, this might cause the following error:

```
?wtr-test-file=%2Fpackages%2Foverlay%2Ftest%2Fposition-mixin-lit.test.js%3Fwtr-manual-session%3Dtrue:151 TypeError: Cannot read properties of undefined (reading 'bottom')
    at PositionedOverlay.__shouldAlignStart (vaadin-overlay-position-mixin.js:305:89)
    at PositionedOverlay.__shouldAlignStartVertically (vaadin-overlay-position-mixin.js:291:19)
    at PositionedOverlay._updatePosition (vaadin-overlay-position-mixin.js:220:47)
    at PositionedOverlay.__positionSettingsChanged (vaadin-overlay-position-mixin.js:201:12)
    at polylit-mixin.js:249:25
    at Map.forEach (<anonymous>)
    at PositionedOverlay.__runComplexObservers (polylit-mixin.js:244:17)
    at PositionedOverlay.updated (polylit-mixin.js:218:14)
    at PositionedOverlay._$AE (reactive-element.js:6:5084)
    at PositionedOverlay.performUpdate (reactive-element.js:6:4946)
``` 

What happens here is: `__positionSettingsChanged` observer is called first and it expects `__margins` to be set.
However, that proprerty is only set by `__overlayOpenedChanged` which is the second and is called later.

~~This PR fixes the issue by changing the `static get observers()` array so that observers run in the right order.~~

UPD: decided to change the fix by adding check for `__margins` object which is more explicit.

## Type of change

- Bugfix
 
## Note

This issue doesn't exist in Polymer as it already runs observers in the right order, as [this loop](https://github.com/Polymer/polymer/blob/1e8b246d01ea99adba305ea04c45d26da31f68f1/lib/mixins/property-effects.js#L129) is related to the order in which props are defined in `static get properties()` block. I was able to reproduce the original issue in Polymer too, by moving `opened` property to the end of `properties` block of `PositionMixin` alongside with `positionTarget`.