### PR TITLE
fix: update vaadin-grid-filter to use input event instead of value-changed

### DIFF
--- a/packages/grid/src/vaadin-grid-filter-element-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.js
@@ -70,7 +70,10 @@ export const GridFilterElementMixin = (superClass) =>
       this._filterController = new SlotController(this, '', 'vaadin-text-field', {
         initializer: (field) => {
           field.addEventListener('value-changed', (e) => {
-            if (field.__previousValue === undefined && e.detail.value === '') {
+            // In Lit version, two value-changed events occur during initialization: first,
+            // value set to undefined and then changes to empty string. Use `hasUpdated` to
+            // detect Lit as in Polymer there is only one event and this logic is not needed.
+            if (field.hasUpdated && field.__previousValue === undefined && e.detail.value === '') {
               field.__previousValue = e.detail.value;
               return;
             }

--- a/packages/grid/src/vaadin-grid-filter-element-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.js
@@ -69,15 +69,8 @@ export const GridFilterElementMixin = (superClass) =>
 
       this._filterController = new SlotController(this, '', 'vaadin-text-field', {
         initializer: (field) => {
-          field.addEventListener('value-changed', (e) => {
-            // In Lit version, two value-changed events occur during initialization: first,
-            // value set to undefined and then changes to empty string. Use `hasUpdated` to
-            // detect Lit as in Polymer there is only one event and this logic is not needed.
-            if (field.hasUpdated && field.__previousValue === undefined && e.detail.value === '') {
-              field.__previousValue = e.detail.value;
-              return;
-            }
-            this.value = e.detail.value;
+          field.addEventListener('input', (e) => {
+            this.value = e.target.value;
           });
 
           this._textField = field;
@@ -91,12 +84,8 @@ export const GridFilterElementMixin = (superClass) =>
       if (path === undefined || value === undefined || !textField) {
         return;
       }
-      if (this._previousValue === undefined && value === '') {
-        return;
-      }
 
       textField.value = value;
-      this._previousValue = value;
 
       this._debouncerFilterChanged = Debouncer.debounce(this._debouncerFilterChanged, timeOut.after(200), () => {
         this.dispatchEvent(new CustomEvent('filter-changed', { bubbles: true }));

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -55,7 +55,7 @@ describe('filter', () => {
     filterWrapper = fixtureSync('<filter-wrapper></filter-wrapper>');
     await nextRender();
     filter = filterWrapper.shadowRoot.querySelector('vaadin-grid-filter');
-    clock = sinon.useFakeTimers();
+    clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
   });
 
   afterEach(() => {
@@ -70,23 +70,26 @@ describe('filter', () => {
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should fire `filter-changed` on field value change', async () => {
+  it('should fire `filter-changed` on field input event', async () => {
     const spy = sinon.spy();
-    const field = filter.querySelector('vaadin-text-field');
+    const input = filter.querySelector('input');
     filter.addEventListener('filter-changed', spy);
-    field.value = 'foo';
+    input.value = 'foo';
+    fire(input, 'input');
     await clock.tickAsync(200);
     expect(spy.calledOnce).to.be.true;
   });
 
-  it('should fire `filter-changed` on field value change to empty string', async () => {
+  it('should fire `filter-changed` on field input event with empty string', async () => {
     const spy = sinon.spy();
-    const field = filter.querySelector('vaadin-text-field');
+    const input = filter.querySelector('input');
     filter.addEventListener('filter-changed', spy);
-    field.value = 'foo';
+    input.value = 'foo';
+    fire(input, 'input');
     await clock.tickAsync(200);
     spy.resetHistory();
-    field.value = '';
+    input.value = '';
+    fire(input, 'input');
     await clock.tickAsync(200);
     expect(spy.calledOnce).to.be.true;
   });
@@ -268,7 +271,8 @@ describe('filtering', () => {
     });
 
     it('should apply the input fields value to the filter', async () => {
-      filterTextField.value = 'foo';
+      filterTextField.inputElement.value = 'foo';
+      fire(filterTextField.inputElement, 'input');
       await nextFrame();
       expect(filter.value).to.equal('foo');
     });

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, LitElement } from 'lit';
 import { flushGrid, getBodyCellContent, getHeaderCellContent, getVisibleItems, scrollToEnd } from './helpers.js';
@@ -25,9 +25,7 @@ class FilterWrapper extends LitElement {
           display: block;
         }
       </style>
-      <vaadin-grid-filter path="foo" .value="${this._filterValue}">
-        <input @input="${this._onFilterInput}" />
-      </vaadin-grid-filter>
+      <vaadin-grid-filter path="foo" .value="${this._filterValue}"></vaadin-grid-filter>
     `;
   }
 
@@ -51,7 +49,7 @@ describe('filter', () => {
 
   beforeEach(async () => {
     filterWrapper = fixtureSync('<filter-wrapper></filter-wrapper>');
-    await filterWrapper.updateComplete;
+    await nextRender();
     filter = filterWrapper.shadowRoot.querySelector('vaadin-grid-filter');
     clock = sinon.useFakeTimers();
   });
@@ -64,6 +62,27 @@ describe('filter', () => {
     const spy = sinon.spy();
     filter.addEventListener('filter-changed', spy);
     filter.value = 'foo';
+    await clock.tickAsync(200);
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should fire `filter-changed` on field value change', async () => {
+    const spy = sinon.spy();
+    const field = filter.querySelector('vaadin-text-field');
+    filter.addEventListener('filter-changed', spy);
+    field.value = 'foo';
+    await clock.tickAsync(200);
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('should fire `filter-changed` on field value change to empty string', async () => {
+    const spy = sinon.spy();
+    const field = filter.querySelector('vaadin-text-field');
+    filter.addEventListener('filter-changed', spy);
+    field.value = 'foo';
+    await clock.tickAsync(200);
+    spy.resetHistory();
+    field.value = '';
     await clock.tickAsync(200);
     expect(spy.calledOnce).to.be.true;
   });

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -25,12 +25,16 @@ class FilterWrapper extends LitElement {
           display: block;
         }
       </style>
-      <vaadin-grid-filter path="foo" .value="${this._filterValue}"></vaadin-grid-filter>
+      <vaadin-grid-filter
+        path="foo"
+        .value="${this._filterValue}"
+        @value-changed="${this._onValueChanged}"
+      ></vaadin-grid-filter>
     `;
   }
 
-  _onFilterInput(e) {
-    this._filterValue = e.target.value;
+  _onValueChanged(e) {
+    this._filterValue = e.detail.value;
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #7247 

Updated the `vaadin-grid-filter` logic to remove workaround added when converting to Lit.

## Type of change

- Bugfix