### PR TITLE
fix: update virtualizer size on requestContentUpdate

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -141,14 +141,20 @@ export const ComboBoxScrollerMixin = (superClass) =>
     }
 
     /**
-     * Requests an update for the virtualizer to re-render items.
+     * Updates the virtualizer's size and items.
      */
     requestContentUpdate() {
-      if (!this.opened) {
+      if (!this.__virtualizer) {
         return;
       }
 
-      this.__virtualizer.update();
+      if (this.items) {
+        this.__virtualizer.size = this.items.length;
+      }
+
+      if (this.opened) {
+        this.__virtualizer.update();
+      }
     }
 
     /**
@@ -223,7 +229,6 @@ export const ComboBoxScrollerMixin = (superClass) =>
     /** @private */
     __itemsChanged(items) {
       if (items && this.__virtualizer) {
-        this.__setVirtualizerItems(items);
         this.requestContentUpdate();
       }
     }
@@ -238,19 +243,10 @@ export const ComboBoxScrollerMixin = (superClass) =>
       if (opened) {
         if (!this.__virtualizer) {
           this.__initVirtualizer();
-
-          if (this.items) {
-            this.__setVirtualizerItems(this.items);
-          }
         }
 
         this.requestContentUpdate();
       }
-    }
-
-    /** @private */
-    __setVirtualizerItems(items) {
-      this.__virtualizer.size = items.length;
     }
 
     /** @private */

--- a/packages/combo-box/test/external-filtering.common.js
+++ b/packages/combo-box/test/external-filtering.common.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { getFocusedItemIndex, setInputValue } from './helpers.js';
+import { getAllItems, getFocusedItemIndex, setInputValue } from './helpers.js';
 
 describe('external filtering', () => {
   let comboBox, overlay;
@@ -81,6 +81,27 @@ describe('external filtering', () => {
       comboBox.loading = false;
       expect(comboBox.hasAttribute('loading')).to.be.false;
       expect(overlay.hasAttribute('loading')).to.be.false;
+    });
+  });
+
+  describe('requestContentUpdate', () => {
+    beforeEach(async () => {
+      comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+      comboBox.filteredItems = ['Item 0'];
+      await nextRender();
+      comboBox.opened = true;
+    });
+
+    it('should re-render items after modifying existing filteredItems through mutation', () => {
+      comboBox.filteredItems[0] = 'New Item';
+      comboBox.requestContentUpdate();
+      expect(getAllItems(comboBox).map((item) => item.textContent)).to.eql(['New Item']);
+    });
+
+    it('should re-render items after adding more filteredItems through mutation', () => {
+      comboBox.filteredItems.push('Item 1');
+      comboBox.requestContentUpdate();
+      expect(getAllItems(comboBox).map((item) => item.textContent)).to.eql(['Item 0', 'Item 1']);
     });
   });
 


### PR DESCRIPTION
## Description

The PR gathers all instances of `virtualizer.size = this.items.length` and replaces them with a single one in the combo-box scroller's `requestContentUpdate`.

## Type of change

- [x] Refactor
