### PR TITLE
docs: add missing annotation for custom-value-set event

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -1283,6 +1283,12 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     // and keep the overlay opened when clicking a chip.
     event.preventDefault();
   }
+
+  /**
+   * Fired when the user sets a custom value.
+   * @event custom-value-set
+   * @param {string} detail the custom value
+   */
 }
 
 defineCustomElement(MultiSelectComboBox);


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/react-components/issues/238

This is needed to ensure that `custom-value-set` event is listed in `web-types.json`:

```
"events": [
  {
    "name": "validated",
    "description": "Fired whenever the field is validated."
  },
  {
    "name": "change",
    "description": "Fired when the user commits a value change."
  },
  {
    "name": "custom-value-set",
    "description": "Fired when the user sets a custom value."
  },
```

The `web-types.json` file is in turn used by React wrappers generator, see https://github.com/vaadin/react-components/issues/238#issuecomment-1970625835.

Note: in `vaadin-combo-box` the corresponding annotation is inherited from `ComboBoxMixin`.

## Type of change

- Documentation / bugfix