### PR TITLE
fix: do not override theme attribute set on slotted buttons

### DIFF
--- a/packages/crud/src/vaadin-crud-controllers.js
+++ b/packages/crud/src/vaadin-crud-controllers.js
@@ -41,7 +41,8 @@ export class ButtonSlotController extends SlotController {
       this.defaultNode = node;
     }
 
-    if (node === this.defaultNode) {
+    // Respect default theme attribute set by the Flow counterpart
+    if (node === this.defaultNode && !node.hasAttribute('theme')) {
       node.setAttribute('theme', this.theme);
     }
 

--- a/packages/crud/test/crud-buttons.test.js
+++ b/packages/crud/test/crud-buttons.test.js
@@ -738,6 +738,25 @@ describe('crud buttons', () => {
 
         expect(button.textContent).to.equal('Add user');
       });
+
+      it('should set theme attribute of the new item button when marked as a default', async () => {
+        button._isDefault = true;
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('primary');
+      });
+
+      it('should not change theme attribute of the new item button when marked as a default', async () => {
+        button._isDefault = true;
+        button.setAttribute('theme', 'primary success');
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('primary success');
+      });
     });
 
     describe('delete', () => {
@@ -773,6 +792,25 @@ describe('crud buttons', () => {
         await nextRender();
 
         expect(button.textContent).to.equal('Drop user');
+      });
+
+      it('should set theme attribute of the delete button when marked as a default', async () => {
+        button._isDefault = true;
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('tertiary error');
+      });
+
+      it('should not change theme attribute of the delete button when marked as a default', async () => {
+        button._isDefault = true;
+        button.setAttribute('theme', 'tertiary contrast');
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('tertiary contrast');
       });
     });
 
@@ -810,6 +848,25 @@ describe('crud buttons', () => {
 
         expect(button.textContent).to.equal('Save user');
       });
+
+      it('should set theme attribute of the save button when marked as a default', async () => {
+        button._isDefault = true;
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('primary');
+      });
+
+      it('should not change theme attribute of the save button when marked as a default', async () => {
+        button._isDefault = true;
+        button.setAttribute('theme', 'primary contrast');
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('primary contrast');
+      });
     });
 
     describe('cancel', () => {
@@ -845,6 +902,25 @@ describe('crud buttons', () => {
         await nextRender();
 
         expect(button.textContent).to.equal('Discard');
+      });
+
+      it('should set theme attribute of the cancel button when marked as a default', async () => {
+        button._isDefault = true;
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('tertiary');
+      });
+
+      it('should not change theme attribute of the cancel button when marked as a default', async () => {
+        button._isDefault = true;
+        button.setAttribute('theme', 'tertiary contrast');
+
+        crud.appendChild(button);
+        await nextRender();
+
+        expect(button.getAttribute('theme')).to.equal('tertiary contrast');
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6123

Added a check to detect if button has `theme` attribute set and if so, do not override it by the default one.

## Type of change

- Bugfix