### PR TITLE
fix: show focus ring for items on mobile

### DIFF
--- a/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-item-styles.js
@@ -13,10 +13,8 @@ const comboBoxItem = css`
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
   }
 
-  @media (any-hover: hover) {
-    :host([focused]:not([disabled])) {
-      box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
-    }
+  :host([focused]:not([disabled])) {
+    box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
   }
 `;
 

--- a/packages/item/theme/lumo/vaadin-item-styles.js
+++ b/packages/item/theme/lumo/vaadin-item-styles.js
@@ -70,10 +70,10 @@ const item = css`
     :host(:hover:not([disabled])) {
       background-color: var(--lumo-primary-color-10pct);
     }
+  }
 
-    :host([focus-ring]:not([disabled])) {
-      box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
-    }
+  :host([focus-ring]:not([disabled])) {
+    box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
   }
 
   /* RTL specific styles */

--- a/packages/item/theme/material/vaadin-item-styles.js
+++ b/packages/item/theme/material/vaadin-item-styles.js
@@ -44,10 +44,10 @@ const item = css`
     :host(:hover:not([disabled])) {
       background-color: var(--material-secondary-background-color);
     }
+  }
 
-    :host([focused]:not([disabled])) {
-      background-color: var(--material-divider-color);
-    }
+  :host([focused]:not([disabled])) {
+    background-color: var(--material-divider-color);
   }
 
   /* Disabled */


### PR DESCRIPTION
## Description

Show focus ring for items on mobile devices. `vaadin-item` and `vaadin-combo-box-item` were the only two instances where the focus ring was not applied due to a media query, for other components the focus ring is already visible on mobile devices as well when using keyboard navigation.

Fixes #7056

## Type of change

- Bugfix