### PR TITLE
feat: expand parent items when item is set current

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -262,8 +262,23 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
   __updateCurrent() {
     this._setCurrent(this.__isCurrent());
     if (this.current) {
+      this.__expandParentItems();
       this.expanded = this._items.length > 0;
     }
+  }
+
+  /** @private */
+  __expandParentItems() {
+    const parentItem = this.__getParentItem();
+    if (parentItem) {
+      parentItem.__expandParentItems();
+    }
+    this.expanded = true;
+  }
+
+  /** @private */
+  __getParentItem() {
+    return this.parentElement instanceof SideNavItem ? this.parentElement : null;
   }
 
   /** @private */

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -195,6 +195,21 @@ describe('side-nav-item', () => {
         await item.updateComplete;
         expect(spy.calledOnce).to.be.true;
       });
+
+      it('should expand parent items when path matches', async () => {
+        item = fixtureSync(`
+          <vaadin-side-nav-item>
+            <vaadin-side-nav-item slot="children">
+                <vaadin-side-nav-item slot="children"></vaadin-side-nav-item>
+            </vaadin-side-nav-item>
+          </vaadin-side-nav-item>
+        `);
+        await nextRender();
+        item._items[0]._items[0].path = '';
+        await item.updateComplete;
+        expect(item.expanded).to.be.true;
+        expect(item._items[0].expanded).to.be.true;
+      });
     });
 
     describe('current item with children', () => {


### PR DESCRIPTION
## Description

This PR expands the parent side nav items when an item is set `current`. The expanding is done recursively, starting from the root level.

Fixes #7182 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
