### PR TITLE
fix: handle focus button mode columns for reordering

### DIFF
--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -113,7 +113,7 @@ describe('keyboard navigation', () => {
       expect(getCellEditor(firstCell)).to.be.not.ok;
     });
 
-    it.skip('should focus correct editable cell after column reordering', () => {
+    it('should focus correct editable cell after column reordering', () => {
       grid.columnReorderingAllowed = true;
       const headerContent = [
         getContainerCell(grid.$.header, 0, 0)._content,

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -251,10 +251,7 @@ export const ColumnReorderingMixin = (superClass) =>
           return element;
         }
         // Check if element is the cell of a focus button mode column
-        if (
-          element.parentElement &&
-          element.parentElement._focusButton === element
-        ) {
+        if (element.parentElement && element.parentElement._focusButton === element) {
           return element.parentElement;
         }
       }

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -251,8 +251,9 @@ export const ColumnReorderingMixin = (superClass) =>
           return element;
         }
         // Check if element is the cell of a focus button mode column
-        if (element.parentElement && element.parentElement._focusButton === element) {
-          return element.parentElement;
+        const { parentElement } = element;
+        if (parentElement && parentElement._focusButton === element) {
+          return parentElement;
         }
       }
       return null;

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -237,13 +237,30 @@ export const ColumnReorderingMixin = (superClass) =>
       if (!this._draggedColumn) {
         this.$.scroller.toggleAttribute('no-content-pointer-events', true);
       }
-      const cell = this.shadowRoot.elementFromPoint(x, y);
+      const elementFromPoint = this.shadowRoot.elementFromPoint(x, y);
       this.$.scroller.toggleAttribute('no-content-pointer-events', false);
 
-      // Make sure the element is actually a cell
-      if (cell && cell._column) {
-        return cell;
+      return this._getCellFromElement(elementFromPoint);
+    }
+
+    /** @private */
+    _getCellFromElement(element) {
+      if (element) {
+        // Check if element is a cell
+        if (element._column) {
+          return element;
+        }
+        // Check if element is the cell of a focus button mode column
+        if (
+          element instanceof HTMLDivElement &&
+          element.getAttribute('role') === 'button' &&
+          element.parentElement &&
+          element.parentElement._column
+        ) {
+          return element.parentElement;
+        }
       }
+      return null;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -252,10 +252,8 @@ export const ColumnReorderingMixin = (superClass) =>
         }
         // Check if element is the cell of a focus button mode column
         if (
-          element instanceof HTMLDivElement &&
-          element.getAttribute('role') === 'button' &&
           element.parentElement &&
-          element.parentElement._column
+          element.parentElement._focusButton === element
         ) {
           return element.parentElement;
         }

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -248,32 +248,6 @@ describe('reordering simple grid', () => {
       expectVisualOrder(grid, [2, 1]);
     });
 
-    it('should reorder focus button mode columns', () => {
-      grid = fixtureSync(`
-        <vaadin-grid column-reordering-allowed>
-          <vaadin-grid-column path="name"></vaadin-grid-column>
-          <vaadin-grid-column path="age"></vaadin-grid-column>
-        </vaadin-grid>
-      `);
-      grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
-        col._focusButtonMode = true;
-      });
-      grid.items = [
-        { name: 'John', age: 30 },
-        { name: 'Ringo', age: 40 },
-      ];
-      flushGrid(grid);
-
-      const headerContent = [
-        getContainerCell(grid.$.header, 0, 0)._content,
-        getContainerCell(grid.$.header, 0, 1)._content,
-      ];
-      dragAndDropOver(headerContent[0], headerContent[1]);
-
-      expect(getVisualHeaderCellContent(grid, 0, 0).innerText).to.be.equal('Age');
-      expect(getVisualHeaderCellContent(grid, 0, 1).innerText).to.be.equal('Name');
-    });
-
     it('should allow dropping over body cell of another column', () => {
       dragAndDropOver(headerContent[0], getVisualCellContent(grid.$.items, 0, 1));
       expectVisualOrder(grid, [2, 1]);
@@ -389,6 +363,41 @@ describe('reordering simple grid', () => {
       expect(spy.calledOnce).to.be.true;
       const e = spy.firstCall.args[0];
       expect(e.detail.columns.map((column) => column.getAttribute('index'))).to.eql(['2', '1', '3', '4']);
+    });
+
+    describe('focus button mode', () => {
+      beforeEach(() => {
+        grid = fixtureSync(`
+          <vaadin-grid column-reordering-allowed>
+            <vaadin-grid-column path="name"></vaadin-grid-column>
+            <vaadin-grid-column path="age"></vaadin-grid-column>
+          </vaadin-grid>
+        `);
+        grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
+          col._focusButtonMode = true;
+        });
+        grid.items = [
+          { name: 'John', age: 30 },
+          { name: 'Ringo', age: 40 },
+        ];
+        flushGrid(grid);
+        headerContent = [
+          getContainerCell(grid.$.header, 0, 0)._content,
+          getContainerCell(grid.$.header, 0, 1)._content,
+        ];
+      });
+
+      it('should reorder the columns', () => {
+        dragAndDropOver(headerContent[0], headerContent[1]);
+        expect(getVisualHeaderCellContent(grid, 0, 0).innerText).to.be.equal('Age');
+        expect(getVisualHeaderCellContent(grid, 0, 1).innerText).to.be.equal('Name');
+      });
+
+      it('should allow dropping over body cell of another column', () => {
+        dragAndDropOver(headerContent[0], getVisualCellContent(grid.$.items, 0, 1));
+        expect(getVisualHeaderCellContent(grid, 0, 0).innerText).to.be.equal('Age');
+        expect(getVisualHeaderCellContent(grid, 0, 1).innerText).to.be.equal('Name');
+      });
     });
   });
 

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -387,7 +387,7 @@ describe('reordering simple grid', () => {
         ];
       });
 
