### PR TITLE
feat: restore focus to the popover target on overlay close

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -128,6 +128,8 @@ class Popover extends PopoverPositionMixin(
         .horizontalAlign="${this.__computeHorizontalAlign(effectivePosition)}"
         .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
         @opened-changed="${this.__onOpenedChanged}"
+        restore-focus-on-close
+        .restoreFocusNode="${this.target}"
         @vaadin-overlay-escape-press="${this.__onEscapePress}"
         @vaadin-overlay-outside-click="${this.__onOutsideClick}"
       ></vaadin-popover-overlay>

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -74,6 +74,12 @@ describe('popover', () => {
       await nextUpdate(popover);
       expect(overlay.positionTarget).to.eql(target);
     });
+
+    it('should set target as overlay restoreFocusNode', async () => {
+      popover.target = target;
+      await nextUpdate(popover);
+      expect(overlay.restoreFocusNode).to.eql(target);
+    });
   });
 
   describe('for', () => {
@@ -145,6 +151,10 @@ describe('popover', () => {
       popover.withBackdrop = false;
       await nextUpdate(popover);
       expect(overlay.withBackdrop).to.be.false;
+    });
+
+    it('should set restoreFocusOnClose on the overlay to true', () => {
+      expect(overlay.restoreFocusOnClose).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Description

Added logic to restore focus on close to the popover target.

## Type of change

- Feature