### PR TITLE
test: add missing data provider tests

### DIFF
--- a/packages/combo-box/test/lazy-loading.common.js
+++ b/packages/combo-box/test/lazy-loading.common.js
@@ -624,6 +624,12 @@ describe('lazy loading', () => {
         expect(comboBox.filteredItems).to.eql(['foo']);
       });
 
+      it('should add items when dataProvider return size undefined', () => {
+        comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], undefined);
+        comboBox.opened = true;
+        expect(comboBox.filteredItems).to.eql(['foo', 'bar']);
+      });
+
       it('should remove extra filteredItems when decreasing size', () => {
         comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 2);
         comboBox.open();

--- a/packages/combo-box/test/lazy-loading.common.js
+++ b/packages/combo-box/test/lazy-loading.common.js
@@ -618,6 +618,12 @@ describe('lazy loading', () => {
         expect(comboBox.size).to.equal(SIZE);
       });
 
+      it('should not add items exceeding the size returned by dataProvider', () => {
+        comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 1);
+        comboBox.opened = true;
+        expect(comboBox.filteredItems).to.eql(['foo']);
+      });
+
       it('should remove extra filteredItems when decreasing size', () => {
         comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 2);
         comboBox.open();


### PR DESCRIPTION
## Description

The PR adds unit tests to ensure that the combo-box adds items to the cache when the data provider returns undefined size and doesn't add items to the cache that exceed the returned size.

Related to https://github.com/vaadin/web-components/pull/7044

## Type of change

- [x] Internal
