### PR TITLE
feat!: match query params when determining higlighted items

### DIFF
--- a/packages/component-base/src/url-utils.d.ts
+++ b/packages/component-base/src/url-utils.d.ts
@@ -5,7 +5,10 @@
  */
 
 /**
- * Check if two paths can be resolved as URLs
- * with the same origin and pathname.
+ * Checks if two paths match based on their origin, pathname, and query parameters.
+ *
+ * The function matches an actual path against an expected path to see if they share the same
+ * base origin (like https://example.com), the same path (like /path/to/page), and if the
+ * actual path contains all query parameters from the expected path.
  */
-export declare function matchPaths(path1: string, path2: string): boolean;
+export declare function matchPaths(actual: string, expected: string): boolean;

--- a/packages/component-base/src/url-utils.d.ts
+++ b/packages/component-base/src/url-utils.d.ts
@@ -7,8 +7,9 @@
 /**
  * Checks if two paths match based on their origin, pathname, and query parameters.
  *
- * The function matches an actual path against an expected path to see if they share the same
- * base origin (like https://example.com), the same path (like /path/to/page), and if the
- * actual path contains all query parameters from the expected path.
+ * The function matches an actual URL against an expected URL to see if they share
+ * the same base origin (like https://example.com), the same path (like /path/to/page),
+ * and if the actual URL contains at least all the query parameters with the same values
+ * from the expected URL.
  */
 export declare function matchPaths(actual: string, expected: string): boolean;

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -11,7 +11,7 @@
  * @param {URLSearchParams} expected
  */
 function containsQueryParams(actual, expected) {
-  return [...expected.entries()].every(([key, value]) => actual.has(key, value));
+  return [...expected.entries()].every(([key, value]) => actual.getAll(key).includes(value));
 }
 
 /**

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -5,15 +5,33 @@
  */
 
 /**
- * Check if two paths can be resolved as URLs
- * with the same origin and pathname.
+ * Checks if one set of URL parameters contains all the parameters from another set.
  *
- * @param {string} path1
- * @param {string} path2
+ * @param {URLSearchParams} actual
+ * @param {URLSearchParams} expected
  */
