### PR TITLE
fix: update max pages value to ensure all rows visible with varying heights

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -25,8 +25,10 @@ export class IronListAdapter {
     this.scrollContainer = scrollContainer;
     this.elementsContainer = elementsContainer || scrollContainer;
     this.reorderElements = reorderElements;
-    // Iron-list uses this value to determine how many pages of elements to render
-    this._maxPages = 1.3;
+    // Iron-list uses this value to determine how many pages of elements to render.
+    // Lower values result in inconsistent grid height when all rows are visible and row heights vary.
+    // See related issue: https://github.com/vaadin/web-components/issues/7160
+    this._maxPages = 1.7;
 
     // Placeholder height (used for sizing elements that have intrinsic 0 height after update)
     this.__placeholderHeight = 200;

--- a/packages/grid/test/basic.common.js
+++ b/packages/grid/test/basic.common.js
@@ -273,6 +273,27 @@ describe('basic features', () => {
     grid.size = 1;
     expect(getFirstCellRenderCount()).to.equal(1);
   });
+
+  it('should render all items with varying row heights when all rows visible', async () => {
+    grid = fixtureSync(`
+      <vaadin-grid all-rows-visible>
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    const rowHeights = [30, 120, 30, 30, 20, 20, 150, 20];
+    grid.items = rowHeights.map((value) => {
+      return { height: value };
+    });
+    column = grid.firstElementChild;
+    column.renderer = (root, _, model) => {
+      root.innerHTML = `<button style="height:${model.item.height}px">Button</button>`;
+    };
+    flushGrid(grid);
+    await nextFrame();
+    expect(getPhysicalItems(grid).length).to.equal(rowHeights.length);
+    const sum = rowHeights.reduce((acc, value) => acc + value, 0);
+    expect(grid.clientHeight).to.be.greaterThan(sum);
+  });
 });
 
 describe('flex child', () => {


### PR DESCRIPTION
## Description

In a performance optimization [PR](https://github.com/vaadin/web-components/pull/2912), the `_maxPages` property of `iron-list-core` was set to `1.3`. However, with specific varying row heights, this leads to the miscalculation of the estimated height. This prevents all items from rendering, causing the rows to be visible only when scrolled to. This scroll also changes the grid height when scrolled.

This PR increases the `_maxPages` value to `1.7`. It preserves the optimization and the problems do not reproduce with a similar setup anymore.

Fixes #7160 
## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.