### PR TITLE
fix: toggle checkbox on selection column cell Space key

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -98,7 +98,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      *
      * @override
      */
-    _defaultHeaderRenderer(root, _column) {
+    _defaultHeaderRenderer(root, column) {
       let checkbox = root.firstElementChild;
       if (!checkbox) {
         checkbox = document.createElement('vaadin-checkbox');
@@ -107,6 +107,12 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.appendChild(checkbox);
         // Add listener after appending, so we can skip the initial change event
         checkbox.addEventListener('checked-changed', this.__onSelectAllCheckedChanged.bind(this));
+        // Toggle on Space without having to enter interaction mode first
+        column._headerCell.addEventListener('keydown', (e) => {
+          if (e.keyCode === 32 && e.composedPath()[0] === column._headerCell) {
+            checkbox.checked = !checkbox.checked;
+          }
+        });
       }
 
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
@@ -132,6 +138,13 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         addListener(root, 'track', this.__onCellTrack.bind(this));
         root.addEventListener('mousedown', this.__onCellMouseDown.bind(this));
         root.addEventListener('click', this.__onCellClick.bind(this));
+        const cell = root.assignedSlot.parentNode;
+        cell.addEventListener('keydown', (e) => {
+          // Prevent handling click on Space twice
+          if (!this.autoSelect && e.keyCode === 32 && e.composedPath()[0] === cell) {
+            checkbox.checked = !checkbox.checked;
+          }
+        });
       }
 
       checkbox.__item = item;

--- a/packages/grid/test/selection.common.js
+++ b/packages/grid/test/selection.common.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { click, fixtureSync, listenOnce, mousedown, nextFrame } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import {
   fire,
@@ -252,6 +253,73 @@ describe('multi selection column', () => {
     expect(grid.selectedItems).to.eql([]);
   });
 
+  it('should add the item to selectedItems on selection column cell Space key', async () => {
+    const cell = getRowCells(rows[1])[0];
+    cell.focus();
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.selectedItems).to.eql([grid.items[1]]);
+  });
+
+  it('should remove the item from selectedItems on selection column cell Space key', async () => {
+    grid.selectItem(grid.items[1]);
+    const cell = getRowCells(rows[1])[0];
+
+    cell.focus();
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.selectedItems).to.eql([]);
+  });
+
+  it('should add the item to selectedItems on selection column cell Space key when autoSelect is false', async () => {
+    selectionColumn.autoSelect = false;
+
+    const cell = getRowCells(rows[1])[0];
+    cell.focus();
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.selectedItems).to.eql([grid.items[1]]);
+  });
+
+  it('should remove the item from selectedItems on selection column cell Space key when autoSelect is false', async () => {
+    selectionColumn.autoSelect = false;
+
+    grid.selectItem(grid.items[1]);
+    const cell = getRowCells(rows[1])[0];
+    cell.focus();
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.selectedItems).to.eql([]);
+  });
+
+  it('should add the item to selectedItems on selection column checkbox Space key', async () => {
+    selectionColumn.autoSelect = false;
+
+    const cell = getRowCells(rows[1])[0];
+    cell.focus();
+
+    // Enter interaction mode to focus checkbox
+    await sendKeys({ press: 'Enter' });
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.selectedItems).to.eql([grid.items[1]]);
+  });
+
+  it('should remove the item from selectedItems on selection column checkbox Space key', async () => {
+    selectionColumn.autoSelect = false;
+
+    grid.selectItem(grid.items[1]);
+
+    const cell = getRowCells(rows[1])[0];
+    cell.focus();
+
+    // Enter interaction mode to focus checkbox
+    await sendKeys({ press: 'Enter' });
+    await sendKeys({ press: 'Space' });
+
+    expect(grid.selectedItems).to.eql([]);
+  });
+
   it('should have bound the body checkbox to selected items', () => {
     const selectCheckbox = firstBodyCheckbox;
 
@@ -271,6 +339,21 @@ describe('multi selection column', () => {
   it('should set selectAll when header checkbox is clicked', async () => {
     selectAllCheckbox.click();
     await nextFrame();
+    expect(selectionColumn.selectAll).to.be.true;
+  });
+
+  it('should set selectAll on header cell Space key', async () => {
+    const headerCell = getRowCells(headerRows[1])[0];
+    headerCell.focus();
+    await sendKeys({ press: 'Space' });
+    expect(selectionColumn.selectAll).to.be.true;
+  });
+
+  it('should set selectAll on header cell checkbox Space key', async () => {
+    const headerCell = getRowCells(headerRows[1])[0];
+    headerCell.focus();
+    await sendKeys({ press: 'Enter' });
+    await sendKeys({ press: 'Space' });
     expect(selectionColumn.selectAll).to.be.true;
   });
 


### PR DESCRIPTION
## Description

Fixes #7146

This PR changes the behavior of `vaadin-grid-selection-column` (and will also apply to its Flow version) like this:

- Pressing <kbd>Space</kbd> on the selection column cell toggles the checkbox regardless of `autoSelect` property,
- In interaction mode, <kbd>Space</kbd> is handled as previously (added logic to prevent toggling `checked` twice).

## Type of change

- Behavior altering fix