### PR TITLE
docs: add a note about crud size only updating with items

### DIFF
--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -512,6 +512,9 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       /**
        * Number of items in the data set which is reported by the grid.
        * Typically it reflects the number of filtered items displayed in the grid.
+       *
+       * Note: As with `<vaadin-grid>`, this property updates automatically only
+       * if `items` is used for data.
        */
       size: {
         type: Number,


### PR DESCRIPTION
## Description

Add a note about crud `size` only updating with `items`

Related to https://github.com/vaadin/web-components/issues/6302

## Type of change

Documentation