### PR TITLE
test: use formatter from date picker in tests

### DIFF
--- a/packages/date-picker/test/value-commit.common.js
+++ b/packages/date-picker/test/value-commit.common.js
@@ -5,15 +5,8 @@ import sinon from 'sinon';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
 
-function formatDateISO(date) {
-  return date.toISOString().split('T')[0];
-}
-
-const TODAY_DATE = formatDateISO(new Date());
-const YESTERDAY_DATE = formatDateISO(new Date(Date.now() - 3600 * 1000 * 24));
-
 describe('value commit', () => {
-  let datePicker, valueChangedSpy, validateSpy, changeSpy, unparsableChangeSpy;
+  let datePicker, valueChangedSpy, validateSpy, changeSpy, unparsableChangeSpy, todayDate, yesterdayDate;
 
   function expectNoValueCommit() {
     expect(valueChangedSpy).to.be.not.called;
@@ -63,6 +56,9 @@ describe('value commit', () => {
     datePicker.addEventListener('unparsable-change', unparsableChangeSpy);
 
     datePicker.focus();
+
+    todayDate = datePicker._formatISO(new Date());
+    yesterdayDate = datePicker._formatISO(new Date(Date.now() - 3600 * 1000 * 24));
   });
 
   describe('default', () => {
@@ -160,7 +156,7 @@ describe('value commit', () => {
 
     describe('value set programmatically', () => {
       beforeEach(() => {
-        datePicker.value = TODAY_DATE;
+        datePicker.value = todayDate;
         valueChangedSpy.resetHistory();
         validateSpy.resetHistory();
       });
@@ -265,22 +261,22 @@ describe('value commit', () => {
     it('should commit on focused date selection with click', () => {
       const date = getDeepActiveElement();
       tap(date);
-      expectValueCommit(YESTERDAY_DATE);
+      expectValueCommit(yesterdayDate);
     });
 
     it('should commit on focused date selection with Enter', async () => {
       await sendKeys({ press: 'Enter' });
-      expectValueCommit(YESTERDAY_DATE);
+      expectValueCommit(yesterdayDate);
     });
 
     it('should commit on focused date selection with Space', async () => {
       await sendKeys({ press: 'Space' });
-      expectValueCommit(YESTERDAY_DATE);
+      expectValueCommit(yesterdayDate);
     });
 
     it('should commit focused date on close with outside click', () => {
       outsideClick();
-      expectValueCommit(YESTERDAY_DATE);
+      expectValueCommit(yesterdayDate);
     });
 
     it('should revert on close with Escape', async () => {
@@ -312,7 +308,7 @@ describe('value commit', () => {
       validateSpy.resetHistory();
       changeSpy.resetHistory();
       outsideClick();
-      expectValueCommit(TODAY_DATE);
+      expectValueCommit(todayDate);
     });
 
     describe('another date focused', () => {
@@ -325,17 +321,17 @@ describe('value commit', () => {
       it('should commit on focused date selection with click', () => {
         const date = getDeepActiveElement();
         tap(date);
-        expectValueCommit(YESTERDAY_DATE);
+        expectValueCommit(yesterdayDate);
       });
 
       it('should commit on focused date selection with Space', async () => {
         await sendKeys({ press: 'Space' });
-        expectValueCommit(YESTERDAY_DATE);
+        expectValueCommit(yesterdayDate);
       });
 
       it('should commit on focused date selection with Enter', async () => {
         await sendKeys({ press: 'Enter' });
-        expectValueCommit(YESTERDAY_DATE);
+        expectValueCommit(yesterdayDate);
       });
     });
   });
@@ -344,7 +340,7 @@ describe('value commit', () => {
     let initialInputElementValue;
 
     beforeEach(() => {
-      datePicker.value = TODAY_DATE;
+      datePicker.value = todayDate;
       initialInputElementValue = datePicker.inputElement.value;
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
@@ -434,7 +430,7 @@ describe('value commit', () => {
 
   describe('with clear button', () => {
     beforeEach(() => {
-      datePicker.value = TODAY_DATE;
+      datePicker.value = todayDate;
       datePicker.clearButtonVisible = true;
       validateSpy.resetHistory();
       valueChangedSpy.resetHistory();


### PR DESCRIPTION
## Description

This PR updates the tests to use the formatter from date picker. The reason is that the current formatter in the test does not take time zones into consideration. This leads to tests failing when time zone is not GMT.

No related issue.

Extracted from https://github.com/vaadin/web-components/pull/7293 as a follow-up to a [comment](https://github.com/vaadin/web-components/pull/7293#discussion_r1555664979). 

## Type of change

- [ ] Bugfix
- [ ] Feature
- [x] Test

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.