### PR TITLE
fix: do not call renderer for disconnected columns

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -947,6 +947,9 @@ export const GridMixin = (superClass) =>
       this._filterDragAndDrop(row, model);
 
       iterateChildren(row, (cell) => {
+        if (cell._column && !cell._column.isConnected) {
+          return;
+        }
         if (cell._renderer) {
           const owner = cell._column || this;
           cell._renderer.call(owner, cell._content, owner, model);

--- a/packages/grid/test/tree-toggle.common.js
+++ b/packages/grid/test/tree-toggle.common.js
@@ -169,6 +169,13 @@ describe('tree toggle', () => {
       expect(getBodyCellContent(grid, 0, 0).firstElementChild).to.equal(toggle);
     });
 
+    it('should not throw when removing column and setting items', () => {
+      expect(() => {
+        grid.removeChild(column);
+        grid.items = [{ name: 'New name' }];
+      }).to.not.throw(Error);
+    });
+
     describe('itemHasChildrenPath', () => {
       beforeEach(() => {
         sinon.stub(console, 'warn');


### PR DESCRIPTION
## Description

Added a check to `_updateItem()` method and a test to verify that removing the `vaadin-grid-tree-column` doesn't throw.

This fixes the following problem that was [reported internally](https://vaadin.slack.com/archives/C3TGRP4HY/p1715082136231939?thread_ts=1715077041.083499&cid=C3TGRP4HY):

```
TypeError: Cannot read properties of undefined (reading 'itemHasChildrenPath')
    at GridTreeColumn.__defaultRenderer (http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/grid/src/vaadin-grid-tree-column-mixin.js?t=1715085767730&v=57315da2:51:56)
    at http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/grid/src/vaadin-grid-mixin.js?t=1715086641624&v=57315da2:955:26
    at Array.forEach (<anonymous>)
    at iterateChildren (http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/grid/src/vaadin-grid-helpers.js?v=57315da2:26:27)
    at Grid._updateItem (http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/grid/src/vaadin-grid-mixin.js?t=1715086641624&v=57315da2:949:7)
    at Grid._getItem (http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/grid/src/vaadin-grid-data-provider-mixin.js?t=1715086247783&v=57315da2:214:14)
    at Grid._updateScrollerItem (http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/grid/src/vaadin-grid-mixin.js?t=1715086641624&v=57315da2:837:12)
    at IronListAdapter.__updateElement (http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/component-base/src/virtualizer-iron-list-adapter.js?v=57315da2:240:12)
    at http://localhost:8080/VAADIN/@fs/Users/serhii/vaadin/web-components/node_modules/@vaadin/component-base/src/virtualizer-iron-list-adapter.js?v=57315da2:173:14
    at Array.forEach (<anonymous>)
```

Did some debugging and here’s what happens in this case:

1. The `vaadin-grid-tree-column` and other columns are detached, `disconnectedCallback()` is called. At this point, `_grid` reference is cleared
2. The `dataProvider` used by the first Grid is replaced with `items` array used by second Grid
3. The `_dataProviderChanged` observer is called by the `vaadin-grid` and it calls `clearCache()`
4. This method calls `__updateVisibleRows()` which re-renders grid cells also for detached columns.
5. Re-rendering is done in the loop inside `_updateItem` method where we don’t check if `column._grid` is defined.

## Type of change

- Bugfix