### PR TITLE
fix: do not render cell for invisible rows

### DIFF
--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -598,6 +598,14 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @protected */
     _runRenderer(renderer, cell, model) {
+      if (
+        !(model && model.item && !cell.parentElement.hidden) &&
+        renderer !== this._headerRenderer &&
+        renderer !== this._footerRenderer
+      ) {
+        return;
+      }
+
       const args = [cell._content, this];
       if (model && model.item) {
         args.push(model);
@@ -634,9 +642,7 @@ export const ColumnBaseMixin = (superClass) =>
 
         cell._renderer = renderer;
 
-        if (model.item || renderer === this._headerRenderer || renderer === this._footerRenderer) {
-          this._runRenderer(renderer, cell, model);
-        }
+        this._runRenderer(renderer, cell, model);
       });
     }
 

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -605,7 +605,7 @@ export const ColumnBaseMixin = (superClass) =>
       }
 
       const args = [cell._content, this];
-      if (model && model.item) {
+      if (isVisibleBodyCell) {
         args.push(model);
       }
 

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -598,11 +598,9 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @protected */
     _runRenderer(renderer, cell, model) {
-      if (
-        !(model && model.item && !cell.parentElement.hidden) &&
-        renderer !== this._headerRenderer &&
-        renderer !== this._footerRenderer
-      ) {
+      const isVisibleBodyCell = model && model.item && !cell.parentElement.hidden;
+      const shouldRender = isVisibleBodyCell || renderer === this._headerRenderer || renderer === this._footerRenderer;
+      if (!shouldRender) {
         return;
       }
 

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -113,6 +113,18 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
       expectBodyCellNotRendered(columns.length - 1);
     });
 
+    it('should not render hidden rows on renderer change', async () => {
+      grid.items = [{ name: 'Item 1' }, { name: 'Item 2' }];
+      grid._getRenderedRows()[1].hidden = true;
+      const renderedItems = [];
+      columns[0].renderer = Sinon.spy((root, _, model) => {
+        renderedItems.push(model.item.name);
+      });
+      await nextFrame();
+      expect(renderedItems).to.include('Item 1');
+      expect(renderedItems).to.not.include('Item 2');
+    });
+
     it('new rows - should render columns inside the viewport', () => {
       resetRenderers();
       grid.items = [{ name: `Item 1` }, { name: `Item 2` }];

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -117,9 +117,9 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
       grid.items = [{ name: 'Item 1' }, { name: 'Item 2' }];
       grid._getRenderedRows()[1].hidden = true;
       const renderedItems = [];
-      columns[0].renderer = Sinon.spy((root, _, model) => {
+      columns[0].renderer = (root, _, model) => {
         renderedItems.push(model.item.name);
-      });
+      };
       await nextFrame();
       expect(renderedItems).to.include('Item 1');
       expect(renderedItems).to.not.include('Item 2');

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -115,7 +115,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
 
     it('should not render hidden rows on renderer change', async () => {
       grid.items = [{ name: 'Item 1' }, { name: 'Item 2' }];
-      grid._getRenderedRows()[1].hidden = true;
+      grid.items = [{ name: 'Item 1' }];
       const renderedItems = [];
       columns[0].renderer = (root, _, model) => {
         renderedItems.push(model.item.name);


### PR DESCRIPTION
## Description

When there are invisible rows and there is a renderer change, the grid column also renders the cells in those invisible rows. This PR adds a check that prevents this unnecessary render.

Fixes #7071 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.