### PR TITLE
refactor: do not initialize filteredItems property repeatedly

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -261,8 +261,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       if (this.items !== undefined && this.dataProvider !== undefined) {
         restoreOldValueCallback();
         throw new Error('Using `items` and `dataProvider` together is not supported');
-      } else if (this.dataProvider && !this.filteredItems) {
-        this.filteredItems = [];
       }
     }
 


### PR DESCRIPTION
## Description

The PR removes the redundant initialization of the `filteredItems` property in `_ensureItemsOrDataProvider()`, as this is already handled by `clearCache()` in `_dataProviderChanged()`, and here is a related test:

https://github.com/vaadin/web-components/blob/f9559b6c8ab642d55093528851c2d56902586167/packages/combo-box/test/lazy-loading.common.js#L254-L261

Extracted from #7044 

## Type of change

- [x] Refactor 
