### PR TITLE
refactor: drop obsolete scroller workaround

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -83,17 +83,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       super.ready();
       this._scroller.addEventListener('index-requested', (e) => {
         const index = e.detail.index;
-        const currentScrollerPos = e.detail.currentScrollerPos;
-        const allowedIndexRange = Math.floor(this.pageSize * 1.5);
-
-        // Ignores the indexes, which are being re-sent during scrolling reset,
-        // if the corresponding page is around the current scroller position.
-        // Otherwise, there might be a last pages duplicates, which cause the
-        // loading indicator hanging and blank items
-        if (this._shouldSkipIndex(index, allowedIndexRange, currentScrollerPos)) {
-          return;
-        }
-
         if (index !== undefined) {
           const page = this._getPageForIndex(index);
           if (this._shouldLoadPage(page)) {
@@ -139,15 +128,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       if (opened && this._shouldLoadPage(0)) {
         this._loadPage(0);
       }
-    }
-
-    /** @private */
-    _shouldSkipIndex(index, allowedIndexRange, currentScrollerPos) {
-      return (
-        currentScrollerPos !== 0 &&
-        index >= currentScrollerPos - allowedIndexRange &&
-        index <= currentScrollerPos + allowedIndexRange
-      );
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -346,7 +346,6 @@ export const ComboBoxScrollerMixin = (superClass) =>
           new CustomEvent('index-requested', {
             detail: {
               index,
-              currentScrollerPos: this._oldScrollerPosition,
             },
           }),
         );


### PR DESCRIPTION
## Description

The `_shouldSkipIndex` workaround was introduced in https://github.com/vaadin/vaadin-combo-box/pull/978 at a time combo-box had its own scroll restoration logic. However, this logic was later removed when replacing iron-list with virtualizer in https://github.com/vaadin/web-components/pull/2339, which makes the workaround also obsolete. Note, there is no such workaround in grid.

## Type of change

- [x] Refactor
