### PR TITLE
Revert "refactor: avoid unnecessary re-renders on virtualizer size change (#5650)"

### DIFF
--- a/dev/virtualizer.html
+++ b/dev/virtualizer.html
@@ -1,80 +1,57 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Virtualizer</title>
-    <script type="module" src="./common.js"></script>
-  </head>
-  <body>
-    <style>
-      html,
-      body {
-        height: 100%;
-      }
-    </style>
+<script type="module" src="./common.js"></script>
+<script type="module">
+  import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 
-    <script type="module">
-      import '@vaadin/button';
-      import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
-      import '@vaadin/horizontal-layout';
-      import '@vaadin/integer-field';
-      import { Notification } from '@vaadin/notification';
-      import '@vaadin/split-layout';
-      import '@vaadin/vertical-layout';
+  const scrollTarget = document.querySelector('#scroll-target');
+  const scrollContainer = document.querySelector('#scroll-container');
 
-      // Set up the virtualizer
-      const scrollTarget = document.querySelector('#scroll-target');
-      const scrollContainer = document.querySelector('#scroll-container');
+  const virtualizer = new Virtualizer({
+    createElements: (count) => [...Array(count)].map(() => document.createElement('div')),
+    updateElement: (el, index) => {
+      el.style.right = '0';
+      el.style.left = '0';
+      el.style.display = 'flex';
+      el.style.alignItems = 'center';
+      el.style.background = index % 2 === 0 ? '#DCDCDC' : '#C0C0C0';
+      el.style.height = '35px';
+      el.style.padding = '0 10px';
+      el.textContent = `Item ${index}`;
+    },
+    scrollTarget,
+    scrollContainer,
+    reorderElements: true,
+  });
 
-      const virtualizer = new Virtualizer({
-        createElements: (count) => [...Array(count)].map(() => document.createElement('div')),
-        updateElement: (el, index) => (el.textContent = `Item ${index}`),
-        scrollTarget,
-        scrollContainer,
-        reorderElements: true,
-      });
+  virtualizer.size = 500000;
 
-      virtualizer.size = 1000;
+  document.querySelector('.scroll-to-end').addEventListener('click', () => {
+    virtualizer.scrollToIndex(virtualizer.size - 1);
+  });
 
-      // Set up the controls
-      const sizeField = document.querySelector('#size');
-      sizeField.addEventListener('value-changed', (e) => (virtualizer.size = e.detail.value));
-      sizeField.value = virtualizer.size;
+  document.querySelector('.scroll-to-index').addEventListener('click', () => {
+    virtualizer.scrollToIndex(400000);
+  });
 
-      const scrollToIndexField = document.querySelector('#scroll-to-index');
-      const scrollButton = document.querySelector('#scroll');
-      scrollButton.addEventListener('click', () => {
-        virtualizer.scrollToIndex(parseInt(scrollToIndexField.value));
-      });
+  document.querySelector('.decrease-size').addEventListener('click', () => {
+    virtualizer.size = 400012;
+  });
 
-      const firstVisibleIndexButton = document.querySelector('#first-last-visible-index');
-      firstVisibleIndexButton.addEventListener('click', () => {
-        Notification.show(
-          `First visible index: ${virtualizer.firstVisibleIndex}, last visible index: ${virtualizer.lastVisibleIndex}`,
-        );
-      });
-    </script>
+  document.querySelector('.increase-size').addEventListener('click', () => {
+      virtualizer.size = 600000;
+    });
 
-    <vaadin-split-layout orientation="vertical" style="height: 100%">
-      <!-- Virtualizer -->
-      <div style="height: 30%; position: relative" id="scroll-target">
-        <div id="scroll-container"></div>
-      </div>
+  window.virtualizer = virtualizer;
+</script>
 
-      <!-- Controls -->
-      <vaadin-vertical-layout style="height: 70%">
-        <vaadin-integer-field id="size" label="Size" min="0"></vaadin-integer-field>
+<button class="scroll-to-end">Scroll to end</button>
 
-        <vaadin-horizontal-layout style="align-items: flex-end" theme="spacing">
-          <vaadin-integer-field id="scroll-to-index" label="Scroll To Index" value="500" min="0"></vaadin-integer-field>
+<button class="scroll-to-index">Scroll to index</button>
 
-          <vaadin-button id="scroll">Scroll</vaadin-button>
-        </vaadin-horizontal-layout>
+<button class="decrease-size">Decrease size</button>
 
