### PR TITLE
fix: allow to prevent creating default slotted buttons

### DIFF
--- a/packages/crud/src/vaadin-crud-controllers.js
+++ b/packages/crud/src/vaadin-crud-controllers.js
@@ -15,8 +15,8 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  * @protected
  */
 export class ButtonSlotController extends SlotController {
-  constructor(host, type, theme) {
-    super(host, `${type}-button`, 'vaadin-button');
+  constructor(host, type, theme, noDefaultNode) {
+    super(host, `${type}-button`, noDefaultNode ? null : 'vaadin-button');
 
     this.type = type;
     this.theme = theme;
@@ -31,6 +31,11 @@ export class ButtonSlotController extends SlotController {
    * @override
    */
   initNode(node) {
+    // Prevent errors when the `noDefaultNode` flag is set
+    if (!node) {
+      return;
+    }
+
     // Needed by Flow counterpart to apply i18n to custom button
     if (node._isDefault) {
       this.defaultNode = node;

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -660,11 +660,6 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this.__onGridSizeChanged = this.__onGridSizeChanged.bind(this);
     this.__onGridActiveItemChanged = this.__onGridActiveItemChanged.bind(this);
 
-    this._newButtonController = new ButtonSlotController(this, 'new', 'primary');
-    this._saveButtonController = new ButtonSlotController(this, 'save', 'primary');
-    this._cancelButtonController = new ButtonSlotController(this, 'cancel', 'tertiary');
-    this._deleteButtonController = new ButtonSlotController(this, 'delete', 'tertiary error');
-
     this.__focusRestorationController = new FocusRestorationController();
   }
 
@@ -703,6 +698,12 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
     this.addController(this._gridController);
 
     this.addController(new FormSlotController(this));
+
+    // Init controllers in `ready()` (not constructor) so that Flow can set `_noDefaultButtons`
+    this._newButtonController = new ButtonSlotController(this, 'new', 'primary', this._noDefaultButtons);
+    this._saveButtonController = new ButtonSlotController(this, 'save', 'primary', this._noDefaultButtons);
+    this._cancelButtonController = new ButtonSlotController(this, 'cancel', 'tertiary', this._noDefaultButtons);
+    this._deleteButtonController = new ButtonSlotController(this, 'delete', 'tertiary error', this._noDefaultButtons);
 
     this.addController(this._newButtonController);
 

--- a/packages/crud/test/crud-buttons.test.js
+++ b/packages/crud/test/crud-buttons.test.js
@@ -849,6 +849,37 @@ describe('crud buttons', () => {
     });
   });
 
+  describe('no default buttons', () => {
+    let crud;
+
+    beforeEach(async () => {
+      crud = document.createElement('vaadin-crud');
+      crud._noDefaultButtons = true;
+      document.body.appendChild(crud);
+      await nextRender();
+    });
+
+    afterEach(() => {
+      crud.remove();
+    });
+
+    it('should not create default new-button', () => {
+      expect(crud.querySelector('[slot="new-button"]')).to.be.null;
+    });
+
+    it('should not create default save-button', () => {
+      expect(crud.querySelector('[slot="save-button"]')).to.be.null;
+    });
+
+    it('should not create default cancel-button', () => {
+      expect(crud.querySelector('[slot="cancel-button"]')).to.be.null;
+    });
+
+    it('should not create default delete-button', () => {
+      expect(crud.querySelector('[slot="delete-button"]')).to.be.null;
+    });
+  });
+
   describe('dataProvider', () => {
     let items;
 


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/flow-components/issues/6080

This PR adds a flag that can be set by the Flow counterpart in the `Crud` constructor like this:

```java
getElement().setProperty("_noDefaultButtons", true);
```

As a result, the web component will not create default buttons and expect the server to provide them.
To do this, we set `tagName` in `SlotController` constructor to `null` (see e.g. `HelperController`).

## Type of change

- Bugfix