### PR TITLE
fix: do not move focus when focused in on grid via clicking (#7323)

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -795,10 +795,12 @@ export const KeyboardNavigationMixin = (superClass) =>
       const rootTarget = e.composedPath()[0];
 
       if (rootTarget === this.$.table || rootTarget === this.$.focusexit) {
-        // The focus enters the top (bottom) of the grid, meaning that user has
-        // tabbed (shift-tabbed) into the grid. Move the focus to
-        // the first (the last) focusable.
-        this._predictFocusStepTarget(rootTarget, rootTarget === this.$.table ? 1 : -1).focus();
+        if (!this._isMousedown) {
+          // The focus enters the top (bottom) of the grid, meaning that user has
+          // tabbed (shift-tabbed) into the grid. Move the focus to
+          // the first (the last) focusable.
+          this._predictFocusStepTarget(rootTarget, rootTarget === this.$.table ? 1 : -1).focus();
+        }
         this._setInteracting(false);
       } else {
         this._detectInteracting(e);

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -547,6 +547,17 @@ describe('keyboard navigation', () => {
       expect(grid.shadowRoot.activeElement).to.equal(tabbableElements[3]);
     });
 
+    it('should not enter grid on table click', () => {
+      const tabbableElements = getTabbableElements(grid.shadowRoot);
+
+      // Click and focusin on table element
+      mouseDown(tabbableElements[0]);
+      focusin(tabbableElements[0], focusable);
+
+      // Expect no focus on header cell
+      expect(grid.shadowRoot.activeElement).to.be.null;
+    });
+
     it('should set native focus to header on header cell click', () => {
       const tabbableElements = getTabbableElements(grid.shadowRoot);
       focusFirstHeaderCell();


### PR DESCRIPTION
## Description

Back-port of the [fix](https://github.com/vaadin/web-components/pull/7323) for the grid horizontal scroll click [issue](https://github.com/vaadin/web-components/issues/2911).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.