-        <vaadin-button id="first-last-visible-index" style="margin-top: 30px">First/last visible index</vaadin-button>
-      </vaadin-vertical-layout>
-    </vaadin-split-layout>
-  </body>
-</html>
+<button class="increase-size">Increase size</button>
+
+<div style="height: 250px; margin: 10px 0;" id="scroll-target">
+  <!-- <div style="height: 50px; background: red; position: sticky; top: 0; z-index: 1"></div> -->
+  <div id="scroll-container"></div>
+</div>

--- a/dev/virtualizer.html
+++ b/dev/virtualizer.html
@@ -1,80 +1,80 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Virtualizer</title>
-  <script type="module" src="./common.js"></script>
-</head>
-<body>
-<style>
-  html,
-  body {
-    height: 100%;
-  }
-</style>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Virtualizer</title>
+    <script type="module" src="./common.js"></script>
+  </head>
+  <body>
+    <style>
+      html,
+      body {
+        height: 100%;
+      }
+    </style>
 
-<script type="module">
-  import '@vaadin/button';
-  import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
-  import '@vaadin/horizontal-layout';
-  import '@vaadin/integer-field';
-  import { Notification } from '@vaadin/notification';
-  import '@vaadin/split-layout';
-  import '@vaadin/vertical-layout';
+    <script type="module">
+      import '@vaadin/button';
+      import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
+      import '@vaadin/horizontal-layout';
+      import '@vaadin/integer-field';
+      import { Notification } from '@vaadin/notification';
+      import '@vaadin/split-layout';
+      import '@vaadin/vertical-layout';
 
-  // Set up the virtualizer
-  const scrollTarget = document.querySelector('#scroll-target');
-  const scrollContainer = document.querySelector('#scroll-container');
+      // Set up the virtualizer
+      const scrollTarget = document.querySelector('#scroll-target');
+      const scrollContainer = document.querySelector('#scroll-container');
 
-  const virtualizer = new Virtualizer({
-    createElements: (count) => [...Array(count)].map(() => document.createElement('div')),
-    updateElement: (el, index) => (el.textContent = `Item ${index}`),
-    scrollTarget,
-    scrollContainer,
-    reorderElements: true,
-  });
+      const virtualizer = new Virtualizer({
+        createElements: (count) => [...Array(count)].map(() => document.createElement('div')),
+        updateElement: (el, index) => (el.textContent = `Item ${index}`),
+        scrollTarget,
+        scrollContainer,
+        reorderElements: true,
+      });
 
-  virtualizer.size = 1000;
+      virtualizer.size = 1000;
 
-  // Set up the controls
-  const sizeField = document.querySelector('#size');
-  sizeField.addEventListener('value-changed', (e) => (virtualizer.size = e.detail.value));
-  sizeField.value = virtualizer.size;
+      // Set up the controls
+      const sizeField = document.querySelector('#size');
+      sizeField.addEventListener('value-changed', (e) => (virtualizer.size = e.detail.value));
+      sizeField.value = virtualizer.size;
 
-  const scrollToIndexField = document.querySelector('#scroll-to-index');
-  const scrollButton = document.querySelector('#scroll');
-  scrollButton.addEventListener('click', () => {
-    virtualizer.scrollToIndex(parseInt(scrollToIndexField.value));
-  });
+      const scrollToIndexField = document.querySelector('#scroll-to-index');
+      const scrollButton = document.querySelector('#scroll');
+      scrollButton.addEventListener('click', () => {
+        virtualizer.scrollToIndex(parseInt(scrollToIndexField.value));
+      });
 
-  const firstVisibleIndexButton = document.querySelector('#first-last-visible-index');
-  firstVisibleIndexButton.addEventListener('click', () => {
-    Notification.show(
-      `First visible index: ${virtualizer.firstVisibleIndex}, last visible index: ${virtualizer.lastVisibleIndex}`,
-    );
-  });
-</script>
+      const firstVisibleIndexButton = document.querySelector('#first-last-visible-index');
+      firstVisibleIndexButton.addEventListener('click', () => {
+        Notification.show(
+          `First visible index: ${virtualizer.firstVisibleIndex}, last visible index: ${virtualizer.lastVisibleIndex}`,
+        );
+      });
+    </script>
 
-<vaadin-split-layout orientation="vertical" style="height: 100%">
-  <!-- Virtualizer -->
-  <div style="height: 30%; position: relative" id="scroll-target">
-    <div id="scroll-container"></div>
-  </div>
+    <vaadin-split-layout orientation="vertical" style="height: 100%">
+      <!-- Virtualizer -->
+      <div style="height: 30%; position: relative" id="scroll-target">
+        <div id="scroll-container"></div>
+      </div>
 
