### PR TITLE
fix: calculate vidxOffset correctly when clientHeight != offsetHeight

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -797,7 +797,7 @@ export class IronListAdapter {
       this.__skipNextVirtualIndexAdjust = false;
     } else if (Math.abs(delta) > 10000) {
       // Process a large scroll position change
-      const scale = this._scrollTop / (this.scrollTarget.scrollHeight - this.scrollTarget.offsetHeight);
+      const scale = this._scrollTop / (this.scrollTarget.scrollHeight - this.scrollTarget.clientHeight);
       this._vidxOffset = Math.round(scale * maxOffset);
     } else {
       // Make sure user can always swipe/wheel scroll to the start and end

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -102,6 +102,16 @@ describe('unlimited size', () => {
     expect(item.getBoundingClientRect().top).to.equal(scrollTarget.getBoundingClientRect().top);
   });
 
+  it('should manually scroll to end when the scroll target has a border', async () => {
+    scrollTarget.style.borderTop = '20px solid black';
+
+    scrollTarget.scrollTop = scrollTarget.scrollHeight;
+    await oneEvent(scrollTarget, 'scroll');
+
+    const item = elementsContainer.querySelector(`#item-${virtualizer.size - 1}`);
+    expect(item.getBoundingClientRect().bottom).to.be.closeTo(scrollTarget.getBoundingClientRect().bottom, 1);
+  });
+
   it('should manually scroll to start after scroll to index', async () => {
     virtualizer.scrollToIndex(virtualizer.size / 400);
 


### PR DESCRIPTION
## Description

The PR fixes the bug that allowed reaching items beyond the set size when the scroll target had a border or horizontal scrollbar i.e. in situations where the scroll target's `clientHeight` didn't equal its `offsetHeight`.

Fixes https://github.com/vaadin/web-components/issues/7188

## Type of change

- [x] Bugfix
