### PR TITLE
feat: add script to build type definitions for theme folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 packages/**/vendor/*.js
 packages/**/dist/*.js
 packages/**/test/dom/__snapshots__/*.snap.js
+packages/**/theme/**/*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ yarn-error.log
 packages/*/test/visual/*/screenshots/*/failed
 packages/icons/test/visual/screenshots/failed
 
+# Generated theme folders .ts files
+packages/**/theme/**/*.d.ts
+
 # MacOS DS_Store files
 .DS_Store
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "private": true,
   "author": "Vaadin Ltd",
   "scripts": {
-    "analyze": "polymer analyze packages/**/vaadin-*.js > analysis.json && node scripts/prepareDocs.js && node scripts/buildWebtypes.js && node scripts/generateLumoAutoCompleteCss.js",
+    "analyze": "polymer analyze packages/**/vaadin-*.js > analysis.json && node scripts/prepareDocs.js && node scripts/buildWebtypes.js && node scripts/generateLumoAutoCompleteCss.js && ./scripts/buildThemeTypings.sh",
     "build:ts": "tsc --build tsconfig.build.json",
-    "build": "./scripts/buildThemeTypings.sh",
     "debug": "web-test-runner --watch",
     "debug:it": "web-test-runner --watch --config web-test-runner-it.config.js",
     "dist": "rimraf dist && yarn analyze && rollup -c rollup.config.js && cp analysis.json dist",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "author": "Vaadin Ltd",
   "scripts": {
     "analyze": "polymer analyze packages/**/vaadin-*.js > analysis.json && node scripts/prepareDocs.js && node scripts/buildWebtypes.js && node scripts/generateLumoAutoCompleteCss.js",
+    "build:ts": "tsc --build tsconfig.build.json",
+    "build": "./scripts/buildThemeTypings.sh",
     "debug": "web-test-runner --watch",
     "debug:it": "web-test-runner --watch --config web-test-runner-it.config.js",
     "dist": "rimraf dist && yarn analyze && rollup -c rollup.config.js && cp analysis.json dist",

--- a/scripts/buildThemeTypings.sh
+++ b/scripts/buildThemeTypings.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Rename .js files to .ts
+for file in packages/**/theme/**/*.js
+do
+  mv "$file" "${file%.js}.ts"
+done
+
+# Build type definitions
+npm run build:ts
+
+# Restore original .js files
+git checkout packages/**/theme/**/*.js
+
+# Remove .ts files but keep .d.ts
+find . -path "./packages/*/theme/*.ts" ! -name "*.d.ts" -type f -delete

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["esnext", "es2018", "dom"],
+    "declaration": true,
+    "strict": true,
+    "skipDefaultLibCheck": true
+  },
+  "include": ["packages/**/theme"]
+}


### PR DESCRIPTION
## Description

Fixes #7073

Added a script that does the following:

1. Renames all`.js` files in theme folders to `.ts`
2. Runs `tsc` to generates `.d.ts` files for them
3. Restores `.js` files back and removes `.ts`

Also added `.d.ts` files to `.gitignore` so we don't commit them.

## Type of change

- Feature