### PR TITLE
fix: hide crud editor focus ring from pointer events

### DIFF
--- a/packages/crud/theme/lumo/vaadin-crud-styles.js
+++ b/packages/crud/theme/lumo/vaadin-crud-styles.js
@@ -108,6 +108,7 @@ registerStyles(
         inset: 0;
         content: '';
         box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
+        pointer-events: none;
       }
 
       :host(:not([editor-position=''])) [part='editor']:not([hidden]) {

--- a/packages/crud/theme/material/vaadin-crud-styles.js
+++ b/packages/crud/theme/material/vaadin-crud-styles.js
@@ -83,6 +83,7 @@ registerStyles(
         inset: 0;
         content: '';
         box-shadow: inset 0 0 0 2px var(--material-primary-color);
+        pointer-events: none;
       }
 
       [part='toolbar'] {


### PR DESCRIPTION
## Description

The problem was that the focus ring element that covers the editor was receiving pointer events so the wheel events were emitted on it instead of the underlying editor:

https://github.com/vaadin/web-components/assets/1222264/b9a9617a-ea8a-43e7-86d5-1683308789e1

This PR hides the crud editor focus ring from pointer events.

Fixes https://github.com/vaadin/web-components/issues/6693

## Type of change

Bugfix