### PR TITLE
refactor: do not register login form wrapper styles twice

### DIFF
--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -193,6 +193,6 @@ const loginFormWrapper = css`
   }
 `;
 
-registerStyles('vaadin-login-form-wrapper', [color, typography, loginFormWrapper], {
+registerStyles('vaadin-login-form-wrapper', [loginFormWrapper], {
   moduleId: 'lumo-login-overlay',
 });

--- a/packages/login/theme/material/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/material/vaadin-login-overlay-styles.js
@@ -347,4 +347,4 @@ const loginFormWrapper = css`
   }
 `;
 
-registerStyles('vaadin-login-form-wrapper', [typography, loginFormWrapper], { moduleId: 'material-login-overlay' });
+registerStyles('vaadin-login-form-wrapper', [loginFormWrapper], { moduleId: 'material-login-overlay' });


### PR DESCRIPTION
## Description

Currently, some style modules (color and typography) are being registered twice. This PR fixes that.

### Lumo

https://github.com/vaadin/web-components/blob/366fd72fd12312b0202558fe7ff8b6026b100577/packages/login/theme/lumo/vaadin-login-form-wrapper-styles.js#L86-L88

https://github.com/vaadin/web-components/blob/366fd72fd12312b0202558fe7ff8b6026b100577/packages/login/theme/lumo/vaadin-login-overlay-styles.js#L196-L198

### Material

https://github.com/vaadin/web-components/blob/366fd72fd12312b0202558fe7ff8b6026b100577/packages/login/theme/material/vaadin-login-form-wrapper-styles.js#L100-L102

https://github.com/vaadin/web-components/blob/366fd72fd12312b0202558fe7ff8b6026b100577/packages/login/theme/material/vaadin-login-overlay-styles.js#L350

## Type of change

- Refactor