### PR TITLE
chore: remove Discord badges, add link to Vaadin Forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-question.yml
+++ b/.github/ISSUE_TEMPLATE/support-question.yml
@@ -1,12 +1,9 @@
 name: 🤗 Support Question
-description: If you have a question 💬, please check out our Discord or StackOverflow!
+description: If you have a question 💬, please check out Vaadin Forum!
 body:
   - type: markdown
     attributes:
-      value: "We primarily use GitHub as an issue tracker. For support questions, please check out these resources below. Thank you!"
-  - type: markdown
-    attributes:
-      value: "* StackOverflow: https://stackoverflow.com/questions/tagged/vaadin using the tag `vaadin`\n* Discord: If it's just a quick question you can ask it on our Discord channel: https://discord.com/invite/MYFq5RTbBn\n* Also have a look at our website for more information on how to get support: https://vaadin.com/support"
+      value: "We primarily use GitHub as an issue tracker. For support questions, please check out https://vaadin.com/forum/. Thank you!"
   - type: input
     id: ignore
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to Vaadin Web Components
 
-*There are many ways to participate to the Vaadin Web Components project. You can ask questions and participate to discussion in [Vaadin Forum](https://vaadin.com/forum/), [fill bug reports](https://github.com/vaadin/web-components/issues/new/choose) and enhancement suggestions and contribute code.*
+*There are many ways to contribute to the Vaadin Web Components project. You can ask questions and participate in discussions in the [Vaadin Forum](https://vaadin.com/forum/), [create issues](https://github.com/vaadin/web-components/issues/new/choose) to file bug reports and enhancement suggestions, or contribute code.*
 
 The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/pr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to Vaadin Web Components
 
-*There are many ways to participate to the Vaadin Web Components project. You can ask questions and participate to discussion in [Discord](https://discord.com/invite/MYFq5RTbBn), [stackoverflow](https://stackoverflow.com/questions/tagged/vaadin), [fill bug reports](https://github.com/vaadin/web-components/issues/new/choose) and enhancement suggestions and contribute code.*
+*There are many ways to participate to the Vaadin Web Components project. You can ask questions and participate to discussion in [Vaadin Forum](https://vaadin.com/forum/), [fill bug reports](https://github.com/vaadin/web-components/issues/new/choose) and enhancement suggestions and contribute code.*
 
-The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/overview
+The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/pr

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 [![Build](https://github.com/vaadin/web-components/actions/workflows/coverage.yml/badge.svg)](https://github.com/vaadin/web-components/actions/workflows/coverage.yml)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/vaadin.svg?label=follow+vaadin)](https://twitter.com/vaadin)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 </div>
 

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -5,7 +5,6 @@ A web component for displaying a vertically stacked set of expandable panels.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/accordion)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/accordion)](https://www.npmjs.com/package/@vaadin/accordion)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-accordion>

--- a/packages/app-layout/README.md
+++ b/packages/app-layout/README.md
@@ -5,7 +5,6 @@ A web component for building common application layouts.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/app-layout)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/app-layout)](https://www.npmjs.com/package/@vaadin/app-layout)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-app-layout>

--- a/packages/avatar-group/README.md
+++ b/packages/avatar-group/README.md
@@ -5,7 +5,6 @@ A web component for grouping multiple [`<vaadin-avatar>`](https://www.npmjs.com/
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/avatar/#avatar-group)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/avatar-group)](https://www.npmjs.com/package/@vaadin/avatar-group)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-avatar-group max-items-visible="3"></vaadin-avatar-group>

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -5,7 +5,6 @@ A web component for graphical representation of an object or entity, for example
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/avatar)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/avatar)](https://www.npmjs.com/package/@vaadin/avatar)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-avatar></vaadin-avatar>

--- a/packages/board/README.md
+++ b/packages/board/README.md
@@ -7,7 +7,6 @@ A powerful and easy to use layout web component for building responsive views.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/board)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/board)](https://www.npmjs.com/package/@vaadin/board)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-board>

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -5,7 +5,6 @@ An accessible and customizable button that allows users to perform actions.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/button)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/button)](https://www.npmjs.com/package/@vaadin/button)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-button theme="primary">Primary</vaadin-button>

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -7,7 +7,6 @@ A feature-rich interactive charting library providing multiple different chart t
 [Documentation + Live Demo ↗](https://charts.demo.vaadin.com/vaadin-charts/)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/charts)](https://www.npmjs.com/package/@vaadin/charts)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-chart type="pie">

--- a/packages/checkbox-group/README.md
+++ b/packages/checkbox-group/README.md
@@ -5,7 +5,6 @@ A web component that allows the user to choose several items from a group of bin
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/checkbox)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/checkbox-group)](https://www.npmjs.com/package/@vaadin/checkbox-group)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-checkbox-group label="Export data">

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -5,7 +5,6 @@ An input field representing a binary choice.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/checkbox)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/checkbox)](https://www.npmjs.com/package/@vaadin/checkbox)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-checkbox label="Checked" checked></vaadin-checkbox>

--- a/packages/combo-box/README.md
+++ b/packages/combo-box/README.md
@@ -5,7 +5,6 @@ A web component for choosing a value from a filterable list of options presented
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/combo-box)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/combo-box)](https://www.npmjs.com/package/@vaadin/combo-box)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-combo-box

--- a/packages/confirm-dialog/README.md
+++ b/packages/confirm-dialog/README.md
@@ -5,7 +5,6 @@ A modal dialog web component for confirming user actions.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/confirm-dialog)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/confirm-dialog)](https://www.npmjs.com/package/@vaadin/confirm-dialog)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-confirm-dialog header="Unsaved changes" confirm-text="Save" reject-text="Discard" cancel reject>

--- a/packages/context-menu/README.md
+++ b/packages/context-menu/README.md
@@ -5,7 +5,6 @@ A web component that can be attached to any component to display a context menu.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/context-menu)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/context-menu)](https://www.npmjs.com/package/@vaadin/context-menu)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-context-menu>

--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -7,7 +7,6 @@ A web component to display a banner for users to give consent to the usage of co
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/cookie-consent)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/cookie-consent)](https://www.npmjs.com/package/@vaadin/cookie-consent)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-cookie-consent></vaadin-cookie-consent>

--- a/packages/crud/README.md
+++ b/packages/crud/README.md
@@ -7,7 +7,6 @@ A web component for displaying, editing, creating, and deleting items from a dat
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/crud)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/crud)](https://www.npmjs.com/package/@vaadin/crud)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-crud items='[{"name": "Juan", "surname": "Garcia"}]'></vaadin-crud>

--- a/packages/custom-field/README.md
+++ b/packages/custom-field/README.md
@@ -5,7 +5,6 @@ A web component for wrapping multiple components as a single field.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/custom-field)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/custom-field)](https://www.npmjs.com/package/@vaadin/custom-field)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-custom-field label="Enrollment period" helper-text="Cannot be longer than 30 days" required>

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -5,7 +5,6 @@ A web component that allows to enter a date by typing or by selecting from a cal
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/date-picker)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/date-picker)](https://www.npmjs.com/package/@vaadin/date-picker)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-date-picker label="Label" value="2018-12-03" clear-button-visible></vaadin-date-picker>

--- a/packages/date-time-picker/README.md
+++ b/packages/date-time-picker/README.md
@@ -5,7 +5,6 @@ An input field web component for selecting both a date and a time.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/date-time-picker)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/date-time-picker)](https://www.npmjs.com/package/@vaadin/date-time-picker)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-date-time-picker></vaadin-date-time-picker>

--- a/packages/details/README.md
+++ b/packages/details/README.md
@@ -5,7 +5,6 @@ A web component that provides an expandable panel for showing and hiding content
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/details)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/details)](https://www.npmjs.com/package/@vaadin/details)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-details opened>

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -5,7 +5,6 @@ A web component for presenting information and user interface elements in an ove
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/dialog)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/dialog)](https://www.npmjs.com/package/@vaadin/dialog)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-dialog opened></vaadin-dialog>

--- a/packages/email-field/README.md
+++ b/packages/email-field/README.md
@@ -5,7 +5,6 @@ An extension of [`<vaadin-text-field>`](https://www.npmjs.com/package/@vaadin/te
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/email-field)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/email-field)](https://www.npmjs.com/package/@vaadin/email-field)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-email-field label="Email"></vaadin-email-field>

--- a/packages/form-layout/README.md
+++ b/packages/form-layout/README.md
@@ -5,7 +5,6 @@ A web component for building responsive forms with multiple columns.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/form-layout)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/form-layout)](https://www.npmjs.com/package/@vaadin/form-layout)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-form-layout>

--- a/packages/grid-pro/README.md
+++ b/packages/grid-pro/README.md
@@ -7,7 +7,6 @@ An extension of the `vaadin-grid` component that provides inline editing with fu
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/grid-pro)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/grid-pro)](https://www.npmjs.com/package/@vaadin/grid-pro)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-grid-pro>

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -5,7 +5,6 @@ A web component for showing tabular data.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/grid)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/grid)](https://www.npmjs.com/package/@vaadin/grid)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-grid theme="row-dividers" column-reordering-allowed multi-sort>

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -5,7 +5,6 @@ A web component for displaying SVG icons.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/ds/foundation/icons)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/icon)](https://www.npmjs.com/package/@vaadin/icon)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-icon name="vaadin:user"></vaadin-icon>

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -5,7 +5,6 @@ A set of 600+ icons designed for web applications.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/ds/foundation/icons/vaadin)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/icons)](https://www.npmjs.com/package/@vaadin/icons)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 [<img src="https://raw.githubusercontent.com/vaadin/web-components/main/packages/icons/screenshot.png" width="728" alt="Screenshot of vaadin-icons">](https://vaadin.com/docs/latest/ds/foundation/icons/vaadin)
 

--- a/packages/integer-field/README.md
+++ b/packages/integer-field/README.md
@@ -5,7 +5,6 @@ An extension of [`<vaadin-number-field>`](https://www.npmjs.com/package/@vaadin/
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/number-field/#integer-field)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/integer-field)](https://www.npmjs.com/package/@vaadin/integer-field)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-integer-field label="X"></vaadin-integer-field>

--- a/packages/item/README.md
+++ b/packages/item/README.md
@@ -5,7 +5,6 @@ A web component for displaying items in list-box, context-menu or select compone
 [Documentation + Live Demo ↗](https://vaadin.com/components/vaadin-item/html-examples)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/item)](https://www.npmjs.com/package/@vaadin/item)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-item>Simple Item</vaadin-item> <vaadin-item disabled>Disabled Item</vaadin-item>

--- a/packages/list-box/README.md
+++ b/packages/list-box/README.md
@@ -5,7 +5,6 @@ A web component for selecting one or more values from a scrollable list of items
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/list-box)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/list-box)](https://www.npmjs.com/package/@vaadin/list-box)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-list-box selected="2">

--- a/packages/login/README.md
+++ b/packages/login/README.md
@@ -5,7 +5,6 @@ A web component for displaying a login form, either inline, or as an overlay.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/login)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/login)](https://www.npmjs.com/package/@vaadin/login)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-login-overlay opened></vaadin-login-overlay>

--- a/packages/map/README.md
+++ b/packages/map/README.md
@@ -7,7 +7,6 @@ A component for displaying web maps.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/map)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/map)](https://www.npmjs.com/package/@vaadin/map)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-map></vaadin-map>

--- a/packages/menu-bar/README.md
+++ b/packages/menu-bar/README.md
@@ -5,7 +5,6 @@ A web component for creating a horizontal button bar with hierarchical drop-down
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/menu-bar)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/menu-bar)](https://www.npmjs.com/package/@vaadin/menu-bar)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-menu-bar></vaadin-menu-bar>

--- a/packages/notification/README.md
+++ b/packages/notification/README.md
@@ -5,7 +5,6 @@ A web component for providing feedback to the user.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/notification)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/notification)](https://www.npmjs.com/package/@vaadin/notification)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-notification opened position="middle" duration="-1"></vaadin-notification>

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -5,7 +5,6 @@ An input field web component that only accepts numeric input.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/number-field)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/number-field)](https://www.npmjs.com/package/@vaadin/number-field)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-number-field label="Balance"></vaadin-number-field>

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -3,7 +3,6 @@
 &lt;vaadin-overlay&gt; is a Web Component meant for internal use in Vaadin components.
 
 [![npm version](https://badgen.net/npm/v/@vaadin/overlay)](https://www.npmjs.com/package/@vaadin/overlay)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ## License
 

--- a/packages/password-field/README.md
+++ b/packages/password-field/README.md
@@ -5,7 +5,6 @@ An extension of [`<vaadin-text-field>`](https://www.npmjs.com/package/@vaadin/te
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/password-field)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/password-field)](https://www.npmjs.com/package/@vaadin/password-field)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-password-field label="Password"></vaadin-password-field>

--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -5,7 +5,6 @@ A web component for showing the completion status of a task or process.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/progress-bar)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/progress-bar)](https://www.npmjs.com/package/@vaadin/progress-bar)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-progress-bar></vaadin-progress-bar>

--- a/packages/rich-text-editor/README.md
+++ b/packages/rich-text-editor/README.md
@@ -7,7 +7,6 @@ An input field web component for entering rich text.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/rich-text-editor)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/rich-text-editor)](https://www.npmjs.com/package/@vaadin/rich-text-editor)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-rich-text-editor></vaadin-rich-text-editor>

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -5,7 +5,6 @@ A web component for selecting a single value from a list of options presented in
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/select)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-select)](https://www.npmjs.com/package/@vaadin/vaadin-select)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-select label="Sort by"></vaadin-select>

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -5,7 +5,6 @@ A web component for navigation menus.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/side-nav)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-side-nav)](https://www.npmjs.com/package/@vaadin/vaadin-side-nav)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-side-nav collapsible>

--- a/packages/split-layout/README.md
+++ b/packages/split-layout/README.md
@@ -5,7 +5,6 @@ A web component with two content areas and a draggable split handle between them
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/split-layout)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/split-layout)](https://www.npmjs.com/package/@vaadin/split-layout)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-split-layout>

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -5,7 +5,6 @@ A web component for organizing and grouping content into sections.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/tabs)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/tabs)](https://www.npmjs.com/package/@vaadin/tabs)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-tabs selected="3">

--- a/packages/tabsheet/README.md
+++ b/packages/tabsheet/README.md
@@ -5,7 +5,6 @@ A web component for organizing and grouping content into sections.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/tabs/#tab-sheet)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/tabsheet)](https://www.npmjs.com/package/@vaadin/tabsheet)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-tabsheet>

--- a/packages/text-area/README.md
+++ b/packages/text-area/README.md
@@ -5,7 +5,6 @@ An input field component for multi-line text input.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/text-area)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/text-area)](https://www.npmjs.com/package/@vaadin/text-area)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-text-area label="Comment"></vaadin-text-area>

--- a/packages/text-field/README.md
+++ b/packages/text-field/README.md
@@ -5,7 +5,6 @@ A web component that allows the user to input and edit text.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/text-field)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/text-field)](https://www.npmjs.com/package/@vaadin/text-field)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-text-field label="Street Address"></vaadin-text-field>

--- a/packages/time-picker/README.md
+++ b/packages/time-picker/README.md
@@ -5,7 +5,6 @@ A web component that allows to enter a time, either by typing, or by selecting f
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/time-picker)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/time-picker)](https://www.npmjs.com/package/@vaadin/time-picker)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-time-picker label="Delivery Time"></vaadin-time-picker>

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -3,7 +3,6 @@
 A web component for creating tooltips.
 
 [![npm version](https://badgen.net/npm/v/@vaadin/tooltip)](https://www.npmjs.com/package/@vaadin/tooltip)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-button id="confirm">Confirm</vaadin-button>

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -5,7 +5,6 @@ A web component for uploading files.
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/upload)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/upload)](https://www.npmjs.com/package/@vaadin/upload)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-upload accept=".pdf">

--- a/packages/vaadin-lumo-styles/README.md
+++ b/packages/vaadin-lumo-styles/README.md
@@ -1,7 +1,6 @@
 # Lumo
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-lumo-styles)](https://www.npmjs.com/package/@vaadin/vaadin-lumo-styles)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 > Lumo – ✨ enchantment (Finnish) and 🔆 light (Esperanto)
 

--- a/packages/vaadin-material-styles/README.md
+++ b/packages/vaadin-material-styles/README.md
@@ -1,7 +1,6 @@
 # Material Theme for Vaadin components
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-material-styles)](https://www.npmjs.com/package/@vaadin/vaadin-material-styles)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 `vaadin-material-styles` is customizable theme for the [Vaadin components](https://vaadin.com/components).
 

--- a/packages/vaadin-themable-mixin/README.md
+++ b/packages/vaadin-themable-mixin/README.md
@@ -5,7 +5,6 @@ A mixin to enable customization of Shadow DOM used by Vaadin components.
 [Documentation ↗](https://vaadin.com/docs/latest/styling/styling-components)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-themable-mixin)](https://www.npmjs.com/package/@vaadin/vaadin-themable-mixin)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ## License
 

--- a/packages/virtual-list/README.md
+++ b/packages/virtual-list/README.md
@@ -5,7 +5,6 @@ A web component for rendering a long list of items without sacrificing performan
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/virtual-list)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/virtual-list)](https://www.npmjs.com/package/@vaadin/virtual-list)
-[![Discord](https://img.shields.io/discord/732335336448852018?label=discord)](https://discord.gg/PHmkCKC)
 
 ```html
 <vaadin-virtual-list></vaadin-virtual-list>


### PR DESCRIPTION
## Description

The Vaadin Discord server is now discontinued and the [Forum](https://vaadin.com/forum/) should be used instead.

## Type of change

- Internal change