### PR TITLE
docs: add missing attr JSDoc annotation to typings

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.d.ts
@@ -43,6 +43,8 @@ export declare class ScrollMixinClass {
    * - Keyboard Navigation: Tabbing through focusable elements inside the grid body may not work as expected because
    * some of the columns that would include focusable elements in the body cells may be outside the visible viewport
    * and thus not rendered.
+   *
+   * @attr {eager|lazy} column-rendering
    */
   columnRendering: ColumnRendering;
 


### PR DESCRIPTION
## Description

The `columnRendering` property was lacking `@attr` annotation in typings, needed for VSCode Lit plugin to show docs:

<img width="665" alt="Screenshot 2024-01-11 at 15 33 06" src="https://github.com/vaadin/web-components/assets/10589913/cb4523fa-7531-4804-bc98-8de75908f988">

## Type of change

- Documentation