### PR TITLE
fix: hide menu-bar tooltip on overlay mouseleave to outside (#7322) (CP: 23.3)

### DIFF
--- a/integration/tests/menu-bar-tooltip.test.js
+++ b/integration/tests/menu-bar-tooltip.test.js
@@ -14,7 +14,7 @@ import {
 import sinon from 'sinon';
 import '@vaadin/menu-bar';
 import { Tooltip } from '@vaadin/tooltip';
-import { mouseleave } from '@vaadin/tooltip/test/helpers.js';
+import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
 
 export function mouseover(target) {
   fire(target, 'mouseover');
@@ -127,6 +127,14 @@ describe('menu-bar with tooltip', () => {
     mouseover(buttons[0]);
     mousedown(buttons[0]);
     expect(tooltip.opened).to.be.false;
+  });
+
+  it('should hide tooltip on mouseleave from overlay to outside', () => {
+    const overlay = tooltip._overlayElement;
+    mouseover(buttons[0]);
+    mouseenter(overlay);
+    mouseleave(overlay);
+    expect(overlay.opened).to.be.false;
   });
 
   it('should not show tooltip on focus without keyboard interaction', async () => {

--- a/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-interactions-mixin.js
@@ -29,6 +29,7 @@ export const InteractionsMixin = (superClass) =>
     constructor() {
       super();
       this.__boundOnContextMenuKeydown = this.__onContextMenuKeydown.bind(this);
+      this.__boundOnTooltipMouseLeave = this.__onTooltipOverlayMouseLeave.bind(this);
     }
 
     static get observers() {
@@ -114,6 +115,11 @@ export const InteractionsMixin = (superClass) =>
           tooltip.generator = ({ item }) => item && item.tooltip;
         }
 
+        if (!tooltip._mouseLeaveListenerAdded) {
+          tooltip._overlayElement.addEventListener('mouseleave', this.__boundOnTooltipMouseLeave);
+          tooltip._mouseLeaveListenerAdded = true;
+        }
+
         if (!this._subMenu.opened) {
           this._tooltipController.setTarget(button);
           this._tooltipController.setContext({ item: button.item });
@@ -132,6 +138,13 @@ export const InteractionsMixin = (superClass) =>
       const tooltip = this._tooltipController.node;
       if (tooltip) {
         tooltip._stateController.close(immediate);
+      }
+    }
+
+    /** @private */
+    __onTooltipOverlayMouseLeave(event) {
+      if (event.relatedTarget !== this._tooltipController.target) {
+        this._hideTooltip();
       }
     }
 


### PR DESCRIPTION
## Description

Cherry-pick of #7322 to `23.3` branch.

## Type of change

- Cherry-pick