### PR TITLE
fix: do not measure overlay boundaries when menu is closed

### DIFF
--- a/integration/tests/component-relayout-page.test.js
+++ b/integration/tests/component-relayout-page.test.js
@@ -1,0 +1,40 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { ContextMenu } from '@vaadin/context-menu';
+
+[{ tagName: ContextMenu.is }].forEach(({ tagName }) => {
+  describe(`${tagName} re-layout`, () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = fixtureSync('<div></div>');
+    });
+
+    function renderChildren() {
+      if (wrapper.children.length) {
+        [...wrapper.children].forEach((child) => child.remove());
+      }
+
+      wrapper.appendChild(document.createElement(tagName));
+
+      for (let i = 0; i < 100; i++) {
+        const btn = document.createElement('button');
+        btn.textContent = `Button ${i}`;
+        wrapper.appendChild(btn);
+        wrapper.appendChild(document.createElement('br'));
+      }
+    }
+
+    it(`should not reset scroll to top when creating a ${tagName}`, async () => {
+      renderChildren();
+      await nextRender();
+
+      document.documentElement.scrollTop = 1000;
+
+      renderChildren();
+      await nextRender();
+
+      expect(document.documentElement.scrollTop).to.equal(1000);
+    });
+  });
+});

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -209,8 +209,11 @@ export const ContextMenuMixin = (superClass) =>
      * @private
      */
     _onOverlayOpened(e) {
-      this._setOpened(e.detail.value);
-      this.__alignOverlayPosition();
+      const opened = e.detail.value;
+      this._setOpened(opened);
+      if (opened) {
+        this.__alignOverlayPosition();
+      }
     }
 
     /**

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -65,7 +65,6 @@ snapshots["context-menu items nested"] =
   dir="ltr"
   modeless=""
   opened=""
-  right-aligned=""
   start-aligned=""
   top-aligned=""
 >
@@ -166,7 +165,6 @@ snapshots["context-menu items overlay class nested"] =
   dir="ltr"
   modeless=""
   opened=""
-  right-aligned=""
   start-aligned=""
   top-aligned=""
 >


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/7271

Because of the error, the `opened-changed` event listener also called `__alignOverlayPosition()` when `opened` was set to `false` (initial value). This triggers some measurements of `vaadin-context-menu-overlay` which [force re-layout](https://gist.github.com/paulirish/5d52fb081b3570c81e3a).

Note: this PR alone is not enough to fix `vaadin-menu-bar`, I'll create another PR for its logic to keep fixes granular.

## Type of change

- Bugfix