### PR TITLE
Removes odd double background color for typical code markup

### DIFF
--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -211,6 +211,9 @@ const color = css`
     background-color: var(--lumo-contrast-10pct);
     border-radius: var(--lumo-border-radius-m);
   }
+  pre code {
+    background: transparent; 
+  }
 `;
 
 registerStyles('', color, { moduleId: 'lumo-color' });

--- a/packages/vaadin-lumo-styles/color.js
+++ b/packages/vaadin-lumo-styles/color.js
@@ -212,7 +212,7 @@ const color = css`
     border-radius: var(--lumo-border-radius-m);
   }
   pre code {
-    background: transparent; 
+    background: transparent;
   }
 `;
 


### PR DESCRIPTION
Code snippets in Vaadin apps look weird without this fix. @jouni says this fixes them all 💪

Example:
![screenshot_2024-04-24_at_17 19 42_720](https://github.com/vaadin/web-components/assets/1478052/d06b32ad-a741-4305-9dd3-55e9d31e0a88)

That kind of html is generated by e.g. all markdown generators

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

