### PR TITLE
feat: add side-nav router integration API

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -189,12 +189,14 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
     this.__updateCurrent();
 
     window.addEventListener('popstate', this.__boundUpdateCurrent);
+    window.addEventListener('side-nav-location-changed', this.__boundUpdateCurrent);
   }
 
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('popstate', this.__boundUpdateCurrent);
+    window.removeEventListener('side-nav-location-changed', this.__boundUpdateCurrent);
   }
 
   /** @protected */

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -7,6 +7,7 @@ import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { SideNavChildrenMixin, type SideNavI18n } from './vaadin-side-nav-children-mixin.js';
+import type { SideNavItem } from './vaadin-side-nav-item.js';
 
 export type { SideNavI18n };
 
@@ -20,6 +21,15 @@ export interface SideNavCustomEventMap {
 }
 
 export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
+
+export type OnNavigateProps = {
+  path: SideNavItem['path'];
+  target: SideNavItem['target'];
+  current: SideNavItem['current'];
+  expanded: SideNavItem['expanded'];
+  pathAliases: SideNavItem['pathAliases'];
+  originalEvent: MouseEvent;
+};
 
 /**
  * `<vaadin-side-nav>` is a Web Component for navigation menus.
@@ -82,6 +92,38 @@ declare class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(Thema
    * Whether the side nav is collapsed. When collapsed, the items are hidden.
    */
   collapsed: boolean;
