### PR TITLE
fix: add click listener in constructor to ensure listener order

### DIFF
--- a/packages/grid/src/vaadin-grid-tree-toggle-mixin.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle-mixin.js
@@ -125,10 +125,8 @@ export const GridTreeToggleMixin = (superClass) =>
       };
     }
 
-    /** @protected */
-    ready() {
-      super.ready();
-
+    constructor() {
+      super();
       this.addEventListener('click', (e) => this._onClick(e));
     }
 

--- a/packages/grid/test/tree-toggle.common.js
+++ b/packages/grid/test/tree-toggle.common.js
@@ -51,11 +51,13 @@ describe('tree toggle', () => {
       });
 
       it('should have the correct expanded state on listener invocation', (done) => {
-        toggle = fixtureSync('<vaadin-grid-tree-toggle></vaadin-grid-tree-toggle>');
+        toggle = document.createElement('vaadin-grid-tree-toggle');
         toggle.addEventListener('click', () => {
           expect(toggle.expanded).to.be.true;
           done();
         });
+        const wrapper = fixtureSync('<div></div>');
+        wrapper.append(toggle);
         click(toggle);
       });
     });

--- a/packages/grid/test/tree-toggle.common.js
+++ b/packages/grid/test/tree-toggle.common.js
@@ -49,6 +49,15 @@ describe('tree toggle', () => {
 
         toggle.removeEventListener('expanded-changed', spy);
       });
+
+      it('should have the correct expanded state on listener invocation', (done) => {
+        toggle = fixtureSync('<vaadin-grid-tree-toggle></vaadin-grid-tree-toggle>');
+        toggle.addEventListener('click', () => {
+          expect(toggle.expanded).to.be.true;
+          done();
+        });
+        click(toggle);
+      });
     });
 
     describe('level', () => {


### PR DESCRIPTION
## Description

The toggle click listener was being added in `ready()`, which caused it to not be the first to be invoked in the listener order. This caused the `expanded` state to be updated after the external click listeners were invoked, which rendered any operation based on the `expanded` state at that point to be incorrect. 

This PR moves adding the internal toggle click listener to the constructor. This ensures that the internal click listener is the first within the listener order.

Fixes #7163 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.