### PR TITLE
fix: implement enter and space handlers instead of button click

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -48,6 +48,7 @@ class MenuBarButton extends Button {
   _onKeyDown(event) {
     this.__triggeredWithActiveKeys = this._activeKeys.includes(event.key);
     super._onKeyDown(event);
+    this.__triggeredWithActiveKeys = null;
   }
 }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -37,20 +37,6 @@ class MenuBarButton extends Button {
   static get is() {
     return 'vaadin-menu-bar-button';
   }
-
-  /**
-   * Override method inherited from `ButtonMixin`. A Space or an Enter key press should not result in a button click for a menu bar button. It also has to focus on the first item in the submenu. These cases are handled in `VaadinMenuBarMixin`.
-   *
-   * @param {KeyboardEvent} event
-   * @protected
-   * @override
-   */
-  _onKeyDown(event) {
-    if (this._activeKeys.includes(event.key)) {
-      return;
-    }
-    super._onKeyDown(event);
-  }
 }
 
 defineCustomElement(MenuBarButton);

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -37,6 +37,20 @@ class MenuBarButton extends Button {
   static get is() {
     return 'vaadin-menu-bar-button';
   }
+
+  /**
+   * Override method inherited from `ButtonMixin`. A Space or an Enter key press should not result in a button click for a menu bar button. It also has to focus on the first item in the submenu. These cases are handled in `VaadinMenuBarMixin`.
+   *
+   * @param {KeyboardEvent} event
+   * @protected
+   * @override
+   */
+  _onKeyDown(event) {
+    if (this._activeKeys.includes(event.key)) {
+      return;
+    }
+    super._onKeyDown(event);
+  }
 }
 
 defineCustomElement(MenuBarButton);

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -39,7 +39,7 @@ class MenuBarButton extends Button {
   }
 
   /**
-   * Override method inherited from `ButtonMixin`. Sets a flag based on whether the key is an active key.
+   * Override method inherited from `ButtonMixin`. Sets a flag based on whether the key is an active key. Unlike a mouse click, Enter and Space should also focus the first item. This flag is used in menu bar to identify the action that triggered the click.
    *
    * @param {KeyboardEvent} event
    * @protected

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -37,6 +37,31 @@ class MenuBarButton extends Button {
   static get is() {
     return 'vaadin-menu-bar-button';
   }
+
+  /**
+   * Override method inherited from `HTMLElement`. Dispatches a `mousedown` event before the click. This allows to communicate the nature of the click to the menu bar. Clicks triggered by Space or an Enter key presses should focus the first item in the submenu. These cases are handled in `VaadinMenuBarMixin`.
+   *
+   * @override
+   */
+  click() {
+    if (!this.__triggeredWithActiveKeys) {
+      window.dispatchEvent(new CustomEvent('mousedown'));
+    }
+    this.__triggeredWithActiveKeys = null;
+    super.click();
+  }
+
+  /**
+   * Override method inherited from `ButtonMixin`. Sets a flag based on whether the key is an active key.
+   *
+   * @param {KeyboardEvent} event
+   * @protected
+   * @override
+   */
+  _onKeyDown(event) {
+    this.__triggeredWithActiveKeys = this._activeKeys.includes(event.key);
+    super._onKeyDown(event);
+  }
 }
 
 defineCustomElement(MenuBarButton);

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -39,19 +39,6 @@ class MenuBarButton extends Button {
   }
 
   /**
-   * Override method inherited from `HTMLElement`. Dispatches a `mousedown` event before the click. This allows to communicate the nature of the click to the menu bar. Clicks triggered by Space or an Enter key presses should focus the first item in the submenu. These cases are handled in `VaadinMenuBarMixin`.
-   *
-   * @override
-   */
-  click() {
-    if (!this.__triggeredWithActiveKeys) {
-      window.dispatchEvent(new CustomEvent('mousedown'));
-    }
-    this.__triggeredWithActiveKeys = null;
-    super.click();
-  }
-
-  /**
    * Override method inherited from `ButtonMixin`. Sets a flag based on whether the key is an active key.
    *
    * @param {KeyboardEvent} event

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -801,7 +801,6 @@ export const MenuBarMixin = (superClass) =>
       if (button) {
         this.__openSubMenu(button, button.__triggeredWithActiveKeys);
       }
-      button.__triggeredWithActiveKeys = null;
     }
 
     /** @private */

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -799,7 +799,7 @@ export const MenuBarMixin = (superClass) =>
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button, e.isTrusted && isKeyboardActive());
+        this.__openSubMenu(button, isKeyboardActive());
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -727,26 +727,6 @@ export const MenuBarMixin = (superClass) =>
     }
 
     /**
-     * Override an event listener from `KeyboardMixin` to open
-     * the sub-menu and focus the first item.
-     *
-     * @param {!KeyboardEvent} event
-     * @protected
-     * @override
-     */
-    _onEnter(event) {
-      this.__handleButtonPressEvent(event, true);
-    }
-
-    /**
-     * @param {!KeyboardEvent} event
-     * @private
-     */
-    _onSpace(event) {
-      this.__handleButtonPressEvent(event, true);
-    }
-
-    /**
      * Override an event listener from `KeyboardMixin`.
      *
      * @param {!KeyboardEvent} event
@@ -760,9 +740,6 @@ export const MenuBarMixin = (superClass) =>
           break;
         case 'ArrowUp':
           this._onArrowUp(event);
-          break;
-        case ' ':
-          this._onSpace(event);
           break;
         default:
           super._onKeyDown(event);
@@ -819,15 +796,10 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     __onButtonClick(e) {
-      this.__handleButtonPressEvent(e, false);
-    }
-
-    /** @private */
-    __handleButtonPressEvent(e, keydown) {
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button, keydown);
+        this.__openSubMenu(button, isKeyboardActive());
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -799,7 +799,7 @@ export const MenuBarMixin = (superClass) =>
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button, isKeyboardActive());
+        this.__openSubMenu(button, e.isTrusted && isKeyboardActive());
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -639,7 +639,7 @@ export const MenuBarMixin = (superClass) =>
       });
 
       if (wasExpanded && item.item && item.item.children) {
-        this.__openSubMenu(item, { keepFocus: true });
+        this.__openSubMenu(item, true, { keepFocus: true });
       } else if (item === this._overflow) {
         this._hideTooltip();
       } else {
@@ -688,7 +688,7 @@ export const MenuBarMixin = (superClass) =>
         // Menu opened previously, focus first item
         this._focusFirstItem();
       } else {
-        this.__openSubMenu(button);
+        this.__openSubMenu(button, true);
       }
     }
 
