### PR TITLE
fix: fire change event on hyperlink edit, update test timings

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -345,8 +345,9 @@ export const RichTextEditorMixin = (superClass) =>
       });
 
       editorContent.addEventListener('focus', () => {
-        // Format changed, but no value changed happened
-        if (this._toolbarState === STATE.CLICKED) {
+        // When editing link, editor gets focus while dialog is still open.
+        // Keep toolbar state as clicked in this case to fire change event.
+        if (this._toolbarState === STATE.CLICKED && !this._linkEditing) {
           this._cleanToolbarState();
         }
       });

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -448,7 +448,7 @@ describe('rich text editor', () => {
           editor.focus();
           editor.setSelection(0, 6);
           btn.click();
-          await nextUpdate(rte);
+          await nextRender();
 
           rte.$.linkUrl.value = url;
 
@@ -456,6 +456,7 @@ describe('rich text editor', () => {
           rte.addEventListener('change', spy);
 
           rte.$.confirmLink.click();
+          await nextRender();
           flushValueDebouncer();
 
           expect(spy.calledOnce).to.be.true;
@@ -468,12 +469,13 @@ describe('rich text editor', () => {
           editor.focus();
           editor.setSelection(0, 6);
           btn.click();
-          await nextUpdate(rte);
+          await nextRender();
 
           const spy = sinon.spy();
           rte.addEventListener('change', spy);
 
           rte.$.cancelLink.click();
+          await nextRender();
           flushValueDebouncer();
           expect(rte.value).to.equal(value);
           expect(spy.called).to.be.false;


### PR DESCRIPTION
## Description

Fixes #7249

When adding link, the `change` event was not fired by `vaadin-rich-text-editor`. Here's what happened:

- editor gets focus as a result of `this._editor.format('link', link, SOURCE.USER)`,
- the editor content `focus` event listener calls `_cleanToolbarState()` immediately,
- in `value` change observer, no change event due to the toolbar in "default" state.

Added a check for `_linkEditing` (which corresponds to the link dialog `opened` property) as a fix.

Note: when removing the `focus` listener completely, all the tests still pass on `main` branch 🙈 

## Type of change

- Bugfix