### PR TITLE
refactor: do not flush virtualizer after updating its size

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -251,7 +251,6 @@ export const ComboBoxScrollerMixin = (superClass) =>
     /** @private */
     __setVirtualizerItems(items) {
       this.__virtualizer.size = items.length;
-      this.__virtualizer.flush();
     }
 
     /** @private */


### PR DESCRIPTION
## Description

There seems to be no need to flush the virtualizer after updating its size in combo-box. The flush was added in https://github.com/vaadin/web-components/pull/2339 when the iron-list was replaced with the virtualizer. However, all tests for both web-components and flow-components pass without it.

## Type of change

- [x] Refactor
