### PR TITLE
feat: support using data-colspan attribute to set colspan

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout.d.ts
@@ -50,7 +50,7 @@ export type FormLayoutResponsiveStep = {
  *
  * ### Spanning Items on Multiple Columns
  *
- * You can use `colspan` attribute on the items.
+ * You can use `colspan` or `data-colspan` attribute on the items.
  * In the example below, the first text field spans on two columns:
  *
  * ```html

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -44,7 +44,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * ### Spanning Items on Multiple Columns
  *
- * You can use `colspan` attribute on the items.
+ * You can use `colspan` or `data-colspan` attribute on the items.
  * In the example below, the first text field spans on two columns:
  *
  * ```html
@@ -290,7 +290,9 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
       mutationRecord.forEach((mutation) => {
         if (
           mutation.type === 'attributes' &&
-          (mutation.attributeName === 'colspan' || mutation.attributeName === 'hidden')
+          (mutation.attributeName === 'colspan' ||
+            mutation.attributeName === 'data-colspan' ||
+            mutation.attributeName === 'hidden')
         ) {
           this._updateLayout();
         }
@@ -482,8 +484,9 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
           return;
         }
 
+        const attrColspan = child.getAttribute('colspan') || child.getAttribute('data-colspan');
         let colspan;
-        colspan = this._naturalNumberOrOne(parseFloat(child.getAttribute('colspan')));
+        colspan = this._naturalNumberOrOne(parseFloat(attrColspan));
 
         // Never span further than the number of columns
         colspan = Math.min(colspan, this._columnCount);

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -569,6 +569,21 @@ describe('form layout', () => {
       expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(2, 0.1);
     });
 
+    it('should update layout after updating a data-colspan attribute', async () => {
+      expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(1, 0.1);
+
+      layout.children[0].setAttribute('data-colspan', 2);
+      await nextRender(container);
+      expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(2, 0.1);
+    });
+
+    it('should prefer colspan attribute over data-colspan when both are set', async () => {
+      layout.children[0].setAttribute('colspan', 2);
+      layout.children[0].setAttribute('data-colspan', 1);
+      await nextRender(container);
+      expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(2, 0.1);
+    });
+
     it('should update style if hidden property of layout-item is changed and the element has not had style yet', async () => {
       const itemWidth = layout.children[0].getBoundingClientRect().width;
       expect(itemWidth).to.be.above(0);


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/react-components/issues/70#issuecomment-1892023308

Added `data-colspan` for usage in React, in order to provide better DX compared to current `{...{ colspan: 2 }}`.

## Type of change

- Feature