### PR TITLE
test: add missing data provider tests

### DIFF
--- a/packages/combo-box/test/lazy-loading.common.js
+++ b/packages/combo-box/test/lazy-loading.common.js
@@ -357,6 +357,12 @@ describe('lazy loading', () => {
           comboBox.open();
           expect(comboBox.dataProvider).to.be.calledOnce;
         });
+
+        it('should request first page on open after clearing cache', () => {
+          comboBox.clearCache();
+          comboBox.open();
+          expect(comboBox.dataProvider).to.be.calledOnce;
+        });
       });
 
       describe('when selecting item', () => {
@@ -1142,23 +1148,6 @@ describe('lazy loading', () => {
           expect(comboBox.opened).to.be.false;
           expect(comboBox.hasAttribute('focused')).to.be.false;
           expect(comboBox.value).to.equal('other value');
-        });
-      });
-
-      describe('empty data set is loaded', () => {
-        const emptyDataProvider = sinon.spy((params, callback) => callback([], 0));
-
-        beforeEach(() => {
-          comboBox.dataProvider = emptyDataProvider;
-          comboBox.open();
-          comboBox.close();
-          emptyDataProvider.resetHistory();
-        });
-
-        it('should request first page on open', () => {
-          comboBox.clearCache();
-          comboBox.open();
-          expect(emptyDataProvider.calledOnce).to.be.true;
         });
       });
     });

--- a/packages/combo-box/test/lazy-loading.common.js
+++ b/packages/combo-box/test/lazy-loading.common.js
@@ -288,15 +288,6 @@ describe('lazy loading', () => {
           expect(spyDataProvider.calledOnce).to.be.true;
         });
 
-        it('should not request empty loaded page again', () => {
-          const dp = sinon.spy((params, callback) => callback([], 0));
-          comboBox.dataProvider = dp;
-          comboBox.open();
-          comboBox.close();
-          comboBox.open();
-          expect(dp.calledOnce).to.be.true;
-        });
-
         it('should request pages asynchronously when scrolling', async () => {
           comboBox.dataProvider = spyDataProvider;
           spyDataProvider.resetHistory();
@@ -345,6 +336,26 @@ describe('lazy loading', () => {
             }
           };
           comboBox.open();
+        });
+      });
+
+      describe('empty data set is loaded', () => {
+        beforeEach(() => {
+          comboBox.dataProvider = sinon.spy((_params, callback) => callback([], 0));
+          comboBox.open();
+          comboBox.close();
+          comboBox.dataProvider.resetHistory();
+        });
+
+        it('should not request first page on open', () => {
+          comboBox.open();
+          expect(comboBox.dataProvider).to.be.not.called;
+        });
+
+        it('should request first page on open after increasing size property', () => {
+          comboBox.size = SIZE;
+          comboBox.open();
+          expect(comboBox.dataProvider).to.be.calledOnce;
         });
       });
 
@@ -1134,7 +1145,7 @@ describe('lazy loading', () => {
         });
       });
 
-      describe('after empty data set loaded', () => {
+      describe('empty data set is loaded', () => {
         const emptyDataProvider = sinon.spy((params, callback) => callback([], 0));
 
         beforeEach(() => {


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/7044

The PR adds a few missing unit tests related to combo-box data provider.

## Type of change

- [x] Internal
