### PR TITLE
feat: add missing focus method to message-input

### DIFF
--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -183,6 +183,12 @@ class MessageInput extends ElementMixin(ThemableMixin(ControllerMixin(PolymerEle
     this.addController(this._tooltipController);
   }
 
+  focus() {
+    if (this._textArea) {
+      this._textArea.focus();
+    }
+  }
+
   /** @private */
   __buttonPropsChanged(button, disabled, i18n) {
     if (button) {

--- a/packages/message-input/test/message-input.test.js
+++ b/packages/message-input/test/message-input.test.js
@@ -123,4 +123,17 @@ describe('message-input', () => {
       expect(messageInput.getAttribute('disabled')).to.exist;
     });
   });
+
+  describe('focus', () => {
+    it('should focus the text-area when calling focus()', () => {
+      const spy = sinon.spy(textArea, 'focus');
+      messageInput.focus();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should not throw on focus when not attached to the DOM', () => {
+      const element = document.createElement('vaadin-message-input');
+      expect(() => element.focus()).not.to.throw(Error);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/6243

This aligns the behavior of `vaadin-message-input` with the `vaadin-date-time-picker` to focus the first focusable element. 

## Type of change

- Internal feature