### PR TITLE
fix: delay column width recalculation until all rows have index

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -497,12 +497,15 @@ export const GridMixin = (superClass) =>
         return;
       }
 
-      // Delay recalculation if any rows are missing an index, which might occur during the grid's initialization
-      // if the recalculation is triggered in the middle of the virtualizer update loop (_updateScrollerItem).
-      // This can happen if the data provider responds synchronously to the page request. In this case, rows after
-      // the one that triggered the page request may not have an index property yet, leading to _onDataProviderPageReceived
-      // not requesting children for these rows, and setting the loading state to false. However, these rows will be processed
-      // shorly after in the next iteration of the virtualizer update loop.
+      // Delay recalculation if any rows are missing an index.
+      // This can happen during the grid's initialization if the recalculation is triggered
+      // as a result of the data provider responding synchronously to a page request created
+      // in the middle of the virtualizer update loop. In this case, rows after the one that
+      // triggered the page request may not have an index property yet. The lack of index
+      // prevents _onDataProviderPageReceived from requesting children for these rows,
+      // resulting in loading state being set to false and the recalculation beginning
+      // before all the data is loaded. Note, rows without index get updated in later iterations
+      // of the virtualizer update loop, ensuring the grid eventually reaches a stable state.
       const hasRowsWithUndefinedIndex = [...this.$.items.children].some((row) => row.index === undefined);
       if (hasRowsWithUndefinedIndex) {
         return;

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -341,14 +341,14 @@ describe('async recalculateWidth columns', () => {
   });
 
   describe('initially empty grid', () => {
-    let spy, dataProvider;
+    let recalculateColumnWidthsSpy, dataProvider;
 
     beforeEach(() => {
-      spy = sinon.spy(grid, 'recalculateColumnWidths');
+      recalculateColumnWidthsSpy = sinon.spy(grid, 'recalculateColumnWidths');
       dataProvider = (_params, callback) => callback([], 0);
       grid.dataProvider = (params, callback) => dataProvider(params, callback);
       flushGrid(grid);
-      spy.resetHistory();
+      recalculateColumnWidthsSpy.resetHistory();
     });
 
     it('should recalculate column widths when child items are loaded asynchonously', async () => {
@@ -366,9 +366,9 @@ describe('async recalculateWidth columns', () => {
       grid.size = 2;
       flushGrid(grid);
 
-      expect(spy).to.be.not.called;
+      expect(recalculateColumnWidthsSpy).to.be.not.called;
       await aTimeout(0);
-      expect(spy).to.be.calledOnce;
+      expect(recalculateColumnWidthsSpy).to.be.calledOnce;
     });
   });
 });


### PR DESCRIPTION
## Description

The PR prevents too early column width recalculation during the grid's initialization when some row elements don't have an index property yet. This can happen if the recalculation is triggered as a result of the data provider responding synchronously to a page request created in the middle of the virtualizer update loop. In this case, rows after the one that triggered the page request may not have an index property yet. The lack of index prevents `_onDataProviderPageReceived` from requesting children for these rows, resulting in the loading state being set to `false` and the recalculation beginning before all the data is actually loaded. Note, rows without index get updated in later iterations of the virtualizer update loop, so the grid eventually reaches a stable state.

> [!NOTE]
> The backport to 23.3 will be done manually.

Fixes https://github.com/vaadin/flow-components/issues/5813



## Type of change

- [x] Bugfix
