### PR TITLE
fix: do not move focus when focused in on grid via clicking

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -814,10 +814,12 @@ export const KeyboardNavigationMixin = (superClass) =>
       const rootTarget = e.composedPath()[0];
 
       if (rootTarget === this.$.table || rootTarget === this.$.focusexit) {
-        // The focus enters the top (bottom) of the grid, meaning that user has
-        // tabbed (shift-tabbed) into the grid. Move the focus to
-        // the first (the last) focusable.
-        this._predictFocusStepTarget(rootTarget, rootTarget === this.$.table ? 1 : -1).focus();
+        if (!this._isMousedown) {
+          // The focus enters the top (bottom) of the grid, meaning that user has
+          // tabbed (shift-tabbed) into the grid. Move the focus to
+          // the first (the last) focusable.
+          this._predictFocusStepTarget(rootTarget, rootTarget === this.$.table ? 1 : -1).focus();
+        }
         this._setInteracting(false);
       } else {
         this._detectInteracting(e);

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -544,6 +544,17 @@ describe('keyboard navigation', () => {
       expect(grid.shadowRoot.activeElement).to.equal(tabbableElements[3]);
     });
 
+    it('should not enter grid on table click', () => {
+      const tabbableElements = getTabbableElements(grid.shadowRoot);
+
+      // Click and focusin on table element
+      mouseDown(tabbableElements[0]);
+      focusin(tabbableElements[0], focusable);
+
+      // Expect no focus on header cell
+      expect(grid.shadowRoot.activeElement).to.be.null;
+    });
+
     it('should set native focus to header on header cell click', () => {
       const tabbableElements = getTabbableElements(grid.shadowRoot);
       focusFirstHeaderCell();


### PR DESCRIPTION
## Description

The [block](https://github.com/vaadin/web-components/blob/main/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js#L816-L824) in the listener `_onFocusin` assumes that if the root target is the top/bottom of the grid, it is the result of a tab/shift-tab action. However, it is also possible that it is the result of a click. In this case, the focus should not be moved.

This PR updates the logic to move focus only if it is not caused by a click.

Fixes #2911

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.