### PR TITLE
fix: allow to set virtualizer items when not opened

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -148,10 +148,6 @@ export const ComboBoxScrollerMixin = (superClass) =>
         return;
       }
 
-      if (!this.__virtualizer) {
-        this.__initVirtualizer();
-      }
-
       this.__virtualizer.update();
     }
 
@@ -226,13 +222,8 @@ export const ComboBoxScrollerMixin = (superClass) =>
 
     /** @private */
     __itemsChanged(items) {
-      if (items && this.opened) {
-        if (!this.__virtualizer) {
-          this.__initVirtualizer();
-        }
-
-        this.__virtualizer.size = items.length;
-        this.__virtualizer.flush();
+      if (items && this.__virtualizer) {
+        this.__setVirtualizerItems(items);
         this.requestContentUpdate();
       }
     }
@@ -245,8 +236,22 @@ export const ComboBoxScrollerMixin = (superClass) =>
     /** @private */
     __openedChanged(opened) {
       if (opened) {
+        if (!this.__virtualizer) {
+          this.__initVirtualizer();
+
+          if (this.items) {
+            this.__setVirtualizerItems(this.items);
+          }
+        }
+
         this.requestContentUpdate();
       }
+    }
+
+    /** @private */
+    __setVirtualizerItems(items) {
+      this.__virtualizer.size = items.length;
+      this.__virtualizer.flush();
     }
 
     /** @private */

--- a/packages/combo-box/test/lazy-loading.common.js
+++ b/packages/combo-box/test/lazy-loading.common.js
@@ -1009,6 +1009,10 @@ describe('lazy loading', () => {
           const pages = spyDataProvider.getCalls().map((call) => call.args[0].page);
           expect(pages).to.contain(1);
         });
+
+        it('should reset visible items count to 0', () => {
+          expect(getVisibleItemsCount(comboBox)).to.equal(0);
+        });
       });
 
       describe('using data provider, lost focus before data is returned', () => {


### PR DESCRIPTION
## Description

Fixes a regression from #7277 

In `vaadin-combo-box`, we have a logic that clears scroller items on close:

https://github.com/vaadin/web-components/blob/2efeeebbeabddfde14c845ee4098f9e62e352ffe/packages/combo-box/src/vaadin-combo-box-mixin.js#L507-L508

In the PR linked above, this behavior was broken by the `items` observer change.

Added a test to ensure visible items count is reset (which is a side effect of clearing items).
This seems to be the easiest way to test the change without accessing `__virtualizer` API.

## Type of change

- Bugfix