-export function matchPaths(path1, path2) {
+function containsQueryParams(actual, expected) {
+  return [...expected.entries()].every(([key, value]) => actual.has(key, value));
+}
+
+/**
+ * Checks if two paths match based on their origin, pathname, and query parameters.
+ *
+ * The function matches an actual URL against an expected URL to see if they share the same
+ * base origin (like https://example.com), the same path (like /path/to/page), and if the
+ * actual URL contains all query parameters from the expected URL.
+ *
+ * @param {string} actual The actual URL to match.
+ * @param {string} expected The expected URL to match.
+ */
+export function matchPaths(actual, expected) {
   const base = document.baseURI;
-  const url1 = new URL(path1, base);
-  const url2 = new URL(path2, base);
-  return url1.origin === url2.origin && url1.pathname === url2.pathname;
+  const actualUrl = new URL(actual, base);
+  const expectedUrl = new URL(expected, base);
+
+  return (
+    actualUrl.origin === expectedUrl.origin &&
+    actualUrl.pathname === expectedUrl.pathname &&
+    containsQueryParams(actualUrl.searchParams, expectedUrl.searchParams)
+  );
 }

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -5,7 +5,8 @@
  */
 
 /**
- * Checks if one set of URL parameters contains all the parameters from another set.
+ * Checks if one set of URL parameters contains all the parameters
+ * with the same values from another set.
  *
  * @param {URLSearchParams} actual
  * @param {URLSearchParams} expected
@@ -19,9 +20,10 @@ function containsQueryParams(actual, expected) {
 /**
  * Checks if two paths match based on their origin, pathname, and query parameters.
  *
- * The function matches an actual URL against an expected URL to see if they share the same
- * base origin (like https://example.com), the same path (like /path/to/page), and if the
- * actual URL contains all query parameters from the expected URL.
+ * The function matches an actual URL against an expected URL to see if they share
+ * the same base origin (like https://example.com), the same path (like /path/to/page),
+ * and if the actual URL contains at least all the query parameters with the same values
+ * from the expected URL.
  *
  * @param {string} actual The actual URL to match.
  * @param {string} expected The expected URL to match.

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -11,7 +11,9 @@
  * @param {URLSearchParams} expected
  */
 function containsQueryParams(actual, expected) {
-  return [...expected.entries()].every(([key, value]) => actual.getAll(key).includes(value));
+  return [...expected.entries()].every(([key, value]) => {
+    return actual.getAll(key).includes(value);
+  });
 }
 
 /**

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -4,7 +4,17 @@ import { matchPaths } from '../src/url-utils.js';
 
 describe('url-utils', () => {
   describe('matchPaths', () => {
+    let baseUri;
+
     const paths = ['', '/', '/path', 'base/path'];
+
+    beforeEach(() => {
+      baseUri = sinon.stub(document, 'baseURI').value('http://localhost/');
+    });
+
+    afterEach(() => {
+      baseUri.restore();
+    });
 
     it('should return true when paths match', () => {
       paths.forEach((path) => expect(matchPaths(path, path)).to.be.true);
@@ -35,20 +45,68 @@ describe('url-utils', () => {
       });
     });
 
-    describe('base url', () => {
-      let baseUri;
+    it('should use document.baseURI as a base url', () => {
+      baseUri.value('https://vaadin.com/docs/');
+      expect(matchPaths('https://vaadin.com/docs/components', 'components')).to.be.true;
+    });
 
-      beforeEach(() => {
-        baseUri = sinon.stub(document, 'baseURI');
+    describe('query params', () => {
+      it('should return true when query params match', () => {
+        expect(matchPaths('/products', '/products')).to.be.true;
+        expect(matchPaths('/products?c=socks', '/products')).to.be.true;
+        expect(matchPaths('/products?c=pants', '/products')).to.be.true;
+        expect(matchPaths('/products?c=', '/products')).to.be.true;
+        expect(matchPaths('/products?c=socks&item=5', '/products')).to.be.true;
+        expect(matchPaths('/products?item=5&c=socks', '/products')).to.be.true;
+        expect(matchPaths('/products?c=socks&c=pants', '/products')).to.be.true;
+        expect(matchPaths('/products?socks', '/products')).to.be.true;
+        expect(matchPaths('/products?socks=', '/products')).to.be.true;
+
+        expect(matchPaths('/products?c=socks', '/products?c=socks')).to.be.true;
+        expect(matchPaths('/products?c=socks&item=5', '/products?c=socks')).to.be.true;
+        expect(matchPaths('/products?item=5&c=socks', '/products?c=socks')).to.be.true;
+        expect(matchPaths('/products?c=socks&c=pants', '/products?c=socks')).to.be.true;
+
+        expect(matchPaths('/products?c=', '/products?c=')).to.be.true;
+
+        expect(matchPaths('/products?c=socks&c=pants', '/products?c=socks&c=pants')).to.be.true;
+
+        expect(matchPaths('/products?socks', '/products?socks')).to.be.true;
+        expect(matchPaths('/products?socks=', '/products?socks')).to.be.true;
       });
 
-      afterEach(() => {
-        baseUri.restore();
-      });
+      it('should return false when query params do not match', () => {
+        expect(matchPaths('/products', '/products?c=socks')).to.be.false;
+        expect(matchPaths('/products?c=pants', '/products?c=socks')).to.be.false;
+        expect(matchPaths('/products?c=', '/products?c=socks')).to.be.false;
+        expect(matchPaths('/products?socks', '/products?c=socks')).to.be.false;
+        expect(matchPaths('/products?socks=', '/products?c=socks')).to.be.false;
 
-      it('should use document.baseURI as a base url', () => {
-        baseUri.value('https://vaadin.com/docs/');
-        expect(matchPaths('https://vaadin.com/docs/components', 'components')).to.be.true;
+        expect(matchPaths('/products', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?c=socks', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?c=pants', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?c=socks&item=5', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?item=5&c=socks', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?c=socks&c=pants', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?socks', '/products?c=')).to.be.false;
+        expect(matchPaths('/products?socks=', '/products?c=')).to.be.false;
+
+        expect(matchPaths('/products', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?c=socks', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?c=pants', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?c=', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?c=socks&item=5', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?item=5&c=socks', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?socks', '/products?c=socks&c=pants')).to.be.false;
+        expect(matchPaths('/products?socks=', '/products?c=socks&c=pants')).to.be.false;
+
+        expect(matchPaths('/products', '/products?socks')).to.be.false;
+        expect(matchPaths('/products?c=socks', '/products?socks')).to.be.false;
+        expect(matchPaths('/products?c=pants', '/products?socks')).to.be.false;
+        expect(matchPaths('/products?c=', '/products?socks')).to.be.false;
+        expect(matchPaths('/products?c=socks&item=5', '/products?socks')).to.be.false;
+        expect(matchPaths('/products?item=5&c=socks', '/products?socks')).to.be.false;
+        expect(matchPaths('/products?c=socks&c=pants', '/products?socks')).to.be.false;
       });
     });
   });

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -4,16 +4,16 @@ import { matchPaths } from '../src/url-utils.js';
 
 describe('url-utils', () => {
   describe('matchPaths', () => {
-    let baseUri;
+    let documentBaseURI;
 
     const paths = ['', '/', '/path', 'base/path'];
 
     beforeEach(() => {
-      baseUri = sinon.stub(document, 'baseURI').value('http://localhost/');
+      documentBaseURI = sinon.stub(document, 'baseURI').value('http://localhost/');
     });
 
     afterEach(() => {
-      baseUri.restore();
+      documentBaseURI.restore();
     });
 
     it('should return true when paths match', () => {
@@ -46,7 +46,7 @@ describe('url-utils', () => {
     });
 
     it('should use document.baseURI as a base url', () => {
-      baseUri.value('https://vaadin.com/docs/');
+      documentBaseURI.value('https://vaadin.com/docs/');
       expect(matchPaths('https://vaadin.com/docs/components', 'components')).to.be.true;
     });
 

--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -94,9 +94,14 @@ declare class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixi
   expanded: boolean;
 
   /**
-   * Whether the path of the item matches the current path.
-   * Set when the item is appended to DOM or when navigated back
-   * to the page that contains this item using the browser.
+   * Whether the item's path matches the current browser URL.
+   *
+   * A match occurs when both share the same base origin (like https://example.com),
+   * the same path (like /path/to/page), and the browser URL contains all
+   * the query parameters with the same values from the item's path.
+   *
+   * The state is updated when the item is added to the DOM or when the browser
+   * navigates to a new page.
    */
   readonly current: boolean;
 

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -115,9 +115,14 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
       },
 
       /**
-       * Whether the path of the item matches the current path.
-       * Set when the item is appended to DOM or when navigated back
-       * to the page that contains this item using the browser.
+       * Whether the item's path matches the current browser URL.
+       *
+       * A match occurs when both share the same base origin (like https://example.com),
+       * the same path (like /path/to/page), and the browser URL contains at least
+       * all the query parameters with the same values from the item's path.
+       *
+       * The state is updated when the item is added to the DOM or when the browser
+       * navigates to a new page.
        *
        * @type {boolean}
        */

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -271,10 +271,9 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
     if (this.path == null) {
       return false;
     }
