### PR TITLE
adjust min-width of vaadin-menu-bar-button for overflow

### DIFF
--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-button-styles.js
@@ -64,7 +64,8 @@ const menuBarButton = css`
   }
 
   :host([slot='overflow']) {
-    min-width: var(--lumo-button-size);
+    width: var(--lumo-size-m);
+    min-width: var(--lumo-size-m);
     padding-left: calc(var(--lumo-button-size) / 4);
     padding-right: calc(var(--lumo-button-size) / 4);
   }


### PR DESCRIPTION
### feat: 
min-width of the vaadin-menu-bar-button did not match the width of the default overflow button (var(--lumo-size-m)), causing inconsistent button widths

###  Changes Made: 

Modified the `min-width` property in the `:host([slot='overflow'])` selector to match the width of the default overflow button (`var(--lumo-size-m)`).

### Fixes #6876