### PR TITLE
fix: hide menu-bar tooltip on overlay mouseleave to outside

### DIFF
--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -14,7 +14,7 @@ import {
 import sinon from 'sinon';
 import '@vaadin/menu-bar';
 import { Tooltip } from '@vaadin/tooltip';
-import { mouseleave } from '@vaadin/tooltip/test/helpers.js';
+import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 export function mouseover(target) {
   fire(target, 'mouseover');
@@ -127,6 +127,14 @@ describe('menu-bar with tooltip', () => {
     mouseover(buttons[0]);
     mousedown(buttons[0]);
     expect(tooltip.opened).to.be.false;
+  });
+
+  it('should hide tooltip on mouseleave from overlay to outside', () => {
+    const overlay = tooltip._overlayElement;
+    mouseover(buttons[0]);
+    mouseenter(overlay);
+    mouseleave(overlay);
+    expect(overlay.opened).to.be.false;
   });
 
   it('should not show tooltip on focus without keyboard interaction', async () => {

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -179,6 +179,7 @@ export const MenuBarMixin = (superClass) =>
     constructor() {
       super();
       this.__boundOnContextMenuKeydown = this.__onContextMenuKeydown.bind(this);
+      this.__boundOnTooltipMouseLeave = this.__onTooltipOverlayMouseLeave.bind(this);
     }
 
     /**
@@ -624,6 +625,11 @@ export const MenuBarMixin = (superClass) =>
           tooltip.generator = ({ item }) => item && item.tooltip;
         }
 
+        if (!tooltip._mouseLeaveListenerAdded) {
+          tooltip._overlayElement.addEventListener('mouseleave', this.__boundOnTooltipMouseLeave);
+          tooltip._mouseLeaveListenerAdded = true;
+        }
+
         if (!this._subMenu.opened) {
           this._tooltipController.setTarget(button);
           this._tooltipController.setContext({ item: button.item });
@@ -642,6 +648,13 @@ export const MenuBarMixin = (superClass) =>
       const tooltip = this._tooltipController && this._tooltipController.node;
       if (tooltip) {
         tooltip._stateController.close(immediate);
+      }
+    }
+
+    /** @private */
+    __onTooltipOverlayMouseLeave(event) {
+      if (event.relatedTarget !== this._tooltipController.target) {
+        this._hideTooltip();
       }
     }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/5614

The issue was caused by the fact that `vaadin-menu-bar` uses `vaadin-tooltip` in manual mode, where the corresponding [listener](https://github.com/vaadin/web-components/blob/2efeeebbeabddfde14c845ee4098f9e62e352ffe/packages/tooltip/src/vaadin-tooltip-mixin.js#L700) added automatically doesn't work. Fixed this by adding event listener manually and copying the corresponding logic.

## Type of change

- Bugfix