### PR TITLE
feat: add target property to side-nav-item

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -100,6 +100,11 @@ declare class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixi
    */
   readonly current: boolean;
 
+  /**
+   * The target of the link. Works only when `path` is set.
+   */
+  target: string | null | undefined;
+
   addEventListener<K extends keyof SideNavItemEventMap>(
     type: K,
     listener: (this: SideNavItem, ev: SideNavItemEventMap[K]) => void,

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -127,6 +127,11 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
         readOnly: true,
         reflectToAttribute: true,
       },
+
+      /**
+       * The target of the link. Works only when `path` is set.
+       */
+      target: String,
     };
   }
 
@@ -201,6 +206,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
           ?disabled="${this.disabled}"
           tabindex="${this.disabled || this.path == null ? '-1' : '0'}"
           href="${ifDefined(this.disabled ? null : this.path)}"
+          target="${ifDefined(this.target)}"
           part="link"
           aria-current="${this.current ? 'page' : 'false'}"
         >

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -292,5 +292,27 @@ describe('side-nav-item', () => {
       toggle.click();
       expect(spy.called).to.be.false;
     });
+
+    describe('target property', () => {
+      it('should set target attribute to the anchor when target is set', async () => {
+        item.target = '_blank';
+        await nextRender();
+        expect(anchor.getAttribute('target')).to.be.equal('_blank');
+      });
+
+      it('should remove target attribute from the anchor when target is removed', async () => {
+        item.target = '_blank';
+        await nextRender();
+        item.target = null;
+        await nextRender();
+        expect(anchor.getAttribute('target')).to.be.not.ok;
+      });
+
+      it('should not set target attribute to the anchor when target is empty string', async () => {
+        item.target = '';
+        await nextRender();
+        expect(anchor.getAttribute('target')).to.be.not.ok;
+      });
+    });
   });
 });

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -305,13 +305,7 @@ describe('side-nav-item', () => {
         await nextRender();
         item.target = null;
         await nextRender();
-        expect(anchor.getAttribute('target')).to.be.not.ok;
-      });
-
-      it('should not set target attribute to the anchor when target is empty string', async () => {
-        item.target = '';
-        await nextRender();
-        expect(anchor.getAttribute('target')).to.be.not.ok;
+        expect(anchor.hasAttribute('target')).to.be.not.ok;
       });
     });
   });


### PR DESCRIPTION
## Description

Make it possible to define a `target` attribute to forward its value to the internal anchor element present in the `<vaadin-side-nav-item>` component.

Part of vaadin/flow-components#5091

## Type of change

- [ ] Bugfix
- [X] Feature
