### PR TITLE
refactor: extract combo-box-light logic to reusable mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-light-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light-mixin.d.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
+import type { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
+import type { ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
+
+export declare function ComboBoxLightMixin<TItem, T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<ComboBoxDataProviderMixinClass<TItem>> &
+  Constructor<ComboBoxLightMixinClass> &
+  Constructor<ComboBoxMixinClass<TItem>> &
+  Constructor<ValidateMixinClass> &
+  T;
+
+export declare class ComboBoxLightMixinClass {
+  /**
+   * Name of the two-way data-bindable property representing the
+   * value of the custom input field.
+   * @attr {string} attr-for-value
+   */
+  attrForValue: string;
+}

--- a/packages/combo-box/src/vaadin-combo-box-light-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-light-mixin.js
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright (c) 2015 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { dashToCamelCase } from '@polymer/polymer/lib/utils/case-map.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
+import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin.js';
+import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
+
+/**
+ * @polymerMixin
+ * @mixes ComboBoxDataProviderMixin
+ * @mixes ComboBoxMixin
+ * @mixes ValidateMixin
+ */
+export const ComboBoxLightMixin = (superClass) =>
+  class ComboBoxLightMixinClass extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixin(superClass))) {
+    static get properties() {
+      return {
+        /**
+         * Name of the two-way data-bindable property representing the
+         * value of the custom input field.
+         * @attr {string} attr-for-value
+         * @type {string}
+         */
+        attrForValue: {
+          type: String,
+          value: 'value',
+        },
+      };
+    }
+
+    /**
+     * Used by `InputControlMixin` as a reference to the clear button element.
+     * @protected
+     * @return {!HTMLElement}
+     */
+    get clearElement() {
+      return this.querySelector('.clear-button');
+    }
+
+    /**
+     * Override this getter from `InputMixin` to allow using
+     * an arbitrary property name instead of `value`
+     * for accessing the input element's value.
+     *
+     * @protected
+     * @override
+     * @return {string}
+     */
+    get _inputElementValueProperty() {
+      return dashToCamelCase(this.attrForValue);
+    }
+
+    /**
+     * @protected
+     * @override
+     * @return {HTMLInputElement | undefined}
+     */
+    get _nativeInput() {
+      const input = this.inputElement;
+
+      if (input) {
+        // Support `<input class="input">`
+        if (input instanceof HTMLInputElement) {
+          return input;
+        }
+
+        // Support `<input>` in light DOM (e.g. `vaadin-text-field`)
+        const slottedInput = input.querySelector('input');
+        if (slottedInput) {
+          return slottedInput;
+        }
+
+        if (input.shadowRoot) {
+          // Support `<input>` in Shadow DOM (e.g. `mwc-textfield`)
+          const shadowInput = input.shadowRoot.querySelector('input');
+          if (shadowInput) {
+            return shadowInput;
+          }
+        }
+      }
+
+      return undefined;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._toggleElement = this.querySelector('.toggle-button');
+
+      // Wait until the slotted input DOM is ready
+      afterNextRender(this, () => {
+        this._setInputElement(this.querySelector('vaadin-text-field,.input'));
+        this._revertInputValue();
+      });
+    }
+
+    /**
+     * Returns true if the current input value satisfies all constraints (if any).
+     * @return {boolean}
+     */
+    checkValidity() {
+      if (this.inputElement && this.inputElement.validate) {
+        return this.inputElement.validate();
+      }
+      return super.checkValidity();
+    }
+
+    /**
+     * @protected
+     * @override
+     */
+    _isClearButton(event) {
+      return (
+        super._isClearButton(event) ||
+        (event.type === 'input' && !event.isTrusted) || // Fake input event dispatched by clear button
+        event.composedPath()[0].getAttribute('part') === 'clear-button'
+      );
+    }
+
+    /**
+     * @protected
+     * @override
+     */
+    _shouldRemoveFocus(event) {
+      const isBlurringControlButtons = event.target === this._toggleElement || event.target === this.clearElement;
+      const isFocusingInputElement = event.relatedTarget && event.relatedTarget === this._nativeInput;
+
+      // prevent closing the overlay when moving focus from clear or toggle buttons to the internal input
+      if (isBlurringControlButtons && isFocusingInputElement) {
+        return false;
+      }
+
+      return super._shouldRemoveFocus(event);
+    }
+  };

