### PR TITLE
fix: update all rendered rows on flat size change from page response

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -323,8 +323,8 @@ export const DataProviderMixin = (superClass) =>
     _onDataProviderPageReceived() {
       // If the page response affected the flat size
       if (this._flatSize !== this._dataProviderController.flatSize) {
-        // Schedule all rendered rows to be updated in _debouncerApplyCachedData,
-        // to ensure that all the rows are loaded by the end of the grid loading.
+        // Schedule an update of all rendered rows by _debouncerApplyCachedData,
+        // to ensure that all pages associated with the rendered rows are loaded.
         this._shouldUpdateAllRenderedRowsAfterPageLoad = true;
 
         // TODO: Updating the flat size property can still result in a synchonous virtualizer update

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -330,8 +330,12 @@ export const DataProviderMixin = (superClass) =>
       this._getRenderedRows().forEach((row) => {
         this._dataProviderController.ensureFlatIndexHierarchy(row.index);
         if (flatSizeChanged) {
-          // To avoid excess requests, ensure the index is loaded only if flat size changed
-          this._dataProviderController.ensureFlatIndexLoaded(row.index);
+          const { item } = this._dataProviderController.getFlatIndexContext(row.index);
+          if (!item) {
+            // To avoid excess requests, ensure the index is loaded only if flat size changed
+            this.__updateLoading(row, true);
+            this._dataProviderController.ensureFlatIndexLoaded(row.index);
+          }
         }
       });
 

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -321,12 +321,18 @@ export const DataProviderMixin = (superClass) =>
 
     /** @protected */
     _onDataProviderPageReceived() {
+      const flatSizeChanged = this._dataProviderController.flatSize !== this._flatSize;
       // With the new items added, update the cache size and the grid's effective size
       this._flatSize = this._dataProviderController.flatSize;
 
       // After updating the cache, check if some of the expanded items should have sub-caches loaded
+      // or if some of the rows are missing an item
       this._getRenderedRows().forEach((row) => {
         this._dataProviderController.ensureFlatIndexHierarchy(row.index);
+        if (flatSizeChanged) {
+          // To avoid excess requests, ensure the index is loaded only if flat size changed
+          this._dataProviderController.ensureFlatIndexLoaded(row.index);
+        }
       });
 
       this._hasData = true;

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -321,12 +321,22 @@ export const DataProviderMixin = (superClass) =>
 
     /** @protected */
     _onDataProviderPageReceived() {
+      const flatSizeChanged = this._dataProviderController.flatSize !== this._flatSize;
       // With the new items added, update the cache size and the grid's effective size
       this._flatSize = this._dataProviderController.flatSize;
 
       // After updating the cache, check if some of the expanded items should have sub-caches loaded
+      // or if some of the rows are missing an item
       this._getRenderedRows().forEach((row) => {
         this._dataProviderController.ensureFlatIndexHierarchy(row.index);
+        if (flatSizeChanged) {
+          const { item } = this._dataProviderController.getFlatIndexContext(row.index);
+          if (!item) {
+            // To avoid excess requests, ensure the index is loaded only if flat size changed
+            this.__updateLoading(row, true);
+            this._dataProviderController.ensureFlatIndexLoaded(row.index);
+          }
+        }
       });
 
       this._hasData = true;
@@ -347,17 +357,6 @@ export const DataProviderMixin = (superClass) =>
 
         this.__scrollToPendingIndexes();
         this.__dispatchPendingBodyCellFocus();
-
-        // Move to loadingchanged?
-        this._debounceUnloadedRows = Debouncer.debounce(this._debounceUnloadedRows, timeOut.after(0), () => {
-          const unloadedRenderedRow = this._getRenderedRows().find((row) => {
-            const { item } = this._dataProviderController.getFlatIndexContext(row.index);
-            return !item;
-          });
-          if (unloadedRenderedRow) {
-            this._dataProviderController.ensureFlatIndexLoaded(unloadedRenderedRow.index);
-          }
-        });
       });
 
       // If the grid is not loading anything, flush the debouncer immediately

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -256,7 +256,9 @@ describe('data provider', () => {
       ]);
     });
 
