### PR TITLE
fix: show placeholder item when an empty item is selected

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -512,23 +512,21 @@ export const SelectBaseMixin = (superClass) =>
 
       valueButton.removeAttribute('placeholder');
 
-      if (!selected) {
-        if (this.placeholder) {
-          const item = this.__createItemElement({ label: this.placeholder });
-          this.__appendValueItemElement(item, valueButton);
-          valueButton.setAttribute('placeholder', '');
-        }
-      } else {
+      if (this._hasContent(selected)) {
         this.__attachSelectedItem(selected);
+      } else if (this.placeholder) {
+        const item = this.__createItemElement({ label: this.placeholder });
+        this.__appendValueItemElement(item, valueButton);
+        valueButton.setAttribute('placeholder', '');
+      }
 
-        if (!this._valueChanging) {
-          this._selectedChanging = true;
-          this.value = selected.value || '';
-          if (this.__dispatchChangePending) {
-            this.__dispatchChange();
-          }
-          delete this._selectedChanging;
+      if (!this._valueChanging && selected) {
+        this._selectedChanging = true;
+        this.value = selected.value || '';
+        if (this.__dispatchChangePending) {
+          this.__dispatchChange();
         }
+        delete this._selectedChanging;
       }
 
       const labelledIdReferenceConfig =
@@ -538,6 +536,14 @@ export const SelectBaseMixin = (superClass) =>
       if (this.accessibleName || this.accessibleNameRef) {
         this._setCustomAriaLabelledBy(this.accessibleNameRef || this._srLabelController.defaultId);
       }
+    }
+
+    /** @private */
+    _hasContent(item) {
+      if (!item) {
+        return false;
+      }
+      return Boolean(item.hasAttribute('label') ? item.getAttribute('label') : item.textContent.trim());
     }
 
     /** @private */

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -447,9 +447,28 @@ describe('vaadin-select', () => {
     });
 
     describe('placeholder', () => {
+      beforeEach(() => {
+        select.placeholder = 'Select an item';
+      });
+
       it('should set placeholder as a value node text content', async () => {
         select.value = null;
-        select.placeholder = 'Select an item';
+        await nextUpdate(select);
+        expect(valueButton.textContent).to.equal('Select an item');
+      });
+
+      it('should show placeholder when selecting an item with empty label', async () => {
+        select.opened = true;
+        await nextRender();
+        click(select._items[4]);
+        await nextUpdate(select);
+        expect(valueButton.textContent).to.equal('Select an item');
+      });
+
+      it('should show placeholder when selecting an item with empty text', async () => {
+        select.opened = true;
+        await nextRender();
+        click(select._items[3]);
         await nextUpdate(select);
         expect(valueButton.textContent).to.equal('Select an item');
       });


### PR DESCRIPTION
## Description

Fixes #7243

Restored `_hasContent` check which was removed by mistake in #2282.

Can be tested with the following snippet:

```html
<vaadin-select placeholder="Select size"></vaadin-select>

<script>
  const select = document.querySelector('vaadin-select');
  select.items = [
    { label: '', value: '' },
    { component: 'hr' },
    { label: 'XS (out of stock)', value: 'xs', disabled: true },
    { label: 'S', value: 's' },
    { label: 'M', value: 'm' },
    { label: 'L', value: 'l' },
    { label: 'XL', value: 'xl' },
  ];
</script>
```

Without a fix, selecting first (empty) item makes it show in the value button, which is not a desirable behavior.
The correct behavior in this case is to not attach selected item and show the placeholder item instead.

## Type of change

- Bugfix