-  <!-- Controls -->
-  <vaadin-vertical-layout style="height: 70%">
-    <vaadin-integer-field id="size" label="Size" min="0"></vaadin-integer-field>
+      <!-- Controls -->
+      <vaadin-vertical-layout style="height: 70%">
+        <vaadin-integer-field id="size" label="Size" min="0"></vaadin-integer-field>
 
-    <vaadin-horizontal-layout style="align-items: flex-end" theme="spacing">
-      <vaadin-integer-field id="scroll-to-index" label="Scroll To Index" value="500" min="0"></vaadin-integer-field>
+        <vaadin-horizontal-layout style="align-items: flex-end" theme="spacing">
+          <vaadin-integer-field id="scroll-to-index" label="Scroll To Index" value="500" min="0"></vaadin-integer-field>
 
-      <vaadin-button id="scroll">Scroll</vaadin-button>
-    </vaadin-horizontal-layout>
+          <vaadin-button id="scroll">Scroll</vaadin-button>
+        </vaadin-horizontal-layout>
 
-    <vaadin-button id="first-last-visible-index" style="margin-top: 30px">First/last visible index</vaadin-button>
-  </vaadin-vertical-layout>
-</vaadin-split-layout>
-</body>
+        <vaadin-button id="first-last-visible-index" style="margin-top: 30px">First/last visible index</vaadin-button>
+      </vaadin-vertical-layout>
+    </vaadin-split-layout>
+  </body>
 </html>

--- a/dev/virtualizer.html
+++ b/dev/virtualizer.html
@@ -1,57 +1,80 @@
-<script type="module" src="./common.js"></script>
-<script type="module">
-  import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Virtualizer</title>
+  <script type="module" src="./common.js"></script>
+</head>
+<body>
+<style>
+  html,
+  body {
+    height: 100%;
+  }
+</style>
 
+<script type="module">
+  import '@vaadin/button';
+  import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
+  import '@vaadin/horizontal-layout';
+  import '@vaadin/integer-field';
+  import { Notification } from '@vaadin/notification';
+  import '@vaadin/split-layout';
+  import '@vaadin/vertical-layout';
+
+  // Set up the virtualizer
   const scrollTarget = document.querySelector('#scroll-target');
   const scrollContainer = document.querySelector('#scroll-container');
 
   const virtualizer = new Virtualizer({
     createElements: (count) => [...Array(count)].map(() => document.createElement('div')),
-    updateElement: (el, index) => {
-      el.style.right = '0';
-      el.style.left = '0';
-      el.style.display = 'flex';
-      el.style.alignItems = 'center';
-      el.style.background = index % 2 === 0 ? '#DCDCDC' : '#C0C0C0';
-      el.style.height = '35px';
-      el.style.padding = '0 10px';
-      el.textContent = `Item ${index}`;
-    },
+    updateElement: (el, index) => (el.textContent = `Item ${index}`),
     scrollTarget,
     scrollContainer,
     reorderElements: true,
   });
 
-  virtualizer.size = 500000;
+  virtualizer.size = 1000;
 
