### PR TITLE
fix: share animationend listener reference in notification

### DIFF
--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -485,16 +485,20 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
   }
 
   /** @private */
+  __cleanUpOpeningClosingState() {
+    this._card.removeAttribute('opening');
+    this._card.removeAttribute('closing');
+    this._card.removeEventListener('animationend', this.__animationEndListener);
+  }
+
+  /** @private */
   _animatedAppendNotificationCard() {
     if (this._card) {
-      this._card.removeAttribute('closing');
+      this.__cleanUpOpeningClosingState();
+
       this._card.setAttribute('opening', '');
       this._appendNotificationCard();
-      this._card.removeEventListener('animationend', this.__animationEndListener);
-      this.__animationEndListener = () => {
-        this._card.removeEventListener('animationend', this.__animationEndListener);
-        this._card.removeAttribute('opening');
-      };
+      this.__animationEndListener = () => this.__cleanUpOpeningClosingState();
       this._card.addEventListener('animationend', this.__animationEndListener);
       this._didAnimateNotificationAppend = true;
     } else {
@@ -540,14 +544,14 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
 
   /** @private */
   _animatedRemoveNotificationCard() {
-    this._card.removeAttribute('opening');
+    this.__cleanUpOpeningClosingState();
+
     this._card.setAttribute('closing', '');
     const name = getComputedStyle(this._card).getPropertyValue('animation-name');
     if (name && name !== 'none') {
-      this._card.removeEventListener('animationend', this.__animationEndListener);
       this.__animationEndListener = () => {
         this._removeNotificationCard();
-        this._card.removeEventListener('animationend', this.__animationEndListener);
+        this.__cleanUpOpeningClosingState();
       };
       this._card.addEventListener('animationend', this.__animationEndListener);
     } else {

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -487,13 +487,15 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
   /** @private */
   _animatedAppendNotificationCard() {
     if (this._card) {
+      this._card.removeAttribute('closing');
       this._card.setAttribute('opening', '');
       this._appendNotificationCard();
-      const listener = () => {
-        this._card.removeEventListener('animationend', listener);
+      this._card.removeEventListener('animationend', this.__animationEndListener);
+      this.__animationEndListener = () => {
+        this._card.removeEventListener('animationend', this.__animationEndListener);
         this._card.removeAttribute('opening');
       };
-      this._card.addEventListener('animationend', listener);
+      this._card.addEventListener('animationend', this.__animationEndListener);
       this._didAnimateNotificationAppend = true;
     } else {
       this._didAnimateNotificationAppend = false;
@@ -538,14 +540,16 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
 
   /** @private */
   _animatedRemoveNotificationCard() {
+    this._card.removeAttribute('opening');
     this._card.setAttribute('closing', '');
     const name = getComputedStyle(this._card).getPropertyValue('animation-name');
     if (name && name !== 'none') {
-      const listener = () => {
+      this._card.removeEventListener('animationend', this.__animationEndListener);
+      this.__animationEndListener = () => {
         this._removeNotificationCard();
-        this._card.removeEventListener('animationend', listener);
+        this._card.removeEventListener('animationend', this.__animationEndListener);
       };
-      this._card.addEventListener('animationend', listener);
+      this._card.addEventListener('animationend', this.__animationEndListener);
     } else {
       this._removeNotificationCard();
     }

--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -34,8 +34,12 @@ describe('animated notifications', () => {
     await aTimeout(animationDuration / 2);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     notifications.forEach((n) => n.close());
+    // Wait for the notification container to be removed
+    while (document.querySelector('body > vaadin-notification-container')) {
+      await aTimeout(1);
+    }
   });
 
   describe('animation', () => {
@@ -78,6 +82,36 @@ describe('animated notifications', () => {
       notifications[1].open();
       expect(notifications[1]._card.hasAttribute('opening')).to.be.true;
       await oneEvent(notifications[1]._card, 'animationend');
+      expect(notifications[1]._card.hasAttribute('opening')).to.be.false;
+    });
+
+    it('should remain opened', async () => {
+      // Close the non-animated notification as it's not relevant for this test
+      notifications[0].close();
+
+      notifications[1].open();
+      notifications[1].close();
+      notifications[1].open();
+      await oneEvent(notifications[1]._card, 'animationend');
+
+      expect(notifications[1].opened).to.be.true;
+      expect(container.isConnected).to.be.true;
+      expect(container.contains(notifications[1]._card)).to.be.true;
+      expect(notifications[1]._card.hasAttribute('closing')).to.be.false;
+      expect(notifications[1]._card.hasAttribute('opening')).to.be.false;
+    });
+
+    it('should remain closed', async () => {
+      // Close the non-animated notification as it's not relevant for this test
+      notifications[0].close();
+
+      notifications[1].open();
+      notifications[1].close();
+      await oneEvent(notifications[1]._card, 'animationend');
+
+      expect(notifications[1].opened).to.be.false;
+      expect(container.isConnected).to.be.false;
+      expect(notifications[1]._card.hasAttribute('closing')).to.be.false;
       expect(notifications[1]._card.hasAttribute('opening')).to.be.false;
     });
   });

--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -85,34 +85,42 @@ describe('animated notifications', () => {
       expect(notifications[1]._card.hasAttribute('opening')).to.be.false;
     });
 
-    it('should remain opened', async () => {
-      // Close the non-animated notification as it's not relevant for this test
-      notifications[0].close();
+    describe('simultaneous opening and closing', () => {
+      let notification, card;
 
-      notifications[1].open();
-      notifications[1].close();
-      notifications[1].open();
-      await oneEvent(notifications[1]._card, 'animationend');
+      beforeEach(() => {
+        // Use the animated notification for these tests
+        notification = notifications[1];
+        card = notification._card;
+        // Close the non-animated notification as it's not relevant for these tests
+        notifications[0].close();
+      });
 
-      expect(notifications[1].opened).to.be.true;
-      expect(container.isConnected).to.be.true;
-      expect(container.contains(notifications[1]._card)).to.be.true;
-      expect(notifications[1]._card.hasAttribute('closing')).to.be.false;
-      expect(notifications[1]._card.hasAttribute('opening')).to.be.false;
-    });
+      it('should remain opened after closing and opening', async () => {
+        // Simultanously close and open the animated notification
+        notification.close();
+        notification.open();
+        await oneEvent(card, 'animationend');
 
-    it('should remain closed', async () => {
-      // Close the non-animated notification as it's not relevant for this test
-      notifications[0].close();
+        expect(notification.opened).to.be.true;
+        expect(card.hasAttribute('closing')).to.be.false;
+        expect(card.hasAttribute('opening')).to.be.false;
+        expect(container.parentNode).to.equal(document.body);
+        expect(container.contains(card)).to.be.true;
+      });
 
-      notifications[1].open();
-      notifications[1].close();
-      await oneEvent(notifications[1]._card, 'animationend');
+      it('should remain closed after opening and closing', async () => {
+        // Simultanously open and close the animated notification
+        notification.close();
+        notification.open();
+        notification.close();
+        await oneEvent(card, 'animationend');
 
-      expect(notifications[1].opened).to.be.false;
-      expect(container.isConnected).to.be.false;
-      expect(notifications[1]._card.hasAttribute('closing')).to.be.false;
-      expect(notifications[1]._card.hasAttribute('opening')).to.be.false;
+        expect(notification.opened).to.be.false;
+        expect(card.hasAttribute('closing')).to.be.false;
+        expect(card.hasAttribute('opening')).to.be.false;
+        expect(container.parentNode).to.not.equal(document.body);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

This PR makes `<vaadin-notification>` use a shared "animationend" listener reference for the opening and closing animations. Using a shared reference makes it possible to remove any active listeners in case an animation starts while another one is still running.

Fixes https://github.com/vaadin/web-components/issues/6878

## Type of change

Bugfix