### PR TITLE
refactor!: rename internal methods for clarity and consistency

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -204,18 +204,26 @@ export const DataProviderMixin = (superClass) =>
      * @param {HTMLElement} row
      * @protected
      */
-    _getItem(row) {
+    _requestOrUpdateRowItem(row) {
       const { item } = this._dataProviderController.getFlatIndexContext(row.index);
       if (item) {
-        this.__updateLoading(row, false);
+        this._updateRowLoading(row, false);
         this._updateItem(row, item);
         if (this._isExpanded(item)) {
-          this._dataProviderController.ensureFlatIndexHierarchy(row.index);
+          this._ensureRowHierarchy(row);
         }
       } else {
-        this.__updateLoading(row, true);
+        this._updateRowLoading(row, true);
         this._dataProviderController.ensureFlatIndexLoaded(row.index);
       }
+    }
+
+    /**
+     * @param {HTMLElement} row
+     * @private
+     */
+    _ensureRowHierarchy(row) {
+      this._dataProviderController.ensureFlatIndexHierarchy(row.index);
     }
 
     /**
@@ -223,7 +231,7 @@ export const DataProviderMixin = (superClass) =>
      * @param {boolean} loading
      * @private
      */
-    __updateLoading(row, loading) {
+    _updateRowLoading(row, loading) {
       const cells = getBodyRowCells(row);
 
       // Row state attribute
@@ -322,9 +330,7 @@ export const DataProviderMixin = (superClass) =>
       this._flatSize = this._dataProviderController.flatSize;
 
       // After updating the cache, check if some of the expanded items should have sub-caches loaded
-      this._getRenderedRows().forEach((row) => {
-        this._dataProviderController.ensureFlatIndexHierarchy(row.index);
-      });
+      this._getRenderedRows().forEach((row) => this._ensureRowHierarchy(row));
 
       this._hasData = true;
     }
@@ -338,7 +344,7 @@ export const DataProviderMixin = (superClass) =>
         this._getRenderedRows().forEach((row) => {
           const { item } = this._dataProviderController.getFlatIndexContext(row.index);
           if (item) {
-            this._getItem(row);
+            this._requestOrUpdateRowItem(row);
           }
         });
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -826,7 +826,7 @@ export const GridMixin = (superClass) =>
 
       this._updateRowOrderParts(row);
       this._a11yUpdateRowRowindex(row);
-      this._getItem(row);
+      this._requestOrUpdateRowItem(row);
     }
 
     /** @private */


### PR DESCRIPTION
## Description

The PR renames some internal row-related grid methods for the sake of clarify and consistency.

Depends on
- https://github.com/vaadin/web-components/pull/7176

## Type of change

- [x] Refactor
