### PR TITLE
refactor: use flag instead of manipulating loading state

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -109,15 +109,11 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       if (this.__previousDataProviderFilter !== filter) {
         this.__previousDataProviderFilter = filter;
 
+        this.__keepOverlayOpened = true;
         this._pendingRequests = {};
-        // Immediately mark as loading if this refresh leads to re-fetching pages
-        // This prevents some issues with the properties below triggering
-        // observers that also rely on the loading state
-        this.loading = this._shouldFetchData();
-        // Reset size and internal loading state
         this.size = undefined;
-
         this.clearCache();
+        this.__keepOverlayOpened = false;
       }
     }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -274,13 +274,19 @@ export const ComboBoxMixin = (subclass) =>
           sync: true,
           observer: '_overlayOpenedChanged',
         },
+
+        /** @private */
+        __keepOverlayOpened: {
+          type: Boolean,
+          sync: true,
+        },
       };
     }
 
     static get observers() {
       return [
         '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
-        '_openedOrItemsChanged(opened, _dropdownItems, loading)',
+        '_openedOrItemsChanged(opened, _dropdownItems, loading, __keepOverlayOpened)',
         '_updateScroller(_scroller, _dropdownItems, opened, loading, selectedItem, itemIdPath, _focusedIndex, renderer, _theme)',
       ];
     }
@@ -529,10 +535,10 @@ export const ComboBoxMixin = (subclass) =>
     }
 
     /** @private */
-    _openedOrItemsChanged(opened, items, loading) {
+    _openedOrItemsChanged(opened, items, loading, keepOverlayOpened) {
       // Close the overlay if there are no items to display.
       // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = !!(opened && (loading || (items && items.length)));
+      this._overlayOpened = opened && (keepOverlayOpened || loading || !!(items && items.length));
     }
 
     /** @private */


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/7044/files

Combo-box has a workaround that manually sets the loading state to true on filter change to prevent the overlay from closing. The PR replaces it with a flag to make it more obvious.

## Type of change

- [x] Refactor
