### PR TITLE
fix: revert input on overlay close by escape

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1003,9 +1003,8 @@ export const DatePickerMixin = (subclass) =>
 
       if (this._closedByEscape) {
         this._applyInputValue(this._selectedDate);
-      } else {
-        this.__commitParsedOrFocusedDate();
       }
+      this.__commitParsedOrFocusedDate();
 
       if (this._nativeInput && this._nativeInput.selectionStart) {
         this._nativeInput.selectionStart = this._nativeInput.selectionEnd;

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -908,7 +908,9 @@ export const DatePickerMixin = (subclass) =>
     /** @protected */
     _onOverlayEscapePress() {
       this._focusedDate = this._selectedDate;
+      this._closedByEscape = true;
       this._close();
+      this._closedByEscape = false;
     }
 
     /** @protected */
@@ -999,7 +1001,11 @@ export const DatePickerMixin = (subclass) =>
       }
       window.removeEventListener('scroll', this._boundOnScroll, true);
 
-      this.__commitParsedOrFocusedDate();
+      if (this._closedByEscape) {
+        this._applyInputValue(this._selectedDate);
+      } else {
+        this.__commitParsedOrFocusedDate();
+      }
 
       if (this._nativeInput && this._nativeInput.selectionStart) {
         this._nativeInput.selectionStart = this._nativeInput.selectionEnd;

--- a/packages/date-picker/test/value-commit.common.js
+++ b/packages/date-picker/test/value-commit.common.js
@@ -5,8 +5,15 @@ import sinon from 'sinon';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
+function formatDateISO(date) {
+  return date.toISOString().split('T')[0];
+}
+
+const TODAY_DATE = formatDateISO(new Date());
+const YESTERDAY_DATE = formatDateISO(new Date(Date.now() - 3600 * 1000 * 24));
+
 describe('value commit', () => {
-  let datePicker, valueChangedSpy, validateSpy, changeSpy, unparsableChangeSpy, todayDate, yesterdayDate;
+  let datePicker, valueChangedSpy, validateSpy, changeSpy, unparsableChangeSpy;
 
   function expectNoValueCommit() {
     expect(valueChangedSpy).to.be.not.called;
@@ -56,9 +63,6 @@ describe('value commit', () => {
     datePicker.addEventListener('unparsable-change', unparsableChangeSpy);
 
     datePicker.focus();
-
-    todayDate = datePicker._formatISO(new Date());
-    yesterdayDate = datePicker._formatISO(new Date(Date.now() - 3600 * 1000 * 24));
   });
 
   describe('default', () => {
@@ -156,7 +160,7 @@ describe('value commit', () => {
 
     describe('value set programmatically', () => {
       beforeEach(() => {
-        datePicker.value = todayDate;
+        datePicker.value = TODAY_DATE;
         valueChangedSpy.resetHistory();
         validateSpy.resetHistory();
       });
@@ -261,22 +265,22 @@ describe('value commit', () => {
     it('should commit on focused date selection with click', () => {
       const date = getDeepActiveElement();
       tap(date);
-      expectValueCommit(yesterdayDate);
+      expectValueCommit(YESTERDAY_DATE);
     });
 
     it('should commit on focused date selection with Enter', async () => {
       await sendKeys({ press: 'Enter' });
-      expectValueCommit(yesterdayDate);
+      expectValueCommit(YESTERDAY_DATE);
     });
 
     it('should commit on focused date selection with Space', async () => {
       await sendKeys({ press: 'Space' });
-      expectValueCommit(yesterdayDate);
+      expectValueCommit(YESTERDAY_DATE);
     });
 
     it('should commit focused date on close with outside click', () => {
       outsideClick();
-      expectValueCommit(yesterdayDate);
+      expectValueCommit(YESTERDAY_DATE);
     });
 
     it('should revert on close with Escape', async () => {
@@ -308,7 +312,7 @@ describe('value commit', () => {
       validateSpy.resetHistory();
       changeSpy.resetHistory();
       outsideClick();
-      expectValueCommit(todayDate);
+      expectValueCommit(TODAY_DATE);
     });
 
     describe('another date focused', () => {
@@ -321,17 +325,17 @@ describe('value commit', () => {
       it('should commit on focused date selection with click', () => {
         const date = getDeepActiveElement();
         tap(date);
-        expectValueCommit(yesterdayDate);
+        expectValueCommit(YESTERDAY_DATE);
       });
 
       it('should commit on focused date selection with Space', async () => {
         await sendKeys({ press: 'Space' });
-        expectValueCommit(yesterdayDate);
+        expectValueCommit(YESTERDAY_DATE);
       });
 
       it('should commit on focused date selection with Enter', async () => {
         await sendKeys({ press: 'Enter' });
-        expectValueCommit(yesterdayDate);
+        expectValueCommit(YESTERDAY_DATE);
       });
     });
   });
@@ -340,7 +344,7 @@ describe('value commit', () => {
     let initialInputElementValue;
 
     beforeEach(() => {
-      datePicker.value = todayDate;
+      datePicker.value = TODAY_DATE;
       initialInputElementValue = datePicker.inputElement.value;
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
@@ -430,7 +434,7 @@ describe('value commit', () => {
 
   describe('with clear button', () => {
     beforeEach(() => {
-      datePicker.value = todayDate;
+      datePicker.value = TODAY_DATE;
       datePicker.clearButtonVisible = true;
       validateSpy.resetHistory();
       valueChangedSpy.resetHistory();

--- a/packages/date-picker/test/value-commit.common.js
+++ b/packages/date-picker/test/value-commit.common.js
@@ -240,9 +240,9 @@ describe('value commit', () => {
         expectUnparsableValueCommit();
       });
 
-      it('should clear and not commit as unparsable value change on close with Escape', async () => {
+      it('should clear and commit as unparsable value change on close with Escape', async () => {
         await sendKeys({ press: 'Escape' });
-        expect(unparsableChangeSpy).to.be.not.called;
+        expectUnparsableValueCommit();
         expect(datePicker.inputElement.value).to.equal('');
       });
     });


### PR DESCRIPTION
## Description

Currently, when
1. the date picker has a value
2. an invalid value is entered
3. date picker overlay is closed using `escape`

the input is not reverted and the date picker is validated using the unparsable input.

This PR reverts the input value to the last selected date if the overlay is closed using `escape`.

!!! This fix was tested with the Flow counterpart. However, if any regressions occur regarding the validation chain, this PR can be the culprit. !!!

Fixes #4354 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.