### PR TITLE
refactor: remove obsolete check for filteredItems

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -143,7 +143,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
     /** @private */
     _shouldLoadPage(page) {
-      if (!this.filteredItems || this._forceNextRequest) {
+      if (this._forceNextRequest) {
         this._forceNextRequest = false;
         return true;
       }


### PR DESCRIPTION
## Description

The PR removes an obsolete check for `filteredItems` in `_shouldLoadPage`. This check became unnecessary after #7262 which stopped `_shouldLoadPage` from being called in `_ensureFirstPage` on open when no data provider is set. Note, when a data provider is set, `filteredItems` are guaranteed to be an array.

## Type of change

- [x] Refactor