-  document.querySelector('.scroll-to-end').addEventListener('click', () => {
-    virtualizer.scrollToIndex(virtualizer.size - 1);
+  // Set up the controls
+  const sizeField = document.querySelector('#size');
+  sizeField.addEventListener('value-changed', (e) => (virtualizer.size = e.detail.value));
+  sizeField.value = virtualizer.size;
+
+  const scrollToIndexField = document.querySelector('#scroll-to-index');
+  const scrollButton = document.querySelector('#scroll');
+  scrollButton.addEventListener('click', () => {
+    virtualizer.scrollToIndex(parseInt(scrollToIndexField.value));
   });
 
-  document.querySelector('.scroll-to-index').addEventListener('click', () => {
-    virtualizer.scrollToIndex(400000);
+  const firstVisibleIndexButton = document.querySelector('#first-last-visible-index');
+  firstVisibleIndexButton.addEventListener('click', () => {
+    Notification.show(
+      `First visible index: ${virtualizer.firstVisibleIndex}, last visible index: ${virtualizer.lastVisibleIndex}`,
+    );
   });
-
-  document.querySelector('.decrease-size').addEventListener('click', () => {
-    virtualizer.size = 400012;
-  });
-
-  document.querySelector('.increase-size').addEventListener('click', () => {
-      virtualizer.size = 600000;
-    });
-
-  window.virtualizer = virtualizer;
 </script>
 
-<button class="scroll-to-end">Scroll to end</button>
+<vaadin-split-layout orientation="vertical" style="height: 100%">
+  <!-- Virtualizer -->
+  <div style="height: 30%; position: relative" id="scroll-target">
+    <div id="scroll-container"></div>
+  </div>
 
-<button class="scroll-to-index">Scroll to index</button>
+  <!-- Controls -->
+  <vaadin-vertical-layout style="height: 70%">
+    <vaadin-integer-field id="size" label="Size" min="0"></vaadin-integer-field>
 
-<button class="decrease-size">Decrease size</button>
+    <vaadin-horizontal-layout style="align-items: flex-end" theme="spacing">
+      <vaadin-integer-field id="scroll-to-index" label="Scroll To Index" value="500" min="0"></vaadin-integer-field>
 
-<button class="increase-size">Increase size</button>
+      <vaadin-button id="scroll">Scroll</vaadin-button>
+    </vaadin-horizontal-layout>
 
-<div style="height: 250px; margin: 10px 0;" id="scroll-target">
-  <!-- <div style="height: 50px; background: red; position: sticky; top: 0; z-index: 1"></div> -->
-  <div id="scroll-container"></div>
-</div>
+    <vaadin-button id="first-last-visible-index" style="margin-top: 30px">First/last visible index</vaadin-button>
+  </vaadin-vertical-layout>
+</vaadin-split-layout>
+</body>
+</html>

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -328,8 +328,6 @@ export class IronListAdapter {
       if (fviOffsetBefore !== undefined && fviOffsetAfter !== undefined) {
         this._scrollTop += fviOffsetBefore - fviOffsetAfter;
       }
-
-      this.__skipNextVirtualIndexAdjust = true;
     }
 
     this.__preventElementUpdates = false;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -322,6 +322,9 @@ export class IronListAdapter {
     // Try to restore the scroll position if the new size is larger than 0
     if (size > 0) {
       fvi = Math.min(fvi, size - 1);
+      // Note, calling scrollToIndex also updates the virtual index offset,
+      // causing the virtualizer to add more items on size decrease,
+      // and remove exceeding items on size decrease.
       this.scrollToIndex(fvi);
 
       const fviOffsetAfter = this.__getIndexScrollOffset(fvi);

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -328,6 +328,8 @@ export class IronListAdapter {
       if (fviOffsetBefore !== undefined && fviOffsetAfter !== undefined) {
         this._scrollTop += fviOffsetBefore - fviOffsetAfter;
       }
+
+      this.__skipNextVirtualIndexAdjust = true;
     }
 
     this.__preventElementUpdates = false;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -300,23 +300,37 @@ export class IronListAdapter {
       this._debouncers._increasePoolIfNeeded.cancel();
     }
 
+    // Prevent element update while the scroll position is being restored
+    this.__preventElementUpdates = true;
+
+    // Record the scroll position before changing the size
+    let fvi; // First visible index
+    let fviOffsetBefore; // Scroll offset of the first visible index
+    if (size > 0) {
+      fvi = this.adjustedFirstVisibleIndex;
+      fviOffsetBefore = this.__getIndexScrollOffset(fvi);
+    }
+
     // Change the size
     this.__size = size;
 
-    if (!this._physicalItems) {
-      // Not initialized yet
-      this._itemsChanged({
-        path: 'items',
-      });
-      this.__preventElementUpdates = true;
-      flush();
-      this.__preventElementUpdates = false;
-    } else {
-      // Already initialized, just update _virtualCount
-      this._updateScrollerSize();
-      this._virtualCount = this.items.length;
-      this._render();
+    this._itemsChanged({
+      path: 'items',
+    });
+    flush();
+
+    // Try to restore the scroll position if the new size is larger than 0
+    if (size > 0) {
+      fvi = Math.min(fvi, size - 1);
+      this.scrollToIndex(fvi);
+
+      const fviOffsetAfter = this.__getIndexScrollOffset(fvi);
+      if (fviOffsetBefore !== undefined && fviOffsetAfter !== undefined) {
+        this._scrollTop += fviOffsetBefore - fviOffsetAfter;
+      }
     }
+
+    this.__preventElementUpdates = false;
 
     // When reducing size while invisible, iron-list does not update items, so
     // their hidden state is not updated and their __lastUpdatedIndex is not
@@ -329,8 +343,7 @@ export class IronListAdapter {
       requestAnimationFrame(() => this._resizeHandler());
     }
 
-    // Schedule and flush a resize handler. This will cause a
-    // re-render for the elements.
+    // Schedule and flush a resize handler
     this._resizeHandler();
     flush();
   }

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -323,8 +323,8 @@ export class IronListAdapter {
     if (size > 0) {
       fvi = Math.min(fvi, size - 1);
       // Note, calling scrollToIndex also updates the virtual index offset,
-      // causing the virtualizer to add more items on size decrease,
-      // and remove exceeding items on size decrease.
+      // causing the virtualizer to add more items when size is increased,
+      // and remove exceeding items when size is decreased.
       this.scrollToIndex(fvi);
 
       const fviOffsetAfter = this.__getIndexScrollOffset(fvi);

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { Virtualizer } from '../src/virtualizer.js';
 
 describe('unlimited size', () => {
@@ -9,7 +9,7 @@ describe('unlimited size', () => {
 
   beforeEach(() => {
     scrollTarget = fixtureSync(`
-      <div style="height: 100px;">
+      <div style="height: 250px;">
         <div></div>
       </div>
     `);
@@ -29,6 +29,10 @@ describe('unlimited size', () => {
 
     virtualizer.size = 1000000;
   });
+
+  function getLastRenderedIndex() {
+    return [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
+  }
 
   it('should scroll to a large index', () => {
     const index = Math.floor(virtualizer.size / 2);
@@ -201,5 +205,77 @@ describe('unlimited size', () => {
       Math.floor(itemRect.top),
       Math.ceil(itemRect.bottom),
     );
+  });
+
+  it('should add more items on size increase', () => {
+    const index = virtualizer.size - 1;
+    virtualizer.scrollToIndex(index);
+    expect(getLastRenderedIndex()).to.equal(index);
+
+    virtualizer.size += 2000;
+    expect(getLastRenderedIndex()).to.be.above(index);
+  });
+
+  it('should remove exceeding items on size decrease', () => {
+    const index = virtualizer.size - 1;
+    virtualizer.scrollToIndex(index);
+    expect(getLastRenderedIndex()).to.equal(index);
+
+    virtualizer.size -= 1000;
+    expect(getLastRenderedIndex()).to.be.below(index);
+  });
+
+  it('should set scroll to end when size decrease affects a visible index', async () => {
+    virtualizer.scrollToIndex(virtualizer.size - 1000);
+    virtualizer.size = virtualizer.firstVisibleIndex - 20;
+    await oneEvent(scrollTarget, 'scroll');
+    const lastItem = elementsContainer.querySelector(`#item-${virtualizer.size - 1}`);
+    expect(lastItem.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
+  });
+
+  it('should preserve scroll position when size decrease affects a buffered index', async () => {
+    // Make sure there are at least 2 buffered items at the end.
+    const lastBufferedIndex = [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
+    expect(lastBufferedIndex - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
+
+    // Scroll to an index and add an additional scroll offset.
+    const index = virtualizer.size - 1000;
+    virtualizer.scrollToIndex(index);
+    scrollTarget.scrollTop += 10;
+
+    // Decrease the size so that the last buffered index exceeds the new size bounds.
+    virtualizer.size = virtualizer.lastVisibleIndex + 1;
+    await oneEvent(scrollTarget, 'scroll');
+
+    const item = elementsContainer.querySelector(`#item-${index}`);
+    expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);
+  });
+
+  // FIXME: Fails due to a scroll offset reset caused by _adjustVirtualIndexOffset on scroll event.
+  it.skip('should preserve scroll position when size decrease does not affect any rendered indexes', async () => {
+    // Scroll to an index and add an additional scroll offset.
+    const index = virtualizer.size - 2000;
+    virtualizer.scrollToIndex(index);
+    scrollTarget.scrollTop += 10;
+
+    // Decrease the size so that no rendered indexes are affected.
+    virtualizer.size -= 1000;
+    await oneEvent(scrollTarget, 'scroll');
+
+    const item = elementsContainer.querySelector(`#item-${index}`);
+    expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);
+  });
+
+  // FIXME: Fails due to a scroll offset reset caused by _adjustVirtualIndexOffset on scroll event.
+  it.skip('should preserve scroll position on size increase', async () => {
+    const index = virtualizer.size - 2000;
+    virtualizer.scrollToIndex(index);
+    scrollTarget.scrollTop += 10;
+
+    virtualizer.size += 1000;
+    await oneEvent(scrollTarget, 'scroll');
+
+    const item = elementsContainer.querySelector(`#item-${index}`);
+    expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);
   });
 });

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { Virtualizer } from '../src/virtualizer.js';
 
 describe('unlimited size', () => {
@@ -9,7 +9,7 @@ describe('unlimited size', () => {
 
   beforeEach(() => {
     scrollTarget = fixtureSync(`
-      <div style="height: 250px;">
+      <div style="height: 200px;">
         <div></div>
       </div>
     `);
@@ -235,13 +235,12 @@ describe('unlimited size', () => {
 
   it('should preserve scroll position when size decrease affects a buffered index', () => {
     // Make sure there are at least 2 buffered items at the end.
-    const lastBufferedIndex = [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
-    expect(lastBufferedIndex - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
+    expect(getLastRenderedIndex() - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
 
     // Scroll to an index and add an additional scroll offset.
     const index = virtualizer.size - 1000;
     virtualizer.scrollToIndex(index);
-    // scrollTarget.scrollTop += 10;
+    scrollTarget.scrollTop += 10;
 
     // Decrease the size so that the last buffered index exceeds the new size bounds.
     virtualizer.size = virtualizer.lastVisibleIndex + 1;

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -233,7 +233,7 @@ describe('unlimited size', () => {
     expect(lastItem.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
   });
 
-  it('should preserve scroll position when size decrease affects a buffered index', async () => {
+  it('should preserve scroll position when size decrease affects a buffered index', () => {
     // Make sure there are at least 2 buffered items at the end.
     const lastBufferedIndex = [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
     expect(lastBufferedIndex - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
@@ -241,11 +241,11 @@ describe('unlimited size', () => {
     // Scroll to an index and add an additional scroll offset.
     const index = virtualizer.size - 1000;
     virtualizer.scrollToIndex(index);
-    scrollTarget.scrollTop += 10;
+    // scrollTarget.scrollTop += 10;
 
     // Decrease the size so that the last buffered index exceeds the new size bounds.
     virtualizer.size = virtualizer.lastVisibleIndex + 1;
-    await oneEvent(scrollTarget, 'scroll');
+    // await oneEvent(scrollTarget, 'scroll');
 
     const item = elementsContainer.querySelector(`#item-${index}`);
     expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -22,9 +22,11 @@ describe('unlimited size', () => {
         el.index = index;
         el.id = `item-${index}`;
         el.textContent = el.id;
+        el.style.right = '0';
+        el.style.left = '0';
         el.style.display = 'flex';
         el.style.alignItems = 'center';
-        el.style.background = index % 2 === 0 ? '#DCDCDC' : '#C0C0C0';
+        el.style.background = index % 2 === 0 ? '#e7e7e7' : '#d0d0d0';
         el.style.height = '30px';
         el.style.padding = '0 10px';
       },

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -233,7 +233,7 @@ describe('unlimited size', () => {
     expect(lastItem.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
   });
 
-  it('should preserve scroll position when size decrease affects a buffered index', () => {
+  it('should preserve scroll position when size decrease affects a buffered index', async () => {
     // Make sure there are at least 2 buffered items at the end.
     expect(getLastRenderedIndex() - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
 
@@ -244,7 +244,7 @@ describe('unlimited size', () => {
 
     // Decrease the size so that the last buffered index exceeds the new size bounds.
     virtualizer.size = virtualizer.lastVisibleIndex + 1;
-    // await oneEvent(scrollTarget, 'scroll');
+    await oneEvent(scrollTarget, 'scroll');
 
     const item = elementsContainer.querySelector(`#item-${index}`);
     expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -9,7 +9,7 @@ describe('unlimited size', () => {
 
   beforeEach(() => {
     scrollTarget = fixtureSync(`
-      <div style="height: 200px;">
+      <div style="height: 250px;">
         <div></div>
       </div>
     `);
@@ -22,6 +22,11 @@ describe('unlimited size', () => {
         el.index = index;
         el.id = `item-${index}`;
         el.textContent = el.id;
+        el.style.display = 'flex';
+        el.style.alignItems = 'center';
+        el.style.background = index % 2 === 0 ? '#DCDCDC' : '#C0C0C0';
+        el.style.height = '30px';
+        el.style.padding = '0 10px';
       },
       scrollTarget,
       scrollContainer,

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -192,7 +192,7 @@ describe('virtualizer', () => {
     expect(lastItem.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
   });
 
-  it('should preserve scroll position when size decrease affects a buffered index', async () => {
+  it('should preserve scroll position when size decrease affects a buffered index', () => {
     const lastBufferedIndex = [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
     expect(lastBufferedIndex - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
 
@@ -203,7 +203,7 @@ describe('virtualizer', () => {
 
     // Decrease the size so that the last buffered index exceeds the new size bounds.
     virtualizer.size = virtualizer.lastVisibleIndex + 1;
-    await oneEvent(scrollTarget, 'scroll');
+    // await oneEvent(scrollTarget, 'scroll');
 
     const item = elementsContainer.querySelector(`#item-${index}`);
     expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -15,7 +15,7 @@ describe('virtualizer', () => {
     }
 
     scrollTarget = fixtureSync(`
-      <div style="height: 200px;">
+      <div style="height: 250px;">
         <div></div>
       </div>
     `);
@@ -30,6 +30,11 @@ describe('virtualizer', () => {
           el.index = index;
           el.id = `item-${index}`;
           el.textContent = el.id;
+          el.style.display = 'flex';
+          el.style.alignItems = 'center';
+          el.style.background = index % 2 === 0 ? '#DCDCDC' : '#C0C0C0';
+          el.style.height = '30px';
+          el.style.padding = '0 10px';
         }),
       scrollTarget,
       scrollContainer,

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -201,25 +201,6 @@ describe('virtualizer', () => {
     expect(updateElement.called).to.be.false;
   });
 
-  it('should not request item updates on size increase when scrolled', async () => {
-    const updateElement = sinon.spy((el, index) => {
-      el.textContent = `item-${index}`;
-    });
-    init({ size: 100, updateElement });
-
-    // Scroll halfway down the list
-    virtualizer.scrollToIndex(50);
-    // Manually scroll down a bit
-    scrollTarget.scrollTop += 100;
-    await nextFrame();
-
-    // Increase the size so it shouldn't affect the current viewport items
-    updateElement.resetHistory();
-    virtualizer.size = 200;
-
-    expect(updateElement.called).to.be.false;
-  });
-
   it('should request a different set of items on size decrease', () => {
     const updateElement = sinon.spy((el, index) => {
       el.textContent = `item-${index}`;

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -15,7 +15,7 @@ describe('virtualizer', () => {
     }
 
     scrollTarget = fixtureSync(`
-      <div style="height: 250px;">
+      <div style="height: 200px;">
         <div></div>
       </div>
     `);
@@ -39,6 +39,10 @@ describe('virtualizer', () => {
   }
 
   beforeEach(() => init({}));
+
+  function getLastRenderedIndex() {
+    return [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
+  }
 
   it('should have the first item at the top', () => {
     const item = elementsContainer.querySelector('#item-0');
@@ -193,8 +197,7 @@ describe('virtualizer', () => {
   });
 
   it('should preserve scroll position when size decrease affects a buffered index', () => {
-    const lastBufferedIndex = [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
-    expect(lastBufferedIndex - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
+    expect(getLastRenderedIndex() - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
 
     // Scroll to an index and add an additional scroll offset.
     const index = 50;

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -15,7 +15,7 @@ describe('virtualizer', () => {
     }
 
     scrollTarget = fixtureSync(`
-      <div style="height: 100px;">
+      <div style="height: 250px;">
         <div></div>
       </div>
     `);
@@ -174,7 +174,7 @@ describe('virtualizer', () => {
     expect(item.getBoundingClientRect().top).to.equal(scrollTarget.getBoundingClientRect().top);
   });
 
-  it('should restore scroll position on size change', () => {
+  it('should preserve scroll position on size increase', () => {
     // Scroll to item 50 and an additional 10 pixels
     virtualizer.scrollToIndex(50);
     scrollTarget.scrollTop += 10;
@@ -184,21 +184,43 @@ describe('virtualizer', () => {
     expect(item.getBoundingClientRect().top).to.equal(scrollTarget.getBoundingClientRect().top - 10);
   });
 
-  it('should not request item updates on size increase', () => {
-    const updateElement = sinon.spy((el, index) => {
-      el.textContent = `item-${index}`;
-    });
-    init({ size: 100, updateElement });
-
-    // Scroll halfway down the list
-    updateElement.resetHistory();
+  it('should set scroll to end when size decrease affects a visible index', async () => {
     virtualizer.scrollToIndex(50);
+    virtualizer.size = virtualizer.firstVisibleIndex - 20;
+    await oneEvent(scrollTarget, 'scroll');
+    const lastItem = elementsContainer.querySelector(`#item-${virtualizer.size - 1}`);
+    expect(lastItem.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
+  });
 
-    // Increase the size so it shouldn't affect the current viewport items
-    updateElement.resetHistory();
-    virtualizer.size = 200;
+  it('should preserve scroll position when size decrease affects a buffered index', async () => {
+    const lastBufferedIndex = [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
+    expect(lastBufferedIndex - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
 
-    expect(updateElement.called).to.be.false;
+    // Scroll to an index and add an additional scroll offset.
+    const index = 50;
+    virtualizer.scrollToIndex(index);
+    scrollTarget.scrollTop += 10;
+
+    // Decrease the size so that the last buffered index exceeds the new size bounds.
+    virtualizer.size = virtualizer.lastVisibleIndex + 1;
+    await oneEvent(scrollTarget, 'scroll');
+
+    const item = elementsContainer.querySelector(`#item-${index}`);
+    expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);
+  });
+
+  it('should preserve scroll position when size decrease does not affect any rendered indexes', async () => {
+    // Scroll to an index and add an additional scroll offset.
+    const index = 50;
+    virtualizer.scrollToIndex(index);
+    scrollTarget.scrollTop += 10;
+
+    // Decrease the size so that no rendered indexes are affected.
+    virtualizer.size = 80;
+    await oneEvent(scrollTarget, 'scroll');
+
+    const item = elementsContainer.querySelector(`#item-${index}`);
+    expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);
   });
 
   it('should request a different set of items on size decrease', () => {

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -30,9 +30,11 @@ describe('virtualizer', () => {
           el.index = index;
           el.id = `item-${index}`;
           el.textContent = el.id;
+          el.style.right = '0';
+          el.style.left = '0';
           el.style.display = 'flex';
           el.style.alignItems = 'center';
-          el.style.background = index % 2 === 0 ? '#DCDCDC' : '#C0C0C0';
+          el.style.background = index % 2 === 0 ? '#e7e7e7' : '#d0d0d0';
           el.style.height = '30px';
           el.style.padding = '0 10px';
         }),

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -196,7 +196,8 @@ describe('virtualizer', () => {
     expect(lastItem.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
   });
 
-  it('should preserve scroll position when size decrease affects a buffered index', () => {
+  it('should preserve scroll position when size decrease affects a buffered index', async () => {
+    // Make sure there are at least 2 buffered items at the end.
     expect(getLastRenderedIndex() - virtualizer.lastVisibleIndex).to.be.greaterThanOrEqual(2);
 
     // Scroll to an index and add an additional scroll offset.
@@ -206,7 +207,7 @@ describe('virtualizer', () => {
 
     // Decrease the size so that the last buffered index exceeds the new size bounds.
     virtualizer.size = virtualizer.lastVisibleIndex + 1;
-    // await oneEvent(scrollTarget, 'scroll');
+    await oneEvent(scrollTarget, 'scroll');
 
     const item = elementsContainer.querySelector(`#item-${index}`);
     expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);

--- a/packages/grid/test/basic.common.js
+++ b/packages/grid/test/basic.common.js
@@ -273,6 +273,27 @@ describe('basic features', () => {
     grid.size = 1;
     expect(getFirstCellRenderCount()).to.equal(1);
   });
+
+  it('should render all items with varying row heights when all rows visible', async () => {
+    grid = fixtureSync(`
+      <vaadin-grid all-rows-visible>
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    const rowHeights = [30, 100, 30, 30, 100, 30];
+    grid.items = rowHeights.map((value) => {
+      return { height: value };
+    });
+    column = grid.firstElementChild;
+    column.renderer = (root, _, model) => {
+      root.innerHTML = `<button style="height:${model.item.height}px">Button</button>`;
+    };
+    flushGrid(grid);
+    await nextFrame();
+    expect(getPhysicalItems(grid).length).to.equal(rowHeights.length);
+    const sum = rowHeights.reduce((acc, value) => acc + value, 0);
+    expect(grid.clientHeight).to.be.greaterThan(sum);
+  });
 });
 
 describe('flex child', () => {


### PR DESCRIPTION
## Description

The PR reverts #5650 due to several regressions mentioned below, and also adds tests that should prevent such regressions in the future.

Fixes https://github.com/vaadin/web-components/issues/7079
Fixes https://github.com/vaadin/web-components/issues/7186
Fixes https://github.com/vaadin/web-components/issues/7160

## Type of change

- [x] Revert
