### PR TITLE
fix: set date-time-picker showWeekNumbers to false by default

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -298,6 +298,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
        */
       showWeekNumbers: {
         type: Boolean,
+        value: false,
       },
 
       /**

--- a/packages/date-time-picker/test/properties.test.js
+++ b/packages/date-time-picker/test/properties.test.js
@@ -200,7 +200,7 @@ function getTimePicker(dateTimePicker) {
     });
 
     it('should propagate showWeekNumbers to date picker', () => {
-      expect(datePicker.showWeekNumbers).to.be.not.ok;
+      expect(datePicker.showWeekNumbers).to.be.false;
       dateTimePicker.showWeekNumbers = true;
       expect(datePicker.showWeekNumbers).to.be.true;
     });


### PR DESCRIPTION
## Description

Fixes #7153 

Note, the original property definition without default value comes from https://github.com/vaadin/vaadin-date-time-picker/pull/18 which was probably just an oversight (especially as that PR didn't contain `i18n` implementation).

The fix works because it passes a non-`undefined` value to this function:

https://github.com/vaadin/web-components/blob/08f04ee30c2048ed537cc56b2526b6d915af18d0/packages/date-picker/src/vaadin-month-calendar-mixin.js#L193-L196

Which is then used to render short day names in the month calendar:

https://github.com/vaadin/web-components/blob/08f04ee30c2048ed537cc56b2526b6d915af18d0/packages/date-picker/src/vaadin-month-calendar.js#L37-L41

## Type of change

- Bugfix