### PR TITLE
fix: clear reference to element removed from split-layout

### DIFF
--- a/packages/split-layout/src/vaadin-split-layout-mixin.js
+++ b/packages/split-layout/src/vaadin-split-layout-mixin.js
@@ -56,7 +56,11 @@ export const SplitLayoutMixin = (superClass) =>
     _cleanupNodes(nodes) {
       nodes.forEach((node) => {
         if (!(node.parentElement instanceof this.constructor)) {
-          node.removeAttribute('slot');
+          const slot = node.getAttribute('slot');
+          if (slot) {
+            this[`_${slot}Child`] = null;
+            node.removeAttribute('slot');
+          }
         }
       });
     }

--- a/packages/split-layout/test/split-layout.common.js
+++ b/packages/split-layout/test/split-layout.common.js
@@ -421,6 +421,22 @@ describe('removing nodes', () => {
     await nextFrame();
     expect(first.hasAttribute('slot')).to.be.false;
   });
+
+  it('should not update splitter position on the removed node', async () => {
+    splitLayout.removeChild(second);
+    await nextFrame();
+    track(splitLayout.$.splitter, -10, 0);
+    expect(second.style.flex).to.be.not.ok;
+  });
+
+  it('should not dispatch `splitter-dragend` event if node is removed', async () => {
+    const spy = sinon.spy();
+    splitLayout.addEventListener('splitter-dragend', spy);
+    splitLayout.removeChild(second);
+    await nextFrame();
+    track(splitLayout.$.splitter, -10, 0);
+    expect(spy.called).to.be.false;
+  });
 });
 
 describe('moving nodes between layouts', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6248

Currently, when removing an element from split-layout, the `_primaryChild` or `_secondaryChild` reference isn't updated.

As a result, `track` event is handled and `splitter-dragend` is fired, which is then handled by the Flow counterpart.
The error is thrown by [this logic](https://github.com/vaadin/flow-components/blob/2b4d418cb8412382eebfc9b1156d2de1cb54e0e7/vaadin-split-layout-flow-parent/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java#L344-L345) which relies on both primary and secondary components to be available.

Added logic to clear the reference along with removal of the corresponding slot and a test to check the event isn't fired.

## Type of change

- Bugfix