### PR TITLE
fix: do not throw on focus before adding to the DOM

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -456,7 +456,9 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   }
 
   focus() {
-    this.__datePicker.focus();
+    if (this.__datePicker) {
+      this.__datePicker.focus();
+    }
   }
 
   /**

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -89,9 +89,17 @@ describe('Basic features', () => {
     expect(dateTimePicker.value).to.equal('2019-09-19T15:00');
   });
 
-  it('should delegate focus() to date picker', () => {
-    dateTimePicker.focus();
-    expect(datePicker.hasAttribute('focused')).to.be.true;
+  describe('focus', () => {
+    it('should focus the date-picker when calling focus()', () => {
+      const spy = sinon.spy(datePicker, 'focus');
+      dateTimePicker.focus();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should not throw on focus when not attached to the DOM', () => {
+      const element = document.createElement('vaadin-date-time-picker');
+      expect(() => element.focus()).not.to.throw(Error);
+    });
   });
 
   describe('focused', () => {


### PR DESCRIPTION
## Description

Added logic and test to ensure `document.createElement('vaadin-date-time-picker').focus()` doesn't throw.

## Type of change

- Bugfix