### PR TITLE
refactor: remove not working logic, reorganize focus tests

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -542,7 +542,6 @@ export const ComboBoxMixin = (subclass) =>
       }
 
       if (opened) {
-        this._openedWithFocusRing = this.hasAttribute('focus-ring');
         // For touch devices, we don't want to popup virtual keyboard
         // unless input element is explicitly focused by the user.
         if (!this._isInputFocused() && !isTouch) {
@@ -554,9 +553,6 @@ export const ComboBoxMixin = (subclass) =>
         this._overlayElement.restoreFocusOnClose = true;
       } else {
         this._onClosed();
-        if (this._openedWithFocusRing && this._isInputFocused()) {
-          this.setAttribute('focus-ring', '');
-        }
       }
 
       const input = this._nativeInput;

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -286,7 +286,7 @@ describe('toggling dropdown', () => {
         expect(document.activeElement).to.equal(input);
       });
 
-      it('should keep focus-ring attribute if it was set before opening and input has focus', () => {
+      it('should keep focus-ring attribute after closing with Escape', () => {
         comboBox.focus();
         comboBox.setAttribute('focus-ring', '');
         comboBox.open();
@@ -294,7 +294,7 @@ describe('toggling dropdown', () => {
         expect(comboBox.hasAttribute('focus-ring')).to.be.true;
       });
 
-      it('should not keep focus-ring attribute if the combo-box is closed on outside click', () => {
+      it('should not keep focus-ring attribute after closing with outside click', () => {
         comboBox.focus();
         comboBox.setAttribute('focus-ring', '');
         comboBox.open();

--- a/packages/combo-box/test/toggling-dropdown.test.js
+++ b/packages/combo-box/test/toggling-dropdown.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import {
   aTimeout,
   click,
+  escKeyDown,
   fire,
   fixtureSync,
   focusout,
@@ -39,13 +40,6 @@ describe('toggling dropdown', () => {
       tap(comboBox.querySelector('[slot="label"]'));
       expect(comboBox.opened).to.be.false;
       expect(overlay.opened).to.be.false;
-    });
-
-    it('should restore attribute focus-ring if it was initially set before opening and combo-box is focused', () => {
-      comboBox.setAttribute('focus-ring', '');
-      comboBox.opened = true;
-      comboBox.opened = false;
-      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
     });
 
     it('should open synchronously by clicking input', () => {
@@ -275,20 +269,40 @@ describe('toggling dropdown', () => {
       expect(comboBox.opened).to.be.true;
     });
 
-    it('should restore focus to the field on outside click', async () => {
-      comboBox.focus();
-      comboBox.open();
-      outsideClick();
-      await aTimeout(0);
-      expect(document.activeElement).to.equal(input);
-    });
+    describe('focus', () => {
+      it('should restore focus to the input on outside click', async () => {
+        comboBox.focus();
+        comboBox.open();
+        outsideClick();
+        await aTimeout(0);
+        expect(document.activeElement).to.equal(input);
+      });
 
-    it('should focus the field on outside click', async () => {
-      expect(document.activeElement).to.equal(document.body);
-      comboBox.open();
-      outsideClick();
-      await aTimeout(0);
-      expect(document.activeElement).to.equal(input);
+      it('should focus the input on outside click if not focused before opening', async () => {
+        expect(document.activeElement).to.equal(document.body);
+        comboBox.open();
+        outsideClick();
+        await aTimeout(0);
+        expect(document.activeElement).to.equal(input);
+      });
+
+      it('should keep focus-ring attribute if it was set before opening and input has focus', () => {
+        comboBox.focus();
+        comboBox.setAttribute('focus-ring', '');
+        comboBox.open();
+        escKeyDown(input);
+        expect(comboBox.hasAttribute('focus-ring')).to.be.true;
+      });
+
+      it('should not keep focus-ring attribute if the combo-box is closed on outside click', () => {
+        comboBox.focus();
+        comboBox.setAttribute('focus-ring', '');
+        comboBox.open();
+        outsideClick();
+        expect(comboBox.hasAttribute('focus-ring')).to.be.false;
+        // FIXME: see https://github.com/vaadin/web-components/issues/4148
+        // expect(comboBox.hasAttribute('focus-ring')).to.be.true;
+      });
     });
 
     describe('virtual keyboard', () => {


### PR DESCRIPTION
## Description

As described in #4148, currently the logic for restoring focus-ring does not work as expected so it can be removed.
The only case for this logic is outside click. On item click, <kbd>Esc</kbd> or <kbd>Enter</kbd> key the `<input>` doesn't lose focus.

The logic was added in https://github.com/vaadin/vaadin-combo-box/pull/599. However, latest V14 version also seems to have the issue.

Note: I quickly tried to apply the fix for a similar issue in the `vaadin-date-picker` - #4341. However, it causes a bunch of tests to fail, apparently due to validation not run on outside click with that approach (or maybe I just got it wrong).

For now, the test about outside click contains `FIXME` with a commented line, to be fixed later.

## Type of change

- Refactor / tests