### PR TITLE
refactor: extract tooltip target logic to separate mixin

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { TooltipTargetMixinClass } from './vaadin-tooltip-target-mixin.js';
 
 export type TooltipPosition =
   | 'bottom-end'
@@ -25,7 +26,7 @@ export type TooltipPosition =
  */
 export declare function TooltipMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<OverlayClassMixinClass> & Constructor<TooltipMixinClass> & T;
+): Constructor<OverlayClassMixinClass> & Constructor<TooltipMixinClass> & Constructor<TooltipTargetMixinClass> & T;
 
 export declare class TooltipMixinClass {
   /**
@@ -48,13 +49,6 @@ export declare class TooltipMixinClass {
    * @attr {number} focus-delay
    */
   focusDelay: number;
-
-  /**
-   * The id of the element used as a tooltip trigger.
-   * The element should be in the DOM by the time when
-   * the attribute is set, otherwise a warning is shown.
-   */
-  for: string | undefined;
 
   /**
    * Function used to generate the tooltip content.
@@ -107,13 +101,6 @@ export declare class TooltipMixinClass {
    * The tooltip is only shown when the function invocation returns `true`.
    */
   shouldShow: (target: HTMLElement, context?: Record<string, unknown>) => boolean;
-
-  /**
-   * Reference to the element used as a tooltip trigger.
-   * The target must be placed in the same shadow scope.
-   * Defaults to an element referenced with `for`.
-   */
-  target: HTMLElement | undefined;
 
   /**
    * String used as a tooltip content.

--- a/packages/tooltip/src/vaadin-tooltip-target-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-target-mixin.d.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2022 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+/**
+ * A mixin providing tooltip target functionality.
+ */
+export declare function TooltipTargetMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<TooltipTargetMixinClass> & T;
+
+export declare class TooltipTargetMixinClass {
+  /**
+   * The id of the element to be used as `target` value.
+   * The element should be in the DOM by the time when
+   * the attribute is set, otherwise a warning is shown.
+   */
+  for: string | undefined;
+
+  /**
+   * Reference to the DOM element used both to trigger the overlay
+   * by user interaction and to visually position it on the screen.
+   *
+   * Defaults to an element referenced with `for` attribute, in
+   * which case it must be located in the same shadow scope.
+   */
+  target: HTMLElement | undefined;
+
+  protected _addTargetListeners(target: HTMLElement): void;
+
+  protected _removeTargetListeners(target: HTMLElement): void;
+}

--- a/packages/tooltip/src/vaadin-tooltip-target-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-target-mixin.js
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright (c) 2022 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+
+/**
+ * A mixin providing tooltip target functionality.
+ *
+ * @polymerMixin
+ */
+export const TooltipTargetMixin = (superClass) =>
+  class TooltipTargetMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * The id of the element to be used as `target` value.
+         * The element should be in the DOM by the time when
+         * the attribute is set, otherwise a warning is shown.
+         */
+        for: {
+          type: String,
+          observer: '__forChanged',
+        },
+
+        /**
+         * Reference to the DOM element used both to trigger the overlay
+         * by user interaction and to visually position it on the screen.
+         *
+         * Defaults to an element referenced with `for` attribute, in
+         * which case it must be located in the same shadow scope.
+         */
+        target: {
+          type: Object,
+          observer: '__targetChanged',
+        },
+      };
+    }
+
+    /** @private */
+    __forChanged(forId) {
+      if (forId) {
+        this.__setTargetByIdDebouncer = Debouncer.debounce(this.__setTargetByIdDebouncer, microTask, () =>
+          this.__setTargetById(forId),
+        );
+      }
+    }
+
+    /** @private */
+    __setTargetById(targetId) {
+      if (!this.isConnected) {
+        return;
+      }
+
+      const target = this.getRootNode().getElementById(targetId);
+
+      if (target) {
+        this.target = target;
+      } else {
+        console.warn(`No element with id="${targetId}" set via "for" property found on the page.`);
+      }
+    }
+
+    /** @private */
+    __targetChanged(target, oldTarget) {
+      if (oldTarget) {
+        this._removeTargetListeners(oldTarget);
+      }
+
+      if (target) {
+        this._addTargetListeners(target);
+      }
+    }
+
+    /**
+     * @param {HTMLElement} _target
+     * @protected
+     */
+    _addTargetListeners(_target) {
+      // To be implemented.
+    }
+
+    /**
+     * @param {HTMLElement} _target
+     * @protected
+     */
+    _removeTargetListeners(_target) {
+      // To be implemented.
+    }
+  };


### PR DESCRIPTION
## Description

Similar to #7406

Extracted `target` and `for` properties and related observers to the separate mixin to enable reusing by `vaadin-popover`.

## Type of change

- Refactor