### PR TITLE
fix: avoid clearing filter when pressing clear button on mobile

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -1067,6 +1067,9 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   _onClearButtonTouchend(event) {
     // Cancel the following click and focus events
     event.preventDefault();
+    // Prevent default combo box behavior which can otherwise unnecessarily
+    // clear the input and filter
+    event.stopPropagation();
 
     this.clear();
   }

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -224,6 +224,17 @@ describe('basic', () => {
       clearButton.dispatchEvent(new CustomEvent('touchend', { cancelable: true }));
       expect(comboBox.selectedItems).to.deep.equal([]);
     });
+
+    it('should not clear filter on clear button touchend', async () => {
+      comboBox.selectedItems = ['apple', 'orange'];
+      inputElement.focus();
+      await sendKeys({ type: 'app' });
+
+      clearButton.dispatchEvent(new CustomEvent('touchend', { cancelable: true, bubbles: true }));
+      expect(inputElement.value).to.equal('app');
+      expect(comboBox.filter).to.equal('app');
+      expect(comboBox.filteredItems).to.deep.equal(['apple']);
+    });
   });
 
   describe('toggle button', () => {


### PR DESCRIPTION
Disables the clear button logic from `vaadin-combo-box-mixin`, which clears the filter input when pressing the clear button. Instead, only the MSCB clear button logic is executed, which only clears the selection.

The bug actually only occurs on the first touch event, and not on subsequent ones. The root cause is that on the first clear, `selectedItem` is changed from `undefined` to `null`, which runs the respective change logic that also resets the input. Ideally `selectedItem` would be initialized with `null`, so the change would never happen. However, doing so results in a lot of test failures. I guess it would require additional changes to handle the initial Polymer change event then, but if someone has an idea feel free to make suggestions.

Fixes https://github.com/vaadin/web-components/issues/7066