### PR TITLE
chore: fix contributing guide and chat links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Are you looking for an example project to get started? Visit [start.vaadin.com](
 
 ## Questions
 
-For help and support questions, please use our [community chat](https://vaad.in/chat).
+For help and support questions, please use [Vaadin Forum](https://vaadin.com/forum/).
 
 ## Big Thanks
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Cross-browser Testing Platform and Open Source <3 Provided by [Sauce Labs](https
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## Development
 


### PR DESCRIPTION
## Description

The current link points to the page that says that it has moved. This PR fixes that.

<img width="572" alt="Screenshot 2024-03-15 at 16 14 16" src="https://github.com/vaadin/web-components/assets/10589913/529763c5-54f4-48c1-8ae6-b4203142d3d6">

Also replaced no longer working [chat link](https://vaad.in/chat) with the Forum.

## Type of change

- Internal change