### PR TITLE
fix: prevent overflowing icon from clipping

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -96,6 +96,8 @@ class Icon extends ThemableMixin(ElementMixin(ControllerMixin(SlotStylesMixin(Ic
           display: block;
           width: 100%;
           height: 100%;
+          /* prevent overflowing icon from clipping, see https://github.com/vaadin/flow-components/issues/5872 */
+          overflow: visible;
         }
 
         :host(:is([icon-class], [font-icon-content])) svg {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5872

Didn't find a better way to address the issue than applying `overflow: visible` on the `<vaadin-icon>`'s `svg` element as also suggested in the issue comments.

The clipping doesn't occur on MacBook retina display but it's visible on my external one with the following:

```html
<vaadin-icon icon="vaadin:adjust" style="padding: 0.1em"></vaadin-icon>
```

![Screenshot 2024-02-07 at 16 03 04](https://github.com/vaadin/web-components/assets/1222264/2f1585cc-12a9-4da9-b8b0-0347dd7c222f)

Unfortunately, the clipping doesn't show when running visual tests on SauceLabs either so there's no test attached to this PR, but I added a code comment linking to the original issue.

## Type of change

Bugfix