### PR TITLE
test: split combo-box tests into common and import files

### DIFF
--- a/packages/combo-box/test/aria-polymer.test.js
+++ b/packages/combo-box/test/aria-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-combo-box.js';
+import './aria.common.js';

--- a/packages/combo-box/test/aria.common.js
+++ b/packages/combo-box/test/aria.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { getAllItems } from './helpers.js';
 
 describe('ARIA', () => {

--- a/packages/combo-box/test/basic-polymer.test.js
+++ b/packages/combo-box/test/basic-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './basic.common.js';

--- a/packages/combo-box/test/basic.common.js
+++ b/packages/combo-box/test/basic.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { getViewportItems, setInputValue } from './helpers.js';
 
 describe('basic features', () => {

--- a/packages/combo-box/test/combo-box-light-polymer.test.js
+++ b/packages/combo-box/test/combo-box-light-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box-light.js';
+import './combo-box-light.common.js';

--- a/packages/combo-box/test/combo-box-light-validation-polymer.test.js
+++ b/packages/combo-box/test/combo-box-light-validation-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box-light.js';
+import './combo-box-light-validation.common.js';

--- a/packages/combo-box/test/combo-box-light-validation.common.js
+++ b/packages/combo-box/test/combo-box-light-validation.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box-light.js';
 
 describe('vaadin-combo-box-light - validation', () => {
   let comboBox, input;

--- a/packages/combo-box/test/combo-box-light.common.js
+++ b/packages/combo-box/test/combo-box-light.common.js
@@ -15,8 +15,6 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
-import './not-animated-styles.js';
-import '../vaadin-combo-box-light.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getFirstItem } from './helpers.js';

--- a/packages/combo-box/test/dynamic-size-polymer.test.js
+++ b/packages/combo-box/test/dynamic-size-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-combo-box.js';
+import './dynamic-size.common.js';

--- a/packages/combo-box/test/dynamic-size.common.js
+++ b/packages/combo-box/test/dynamic-size.common.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import '../src/vaadin-combo-box.js';
 import { flushComboBox, getViewportItems, scrollToIndex } from './helpers.js';
 
 describe('dynamic size change', () => {

--- a/packages/combo-box/test/events-polymer.test.js
+++ b/packages/combo-box/test/events-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './events.common.js';

--- a/packages/combo-box/test/events.common.js
+++ b/packages/combo-box/test/events.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, focusout, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { clickItem, setInputValue } from './helpers.js';
 
 describe('events', () => {

--- a/packages/combo-box/test/external-filtering-polymer.test.js
+++ b/packages/combo-box/test/external-filtering-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './external-filtering.common.js';

--- a/packages/combo-box/test/external-filtering.common.js
+++ b/packages/combo-box/test/external-filtering.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { getFocusedItemIndex, setInputValue } from './helpers.js';
 
 describe('external filtering', () => {

--- a/packages/combo-box/test/interactions-polymer.test.js
+++ b/packages/combo-box/test/interactions-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './interactions.common.js';

--- a/packages/combo-box/test/interactions.common.js
+++ b/packages/combo-box/test/interactions.common.js
@@ -13,8 +13,6 @@ import {
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getFirstItem, setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/internal-filtering-polymer.test.js
+++ b/packages/combo-box/test/internal-filtering-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './internal-filtering.common.js';

--- a/packages/combo-box/test/internal-filtering.common.js
+++ b/packages/combo-box/test/internal-filtering.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import { getAllItems, getFocusedItemIndex, makeItems, onceOpened, setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/item-renderer-polymer.test.js
+++ b/packages/combo-box/test/item-renderer-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './item-renderer.common.js';

--- a/packages/combo-box/test/item-renderer.common.js
+++ b/packages/combo-box/test/item-renderer.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { getAllItems, getFirstItem, setInputValue } from './helpers.js';
 
 describe('item renderer', () => {

--- a/packages/combo-box/test/keyboard-polymer.test.js
+++ b/packages/combo-box/test/keyboard-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-combo-box.js';
+import './keyboard.common.js';

--- a/packages/combo-box/test/keyboard.common.js
+++ b/packages/combo-box/test/keyboard.common.js
@@ -12,7 +12,6 @@ import {
 } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import '../src/vaadin-combo-box.js';
 import { getViewportItems, getVisibleItemsCount, scrollToIndex, setInputValue } from './helpers.js';
 
 describe('keyboard', () => {

--- a/packages/combo-box/test/lazy-loading-polymer.test.js
+++ b/packages/combo-box/test/lazy-loading-polymer.test.js
@@ -1,0 +1,6 @@
+import './not-animated-styles.js';
+import './lazy-loading-styles.js';
+import '@vaadin/text-field/vaadin-text-field.js';
+import '../vaadin-combo-box-light.js';
+import '../vaadin-combo-box.js';
+import './lazy-loading.common.js';

--- a/packages/combo-box/test/lazy-loading-styles.js
+++ b/packages/combo-box/test/lazy-loading-styles.js
@@ -1,0 +1,10 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-combo-box*',
+  css`
+    :host {
+      --vaadin-combo-box-overlay-max-height: 400px;
+    }
+  `,
+);

--- a/packages/combo-box/test/lazy-loading.common.js
+++ b/packages/combo-box/test/lazy-loading.common.js
@@ -1,11 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/text-field/vaadin-text-field.js';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
-import '../vaadin-combo-box-light.js';
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
   clickItem,
@@ -20,15 +15,6 @@ import {
   scrollToIndex,
   setInputValue,
 } from './helpers.js';
-
-registerStyles(
-  'vaadin-combo-box*',
-  css`
-    :host {
-      --vaadin-combo-box-overlay-max-height: 400px;
-    }
-  `,
-);
 
 describe('lazy loading', () => {
   const DEFAULT_PAGE_SIZE = 50;

--- a/packages/combo-box/test/lit-polymer.test.js
+++ b/packages/combo-box/test/lit-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './lit.common.js';

--- a/packages/combo-box/test/lit-renderer-directives-polymer.test.js
+++ b/packages/combo-box/test/lit-renderer-directives-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './lit-renderer-directives.common.js';

--- a/packages/combo-box/test/lit-renderer-directives.common.js
+++ b/packages/combo-box/test/lit-renderer-directives.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-combo-box.js';
 import { html, render } from 'lit';
 import { comboBoxRenderer } from '../lit.js';
 import { getAllItems } from './helpers.js';

--- a/packages/combo-box/test/lit.common.js
+++ b/packages/combo-box/test/lit.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { html, LitElement, render } from 'lit';
 import { getViewportItems } from './helpers.js';
 

--- a/packages/combo-box/test/object-values-polymer.test.js
+++ b/packages/combo-box/test/object-values-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../src/vaadin-combo-box.js';
+import './object-values.common.js';

--- a/packages/combo-box/test/object-values.common.js
+++ b/packages/combo-box/test/object-values.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { clickItem, getFirstItem, getViewportItems } from './helpers.js';
 
 describe('object values', () => {

--- a/packages/combo-box/test/overlay-opening-polymer.test.js
+++ b/packages/combo-box/test/overlay-opening-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './overlay-opening.common.js';

--- a/packages/combo-box/test/overlay-opening.common.js
+++ b/packages/combo-box/test/overlay-opening.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { arrowDownKeyDown, arrowUpKeyDown, click, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { setInputValue } from './helpers.js';
 
 describe('overlay opening', () => {

--- a/packages/combo-box/test/overlay-position-polymer.test.js
+++ b/packages/combo-box/test/overlay-position-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './overlay-position.common.js';

--- a/packages/combo-box/test/overlay-position.common.js
+++ b/packages/combo-box/test/overlay-position.common.js
@@ -1,7 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-combo-box.js';
-import './not-animated-styles.js';
 import { makeItems, setInputValue } from './helpers.js';
 
 describe('overlay position', () => {

--- a/packages/combo-box/test/selecting-items-polymer.test.js
+++ b/packages/combo-box/test/selecting-items-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './selecting-items.common.js';

--- a/packages/combo-box/test/selecting-items.common.js
+++ b/packages/combo-box/test/selecting-items.common.js
@@ -1,8 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fire, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 import { clickItem, getAllItems, getFirstItem, onceScrolled, scrollToIndex, setInputValue } from './helpers.js';
 
 describe('selecting items', () => {

--- a/packages/combo-box/test/validation-polymer.test.js
+++ b/packages/combo-box/test/validation-polymer.test.js
@@ -1,0 +1,3 @@
+import './not-animated-styles.js';
+import '../vaadin-combo-box.js';
+import './validation.common.js';

--- a/packages/combo-box/test/validation.common.js
+++ b/packages/combo-box/test/validation.common.js
@@ -2,8 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
 
 describe('validation', () => {
   let comboBox, input;


### PR DESCRIPTION
## Description

Same as #6564 but for `vaadin-combo-box`.

In preparation for implementing the Lit-based combo-box, split the unit test files in two parts:

- The common part is a copy of the old test file with the combo-box imports removed,
- The `-polymer.test.js` files include imports for the Polymer-based combo-box.

Any timing changes required by the Lit migration e.g. `await nextRender()` are excluded from this PR.

## Type of change

- Test