### PR TITLE
fix: use document scroll instead of the visual viewport

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -149,9 +149,7 @@ export const PositionMixin = (superClass) =>
       window.visualViewport.addEventListener('resize', this._updatePosition);
       window.visualViewport.addEventListener('scroll', this.__onScroll, true);
 
-      this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget).filter(
-        (node) => node !== document,
-      );
+      this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget);
       this.__positionTargetAncestorRootNodes.forEach((node) => {
         node.addEventListener('scroll', this.__onScroll, true);
       });

--- a/packages/overlay/test/position-mixin-listeners.test.js
+++ b/packages/overlay/test/position-mixin-listeners.test.js
@@ -78,6 +78,11 @@ describe('position mixin listeners', () => {
       expect(updatePositionSpy.called).to.be.false;
     });
 
+    it('should not update position on visual viewport scroll', () => {
+      scroll(window.visualViewport);
+      expect(updatePositionSpy.called).to.be.false;
+    });
+
     it('should not update position on ancestor scroll', () => {
       const scrollableAncestor = wrapper.shadowRoot.querySelector('#scrollable');
       scroll(scrollableAncestor);
@@ -95,6 +100,13 @@ describe('position mixin listeners', () => {
       overlay.positionTarget = target;
       updatePositionSpy.resetHistory();
       scroll(window.visualViewport);
+      expect(updatePositionSpy.called).to.be.true;
+    });
+
+    it('should update position on document scroll after assigning a position target', () => {
+      overlay.positionTarget = target;
+      updatePositionSpy.resetHistory();
+      scroll(document);
       expect(updatePositionSpy.called).to.be.true;
     });
 
@@ -131,9 +143,9 @@ describe('position mixin listeners', () => {
       expect(updatePositionSpy.called).to.be.false;
     });
 
-    it('should not update position on document scroll', () => {
+    it('should update position on document scroll', () => {
       scroll(document);
-      expect(updatePositionSpy.called).to.be.false;
+      expect(updatePositionSpy.called).to.be.true;
     });
 
     it('should update position on visual viewport resize', () => {
@@ -150,6 +162,12 @@ describe('position mixin listeners', () => {
     it('should update position on visual viewport scroll', () => {
       scroll(window.visualViewport);
       expect(updatePositionSpy.called).to.be.true;
+    });
+
+    it('should not update position on document scroll when closed', () => {
+      overlay.opened = false;
+      scroll(document);
+      expect(updatePositionSpy.called).to.be.false;
     });
 
     it('should not update position on visual viewport scroll when closed', () => {
@@ -171,11 +189,14 @@ describe('position mixin listeners', () => {
       expect(updatePositionSpy.called).to.be.false;
     });
 
-    ['visual viewport', 'ancestor'].forEach((name) => {
+    ['document', 'visual viewport', 'ancestor'].forEach((name) => {
       describe(name, () => {
         let scrollableNode;
 
         beforeEach(() => {
+          if (name === 'document') {
+            scrollableNode = document;
+          }
           if (name === 'visual viewport') {
             scrollableNode = window.visualViewport;
           }
@@ -229,6 +250,11 @@ describe('position mixin listeners', () => {
         updatePositionSpy.resetHistory();
       });
 
+      it('should update position on document scroll', () => {
+        scroll(document);
+        expect(updatePositionSpy.called).to.be.true;
+      });
+
       it('should update position on visual viewport scroll', () => {
         scroll(window.visualViewport);
         expect(updatePositionSpy.called).to.be.true;
@@ -253,6 +279,19 @@ describe('position mixin listeners', () => {
       beforeEach(() => {
         newWrapper = fixtureSync(`<scrollable-wrapper></scrollable-wrapper>`);
         newWrapper.appendChild(target);
+      });
+
+      it('should update position on document scroll after re-opened', async () => {
+        scroll(document);
+        expect(updatePositionSpy.called).to.be.true;
+
+        overlay.opened = false;
+        overlay.opened = true;
+        await nextFrame();
+        updatePositionSpy.resetHistory();
+
+        scroll(document);
+        expect(updatePositionSpy.called).to.be.true;
       });
 
       it('should update position on visual viewport scroll after re-opened', async () => {


### PR DESCRIPTION
## Description

Follow-up to #7279 

After merging the above PR, I discovered that for some reason, `scroll` event isn't fired on `window.visualViewport` on desktop browsers, so e.g. `vaadin-combo-box` overlay doesn't reposition on scroll with that change:

https://github.com/vaadin/web-components/assets/10589913/cc15e452-fb30-4bad-9805-c484e590ae3e

Restored listening to `scroll` event on the `document` in addition to `window.visualViewport` (used by iOS).

## Type of change

- Bugfix