### PR TITLE
fix: close select overlay when clicking already selected item

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -259,8 +259,10 @@ export const SelectBaseMixin = (superClass) =>
         menuElement.addEventListener('keydown', (e) => this._onKeyDownInside(e), true);
         menuElement.addEventListener(
           'click',
-          () => {
-            this.__dispatchChangePending = true;
+          (e) => {
+            const value = e.target.value;
+            this.__dispatchChangePending = value !== undefined && value !== this.value;
+            this.opened = false;
           },
           true,
         );
@@ -523,7 +525,6 @@ export const SelectBaseMixin = (superClass) =>
           this._selectedChanging = true;
           this.value = selected.value || '';
           if (this.__dispatchChangePending) {
-            this.opened = false;
             this.__dispatchChange();
           }
           delete this._selectedChanging;

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -132,6 +132,18 @@ describe('vaadin-select', () => {
         expect(select._overlayElement.opened).to.be.false;
       });
 
+      it('should close the overlay when clicking an already selected item', async () => {
+        click(select._items[1]);
+        await nextUpdate(select);
+
+        select.opened = true;
+        await nextRender();
+
+        click(select._items[1]);
+        await nextUpdate(select);
+        expect(select._overlayElement.opened).to.be.false;
+      });
+
       it('should preserve the selected attribute when selecting the disabled item', async () => {
         menu.selected = 5;
         await nextUpdate(select);


### PR DESCRIPTION
## Description

Fixes #7286

The PR where the change was introduced contains some clarification: https://github.com/vaadin/web-components/pull/6256/files#r1276178338

However, it turns out that removal of `this.opened = false` was problematic as it resulted in the regression.

## Type of change

- Bugfix