### PR TITLE
chore: include current nodes in slot observer callback

### DIFF
--- a/packages/component-base/src/slot-observer.d.ts
+++ b/packages/component-base/src/slot-observer.d.ts
@@ -10,7 +10,7 @@
 export class SlotObserver {
   constructor(
     slot: HTMLSlotElement,
-    callback: (info: { addedNodes: Node[]; movedNodes: Node[]; removedNodes: Node[] }) => void,
+    callback: (info: { addedNodes: Node[]; currentNodes: Node[]; movedNodes: Node[]; removedNodes: Node[] }) => void,
   );
 
   /**

--- a/packages/component-base/src/slot-observer.js
+++ b/packages/component-base/src/slot-observer.js
@@ -97,7 +97,7 @@ export class SlotObserver {
     }
 
     if (addedNodes.length || removedNodes.length || movedNodes.length) {
-      this.callback({ addedNodes, movedNodes, removedNodes });
+      this.callback({ addedNodes, currentNodes, movedNodes, removedNodes });
     }
 
     this._storedNodes = currentNodes;

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -162,4 +162,28 @@ describe('SlotObserver', () => {
 
     expect(spy.calledOnce).to.be.true;
   });
+
+  it('should include current nodes in the callback', async () => {
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy);
+    expect(spy.called).to.be.false;
+
+    await Promise.resolve();
+
+    const childNodes = [...host.childNodes];
+    const currentNodes = spy.firstCall.args[0].currentNodes;
+
+    expect(currentNodes).to.be.an('array');
+    expect(currentNodes.length).to.equal(3);
+    expect(currentNodes).to.eql(childNodes);
+
+    spy.resetHistory();
+
+    childNodes[1].remove();
+    observer.flush();
+
+    const newCurrentNodes = spy.firstCall.args[0].currentNodes;
+    expect(newCurrentNodes.length).to.equal(2);
+    expect(newCurrentNodes).to.eql([childNodes[0], childNodes[2]]);
+  });
 });


### PR DESCRIPTION
## Description

Include current nodes in slot observer callback

Related to https://github.com/vaadin/web-components/issues/2043

## Type of change

- Chore (internal feature)