### PR TITLE
refactor: remove no longer needed flex-grow CSS override

### DIFF
--- a/packages/text-field/src/vaadin-lit-text-field.js
+++ b/packages/text-field/src/vaadin-lit-text-field.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/input-container/src/vaadin-lit-input-container.js';
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -28,14 +28,7 @@ export class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(Polylit
   }
 
   static get styles() {
-    return [
-      inputFieldShared,
-      css`
-        [part='input-field'] {
-          flex-grow: 0;
-        }
-      `,
-    ];
+    return [inputFieldShared];
   }
 
   /** @protected */

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -90,12 +90,6 @@ export class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(Polymer
 
   static get template() {
     return html`
-      <style>
-        [part='input-field'] {
-          flex-grow: 0;
-        }
-      </style>
-
       <div class="vaadin-field-container">
         <div part="label">
           <slot name="label"></slot>


### PR DESCRIPTION
## Description

This CSS was added in #2274. Later on, we fixed `vaadin-input-container` to set `flex-grow: 0` in #2612 so that all input fields behave the same in this regard. So this style block is no longer needed and can be removed.

## Type of change

- Refactor