### PR TITLE
fix: do not throw when clearing cache of an unattached grid

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -374,7 +374,7 @@ export const DataProviderMixin = (superClass) =>
       this._hasData = false;
       this.__updateVisibleRows();
 
-      if (!this.__virtualizer.size) {
+      if (!this.__virtualizer || !this.__virtualizer.size) {
         this._dataProviderController.loadFirstPage();
       }
     }

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -690,6 +690,13 @@ describe('attached', () => {
   });
 });
 
+describe('unattached', () => {
+  it('should not throw on clearCache', () => {
+    const grid = document.createElement('vaadin-grid');
+    expect(() => grid.clearCache()).to.not.throw(Error);
+  });
+});
+
 describe('page size grid', () => {
   it('should render grid rows when setting page-size before size', () => {
     const container = fixtureSync('<page-size-grid></page-size-grid>');


### PR DESCRIPTION
## Description

Check for `this.__virtualizer` in grid's `clearCache` before accessing it. It's possible for it to not exist if the grid hasn't yet been attached.

## Type of change

Bugfix