### PR TITLE
refactor!: move setting row index to _updateScrollerItem

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -57,11 +57,10 @@ export const A11yMixin = (superClass) =>
 
     /**
      * @param {!HTMLElement} row
-     * @param {number} index
      * @protected
      */
-    _a11yUpdateRowRowindex(row, index) {
-      row.setAttribute('aria-rowindex', index + this._a11yGetHeaderRowCount(this._columnTree) + 1);
+    _a11yUpdateRowRowindex(row) {
+      row.setAttribute('aria-rowindex', row.index + this._a11yGetHeaderRowCount(this._columnTree) + 1);
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -201,23 +201,20 @@ export const DataProviderMixin = (superClass) =>
     }
 
     /**
-     * @param {number} index
-     * @param {HTMLElement} el
+     * @param {HTMLElement} row
      * @protected
      */
-    _getItem(index, el) {
-      el.index = index;
-
-      const { item } = this._dataProviderController.getFlatIndexContext(index);
+    _getItem(row) {
+      const { item } = this._dataProviderController.getFlatIndexContext(row.index);
       if (item) {
-        this.__updateLoading(el, false);
-        this._updateItem(el, item);
+        this.__updateLoading(row, false);
+        this._updateItem(row, item);
         if (this._isExpanded(item)) {
-          this._dataProviderController.ensureFlatIndexHierarchy(index);
+          this._dataProviderController.ensureFlatIndexHierarchy(row.index);
         }
       } else {
-        this.__updateLoading(el, true);
-        this._dataProviderController.ensureFlatIndexLoaded(index);
+        this.__updateLoading(row, true);
+        this._dataProviderController.ensureFlatIndexLoaded(row.index);
       }
     }
 
@@ -341,7 +338,7 @@ export const DataProviderMixin = (superClass) =>
         this._getRenderedRows().forEach((row) => {
           const { item } = this._dataProviderController.getFlatIndexContext(row.index);
           if (item) {
-            this._getItem(row.index, row);
+            this._getItem(row);
           }
         });
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -822,10 +822,11 @@ export const GridMixin = (superClass) =>
         return;
       }
 
-      this._updateRowOrderParts(row, index);
+      row.index = index;
 
-      this._a11yUpdateRowRowindex(row, index);
-      this._getItem(index, row);
+      this._updateRowOrderParts(row);
+      this._a11yUpdateRowRowindex(row);
+      this._getItem(row);
     }
 
     /** @private */
@@ -836,12 +837,12 @@ export const GridMixin = (superClass) =>
     }
 
     /** @private */
-    _updateRowOrderParts(row, index = row.index) {
+    _updateRowOrderParts(row) {
       updateBooleanRowStates(row, {
-        first: index === 0,
-        last: index === this._flatSize - 1,
-        odd: index % 2 !== 0,
-        even: index % 2 === 0,
+        first: row.index === 0,
+        last: row.index === this._flatSize - 1,
+        odd: row.index % 2 !== 0,
+        even: row.index % 2 === 0,
       });
     }
 


### PR DESCRIPTION
## Description

The PR moves setting row index from `_getItem` method to `_updateScrollerItem`, which feels being a more suitable place for this operation.

## Type of change

- [x] Refactor