@@ -705,7 +705,7 @@ export const MenuBarMixin = (superClass) =>
         // Menu opened previously, focus last item
         this._focusLastItem();
       } else {
-        this.__openSubMenu(button, { focusLast: true });
+        this.__openSubMenu(button, true, { focusLast: true });
       }
     }
 
@@ -759,7 +759,7 @@ export const MenuBarMixin = (superClass) =>
       } else if (button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
         if (button.item.children && (this.openOnHover || isOpened)) {
-          this.__openSubMenu(button);
+          this.__openSubMenu(button, false);
         } else if (isOpened) {
           this._close();
         }
@@ -799,12 +799,13 @@ export const MenuBarMixin = (superClass) =>
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button);
+        this.__openSubMenu(button, button.__triggeredWithActiveKeys);
       }
+      button.__triggeredWithActiveKeys = null;
     }
 
     /** @private */
-    __openSubMenu(button, options = {}) {
+    __openSubMenu(button, keydown, options = {}) {
       const subMenu = this._subMenu;
       const item = button.item;
 
@@ -856,7 +857,7 @@ export const MenuBarMixin = (superClass) =>
           }
 
           // Do not focus item when open not from keyboard
-          if (!isKeyboardActive()) {
+          if (!keydown) {
             overlay.$.overlay.focus();
           }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -727,6 +727,26 @@ export const MenuBarMixin = (superClass) =>
     }
 
     /**
+     * Override an event listener from `KeyboardMixin` to open
+     * the sub-menu and focus the first item.
+     *
+     * @param {!KeyboardEvent} event
+     * @protected
+     * @override
+     */
+    _onEnter(event) {
+      this.__handleButtonPressEvent(event, true);
+    }
+
+    /**
+     * @param {!KeyboardEvent} event
+     * @private
+     */
+    _onSpace(event) {
+      this.__handleButtonPressEvent(event, true);
+    }
+
+    /**
      * Override an event listener from `KeyboardMixin`.
      *
      * @param {!KeyboardEvent} event
@@ -740,6 +760,9 @@ export const MenuBarMixin = (superClass) =>
           break;
         case 'ArrowUp':
           this._onArrowUp(event);
+          break;
+        case ' ':
+          this._onSpace(event);
           break;
         default:
           super._onKeyDown(event);
@@ -796,10 +819,15 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     __onButtonClick(e) {
+      this.__handleButtonPressEvent(e, false);
+    }
+
+    /** @private */
+    __handleButtonPressEvent(e, keydown) {
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button, false);
+        this.__openSubMenu(button, keydown);
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -639,7 +639,7 @@ export const MenuBarMixin = (superClass) =>
       });
 
       if (wasExpanded && item.item && item.item.children) {
-        this.__openSubMenu(item, true, { keepFocus: true });
+        this.__openSubMenu(item, { keepFocus: true });
       } else if (item === this._overflow) {
         this._hideTooltip();
       } else {
@@ -688,7 +688,7 @@ export const MenuBarMixin = (superClass) =>
         // Menu opened previously, focus first item
         this._focusFirstItem();
       } else {
-        this.__openSubMenu(button, true);
+        this.__openSubMenu(button);
       }
     }
 
