### PR TITLE
fix: check if sizer cells are assigned for lazy column rendering

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -248,17 +248,11 @@ export const ScrollMixin = (superClass) =>
 
     /** @private */
     __updateColumnsBodyContentHidden() {
-      if (!this._columnTree) {
+      if (!this._columnTree || !this._areSizerCellsAssigned()) {
         return;
       }
 
       const columnsInOrder = this._getColumnsInOrder();
-
-      // Return if sizer cells are not yet assigned to columns
-      if (!columnsInOrder[0] || !columnsInOrder[0]._sizerCell) {
-        return;
-      }
-
       let bodyContentHiddenChanged = false;
 
       // Remove the column cells from the DOM if the column is outside the viewport.
@@ -498,7 +492,7 @@ export const ScrollMixin = (superClass) =>
 
       let transformFrozenToEndBody = transformFrozenToEnd;
 
-      if (this._lazyColumns) {
+      if (this._lazyColumns && this._areSizerCellsAssigned()) {
         // Lazy column rendering is used, calculate the offset to apply to the frozen to end cells
         const columnsInOrder = this._getColumnsInOrder();
 
@@ -527,5 +521,17 @@ export const ScrollMixin = (superClass) =>
       if (this.hasAttribute('navigating') && this.__rowFocusMode) {
         this.$.table.style.setProperty('--_grid-horizontal-scroll-position', `${-x}px`);
       }
+    }
+
+    /** @private */
+    _areSizerCellsAssigned() {
+      const columnsInOrder = this._getColumnsInOrder();
+      if (columnsInOrder.length === 0) {
+        return false;
+      }
+      if (this._lazyColumns) {
+        return columnsInOrder.every((column) => column._sizerCell);
+      }
+      return !!columnsInOrder[0]._sizerCell;
     }
   };

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -525,13 +525,6 @@ export const ScrollMixin = (superClass) =>
 
     /** @private */
     _areSizerCellsAssigned() {
-      const columnsInOrder = this._getColumnsInOrder();
-      if (columnsInOrder.length === 0) {
-        return false;
-      }
-      if (this._lazyColumns) {
-        return columnsInOrder.every((column) => column._sizerCell);
-      }
-      return !!columnsInOrder[0]._sizerCell;
+      return this._getColumnsInOrder().every((column) => column._sizerCell);
     }
   };

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -215,6 +215,23 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
       expect(secondRect.top).to.equal(firstRect.bottom + detailsHeight);
     });
 
+    it('should render new appended column', async () => {
+      grid = fixtureSync(`
+        <vaadin-grid item-id-path="name" column-rendering="lazy">
+          <vaadin-grid-column path="name"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      grid.items = [{ name: `Item 1` }];
+      await onceResized(grid);
+      flushGrid(grid);
+
+      const newColumn = document.createElement('vaadin-grid-column');
+      grid.appendChild(newColumn);
+      await nextFrame();
+
+      expect(isColumnInViewport(newColumn)).to.be.true;
+    });
+
     describe(`scroll horizontally - ${dir}`, () => {
       /**
        * Expect the cells DOM order to match the column order


### PR DESCRIPTION
## Description

When a new column is added to a grid with lazy column rendering, some of the listeners are invoked before the column tree is updated and the sizer cells are assigned. This creates problems when the sizer cell is needed for calculations. A new column currently cannot be appended to a grid with lazy column rendering. Those calculations involving the sizer cells are made again after the node observer is invoked and the column tree is updated. Therefore, it seems like they can be safely skipped.

This PR skips the calculations that require sizer cells if they are not assigned yet.

Fixes #7281 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.