### PR TITLE
fix: only clear overlay root when assigning a renderer if needed

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -220,12 +220,13 @@ export const OverlayMixin = (superClass) =>
       this._oldOwner = owner;
 
       const rendererChanged = this._oldRenderer !== renderer;
+      const hasOldRenderer = this._oldRenderer !== undefined;
       this._oldRenderer = renderer;
 
       const openedChanged = this._oldOpened !== opened;
       this._oldOpened = opened;
 
-      if (rendererChanged) {
+      if (rendererChanged && hasOldRenderer) {
         this.innerHTML = '';
         // Whenever a Lit-based renderer is used, it assigns a Lit part to the node it was rendered into.
         // When clearing the rendered content, this part needs to be manually disposed of.

--- a/packages/overlay/test/renderer.common.js
+++ b/packages/overlay/test/renderer.common.js
@@ -140,4 +140,29 @@ describe('renderer', () => {
     await nextRender();
     expect(overlay.textContent.trim()).to.equal('');
   });
+
+  it('should not clear the root on open when setting renderer', async () => {
+    const spy = sinon.spy(overlay, 'innerHTML', ['set']);
+    overlay.renderer = (root) => {
+      if (!root.innerHTML) {
+        root.appendChild(content);
+      }
+    };
+    overlay.opened = true;
+    await nextRender();
+    expect(spy.set).to.not.be.called;
+  });
+
+  it('should not re-render when opened after requesting content update', async () => {
+    const spy = sinon.spy(overlay, 'appendChild');
+    overlay.renderer = (root) => {
+      if (!root.innerHTML) {
+        root.appendChild(content);
+      }
+    };
+    overlay.requestContentUpdate();
+    overlay.opened = true;
+    await nextRender();
+    expect(spy).to.be.calledOnce;
+  });
 });


### PR DESCRIPTION
## Description

This PR is needed for `vaadin-combo-box` Lit version to prevent issue with re-creating `vaadin-combo-box-scroller`.

Currently with the Lit version, setting `overlay.renderer` triggers observer in `OverlayMixin` which [clears `innerHTML`](https://github.com/vaadin/web-components/blob/900a453b3dab37cd20f8132aa440ad3a357bde48/packages/overlay/src/vaadin-overlay-mixin.js#L228-L234) without checking for the old renderer. Then on overlay open, the scroller is re-attached by calling `appendChild()`.

This isn't the case in Polymer version where observers run differently and clearing `innerHTML` is called before the first renderer invocation by `requestContentUpdate()`. Note: changing all the properties to use `sync: true` doesn't help.

While `vaadin-combo-box` Lit tests pass on the main branch, they start to fail in Safari after postponing the virtualizer initialization until open in #7227 - and apparently the fact that scroller is reattached is related to that.

I figured out that we don't need to clear `innerHTML` anyway if there is no old renderer yet.

## Type of change

- Bugfix