### PR TITLE
fix: do not throw error when opened is set before adding to DOM

### DIFF
--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -101,6 +101,15 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
     `;
   }
 
+  /** @protected */
+  ready() {
+    super.ready();
+
+    const overlay = this.shadowRoot.querySelector('vaadin-select-overlay');
+    overlay.owner = this;
+    this._overlayElement = overlay;
+  }
+
   /** @private */
   _onOpenedChanged(event) {
     this.opened = event.detail.value;

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -171,10 +171,6 @@ export const SelectBaseMixin = (superClass) =>
     ready() {
       super.ready();
 
-      const overlay = this.shadowRoot.querySelector('vaadin-select-overlay');
-      overlay.owner = this;
-      this._overlayElement = overlay;
-
       this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
 
       this._valueButtonController = new ButtonController(this);

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -55,6 +55,17 @@ export class SelectOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableM
     `;
   }
 
+  /** @protected */
+  ready() {
+    super.ready();
+
+    // When setting `opened` as an attribute, the overlay is already teleported to body
+    // by the time when `ready()` callback of the `vaadin-select` is executed by Polymer,
+    // so querySelector() would return null. So we use this workaround to set properties.
+    this.owner = this.__dataHost;
+    this.owner._overlayElement = this;
+  }
+
   requestContentUpdate() {
     super.requestContentUpdate();
 

--- a/packages/select/test/pre-opened-polymer.test.js
+++ b/packages/select/test/pre-opened-polymer.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../vaadin-select.js';
+
+// NOTE: this test is Polymer only as it checks for Polymer specific bug.
+// Do not import `not-animated-styles.js` in this test intentionally, as
+// otherwise the immediately closed overlay would make it false positive.
+
+describe('pre-opened', () => {
+  it('should not throw error when adding a pre-opened select', () => {
+    expect(() => {
+      fixtureSync('<vaadin-select opened></vaadin-select>');
+    }).to.not.throw(Error);
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6148

See also https://github.com/vaadin/web-components/pull/4610 for a similar `vaadin-tooltip` fix.

When `opened` is set to the select in the template as an attribute, in the Polymer version overlay opens before the `ready()` callback is called. The `opened` is then [reset to `false`](https://github.com/vaadin/web-components/blob/8e5223bcb61a5561fd984db5d11b31a73ec98eaa/packages/select/src/vaadin-select-base-mixin.js#L355-L357) as `_overlayElement` is empty, but due to the animation the overlay doesn't close immediately and is still under `<body>` by the time `querySelector()` is called, so the error is thrown.

Lit version doesn't have this issue since by the time `ready()` is called on the `vaadin-select`, its overlay is not yet moved to the `<body>`. This is apparently because in Polymer, the order of `ready()` callbacks invocations is from child to parent (overlay -> select), and in Lit it's from parent to child (select -> overlay).

## Type of change

- Bugfix