### PR TITLE
fix: avoid removing ql-* from HTML content

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -673,7 +673,7 @@ export const RichTextEditorMixin = (superClass) =>
       let content = editor.innerHTML;
 
       // Remove Quill classes, e.g. ql-syntax, except for align
-      content = content.replace(/\s*ql-(?!align)[\w-]*\s*/gu, '');
+      content = content.replace(/(?<=class="[^"]*)ql-(?!align)[\w-]*(?=[^"]*")/gu, '');
       // Remove meta spans, e.g. cursor which are empty after Quill classes removed
       content = content.replace(/<\/?span[^>]*>/gu, '');
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -673,7 +673,12 @@ export const RichTextEditorMixin = (superClass) =>
       let content = editor.innerHTML;
 
       // Remove Quill classes, e.g. ql-syntax, except for align
-      content = content.replace(/(?<=class="[^"]*)ql-(?!align)[\w-]*(?=[^"]*")/gu, '');
+      content = content.replace(/class="([^"]*)"/gu, (match, group1) => {
+        const classes = group1.split(' ').filter((className) => {
+          return !className.startsWith('ql-') || className.startsWith('ql-align');
+        });
+        return `class="${classes.join(' ')}"`;
+      });
       // Remove meta spans, e.g. cursor which are empty after Quill classes removed
       content = content.replace(/<\/?span[^>]*>/gu, '');
 

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -727,6 +727,21 @@ describe('rich text editor', () => {
       expect(rte.htmlValue).to.equal('<h3><em>Foo</em>Bar</h3>');
     });
 
+    it('should filter out ql-* class names', () => {
+      // Modify the editor content directly, as setDangerouslyHtmlValue() strips
+      // classes
+      rte.shadowRoot.querySelector('.ql-editor').innerHTML =
+        '<pre class="ql-syntax foo ql-cursor"><code>console.log("hello")</code></pre>';
+      rte.__updateHtmlValue();
+      expect(rte.htmlValue).to.equal('<pre class=" foo "><code>console.log("hello")</code></pre>');
+    });
+
+    it('should not filter out ql-* in content', () => {
+      rte.dangerouslySetHtmlValue('<p>mysql-driver</p>');
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal('<p>mysql-driver</p>');
+    });
+
     it('should filter out empty span elements from the resulting htmlValue', () => {
       rte.dangerouslySetHtmlValue(
         '<p><strong>Hello </strong></p><p><strong><span class="ql-cursor"></span>world</strong></p>',

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -733,7 +733,7 @@ describe('rich text editor', () => {
       rte.shadowRoot.querySelector('.ql-editor').innerHTML =
         '<pre class="ql-syntax foo ql-cursor"><code>console.log("hello")</code></pre>';
       rte.__updateHtmlValue();
-      expect(rte.htmlValue).to.equal('<pre class=" foo "><code>console.log("hello")</code></pre>');
+      expect(rte.htmlValue).to.equal('<pre class="foo"><code>console.log("hello")</code></pre>');
     });
 
     it('should not filter out ql-* in content', () => {


### PR DESCRIPTION
RTE contains logic to remove Quill-specific CSS classes from the HTML value, however the current logic simply removes any occurence of `ql-*`, even within HTML text content. That means typing something like `mysql-connector-j` gets shortened to `mys`.

This changes the regex to only look for occurences in `class="..."` attributes.

Ideally we could work with the actual DOM (by cloning the editor node) and `classList` here, but that would require some testing regarding the performance impact as this runs on every value change.

Fixes https://github.com/vaadin/web-components/issues/7093