### PR TITLE
feat: implement basic popover logic, move mixins from tooltip

### DIFF
--- a/dev/popover.html
+++ b/dev/popover.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Popover</title>
+    <script type="module" src="./common.js"></script>
+
+    <script type="module">
+      import '@vaadin/button';
+      import '@vaadin/popover';
+    </script>
+  </head>
+
+  <body>
+    <vaadin-button id="button">Toggle popover</vaadin-button>
+
+    <vaadin-popover for="button" position="bottom-start"></vaadin-popover>
+
+    <script type="module">
+      const popover = document.querySelector('vaadin-popover');
+
+      popover.renderer = (root) => {
+        if (root.firstChild) {
+          return;
+        }
+
+        const text = document.createElement('p');
+        text.textContent = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
+        text.style.marginTop = '0';
+
+        root.append(text);
+      };
+    </script>
+  </body>
+</html>

--- a/dev/popover.html
+++ b/dev/popover.html
@@ -9,12 +9,14 @@
 
     <script type="module">
       import '@vaadin/button';
+      import '@vaadin/horizontal-layout';
       import '@vaadin/popover';
+      import '@vaadin/text-field';
     </script>
   </head>
 
   <body>
-    <vaadin-button id="button">Toggle popover</vaadin-button>
+    <vaadin-button id="button">Discount</vaadin-button>
 
     <vaadin-popover for="button" position="bottom-start"></vaadin-popover>
 
@@ -26,11 +28,19 @@
           return;
         }
 
-        const text = document.createElement('p');
-        text.textContent = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
-        text.style.marginTop = '0';
+        const layout = document.createElement('vaadin-horizontal-layout');
+        layout.setAttribute('theme', 'spacing-s');
+        layout.style.alignItems = 'baseline';
 
-        root.append(text);
+        const field = document.createElement('vaadin-text-field');
+        field.label = 'Discount code';
+
+        const button = document.createElement('vaadin-button');
+        button.textContent = 'Apply';
+
+        layout.append(field, button);
+
+        root.append(layout);
       };
     </script>
   </body>

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/component-base": "24.5.0-alpha0",
+    "@vaadin/overlay": "24.5.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha0",
     "@vaadin/vaadin-material-styles": "24.5.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha0",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -44,7 +44,8 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/testing-helpers": "^0.6.0"