-      it('should reorder the columns', () => {
+      it('should allow dropping over header cell of another column', () => {
         dragAndDropOver(headerContent[0], headerContent[1]);
         expect(getVisualHeaderCellContent(grid, 0, 0).innerText).to.be.equal('Age');
         expect(getVisualHeaderCellContent(grid, 0, 1).innerText).to.be.equal('Name');

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -248,32 +248,6 @@ describe('reordering simple grid', () => {
       expectVisualOrder(grid, [2, 1]);
     });
 
-    it('should reorder focus button mode columns', () => {
-      grid = fixtureSync(`
-        <vaadin-grid column-reordering-allowed>
-          <vaadin-grid-column path="name"></vaadin-grid-column>
-          <vaadin-grid-column path="age"></vaadin-grid-column>
-        </vaadin-grid>
-      `);
-      grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
-        col._focusButtonMode = true;
-      });
-      grid.items = [
-        { name: 'John', age: 30 },
-        { name: 'Ringo', age: 40 },
-      ];
-      flushGrid(grid);
-
-      const headerContent = [
-        getContainerCell(grid.$.header, 0, 0)._content,
-        getContainerCell(grid.$.header, 0, 1)._content,
-      ];
-      dragAndDropOver(headerContent[0], headerContent[1]);
-
-      expect(getVisualHeaderCellContent(grid, 0, 0).innerText).to.be.equal('Age');
-      expect(getVisualHeaderCellContent(grid, 0, 1).innerText).to.be.equal('Name');
-    });
-
     it('should allow dropping over body cell of another column', () => {
       dragAndDropOver(headerContent[0], getVisualCellContent(grid.$.items, 0, 1));
       expectVisualOrder(grid, [2, 1]);

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -248,6 +248,32 @@ describe('reordering simple grid', () => {
       expectVisualOrder(grid, [2, 1]);
     });
 
+    it('should reorder focus button mode columns', () => {
+      grid = fixtureSync(`
+        <vaadin-grid column-reordering-allowed>
+          <vaadin-grid-column path="name"></vaadin-grid-column>
+          <vaadin-grid-column path="age"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
+        col._focusButtonMode = true;
+      });
+      grid.items = [
+        { name: 'John', age: 30 },
+        { name: 'Ringo', age: 40 },
+      ];
+      flushGrid(grid);
+
+      const headerContent = [
+        getContainerCell(grid.$.header, 0, 0)._content,
+        getContainerCell(grid.$.header, 0, 1)._content,
+      ];
+      dragAndDropOver(headerContent[0], headerContent[1]);
+
+      expect(getVisualHeaderCellContent(grid, 0, 0).innerText).to.be.equal('Age');
+      expect(getVisualHeaderCellContent(grid, 0, 1).innerText).to.be.equal('Name');
+    });
+
     it('should allow dropping over body cell of another column', () => {
       dragAndDropOver(headerContent[0], getVisualCellContent(grid.$.items, 0, 1));
       expectVisualOrder(grid, [2, 1]);


### PR DESCRIPTION
## Description

This is not to a GridPro edit column issue, but can also be reproduced using regular columns with `_focusButtonMode` property. When focus button mode is used, the cell is content is wrapped into a div. Because of this, the cell from point is not correctly determined during tracking events.

This PR adds another clause for extracting the cell from point, which enables reordering focus button mode columns.

Fixes #7229 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.