### PR TITLE
fix: preserve filter when committing an invalid option

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -772,11 +772,7 @@ export const ComboBoxMixin = (subclass) =>
       // Do not commit value when custom values are disallowed and input value is not a valid option
       // also stop propagation of the event, otherwise the user could submit a form while the input
       // still contains an invalid value
-      const hasInvalidOption =
-        this._focusedIndex < 0 &&
-        this._inputElementValue !== '' &&
-        this._getItemLabel(this.selectedItem) !== this._inputElementValue;
-      if (!this.allowCustomValue && hasInvalidOption) {
+      if (!this._hasValidInputValue()) {
         // Do not submit the surrounding form.
         e.preventDefault();
         // Do not trigger global listeners
@@ -794,6 +790,18 @@ export const ComboBoxMixin = (subclass) =>
       }
 
       this._closeOrCommit();
+    }
+
+    /**
+     * @protected
+     */
+    _hasValidInputValue() {
+      const hasInvalidOption =
+        this._focusedIndex < 0 &&
+        this._inputElementValue !== '' &&
+        this._getItemLabel(this.selectedItem) !== this._inputElementValue;
+
+      return this.allowCustomValue || !hasInvalidOption;
     }
 
     /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -244,7 +244,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
       if (this.readonly) {
         this.close();
-      } else {
+      } else if (this._hasValidInputValue()) {
         // Keep selected item focused after committing on Enter.
         const focusedItem = this._dropdownItems[this._focusedIndex];
         this._commitValue();

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -125,6 +125,14 @@ describe('selecting items', () => {
       comboBox.clear();
       expect(comboBox.selectedItems).to.deep.equal([]);
     });
+
+    it('should keep the filter and input value when committing an invalid option', async () => {
+      await sendKeys({ type: 'an' });
+      await sendKeys({ down: 'Enter' });
+      expect(comboBox.opened).to.be.true;
+      expect(comboBox.filter).to.equal('an');
+      expect(inputElement.value).to.equal('an');
+    });
   });
 
   describe('dataProvider', () => {
@@ -410,14 +418,14 @@ describe('selecting items', () => {
       expect(inputElement.value).to.equal('');
     });
 
-    it('should clear the filter when committing a non-existing item', async () => {
+    it('should keep the filter and input value when committing an invalid option', async () => {
       await sendKeys({ type: 'an' });
       expectItems(['banana', 'orange']);
 
       await sendKeys({ down: 'Enter' });
       expect(comboBox.opened).to.be.true;
-      expect(inputElement.value).to.equal('');
-      expect(comboBox.filter).to.equal('');
+      expect(inputElement.value).to.equal('an');
+      expect(comboBox.filter).to.equal('an');
     });
 
     it('should allow toggling items via keyboard', async () => {


### PR DESCRIPTION
## Description

Fixes MSBC to not reset the filter + input value when pressing Enter while the input value does not match any option. That is how the regular combo-box works, and it improves the UX as the user doesn't lose their filter, for example if they try to add a custom value even though that is not allowed.

Clearing the filter is probably a regression (I assume it's unintentional) from https://github.com/vaadin/web-components/pull/6372, as such it also realigns the behavior with the v23 MSCB.

## Type of change

- Bugfix