+    "@vaadin/testing-helpers": "^0.6.0",
+    "sinon": "^13.0.2"
   },
   "web-types": [
     "web-types.json",

--- a/packages/popover/src/vaadin-popover-overlay-mixin.js
+++ b/packages/popover/src/vaadin-popover-overlay-mixin.js
@@ -13,8 +13,8 @@ import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin
  * @mixes PositionMixin
  * @mixes OverlayMixin
  */
-export const TooltipOverlayMixin = (superClass) =>
-  class TooltipOverlayMixinClass extends PositionMixin(OverlayMixin(superClass)) {
+export const PopoverOverlayMixin = (superClass) =>
+  class PopoverOverlayMixinClass extends PositionMixin(OverlayMixin(superClass)) {
     static get properties() {
       return {
         position: {
@@ -30,13 +30,13 @@ export const TooltipOverlayMixin = (superClass) =>
      * @return {string}
      */
     get _tagNamePrefix() {
-      return 'vaadin-tooltip';
+      return 'vaadin-popover';
     }
 
     requestContentUpdate() {
       super.requestContentUpdate();
 
-      // Copy custom properties from the tooltip
+      // Copy custom properties from the owner
       if (this.positionTarget && this.owner) {
         const style = getComputedStyle(this.owner);
         ['top', 'bottom', 'start', 'end'].forEach((prop) => {

--- a/packages/popover/src/vaadin-popover-overlay-mixin.js
+++ b/packages/popover/src/vaadin-popover-overlay-mixin.js
@@ -7,7 +7,7 @@ import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
 /**
- * A mixin providing common tooltip overlay functionality.
+ * A mixin providing common popover overlay functionality.
  *
  * @polymerMixin
  * @mixes PositionMixin
@@ -59,7 +59,7 @@ export const PopoverOverlayMixin = (superClass) =>
         return;
       }
 
-      // Center the tooltip overlay horizontally
+      // Center the overlay horizontally
       if (this.position === 'bottom' || this.position === 'top') {
         const targetRect = this.positionTarget.getBoundingClientRect();
         const overlayRect = this.$.overlay.getBoundingClientRect();
@@ -81,7 +81,7 @@ export const PopoverOverlayMixin = (superClass) =>
         }
       }
 
-      // Center the tooltip overlay vertically
+      // Center the overlay vertically
       if (this.position === 'start' || this.position === 'end') {
         const targetRect = this.positionTarget.getBoundingClientRect();
         const overlayRect = this.$.overlay.getBoundingClientRect();

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -53,22 +53,6 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
     ];
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   /** @protected */
   render() {
     return html`

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { TooltipOverlayMixin } from '@vaadin/tooltip/src/vaadin-tooltip-overlay-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-popover>`. Not intended to be used separately.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @mixes DirMixin
+ * @mixes ThemableMixin
+ * @mixes TooltipOverlayMixin
+ * @private
+ */
+class TooltipOverlay extends TooltipOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-popover-overlay';
+  }
+
+  static get styles() {
+    return [overlayStyles];
+  }
+
+  static get properties() {
+    return {
+      /**
+       * When true, the overlay is visible and attached to body.
+       * This property config is overridden to set `sync: true`.
+       */
+      opened: {
+        type: Boolean,
+        notify: true,
+        observer: '_openedChanged',
+        reflectToAttribute: true,
+        sync: true,
+      },
+    };
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div id="backdrop" part="backdrop" hidden ?hidden="${!this.withBackdrop}"></div>
+      <div part="overlay" id="overlay">
+        <div part="content" id="content"><slot></slot></div>
+      </div>
+    `;
+  }
+}
+
+defineCustomElement(TooltipOverlay);

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -8,8 +8,8 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
-import { TooltipOverlayMixin } from '@vaadin/tooltip/src/vaadin-tooltip-overlay-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { PopoverOverlayMixin } from './vaadin-popover-overlay-mixin.js';
 
 /**
  * An element used internally by `<vaadin-popover>`. Not intended to be used separately.
@@ -17,11 +17,11 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @customElement
  * @extends HTMLElement
  * @mixes DirMixin
+ * @mixes PopoverOverlayMixin
  * @mixes ThemableMixin
- * @mixes TooltipOverlayMixin
  * @private
  */
-class TooltipOverlay extends TooltipOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {
     return 'vaadin-popover-overlay';
   }
@@ -57,4 +57,4 @@ class TooltipOverlay extends TooltipOverlayMixin(DirMixin(ThemableMixin(PolylitM
   }
 }
 
-defineCustomElement(TooltipOverlay);
+defineCustomElement(PopoverOverlay);

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html, LitElement } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -27,7 +27,30 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
   }
 
   static get styles() {
-    return [overlayStyles];
+    return [
+      overlayStyles,
+      css`
+        :host([position^='top'][top-aligned]) [part='overlay'],
+        :host([position^='bottom'][top-aligned]) [part='overlay'] {
+          margin-top: var(--vaadin-popover-offset-top, 0);
+        }
+
+        :host([position^='top'][bottom-aligned]) [part='overlay'],
+        :host([position^='bottom'][bottom-aligned]) [part='overlay'] {
+          margin-bottom: var(--vaadin-popover-offset-bottom, 0);
+        }
+
+        :host([position^='start'][start-aligned]) [part='overlay'],
+        :host([position^='end'][start-aligned]) [part='overlay'] {
+          margin-inline-start: var(--vaadin-popover-offset-start, 0);
+        }
+
+        :host([position^='start'][end-aligned]) [part='overlay'],
+        :host([position^='end'][end-aligned]) [part='overlay'] {
+          margin-inline-end: var(--vaadin-popover-offset-end, 0);
+        }
+      `,
+    ];
   }
 
   static get properties() {

--- a/packages/popover/src/vaadin-popover-position-mixin.d.ts
+++ b/packages/popover/src/vaadin-popover-position-mixin.d.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright (c) 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export type PopoverPosition =
+  | 'bottom-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'end-bottom'
+  | 'end-top'
+  | 'end'
+  | 'start-bottom'
+  | 'start-top'
+  | 'start'
+  | 'top-end'
+  | 'top-start'
+  | 'top';
+
+/**
+ * A mixin providing popover position functionality.
+ */
+export declare function PopoverPositionMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<PopoverPositionMixinClass> & T;
+
+export declare class PopoverPositionMixinClass {
+  /**
+   * Position of the overlay with respect to the target.
+   * Supported values: `top-start`, `top`, `top-end`,
+   * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
+   * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
+   */
+  position: PopoverPosition;
+}

--- a/packages/popover/src/vaadin-popover-position-mixin.js
+++ b/packages/popover/src/vaadin-popover-position-mixin.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin providing popover position functionality.
+ *
+ * @polymerMixin
+ */
+export const PopoverPositionMixin = (superClass) =>
+  class PopoverPositionMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * Position of the overlay with respect to the target.
+         * Supported values: `top-start`, `top`, `top-end`,
+         * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
+         * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
+         */
+        position: {
+          type: String,
+        },
+
+        /**
+         * Default value used when `position` property is not set.
+         * @protected
+         */
+        _position: {
+          type: String,
+          value: 'bottom',
+        },
+
+        /** @private */
+        __effectivePosition: {
+          type: String,
+          computed: '__computePosition(position, _position)',
+        },
+      };
+    }
+
+    /** @protected */
+    __computeHorizontalAlign(position) {
+      return ['top-end', 'bottom-end', 'start-top', 'start', 'start-bottom'].includes(position) ? 'end' : 'start';
+    }
+
+    /** @protected */
+    __computeNoHorizontalOverlap(position) {
+      return ['start-top', 'start', 'start-bottom', 'end-top', 'end', 'end-bottom'].includes(position);
+    }
+
+    /** @protected */
+    __computeNoVerticalOverlap(position) {
+      return ['top-start', 'top-end', 'top', 'bottom-start', 'bottom', 'bottom-end'].includes(position);
+    }
+
+    /** @protected */
+    __computeVerticalAlign(position) {
+      return ['top-start', 'top-end', 'top', 'start-bottom', 'end-bottom'].includes(position) ? 'bottom' : 'top';
+    }
+
+    /** @private */
+    __computePosition(position, defaultPosition) {
+      return position || defaultPosition;
+    }
+  };

--- a/packages/popover/src/vaadin-popover-target-mixin.d.ts
+++ b/packages/popover/src/vaadin-popover-target-mixin.d.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+/**
+ * A mixin providing popover target functionality.
+ */
+export declare function PopoverTargetMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<PopoverTargetMixinClass> & T;
+
+export declare class PopoverTargetMixinClass {
+  /**
+   * The id of the element to be used as `target` value.
+   * The element should be in the DOM by the time when
+   * the attribute is set, otherwise a warning is shown.
+   */
+  for: string | undefined;
+
+  /**
+   * Reference to the DOM element used both to trigger the overlay
+   * by user interaction and to visually position it on the screen.
+   *
+   * Defaults to an element referenced with `for` attribute, in
+   * which case it must be located in the same shadow scope.
+   */
+  target: HTMLElement | undefined;
+
+  protected _addTargetListeners(target: HTMLElement): void;
+
+  protected _removeTargetListeners(target: HTMLElement): void;
+}

--- a/packages/popover/src/vaadin-popover-target-mixin.js
+++ b/packages/popover/src/vaadin-popover-target-mixin.js
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright (c) 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+
+/**
+ * A mixin providing popover target functionality.
+ *
+ * @polymerMixin
+ */
+export const PopoverTargetMixin = (superClass) =>
+  class PopoverTargetMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * The id of the element to be used as `target` value.
+         * The element should be in the DOM by the time when
+         * the attribute is set, otherwise a warning is shown.
+         */
+        for: {
+          type: String,
+          observer: '__forChanged',
+        },
+
+        /**
+         * Reference to the DOM element used both to trigger the overlay
+         * by user interaction and to visually position it on the screen.
+         *
+         * Defaults to an element referenced with `for` attribute, in
+         * which case it must be located in the same shadow scope.
+         */
+        target: {
+          type: Object,
+          observer: '__targetChanged',
+        },
+      };
+    }
+
+    /** @private */
+    __forChanged(forId) {
+      if (forId) {
+        this.__setTargetByIdDebouncer = Debouncer.debounce(this.__setTargetByIdDebouncer, microTask, () =>
+          this.__setTargetById(forId),
+        );
+      }
+    }
+
+    /** @private */
+    __setTargetById(targetId) {
+      if (!this.isConnected) {
+        return;
+      }
+
+      const target = this.getRootNode().getElementById(targetId);
+
+      if (target) {
+        this.target = target;
+      } else {
+        console.warn(`No element with id="${targetId}" set via "for" property found on the page.`);
+      }
+    }
+
+    /** @private */
+    __targetChanged(target, oldTarget) {
+      if (oldTarget) {
+        this._removeTargetListeners(oldTarget);
+      }
+
+      if (target) {
+        this._addTargetListeners(target);
+      }
+    }
+
+    /**
+     * @param {HTMLElement} _target
+     * @protected
+     */
+    _addTargetListeners(_target) {
+      // To be implemented.
+    }
+
+    /**
+     * @param {HTMLElement} _target
+     * @protected
+     */
+    _removeTargetListeners(_target) {
+      // To be implemented.
+    }
+  };

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -5,8 +5,11 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
 import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
+
+export type { PopoverPosition } from './vaadin-popover-position-mixin.js';
 
 export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
 
@@ -17,7 +20,9 @@ export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
  * Unlike `<vaadin-tooltip>`, the popover supports rich content
  * that can be provided by using `renderer` function.
  */
-declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(OverlayClassMixin(ElementMixin(HTMLElement)))) {
+declare class Popover extends PopoverPositionMixin(
+  PopoverTargetMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement)))),
+) {
   /**
    * Custom function for rendering the content of the overlay.
    * Receives two arguments:

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -4,6 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
+import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
+
+export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
 
 /**
  * `<vaadin-popover>` is a Web Component for creating overlays
@@ -11,7 +15,16 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
  *
  * Unlike `<vaadin-tooltip>`, the popover supports rich content.
  */
-declare class Popover extends ElementMixin(HTMLElement) {}
+declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(HTMLElement))) {
+  /**
+   * Custom function for rendering the content of the overlay.
+   * Receives two arguments:
+   *
+   * - `root` The root container DOM element. Append your content to it.
+   * - `popover` The reference to the `vaadin-popover` element (overlay host).
+   */
+  renderer: PopoverRenderer | null | undefined;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
 import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
 
@@ -13,9 +14,10 @@ export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
  * `<vaadin-popover>` is a Web Component for creating overlays
  * that are positioned next to specified DOM element (target).
  *
- * Unlike `<vaadin-tooltip>`, the popover supports rich content.
+ * Unlike `<vaadin-tooltip>`, the popover supports rich content
+ * that can be provided by using `renderer` function.
  */
-declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(HTMLElement))) {
+declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(OverlayClassMixin(ElementMixin(HTMLElement)))) {
   /**
    * Custom function for rendering the content of the overlay.
    * Receives two arguments:
@@ -24,6 +26,14 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMix
    * - `popover` The reference to the `vaadin-popover` element (overlay host).
    */
   renderer: PopoverRenderer | null | undefined;
+
+  /**
+   * Requests an update for the content of the popover.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   */
+  requestContentUpdate(): void;
 }
 
 declare global {

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -3,10 +3,14 @@
  * Copyright (c) 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import './vaadin-popover-overlay.js';
 import { html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
+import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
 
 /**
  * `<vaadin-popover>` is a Web Component for creating overlays
@@ -17,15 +21,46 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
  * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin
+ * @mixes PopoverPositionMixin
+ * @mixes PopoverTargetMixin
  */
-class Popover extends ElementMixin(PolylitMixin(LitElement)) {
+class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(PolylitMixin(LitElement)))) {
   static get is() {
     return 'vaadin-popover';
   }
 
+  static get properties() {
+    return {
+      /**
+       * Custom function for rendering the content of the overlay.
+       * Receives two arguments:
+       *
+       * - `root` The root container DOM element. Append your content to it.
+       * - `popover` The reference to the `vaadin-popover` element (overlay host).
+       */
+      renderer: {
+        type: Object,
+      },
+    };
+  }
+
   /** @protected */
   render() {
-    return html``;
+    const effectivePosition = this.__effectivePosition;
+
+    return html`
+      <vaadin-popover-overlay
+        .renderer="${this.renderer}"
+        .owner="${this}"
+        theme="${ifDefined(this._theme)}"
+        .positionTarget="${this.target}"
+        .position="${effectivePosition}"
+        ?no-horizontal-overlap="${this.__computeNoHorizontalOverlap(effectivePosition)}"
+        ?no-vertical-overlap="${this.__computeNoVerticalOverlap(effectivePosition)}"
+        .horizontalAlign="${this.__computeHorizontalAlign(effectivePosition)}"
+        .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
+      ></vaadin-popover-overlay>
+    `;
   }
 }
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -50,7 +50,7 @@ class Popover extends PopoverPositionMixin(
       /** @private */
       _opened: {
         type: Boolean,
-        sync: true,
+        value: false,
       },
     };
   }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -8,6 +8,7 @@ import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
 import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
@@ -16,15 +17,19 @@ import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
  * `<vaadin-popover>` is a Web Component for creating overlays
  * that are positioned next to specified DOM element (target).
  *
- * Unlike `<vaadin-tooltip>`, the popover supports rich content.
+ * Unlike `<vaadin-tooltip>`, the popover supports rich content
+ * that can be provided by using `renderer` function.
  *
  * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin
+ * @mixes ElementMixin
  * @mixes PopoverPositionMixin
  * @mixes PopoverTargetMixin
  */
-class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(PolylitMixin(LitElement)))) {
+class Popover extends PopoverPositionMixin(
+  PopoverTargetMixin(OverlayClassMixin(ElementMixin(PolylitMixin(LitElement)))),
+) {
   static get is() {
     return 'vaadin-popover';
   }
@@ -74,6 +79,27 @@ class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(Polyl
         @opened-changed="${this.__onOpenedChanged}"
       ></vaadin-popover-overlay>
     `;
+  }
+
+  /**
+   * Requests an update for the content of the popover.
+   * While performing the update, it invokes the renderer passed in the `renderer` property.
+   *
+   * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   */
+  requestContentUpdate() {
+    if (!this.renderer || !this._overlayElement) {
+      return;
+    }
+
+    this._overlayElement.requestContentUpdate();
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this._overlayElement = this.shadowRoot.querySelector('vaadin-popover-overlay');
   }
 
   /** @protected */

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -10,6 +10,7 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
 import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
 
@@ -26,9 +27,10 @@ import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
  * @mixes ElementMixin
  * @mixes PopoverPositionMixin
  * @mixes PopoverTargetMixin
+ * @mixes ThemePropertyMixin
  */
 class Popover extends PopoverPositionMixin(
-  PopoverTargetMixin(OverlayClassMixin(ElementMixin(PolylitMixin(LitElement)))),
+  PopoverTargetMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-popover';

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -76,6 +76,13 @@ class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(Polyl
     `;
   }
 
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this._opened = false;
+  }
+
   /**
    * @param {HTMLElement} target
    * @protected

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -41,7 +41,18 @@ class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(Polyl
       renderer: {
         type: Object,
       },
+
+      /** @private */
+      _opened: {
+        type: Boolean,
+        sync: true,
+      },
     };
+  }
+
+  constructor() {
+    super();
+    this.__onTargetClick = this.__onTargetClick.bind(this);
   }
 
   /** @protected */
@@ -55,12 +66,42 @@ class Popover extends PopoverPositionMixin(PopoverTargetMixin(ElementMixin(Polyl
         theme="${ifDefined(this._theme)}"
         .positionTarget="${this.target}"
         .position="${effectivePosition}"
+        .opened="${this._opened}"
         ?no-horizontal-overlap="${this.__computeNoHorizontalOverlap(effectivePosition)}"
         ?no-vertical-overlap="${this.__computeNoVerticalOverlap(effectivePosition)}"
         .horizontalAlign="${this.__computeHorizontalAlign(effectivePosition)}"
         .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
+        @opened-changed="${this.__onOpenedChanged}"
       ></vaadin-popover-overlay>
     `;
+  }
+
+  /**
+   * @param {HTMLElement} target
+   * @protected
+   * @override
+   */
+  _addTargetListeners(target) {
+    target.addEventListener('click', this.__onTargetClick);
+  }
+
+  /**
+   * @param {HTMLElement} target
+   * @protected
+   * @override
+   */
+  _removeTargetListeners(target) {
+    target.removeEventListener('click', this.__onTargetClick);
+  }
+
+  /** @private */
+  __onTargetClick() {
+    this._opened = !this._opened;
+  }
+
+  /** @private */
+  __onOpenedChanged(event) {
+    this._opened = event.detail.value;
   }
 }
 

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -131,6 +131,15 @@ describe('popover', () => {
       expect(overlay.opened).to.be.true;
     });
 
+    it('should close overlay on subsequent target click', async () => {
+      target.click();
+      await nextRender();
+
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
     it('should close overlay on outside click by default', async () => {
       target.click();
       await nextRender();
@@ -154,6 +163,7 @@ describe('popover', () => {
       await nextRender();
 
       popover.remove();
+      await nextRender();
       expect(overlay.opened).to.be.false;
     });
   });

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import './not-animated-styles.js';
 import '../vaadin-popover.js';
 
 describe('popover', () => {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -114,5 +114,13 @@ describe('popover', () => {
       await nextRender();
       expect(overlay.opened).to.be.false;
     });
+
+    it('should close overlay on when popover is detached', async () => {
+      target.click();
+      await nextRender();
+
+      popover.remove();
+      expect(overlay.opened).to.be.false;
+    });
   });
 });

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -29,6 +29,39 @@ describe('popover', () => {
     });
   });
 
+  describe('renderer', () => {
+    let renderer;
+
+    beforeEach(async () => {
+      renderer = sinon.stub();
+      popover.renderer = renderer;
+      await nextUpdate(popover);
+    });
+
+    it('should propagate renderer property to overlay', () => {
+      expect(overlay.renderer).to.eql(renderer);
+    });
+
+    it('should call renderer when requesting content update', () => {
+      popover.requestContentUpdate();
+      expect(overlay.renderer).to.be.calledOnce;
+    });
+
+    it('should not request overlay content update when renderer is unset', async () => {
+      popover.renderer = null;
+      await nextUpdate(popover);
+
+      const spy = sinon.spy(overlay, 'requestContentUpdate');
+      popover.requestContentUpdate();
+      expect(spy).to.not.be.called;
+    });
+
+    it('should not throw when requesting content update before adding to DOM', () => {
+      const element = document.createElement('vaadin-popover');
+      expect(() => element.requestContentUpdate()).not.to.throw(Error);
+    });
+  });
+
   describe('target', () => {
     let target;
 

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-popover.js';
 
@@ -79,6 +79,40 @@ describe('popover', () => {
         await nextUpdate(popover);
         expect(popover.target).to.eql(target);
       });
+    });
+  });
+
+  describe('interactions', () => {
+    let target;
+
+    beforeEach(async () => {
+      target = fixtureSync('<button>Target</button>');
+      popover.target = target;
+      await nextUpdate(popover);
+    });
+
+    it('should open overlay on target click by default', async () => {
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close overlay on outside click by default', async () => {
+      target.click();
+      await nextRender();
+
+      outsideClick();
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close overlay on Escape press by default', async () => {
+      target.click();
+      await nextRender();
+
+      esc(document.body);
+      await nextRender();
+      expect(overlay.opened).to.be.false;
     });
   });
 });

--- a/packages/popover/test/not-animated-styles.js
+++ b/packages/popover/test/not-animated-styles.js
@@ -1,0 +1,13 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-popover-overlay',
+  css`
+    :host([opening]),
+    :host([closing]),
+    :host([opening]) [part='overlay'],
+    :host([closing]) [part='overlay'] {
+      animation: none !important;
+    }
+  `,
+);

--- a/packages/popover/test/position.test.js
+++ b/packages/popover/test/position.test.js
@@ -1,0 +1,172 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '../src/vaadin-popover.js';
+
+describe('position', () => {
+  let popover, target, overlay;
+
+  beforeEach(async () => {
+    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
+    popover.renderer = (root) => {
+      root.textContent = 'Content';
+    };
+    target = fixtureSync('<div style="width: 100px; height: 100px; margin: 100px; outline: 1px solid red;"></div>');
+    popover.target = target;
+    await nextRender();
+    overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+  });
+
+  // Overlay above the target (position="top-*")
+  function assertPlacedAbove(overlayRect, targetRect) {
+    expect(overlayRect.bottom).to.be.closeTo(targetRect.top, 1);
+  }
+
+  // Overlay below the target (position="bottom-*")
+  function assertPlacedBelow(overlayRect, targetRect) {
+    expect(overlayRect.top).to.be.closeTo(targetRect.bottom, 1);
+  }
+
+  // Overlay before the target (position="start-*")
+  function assertPlacedBefore(overlayRect, targetRect, dir) {
+    const x1 = dir === 'rtl' ? 'left' : 'right';
+    const x2 = dir === 'rtl' ? 'right' : 'left';
+    expect(overlayRect[x1]).to.be.closeTo(targetRect[x2], 1);
+  }
+
+  // Overlay after the target (position="end-*")
+  function assertPlacedAfter(overlayRect, targetRect, dir) {
+    const x1 = dir === 'rtl' ? 'right' : 'left';
+    const x2 = dir === 'rtl' ? 'left' : 'right';
+    expect(overlayRect[x1]).to.be.closeTo(targetRect[x2], 1);
+  }
+
+  function assertStartAligned(overlayRect, targetRect, dir) {
+    const x = dir === 'rtl' ? 'right' : 'left';
+    expect(overlayRect[x]).to.be.closeTo(targetRect[x], 1);
+  }
+
+  function assertEndAligned(overlayRect, targetRect, dir) {
+    const x = dir === 'rtl' ? 'left' : 'right';
+    expect(overlayRect[x]).to.be.closeTo(targetRect[x], 1);
+  }
+
+  function assertTopAligned(overlayRect, targetRect) {
+    expect(overlayRect.top).to.be.closeTo(targetRect.top, 1);
+  }
+
+  function assertBottomAligned(overlayRect, targetRect) {
+    expect(overlayRect.bottom).to.be.closeTo(targetRect.bottom, 1);
+  }
+
+  function assertCenteredHorizontally(overlayRect, targetRect, dir) {
+    const coord = dir === 'rtl' ? 'right' : 'left';
+    const offset = targetRect.width / 2 - overlayRect.width / 2;
+    expect(overlayRect[coord]).to.be.closeTo(targetRect[coord] + (dir === 'rtl' ? offset * -1 : offset), 1);
+  }
+
+  function assertCenteredVertically(overlayRect, targetRect) {
+    const offset = targetRect.height / 2 - overlayRect.height / 2;
+    expect(overlayRect.top).to.be.closeTo(targetRect.top + offset, 1);
+  }
+
+  describe('default', () => {
+    it('should not set position property value by default', () => {
+      expect(popover.position).to.be.undefined;
+    });
+
+    it('should set overlay position to bottom by default', () => {
+      expect(overlay.position).to.be.equal('bottom');
+    });
+  });
+
+  [
+    {
+      position: 'top-start',
+      assertPlaced: assertPlacedAbove,
+      assertAligned: assertStartAligned,
+    },
+    {
+      position: 'top',
+      assertPlaced: assertPlacedAbove,
+      assertAligned: assertCenteredHorizontally,
+    },
+    {
+      position: 'top-end',
+      assertPlaced: assertPlacedAbove,
+      assertAligned: assertEndAligned,
+    },
+    {
+      position: 'bottom-start',
+      assertPlaced: assertPlacedBelow,
+      assertAligned: assertStartAligned,
+    },
+    {
+      position: 'bottom',
+      assertPlaced: assertPlacedBelow,
+      assertAligned: assertCenteredHorizontally,
+    },
+    {
+      position: 'bottom-end',
+      assertPlaced: assertPlacedBelow,
+      assertAligned: assertEndAligned,
+    },
+    {
+      position: 'start-top',
+      assertPlaced: assertPlacedBefore,
+      assertAligned: assertTopAligned,
+    },
+    {
+      position: 'start',
+      assertPlaced: assertPlacedBefore,
+      assertAligned: assertCenteredVertically,
+    },
+    {
+      position: 'start-bottom',
+      assertPlaced: assertPlacedBefore,
+      assertAligned: assertBottomAligned,
+    },
+    {
+      position: 'end-top',
+      assertPlaced: assertPlacedAfter,
+      assertAligned: assertTopAligned,
+    },
+    {
+      position: 'end',
+      assertPlaced: assertPlacedAfter,
+      assertAligned: assertCenteredVertically,
+    },
+    {
+      position: 'end-bottom',
+      assertPlaced: assertPlacedAfter,
+      assertAligned: assertBottomAligned,
+    },
+  ].forEach(({ position, assertPlaced, assertAligned }) => {
+    describe(position, () => {
+      ['ltr', 'rtl'].forEach((dir) => {
+        describe(`${position} ${dir}`, () => {
+          before(() => {
+            document.documentElement.setAttribute('dir', dir);
+          });
+
+          after(() => {
+            document.documentElement.removeAttribute('dir');
+          });
+
+          it(`should position overlay against target ${position} with ${dir}`, async () => {
+            popover.position = position;
+            await nextUpdate(popover);
+
+            target.click();
+            await oneEvent(overlay, 'vaadin-overlay-open');
+            const overlayRect = overlay.$.overlay.getBoundingClientRect();
+            const targetRect = target.getBoundingClientRect();
+
+            assertPlaced(overlayRect, targetRect, dir);
+            assertAligned(overlayRect, targetRect, dir);
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -1,0 +1,25 @@
+import '../../vaadin-popover.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import type { PopoverPositionMixinClass } from '../../src/vaadin-popover-position-mixin.js';
+import type { PopoverTargetMixinClass } from '../../src/vaadin-popover-target-mixin.js';
+import type { PopoverPosition, PopoverRenderer } from '../../vaadin-popover.js';
+
+const assertType = <TExpected>(actual: TExpected) => actual;
+
+const popover = document.createElement('vaadin-popover');
+
+// Mixins
+assertType<ElementMixinClass>(popover);
+assertType<OverlayClassMixinClass>(popover);
+assertType<ThemePropertyMixinClass>(popover);
+assertType<PopoverPositionMixinClass>(popover);
+assertType<PopoverTargetMixinClass>(popover);
+
+// Properties
+assertType<string | undefined>(popover.for);
+assertType<HTMLElement | undefined>(popover.target);
+assertType<PopoverPosition>(popover.position);
+assertType<PopoverRenderer | null | undefined>(popover.renderer);
+assertType<string>(popover.overlayClass);

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -39,6 +39,7 @@
     "@vaadin/a11y-base": "24.5.0-alpha0",
     "@vaadin/component-base": "24.5.0-alpha0",
     "@vaadin/overlay": "24.5.0-alpha0",
+    "@vaadin/popover": "24.5.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha0",
     "@vaadin/vaadin-material-styles": "24.5.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha0"

--- a/packages/tooltip/src/vaadin-lit-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-lit-tooltip-overlay.js
@@ -8,8 +8,8 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { PopoverOverlayMixin } from '@vaadin/popover/src/vaadin-popover-overlay-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TooltipOverlayMixin } from './vaadin-tooltip-overlay-mixin.js';
 import { tooltipOverlayStyles } from './vaadin-tooltip-overlay-styles.js';
 
 /**
@@ -19,16 +19,25 @@ import { tooltipOverlayStyles } from './vaadin-tooltip-overlay-styles.js';
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ThemableMixin
- * @mixes TooltipOverlayMixin
+ * @mixes PopoverOverlayMixin
  * @private
  */
-class TooltipOverlay extends TooltipOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+class TooltipOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {
     return 'vaadin-tooltip-overlay';
   }
 
   static get styles() {
     return [overlayStyles, tooltipOverlayStyles];
+  }
+
+  /**
+   * Tag name prefix used by custom properties.
+   * @protected
+   * @return {string}
+   */
+  get _tagNamePrefix() {
+    return 'vaadin-tooltip';
   }
 
   /** @protected */

--- a/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
@@ -5,27 +5,21 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { PopoverPositionMixinClass } from '@vaadin/popover/src/vaadin-popover-position-mixin.js';
+import type { PopoverTargetMixinClass } from '@vaadin/popover/src/vaadin-popover-target-mixin.js';
 
-export type TooltipPosition =
-  | 'bottom-end'
-  | 'bottom-start'
-  | 'bottom'
-  | 'end-bottom'
-  | 'end-top'
-  | 'end'
-  | 'start-bottom'
-  | 'start-top'
-  | 'start'
-  | 'top-end'
-  | 'top-start'
-  | 'top';
+export type { PopoverPosition as TooltipPosition } from '@vaadin/popover/src/vaadin-popover-position-mixin.js';
 
 /**
  * A mixin providing common tooltip functionality.
  */
 export declare function TooltipMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<OverlayClassMixinClass> & Constructor<TooltipMixinClass> & T;
+): Constructor<OverlayClassMixinClass> &
+  Constructor<PopoverPositionMixinClass> &
+  Constructor<PopoverTargetMixinClass> &
+  Constructor<TooltipMixinClass> &
+  T;
 
 export declare class TooltipMixinClass {
   /**
@@ -48,13 +42,6 @@ export declare class TooltipMixinClass {
    * @attr {number} focus-delay
    */
   focusDelay: number;
-
-  /**
-   * The id of the element used as a tooltip trigger.
-   * The element should be in the DOM by the time when
-   * the attribute is set, otherwise a warning is shown.
-   */
-  for: string | undefined;
 
   /**
    * Function used to generate the tooltip content.
@@ -92,14 +79,6 @@ export declare class TooltipMixinClass {
   opened: boolean;
 
   /**
-   * Position of the tooltip with respect to its target.
-   * Supported values: `top-start`, `top`, `top-end`,
-   * `bottom-start`, `bottom`, `bottom-end`, `start-top`,
-   * `start`, `start-bottom`, `end-top`, `end`, `end-bottom`.
-   */
-  position: TooltipPosition;
-
-  /**
    * Function used to detect whether to show the tooltip based on a condition,
    * called every time the tooltip is about to be shown on hover and focus.
    * The function takes two parameters: `target` and `context`, which contain
@@ -107,13 +86,6 @@ export declare class TooltipMixinClass {
    * The tooltip is only shown when the function invocation returns `true`.
    */
   shouldShow: (target: HTMLElement, context?: Record<string, unknown>) => boolean;
-
-  /**
-   * Reference to the element used as a tooltip trigger.
-   * The target must be placed in the same shadow scope.
-   * Defaults to an element referenced with `for`.
-   */
-  target: HTMLElement | undefined;
 
   /**
    * String used as a tooltip content.

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -7,8 +7,8 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
+import { PopoverOverlayMixin } from '@vaadin/popover/src/vaadin-popover-overlay-mixin.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { TooltipOverlayMixin } from './vaadin-tooltip-overlay-mixin.js';
 import { tooltipOverlayStyles } from './vaadin-tooltip-overlay-styles.js';
 
 registerStyles('vaadin-tooltip-overlay', [overlayStyles, tooltipOverlayStyles], {
@@ -22,10 +22,10 @@ registerStyles('vaadin-tooltip-overlay', [overlayStyles, tooltipOverlayStyles], 
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ThemableMixin
- * @mixes TooltipOverlayMixin
+ * @mixes PopoverOverlayMixin
  * @private
  */
-class TooltipOverlay extends TooltipOverlayMixin(DirMixin(ThemableMixin(PolymerElement))) {
+class TooltipOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-tooltip-overlay';
   }
@@ -37,6 +37,15 @@ class TooltipOverlay extends TooltipOverlayMixin(DirMixin(ThemableMixin(PolymerE
         <div part="content" id="content"><slot></slot></div>
       </div>
     `;
+  }
+
+  /**
+   * Tag name prefix used by custom properties.
+   * @protected
+   * @return {string}
+   */
+  get _tagNamePrefix() {
+    return 'vaadin-tooltip';
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/5271

Implemented the following logic of `vaadin-popover`:

- `target`, `for` and `position` properties (corresponding mixins extracted from `vaadin-tooltip`)
- `renderer` property and `requestContentUpdate()` method (logic copied from `vaadin-dialog`)
- overlay opens on target click , closes on outside click and <kbd>Esc</kbd> press (default overlay behavior)

## Type of change

- Feature