### PR TITLE
experiment: add side-effect free entrypoints for Button

### DIFF
--- a/dev/register.html
+++ b/dev/register.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Register</title>
+    <script type="module" src="./common.js"></script>
+  </head>
+
+  <body>
+    <vaadin-button>Button</vaadin-button>
+
+    <script type="module">
+      import { Button } from '@vaadin/button/vaadin-button-component.js';
+
+      setTimeout(() => {
+        Button.register();
+      }, 1000);
+    </script>
+  </body>
+</html>

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -33,6 +33,16 @@
     "web-components",
     "web-component"
   ],
+  "sideEffects": [
+    "vaadin-button.js",
+    "vaadin-lit-button.js",
+    "src/vaadin-button.js",
+    "src/vaadin-lit-button.js",
+    "theme/lumo/vaadin-button.js",
+    "theme/lumo/vaadin-lit-button.js",
+    "theme/material/vaadin-button.js",
+    "theme/material/vaadin-lit-button.js"
+  ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",

--- a/packages/button/src/vaadin-button-component.d.ts
+++ b/packages/button/src/vaadin-button-component.d.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
+
+/**
+ * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
+ *
+ * ```html
+ * <vaadin-button>Press me</vaadin-button>
+ * ```
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name | Description
+ * ----------|-------------
+ * `label`   | The label (text) inside the button.
+ * `prefix`  | A slot for content before the label (e.g. an icon).
+ * `suffix`  | A slot for content after the label (e.g. an icon).
+ *
+ * The following attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `active`     | Set when the button is pressed down, either with mouse, touch or the keyboard.
+ * `disabled`   | Set when the button is disabled.
+ * `focus-ring` | Set when the button is focused using the keyboard.
+ * `focused`    | Set when the button is focused.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ */
+declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
+
+export { Button };

--- a/packages/button/src/vaadin-button-component.js
+++ b/packages/button/src/vaadin-button-component.js
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { buttonStyles, buttonTemplate } from './vaadin-button-base.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
+
+registerStyles('vaadin-button', buttonStyles, { moduleId: 'vaadin-button-styles' });
+
+/**
+ * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
+ *
+ * ```html
+ * <vaadin-button>Press me</vaadin-button>
+ * ```
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name | Description
+ * ----------|-------------
+ * `label`   | The label (text) inside the button.
+ * `prefix`  | A slot for content before the label (e.g. an icon).
+ * `suffix`  | A slot for content after the label (e.g. an icon).
+ *
+ * The following attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `active`     | Set when the button is pressed down, either with mouse, touch or the keyboard.
+ * `disabled`   | Set when the button is disabled.
+ * `focus-ring` | Set when the button is focused using the keyboard.
+ * `focused`    | Set when the button is focused.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @mixes ButtonMixin
+ * @mixes ControllerMixin
+ * @mixes ElementMixin
+ * @mixes ThemableMixin
+ */
+class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))) {
+  static get is() {
+    return 'vaadin-button';
+  }
+
+  static get template() {
+    return buttonTemplate(html);
+  }
+
+  /** @protected */
+  static registerStyles() {
+    // To be overridden by the theme
+  }
+
+  static register() {
+    if (!customElements.get(this.is)) {
+      this.registerStyles();
+
+      defineCustomElement(this);
+    }
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+  }
+}
+
+export { Button };

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -3,40 +3,7 @@
  * Copyright (c) 2017 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ButtonMixin } from './vaadin-button-mixin.js';
-
-/**
- * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
- *
- * ```html
- * <vaadin-button>Press me</vaadin-button>
- * ```
- *
- * ### Styling
- *
- * The following shadow DOM parts are available for styling:
- *
- * Part name | Description
- * ----------|-------------
- * `label`   | The label (text) inside the button.
- * `prefix`  | A slot for content before the label (e.g. an icon).
- * `suffix`  | A slot for content after the label (e.g. an icon).
- *
- * The following attributes are available for styling:
- *
- * Attribute    | Description
- * -------------|-------------
- * `active`     | Set when the button is pressed down, either with mouse, touch or the keyboard.
- * `disabled`   | Set when the button is disabled.
- * `focus-ring` | Set when the button is focused using the keyboard.
- * `focused`    | Set when the button is focused.
- *
- * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
- */
-declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(HTMLElement)))) {}
+import { Button } from './vaadin-button-component.js';
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -3,70 +3,8 @@
  * Copyright (c) 2017 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { defineCustomElement } from '@vaadin/component-base/src/define.js';
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { buttonStyles, buttonTemplate } from './vaadin-button-base.js';
-import { ButtonMixin } from './vaadin-button-mixin.js';
+import { Button } from './vaadin-button-component.js';
 
