### PR TITLE
fix: make sure virtualizer has next focusable element

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -139,6 +139,7 @@ export const ComboBoxScrollerMixin = (superClass) =>
         elementsContainer: this,
         scrollTarget: this,
         scrollContainer: this.$.selector,
+        reorderElements: true,
       });
     }
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -55,7 +55,7 @@ export class IronListAdapter {
     this._scrollLineHeight = this._getScrollLineHeight();
     this.scrollTarget.addEventListener('wheel', (e) => this.__onWheel(e));
 
-    this.scrollTarget.addEventListener('virtualizer-element-focused', (e) => this.__elementFocused(e));
+    this.scrollTarget.addEventListener('virtualizer-element-focused', (e) => this.__onElementFocused(e));
     this.elementsContainer.addEventListener('focusin', (e) => {
       this.scrollTarget.dispatchEvent(
         new CustomEvent('virtualizer-element-focused', { detail: { element: this.__getFocusedElement() } }),
@@ -462,14 +462,12 @@ export class IronListAdapter {
   }
 
   /** @private */
-  __elementFocused(e) {
+  __onElementFocused(e) {
     if (!this.reorderElements) {
       return;
     }
 
-    const visibleElements = this.__getVisibleElements();
     const focusedElement = e.detail.element;
-
     if (!focusedElement) {
       return;
     }
@@ -478,6 +476,7 @@ export class IronListAdapter {
     // Check if a next or previous focusable sibling is missing while it should be there (so the user can continue tabbing).
     // The focusable sibling might be missing due to the elements not yet being in the correct DOM order.
     // First try flushing (which also flushes any active __scrollReorderDebouncer).
+    const visibleElements = this.__getVisibleElements();
     if (
       this.__previousFocusableSiblingMissing(focusedElement, visibleElements) ||
       this.__nextFocusableSiblingMissing(focusedElement, visibleElements)
@@ -487,7 +486,7 @@ export class IronListAdapter {
 
     // If the focusable sibling is still missing (because the focused element is at the edge of the viewport and
     // the virtual scrolling logic hasn't had the need to recycle elements), scroll the virtualizer just enough to
-    // have the focusable sibling inside the visible viewport to force the virtualizer to recycle elements.
+    // have the focusable sibling inside the visible viewport to force the virtualizer to recycle.
     const reorderedVisibleElements = this.__getVisibleElements();
     if (this.__nextFocusableSiblingMissing(focusedElement, reorderedVisibleElements)) {
       this._scrollTop +=

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -54,7 +54,13 @@ export class IronListAdapter {
 
     this._scrollLineHeight = this._getScrollLineHeight();
     this.scrollTarget.addEventListener('wheel', (e) => this.__onWheel(e));
-    this.elementsContainer.addEventListener('focusin', () => this.__onFocusIn());
+
+    this.scrollTarget.addEventListener('virtualizer-element-focused', (e) => this.__elementFocused(e));
+    this.elementsContainer.addEventListener('focusin', (e) => {
+      this.scrollTarget.dispatchEvent(
+        new CustomEvent('virtualizer-element-focused', { detail: { element: this.__getFocusedElement() } }),
+      );
+    });
 
     if (this.reorderElements) {
       // Reordering the physical elements cancels the user's grab of the scroll bar handle on Safari.
@@ -427,7 +433,7 @@ export class IronListAdapter {
   toggleScrollListener() {}
 
   /** @private */
-  __getFocusedElement(visibleElements) {
+  __getFocusedElement(visibleElements = this.__getVisibleElements()) {
     return visibleElements.find(
       (element) =>
         element.contains(this.elementsContainer.getRootNode().activeElement) ||
@@ -456,13 +462,13 @@ export class IronListAdapter {
   }
 
   /** @private */
-  __onFocusIn() {
+  __elementFocused(e) {
     if (!this.reorderElements) {
       return;
     }
 
     const visibleElements = this.__getVisibleElements();
-    const focusedElement = this.__getFocusedElement(visibleElements);
+    const focusedElement = e.detail.element;
 
     if (!focusedElement) {
       return;

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -124,15 +124,17 @@ export const ScrollMixin = (superClass) =>
         const itemsIndex = e.composedPath().indexOf(this.$.items);
         this._rowWithFocusedElement = e.composedPath()[itemsIndex - 1];
 
-        // Make sure the row with the focused element is fully inside the visible viewport
-        this.__scrollIntoViewport(this._rowWithFocusedElement.index);
+        if (this._rowWithFocusedElement) {
+          // Make sure the row with the focused element is fully inside the visible viewport
+          this.__scrollIntoViewport(this._rowWithFocusedElement.index);
 
-        if (this._rowWithFocusedElement && !this.$.table.contains(e.relatedTarget)) {
-          // Virtualizer can't catch the event because if orginates from the light DOM.
-          // Dispatch a virtualizer-element-focused event for virtualizer to catch.
-          this.$.table.dispatchEvent(
-            new CustomEvent('virtualizer-element-focused', { detail: { element: this._rowWithFocusedElement } }),
-          );
+          if (!this.$.table.contains(e.relatedTarget)) {
+            // Virtualizer can't catch the event because if orginates from the light DOM.
+            // Dispatch a virtualizer-element-focused event for virtualizer to catch.
+            this.$.table.dispatchEvent(
+              new CustomEvent('virtualizer-element-focused', { detail: { element: this._rowWithFocusedElement } }),
+            );
+          }
         }
       });
       this.$.items.addEventListener('focusout', () => {

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -129,7 +129,7 @@ export const ScrollMixin = (superClass) =>
 
         if (this._rowWithFocusedElement && !this.$.table.contains(e.relatedTarget)) {
           // Virtualizer can't catch the event because if orginates from the light DOM.
-          // Dispatch a virtualizer-element-focused event for virtualizer to catch
+          // Dispatch a virtualizer-element-focused event for virtualizer to catch.
           this.$.table.dispatchEvent(
             new CustomEvent('virtualizer-element-focused', { detail: { element: this._rowWithFocusedElement } }),
           );

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -123,6 +123,17 @@ export const ScrollMixin = (superClass) =>
       this.$.items.addEventListener('focusin', (e) => {
         const itemsIndex = e.composedPath().indexOf(this.$.items);
         this._rowWithFocusedElement = e.composedPath()[itemsIndex - 1];
+
+        // Make sure the row with the focused element is fully inside the visible viewport
+        this.__scrollIntoViewport(this._rowWithFocusedElement.index);
+
+        if (this._rowWithFocusedElement && !this.$.table.contains(e.relatedTarget)) {
+          // Virtualizer can't catch the event because if orginates from the light DOM.
+          // Dispatch a virtualizer-element-focused event for virtualizer to catch
+          this.$.table.dispatchEvent(
+            new CustomEvent('virtualizer-element-focused', { detail: { element: this._rowWithFocusedElement } }),
+          );
+        }
       });
       this.$.items.addEventListener('focusout', () => {
         this._rowWithFocusedElement = undefined;

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -175,6 +175,10 @@ function getFocusedCellIndex() {
 
 function getFocusedRowIndex() {
   const focusedRow = grid.shadowRoot.activeElement.parentNode;
+  if (grid.$.items.contains(focusedRow)) {
+    // If the focusedRow is a body row, we musn't rely on its DOM position within its parent
+    return focusedRow.index;
+  }
   return Array.from(focusedRow.parentNode.children).indexOf(focusedRow);
 }
 

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -73,6 +73,7 @@ export const VirtualListMixin = (superClass) =>
         elementsContainer: this,
         scrollTarget: this,
         scrollContainer: this.shadowRoot.querySelector('#items'),
+        reorderElements: true,
       });
 
       this.__overflowController = new OverflowController(this);


### PR DESCRIPTION
## Description

As suggested in https://github.com/vaadin/web-components/issues/4280#issuecomment-1923607349, this PR enhances virtualizer to make sure the next/previous element is synchronously available when navigating the items with keyboard (tabbing focusable content).

For example. the buttons in the following example can be tabbed through after the change:
```html
<script type="module">
  import '@vaadin/virtual-list';

  const items = Array.from({ length: 100 }).map((_, i) => {
    return { label: `Item ${i}` };
  });

  const renderer = (root, _, { item }) => {
    root.innerHTML = `<button>${item.label}</button>`;
  };

  const list = document.querySelector('vaadin-virtual-list');
  list.items = items;
  list.renderer = renderer;
</script>

<vaadin-virtual-list style="height: 200px"></vaadin-virtual-list>
```

https://github.com/vaadin/web-components/assets/1222264/96765bb0-d05a-4eb7-b444-96ded82f0b7a

Since the virtualizer can't listen to "focusin" events inside the grid's light DOM, some additional logic was added to the grid to inform the virtualizer when body row cell content has been focused to support tabbing through the grid content on interaction mode:

https://github.com/vaadin/web-components/assets/1222264/d98559c9-7ce7-4790-b7e3-47e3bf7ba6f7


As mentioned [here](https://stackoverflow.com/questions/31006404/accessibility-android-talkback-doesnt-fire-focus-event-on-html-content/31034495#31034495), "accessibility focus" is only tracked by AT and doesn't produce any DOM event for virtualizer to react to, so fully fixing the issue for screen readers might not be doable. At least on Android Talkback, this PR doesn't seem to fix the original issue.

Part of https://github.com/vaadin/web-components/issues/4280

## Type of change

Bugfix