### PR TITLE
refactor: remove unnecessary check from DataProviderMixin

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -206,10 +206,6 @@ export const DataProviderMixin = (superClass) =>
      * @protected
      */
     _getItem(index, el) {
-      if (index >= this._flatSize) {
-        return;
-      }
-
       el.index = index;
 
       const { item } = this._dataProviderController.getFlatIndexContext(index);


### PR DESCRIPTION
## Description

Making sure that the row's index doesn't exceed the flat size before requesting data for that row seems unnecessary, as (1) grid nowadays hides rows synchronously on flat size change, and (2) `_getItem` is only called for rows received from `_getRenderedRows` which throws away hidden rows.

## Type of change

- [x] Refactor
