### PR TITLE
refactor!: remove column re-exports from grid root entrypoint

### DIFF
--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -30,17 +30,14 @@ import type { SelectionMixinClass } from '../../src/vaadin-grid-selection-mixin'
 import type { SortMixinClass } from '../../src/vaadin-grid-sort-mixin';
 import type { StylingMixinClass } from '../../src/vaadin-grid-styling-mixin';
 import type {
-  ColumnBaseMixinClass,
   Grid,
   GridActiveItemChangedEvent,
   GridBodyRenderer,
   GridCellActivateEvent,
   GridCellClassNameGenerator,
   GridCellFocusEvent,
-  GridColumn,
   GridColumnReorderEvent,
   GridColumnResizeEvent,
-  GridColumnTextAlign,
   GridDataProvider,
   GridDataProviderCallback,
   GridDataProviderChangedEvent,
@@ -60,6 +57,7 @@ import type {
   GridSorterDefinition,
   GridSorterDirection,
 } from '../../vaadin-grid.js';
+import type { ColumnBaseMixinClass, GridColumn, GridColumnTextAlign } from '../../vaadin-grid-column.js';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/grid/test/typings/lit-grid.types.ts
+++ b/packages/grid/test/typings/lit-grid.types.ts
@@ -30,17 +30,14 @@ import type { SelectionMixinClass } from '../../src/vaadin-grid-selection-mixin'
 import type { SortMixinClass } from '../../src/vaadin-grid-sort-mixin';
 import type { StylingMixinClass } from '../../src/vaadin-grid-styling-mixin';
 import type {
-  ColumnBaseMixinClass,
   Grid,
   GridActiveItemChangedEvent,
   GridBodyRenderer,
   GridCellActivateEvent,
   GridCellClassNameGenerator,
   GridCellFocusEvent,
-  GridColumn,
   GridColumnReorderEvent,
   GridColumnResizeEvent,
-  GridColumnTextAlign,
   GridDataProvider,
   GridDataProviderCallback,
   GridDataProviderChangedEvent,
@@ -60,6 +57,7 @@ import type {
   GridSorterDefinition,
   GridSorterDirection,
 } from '../../vaadin-lit-grid.js';
+import type { ColumnBaseMixinClass, GridColumn, GridColumnTextAlign } from '../../vaadin-lit-grid-column.js';
 
 interface TestGridItem {
   testProperty: string;

--- a/packages/grid/vaadin-grid.d.ts
+++ b/packages/grid/vaadin-grid.d.ts
@@ -1,2 +1,1 @@
 export * from './src/vaadin-grid.js';
-export * from './src/vaadin-grid-column.js';

--- a/packages/grid/vaadin-grid.js
+++ b/packages/grid/vaadin-grid.js
@@ -1,4 +1,3 @@
 import './theme/lumo/vaadin-grid.js';
 
-export * from './src/vaadin-grid-column.js';
 export * from './src/vaadin-grid.js';

--- a/packages/grid/vaadin-lit-grid.d.ts
+++ b/packages/grid/vaadin-lit-grid.d.ts
@@ -1,2 +1,1 @@
 export * from './src/vaadin-grid.js';
-export * from './src/vaadin-grid-column.js';

--- a/packages/grid/vaadin-lit-grid.js
+++ b/packages/grid/vaadin-lit-grid.js
@@ -1,4 +1,3 @@
 import './theme/lumo/vaadin-lit-grid.js';
 
-export * from './src/vaadin-lit-grid-column.js';
 export * from './src/vaadin-lit-grid.js';


### PR DESCRIPTION
## Description

We need this minor breaking change for React components, see https://github.com/vaadin/react-components/pull/221#discussion_r1455091782 and older workaround in https://github.com/vaadin/react-components/pull/89. From now on, TS users should import `GridColumn` related types from `vaadnin-grid-column.js` instead of `vaadin-grid.js` - this will help us to avoid conflicting namespaces problem.

## Type of change

- Behavior altering change