-registerStyles('vaadin-button', buttonStyles, { moduleId: 'vaadin-button-styles' });
-
-/**
- * `<vaadin-button>` is an accessible and customizable button that allows users to perform actions.
- *
- * ```html
- * <vaadin-button>Press me</vaadin-button>
- * ```
- *
- * ### Styling
- *
- * The following shadow DOM parts are available for styling:
- *
- * Part name | Description
- * ----------|-------------
- * `label`   | The label (text) inside the button.
- * `prefix`  | A slot for content before the label (e.g. an icon).
- * `suffix`  | A slot for content after the label (e.g. an icon).
- *
- * The following attributes are available for styling:
- *
- * Attribute    | Description
- * -------------|-------------
- * `active`     | Set when the button is pressed down, either with mouse, touch or the keyboard.
- * `disabled`   | Set when the button is disabled.
- * `focus-ring` | Set when the button is focused using the keyboard.
- * `focused`    | Set when the button is focused.
- *
- * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
- *
- * @customElement
- * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes ControllerMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
- */
-class Button extends ButtonMixin(ElementMixin(ThemableMixin(ControllerMixin(PolymerElement)))) {
-  static get is() {
-    return 'vaadin-button';
-  }
-
-  static get template() {
-    return buttonTemplate(html);
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._tooltipController = new TooltipController(this);
-    this.addController(this._tooltipController);
-  }
-}
-
-defineCustomElement(Button);
+Button.register();
 
 export { Button };

--- a/packages/button/src/vaadin-lit-button-component.d.ts
+++ b/packages/button/src/vaadin-lit-button-component.d.ts
@@ -3,8 +3,4 @@
  * Copyright (c) 2017 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { Button } from './vaadin-lit-button-component.js';
-
-Button.register();
-
-export { Button };
+export * from './vaadin-button-component.js';

--- a/packages/button/src/vaadin-lit-button-component.js
+++ b/packages/button/src/vaadin-lit-button-component.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { buttonStyles, buttonTemplate } from './vaadin-button-base.js';
+import { ButtonMixin } from './vaadin-button-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-button>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment not intended for publishing to npm.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-button';
+  }
+
+  static get styles() {
+    return buttonStyles;
+  }
+
+  /** @protected */
+  static registerStyles() {
+    // To be overridden by the theme
+  }
+
+  static register() {
+    if (!customElements.get(this.is)) {
+      this.registerStyles();
+
+      defineCustomElement(this);
+    }
+  }
+
+  /** @protected */
+  render() {
+    return buttonTemplate(html);
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+  }
+}
+
+export { Button };

--- a/packages/button/theme/lumo/vaadin-button-component.js
+++ b/packages/button/theme/lumo/vaadin-button-component.js
@@ -1,0 +1,13 @@
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { Button as _Button } from '../../src/vaadin-button-component.js';
+import { button } from './vaadin-button-styles.js';
+
+export class Button extends _Button {
+  /**
+   * @protected
+   * @override
+   */
+  static registerStyles() {
+    registerStyles('vaadin-button', button, { moduleId: 'lumo-button' });
+  }
+}

