### PR TITLE
fix: add missing invalid-changed and validated event types

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -24,10 +24,24 @@ export type CheckboxCheckedChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type CheckboxIndeterminateChangedEvent = CustomEvent<{ value: boolean }>;
 
+/**
+ * Fired when the `invalid` property changes.
+ */
+export type CheckboxInvalidChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
+ * Fired whenever the checkbox is validated.
+ */
+export type CheckboxValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface CheckboxCustomEventMap {
   'checked-changed': CheckboxCheckedChangedEvent;
 
   'indeterminate-changed': CheckboxIndeterminateChangedEvent;
+
+  'invalid-changed': CheckboxInvalidChangedEvent;
+
+  validated: CheckboxValidatedEvent;
 }
 
 export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEventMap {

--- a/packages/checkbox/test/typings/checkbox.types.ts
+++ b/packages/checkbox/test/typings/checkbox.types.ts
@@ -17,6 +17,8 @@ import type {
   CheckboxChangeEvent,
   CheckboxCheckedChangedEvent,
   CheckboxIndeterminateChangedEvent,
+  CheckboxInvalidChangedEvent,
+  CheckboxValidatedEvent,
 } from '../../vaadin-checkbox.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
@@ -62,4 +64,14 @@ checkbox.addEventListener('indeterminate-changed', (event) => {
 checkbox.addEventListener('change', (event) => {
   assertType<CheckboxChangeEvent>(event);
   assertType<Checkbox>(event.target);
+});
+
+checkbox.addEventListener('invalid-changed', (event) => {
+  assertType<CheckboxInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+checkbox.addEventListener('validated', (event) => {
+  assertType<CheckboxValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });


### PR DESCRIPTION
## Description

Follow-up to #7285

Added missing event types for `invalid-changed` and `validated` event (reported by React components release build):

```
[dts] src/generated/Checkbox.ts(8,46): error TS2339: Property 'validated' does not exist on type 'CheckboxEventMap'.
[dts] src/generated/Checkbox.ts(11,51): error TS2339: Property 'invalid-changed' does not exist on type 'CheckboxEventMap'.
```

## Type of change

- Bugfix