### PR TITLE
refactor!: simplify logic for first page request on open

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -70,6 +70,12 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         __previousDataProviderFilter: {
           type: String,
         },
+
+        /** @private */
+        _hasData: {
+          type: Boolean,
+          value: false,
+        },
       };
     }
 
@@ -136,23 +142,15 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         return;
       }
 
-      if (opened && this._shouldLoadPage(0)) {
+      if (opened && !this._hasData) {
         this._loadPage(0);
       }
     }
 
     /** @private */
     _shouldLoadPage(page) {
-      if (this._forceNextRequest) {
-        this._forceNextRequest = false;
-        return true;
-      }
-
       const loadedItem = this.filteredItems[page * this.pageSize];
-      if (loadedItem !== undefined) {
-        return loadedItem instanceof ComboBoxPlaceholder;
-      }
-      return this.size === undefined;
+      return loadedItem instanceof ComboBoxPlaceholder;
     }
 
     /** @private */
@@ -185,6 +183,8 @@ export const ComboBoxDataProviderMixin = (superClass) =>
           this.size = size;
         }
 
+        this._hasData = true;
+
         delete this._pendingRequests[page];
 
         if (Object.keys(this._pendingRequests).length === 0) {
@@ -214,6 +214,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         return;
       }
 
+      this._hasData = false;
       this._pendingRequests = {};
       const filteredItems = [];
       for (let i = 0; i < (this.size || 0); i++) {
@@ -222,10 +223,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       this.filteredItems = filteredItems;
 
       if (this._shouldFetchData()) {
-        this._forceNextRequest = false;
         this._loadPage(0);
-      } else {
-        this._forceNextRequest = true;
       }
     }
 


### PR DESCRIPTION
## Description

The PR introduces a `_hasData` property that replaces `_forceNextRequest` in combo-box. This slightly streamlines the logic for requesting the first page on combo-box open, besides aligning it more closely with the approach used in grid.

Depends on 
- https://github.com/vaadin/web-components/pull/7262

## Breaking change

The PR introduces a minor breaking change in the timing of the first page request in the following cases:

### Case 1
1. Open the dropdown
2. The data provider returns 0 as size and no items
3. Close the dropdown
4. Change the size property to 10 manually
5. Open the dropdown again
6. **Before:** the first page is requested synchronously. **After:** the first page is requested asynchronously in the next animation frame.

### Case 2
1. Open the dropdown
2. The data provider returns undefined as size and no items
3. Close the dropdown
4. Open the dropdown again
5. **Before:** the first page is requested again. **After:** the first page is not requested, same as for size 0.

## Type of change

- [x] Refactor
