### PR TITLE
fix: do not throw when overlayClass is set to empty string

### DIFF
--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -69,7 +69,7 @@ export const OverlayClassMixin = (superclass) =>
       }
 
       // Add new classes based on the overlayClass
-      const classesToAdd = typeof overlayClass === 'string' ? overlayClass.split(' ') : [];
+      const classesToAdd = typeof overlayClass === 'string' ? overlayClass.split(' ').filter(Boolean) : [];
       if (classesToAdd.length > 0) {
         classList.add(...classesToAdd);
       }

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -79,6 +79,17 @@ const runTests = (defineHelper, baseMixin) => {
       expect(overlay.classList.contains('foo')).to.be.false;
       expect(overlay.classList.contains('bar')).to.be.false;
     });
+
+    it('should remove class names when setting whitespace string', async () => {
+      element.overlayClass = 'foo bar';
+      await nextUpdate(element);
+
+      element.overlayClass = ' ';
+      await nextUpdate(element);
+
+      expect(overlay.classList.contains('foo')).to.be.false;
+      expect(overlay.classList.contains('bar')).to.be.false;
+    });
   });
 
   describe('custom classes', () => {

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -68,6 +68,17 @@ const runTests = (defineHelper, baseMixin) => {
       expect(overlay.classList.contains('foo')).to.be.true;
       expect(overlay.classList.contains('bar')).to.be.false;
     });
+
+    it('should remove class names when setting empty string', async () => {
+      element.overlayClass = 'foo bar';
+      await nextUpdate(element);
+
+      element.overlayClass = '';
+      await nextUpdate(element);
+
+      expect(overlay.classList.contains('foo')).to.be.false;
+      expect(overlay.classList.contains('bar')).to.be.false;
+    });
   });
 
   describe('custom classes', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6274

## Type of change

- Bugfix