### PR TITLE
fix: make Lumo font custom properties work for vaadin-select

### DIFF
--- a/packages/select/theme/lumo/vaadin-select-styles.js
+++ b/packages/select/theme/lumo/vaadin-select-styles.js
@@ -27,7 +27,7 @@ const select = css`
   }
 
   [part='input-field'] ::slotted([slot='value']) {
-    font-weight: 500;
+    font-weight: var(--vaadin-input-field-value-font-weight, 500);
   }
 
   [part='input-field'] ::slotted([slot='value']:not([placeholder])) {
@@ -79,6 +79,7 @@ registerStyles(
       min-height: var(--_lumo-selected-item-height);
       padding-top: var(--_lumo-selected-item-padding);
       padding-bottom: var(--_lumo-selected-item-padding);
+      font-size: inherit;
     }
 
     ::slotted(*:hover) {


### PR DESCRIPTION
## Description

Fixes #7234

When introducing custom CSS properties for font-weight, we missed to use it in `vaadin-select`.
Regarding font-size property, it is used but slotted `vaadin-select-item` overrides its value.

Note: I'm not sure why font-weight is set to `500` for select and not `400` like in text-field etc.

## Type of change

- Bugfix