### PR TITLE
fix: measure auto-width correctly for focusButtonMode columns

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -425,11 +425,13 @@ export const GridMixin = (superClass) =>
             // Prepare the cell for having its intrinsic width measured
             cell.style.width = 'auto';
             cell.style.position = 'absolute';
+            cell.setAttribute('measuring-auto-width', '');
           } else {
             // Restore the original width
             cell.style.width = cell.__originalWidth;
             delete cell.__originalWidth;
             cell.style.position = '';
+            cell.removeAttribute('measuring-auto-width');
           }
         });
     }

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -425,15 +425,19 @@ export const GridMixin = (superClass) =>
             // Prepare the cell for having its intrinsic width measured
             cell.style.width = 'auto';
             cell.style.position = 'absolute';
-            cell.setAttribute('measuring-auto-width', '');
           } else {
             // Restore the original width
             cell.style.width = cell.__originalWidth;
             delete cell.__originalWidth;
             cell.style.position = '';
-            cell.removeAttribute('measuring-auto-width');
           }
         });
+
+      if (autoWidth) {
+        this.$.scroller.setAttribute('measuring-auto-width', '');
+      } else {
+        this.$.scroller.removeAttribute('measuring-auto-width');
+      }
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -154,7 +154,7 @@ export const gridStyles = css`
 
   /* Switch the focusButtonMode wrapping element to "position: static" temporarily
      when measuring real width of the cells in the auto-width columns. */
-  [part~='cell'][measuring-auto-width] > [tabindex] {
+  [measuring-auto-width] [part~='cell'] > [tabindex] {
     position: static;
   }
 

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -152,6 +152,12 @@ export const gridStyles = css`
     inset: 0;
   }
 
+  /* Switch the focusButtonMode wrapping element to "position: static" temporarily
+     when measuring real width of the cells in the auto-width columns. */
+  [part~='cell'][measuring-auto-width] > [tabindex] {
+    position: static;
+  }
+
   [part~='details-cell'] {
     position: absolute;
     bottom: 0;

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getContainerCell } from './helpers.js';
 
@@ -220,6 +220,26 @@ describe('column auto-width', () => {
     await recalculateWidths();
 
     expect(headerCell.getBoundingClientRect().width).to.be.closeTo(headerCellWidth, 5);
+  });
+
+  describe('focusButtonMode column', () => {
+    beforeEach(async () => {
+      const column = document.createElement('vaadin-grid-column');
+      column.autoWidth = true;
+      column.path = 'b';
+      column._focusButtonMode = true;
+      grid.insertBefore(column, grid.firstElementChild);
+      columns = grid.querySelectorAll('vaadin-grid-column');
+
+      await aTimeout(0);
+    });
+
+    it('should calculate auto-width of focusButtonMode column correctly', async () => {
+      grid.items = testItems;
+
+      await recalculateWidths();
+      expectColumnWidthsToBeOk(columns, [114, 71, 114, 84, 107]);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

When calculating the auto-width of the grid column, the cells of the column are temporarily set to have `width: auto` ([in here](https://github.com/vaadin/web-components/blob/70c0d989a0d4224b3ecbe17da0d9b3e7ef3c42d2/packages/grid/src/vaadin-grid-mixin.js#L426)). This helps to fully expand the cell content and therefore gives a chance to measure the real total width of the cell content. This number is then taken into account when calculating the auto-width. Once the calculation is done, the original `width` of the cell is restored.

For the `vaadin-grid-pro-edit-column`, this mechanism didn't work correctly, because this column wraps the cell's slot with an additional div (aka wrapping-div) because of accessibility reasons - using the [focusButtonMode property](https://github.com/vaadin/web-components/blob/a178c0c1eb10d71b454b40261c3bae4f2f343695/packages/grid/src/vaadin-grid-column-mixin.js#L943). This wrapping element has style set to use [the absolute positioning](https://github.com/vaadin/web-components/blob/70c0d989a0d4224b3ecbe17da0d9b3e7ef3c42d2/packages/grid/src/vaadin-grid-styles.js#L151).

The problem is that when you set the cell to `width: auto` and have a wrapping-div in it with `position: absolute`, then the width of the wrapping-div collapses to zero (instead of the full width of the content)... and therefore the auto-width mechanism computation fails.

The solution here is to temporarily set the wrapping-div positioning to `static`, so we can measure the width of the `div` and then restore the positioning after the measurement. I believe that setting a `measuring-auto-width` attribute on the cell opens a way how to fix similar problems with cell width measuring also in the future.

Fixes #6985

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.