### PR TITLE
feat: add keepFilter option

### DIFF
--- a/dev/multi-select-combo-box.html
+++ b/dev/multi-select-combo-box.html
@@ -19,9 +19,9 @@
       clear-button-visible
       required
       error-message="Select at least one"
+      allow-custom-value
       auto-expand-horizontally
       auto-expand-vertically
-      keep-filter
     >
       <vaadin-tooltip slot="tooltip" text="Vaadin multi-select-combo-box tooltip text"></vaadin-tooltip>
     </vaadin-multi-select-combo-box>

--- a/dev/multi-select-combo-box.html
+++ b/dev/multi-select-combo-box.html
@@ -19,9 +19,9 @@
       clear-button-visible
       required
       error-message="Select at least one"
-      allow-custom-value
       auto-expand-horizontally
       auto-expand-vertically
+      keep-filter
     >
       <vaadin-tooltip slot="tooltip" text="Vaadin multi-select-combo-box tooltip text"></vaadin-tooltip>
     </vaadin-multi-select-combo-box>

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -947,7 +947,7 @@ export const ComboBoxMixin = (subclass) =>
           this.value = this._getItemValue(itemMatchingInputValue);
         } else {
           // Revert the input value
-          this._inputElementValue = this.selectedItem ? this._getItemLabel(this.selectedItem) : this.value || '';
+          this._revertInputValueToValue();
         }
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -891,7 +891,7 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
-    _commitValue() {
+    _commitValue(keepFilter = false) {
       if (this._focusedIndex > -1) {
         const focusedItem = this._dropdownItems[this._focusedIndex];
         if (this.selectedItem !== focusedItem) {
@@ -946,7 +946,9 @@ export const ComboBoxMixin = (subclass) =>
 
       this._clearSelectionRange();
 
-      this.filter = '';
+      if (!keepFilter) {
+        this.filter = '';
+      }
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -868,6 +868,15 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /**
+     * Clears the current filter. Should be used instead of setting the property
+     * directly in order to allow overriding this in multi-select combo box.
+     * @protected
+     */
+    _clearFilter() {
+      this.filter = '';
+    }
+
+    /**
      * Reverts back to original value.
      */
     cancel() {
@@ -891,7 +900,7 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
-    _commitValue(keepFilter = false) {
+    _commitValue() {
       if (this._focusedIndex > -1) {
         const focusedItem = this._dropdownItems[this._focusedIndex];
         if (this.selectedItem !== focusedItem) {
@@ -946,9 +955,7 @@ export const ComboBoxMixin = (subclass) =>
 
       this._clearSelectionRange();
 
-      if (!keepFilter) {
-        this.filter = '';
-      }
+      this._clearFilter();
     }
 
     /**
@@ -1089,7 +1096,7 @@ export const ComboBoxMixin = (subclass) =>
         this.selectedItem = null;
       }
 
-      this.filter = '';
+      this._clearFilter();
 
       // In the next _detectAndDispatchChange() call, the change detection should pass
       this._lastCommittedValue = undefined;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -277,8 +277,9 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
-   * Override from combo-box to not clear filter if the keepFilter
-   * option is enabled and the overlay is still open.
+   * Override from combo-box to ignore requests to clear the filter if the
+   * keepFilter option is enabled. Exceptions are when the dropdown is closed,
+   * so the filter is still cleared on cancel and focus out.
    * @protected
    * @override
    */
@@ -289,10 +290,8 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
-   * Override method from combo-box
-   * This is called in several cases, for example on cancel or when reverting
-   * from a value with no matches on commit. In these cases we also want to
-   * clear the filter, regardless of the keepFilter option.
+   * Override method from combo-box to always clear the filter when reverting
+   * the input value, regardless of the keepFilter option.
    * @override
    * @protected
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -277,6 +277,18 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override from combo-box to not clear filter if the keepFilter
+   * option is enabled and the overlay is still open.
+   * @protected
+   * @override
+   */
+  _clearFilter() {
+    if (!this.keepFilter || !this.opened) {
+      super._clearFilter();
+    }
+  }
+
+  /**
    * @protected
    * @override
    */
@@ -285,7 +297,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     // an item which is already selected, to not un-select it.
     this.lastFilter = this.filter;
 
-    super._commitValue(this.keepFilter);
+    super._commitValue();
   }
 
   /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -61,6 +61,14 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
       },
 
       /**
+       * When true, filter string isn't cleared after selecting an item.
+       */
+      keepFilter: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
        * When set to `true`, "loading" attribute is set
        * on the host and the overlay element.
        * @type {boolean}
@@ -277,7 +285,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     // an item which is already selected, to not un-select it.
     this.lastFilter = this.filter;
 
-    super._commitValue();
+    super._commitValue(this.keepFilter);
   }
 
   /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -289,6 +289,19 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
   }
 
   /**
+   * Override method from combo-box
+   * This is called in several cases, for example on cancel or when reverting
+   * from a value with no matches on commit. In these cases we also want to
+   * clear the filter, regardless of the keepFilter option.
+   * @override
+   * @protected
+   */
+  _revertInputValueToValue() {
+    super._revertInputValueToValue();
+    this.filter = '';
+  }
+
+  /**
    * @protected
    * @override
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -275,6 +275,12 @@ declare class MultiSelectComboBox<TItem = ComboBoxDefaultItem> extends HTMLEleme
   i18n: MultiSelectComboBoxI18n;
 
   /**
+   * When true, filter string isn't cleared after selecting an item.
+   * @attr {boolean} keep-filter
+   */
+  keepFilter: boolean;
+
+  /**
    * True when loading items from the data provider, false otherwise.
    */
   loading: boolean;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -882,9 +882,16 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
 
     // Suppress `value-changed` event.
     if (!this.keepFilter) {
+      // Clear both combo box value and filter.
       this.__clearFilter();
     } else {
-      this.filter = this._lastFilter;
+      // Only clear combo box value. This effectively resets _lastCommittedValue
+      // which allows toggling the same item multiple times via keyboard.
+      this.$.comboBox.clear();
+      // Restore input to the filter value. Needed when items are
+      // navigated with keyboard, which overrides the input value
+      // with the item label.
+      this._inputElementValue = this.filter;
     }
 
     this.__announceItem(itemLabel, isSelected, itemsCopy.length);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -183,6 +183,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
           top-group="[[_topGroup]]"
           opened="{{opened}}"
           renderer="[[renderer]]"
+          keep-filter="[[keepFilter]]"
           theme$="[[_theme]]"
           on-combo-box-item-selected="_onComboBoxItemSelected"
           on-change="_onComboBoxChange"
@@ -303,6 +304,14 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       itemIdPath: {
         type: String,
+      },
+
+      /**
+       * When true, filter string isn't cleared after selecting an item.
+       */
+      keepFilter: {
+        type: Boolean,
+        value: false,
       },
 
       /**
@@ -872,7 +881,11 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     this.__updateSelection(itemsCopy);
 
     // Suppress `value-changed` event.
-    this.__clearFilter();
+    if (!this.keepFilter) {
+      this.__clearFilter();
+    } else {
+      this.filter = this._lastFilter;
+    }
 
     this.__announceItem(itemLabel, isSelected, itemsCopy.length);
   }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -307,14 +307,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       },
 
       /**
-       * When true, filter string isn't cleared after selecting an item.
-       */
-      keepFilter: {
-        type: Boolean,
-        value: false,
-      },
-
-      /**
        * The object used to localize this component.
        * To change the default localization, replace the entire
        * _i18n_ object or just the property you want to modify.
@@ -349,6 +341,14 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
             total: '{count} items selected',
           };
         },
+      },
+
+      /**
+       * When true, filter string isn't cleared after selecting an item.
+       */
+      keepFilter: {
+        type: Boolean,
+        value: false,
       },
 
       /**
@@ -838,7 +838,8 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
    * when the `keepFilter` option is enabled. Using `force` can enforce clearing
    * the filter.
    * @param {boolean} force overrides the keepFilter option
-   * @private */
+   * @private
+   */
   __clearInternalValue(force = false) {
     if (!this.keepFilter || force) {
       // Clear both combo box value and filter.

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -362,7 +362,10 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'Enter' });
       expect(comboBox.selectedItems).to.deep.equal(['banana']);
+      expect(comboBox.filter).to.equal('an');
+      expect(inputElement.value).to.equal('an');
       expectItems(['banana', 'orange']);
+      // Filter should never change, otherwise data provider would be called
       expect(filterChangeSpy.notCalled).to.be.true;
     });
 
@@ -373,9 +376,6 @@ describe('selecting items', () => {
       inputElement.blur();
       expect(comboBox.filter).to.equal('');
       expect(inputElement.value).to.equal('');
-
-      comboBox.opened = true;
-      expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
     it('should clear a matching filter when closing the overlay', async () => {
@@ -385,9 +385,6 @@ describe('selecting items', () => {
       expect(comboBox.selectedItems).to.deep.equal([]);
       expect(comboBox.filter).to.equal('');
       expect(inputElement.value).to.equal('');
-
-      comboBox.opened = true;
-      expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
     it('should clear the filter when pressing escape', async () => {
@@ -397,9 +394,6 @@ describe('selecting items', () => {
       await sendKeys({ down: 'Escape' });
       expect(comboBox.filter).to.equal('');
       expect(inputElement.value).to.equal('');
-
-      comboBox.opened = true;
-      expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
     it('should clear the filter when pressing escape after selecting an item', async () => {
@@ -414,9 +408,6 @@ describe('selecting items', () => {
       expect(comboBox.opened).to.be.false;
       expect(comboBox.filter).to.equal('');
       expect(inputElement.value).to.equal('');
-
-      comboBox.opened = true;
-      expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
     it('should clear the filter when committing a non-existing item', async () => {
@@ -427,7 +418,6 @@ describe('selecting items', () => {
       expect(comboBox.opened).to.be.true;
       expect(inputElement.value).to.equal('');
       expect(comboBox.filter).to.equal('');
-      expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
     it('should allow toggling items via keyboard', async () => {

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -378,6 +378,18 @@ describe('selecting items', () => {
       expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
+    it('should clear a matching filter when closing the overlay', async () => {
+      await sendKeys({ type: 'apple' });
+
+      inputElement.blur();
+      expect(comboBox.selectedItems).to.deep.equal([]);
+      expect(comboBox.filter).to.equal('');
+      expect(inputElement.value).to.equal('');
+
+      comboBox.opened = true;
+      expectItems(['apple', 'banana', 'lemon', 'orange']);
+    });
+
     it('should clear the filter when pressing escape', async () => {
       await sendKeys({ type: 'an' });
       expectItems(['banana', 'orange']);
@@ -407,10 +419,15 @@ describe('selecting items', () => {
       expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
-    it('should not select filtered value when closing the overlay', async () => {
-      await sendKeys({ type: 'apple' });
-      inputElement.blur();
-      expect(comboBox.selectedItems).to.deep.equal([]);
+    it('should clear the filter when committing a non-existing item', async () => {
+      await sendKeys({ type: 'an' });
+      expectItems(['banana', 'orange']);
+
+      await sendKeys({ down: 'Enter' });
+      expect(comboBox.opened).to.be.true;
+      expect(inputElement.value).to.equal('');
+      expect(comboBox.filter).to.equal('');
+      expectItems(['apple', 'banana', 'lemon', 'orange']);
     });
 
     it('should allow toggling items via keyboard', async () => {
@@ -429,6 +446,19 @@ describe('selecting items', () => {
       await sendKeys({ down: 'Enter' });
       expect(comboBox.selectedItems).to.deep.equal(['banana']);
       expect(inputElement.value).to.equal('an');
+    });
+
+    describe('with allowCustomValue', () => {
+      beforeEach(() => {
+        comboBox.allowCustomValue = true;
+      });
+
+      it('should clear the filter value after entering custom value', async () => {
+        await sendKeys({ type: 'pear' });
+        await sendKeys({ down: 'Enter' });
+        expect(comboBox.filter).to.equal('');
+        expect(inputElement.value).to.equal('');
+      });
     });
   });
 });


### PR DESCRIPTION
Adds a `keepFilter` option to `<vaadin-multi-select-combo-box>` that allows to keep the filter value after selecting an item.

Some notes regarding the behavior:
- Filter is preserved when selecting items using either mouse or keyboard
- Input value is restored to the filter after selecting items using keyboard. Selecting items using keyboard overrides the input value with the item label so this needs to be reverted.
- The filter is cleared when:
  - Closing the overlay either due to focus out or canceling input with Escape
  - Adding a custom value
  - Trying to commit a non-existing value. Might be better UX to keep the filter, but I left it out due to complexity, and it seems like an edge-case.

Closes https://github.com/vaadin/web-components/issues/5930