### PR TITLE
feat: disable editing for individual cells

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.d.ts
@@ -58,6 +58,24 @@ export declare class GridProEditColumnMixinClass<TItem> {
    */
   editorValuePath: string;
 
+  /**
+   * A function to check whether a specific cell of this column can be
+   * edited. This allows to disable editing of individual rows or cells,
+   * based on the item.
+   *
+   * Receives a `model` object containing the item for an individual row,
+   * and should return a boolean indicating whether the column's cell in
+   * that row is editable.
+   *
+   * The `model` object contains:
+   * - `model.index` The index of the item.
+   * - `model.item` The item.
+   * - `model.expanded` Sublevel toggle state.
+   * - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
+   * - `model.selected` Selected state.
+   */
+  isCellEditable: (model: GridItemModel<TItem>) => boolean;
+
   protected _getEditorComponent(cell: HTMLElement): HTMLElement | null;
 
   protected _getEditorValue(editor: HTMLElement): unknown | null;

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -83,6 +83,29 @@ export const GridProEditColumnMixin = (superClass) =>
           sync: true,
         },
 
+        /**
+         * A function to check whether a specific cell of this column can be
+         * edited. This allows to disable editing of individual rows or cells,
+         * based on the item.
+         *
+         * Receives a `model` object containing the item for an individual row,
+         * and should return a boolean indicating whether the column's cell in
+         * that row is editable.
+         *
+         * The `model` object contains:
+         * - `model.index` The index of the item.
+         * - `model.item` The item.
+         * - `model.expanded` Sublevel toggle state.
+         * - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
+         * - `model.selected` Selected state.
+         *
+         * @type {function(GridItemModel): boolean}
+         */
+        isCellEditable: {
+          type: Function,
+          value: () => () => true,
+        },
+
         /** @private */
         _oldRenderer: Function,
       };
@@ -110,6 +133,8 @@ export const GridProEditColumnMixin = (superClass) =>
         `;
         }
       };
+
+      this.isCellEditable = () => true;
     }
 
     /** @private */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -104,7 +104,6 @@ export const GridProEditColumnMixin = (superClass) =>
         isCellEditable: {
           type: Function,
           observer: '_isCellEditableChanged',
-          value: () => () => true,
         },
 
         /** @private */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -103,6 +103,7 @@ export const GridProEditColumnMixin = (superClass) =>
          */
         isCellEditable: {
           type: Function,
+          observer: '_isCellEditableChanged',
           value: () => () => true,
         },
 
@@ -133,8 +134,6 @@ export const GridProEditColumnMixin = (superClass) =>
         `;
         }
       };
-
-      this.isCellEditable = () => true;
     }
 
     /** @private */
@@ -142,6 +141,16 @@ export const GridProEditColumnMixin = (superClass) =>
       if (!path || path.length === 0) {
         throw new Error('You should specify the path for the edit column');
       }
+    }
+
+    /** @private */
+    _isCellEditableChanged(newValue, oldValue) {
+      // Ignore setting initial / default function
+      if (!oldValue) {
+        return;
+      }
+      // Re-render grid to update editable-cell part names
+      this._grid.requestContentUpdate();
     }
 
     /** @private */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -99,7 +99,7 @@ export const GridProEditColumnMixin = (superClass) =>
          * - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
          * - `model.selected` Selected state.
          *
