### PR TITLE
chore: ignore sonar for execSync in wtr-utils

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -40,7 +40,7 @@ const hasAllParam = process.argv.includes('--all');
  * Check if lockfile has changed.
  */
 const isLockfileChanged = () => {
-  const log = execSync('git diff --name-only origin/main HEAD').toString();
+  const log = execSync('git diff --name-only origin/main HEAD').toString(); // NOSONAR
   return log.split('\n').some((line) => line.includes('yarn.lock'));
 };
 


### PR DESCRIPTION
## Description

An `execSync` call in wtr-utils keeps [failing](https://github.com/vaadin/web-components/runs/21972193519) SonarCloud code analysis. Ignore the line.

## Type of change

Chore