### PR TITLE
chore: fix incorrect npm version badges in READMEs

### DIFF
--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -4,7 +4,7 @@ A web component for selecting a single value from a list of options presented in
 
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/select)
 
-[![npm version](https://badgen.net/npm/v/@vaadin/vaadin-select)](https://www.npmjs.com/package/@vaadin/vaadin-select)
+[![npm version](https://badgen.net/npm/v/@vaadin/select)](https://www.npmjs.com/package/@vaadin/select)
 
 ```html
 <vaadin-select label="Sort by"></vaadin-select>

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -4,7 +4,7 @@ A web component for navigation menus.
 
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/side-nav)
 
-[![npm version](https://badgen.net/npm/v/@vaadin/vaadin-side-nav)](https://www.npmjs.com/package/@vaadin/vaadin-side-nav)
+[![npm version](https://badgen.net/npm/v/@vaadin/side-nav)](https://www.npmjs.com/package/@vaadin/side-nav)
 
 ```html
 <vaadin-side-nav collapsible>


### PR DESCRIPTION
## Description

The `vaadin-select` had incorrect `@vaadin/vaadin-select` npm version badge in README (the one that refers to Vaadin 23), and `vaadin-side-nav` was apparently copied from there by mistake. This PR fixes that.

## Type of change

- Internal change