### PR TITLE
fix: do not modify readonly group label color on hover

### DIFF
--- a/packages/checkbox-group/theme/lumo/vaadin-checkbox-group-styles.js
+++ b/packages/checkbox-group/theme/lumo/vaadin-checkbox-group-styles.js
@@ -39,14 +39,14 @@ const checkboxGroup = css`
     color: var(--lumo-primary-text-color);
   }
 
-  :host(:hover:not([disabled]):not([focused])) [part='label'],
-  :host(:hover:not([disabled]):not([focused])) [part='helper-text'] {
+  :host(:hover:not([readonly]):not([disabled]):not([focused])) [part='label'],
+  :host(:hover:not([readonly]):not([disabled]):not([focused])) [part='helper-text'] {
     color: var(--lumo-body-text-color);
   }
 
   /* Touch device adjustment */
   @media (pointer: coarse) {
-    :host(:hover:not([disabled]):not([focused])) [part='label'] {
+    :host(:hover:not([readonly]):not([disabled]):not([focused])) [part='label'] {
       color: var(--lumo-secondary-text-color);
     }
   }


### PR DESCRIPTION
## Description

Updated `vaadin-checkbox-group` Lumo label color styles to align with the input fields and `vaadin-radio-group`.

## Type of change

- Bugfix