### PR TITLE
fix: update position on visual viewport scroll and resize

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -146,7 +146,8 @@ export const PositionMixin = (superClass) =>
 
     /** @private */
     __addUpdatePositionEventListeners() {
-      window.addEventListener('resize', this._updatePosition);
+      window.visualViewport.addEventListener('resize', this._updatePosition);
+      window.visualViewport.addEventListener('scroll', this.__onScroll, true);
 
       this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget);
       this.__positionTargetAncestorRootNodes.forEach((node) => {
@@ -156,7 +157,8 @@ export const PositionMixin = (superClass) =>
 
     /** @private */
     __removeUpdatePositionEventListeners() {
-      window.removeEventListener('resize', this._updatePosition);
+      window.visualViewport.removeEventListener('resize', this._updatePosition);
+      window.visualViewport.removeEventListener('scroll', this.__onScroll, true);
 
       if (this.__positionTargetAncestorRootNodes) {
         this.__positionTargetAncestorRootNodes.forEach((node) => {
@@ -204,9 +206,11 @@ export const PositionMixin = (superClass) =>
     /** @private */
     __onScroll(e) {
       // If the scroll event occurred inside the overlay, ignore it.
-      if (!this.contains(e.target)) {
-        this._updatePosition();
+      if (e.target instanceof Node && this.contains(e.target)) {
+        return;
       }
+
+      this._updatePosition();
     }
 
     _updatePosition() {

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -149,7 +149,9 @@ export const PositionMixin = (superClass) =>
       window.visualViewport.addEventListener('resize', this._updatePosition);
       window.visualViewport.addEventListener('scroll', this.__onScroll, true);
 
-      this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget);
+      this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget).filter(
+        (node) => node !== document,
+      );
       this.__positionTargetAncestorRootNodes.forEach((node) => {
         node.addEventListener('scroll', this.__onScroll, true);
       });

--- a/packages/overlay/test/position-mixin-listeners.test.js
+++ b/packages/overlay/test/position-mixin-listeners.test.js
@@ -126,6 +126,16 @@ describe('position mixin listeners', () => {
       updatePositionSpy.resetHistory();
     });
 
+    it('should not update position on window resize', () => {
+      resize(window);
+      expect(updatePositionSpy.called).to.be.false;
+    });
+
+    it('should not update position on document scroll', () => {
+      scroll(document);
+      expect(updatePositionSpy.called).to.be.false;
+    });
+
     it('should update position on visual viewport resize', () => {
       resize(window.visualViewport);
       expect(updatePositionSpy.called).to.be.true;

--- a/packages/overlay/test/position-mixin-listeners.test.js
+++ b/packages/overlay/test/position-mixin-listeners.test.js
@@ -91,10 +91,10 @@ describe('position mixin listeners', () => {
       expect(updatePositionSpy.called).to.be.true;
     });
 
-    it('should update position on document scroll after assigning a position target', () => {
+    it('should update position on visual viewport scroll after assigning a position target', () => {
       overlay.positionTarget = target;
       updatePositionSpy.resetHistory();
-      scroll(document);
+      scroll(window.visualViewport);
       expect(updatePositionSpy.called).to.be.true;
     });
 
@@ -161,13 +161,13 @@ describe('position mixin listeners', () => {
       expect(updatePositionSpy.called).to.be.false;
     });
 
-    ['document', 'ancestor'].forEach((name) => {
+    ['visual viewport', 'ancestor'].forEach((name) => {
       describe(name, () => {
         let scrollableNode;
 
         beforeEach(() => {
-          if (name === 'document') {
-            scrollableNode = document;
+          if (name === 'visual viewport') {
+            scrollableNode = window.visualViewport;
           }
           if (name === 'ancestor') {
             scrollableNode = wrapper.shadowRoot.querySelector('#scrollable');
@@ -219,8 +219,8 @@ describe('position mixin listeners', () => {
         updatePositionSpy.resetHistory();
       });
 
-      it('should update position on document scroll', () => {
-        scroll(document);
+      it('should update position on visual viewport scroll', () => {
+        scroll(window.visualViewport);
         expect(updatePositionSpy.called).to.be.true;
       });
 
@@ -245,8 +245,8 @@ describe('position mixin listeners', () => {
         newWrapper.appendChild(target);
       });
 
-      it('should update position on document scroll after re-opened', async () => {
-        scroll(document);
+      it('should update position on visual viewport scroll after re-opened', async () => {
+        scroll(window.visualViewport);
         expect(updatePositionSpy.called).to.be.true;
 
         overlay.opened = false;
@@ -254,7 +254,7 @@ describe('position mixin listeners', () => {
         await nextFrame();
         updatePositionSpy.resetHistory();
 
-        scroll(document);
+        scroll(window.visualViewport);
         expect(updatePositionSpy.called).to.be.true;
       });
 

--- a/packages/overlay/test/position-mixin-listeners.test.js
+++ b/packages/overlay/test/position-mixin-listeners.test.js
@@ -68,8 +68,8 @@ describe('position mixin listeners', () => {
       updatePositionSpy.resetHistory();
     });
 
-    it('should not update position on resize', () => {
-      resize(window);
+    it('should not update position on visual viewport resize', () => {
+      resize(window.visualViewport);
       expect(updatePositionSpy.called).to.be.false;
     });
 
@@ -84,10 +84,10 @@ describe('position mixin listeners', () => {
       expect(updatePositionSpy.called).to.be.false;
     });
 
-    it('should update position on resize after assigning a position target', () => {
+    it('should update position on visual viewport resize after assigning a position target', () => {
       overlay.positionTarget = target;
       updatePositionSpy.resetHistory();
-      resize(window);
+      resize(window.visualViewport);
       expect(updatePositionSpy.called).to.be.true;
     });
 
@@ -126,14 +126,25 @@ describe('position mixin listeners', () => {
       updatePositionSpy.resetHistory();
     });
 
-    it('should update position on resize', () => {
-      resize(window);
+    it('should update position on visual viewport resize', () => {
+      resize(window.visualViewport);
       expect(updatePositionSpy.called).to.be.true;
     });
 
-    it('should not update position on resize when closed', () => {
+    it('should not update position on visual viewport resize when closed', () => {
       overlay.opened = false;
-      resize(window);
+      resize(window.visualViewport);
+      expect(updatePositionSpy.called).to.be.false;
+    });
+
+    it('should update position on visual viewport scroll', () => {
+      scroll(window.visualViewport);
+      expect(updatePositionSpy.called).to.be.true;
+    });
+
+    it('should not update position on visual viewport scroll when closed', () => {
+      overlay.opened = false;
+      scroll(window.visualViewport);
       expect(updatePositionSpy.called).to.be.false;
     });
 


### PR DESCRIPTION
## Description

The PR adds listeners for visual viewport scroll and resize events to update the overlay's position accordingly. Based on my testing, the visual viewport events are triggered in all scenarios in which the corresponding window events are triggered, so I completely replaced the window scroll and resize listeners with the visual viewport ones.

The [Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API) has [good support](https://caniuse.com/mdn-api_visualviewport) across all browsers supported by Vaadin 24:

<img width="964" alt="Screenshot 2024-03-27 at 16 13 45" src="https://github.com/vaadin/web-components/assets/5039436/b6dbf5c2-7b6f-468e-b1c4-38daa23d8454">

Fixes https://github.com/vaadin/web-components/issues/7214

## Type of change

- [x] Bugfix