-    return (
-      matchPaths(document.location.pathname, this.path) ||
-      this.pathAliases.some((alias) => matchPaths(document.location.pathname, alias))
-    );
+
+    const browserPath = `${document.location.pathname}${document.location.search}`;
+    return matchPaths(browserPath, this.path) || this.pathAliases.some((alias) => matchPaths(browserPath, alias));
   }
 }
 

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -1,11 +1,20 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../../src/vaadin-side-nav-item.js';
 import '@vaadin/icon';
 import '@vaadin/icons';
 
 describe('vaadin-side-nav-item', () => {
-  let sideNavItem;
+  let sideNavItem, baseUri;
+
+  beforeEach(() => {
+    baseUri = sinon.stub(document, 'baseURI').value('http://localhost/');
+  });
+
+  afterEach(() => {
+    baseUri.restore();
+  });
 
   beforeEach(async () => {
     sideNavItem = fixtureSync(

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -6,14 +6,14 @@ import '@vaadin/icon';
 import '@vaadin/icons';
 
 describe('vaadin-side-nav-item', () => {
-  let sideNavItem, baseUri;
+  let sideNavItem, documentBaseURI;
 
   beforeEach(() => {
-    baseUri = sinon.stub(document, 'baseURI').value('http://localhost/');
+    documentBaseURI = sinon.stub(document, 'baseURI').value('http://localhost/');
   });
 
   afterEach(() => {
-    baseUri.restore();
+    documentBaseURI.restore();
   });
 
   beforeEach(async () => {

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -4,7 +4,15 @@ import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';
 
 describe('side-nav-item', () => {
-  let item;
+  let item, baseUri;
+
+  beforeEach(() => {
+    baseUri = sinon.stub(document, 'baseURI').value('http://localhost/');
+  });
+
+  afterEach(() => {
+    baseUri.restore();
+  });
 
   describe('custom element definition', () => {
     let tagName;

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -4,14 +4,14 @@ import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';
 
 describe('side-nav-item', () => {
-  let item, baseUri;
+  let item, documentBaseURI;
 
   beforeEach(() => {
-    baseUri = sinon.stub(document, 'baseURI').value('http://localhost/');
+    documentBaseURI = sinon.stub(document, 'baseURI').value('http://localhost/');
   });
 
   afterEach(() => {
-    baseUri.restore();
+    documentBaseURI.restore();
   });
 
   describe('custom element definition', () => {


### PR DESCRIPTION
## Description

The PR adds new logic to side-nav to match query params when determining highlighted items. A side-nav item is highlighted if the browser URL has the same base origin, the same path, and at least contains all the query parameters from the item's path.

Here is a table that illustrates which browser URLs would match which item URLs with the new logic:

| Item URL ➡️ <br>Browser URL ⬇️ | `/products` | `/products?c=socks` | `/products?c=` | `/products?c=socks&c=pants` | `/products?socks` |
| ---- | ---- | ---- | ---- | ---- | ---- |
| `/products` | ✅ | ❌ | ❌ | ❌ | ❌ |
| `/products?c=socks` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `/products?c=pants` | ✅ | ❌ | ❌ | ❌ | ❌ |
| `/products?c=` | ✅ | ❌ | ✅ | ❌ | ❌ |
| `/products?c=socks&item=5` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `/products?item=5&c=socks` | ✅ | ✅ | ❌ | ❌ | ❌ |
| `/products?c=socks&c=pants` | ✅ | ✅ | ❌ | ✅ | ❌ |
| `/products?socks` | ✅ | ❌ | ❌ | ❌ | ✅ |
| `/products?socks=` | ✅ | ❌ | ❌ | ❌ | ✅ |

Fixes https://github.com/vaadin/web-components/issues/6778

> [!WARNING]
> Note, this is a breaking change for some configurations. When using an item's URL to set defaults for dynamic params, such as for filtering or pagination, then changing those params would break matching. For example, if you configure an item with a URL like /products?pageSize=10 and then the page size is changed, the item wouldn't match anymore. Could be fixed on the application side by adding a path alias without the dynamic query params, or applying the defaults based on their absence in the URL.



## Type of change

- [x] Feature