-    it('should not request again when resolving with an empty array', async () => {
+    // TODO: Should we support this use case (resolving with an empty array and expecting grid not to request missing rows (until scrolled to again))?
+    // If so, we could consider flagging these rows explicitly as "__empty" and not requesting them again automatically.
+    it.skip('should not request again when resolving with an empty array', async () => {
       grid.dataProvider = sinon.spy((_params, callback) => callback([], 10));
 
       grid.dataProvider.resetHistory();
@@ -463,13 +465,6 @@ describe('data provider', () => {
 
           setTimeout(() => {
             cb(pageItems, levelSize);
-
-            for (const row of getRows(grid.$.items)) {
-              if (!grid._dataProviderController.getFlatIndexContext(row.index).item) {
-                // Rows that don't have a cached item after the callback resolves should be in loading state
-                expect(row.hasAttribute('loading')).to.be.true;
-              }
-            }
           }, 10);
         };
 

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -256,9 +256,7 @@ describe('data provider', () => {
       ]);
     });
 
-    // TODO: Should we support this use case (resolving with an empty array and expecting grid not to request missing rows (until scrolled to again))?
-    // If so, we could consider flagging these rows explicitly as "__empty" and not requesting them again automatically.
-    it.skip('should not request again when resolving with an empty array', async () => {
+    it('should not request again when resolving with an empty array', async () => {
       grid.dataProvider = sinon.spy((_params, callback) => callback([], 10));
 
       grid.dataProvider.resetHistory();
@@ -465,6 +463,13 @@ describe('data provider', () => {
 
           setTimeout(() => {
             cb(pageItems, levelSize);
+
+            for (const row of getRows(grid.$.items)) {
+              if (!grid._dataProviderController.getFlatIndexContext(row.index).item) {
+                // Rows that don't have a cached item after the callback resolves should be in loading state
+                expect(row.hasAttribute('loading')).to.be.true;
+              }
+            }
           }, 10);
         };
 

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -461,7 +461,16 @@ describe('data provider', () => {
             };
           });
 
-          setTimeout(() => cb(pageItems, levelSize), 0);
+          setTimeout(() => {
+            cb(pageItems, levelSize);
+
+            for (const row of getRows(grid.$.items)) {
+              if (!grid._dataProviderController.getFlatIndexContext(row.index).item) {
+                // Rows that don't have a cached item after the callback resolves should be in loading state
+                expect(row.hasAttribute('loading')).to.be.true;
+              }
+            }
+          }, 10);
         };
 
         const expectedRowContent = ['0', '0-0', '0-0-0', '0-0-1', '0-0-2', '0-0-3', '0-0-4', '0-1', '0-2', '0-3'];

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -13,7 +13,6 @@ export const flushGrid = (grid) => {
     grid._debouncerHiddenChanged,
     grid._debouncerApplyCachedData,
     grid.__debounceUpdateFrozenColumn,
-    grid._debouncerLoadedItems,
   ].forEach((debouncer) => debouncer?.flush());
 
   grid.__virtualizer.flush();

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -13,6 +13,7 @@ export const flushGrid = (grid) => {
     grid._debouncerHiddenChanged,
     grid._debouncerApplyCachedData,
     grid.__debounceUpdateFrozenColumn,
+    grid._debouncerLoadedItems,
   ].forEach((debouncer) => debouncer?.flush());
 
   grid.__virtualizer.flush();


### PR DESCRIPTION
## Description

The PR causes grid to update all rendered rows once it receives a page response that affects the flat size. This guarantees that all pages associated with the rendered rows are loaded.

> [!WARNING]
> It's been decided to wait until https://github.com/vaadin/flow/issues/19006 is fixed, as it's currently causing interference in many scenarios related to the current regression, making it difficult to distinguish the causes.

Fixes https://github.com/vaadin/web-components/issues/7097

## Type of change

Bugfix