--- a/packages/button/theme/lumo/vaadin-button-styles.js
+++ b/packages/button/theme/lumo/vaadin-button-styles.js
@@ -3,7 +3,7 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const button = css`
   :host {
@@ -269,7 +269,5 @@ const button = css`
     margin-right: 0;
   }
 `;
-
-registerStyles('vaadin-button', button, { moduleId: 'lumo-button' });
 
 export { button };

--- a/packages/button/theme/lumo/vaadin-button.js
+++ b/packages/button/theme/lumo/vaadin-button.js
@@ -1,2 +1,5 @@
-import './vaadin-button-styles.js';
-import '../../src/vaadin-button.js';
+import { Button } from './vaadin-button-component.js';
+
+Button.register();
+
+export { Button };

--- a/packages/button/theme/lumo/vaadin-lit-button-component.js
+++ b/packages/button/theme/lumo/vaadin-lit-button-component.js
@@ -1,0 +1,13 @@
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { Button as _Button } from '../../src/vaadin-lit-button-component.js';
+import { button } from './vaadin-button-styles.js';
+
+export class Button extends _Button {
+  /**
+   * @protected
+   * @override
+   */
+  static registerStyles() {
+    registerStyles('vaadin-button', button, { moduleId: 'lumo-button' });
+  }
+}

--- a/packages/button/theme/lumo/vaadin-lit-button.js
+++ b/packages/button/theme/lumo/vaadin-lit-button.js
@@ -1,2 +1,5 @@
-import './vaadin-button-styles.js';
-import '../../src/vaadin-lit-button.js';
+import { Button } from './vaadin-lit-button-component.js';
+
+Button.register();
+
+export { Button };

--- a/packages/button/theme/material/vaadin-button-component.js
+++ b/packages/button/theme/material/vaadin-button-component.js
@@ -1,0 +1,13 @@
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { Button as _Button } from '../../src/vaadin-button-component.js';
+import { button } from './vaadin-button-styles.js';
+
+export class Button extends _Button {
+  /**
+   * @protected
+   * @override
+   */
+  static registerStyles() {
+    registerStyles('vaadin-button', button, { moduleId: 'material-button' });
+  }
+}

--- a/packages/button/theme/material/vaadin-button-styles.js
+++ b/packages/button/theme/material/vaadin-button-styles.js
@@ -1,7 +1,7 @@
 import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
 import '@vaadin/vaadin-material-styles/typography.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const button = css`
   :host {
@@ -164,7 +164,5 @@ const button = css`
     margin-right: 8px;
   }
 `;
-
-registerStyles('vaadin-button', button, { moduleId: 'material-button' });
 
 export { button };

--- a/packages/button/theme/material/vaadin-button.js
+++ b/packages/button/theme/material/vaadin-button.js
@@ -1,2 +1,5 @@
-import './vaadin-button-styles.js';
-import '../../src/vaadin-button.js';
+import { Button } from './vaadin-button-component.js';
+
+Button.register();
+
+export { Button };

--- a/packages/button/theme/material/vaadin-lit-button-component.js
+++ b/packages/button/theme/material/vaadin-lit-button-component.js
@@ -1,0 +1,13 @@
+import { registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { Button as _Button } from '../../src/vaadin-lit-button-component.js';
+import { button } from './vaadin-button-styles.js';
+
+export class Button extends _Button {
+  /**
+   * @protected
+   * @override
+   */
+  static registerStyles() {
+    registerStyles('vaadin-button', button, { moduleId: 'material-button' });
+  }
+}

--- a/packages/button/theme/material/vaadin-lit-button.js
+++ b/packages/button/theme/material/vaadin-lit-button.js
@@ -1,2 +1,5 @@
-import './vaadin-button-styles.js';
-import '../../src/vaadin-lit-button.js';
+import { Button } from './vaadin-lit-button-component.js';
+
+Button.register();
+
+export { Button };

--- a/packages/button/vaadin-button-component.d.ts
+++ b/packages/button/vaadin-button-component.d.ts
@@ -1,0 +1,1 @@
+export * from './theme/lumo/vaadin-button-component.js';

--- a/packages/button/vaadin-button-component.js
+++ b/packages/button/vaadin-button-component.js
@@ -1,0 +1,1 @@
+export * from './theme/lumo/vaadin-button-component.js';

--- a/packages/button/vaadin-button.js
+++ b/packages/button/vaadin-button.js
@@ -1,3 +1,3 @@
 import './theme/lumo/vaadin-button.js';
 
-export * from './src/vaadin-button.js';
+export * from './theme/lumo/vaadin-button.js';

--- a/packages/button/vaadin-lit-button.js
+++ b/packages/button/vaadin-lit-button.js
@@ -1,3 +1,3 @@
 import './theme/lumo/vaadin-lit-button.js';
 
-export * from './src/vaadin-lit-button.js';
+export * from './theme/lumo/vaadin-lit-button.js';

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -3,7 +3,6 @@ import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import '@vaadin/vaadin-lumo-styles/style.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
-import '@vaadin/button/theme/lumo/vaadin-button-styles.js';
 import './vaadin-date-picker-year-styles.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/date-picker/theme/lumo/vaadin-date-picker.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker.js
@@ -1,3 +1,4 @@
+import '@vaadin/button/theme/lumo/vaadin-button.js';
 import './vaadin-date-picker-overlay-styles.js';
 import './vaadin-date-picker-overlay-content-styles.js';
 import './vaadin-month-calendar-styles.js';

--- a/packages/date-picker/theme/lumo/vaadin-lit-date-picker.js
+++ b/packages/date-picker/theme/lumo/vaadin-lit-date-picker.js
@@ -1,3 +1,4 @@
+import '@vaadin/button/theme/lumo/vaadin-lit-button.js';
 import './vaadin-date-picker-overlay-styles.js';
 import './vaadin-date-picker-overlay-content-styles.js';
 import './vaadin-month-calendar-styles.js';

--- a/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker-overlay-content-styles.js
@@ -2,7 +2,6 @@ import '@vaadin/vaadin-material-styles/color.js';
 import '@vaadin/vaadin-material-styles/font-icons.js';
 import '@vaadin/vaadin-material-styles/typography.js';
 import '@vaadin/vaadin-material-styles/shadow.js';
-import '@vaadin/button/theme/material/vaadin-button-styles.js';
 import './vaadin-date-picker-year-styles.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 

--- a/packages/date-picker/theme/material/vaadin-date-picker.js
+++ b/packages/date-picker/theme/material/vaadin-date-picker.js
@@ -1,3 +1,4 @@
+import '@vaadin/button/theme/material/vaadin-button.js';
 import './vaadin-date-picker-overlay-styles.js';
 import './vaadin-date-picker-overlay-content-styles.js';
 import './vaadin-month-calendar-styles.js';

--- a/packages/date-picker/theme/material/vaadin-lit-date-picker.js
+++ b/packages/date-picker/theme/material/vaadin-lit-date-picker.js
@@ -1,3 +1,4 @@
+import '@vaadin/button/theme/material/vaadin-lit-button.js';
 import './vaadin-date-picker-overlay-styles.js';
 import './vaadin-date-picker-overlay-content-styles.js';
 import './vaadin-month-calendar-styles.js';

--- a/packages/rich-text-editor/theme/lumo/vaadin-lit-rich-text-editor.js
+++ b/packages/rich-text-editor/theme/lumo/vaadin-lit-rich-text-editor.js
@@ -1,4 +1,4 @@
-import '@vaadin/button/theme/lumo/vaadin-button-styles.js';
+import '@vaadin/button/theme/lumo/vaadin-lit-button.js';
 import '@vaadin/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js';
 import '@vaadin/text-field/theme/lumo/vaadin-text-field-styles.js';
 import '@vaadin/tooltip/theme/lumo/vaadin-tooltip-styles.js';

--- a/packages/rich-text-editor/theme/material/vaadin-lit-rich-text-editor.js
+++ b/packages/rich-text-editor/theme/material/vaadin-lit-rich-text-editor.js
@@ -1,4 +1,4 @@
-import '@vaadin/button/theme/material/vaadin-button-styles.js';
+import '@vaadin/button/theme/material/vaadin-lit-button.js';
 import '@vaadin/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js';
 import '@vaadin/text-field/theme/material/vaadin-text-field-styles.js';
 import '@vaadin/tooltip/theme/material/vaadin-tooltip-styles.js';


### PR DESCRIPTION
## Description

Related to #6999 and https://github.com/vaadin/react-components/issues/199

This is a PR to discuss potential changes needed to web components if we decide to follow this approach:

| Path                         | Description              |
|--------------------|--------------------|
| `src/vaadin-button-component.js` | side-effects free class |
| `src/vaadin-button.js` |  file that defines an unstyled custom element |
| `theme/lumo/vaadin-button-component.js` | side-effects free class with themes |
| `theme/lumo/vaadin-button-styles.js` | side-effects free CSS literal |
| `theme/lumo/vaadin-button.js` |  file that defines a themed custom element |

## Type of change

- Experiment

## Note

In order for themed version to work, `theme/lumo/vaadin-button.js` has to be imported before `src/vaadin-button.js` as both files call `Button.register()` - that method only runs  `registerStyles()` once, next calls are no-op.