### PR TITLE
fix: reset tabindex to -1 when initializing menu item

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -178,6 +178,7 @@ export const ItemsMixin = (superClass) =>
       // Support menu-bar / context-menu item
       if (component._hasVaadinItemMixin) {
         component.setAttribute('role', 'menuitem');
+        component.tabIndex = -1;
       }
 
       if (component.localName === 'hr') {

--- a/packages/menu-bar/test/sub-menu.common.js
+++ b/packages/menu-bar/test/sub-menu.common.js
@@ -4,7 +4,6 @@ import {
   arrowLeft,
   arrowRight,
   arrowUp,
-  aTimeout,
   click,
   enter,
   esc,
@@ -29,6 +28,12 @@ const menuOpenEvent = isTouch ? 'click' : 'mouseover';
 describe('sub-menu', () => {
   let menu, buttons, subMenu, subMenuOverlay, item;
 
+  const createComponent = (text) => {
+    const item = document.createElement('vaadin-menu-bar-item');
+    item.textContent = text;
+    return item;
+  };
+
   beforeEach(async () => {
     menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
     menu.items = [
@@ -45,7 +50,14 @@ describe('sub-menu', () => {
       { text: 'Menu Item 2' },
       {
         text: 'Menu Item 3',
-        children: [{ text: 'Menu Item 3 1' }, { text: 'Menu Item 3 2' }],
+        children: [
+          {
+            component: createComponent('Menu Item 3 1'),
+          },
+          {
+            component: createComponent('Menu Item 3 2'),
+          },
+        ],
       },
     ];
     await nextRender(menu);
@@ -150,6 +162,22 @@ describe('sub-menu', () => {
     const spy = sinon.spy(last, 'focus');
     await nextRender(subMenu);
     expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should focus first item after re-opening when using components', async () => {
+    arrowDown(buttons[2]);
+    await nextRender(subMenu);
+
+    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    arrowDown(items[0]);
+    expect(items[1].hasAttribute('focus-ring')).to.be.true;
+
+    // Close and re-open
+    esc(items[1]);
+    arrowDown(buttons[2]);
+    await nextRender(subMenu);
+
+    expect(items[0].hasAttribute('focus-ring')).to.be.true;
   });
 
   it('should close sub-menu on first item arrow up', async () => {


### PR DESCRIPTION
## Description

Fixes #7202

This change ensures that items on sub-menu reopening do not preserve old `tabindex` attribute value. Previously, using `item.text` the items were re-generated and list-box reset their tabindex, but with `item.component` it didn't happen.

Also related to #924 which requested resetting focus in list-box specifically for `vaadin-context-menu`:

> This would at least help when used inside vaadin-context-menu, where the common case is that when the menu opens the focus should be on the first item in the menu.

## Type of change

- Bugfix