### PR TITLE
refactor: set role attribute directly in template

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -103,6 +103,7 @@ class Dialog extends DialogDraggableMixin(
 
       <vaadin-dialog-overlay
         id="overlay"
+        role="dialog"
         header-title="[[headerTitle]]"
         on-opened-changed="_onOverlayOpened"
         on-mousedown="_bringOverlayToFront"
@@ -146,8 +147,6 @@ class Dialog extends DialogDraggableMixin(
   /** @protected */
   ready() {
     super.ready();
-
-    this._overlayElement.setAttribute('role', 'dialog');
 
     processTemplates(this);
   }

--- a/packages/dialog/src/vaadin-lit-dialog.js
+++ b/packages/dialog/src/vaadin-lit-dialog.js
@@ -72,6 +72,7 @@ class Dialog extends DialogDraggableMixin(
     return html`
       <vaadin-dialog-overlay
         id="overlay"
+        role="dialog"
         .owner="${this}"
         .opened="${this.opened}"
         .headerTitle="${this.headerTitle}"
@@ -90,13 +91,6 @@ class Dialog extends DialogDraggableMixin(
         focus-trap
       ></vaadin-dialog-overlay>
     `;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._overlayElement.setAttribute('role', 'dialog');
   }
 }
 


### PR DESCRIPTION
## Description

The PR updates the dialog to set the `role` attribute directly in the template rather than in the `ready()` method.

## Type of change

- [x] Refactor
