### PR TITLE
refactor: use _shouldFetchData to prevent requests for readonly

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -85,6 +85,10 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     ready() {
       super.ready();
       this._scroller.addEventListener('index-requested', (e) => {
+        if (!this._shouldFetchData()) {
+          return;
+        }
+
         const index = e.detail.index;
         if (index !== undefined) {
           const page = this._getPageForIndex(index);
@@ -128,6 +132,10 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
     /** @private */
     _ensureFirstPage(opened) {
+      if (!this._shouldFetchData()) {
+        return;
+      }
+
       if (opened && this._shouldLoadPage(0)) {
         this._loadPage(0);
       }

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -121,7 +121,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       }
     }
 
-    /** @private */
+    /** @protected */
     _shouldFetchData() {
       if (!this.dataProvider) {
         return false;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -413,17 +413,15 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
    * Override method inherited from the combo-box
    * to not request data provider when read-only.
    *
-   * @param {number}
-   * @return {boolean}
    * @protected
    * @override
    */
-  _shouldLoadPage(page) {
+  _shouldFetchData() {
     if (this.readonly) {
       return false;
     }
 
-    return super._shouldLoadPage(page);
+    return super._shouldFetchData();
   }
 
   /**


### PR DESCRIPTION
## Description

The PR moves the logic that prevents  data provider requests for the readonly state from `_shouldLoadPage` to `_shouldFetchData` in multi-select-combo-box, as this seems more logical considering the method name.

## Type of change

- [x] Refactor