--- a/packages/combo-box/src/vaadin-combo-box-light.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-light.d.ts
@@ -11,6 +11,7 @@ import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.j
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { ComboBoxDataProviderMixinClass } from './vaadin-combo-box-data-provider-mixin.js';
+import type { ComboBoxLightMixinClass } from './vaadin-combo-box-light-mixin.js';
 import type { ComboBoxDefaultItem, ComboBoxMixinClass } from './vaadin-combo-box-mixin.js';
 export {
   ComboBoxDataProvider,
@@ -126,13 +127,6 @@ export interface ComboBoxLightEventMap<TItem> extends HTMLElementEventMap {
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class ComboBoxLight<TItem = ComboBoxDefaultItem> extends HTMLElement {
-  /**
-   * Name of the two-way data-bindable property representing the
-   * value of the custom input field.
-   * @attr {string} attr-for-value
-   */
-  attrForValue: string;
-
   addEventListener<K extends keyof ComboBoxLightEventMap<TItem>>(
     type: K,
     listener: (this: ComboBoxLight<TItem>, ev: ComboBoxLightEventMap<TItem>[K]) => void,
@@ -148,6 +142,7 @@ declare class ComboBoxLight<TItem = ComboBoxDefaultItem> extends HTMLElement {
 
 interface ComboBoxLight<TItem = ComboBoxDefaultItem>
   extends ComboBoxDataProviderMixinClass<TItem>,
+    ComboBoxLightMixinClass,
     ComboBoxMixinClass<TItem>,
     KeyboardMixinClass,
     InputMixinClass,

--- a/packages/combo-box/src/vaadin-combo-box-light.js
+++ b/packages/combo-box/src/vaadin-combo-box-light.js
@@ -6,14 +6,10 @@
 import './vaadin-combo-box-item.js';
 import './vaadin-combo-box-overlay.js';
 import './vaadin-combo-box-scroller.js';
-import { dashToCamelCase } from '@polymer/polymer/lib/utils/case-map.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
-import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin.js';
-import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
+import { ComboBoxLightMixin } from './vaadin-combo-box-light-mixin.js';
 
 /**
  * `<vaadin-combo-box-light>` is a customizable version of the `<vaadin-combo-box>` providing
@@ -63,12 +59,10 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  *
  * @customElement
  * @extends HTMLElement
- * @mixes ComboBoxDataProviderMixin
- * @mixes ComboBoxMixin
+ * @mixes ComboBoxLightMixin
  * @mixes ThemableMixin
- * @mixes ValidateMixin
  */
-class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixin(ThemableMixin(PolymerElement)))) {
+class ComboBoxLight extends ComboBoxLightMixin(ThemableMixin(PolymerElement)) {
   static get is() {
     return 'vaadin-combo-box-light';
   }
@@ -93,124 +87,6 @@ class ComboBoxLight extends ComboBoxDataProviderMixin(ComboBoxMixin(ValidateMixi
         restore-focus-node="[[inputElement]]"
       ></vaadin-combo-box-overlay>
     `;
-  }
-
-  static get properties() {
-    return {
-      /**
-       * Name of the two-way data-bindable property representing the
-       * value of the custom input field.
-       * @attr {string} attr-for-value
-       * @type {string}
-       */
-      attrForValue: {
-        type: String,
-        value: 'value',
-      },
-    };
-  }
-
-  /**
-   * Used by `InputControlMixin` as a reference to the clear button element.
-   * @protected
-   * @return {!HTMLElement}
-   */
-  get clearElement() {
-    return this.querySelector('.clear-button');
-  }
-
-  /**
-   * Override this getter from `InputMixin` to allow using
-   * an arbitrary property name instead of `value`
-   * for accessing the input element's value.
-   *
-   * @protected
-   * @override
-   * @return {string}
-   */
-  get _inputElementValueProperty() {
-    return dashToCamelCase(this.attrForValue);
-  }
-
-  /**
-   * @protected
-   * @override
-   * @return {HTMLInputElement | undefined}
-   */
-  get _nativeInput() {
-    const input = this.inputElement;
-
-    if (input) {
-      // Support `<input class="input">`
-      if (input instanceof HTMLInputElement) {
-        return input;
-      }
-
-      // Support `<input>` in light DOM (e.g. `vaadin-text-field`)
-      const slottedInput = input.querySelector('input');
-      if (slottedInput) {
-        return slottedInput;
-      }
-
-      if (input.shadowRoot) {
-        // Support `<input>` in Shadow DOM (e.g. `mwc-textfield`)
-        const shadowInput = input.shadowRoot.querySelector('input');
-        if (shadowInput) {
-          return shadowInput;
-        }
-      }
-    }
-
-    return undefined;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._toggleElement = this.querySelector('.toggle-button');
-
-    // Wait until the slotted input DOM is ready
-    afterNextRender(this, () => {
-      this._setInputElement(this.querySelector('vaadin-text-field,.input'));
-      this._revertInputValue();
-    });
-  }
-
-  /**
-   * Returns true if the current input value satisfies all constraints (if any).
-   * @return {boolean}
-   */
-  checkValidity() {
-    if (this.inputElement && this.inputElement.validate) {
-      return this.inputElement.validate();
-    }
-    return super.checkValidity();
-  }
-
-  /** @protected */
-  _isClearButton(event) {
-    return (
-      super._isClearButton(event) ||
-      (event.type === 'input' && !event.isTrusted) || // Fake input event dispatched by clear button
-      event.composedPath()[0].getAttribute('part') === 'clear-button'
-    );
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  _shouldRemoveFocus(event) {
-    const isBlurringControlButtons = event.target === this._toggleElement || event.target === this.clearElement;
-    const isFocusingInputElement = event.relatedTarget && event.relatedTarget === this._nativeInput;
-
-    // prevent closing the overlay when moving focus from clear or toggle buttons to the internal input
-    if (isBlurringControlButtons && isFocusingInputElement) {
-      return false;
-    }
-
-    return super._shouldRemoveFocus(event);
   }
 }
 

--- a/packages/combo-box/test/typings/combo-box.types.ts
+++ b/packages/combo-box/test/typings/combo-box.types.ts
@@ -19,6 +19,7 @@ import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import type { ComboBoxDataProviderMixinClass } from '../../src/vaadin-combo-box-data-provider-mixin';
 import type { ComboBoxItem } from '../../src/vaadin-combo-box-item';
 import type { ComboBoxItemMixinClass, ComboBoxItemRenderer } from '../../src/vaadin-combo-box-item-mixin';
+import type { ComboBoxLightMixinClass } from '../../src/vaadin-combo-box-light-mixin.js';
 import type { ComboBoxMixinClass } from '../../src/vaadin-combo-box-mixin';
 import type {
   ComboBox,
@@ -209,9 +210,11 @@ assertType<boolean>(narrowedComboBoxLight.invalid);
 assertType<boolean>(narrowedComboBoxLight.disabled);
 assertType<boolean>(narrowedComboBoxLight.readonly);
 assertType<string>(narrowedComboBoxLight.value);
+assertType<string>(narrowedComboBoxLight.attrForValue);
 
 // ComboBoxLight mixins
 assertType<ComboBoxDataProviderMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
+assertType<ComboBoxLightMixinClass>(narrowedComboBoxLight);
 assertType<ComboBoxMixinClass<TestComboBoxItem>>(narrowedComboBoxLight);
 assertType<DisabledMixinClass>(narrowedComboBoxLight);
 assertType<InputMixinClass>(narrowedComboBoxLight);


### PR DESCRIPTION
## Description

Extracted logic from `vaadin-combo-box-light` to `ComboBoxLightMixin` for reusing by the Lit based version.

## Type of change

- Refactor