### PR TITLE
refactor: remove useless _filterValue property and related listeners

### DIFF
--- a/packages/grid/src/vaadin-grid-filter-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-column-mixin.js
@@ -30,13 +30,7 @@ export const GridFilterColumnMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, _filterValue)'];
-    }
-
-    constructor() {
-      super();
-
-      this.__boundOnFilterValueChanged = this.__onFilterValueChanged.bind(this);
+      return ['_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header)'];
     }
 
     /**
@@ -54,16 +48,12 @@ export const GridFilterColumnMixin = (superClass) =>
         textField.setAttribute('theme', 'small');
         textField.setAttribute('style', 'max-width: 100%;');
         textField.setAttribute('focus-target', '');
-        textField.addEventListener('value-changed', this.__boundOnFilterValueChanged);
         filter.appendChild(textField);
         root.appendChild(filter);
       }
 
       filter.path = this.path;
-      filter.value = this._filterValue;
 
-      textField.__rendererValue = this._filterValue;
-      textField.value = this._filterValue;
       textField.label = this.__getHeader(this.header, this.path);
     }
 
@@ -76,21 +66,6 @@ export const GridFilterColumnMixin = (superClass) =>
      */
     _computeHeaderRenderer() {
       return this._defaultHeaderRenderer;
-    }
-
-    /**
-     * Updates the internal filter value once the filter text field is changed.
-     * The listener handles only user-fired events.
-     *
-     * @private
-     */
-    __onFilterValueChanged(e) {
-      // Skip if the value is changed by the renderer.
-      if (e.detail.value === e.target.__rendererValue) {
-        return;
-      }
-
-      this._filterValue = e.detail.value;
     }
 
     /** @private */


### PR DESCRIPTION
## Description

The PR removes the `_filterValue` property along with its related listeners from `<vaadin-grid-filter-column />`. This property seems to be useless, as the grid listens for `filter-changed` [directly](https://github.com/vaadin/web-components/blob/ac5c22e8ae9a78f3a0673d989f668416d4b6b730/packages/grid/src/vaadin-grid-filter-mixin.js#L25-L26) on `<vaadin-grid-filter />`.

## Type of change

- [x] Refactor