-         * @type {function(GridItemModel): boolean}
+         * @type {(model: GridItemModel) => boolean}
          */
         isCellEditable: {
           type: Function,

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -8,7 +8,6 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { addValueToAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { get, set } from '@vaadin/component-base/src/path-utils.js';
 
 /**
@@ -90,7 +89,7 @@ export const GridProEditColumnMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_editModeRendererChanged(editModeRenderer, __initialized)', '_cellsChanged(_cells)'];
+      return ['_editModeRendererChanged(editModeRenderer, __initialized)'];
     }
 
     constructor() {
@@ -118,14 +117,6 @@ export const GridProEditColumnMixin = (superClass) =>
       if (!path || path.length === 0) {
         throw new Error('You should specify the path for the edit column');
       }
-    }
-
-    /** @private */
-    _cellsChanged() {
-      this._cells.forEach((cell) => {
-        const target = cell._focusButton || cell;
-        addValueToAttribute(target, 'part', 'editable-cell');
-      });
     }
 
     /** @private */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -144,10 +144,6 @@ export const GridProEditColumnMixin = (superClass) =>
 
     /** @private */
     _isCellEditableChanged(newValue, oldValue) {
-      // Ignore setting initial / default function
-      if (!oldValue) {
-        return;
-      }
       // Re-render grid to update editable-cell part names
       this._grid.requestContentUpdate();
     }

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -531,9 +531,9 @@ export const InlineEditingMixin = (superClass) =>
       if (!this._isEditColumn(column)) {
         return false;
       }
-      // isCellEditable can be undefined if edit column is not imported
+      // Cell is editable by default if isCellEditable is not configured
       if (!column.isCellEditable) {
-        return false;
+        return true;
       }
       // Otherwise, check isCellEditable function
       const model = this.__getRowModel(cell.parentElement);

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -57,11 +57,6 @@ export const InlineEditingMixin = (superClass) =>
         _editingDisabled: {
           type: Boolean,
         },
-
-        cellEditableProvider: {
-          type: Function,
-          sync: true,
-        },
       };
     }
 
@@ -526,13 +521,13 @@ export const InlineEditingMixin = (superClass) =>
       if (!this._isEditColumn(column)) {
         return false;
       }
