### PR TITLE
fix: focus first non-disabled item if all items have tabindex -1

### DIFF
--- a/packages/a11y-base/src/keyboard-direction-mixin.js
+++ b/packages/a11y-base/src/keyboard-direction-mixin.js
@@ -36,7 +36,7 @@ export const KeyboardDirectionMixin = (superclass) =>
       if (Array.isArray(items)) {
         const idx = this._getAvailableIndex(items, 0, null, (item) => !isElementHidden(item));
         if (idx >= 0) {
-          items[idx].focus();
+          this._focus(idx);
         }
       }
     }

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -117,8 +117,13 @@ export const ListMixin = (superClass) =>
       if (this._observer) {
         this._observer.flush();
       }
-      const firstItem = this.querySelector('[tabindex="0"]') || (this.items ? this.items[0] : null);
-      this._focusItem(firstItem);
+      const firstItem = this.querySelector('[tabindex="0"]');
+      if (firstItem) {
+        this._focusItem(firstItem);
+      } else {
+        // Call `KeyboardDirectionMixin` logic to focus first non-disabled item.
+        super.focus();
+      }
     }
 
     /** @protected */

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -8,6 +8,7 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getNormalizedScrollLeft, setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import { getFlattenedElements } from '@vaadin/component-base/src/dom-utils.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
+import { isElementHidden } from './focus-utils.js';
 import { KeyboardDirectionMixin } from './keyboard-direction-mixin.js';
 
 /**
@@ -118,7 +119,7 @@ export const ListMixin = (superClass) =>
         this._observer.flush();
       }
       const firstItem = this.querySelector('[tabindex="0"]');
-      if (firstItem) {
+      if (firstItem && !isElementHidden(firstItem)) {
         this._focusItem(firstItem);
       } else {
         // Call `KeyboardDirectionMixin` logic to focus first non-disabled item.

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -118,9 +118,11 @@ export const ListMixin = (superClass) =>
       if (this._observer) {
         this._observer.flush();
       }
-      const firstItem = this.querySelector('[tabindex="0"]');
-      if (firstItem && !isElementHidden(firstItem)) {
-        this._focusItem(firstItem);
+
+      const items = Array.isArray(this.items) ? this.items : [];
+      const idx = this._getAvailableIndex(items, 0, null, (item) => item.tabIndex === 0 && !isElementHidden(item));
+      if (idx >= 0) {
+        this._focus(idx);
       } else {
         // Call `KeyboardDirectionMixin` logic to focus first non-disabled item.
         super.focus();

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -297,6 +297,16 @@ const runTests = (defineHelper, baseMixin) => {
       list.focus();
       expect(spy.calledOnce).to.be.true;
     });
+
+    it('should call focus() on the first non-disabled visible item if all items have tabindex -1', () => {
+      list.items.forEach((item) => {
+        item.tabIndex = -1;
+      });
+      list.items[2].setAttribute('hidden', '');
+      const spy = sinon.spy(list.items[3], 'focus');
+      list.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
   });
 
   describe('tabIndex when all the items are disabled', () => {

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -288,6 +288,15 @@ const runTests = (defineHelper, baseMixin) => {
       list.focus();
       expect(spy.calledOnce).to.be.true;
     });
+
+    it('should call focus() on the first non-disabled item if all items have tabindex -1', () => {
+      list.items.forEach((item) => {
+        item.tabIndex = -1;
+      });
+      const spy = sinon.spy(list.items[2], 'focus');
+      list.focus();
+      expect(spy.calledOnce).to.be.true;
+    });
   });
 
   describe('tabIndex when all the items are disabled', () => {

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -307,6 +307,14 @@ const runTests = (defineHelper, baseMixin) => {
       list.focus();
       expect(spy.calledOnce).to.be.true;
     });
+
+    it('should change tabindex from -1 to 0 on first non-disabled item when focusing it', () => {
+      list.items.forEach((item) => {
+        item.tabIndex = -1;
+      });
+      list.focus();
+      [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
+    });
   });
 
   describe('tabIndex when all the items are disabled', () => {

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -315,6 +315,13 @@ const runTests = (defineHelper, baseMixin) => {
       list.focus();
       [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
     });
+
+    it('should change tabindex from 0 to -1 on items with tabindex 0 other than focused one', () => {
+      list.items[2].tabIndex = 0;
+      list.items[3].tabIndex = 0;
+      list.focus();
+      [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
+    });
   });
 
   describe('tabIndex when all the items are disabled', () => {

--- a/packages/context-menu/test/items.common.js
+++ b/packages/context-menu/test/items.common.js
@@ -427,7 +427,6 @@ describe('items', () => {
     const subMenu2 = getSubMenu(rootMenu);
     const items = getMenuItems(subMenu2);
 
-    // expect(items[1].hasAttribute('focus-ring')).to.be.true;
     // Arrow Down to focus next item
     items[1].focus();
     arrowDownKeyDown(items[1]);

--- a/packages/context-menu/test/items.common.js
+++ b/packages/context-menu/test/items.common.js
@@ -414,6 +414,35 @@ describe('items', () => {
     expect(items[0].hasAttribute('focus-ring')).to.be.true;
   });
 
+  it('should focus first non-disabled item after re-opening when using components', async () => {
+    subMenu.close();
+    rootOverlay.focus();
+
+    rootMenu.items[3].children[0].disabled = true;
+
+    const rootItem = getMenuItems(rootMenu)[3];
+
+    // Open the sub-menu with item components
+    await openMenu(rootItem);
+    const subMenu2 = getSubMenu(rootMenu);
+    const items = getMenuItems(subMenu2);
+
+    // expect(items[1].hasAttribute('focus-ring')).to.be.true;
+    // Arrow Down to focus next item
+    items[1].focus();
+    arrowDownKeyDown(items[1]);
+    expect(items[2].hasAttribute('focus-ring')).to.be.true;
+
+    // Arrow Left to close the sub-menu
+    arrowLeftKeyDown(items[2]);
+    await nextFrame();
+    expect(rootItem.hasAttribute('focus-ring')).to.be.true;
+
+    // Re-open sub-menu and check focus
+    await openMenu(rootItem);
+    expect(items[1].hasAttribute('focus-ring')).to.be.true;
+  });
+
   it('should have modeless sub menus', () => {
     const rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
     const element = document.elementFromPoint(rootItemRect.left, rootItemRect.top);

--- a/packages/menu-bar/test/sub-menu.common.js
+++ b/packages/menu-bar/test/sub-menu.common.js
@@ -190,11 +190,10 @@ describe('sub-menu', () => {
     await nextRender(subMenu);
 
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
-    arrowDown(items[1]);
-    expect(items[2].hasAttribute('focus-ring')).to.be.true;
+    expect(items[1].hasAttribute('focus-ring')).to.be.true;
 
     // Close and re-open
-    esc(items[2]);
+    esc(items[1]);
     arrowDown(buttons[2]);
     await nextRender(subMenu);
 

--- a/packages/menu-bar/test/sub-menu.common.js
+++ b/packages/menu-bar/test/sub-menu.common.js
@@ -57,6 +57,9 @@ describe('sub-menu', () => {
           {
             component: createComponent('Menu Item 3 2'),
           },
+          {
+            component: createComponent('Menu Item 3 3'),
+          },
         ],
       },
     ];
@@ -178,6 +181,24 @@ describe('sub-menu', () => {
     await nextRender(subMenu);
 
     expect(items[0].hasAttribute('focus-ring')).to.be.true;
+  });
+
+  it('should focus first non-disabled item after re-opening when using components', async () => {
+    menu.items[2].children[0].disabled = true;
+
+    arrowDown(buttons[2]);
+    await nextRender(subMenu);
+
+    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    arrowDown(items[1]);
+    expect(items[2].hasAttribute('focus-ring')).to.be.true;
+
+    // Close and re-open
+    esc(items[2]);
+    arrowDown(buttons[2]);
+    await nextRender(subMenu);
+
+    expect(items[1].hasAttribute('focus-ring')).to.be.true;
   });
 
   it('should close sub-menu on first item arrow up', async () => {


### PR DESCRIPTION
## Description

Fixes #7228

The logic in `focus()` method of `ListMixin` is problematic since it focuses first item without checking if it's disabled.
Updated to use logic from `KeyboardDirectionMixin` and added `vaadin-context-menu` and `vaadin-menu-bar` tests.

## Type of change

- Bugfix

## Note

Setting `tabindex` to `-1` on all the items is done since #7203 which was a fix for #7202. While that issue could be fixed in a different way, IMO the approach used in this PR was correct. The current PR should be a proper fix for #7142.