+
+  /**
+   * Callback function for router integration.
+   *
+   * When a side nav item link is clicked, this function is called and the default click action is cancelled.
+   * This delegates the responsibility of navigation to the function's logic.
+   *
+   * The click event is not cancelled in the following cases:
+   * - The click event has a modifier (e.g. `metaKey`, `shiftKey`)
+   * - The click event is on an external link
+   * - The click event is on a link with `target="_blank"`
+   * - The function explicitly returns `false`
+   *
+   * The function receives an object with the properties of the clicked side-nav item:
+   * - `path`: The path of the navigation item.
+   * - `target`: The target of the navigation item.
+   * - `current`: A boolean indicating whether the navigation item is currently selected.
+   * - `expanded`: A boolean indicating whether the navigation item is expanded.
+   * - `pathAliases`: An array of path aliases for the navigation item.
+   * - `originalEvent`: The original DOM event that triggered the navigation.
+   *
+   * Also see the `location` property for updating the highlighted navigation item on route change.
+   */
+  onNavigate?: ((event: OnNavigateProps) => boolean) | ((event: OnNavigateProps) => void);
+
+  /**
+   * The current route of the application.
+   *
+   * This property should be kept in sync with the application's state. While it usually reflects the browser's URL,
+   * it can be set to any value. Changes to `location` update the highlighted item in the side navigation.
+   */
+  location: any;
 
   addEventListener<K extends keyof SideNavEventMap>(
     type: K,

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -118,10 +118,12 @@ declare class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(Thema
   onNavigate?: ((event: NavigateEvent) => boolean) | ((event: NavigateEvent) => void);
 
   /**
-   * The current route of the application.
+   * A change to this property triggers an update of the highlighted item in the side navigation. While it typically
+   * corresponds to the browser's URL, the specific value assigned to the property is irrelevant. The component has
+   * its own internal logic for determining which item is highlighted.
    *
-   * This property should be kept in sync with the application's state. While it usually reflects the browser's URL,
-   * it can be set to any value. Changes to `location` update the highlighted item in the side navigation.
+   * The main use case for this property is when the side navigation is used with a client-side router. In this case,
+   * the component needs to be informed about route changes so it can update the highlighted item.
    */
   location: any;
 

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -22,7 +22,7 @@ export interface SideNavCustomEventMap {
 
 export type SideNavEventMap = HTMLElementEventMap & SideNavCustomEventMap;
 
-export type OnNavigateProps = {
+export type NavigateEvent = {
   path: SideNavItem['path'];
   target: SideNavItem['target'];
   current: SideNavItem['current'];
@@ -99,7 +99,7 @@ declare class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(Thema
    * When a side nav item link is clicked, this function is called and the default click action is cancelled.
    * This delegates the responsibility of navigation to the function's logic.
    *
-   * The click event is not cancelled in the following cases:
+   * The click event action is not cancelled in the following cases:
    * - The click event has a modifier (e.g. `metaKey`, `shiftKey`)
    * - The click event is on an external link
    * - The click event is on a link with `target="_blank"`
@@ -115,7 +115,7 @@ declare class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(Thema
    *
    * Also see the `location` property for updating the highlighted navigation item on route change.
    */
-  onNavigate?: ((event: OnNavigateProps) => boolean) | ((event: OnNavigateProps) => void);
+  onNavigate?: ((event: NavigateEvent) => boolean) | ((event: NavigateEvent) => void);
 
   /**
    * The current route of the application.

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -264,6 +264,7 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
 
     const hasModifier = e.metaKey || e.shiftKey;
     if (hasModifier) {
+      // Allow default action for clicks with modifiers
       return;
     }
 
@@ -271,18 +272,22 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
     const item = composedPath.find((el) => el instanceof SideNavItem);
     const anchor = composedPath.find((el) => el instanceof HTMLAnchorElement);
     if (!item || !anchor) {
+      // Not a click on a side-nav-item anchor
       return;
     }
 
     const isRelative = anchor.href && anchor.href.startsWith(location.origin);
     if (!isRelative) {
+      // Allow default action for external links
       return;
     }
 
     if (item.target === '_blank') {
+      // Allow default action for links with target="_blank"
       return;
     }
 
+    // Call the onNavigate callback
     const result = this.onNavigate({
       path: item.path,
       target: item.target,
@@ -293,6 +298,7 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
     });
 
     if (result !== false) {
+      // Cancel the default action if the callback didn't return false
       e.preventDefault();
     }
   }

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -264,7 +264,6 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
 
     const hasModifier = e.metaKey || e.shiftKey;
     if (hasModifier) {
-      // TODO: Is this a good default?
       return;
     }
 
@@ -277,12 +276,10 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
 
     const isRelative = anchor.href && anchor.href.startsWith(location.origin);
     if (!isRelative) {
-      // TODO: Is this a good default?
       return;
     }
 
     if (item.target === '_blank') {
-      // TODO: Is this a good default?
       return;
     }
 

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -108,6 +108,11 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
       onNavigate: {
         type: Function,
       },
+
+      location: {
+        type: Object,
+        observer: '__locationChanged',
+      },
     };
   }
 
@@ -210,6 +215,11 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
   }
 
   /** @private */
+  __locationChanged() {
+    window.dispatchEvent(new CustomEvent('side-nav-location-changed'));
+  }
+
+  /** @private */
   __toggleCollapsed() {
     this.collapsed = !this.collapsed;
   }
@@ -256,13 +266,6 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
     if (result !== false) {
       e.preventDefault();
     }
-  }
-
-  /**
-   * Helper static method that dispatches a `side-nav-location-changed` event
-   */
-  static dispatchLocationChangedEvent() {
-    window.dispatchEvent(new CustomEvent('side-nav-location-changed'));
   }
 }
 

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -133,10 +133,12 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
       },
 
       /**
-       * The current route of the application.
+       * A change to this property triggers an update of the highlighted item in the side navigation. While it typically
+       * corresponds to the browser's URL, the specific value assigned to the property is irrelevant. The component has
+       * its own internal logic for determining which item is highlighted.
        *
-       * This property should be kept in sync with the application's state. While it usually reflects the browser's URL,
-       * it can be set to any value. Changes to `location` update the highlighted item in the side navigation.
+       * The main use case for this property is when the side navigation is used with a client-side router. In this case,
+       * the component needs to be informed about route changes so it can update the highlighted item.
        *
        * @type {any}
        */

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -12,7 +12,6 @@ import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js'
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { sideNavBaseStyles } from './vaadin-side-nav-base-styles.js';
 import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
-import { SideNavItem } from './vaadin-side-nav-item.js';
 
 /**
  * `<vaadin-side-nav>` is a Web Component for navigation menus.
@@ -268,7 +267,7 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
     }
 
     const composedPath = e.composedPath();
-    const item = composedPath.find((el) => el instanceof SideNavItem);
+    const item = composedPath.find((el) => el.localName && el.localName.includes('side-nav-item'));
     const anchor = composedPath.find((el) => el instanceof HTMLAnchorElement);
     if (!item || !item.shadowRoot.contains(anchor)) {
       // Not a click on a side-nav-item anchor

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -271,7 +271,7 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
     const composedPath = e.composedPath();
     const item = composedPath.find((el) => el instanceof SideNavItem);
     const anchor = composedPath.find((el) => el instanceof HTMLAnchorElement);
-    if (!item || !anchor) {
+    if (!item || !item.shadowRoot.contains(anchor)) {
       // Not a click on a side-nav-item anchor
       return;
     }

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -105,10 +105,42 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
         reflectToAttribute: true,
       },
 
+      /**
+       * Callback function for router integration.
+       *
+       * When a side nav item link is clicked, this function is called and the default click action is cancelled.
+       * This delegates the responsibility of navigation to the function's logic.
+       *
+       * The click event is not cancelled in the following cases:
+       * - The click event has a modifier (e.g. `metaKey`, `shiftKey`)
+       * - The click event is on an external link
+       * - The click event is on a link with `target="_blank"`
+       * - The function explicitly returns `false`
+       *
+       * The function receives an object with the properties of the clicked side-nav item:
+       * - `path`: The path of the navigation item.
+       * - `target`: The target of the navigation item.
+       * - `current`: A boolean indicating whether the navigation item is currently selected.
+       * - `expanded`: A boolean indicating whether the navigation item is expanded.
+       * - `pathAliases`: An array of path aliases for the navigation item.
+       * - `originalEvent`: The original DOM event that triggered the navigation.
+       *
+       * Also see the `location` property for updating the highlighted navigation item on route change.
+       *
+       * @type {function(Object): boolean | undefined}
+       */
       onNavigate: {
-        type: Function,
+        attribute: false,
       },
 
+      /**
+       * The current route of the application.
+       *
+       * This property should be kept in sync with the application's state. While it usually reflects the browser's URL,
+       * it can be set to any value. Changes to `location` update the highlighted item in the side navigation.
+       *
+       * @type {Object}
+       */
       location: {
         type: Object,
         observer: '__locationChanged',

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -111,7 +111,7 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
        * When a side nav item link is clicked, this function is called and the default click action is cancelled.
        * This delegates the responsibility of navigation to the function's logic.
        *
-       * The click event is not cancelled in the following cases:
+       * The click event action is not cancelled in the following cases:
        * - The click event has a modifier (e.g. `metaKey`, `shiftKey`)
        * - The click event is on an external link
        * - The click event is on a link with `target="_blank"`
@@ -139,10 +139,9 @@ class SideNav extends SideNavChildrenMixin(FocusMixin(ElementMixin(ThemableMixin
        * This property should be kept in sync with the application's state. While it usually reflects the browser's URL,
        * it can be set to any value. Changes to `location` update the highlighted item in the side navigation.
        *
-       * @type {Object}
+       * @type {any}
        */
       location: {
-        type: Object,
         observer: '__locationChanged',
       },
     };

--- a/packages/side-nav/test/navigation-callback.test.js
+++ b/packages/side-nav/test/navigation-callback.test.js
@@ -1,0 +1,99 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-side-nav-item.js';
+import '../vaadin-side-nav.js';
+
+describe('navigation callback', () => {
+  let sideNav, sideNavItem;
+
+  function clickItemLink(item, props = {}) {
+    const itemLink = item.shadowRoot.querySelector('a');
+    const event = new MouseEvent('click', { bubbles: true, composed: true, cancelable: true, ...props });
+    itemLink.dispatchEvent(event);
+    return event;
+  }
+
+  beforeEach(async () => {
+    sideNav = fixtureSync(`
+      <vaadin-side-nav>
+        <span slot="label">Main menu</span>
+        <vaadin-side-nav-item path="/foobar">Item</vaadin-side-nav-item>
+      </vaadin-side-nav>
+    `);
+
+    sideNav.addEventListener('click', (e) => {
+      const { defaultPrevented } = e;
+      // Prevent the tests from navigating away
+      e.preventDefault();
+      // Restore the defaultPrevented property
+      Object.defineProperty(e, 'defaultPrevented', { value: defaultPrevented });
+    });
+
+    sideNav.onNavigate = sinon.spy();
+
+    await nextRender();
+    sideNavItem = sideNav.querySelector('vaadin-side-nav-item');
+  });
+
+  it('should cancel the click event', () => {
+    const clickEvent = clickItemLink(sideNavItem);
+    expect(clickEvent.defaultPrevented).to.be.true;
+  });
+
+  it('should not cancel the click event on meta key + click', () => {
+    const clickEvent = clickItemLink(sideNavItem, { metaKey: true });
+    expect(clickEvent.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel the click event on shift key + click', () => {
+    const clickEvent = clickItemLink(sideNavItem, { shiftKey: true });
+    expect(clickEvent.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel the click event for external link', async () => {
+    sideNavItem.path = 'https://vaadin.com';
+    await nextRender();
+    const clickEvent = clickItemLink(sideNavItem);
+    expect(clickEvent.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel the click event if callback is not defined', () => {
+    sideNav.onNavigate = undefined;
+    const clickEvent = clickItemLink(sideNavItem);
+    expect(clickEvent.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel the click event if callback returns false', () => {
+    sideNav.onNavigate = () => false;
+    const clickEvent = clickItemLink(sideNavItem);
+    expect(clickEvent.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel the click event if target is _blank', () => {
+    sideNavItem.target = '_blank';
+    const clickEvent = clickItemLink(sideNavItem);
+    expect(clickEvent.defaultPrevented).to.be.false;
+  });
+
+  it('should pass correct properties to the callback', () => {
+    const clickEvent = clickItemLink(sideNavItem);
+
+    expect(sideNav.onNavigate.calledOnce).to.be.true;
+    const callbackArguments = sideNav.onNavigate.firstCall.args;
+    expect(callbackArguments).to.eql([
+      {
+        path: '/foobar',
+        target: undefined,
+        current: false,
+        expanded: false,
+        pathAliases: [],
+        originalEvent: clickEvent,
+      },
+    ]);
+  });
+
+  it('should not throw on label click', () => {
+    expect(() => sideNav.shadowRoot.querySelector('[part="label"]').click()).to.not.throw();
+  });
+});

--- a/packages/side-nav/test/navigation-callback.test.js
+++ b/packages/side-nav/test/navigation-callback.test.js
@@ -17,8 +17,12 @@ describe('navigation callback', () => {
   beforeEach(async () => {
     sideNav = fixtureSync(`
       <vaadin-side-nav>
-        <span slot="label">Main menu</span>
-        <vaadin-side-nav-item path="/foobar">Item</vaadin-side-nav-item>
+        <a slot="label" href="/home">Home</a>
+
+        <vaadin-side-nav-item path="/foo">
+          foo
+          <vaadin-side-nav-item slot="children" path="/bar">bar</vaadin-side-nav-item>
+        </vaadin-side-nav-item>
       </vaadin-side-nav>
     `);
 
@@ -76,6 +80,26 @@ describe('navigation callback', () => {
     expect(clickEvent.defaultPrevented).to.be.false;
   });
 
+  it('should not cancel label click event', () => {
+    const event = new MouseEvent('click', { bubbles: true, composed: true, cancelable: true });
+    const label = sideNav.querySelector('[slot="label"]');
+    expect(() => label.dispatchEvent(event)).to.not.throw();
+    expect(event.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel toggle click event', () => {
+    const event = new MouseEvent('click', { bubbles: true, composed: true, cancelable: true });
+    const toggle = sideNavItem.shadowRoot.querySelector('button');
+    expect(() => toggle.dispatchEvent(event)).to.not.throw();
+    expect(event.defaultPrevented).to.be.false;
+  });
+
+  it('should not cancel item click event', () => {
+    const event = new MouseEvent('click', { bubbles: true, composed: true, cancelable: true });
+    expect(() => sideNavItem.dispatchEvent(event)).to.not.throw();
+    expect(event.defaultPrevented).to.be.false;
+  });
+
   it('should pass correct properties to the callback', () => {
     const clickEvent = clickItemLink(sideNavItem);
 
@@ -83,7 +107,7 @@ describe('navigation callback', () => {
     const callbackArguments = sideNav.onNavigate.firstCall.args;
     expect(callbackArguments).to.eql([
       {
-        path: '/foobar',
+        path: '/foo',
         target: undefined,
         current: false,
         expanded: false,
@@ -91,9 +115,5 @@ describe('navigation callback', () => {
         originalEvent: clickEvent,
       },
     ]);
-  });
-
-  it('should not throw on label click', () => {
-    expect(() => sideNav.shadowRoot.querySelector('[part="label"]').click()).to.not.throw();
   });
 });

--- a/packages/side-nav/test/navigation.test.js
+++ b/packages/side-nav/test/navigation.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';
-import '../vaadin-side-nav.js';
+import { SideNav } from '../vaadin-side-nav.js';
 
 describe('navigation', () => {
   let sideNav, items;
@@ -59,5 +60,120 @@ describe('navigation', () => {
     navigate('2');
     await nextRender();
     expect(items[1].hasAttribute('expanded')).to.be.true;
+  });
+
+  it('should update current attribute with dispatchLocationChangedEvent', async () => {
+    history.pushState({}, '', '1');
+    SideNav.dispatchLocationChangedEvent();
+
+    await nextRender();
+
+    expect(items[0].hasAttribute('current')).to.be.true;
+    expect(items[1].hasAttribute('current')).to.be.false;
+    expect(items[2].hasAttribute('current')).to.be.false;
+  });
+});
+
+describe('custom item click actions', () => {
+  let sideNav, item, itemLink;
+  let clickListener;
+
+  beforeEach(async () => {
+    const currentURL = location.href;
+    sideNav = fixtureSync(`
+      <vaadin-side-nav>
+        <span slot="label">Main menu</span>
+        <vaadin-side-nav-item path="/foobar">Item</vaadin-side-nav-item>
+      </vaadin-side-nav>
+    `);
+
+    clickListener = sinon.spy();
+    sideNav.addEventListener('click', (e) => {
+      clickListener({
+        defaultPreventedByComponent: e.defaultPrevented,
+        clickEvent: e,
+      });
+
+      // Prevent the tests from navigating away
+      e.preventDefault();
+    });
+
+    sideNav.onNavigate = sinon.spy();
+
+    await nextRender();
+    item = sideNav.querySelector('vaadin-side-nav-item');
+    itemLink = item.shadowRoot.querySelector('a');
+  });
+
+  it('should cancel the click event', () => {
+    itemLink.click();
+    expect(clickListener.calledOnce).to.be.true;
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.true;
+  });
+
+  it('should not cancel the click event on meta key + click', () => {
+    itemLink.dispatchEvent(new MouseEvent('click', { metaKey: true, bubbles: true, composed: true, cancelable: true }));
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.false;
+  });
+
+  it('should not cancel the click event on shift key + click', () => {
+    itemLink.dispatchEvent(
+      new MouseEvent('click', { shiftKey: true, bubbles: true, composed: true, cancelable: true }),
+    );
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.false;
+  });
+
+  it('should not cancel the click event for external link', async () => {
+    item.path = 'https://vaadin.com';
+    await nextRender();
+    itemLink.click();
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.false;
+  });
+
+  it('should not cancel the click event if callback is not defined', () => {
+    sideNav.onNavigate = undefined;
+    itemLink.click();
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.false;
+  });
+
+  it('should not cancel the click event if callback returns false', () => {
+    sideNav.onNavigate = () => false;
+    itemLink.click();
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.false;
+  });
+
+  it('should not cancel the click event if target is _blank', () => {
+    item.target = '_blank';
+    itemLink.click();
+    const { defaultPreventedByComponent } = clickListener.firstCall.firstArg;
+    expect(defaultPreventedByComponent).to.be.false;
+  });
+
+  it('should pass correct properties to the callback', () => {
+    itemLink.click();
+    const { clickEvent } = clickListener.firstCall.firstArg;
+
+    expect(sideNav.onNavigate.calledOnce).to.be.true;
+    const callbackArguments = sideNav.onNavigate.firstCall.args;
+    expect(callbackArguments).to.eql([
+      {
+        path: '/foobar',
+        target: undefined,
+        current: false,
+        expanded: false,
+        pathAliases: [],
+        originalEvent: clickEvent,
+      },
+    ]);
+  });
+
+  it('should not throw on label click', () => {
+    expect(() => sideNav.shadowRoot.querySelector('[part="label"]').click()).to.not.throw();
   });
 });

--- a/packages/side-nav/test/navigation.test.js
+++ b/packages/side-nav/test/navigation.test.js
@@ -62,9 +62,9 @@ describe('navigation', () => {
     expect(items[1].hasAttribute('expanded')).to.be.true;
   });
 
-  it('should update current attribute with dispatchLocationChangedEvent', async () => {
+  it('should update current attribute on location change', async () => {
     history.pushState({}, '', '1');
-    SideNav.dispatchLocationChangedEvent();
+    sideNav.location = '1';
 
     await nextRender();
 

--- a/packages/side-nav/test/navigation.test.js
+++ b/packages/side-nav/test/navigation.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';
-import { SideNav } from '../vaadin-side-nav.js';
+import '../vaadin-side-nav.js';
 
 describe('navigation', () => {
   let sideNav, items;
@@ -63,110 +62,12 @@ describe('navigation', () => {
   });
 
   it('should update current attribute on location change', async () => {
+    expect(items[0].hasAttribute('current')).to.be.false;
+
     history.pushState({}, '', '1');
     sideNav.location = '1';
 
     await nextRender();
-
     expect(items[0].hasAttribute('current')).to.be.true;
-    expect(items[1].hasAttribute('current')).to.be.false;
-    expect(items[2].hasAttribute('current')).to.be.false;
-  });
-});
-
-describe('custom item click actions', () => {
-  let sideNav, sideNavItem;
-  let clickListener;
-
-  function clickItemLink(item, props = {}) {
-    const itemLink = item.shadowRoot.querySelector('a');
-    itemLink.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true, cancelable: true, ...props }));
-  }
-
-  beforeEach(async () => {
-    sideNav = fixtureSync(`
-      <vaadin-side-nav>
-        <span slot="label">Main menu</span>
-        <vaadin-side-nav-item path="/foobar">Item</vaadin-side-nav-item>
-      </vaadin-side-nav>
-    `);
-
-    clickListener = sinon.spy();
-    sideNav.addEventListener('click', clickListener);
-
-    sideNav.onNavigate = sinon.spy();
-
-    await nextRender();
-    sideNavItem = sideNav.querySelector('vaadin-side-nav-item');
-  });
-
-  it('should cancel the click event', () => {
-    clickItemLink(sideNavItem);
-    expect(clickListener.calledOnce).to.be.true;
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.true;
-  });
-
-  it('should not cancel the click event on meta key + click', () => {
-    clickItemLink(sideNavItem, { metaKey: true });
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.false;
-  });
-
-  it('should not cancel the click event on shift key + click', () => {
-    clickItemLink(sideNavItem, { shiftKey: true });
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.false;
-  });
-
-  it('should not cancel the click event for external link', async () => {
-    sideNavItem.path = 'https://vaadin.com';
-    await nextRender();
-    clickItemLink(sideNavItem);
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.false;
-  });
-
-  it('should not cancel the click event if callback is not defined', () => {
-    sideNav.onNavigate = undefined;
-    clickItemLink(sideNavItem);
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.false;
-  });
-
-  it('should not cancel the click event if callback returns false', () => {
-    sideNav.onNavigate = () => false;
-    clickItemLink(sideNavItem);
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.false;
-  });
-
-  it('should not cancel the click event if target is _blank', () => {
-    sideNavItem.target = '_blank';
-    clickItemLink(sideNavItem);
-    const clickEvent = clickListener.firstCall.firstArg;
-    expect(clickEvent.defaultPrevented).to.be.false;
-  });
-
-  it('should pass correct properties to the callback', () => {
-    clickItemLink(sideNavItem);
-    const clickEvent = clickListener.firstCall.firstArg;
-
-    expect(sideNav.onNavigate.calledOnce).to.be.true;
-    const callbackArguments = sideNav.onNavigate.firstCall.args;
-    expect(callbackArguments).to.eql([
-      {
-        path: '/foobar',
-        target: undefined,
-        current: false,
-        expanded: false,
-        pathAliases: [],
-        originalEvent: clickEvent,
-      },
-    ]);
-  });
-
-  it('should not throw on label click', () => {
-    expect(() => sideNav.shadowRoot.querySelector('[part="label"]').click()).to.not.throw();
   });
 });

--- a/packages/side-nav/test/typings/side-nav.types.ts
+++ b/packages/side-nav/test/typings/side-nav.types.ts
@@ -3,7 +3,7 @@ import '../../vaadin-side-nav-item.js';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { SideNav, SideNavCollapsedChangedEvent, SideNavI18n } from '../../src/vaadin-side-nav';
+import type { OnNavigateProps, SideNav, SideNavCollapsedChangedEvent, SideNavI18n } from '../../src/vaadin-side-nav';
 import type { SideNavChildrenMixinClass } from '../../src/vaadin-side-nav-children-mixin.js';
 import type { SideNavItem, SideNavItemExpandedChangedEvent } from '../../src/vaadin-side-nav-item';
 
@@ -26,6 +26,21 @@ sideNav.addEventListener('collapsed-changed', (event) => {
   assertType<SideNavCollapsedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
+
+// Router integration
+sideNav.onNavigate = undefined;
+sideNav.onNavigate = () => false;
+sideNav.onNavigate = (event) => {
+  assertType<OnNavigateProps>(event);
+  assertType<string | null | undefined>(event.path);
+  assertType<string | null | undefined>(event.target);
+  assertType<boolean>(event.current);
+  assertType<boolean>(event.expanded);
+  assertType<string[]>(event.pathAliases);
+  assertType<MouseEvent>(event.originalEvent);
+};
+
+assertType<any>(sideNav.location);
 
 const sideNavItem: SideNavItem = document.createElement('vaadin-side-nav-item');
 

--- a/packages/side-nav/test/typings/side-nav.types.ts
+++ b/packages/side-nav/test/typings/side-nav.types.ts
@@ -3,7 +3,7 @@ import '../../vaadin-side-nav-item.js';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { OnNavigateProps, SideNav, SideNavCollapsedChangedEvent, SideNavI18n } from '../../src/vaadin-side-nav';
+import type { NavigateEvent, SideNav, SideNavCollapsedChangedEvent, SideNavI18n } from '../../src/vaadin-side-nav';
 import type { SideNavChildrenMixinClass } from '../../src/vaadin-side-nav-children-mixin.js';
 import type { SideNavItem, SideNavItemExpandedChangedEvent } from '../../src/vaadin-side-nav-item';
 
@@ -31,7 +31,7 @@ sideNav.addEventListener('collapsed-changed', (event) => {
 sideNav.onNavigate = undefined;
 sideNav.onNavigate = () => false;
 sideNav.onNavigate = (event) => {
-  assertType<OnNavigateProps>(event);
+  assertType<NavigateEvent>(event);
   assertType<string | null | undefined>(event.path);
   assertType<string | null | undefined>(event.target);
   assertType<boolean>(event.current);


### PR DESCRIPTION
## Description

This PR adds `onNavigate` and `location` properties to `<vaadin-side-nav>`. The properties can be used to integrate the component with a client-side router.

Example usage with React router:

```jsx
import { SideNav, SideNavItem } from "@vaadin/react-components";
import { useNavigate, useLocation } from "react-router";

function SideNavigation() {
  const navigate = useNavigate();
  const location = useLocation();

  return (
    <SideNav onNavigate={({ path }) => navigate(path)} location={location}>
      <SideNavItem path="contacts">Contacts</SideNavItem>
      <SideNavItem path="hello">Hello</SideNavItem>
    </SideNav>
  );
}
```

Fixes https://github.com/vaadin/web-components/issues/6468

Note: Once [navigation API](https://caniuse.com/mdn-api_navigation) is available in all supported browsers, we can update `<vaadin-side-nav-item>` to use it and remove the `location` property.

## Type of change

Feature