### PR TITLE
fix: render message avatars with Lit to keep them on items update

### DIFF
--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -163,8 +163,8 @@ class MessageList extends KeyboardDirectionMixin(ElementMixin(ThemableMixin(Poly
                 theme="${ifDefined(item.theme)}"
                 class="${ifDefined(item.className)}"
                 @focusin="${this._onMessageFocusIn}"
-                >${item.text}</vaadin-message
-              >
+                >${item.text}<vaadin-avatar slot="avatar"></vaadin-avatar
+              ></vaadin-message>
             `,
         )}
       `,

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -144,6 +144,12 @@ describe('message-list', () => {
         expect(items[0]).to.eql(firstMessage);
         expect(items[1]).to.not.eql(firstMessage);
       });
+
+      it('should not remove vaadin-avatar elements when updating items', async () => {
+        messageList.items = [{ text: '', userName: 'Assistant' }];
+        await nextRender();
+        expect(messageList.querySelector('vaadin-avatar')).to.be.ok;
+      });
     });
 
     describe('scroll', () => {


### PR DESCRIPTION
## Description

Fixes #6544

Currently, `vaadin-message-list` re-renders `vaadin-message` items using Lit `render` function and that discards slotted `vaadin-avatar` elements created by `SlotController`. Updated to include `vaadin-avatar` to the Lit template.

## Type of change

- Bugfix