### PR TITLE
test: remove not needed use strict from unit tests

### DIFF
--- a/packages/rich-text-editor/test/a11y.common.js
+++ b/packages/rich-text-editor/test/a11y.common.js
@@ -13,7 +13,6 @@ import sinon from 'sinon';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('accessibility', () => {
-  'use strict';
   let rte, content, buttons, announcer, editor;
 
   const flushFormatAnnouncer = () => {

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import { createImage } from './helpers.js';
 
 describe('rich text editor', () => {
-  'use strict';
   let rte, editor;
 
   const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();


### PR DESCRIPTION
## Description

Removed `'use strict'` lines that were added when converting to Polymer 3 in https://github.com/vaadin/vaadin-rich-text-editor/pull/173.
We don't need them as our tests are implemented using ES modules and therefore use strict mode automatically.

## Type of change

- Test