### PR TITLE
fix: detect item correctly when clicking item content

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -256,7 +256,8 @@ export const SelectBaseMixin = (superClass) =>
         menuElement.addEventListener(
           'click',
           (e) => {
-            const value = e.target.value;
+            const item = e.composedPath().find((el) => el._hasVaadinItemMixin);
+            const value = item && item.value;
             this.__dispatchChangePending = value !== undefined && value !== this.value;
             this.opened = false;
           },

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -96,7 +96,7 @@ describe('vaadin-select', () => {
           html`
             <vaadin-list-box>
               <vaadin-item>Option 1</vaadin-item>
-              <vaadin-item value="v2" label="o2">Option 2</vaadin-item>
+              <vaadin-item value="v2" label="o2"><span>Option 2</span></vaadin-item>
               <vaadin-item value="">Option 3</vaadin-item>
               <vaadin-item></vaadin-item>
               <vaadin-item label="">Empty</vaadin-item>
@@ -613,6 +613,15 @@ describe('vaadin-select', () => {
         select.opened = true;
         await nextUpdate(select);
         menu.firstElementChild.click();
+        await nextUpdate(select);
+        expect(changeSpy.callCount).to.equal(1);
+      });
+
+      it('should fire `change` event when value changes by user clicking the element inside item', async () => {
+        select.opened = true;
+        await nextUpdate(select);
+        const span = menu.children[1].firstElementChild;
+        span.click();
         await nextUpdate(select);
         expect(changeSpy.callCount).to.equal(1);
       });


### PR DESCRIPTION
## Description

Fixes a regression from #7288

When using `vaadin-item` with some element inside it e.g. icon etc, `event.target` is pointing to that element on click.
This PR fixes that to check `event.composedPath()` and detect if there is an element implementing `ItemMixin`.

## Type of change

- Bugfix