### PR TITLE
refactor: extract tooltip position logic to separate mixin

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
@@ -5,27 +5,16 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { TooltipPositionMixinClass } from './vaadin-tooltip-position-mixin.js';
 
-export type TooltipPosition =
-  | 'bottom-end'
-  | 'bottom-start'
-  | 'bottom'
-  | 'end-bottom'
-  | 'end-top'
-  | 'end'
-  | 'start-bottom'
-  | 'start-top'
-  | 'start'
-  | 'top-end'
-  | 'top-start'
-  | 'top';
+export type { TooltipPosition } from './vaadin-tooltip-position-mixin.js';
 
 /**
  * A mixin providing common tooltip functionality.
  */
 export declare function TooltipMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<OverlayClassMixinClass> & Constructor<TooltipMixinClass> & T;
+): Constructor<OverlayClassMixinClass> & Constructor<TooltipMixinClass> & Constructor<TooltipPositionMixinClass> & T;
 
 export declare class TooltipMixinClass {
   /**
@@ -90,14 +79,6 @@ export declare class TooltipMixinClass {
    * Only works if `manual` is set to `true`.
    */
   opened: boolean;
-
-  /**
-   * Position of the tooltip with respect to its target.
-   * Supported values: `top-start`, `top`, `top-end`,
-   * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
-   * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
-   */
-  position: TooltipPosition;
 
   /**
    * Function used to detect whether to show the tooltip based on a condition,

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -10,6 +10,7 @@ import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+import { TooltipPositionMixin } from './vaadin-tooltip-position-mixin.js';
 
 const DEFAULT_DELAY = 500;
 
@@ -216,9 +217,10 @@ class TooltipStateController {
  *
  * @polymerMixin
  * @mixes OverlayClassMixin
+ * @mixes TooltipPositionMixin
  */
 export const TooltipMixin = (superClass) =>
-  class TooltipMixinClass extends OverlayClassMixin(superClass) {
+  class TooltipMixinClass extends TooltipPositionMixin(OverlayClassMixin(superClass)) {
     static get properties() {
       return {
         /**
@@ -311,16 +313,6 @@ export const TooltipMixin = (superClass) =>
         },
 
         /**
-         * Position of the tooltip with respect to its target.
-         * Supported values: `top-start`, `top`, `top-end`,
-         * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
-         * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
-         */
-        position: {
-          type: String,
-        },
-
-        /**
          * Function used to detect whether to show the tooltip based on a condition,
          * called every time the tooltip is about to be shown on hover and focus.
          * The function takes two parameters: `target` and `context`, which contain
@@ -375,12 +367,6 @@ export const TooltipMixin = (superClass) =>
         },
 
         /** @private */
-        __effectivePosition: {
-          type: String,
-          computed: '__computePosition(position, _position)',
-        },
-
-        /** @private */
         __isTargetHidden: {
           type: Boolean,
           value: false,
@@ -390,15 +376,6 @@ export const TooltipMixin = (superClass) =>
         _isConnected: {
           type: Boolean,
           sync: true,
-        },
-
-        /**
-         * Default value used when `position` property is not set.
-         * @protected
-         */
-        _position: {
-          type: String,
-          value: 'bottom',
         },
 
         /** @private */
@@ -510,33 +487,8 @@ export const TooltipMixin = (superClass) =>
     }
 
     /** @private */
-    __computeHorizontalAlign(position) {
-      return ['top-end', 'bottom-end', 'start-top', 'start', 'start-bottom'].includes(position) ? 'end' : 'start';
-    }
-
-    /** @private */
-    __computeNoHorizontalOverlap(position) {
-      return ['start-top', 'start', 'start-bottom', 'end-top', 'end', 'end-bottom'].includes(position);
-    }
-
-    /** @private */
-    __computeNoVerticalOverlap(position) {
-      return ['top-start', 'top-end', 'top', 'bottom-start', 'bottom', 'bottom-end'].includes(position);
-    }
-
-    /** @private */
-    __computeVerticalAlign(position) {
-      return ['top-start', 'top-end', 'top', 'start-bottom', 'end-bottom'].includes(position) ? 'bottom' : 'top';
-    }
-
-    /** @private */
     __computeOpened(manual, opened, autoOpened, connected) {
       return connected && (manual ? opened : autoOpened);
-    }
-
-    /** @private */
-    __computePosition(position, defaultPosition) {
-      return position || defaultPosition;
     }
 
     /** @private */

--- a/packages/tooltip/src/vaadin-tooltip-position-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-position-mixin.d.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2022 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export type TooltipPosition =
+  | 'bottom-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'end-bottom'
+  | 'end-top'
+  | 'end'
+  | 'start-bottom'
+  | 'start-top'
+  | 'start'
+  | 'top-end'
+  | 'top-start'
+  | 'top';
+
+/**
+ * A mixin providing tooltip position functionality.
+ */
+export declare function TooltipPositionMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<TooltipPositionMixinClass> & T;
+
+export declare class TooltipPositionMixinClass {
+  /**
+   * Position of the overlay with respect to the target.
+   * Supported values: `top-start`, `top`, `top-end`,
+   * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
+   * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
+   */
+  position: TooltipPosition;
+}

--- a/packages/tooltip/src/vaadin-tooltip-position-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-position-mixin.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2022 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin providing tooltip position functionality.
+ *
+ * @polymerMixin
+ */
+export const TooltipPositionMixin = (superClass) =>
+  class TooltipPositionMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * Position of the overlay with respect to the target.
+         * Supported values: `top-start`, `top`, `top-end`,
+         * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
+         * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
+         */
+        position: {
+          type: String,
+        },
+
+        /**
+         * Default value used when `position` property is not set.
+         * @protected
+         */
+        _position: {
+          type: String,
+          value: 'bottom',
+        },
+
+        /** @private */
+        __effectivePosition: {
+          type: String,
+          computed: '__computePosition(position, _position)',
+        },
+      };
+    }
+
+    /** @private */
+    __computeHorizontalAlign(position) {
+      return ['top-end', 'bottom-end', 'start-top', 'start', 'start-bottom'].includes(position) ? 'end' : 'start';
+    }
+
+    /** @private */
+    __computeNoHorizontalOverlap(position) {
+      return ['start-top', 'start', 'start-bottom', 'end-top', 'end', 'end-bottom'].includes(position);
+    }
+
+    /** @private */
+    __computeNoVerticalOverlap(position) {
+      return ['top-start', 'top-end', 'top', 'bottom-start', 'bottom', 'bottom-end'].includes(position);
+    }
+
+    /** @private */
+    __computeVerticalAlign(position) {
+      return ['top-start', 'top-end', 'top', 'start-bottom', 'end-bottom'].includes(position) ? 'bottom' : 'top';
+    }
+
+    /** @private */
+    __computePosition(position, defaultPosition) {
+      return position || defaultPosition;
+    }
+  };


### PR DESCRIPTION
## Description

Extracted `position` property and related private methods to the separate mixin to enable reusing by `vaadin-popover`.

## Type of change

- Refactor