### PR TITLE
test: remove has-label attribute tests from radio-button

### DIFF
--- a/packages/radio-group/test/dom/__snapshots__/radio-button.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-button.test.snap.js
@@ -2,10 +2,28 @@
 export const snapshots = {};
 
 snapshots["vaadin-radio-button host default"] = 
+`<vaadin-radio-button has-value="">
+  <label
+    for="input-vaadin-radio-button-1"
+    id="label-vaadin-radio-button-0"
+    slot="label"
+  >
+  </label>
+  <input
+    id="input-vaadin-radio-button-1"
+    slot="input"
+    tabindex="0"
+    type="radio"
+    value="on"
+  >
+</vaadin-radio-button>
+`;
+/* end snapshot vaadin-radio-button host default */
+
+snapshots["vaadin-radio-button host label"] = 
 `<vaadin-radio-button
   has-label=""
   has-value=""
-  label="Radio button"
 >
   <label
     for="input-vaadin-radio-button-1"
@@ -23,22 +41,19 @@ snapshots["vaadin-radio-button host default"] =
   >
 </vaadin-radio-button>
 `;
-/* end snapshot vaadin-radio-button host default */
+/* end snapshot vaadin-radio-button host label */
 
 snapshots["vaadin-radio-button host disabled"] = 
 `<vaadin-radio-button
   aria-disabled="true"
   disabled=""
-  has-label=""
   has-value=""
-  label="Radio button"
 >
   <label
     for="input-vaadin-radio-button-1"
     id="label-vaadin-radio-button-0"
     slot="label"
   >
-    Radio button
   </label>
   <input
     disabled=""

--- a/packages/radio-group/test/dom/radio-button.test.js
+++ b/packages/radio-group/test/dom/radio-button.test.js
@@ -8,11 +8,16 @@ describe('vaadin-radio-button', () => {
 
   beforeEach(() => {
     resetUniqueId();
-    radio = fixtureSync('<vaadin-radio-button label="Radio button"></vaadin-radio-button>');
+    radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
   });
 
   describe('host', () => {
     it('default', async () => {
+      await expect(radio).dom.to.equalSnapshot();
+    });
+
+    it('label', async () => {
+      radio.label = 'Radio button';
       await expect(radio).dom.to.equalSnapshot();
     });
 

--- a/packages/radio-group/test/radio-button.common.js
+++ b/packages/radio-group/test/radio-button.common.js
@@ -250,26 +250,6 @@ describe('radio-button', () => {
     });
   });
 
-  describe('has-label attribute', () => {
-    beforeEach(async () => {
-      radio = fixtureSync('<vaadin-radio-button></vaadin-radio-button>');
-      await nextRender();
-    });
-
-    it('should not set has-label attribute when label content is empty', () => {
-      expect(radio.hasAttribute('has-label')).to.be.false;
-    });
-
-    it('should set has-label attribute when the label is added', async () => {
-      const paragraph = document.createElement('p');
-      paragraph.textContent = 'Added label';
-      paragraph.setAttribute('slot', 'label');
-      radio.appendChild(paragraph);
-      await nextFrame();
-      expect(radio.hasAttribute('has-label')).to.be.true;
-    });
-  });
-
   describe('focus', () => {
     let inputX, inputY;
 


### PR DESCRIPTION
## Description

These tests were added in #2572. Since then, we added snapshot tests in #3520 and they cover `has-label` attribute.
No other components have dedicated tests for `has-label`, and corresponding logic is covered by `LabelMixin` tests.

## Type of change

- Test