### PR TITLE
fix: only create focus button mode div for body cells

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -589,10 +589,6 @@ export const GridMixin = (superClass) =>
         });
       }
 
-      if (column && column._onCellKeyDown) {
-        cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
-      }
-
       const slot = document.createElement('slot');
       slot.setAttribute('name', slotName);
 
@@ -681,6 +677,9 @@ export const GridMixin = (superClass) =>
             cell = column._cells.find((cell) => cell._vacant);
             if (!cell) {
               cell = this._createCell('td', column);
+              if (column._onCellKeyDown) {
+                cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
+              }
               column._cells.push(cell);
             }
             cell.setAttribute('part', 'cell body-cell');
@@ -724,7 +723,10 @@ export const GridMixin = (superClass) =>
             // Header & footer
             const tagName = section === 'header' ? 'th' : 'td';
             if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
-              cell = column[`_${section}Cell`] || this._createCell(tagName, column);
+              cell = column[`_${section}Cell`] || this._createCell(tagName);
+              if (column._onCellKeyDown) {
+                cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
+              }
               cell._column = column;
               row.appendChild(cell);
               column[`_${section}Cell`] = cell;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -723,9 +723,12 @@ export const GridMixin = (superClass) =>
             // Header & footer
             const tagName = section === 'header' ? 'th' : 'td';
             if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
-              cell = column[`_${section}Cell`] || this._createCell(tagName);
-              if (column._onCellKeyDown) {
-                cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
+              cell = column[`_${section}Cell`];
+              if (!cell) {
+                cell = this._createCell(tagName);
+                if (column._onCellKeyDown) {
+                  cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
+                }
               }
               cell._column = column;
               row.appendChild(cell);

--- a/packages/grid/test/keyboard-navigation-cell-button.common.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.common.js
@@ -5,6 +5,10 @@ import { flushGrid } from './helpers.js';
 
 let grid;
 
+function getHeaderCell(grid, index) {
+  return grid.$.header.querySelectorAll('[part~="cell"]')[index];
+}
+
 function getRowCell(rowIndex, cellIndex) {
   return grid.$.items.children[rowIndex].children[cellIndex];
 }
@@ -88,5 +92,10 @@ describe('keyboard navigation - focus button mode', () => {
     const cell2 = getRowFirstCell(1);
     cell2.focus();
     expect(cell.firstChild.getAttribute('part')).to.be.null;
+  });
+
+  it('should not create a focusable div with role="button" inside the header cell', () => {
+    const headerCell = getHeaderCell(grid, 0);
+    expect(headerCell.firstChild.localName).to.equal('slot');
   });
 });


### PR DESCRIPTION
## Description

Fixes #7267

The regression was caused by the fact that `_createCell(tagName, column)` resulted in `column._focusButtonMode` to be applied to header and footer cells, while it's supposed to be only used by the body cells (e.g. in `vaadin-grid-pro`).

Visual tests can't catch this as we run them on Windows and the "focus button" mode is specific to Mac OS 😕 

## Type of change

- Bugfix

## Note

The logic of “focus button mode” is currently a bit fragile since it relies on the second argument of `_createCell()` being passed to body cells only (not header / footer / details). Also, I don't really like copy-pasting of `addEventListener()`.