### PR TITLE
docs: update the grid readme example not to use em units

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Import the component's JavaScript module, use the component in your HTML, and co
   </head>
   <body>
     <!-- Use web components in your HTML like regular built-in elements. -->
-    <vaadin-grid theme="row-dividers" column-reordering-allowed multi-sort>
+    <vaadin-grid column-reordering-allowed multi-sort>
       <vaadin-grid-selection-column auto-select frozen></vaadin-grid-selection-column>
-      <vaadin-grid-sort-column width="9em" path="firstName"></vaadin-grid-sort-column>
-      <vaadin-grid-sort-column width="9em" path="lastName"></vaadin-grid-sort-column>
-      <vaadin-grid-column width="9em" path="address.city"></vaadin-grid-column>
+      <vaadin-grid-sort-column width="9rem" path="firstName"></vaadin-grid-sort-column>
+      <vaadin-grid-sort-column width="9rem" path="lastName"></vaadin-grid-sort-column>
+      <vaadin-grid-column width="9rem" path="address.city"></vaadin-grid-column>
     </vaadin-grid>
 
     <!-- Vaadin web components use standard JavaScript modules. -->

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -7,11 +7,11 @@ A web component for showing tabular data.
 [![npm version](https://badgen.net/npm/v/@vaadin/grid)](https://www.npmjs.com/package/@vaadin/grid)
 
 ```html
-<vaadin-grid theme="row-dividers" column-reordering-allowed multi-sort>
+<vaadin-grid column-reordering-allowed multi-sort>
   <vaadin-grid-selection-column auto-select frozen></vaadin-grid-selection-column>
-  <vaadin-grid-sort-column width="9em" path="firstName"></vaadin-grid-sort-column>
-  <vaadin-grid-sort-column width="9em" path="lastName"></vaadin-grid-sort-column>
-  <vaadin-grid-column id="address" width="15em" flex-grow="2" header="Address"></vaadin-grid-column>
+  <vaadin-grid-sort-column width="9rem" path="firstName"></vaadin-grid-sort-column>
+  <vaadin-grid-sort-column width="9rem" path="lastName"></vaadin-grid-sort-column>
+  <vaadin-grid-column id="address" width="15rem" flex-grow="2" header="Address"></vaadin-grid-column>
 </vaadin-grid>
 
 <script>


### PR DESCRIPTION
## Description

Update the grid readme example not to use em units. See https://github.com/vaadin/web-components/issues/6974#issuecomment-1867309522

Also, remove `theme="row-dividers"` since grid doesn't have such a theme variant.

## Type of change

Documentation