-      // Editable by default if no cellEditableProvider is set
-      if (!this.cellEditableProvider) {
-        return true;
+      // isCellEditable can be undefined if edit column is not imported
+      if (!column.isCellEditable) {
+        return false;
       }
-      // Otherwise, check the cellEditableProvider
+      // Otherwise, check isCellEditable function
       const model = this.__getRowModel(cell.parentElement);
-      return this.cellEditableProvider(column, model);
+      return column.isCellEditable(model);
     }
 
     /**

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -444,11 +444,11 @@ export const InlineEditingMixin = (superClass) =>
         directionX = e.shiftKey ? -1 : 1;
       }
 
+      // Try to find the next editable cell
       let nextIndex = model.index;
       let nextColumn = column;
       let nextCell = cell;
 
-      // Try to find the next editable cell
       if (directionX || directionY) {
         while (nextCell) {
           if (directionX) {
@@ -474,7 +474,7 @@ export const InlineEditingMixin = (superClass) =>
         }
       }
 
-      // Use current cell as fallback
+      // Focus current cell as fallback
       if (!nextCell) {
         nextCell = cell;
         nextIndex = model.index;
@@ -524,6 +524,7 @@ export const InlineEditingMixin = (superClass) =>
       });
     }
 
+    /** @private */
     _isCellEditable(cell) {
       const column = cell._column;
       // Not editable if the column is not an edit column

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -431,6 +431,15 @@ export const InlineEditingMixin = (superClass) =>
       const editableColumns = this._getEditColumns();
       const { cell, column, model } = this.__edited;
 
+      this._stopEdit();
+      e.preventDefault();
+      // Prevent vaadin-grid handler from being called
+      e.stopImmediatePropagation();
+
+      // Try to find the next editable cell
+      let nextIndex = model.index;
+      let nextColumn = column;
+      let nextCell = cell;
       let directionX = 0;
       let directionY = 0;
 
@@ -443,11 +452,6 @@ export const InlineEditingMixin = (superClass) =>
       if (e.keyCode === 9) {
         directionX = e.shiftKey ? -1 : 1;
       }
-
-      // Try to find the next editable cell
-      let nextIndex = model.index;
-      let nextColumn = column;
-      let nextCell = cell;
 
       if (directionX || directionY) {
         while (nextCell) {
@@ -479,11 +483,6 @@ export const InlineEditingMixin = (superClass) =>
         nextCell = cell;
         nextIndex = model.index;
       }
-
-      this._stopEdit();
-      e.preventDefault();
-      // Prevent vaadin-grid handler from being called
-      e.stopImmediatePropagation();
 
       if (!this.singleCellEdit && nextCell !== cell) {
         this._startEdit(nextCell, nextColumn);

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -281,14 +281,15 @@ describe('edit column', () => {
     beforeEach(async () => {
       grid = fixtureSync(`
         <vaadin-grid-pro>
-          <vaadin-grid-column path="status"></vaadin-grid-column>
+          <vaadin-grid-column path="id"></vaadin-grid-column>
+          <vaadin-grid-pro-edit-column path="status"></vaadin-grid-pro-edit-column>
           <vaadin-grid-pro-edit-column path="amount"></vaadin-grid-pro-edit-column>
           <vaadin-grid-pro-edit-column path="notes"></vaadin-grid-pro-edit-column>
         </vaadin-grid-pro>
       `);
       grid.items = [
-        { status: 'draft', amount: 100, notes: 'foo' },
-        { status: 'completed', amount: 200, notes: 'bar' },
+        { id: 1, status: 'draft', amount: 100, notes: 'foo' },
+        { id: 2, status: 'completed', amount: 200, notes: 'bar' },
       ];
       // Disable editing for the amount when status is completed
       amountColumn = grid.querySelector('[path="amount"]');
@@ -301,67 +302,73 @@ describe('edit column', () => {
       // Cells in first row are editable
       expect(isCellEditable(0, 1)).to.be.true;
       expect(isCellEditable(0, 2)).to.be.true;
+      expect(isCellEditable(0, 3)).to.be.true;
       // Amount cell in second row is not editable
-      expect(isCellEditable(1, 1)).to.be.false;
-      expect(isCellEditable(1, 2)).to.be.true;
+      expect(isCellEditable(1, 1)).to.be.true;
+      expect(isCellEditable(1, 2)).to.be.false;
+      expect(isCellEditable(1, 3)).to.be.true;
     });
 
     it('should show editor when cell becomes editable after updating provider function', () => {
       // Not editable initially
-      expect(isCellEditable(1, 1)).to.be.false;
+      expect(isCellEditable(1, 2)).to.be.false;
       // Enable editing
       amountColumn.isCellEditable = () => true;
-      expect(isCellEditable(1, 1)).to.be.true;
+      expect(isCellEditable(1, 2)).to.be.true;
     });
 
     it('should show editor when cell becomes editable after removing provider function', () => {
       // Not editable initially
-      expect(isCellEditable(1, 1)).to.be.false;
+      expect(isCellEditable(1, 2)).to.be.false;
       // Remove provider
       amountColumn.isCellEditable = null;
-      expect(isCellEditable(1, 1)).to.be.true;
+      expect(isCellEditable(1, 2)).to.be.true;
     });
 
     it('should not add editable-cell part to non-editable cells', () => {
+      expect(hasEditablePart(0, 0)).to.be.false;
       expect(hasEditablePart(0, 1)).to.be.true;
       expect(hasEditablePart(0, 2)).to.be.true;
-      expect(hasEditablePart(1, 1)).to.be.false;
-      expect(hasEditablePart(1, 2)).to.be.true;
+      expect(hasEditablePart(0, 3)).to.be.true;
+      expect(hasEditablePart(1, 0)).to.be.false;
+      expect(hasEditablePart(1, 1)).to.be.true;
+      expect(hasEditablePart(1, 2)).to.be.false;
+      expect(hasEditablePart(1, 3)).to.be.true;
     });
 
     it('should update part name when cell becomes editable after updating provider function', async () => {
       // Not editable initially
-      expect(hasEditablePart(1, 1)).to.be.false;
+      expect(hasEditablePart(1, 2)).to.be.false;
       // Enable editing
       amountColumn.isCellEditable = () => true;
       await nextFrame();
-      expect(hasEditablePart(1, 1)).to.be.true;
+      expect(hasEditablePart(1, 2)).to.be.true;
     });
 
     it('should not be in navigating state when clicking non-editable cells', () => {
       expect(triggersNavigatingState(0, 1)).to.be.true;
       expect(triggersNavigatingState(0, 2)).to.be.true;
-      expect(triggersNavigatingState(1, 1)).to.be.false;
-      expect(triggersNavigatingState(1, 2)).to.be.true;
+      expect(triggersNavigatingState(1, 1)).to.be.true;
+      expect(triggersNavigatingState(1, 2)).to.be.false;
     });
 
     it('should be in navigating state when cell becomes editable after updating provider function', () => {
       // Not editable initially
-      expect(triggersNavigatingState(1, 1)).to.be.false;
+      expect(triggersNavigatingState(1, 2)).to.be.false;
       // Enable editing
       amountColumn.isCellEditable = () => true;
-      expect(triggersNavigatingState(1, 1)).to.be.true;
+      expect(triggersNavigatingState(1, 2)).to.be.true;
     });
 
     describe('editor navigation', () => {
       beforeEach(async () => {
         // Five rows, only second and forth are editable
         grid.items = [
-          { status: 'completed', amount: 100, notes: 'foo' },
-          { status: 'draft', amount: 200, notes: 'bar' },
-          { status: 'completed', amount: 100, notes: 'foo' },
-          { status: 'draft', amount: 100, notes: 'foo' },
-          { status: 'completed', amount: 200, notes: 'bar' },
+          { id: 1, status: 'completed', amount: 100, notes: 'foo' },
+          { id: 2, status: 'draft', amount: 200, notes: 'bar' },
+          { id: 3, status: 'completed', amount: 100, notes: 'foo' },
+          { id: 4, status: 'draft', amount: 100, notes: 'foo' },
+          { id: 5, status: 'completed', amount: 200, notes: 'bar' },
         ];
         grid.querySelectorAll('vaadin-grid-pro-edit-column').forEach((column) => {
           column.isCellEditable = (model) => model.item.status !== 'completed';
@@ -372,15 +379,15 @@ describe('edit column', () => {
 
       describe('with Tab', () => {
         it('should skip non-editable cells when navigating with Tab', () => {
-          let cell = getContainerCell(grid.$.items, 1, 1);
+          let cell = getContainerCell(grid.$.items, 1, 2);
           enter(cell);
           expect(getCellEditor(cell)).to.be.ok;
 
           tab(cell);
-          cell = getContainerCell(grid.$.items, 1, 2);
+          cell = getContainerCell(grid.$.items, 1, 3);
           expect(getCellEditor(cell)).to.be.ok;
 
-          // Should skip non-editable rows
+          // Should skip non-editable row
           tab(cell);
           cell = getContainerCell(grid.$.items, 3, 1);
           expect(getCellEditor(cell)).to.be.ok;
@@ -401,16 +408,30 @@ describe('edit column', () => {
 
           // Should skip non-editable rows
           tab(cell, ['shift']);
-          cell = getContainerCell(grid.$.items, 1, 2);
+          cell = getContainerCell(grid.$.items, 1, 3);
           expect(getCellEditor(cell)).to.be.ok;
 
           tab(cell, ['shift']);
-          cell = getContainerCell(grid.$.items, 1, 1);
+          cell = getContainerCell(grid.$.items, 1, 2);
+          expect(getCellEditor(cell)).to.be.ok;
+        });
+
+        it('should skip cells that become non-editable after editing current cell', () => {
+          // Edit status in row 2 to be completed, so none of the cells in this
+          // row should be editable anymore
+          let cell = getContainerCell(grid.$.items, 1, 1);
+          enter(cell);
+          const input = getCellEditor(cell);
+          input.value = 'completed';
+          tab(cell);
+
+          // Should skip to row 4
+          cell = getContainerCell(grid.$.items, 3, 1);
           expect(getCellEditor(cell)).to.be.ok;
         });
 
         it('should stop editing and focus last edited cell if there are no more editable cells with Tab', () => {
-          const cell = getContainerCell(grid.$.items, 3, 2);
+          const cell = getContainerCell(grid.$.items, 3, 3);
           enter(cell);
           expect(getCellEditor(cell)).to.be.ok;
           expect(grid.querySelector('vaadin-grid-pro-edit-text-field')).to.be.ok;

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -314,6 +314,14 @@ describe('edit column', () => {
       expect(isCellEditable(1, 1)).to.be.true;
     });
 
+    it('should show editor when cell becomes editable after removing provider function', () => {
+      // Not editable initially
+      expect(isCellEditable(1, 1)).to.be.false;
+      // Remove provider
+      amountColumn.isCellEditable = null;
+      expect(isCellEditable(1, 1)).to.be.true;
+    });
+
     it('should not add editable-cell part to non-editable cells', () => {
       expect(hasEditablePart(0, 1)).to.be.true;
       expect(hasEditablePart(0, 2)).to.be.true;

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -268,7 +268,7 @@ describe('edit column', () => {
     function hasEditablePart(row, col) {
       const cell = getContainerCell(grid.$.items, row, col);
       const target = cell._focusButton || cell;
-      return (target.getAttribute('part') || '').includes('editable-cell');
+      return !!target.getAttribute('part')?.includes('editable-cell');
     }
 
     function triggersNavigatingState(row, col) {

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -254,7 +254,7 @@ describe('edit column', () => {
     });
   });
 
-  describe('cell editable provider', () => {
+  describe('isCellEditable', () => {
     let grid;
 
     function isCellEditable(row, col) {
@@ -298,10 +298,9 @@ describe('edit column', () => {
           notes: 'bar',
         },
       ];
-      grid.cellEditableProvider = (column, model) => {
-        // Disable editing for the amount when status is completed
-        return !(column.path === 'amount' && model.item.status === 'completed');
-      };
+      // Disable editing for the amount when status is completed
+      const amountColumn = grid.querySelector('[path="amount"]');
+      amountColumn.isCellEditable = (model) => model.item.status !== 'completed';
       flushGrid(grid);
       await nextFrame();
     });

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -255,7 +255,7 @@ describe('edit column', () => {
   });
 
   describe('isCellEditable', () => {
-    let grid;
+    let grid, amountColumn;
 
     function isCellEditable(row, col) {
       const cell = getContainerCell(grid.$.items, row, col);
@@ -299,7 +299,7 @@ describe('edit column', () => {
         },
       ];
       // Disable editing for the amount when status is completed
-      const amountColumn = grid.querySelector('[path="amount"]');
+      amountColumn = grid.querySelector('[path="amount"]');
       amountColumn.isCellEditable = (model) => model.item.status !== 'completed';
       flushGrid(grid);
       await nextFrame();
@@ -314,6 +314,14 @@ describe('edit column', () => {
       expect(isCellEditable(1, 2)).to.be.true;
     });
 
+    it('should show editor when cell becomes editable after updating provider function', () => {
+      // Not editable initially
+      expect(isCellEditable(1, 1)).to.be.false;
+      // Enable editing
+      amountColumn.isCellEditable = () => true;
+      expect(isCellEditable(1, 1)).to.be.true;
+    });
+
     it('should not add editable-cell part to non-editable cells', () => {
       expect(hasEditablePart(0, 1)).to.be.true;
       expect(hasEditablePart(0, 2)).to.be.true;
@@ -321,11 +329,27 @@ describe('edit column', () => {
       expect(hasEditablePart(1, 2)).to.be.true;
     });
 
+    it('should update part name when cell becomes editable after updating provider function', () => {
+      // Not editable initially
+      expect(hasEditablePart(1, 1)).to.be.false;
+      // Enable editing
+      amountColumn.isCellEditable = () => true;
+      expect(hasEditablePart(1, 1)).to.be.true;
+    });
+
     it('should not be in navigating state when clicking non-editable cells', () => {
       expect(triggersNavigatingState(0, 1)).to.be.true;
       expect(triggersNavigatingState(0, 2)).to.be.true;
       expect(triggersNavigatingState(1, 1)).to.be.false;
       expect(triggersNavigatingState(1, 2)).to.be.true;
+    });
+
+    it('should be in navigating state when cell becomes editable after updating provider function', () => {
+      // Not editable initially
+      expect(triggersNavigatingState(1, 1)).to.be.false;
+      // Enable editing
+      amountColumn.isCellEditable = () => true;
+      expect(triggersNavigatingState(1, 1)).to.be.true;
     });
   });
 


### PR DESCRIPTION
Adds a `isCellEditable` API to `vaadin-grid-pro-edit-column` that allows to disable editing for individual cells, or whole rows by applying the same function to all edit columns. If the function returns false for a cell it:
- Prevents editing the cell
- Does not apply the `navigating` mode to the grid when clicking on the cell (so does not show focus ring)
- Does not add the `editable-cell` part name
- Skips over that cell when trying to navigate from one cell editor to the next with Tab or Enter. If there are multiple non-editable cells, the logic should skip over all of those until it finds the next editable cell.

Part of https://github.com/vaadin/flow-components/issues/4524
AC: https://github.com/vaadin/platform/issues/5177