### PR TITLE
fix: do not count columns with path and null header in a11y headers

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -16,7 +16,9 @@ export const A11yMixin = (superClass) =>
 
     /** @private */
     _a11yGetHeaderRowCount(_columnTree) {
-      return _columnTree.filter((level) => level.some((col) => col.headerRenderer || col.path || col.header)).length;
+      return _columnTree.filter((level) =>
+        level.some((col) => col.headerRenderer || (col.path && col.header !== null) || col.header),
+      ).length;
     }
 
     /** @private */

--- a/packages/grid/test/accessibility.common.js
+++ b/packages/grid/test/accessibility.common.js
@@ -274,6 +274,16 @@ describe('accessibility', () => {
       expect(grid.$.table.getAttribute('aria-rowcount')).to.equal('3');
     });
 
+    it('should not count a column with a path and null header in aria-rowcount', () => {
+      col.path = 'value';
+      col.header = null;
+      flushGrid(grid);
+
+      const rowCount = Array.from(grid.$.table.querySelectorAll('tr')).filter((tr) => !tr.hidden).length;
+      expect(grid.$.table.getAttribute('aria-rowcount')).to.equal(String(rowCount));
+      expect(grid.$.table.getAttribute('aria-rowcount')).to.equal('2');
+    });
+
     it('should have aria-rowcount on the table (header)', () => {
       col.header = 'Foo';
       flushGrid(grid);


### PR DESCRIPTION
## Description

Currently, when the header row count is calculated in order to get `aria-rowcount`, any column with `path` matches the filter. However, when a column has a `path` but also has an explicitly `null` `header`, the header row will not be displayed.

This PR fixes this case by adding the null header check in the filter.

Fixes #7244 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.