@@ -705,7 +705,7 @@ export const MenuBarMixin = (superClass) =>
         // Menu opened previously, focus last item
         this._focusLastItem();
       } else {
-        this.__openSubMenu(button, true, { focusLast: true });
+        this.__openSubMenu(button, { focusLast: true });
       }
     }
 
@@ -759,7 +759,7 @@ export const MenuBarMixin = (superClass) =>
       } else if (button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
         if (button.item.children && (this.openOnHover || isOpened)) {
-          this.__openSubMenu(button, false);
+          this.__openSubMenu(button);
         } else if (isOpened) {
           this._close();
         }
@@ -799,12 +799,12 @@ export const MenuBarMixin = (superClass) =>
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button, isKeyboardActive());
+        this.__openSubMenu(button);
       }
     }
 
     /** @private */
-    __openSubMenu(button, keydown, options = {}) {
+    __openSubMenu(button, options = {}) {
       const subMenu = this._subMenu;
       const item = button.item;
 
@@ -856,7 +856,7 @@ export const MenuBarMixin = (superClass) =>
           }
 
           // Do not focus item when open not from keyboard
-          if (!keydown) {
+          if (!isKeyboardActive()) {
             overlay.$.overlay.focus();
           }
 

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -5,12 +5,14 @@ import {
   arrowRight,
   arrowUp,
   click,
+  enter,
   esc,
   fire,
   fixtureSync,
   isDesktopSafari as isSafari,
   nextRender,
   oneEvent,
+  space,
   touchend,
   touchstart,
 } from '@vaadin/testing-helpers';
@@ -123,6 +125,20 @@ describe('sub-menu', () => {
     const spy = sinon.spy(item, 'focus');
     await nextRender(subMenu);
     expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should focus the first item on button space', async () => {
+    space(buttons[0]);
+    await nextRender(subMenu);
+    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    expect(item.hasAttribute('focused')).to.be.true;
+  });
+
+  it('should focus the first item on button enter', async () => {
+    enter(buttons[0]);
+    await nextRender(subMenu);
+    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    expect(item.hasAttribute('focused')).to.be.true;
   });
 
   it('should open sub-menu and focus last item on arrow up', async () => {


### PR DESCRIPTION
## Description

In a Menu Bar Button, an Enter or Space key press is handled in the same way as a click. This behaviour is inherited from Button. The expected click behaviour (just opening the submenu) does not fit the Enter and Space key presses, since the first submenu item is not focused. 

This PR overrides `_onKeyDown` Menu Bar Button to leave the handling of Enter and Space (the default active keys for a button) to Menu Bar. This way, the behaviour can be customized to also focus on the first item.

Fixes #4861 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.