### PR TITLE
fix: ensure to append sizer cell of columns outside the viewport

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -674,11 +674,13 @@ export const GridMixin = (superClass) =>
             cell.__parentRow = row;
             // Cache the cell reference
             row.__cells.push(cell);
-            if (!column._bodyContentHidden) {
+
+            const isSizerRow = row === this.$.sizer;
+            if (!column._bodyContentHidden || isSizerRow) {
               row.appendChild(cell);
             }
 
-            if (row === this.$.sizer) {
+            if (isSizerRow) {
               column._sizerCell = cell;
             }
 

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -455,6 +455,32 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
         // Expect the cell that was previously not visible to have the last-row-cell part
         expect(getBodyCell(1, 0).getAttribute('part')).to.include('last-row-cell');
       });
+
+      it('should have only one cell removed from sizer row after a column is hidden', async () => {
+        await scrollHorizontally(-100);
+        columns[4].hidden = true;
+
+        await nextFrame();
+
+        const sizerCellsCount = grid.$.sizer.querySelectorAll('td').length;
+        expect(sizerCellsCount).to.equal(columns.length - 1);
+      });
+
+      it('should have the same amount of visible columns after a column is hidden', async () => {
+        let columnsInViewport = columns.filter((column) => !column.hidden && isColumnInViewport(column));
+        const isCellsInViewportVisibleBefore = columnsInViewport.every(
+          (col) => !isBodyCellContentHidden(columns.indexOf(col)),
+        );
+        columns[7].hidden = true;
+        await scrollHorizontally(-100);
+        await nextFrame();
+
+        columnsInViewport = columns.filter((column) => !column.hidden && isColumnInViewport(column));
+        const isCellsOnViewportVisible = columnsInViewport.every(
+          (col) => !isBodyCellContentHidden(columns.indexOf(col)),
+        );
+        expect(isCellsOnViewportVisible).to.equal(isCellsInViewportVisibleBefore);
+      });
     });
 
     describe(`keyboard navigation - ${dir}`, () => {


### PR DESCRIPTION
## Description

In some cases, like changing a column's `hidden` state, the `_updateRow` method in `GridMixin` is called. In that scenario, when `columnRendering` is defined as `lazy`, the sizer cells that are not visible in the viewport are not appended to the `caption#sizer` element. When that happens, the logic that checks whether a column is within the viewport or not can not work as expected.

This change ensures that sizer cells are always appended, even for columns that are outside of the viewport.

Fixes #7051

## Type of change

- [X] Bugfix
- [ ] Feature
