### PR TITLE
fix: set role attribute on the CRUD edit dialog overlay

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -145,6 +145,7 @@ class CrudDialog extends DialogBaseMixin(OverlayClassMixin(ThemePropertyMixin(Po
         with-backdrop="[[!modeless]]"
         resizable$="[[resizable]]"
         fullscreen$="[[fullscreen]]"
+        role="dialog"
         focus-trap
       ></vaadin-crud-dialog-overlay>
     `;

--- a/packages/crud/test/a11y.test.js
+++ b/packages/crud/test/a11y.test.js
@@ -292,7 +292,7 @@ describe('a11y', () => {
     });
   });
 
-  describe('dialog aria-label', () => {
+  describe('dialog ARIA attributes', () => {
     let newButton, editButtons, dialog;
 
     beforeEach(async () => {
@@ -307,6 +307,12 @@ describe('a11y', () => {
     afterEach(async () => {
       crud.editorOpened = false;
       await nextRender();
+    });
+
+    it('should set correct role attribute to the dialog overlay', async () => {
+      newButton.click();
+      await nextRender();
+      expect(dialog.$.overlay.getAttribute('role')).to.equal('dialog');
     });
 
     it('should set correct aria-label to the new item dialog', async () => {


### PR DESCRIPTION
## Description

Finding from https://github.com/vaadin/web-components/pull/7264#issuecomment-2019904617

When decoupling `vaadin-crud-dialog` from `vaadin-dialog`, I missed to set `role` attribute. This PR fixes that.

## Type of change

- Bugfix