### PR TITLE
Revert "fix: flush virtualizer until physical count stabilizes (#6684)"

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -143,7 +143,6 @@ export class IronListAdapter {
   }
 
   flush() {
-    const startPhysicalCount = this._physicalCount;
     // The scroll target is hidden.
     if (this.scrollTarget.offsetHeight === 0) {
       return;
@@ -160,11 +159,6 @@ export class IronListAdapter {
     }
     if (this.__debouncerWheelAnimationFrame) {
       this.__debouncerWheelAnimationFrame.flush();
-    }
-
-    if (this._physicalCount !== startPhysicalCount) {
-      // Flushing again until physical count stabilizes fixes https://github.com/vaadin/flow-components/issues/5595#issuecomment-1770278913
-      this.flush();
     }
   }
 


### PR DESCRIPTION
## Description

The PR reverts #6684 as I found in my [investigation](https://github.com/vaadin/flow-components/issues/5813#issuecomment-1971434398) that it has no impact on the issue (or not anymore) and the [related integration test](https://github.com/vaadin/flow-components/pull/5621) passes without it. The issue will be fixed by https://github.com/vaadin/web-components/pull/7165 instead.

## Type of change

- [x] Revert
