### PR TITLE
refactor: simplify button imports in confirm-dialog themes

### DIFF
--- a/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-confirm-dialog-styles.js
@@ -1,4 +1,3 @@
-import '@vaadin/button/theme/lumo/vaadin-button-styles.js';
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import { dialogOverlay } from '@vaadin/dialog/theme/lumo/vaadin-dialog-styles.js';

--- a/packages/confirm-dialog/theme/lumo/vaadin-lit-confirm-dialog.js
+++ b/packages/confirm-dialog/theme/lumo/vaadin-lit-confirm-dialog.js
@@ -1,3 +1,3 @@
-import '@vaadin/button/theme/lumo/vaadin-button-styles.js';
+import '@vaadin/button/theme/lumo/vaadin-lit-button.js';
 import './vaadin-confirm-dialog-styles.js';
 import '../../src/vaadin-lit-confirm-dialog.js';

--- a/packages/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js
+++ b/packages/confirm-dialog/theme/material/vaadin-confirm-dialog-styles.js
@@ -1,4 +1,3 @@
-import '@vaadin/button/theme/material/vaadin-button-styles.js';
 import { dialogOverlay } from '@vaadin/dialog/theme/material/vaadin-dialog-styles.js';
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/confirm-dialog/theme/material/vaadin-lit-confirm-dialog.js
+++ b/packages/confirm-dialog/theme/material/vaadin-lit-confirm-dialog.js
@@ -1,3 +1,3 @@
-import '@vaadin/button/theme/material/vaadin-button-styles.js';
+import '@vaadin/button/theme/material/vaadin-lit-button.js';
 import './vaadin-confirm-dialog-styles.js';
 import '../../src/vaadin-lit-confirm-dialog.js';


### PR DESCRIPTION
## Description

Follow-up to #6569

Updated themed Lit entrypoints of `vaadin-confirm-dialog` to import corresponding Lit based `vaadin-button` theme files added in #6773. This makes Lit versions aligned with the corresponding Polymer based theme entrypoints.

## Type of change

- Refactor