### PR TITLE
fix: preserve filter when committing an invalid option (#7072) (CP: 24.3)

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -772,11 +772,7 @@ export const ComboBoxMixin = (subclass) =>
       // Do not commit value when custom values are disallowed and input value is not a valid option
       // also stop propagation of the event, otherwise the user could submit a form while the input
       // still contains an invalid value
-      const hasInvalidOption =
-        this._focusedIndex < 0 &&
-        this._inputElementValue !== '' &&
-        this._getItemLabel(this.selectedItem) !== this._inputElementValue;
-      if (!this.allowCustomValue && hasInvalidOption) {
+      if (!this._hasValidInputValue()) {
         // Do not submit the surrounding form.
         e.preventDefault();
         // Do not trigger global listeners
@@ -794,6 +790,18 @@ export const ComboBoxMixin = (subclass) =>
       }
 
       this._closeOrCommit();
+    }
+
+    /**
+     * @protected
+     */
+    _hasValidInputValue() {
+      const hasInvalidOption =
+        this._focusedIndex < 0 &&
+        this._inputElementValue !== '' &&
+        this._getItemLabel(this.selectedItem) !== this._inputElementValue;
+
+      return this.allowCustomValue || !hasInvalidOption;
     }
 
     /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -227,7 +227,7 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
 
       if (this.readonly) {
         this.close();
-      } else {
+      } else if (this._hasValidInputValue()) {
         // Keep selected item focused after committing on Enter.
         const focusedItem = this._dropdownItems[this._focusedIndex];
         this._commitValue();

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -117,6 +117,14 @@ describe('selecting items', () => {
       comboBox.clear();
       expect(comboBox.selectedItems).to.deep.equal([]);
     });
+
+    it('should keep the filter and input value when committing an invalid option', async () => {
+      await sendKeys({ type: 'an' });
+      await sendKeys({ down: 'Enter' });
+      expect(comboBox.opened).to.be.true;
+      expect(comboBox.filter).to.equal('an');
+      expect(inputElement.value).to.equal('an');
+    });
   });
 
   describe('dataProvider', () => {


### PR DESCRIPTION
Cherry-pick of #7072
