### PR TITLE
feat: add scrollToStart and scrollToEnd API for text-area

### DIFF
--- a/packages/text-area/src/vaadin-text-area-mixin.d.ts
+++ b/packages/text-area/src/vaadin-text-area-mixin.d.ts
@@ -61,4 +61,14 @@ export declare class TextAreaMixinClass {
    * The pattern must match the entire value, not just some subset.
    */
   pattern: string;
+
+  /**
+   * Scrolls the textarea to the start.
+   */
+  scrollToStart(): void;
+
+  /**
+   * Scrolls the textarea to the end.
+   */
+  scrollToEnd(): void;
 }

--- a/packages/text-area/src/vaadin-text-area-mixin.d.ts
+++ b/packages/text-area/src/vaadin-text-area-mixin.d.ts
@@ -63,12 +63,12 @@ export declare class TextAreaMixinClass {
   pattern: string;
 
   /**
-   * Scrolls the textarea to the start.
+   * Scrolls the textarea to the start if it has a vertical scrollbar.
    */
   scrollToStart(): void;
 
   /**
-   * Scrolls the textarea to the end.
+   * Scrolls the textarea to the end if it has a vertical scrollbar.
    */
   scrollToEnd(): void;
 }

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -178,13 +178,17 @@ export const TextAreaMixin = (superClass) =>
       inputField.scrollTop = scrollTop;
     }
 
+    /**
+     * Scrolls the textarea to the start.
+     */
     scrollToStart() {
-      // Scroll to the start of the textarea
       this._inputField.scrollTop = 0;
     }
 
+    /**
+     * Scrolls the textarea to the end.
+     */
     scrollToEnd() {
-      // Scroll to the end of the textarea
       this._inputField.scrollTop = this._inputField.scrollHeight;
     }
 

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -188,15 +188,6 @@ export const TextAreaMixin = (superClass) =>
       this._inputField.scrollTop = this._inputField.scrollHeight;
     }
 
-    setCursorPosition(value) {
-      // Set the cursor position in the textarea
-      // Ensure the value is within the valid range
-      this.inputElement.focus();
-      value = Math.max(0, Math.min(value, this.inputElement.value.length));
-      this.inputElement.selectionStart = value;
-      this.inputElement.selectionEnd = value;
-    }
-
     /**
      * Returns true if the current textarea value satisfies all constraints (if any).
      * @return {boolean}

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -178,6 +178,25 @@ export const TextAreaMixin = (superClass) =>
       inputField.scrollTop = scrollTop;
     }
 
+    scrollToStart() {
+      // Scroll to the start of the textarea
+      this._inputField.scrollTop = 0;
+    }
+
+    scrollToEnd() {
+      // Scroll to the end of the textarea
+      this._inputField.scrollTop = this._inputField.scrollHeight;
+    }
+
+    setCursorPosition(value) {
+      // Set the cursor position in the textarea
+      // Ensure the value is within the valid range
+      this.inputElement.focus();
+      value = Math.max(0, Math.min(value, this.inputElement.value.length));
+      this.inputElement.selectionStart = value;
+      this.inputElement.selectionEnd = value;
+    }
+
     /**
      * Returns true if the current textarea value satisfies all constraints (if any).
      * @return {boolean}

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -179,14 +179,14 @@ export const TextAreaMixin = (superClass) =>
     }
 
     /**
-     * Scrolls the textarea to the start.
+     * Scrolls the textarea to the start if it has a vertical scrollbar.
      */
     scrollToStart() {
       this._inputField.scrollTop = 0;
     }
 
     /**
-     * Scrolls the textarea to the end.
+     * Scrolls the textarea to the end if it has a vertical scrollbar.
      */
     scrollToEnd() {
       this._inputField.scrollTop = this._inputField.scrollHeight;

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -419,7 +419,7 @@ describe('text-area', () => {
     });
   });
 
-  describe('scrolling behavior', () => {
+  describe('programmatic scrolling', () => {
     beforeEach(() => {
       textArea.value = Array(400).join('400');
       textArea.style.height = '300px';

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -423,8 +423,6 @@ describe('text-area', () => {
     beforeEach(() => {
       textArea.value = Array(400).join('400');
       textArea.style.height = '300px';
-      textArea._inputField.style.border = 'none';
-      textArea.style.padding = '0';
     });
 
     it('should scroll to start', () => {

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -418,4 +418,32 @@ describe('text-area', () => {
       });
     });
   });
+
+  describe('scrolling and cursor positioning', () => {
+    beforeEach(() => {
+      textArea.value = Array(400).join('400');
+      textArea.style.height = '300px';
+      textArea._inputField.style.border = 'none';
+      textArea.style.padding = '0';
+    });
+
+    it('should scroll to start', () => {
+      textArea._inputField.scrollTop = 100; // Simulate scrolling
+      textArea.scrollToStart();
+      expect(textArea._inputField.scrollTop).to.equal(0);
+    });
+
+    it('should scroll to end', () => {
+      textArea.scrollToStart();
+      expect(textArea._inputField.scrollTop).to.equal(0);
+      textArea.scrollToEnd();
+      expect(textArea._inputField.scrollTop).to.equal(textArea._inputField.scrollHeight - textArea.scrollHeight);
+    });
+
+    it('should set cursor position', () => {
+      textArea.setCursorPosition(5);
+      expect(textArea.inputElement.selectionStart).to.equal(5);
+      expect(textArea.inputElement.selectionEnd).to.equal(5);
+    });
+  });
 });

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -435,7 +435,9 @@ describe('text-area', () => {
       textArea.scrollToStart();
       expect(textArea._inputField.scrollTop).to.equal(0);
       textArea.scrollToEnd();
-      expect(textArea._inputField.scrollTop).to.equal(textArea._inputField.scrollHeight - textArea.scrollHeight);
+      expect(textArea._inputField.scrollTop).to.equal(
+        textArea._inputField.scrollHeight - textArea._inputField.clientHeight,
+      );
     });
   });
 });

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -419,7 +419,7 @@ describe('text-area', () => {
     });
   });
 
-  describe('scrolling and cursor positioning', () => {
+  describe('scrolling behavior', () => {
     beforeEach(() => {
       textArea.value = Array(400).join('400');
       textArea.style.height = '300px';
@@ -438,12 +438,6 @@ describe('text-area', () => {
       expect(textArea._inputField.scrollTop).to.equal(0);
       textArea.scrollToEnd();
       expect(textArea._inputField.scrollTop).to.equal(textArea._inputField.scrollHeight - textArea.scrollHeight);
-    });
-
-    it('should set cursor position', () => {
-      textArea.setCursorPosition(5);
-      expect(textArea.inputElement.selectionStart).to.equal(5);
-      expect(textArea.inputElement.selectionEnd).to.equal(5);
     });
   });
 });

--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -45,3 +45,6 @@ area.addEventListener('validated', (event) => {
   assertType<TextAreaValidatedEvent>(event);
   assertType<boolean>(event.detail.valid);
 });
+
+assertType<() => void>(area.scrollToStart);
+assertType<() => void>(area.scrollToEnd);


### PR DESCRIPTION
## Description

The PR introduces `scrollToStart` and `scrollToEnd` methods for the text-area component.

Followed by:

- https://github.com/vaadin/flow-components/pull/6041

Fixes https://github.com/vaadin/flow-components/issues/6042

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
