### PR TITLE
test: disable invalid test

### DIFF
--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -113,7 +113,7 @@ describe('keyboard navigation', () => {
       expect(getCellEditor(firstCell)).to.be.not.ok;
     });
 
-    it('should focus correct editable cell after column reordering', () => {
+    it.skip('should focus correct editable cell after column reordering', () => {
       grid.columnReorderingAllowed = true;
       const headerContent = [
         getContainerCell(grid.$.header, 0, 0)._content,


### PR DESCRIPTION
The test setup doesn't work properly at the moment as drag and drop for Grid Pro is broken as mentioned in #7229. The test passes in CI, but fails locally. Let's disable it for now.

Should be restored as part of https://github.com/vaadin/web-components/issues/7229