### PR TITLE
feat: add trigger property, make opened property public

### DIFF
--- a/dev/popover.html
+++ b/dev/popover.html
@@ -23,6 +23,8 @@
     <script type="module">
       const popover = document.querySelector('vaadin-popover');
 
+      // popover.trigger = ['hover', 'focus'];
+
       popover.renderer = (root) => {
         if (root.firstChild) {
           return;

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
+    "@vaadin/a11y-base": "24.5.0-alpha0",
     "@vaadin/component-base": "24.5.0-alpha0",
     "@vaadin/overlay": "24.5.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha0",

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css, html, LitElement } from 'lit';
+import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -86,6 +87,24 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
         <div part="content" id="content"><slot></slot></div>
       </div>
     `;
+  }
+
+  /**
+   * Override method inherited from `OverlayMixin` to not close
+   * modal popover on outside click when opening on focus.
+   *
+   * @param {Event} event
+   * @return {boolean}
+   * @protected
+   */
+  _shouldCloseOnOutsideClick(event) {
+    // When opening a modal popover on mouse focusin, the focus moves to the overlay
+    // and then outside click listener is fired. Detect this case and prevent closing.
+    if (this.owner.__hasTrigger('focus') && isElementFocused(this)) {
+      return false;
+    }
+
+    return super._shouldCloseOnOutsideClick(event);
   }
 }
 

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -39,6 +39,27 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
           margin-top: var(--vaadin-popover-offset-top, 0);
         }
 
+        [part='overlay'] {
+          position: relative;
+          overflow: visible;
+        }
+
+        [part='content'] {
+          overflow: auto;
+        }
+
+        /* Increase the area of the popover so the pointer can go from the target directly to it. */
+        [part='overlay']::before {
+          position: absolute;
+          content: '';
+          top: calc(var(--vaadin-popover-offset-top, 0) * -1);
+          bottom: calc(var(--vaadin-popover-offset-bottom, 0) * -1);
+          inset-inline-start: calc(var(--vaadin-popover-offset-start, 0) * -1);
+          inset-inline-end: calc(var(--vaadin-popover-offset-end, 0) * -1);
+          z-index: -1;
+          pointer-events: auto;
+        }
+
         :host([position^='top'][bottom-aligned]) [part='overlay'],
         :host([position^='bottom'][bottom-aligned]) [part='overlay'] {
           margin-bottom: var(--vaadin-popover-offset-bottom, 0);

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -16,11 +16,24 @@ export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
 export type PopoverTrigger = 'click' | 'hover-or-click' | 'hover-or-focus' | 'manual';
 
 /**
+ * Fired when the `opened` property changes.
+ */
+export type PopoverOpenedChangedEvent = CustomEvent<{ value: boolean }>;
+
+export interface PopoverCustomEventMap {
+  'opened-changed': PopoverOpenedChangedEvent;
+}
+
+export type PopoverEventMap = HTMLElementEventMap & PopoverCustomEventMap;
+
+/**
  * `<vaadin-popover>` is a Web Component for creating overlays
  * that are positioned next to specified DOM element (target).
  *
  * Unlike `<vaadin-tooltip>`, the popover supports rich content
  * that can be provided by using `renderer` function.
+ *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  */
 declare class Popover extends PopoverPositionMixin(
   PopoverTargetMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement)))),
@@ -92,6 +105,18 @@ declare class Popover extends PopoverPositionMixin(
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
    */
   requestContentUpdate(): void;
+
+  addEventListener<K extends keyof PopoverEventMap>(
+    type: K,
+    listener: (this: Popover, ev: PopoverEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof PopoverEventMap>(
+    type: K,
+    listener: (this: Popover, ev: PopoverEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
 }
 
 declare global {

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -77,7 +77,7 @@ declare class Popover extends PopoverPositionMixin(
   noCloseOnEsc: boolean;
 
   /**
-   * Popover trigger mode, used to configure the way how the overlay is opened or closed.
+   * Popover trigger mode, used to configure how the overlay is opened or closed.
    * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
    *
    * Supported values:

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -13,6 +13,8 @@ export type { PopoverPosition } from './vaadin-popover-position-mixin.js';
 
 export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
 
+export type PopoverTrigger = 'click' | 'hover-or-click' | 'hover-or-focus' | 'manual';
+
 /**
  * `<vaadin-popover>` is a Web Component for creating overlays
  * that are positioned next to specified DOM element (target).
@@ -23,6 +25,11 @@ export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
 declare class Popover extends PopoverPositionMixin(
   PopoverTargetMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement)))),
 ) {
+  /**
+   * True if the popover overlay is opened, false otherwise.
+   */
+  opened: boolean;
+
   /**
    * Custom function for rendering the content of the overlay.
    * Receives two arguments:
@@ -55,6 +62,20 @@ declare class Popover extends PopoverPositionMixin(
    * @attr {boolean} no-close-on-esc
    */
   noCloseOnEsc: boolean;
+
+  /**
+   * Used to configure the way how the popover overlay is opened or closed, based on
+   * the user interactions with the target element.
+   *
+   * Supported values:
+   * - `click` (default) - opens on target click, closes on outside click and Escape
+   * - `hover-or-click` - also opens on target mouseenter, closes on target mouseleave
+   * - `hover-or-focus` - opens on mouseenter and focus, closes on mouseleave and blur
+   * - `manual` - only can be opened by setting `opened` property on the host
+   *
+   * Note: moving mouse or focus inside the popover overlay content does not close it.
+   */
+  trigger: PopoverTrigger;
 
   /**
    * When true, the overlay has a backdrop (modality curtain) on top of the

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -82,7 +82,8 @@ declare class Popover extends PopoverPositionMixin(
    *
    * Supported values:
    * - `click` (default) - opens on target click, closes on outside click and Escape
-   * - `hover-or-click` - also opens on target mouseenter, closes on target mouseleave
+   * - `hover-or-click` - opens on target mouseenter, closes on target mouseleave.
+   * Also opens on click but only in case it originates from the keyboard (Enter / Space).
    * - `hover-or-focus` - opens on mouseenter and focus, closes on mouseleave and blur
    * - `manual` - only can be opened by setting `opened` property on the host
    *

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -13,7 +13,7 @@ export type { PopoverPosition } from './vaadin-popover-position-mixin.js';
 
 export type PopoverRenderer = (root: HTMLElement, popover: Popover) => void;
 
-export type PopoverTrigger = 'click' | 'hover-or-click' | 'hover-or-focus' | 'manual';
+export type PopoverTrigger = 'click' | 'focus' | 'hover';
 
 /**
  * Fired when the `opened` property changes.
@@ -77,19 +77,24 @@ declare class Popover extends PopoverPositionMixin(
   noCloseOnEsc: boolean;
 
   /**
-   * Used to configure the way how the popover overlay is opened or closed, based on
-   * the user interactions with the target element.
+   * Popover trigger mode, used to configure the way how the overlay is opened or closed.
+   * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
    *
    * Supported values:
-   * - `click` (default) - opens on target click, closes on outside click and Escape
-   * - `hover-or-click` - opens on target mouseenter, closes on target mouseleave.
-   * Also opens on click but only in case it originates from the keyboard (Enter / Space).
-   * - `hover-or-focus` - opens on mouseenter and focus, closes on mouseleave and blur
-   * - `manual` - only can be opened by setting `opened` property on the host
+   * - `click` (default) - opens and closes on target click.
+   * - `hover` - opens on target mouseenter, closes on target mouseleave. Moving mouse
+   * to the popover overlay content keeps the overlay opened.
+   * - `focus` - opens on target focus, closes on target blur. Moving focus to the
+   * popover overlay content keeps the overlay opened.
    *
-   * Note: moving mouse or focus inside the popover overlay content does not close it.
+   * In addition to the behavior specified by `trigger`, the popover can be closed by:
+   * - pressing Escape key (unless `noCloseOnEsc` property is true)
+   * - outside click (unless `noCloseOnOutsideClick` property is true)
+   *
+   * When setting `trigger` property to `null`, `undefined` or empty array, the popover
+   * can be only opened or closed programmatically by changing `opened` property.
    */
-  trigger: PopoverTrigger;
+  trigger: PopoverTrigger[] | null | undefined;
 
   /**
    * When true, the overlay has a backdrop (modality curtain) on top of the

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -6,6 +6,7 @@
 import './vaadin-popover-overlay.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
@@ -274,6 +275,13 @@ class Popover extends PopoverPositionMixin(
     this.__focusInside = true;
 
     if (this.__hasTrigger('focus')) {
+      // When trigger is set to both focus and click, only open on
+      // keyboard focus, to prevent issue when immediately closing
+      // on click which occurs after the focus caused by mousedown.
+      if (this.__hasTrigger('click') && !isKeyboardActive()) {
+        return;
+      }
+
       this.opened = true;
     }
   }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -6,6 +6,7 @@
 import './vaadin-popover-overlay.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
@@ -99,7 +100,8 @@ class Popover extends PopoverPositionMixin(
        *
        * Supported values:
        * - `click` (default) - opens on target click, closes on outside click and Escape
-       * - `hover-or-click` - also opens on target mouseenter, closes on target mouseleave
+       * - `hover-or-click` - opens on target mouseenter, closes on target mouseleave.
+       * Also opens on click but only in case it originates from the keyboard (Enter / Space).
        * - `hover-or-focus` - opens on mouseenter and focus, closes on mouseleave and blur
        * - `manual` - only can be opened by setting `opened` property on the host
        *
@@ -255,7 +257,7 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetClick() {
-    if (this.trigger === 'click' || this.trigger === 'hover-or-click') {
+    if (this.trigger === 'click' || (this.trigger === 'hover-or-click' && isKeyboardActive())) {
       this.opened = !this.opened;
     }
   }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -125,11 +125,6 @@ class Popover extends PopoverPositionMixin(
     };
   }
 
-  /** @private */
-  get __isHoverTrigger() {
-    return this.trigger === 'hover-or-click' || this.trigger === 'hover-or-focus';
-  }
-
   constructor() {
     super();
     this.__onGlobalClick = this.__onGlobalClick.bind(this);
@@ -286,18 +281,14 @@ class Popover extends PopoverPositionMixin(
       return;
     }
 
-    this.__focusInside = false;
-
-    if (this.trigger === 'hover-or-focus' && !this.__hoverInside) {
-      this.opened = false;
-    }
+    this.__handleFocusout();
   }
 
   /** @private */
   __onTargetMouseEnter() {
     this.__hoverInside = true;
 
-    if (this.__isHoverTrigger) {
+    if (this.trigger === 'hover-or-click' || this.trigger === 'hover-or-focus') {
       this.opened = true;
     }
   }
@@ -308,15 +299,7 @@ class Popover extends PopoverPositionMixin(
       return;
     }
 
-    this.__hoverInside = false;
-
-    if (this.trigger === 'hover-or-focus' && this.__focusInside) {
-      return;
-    }
-
-    if (this.__isHoverTrigger) {
-      this.opened = false;
-    }
+    this.__handleMouseLeave();
   }
 
   /** @private */
@@ -330,11 +313,7 @@ class Popover extends PopoverPositionMixin(
       return;
     }
 
-    this.__focusInside = false;
-
-    if (this.trigger === 'hover-or-focus' && !this.__hoverInside) {
-      this.opened = false;
-    }
+    this.__handleFocusout();
   }
 
   /** @private */
@@ -348,13 +327,27 @@ class Popover extends PopoverPositionMixin(
       return;
     }
 
+    this.__handleMouseLeave();
+  }
+
+  /** @private */
+  __handleFocusout() {
+    this.__focusInside = false;
+
+    if (this.trigger === 'hover-or-focus' && !this.__hoverInside) {
+      this.opened = false;
+    }
+  }
+
+  /** @private */
+  __handleMouseLeave() {
     this.__hoverInside = false;
 
     if (this.trigger === 'hover-or-focus' && this.__focusInside) {
       return;
     }
 
-    if (this.__isHoverTrigger) {
+    if (this.trigger === 'hover-or-click' || this.trigger === 'hover-or-focus') {
       this.opened = false;
     }
   }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -244,7 +244,7 @@ class Popover extends PopoverPositionMixin(
   __onGlobalClick(event) {
     if (
       this.opened &&
-      !this.__isManual() &&
+      !this.__isManual &&
       !this.modal &&
       !event.composedPath().some((el) => el === this._overlayElement || el === this.target) &&
       !this.noCloseOnOutsideClick
@@ -262,7 +262,7 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetKeydown(event) {
-    if (event.key === 'Escape' && !this.noCloseOnEsc && this.opened && !this.__isManual()) {
+    if (event.key === 'Escape' && !this.noCloseOnEsc && this.opened && !this.__isManual) {
       // Prevent closing parent overlay (e.g. dialog)
       event.stopPropagation();
       this.opened = false;
@@ -369,7 +369,7 @@ class Popover extends PopoverPositionMixin(
    * @private
    */
   __onEscapePress(e) {
-    if (this.noCloseOnEsc || this.__isManual()) {
+    if (this.noCloseOnEsc || this.__isManual) {
       e.preventDefault();
     }
   }
@@ -379,7 +379,7 @@ class Popover extends PopoverPositionMixin(
    * @private
    */
   __onOutsideClick(e) {
-    if (this.noCloseOnOutsideClick || this.__isManual()) {
+    if (this.noCloseOnOutsideClick || this.__isManual) {
       e.preventDefault();
     }
   }
@@ -390,7 +390,7 @@ class Popover extends PopoverPositionMixin(
   }
 
   /** @private */
-  __isManual() {
+  get __isManual() {
     return this.trigger == null || (Array.isArray(this.trigger) && this.trigger.length === 0);
   }
 }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -23,6 +23,8 @@ import { PopoverTargetMixin } from './vaadin-popover-target-mixin.js';
  * Unlike `<vaadin-tooltip>`, the popover supports rich content
  * that can be provided by using `renderer` function.
  *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ *
  * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -6,8 +6,6 @@
 import './vaadin-popover-overlay.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { timeOut } from '@vaadin/component-base/src/async.js';
-import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
@@ -298,8 +296,6 @@ class Popover extends PopoverPositionMixin(
     this.__hoverInside = true;
 
     if (this.__isHoverTrigger) {
-      // Retain opened state when moving pointer back to the target.
-      this.__abortClosing();
       this.opened = true;
     }
   }
@@ -317,7 +313,7 @@ class Popover extends PopoverPositionMixin(
     }
 
     if (this.__isHoverTrigger) {
-      this.__enqueueClosing();
+      this.opened = false;
     }
   }
 
@@ -342,13 +338,6 @@ class Popover extends PopoverPositionMixin(
   /** @private */
   __onOverlayMouseEnter() {
     this.__hoverInside = true;
-
-    // Retain opened state when moving pointer over the overlay.
-    // Closing can start due to an offset between the target and
-    // the overlay itself. If that's the case, cancel closing.
-    if (this.__isHoverTrigger) {
-      this.__abortClosing();
-    }
   }
 
   /** @private */
@@ -364,7 +353,7 @@ class Popover extends PopoverPositionMixin(
     }
 
     if (this.__isHoverTrigger) {
-      this.__enqueueClosing();
+      this.opened = false;
     }
   }
 
@@ -390,22 +379,6 @@ class Popover extends PopoverPositionMixin(
   __onOutsideClick(e) {
     if (this.noCloseOnOutsideClick || this.trigger === 'manual') {
       e.preventDefault();
-    }
-  }
-
-  /** @private */
-  __enqueueClosing() {
-    // NOTE: use 50ms timeout as a grace period to prevent immediate overlay closing
-    // as pointer moves to <body> due to offset between the target and the overlay.
-    this.__debounceClosing = Debouncer.debounce(this.__debounceClosing, timeOut.after(50), () => {
-      this.opened = false;
-    });
-  }
-
-  /** @private */
-  __abortClosing() {
-    if (this.__debounceClosing && this.__debounceClosing.isActive()) {
-      this.__debounceClosing.cancel();
     }
   }
 }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -164,7 +164,6 @@ class Popover extends PopoverPositionMixin(
         @focusin="${this.__onOverlayFocusin}"
         @focusout="${this.__onOverlayFocusout}"
         @opened-changed="${this.__onOpenedChanged}"
-        .restoreFocusOnClose="${this.__hasTrigger('click') && this.trigger.length === 1}"
         .restoreFocusNode="${this.target}"
         @vaadin-overlay-escape-press="${this.__onEscapePress}"
         @vaadin-overlay-outside-click="${this.__onOutsideClick}"

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -94,7 +94,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Popover trigger mode, used to configure the way how the overlay is opened or closed.
+       * Popover trigger mode, used to configure how the overlay is opened or closed.
        * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
        *
        * Supported values:
@@ -164,7 +164,7 @@ class Popover extends PopoverPositionMixin(
         @focusin="${this.__onOverlayFocusin}"
         @focusout="${this.__onOverlayFocusout}"
         @opened-changed="${this.__onOpenedChanged}"
-        .restoreFocusOnClose="${this.__isTrigger('click') && this.trigger.length === 1}"
+        .restoreFocusOnClose="${this.__hasTrigger('click') && this.trigger.length === 1}"
         .restoreFocusNode="${this.target}"
         @vaadin-overlay-escape-press="${this.__onEscapePress}"
         @vaadin-overlay-outside-click="${this.__onOutsideClick}"
@@ -256,7 +256,7 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetClick() {
-    if (this.__isTrigger('click')) {
+    if (this.__hasTrigger('click')) {
       this.opened = !this.opened;
     }
   }
@@ -274,7 +274,7 @@ class Popover extends PopoverPositionMixin(
   __onTargetFocusin() {
     this.__focusInside = true;
 
-    if (this.__isTrigger('focus')) {
+    if (this.__hasTrigger('focus')) {
       this.opened = true;
     }
   }
@@ -292,7 +292,7 @@ class Popover extends PopoverPositionMixin(
   __onTargetMouseEnter() {
     this.__hoverInside = true;
 
-    if (this.__isTrigger('hover')) {
+    if (this.__hasTrigger('hover')) {
       this.opened = true;
     }
   }
@@ -338,11 +338,11 @@ class Popover extends PopoverPositionMixin(
   __handleFocusout() {
     this.__focusInside = false;
 
-    if (this.__isTrigger('hover') && this.__hoverInside) {
+    if (this.__hasTrigger('hover') && this.__hoverInside) {
       return;
     }
 
-    if (this.__isTrigger('focus')) {
+    if (this.__hasTrigger('focus')) {
       this.opened = false;
     }
   }
@@ -351,11 +351,11 @@ class Popover extends PopoverPositionMixin(
   __handleMouseLeave() {
     this.__hoverInside = false;
 
-    if (this.__isTrigger('focus') && this.__focusInside) {
+    if (this.__hasTrigger('focus') && this.__focusInside) {
       return;
     }
 
-    if (this.__isTrigger('hover')) {
+    if (this.__hasTrigger('hover')) {
       this.opened = false;
     }
   }
@@ -386,7 +386,7 @@ class Popover extends PopoverPositionMixin(
   }
 
   /** @private */
-  __isTrigger(trigger) {
+  __hasTrigger(trigger) {
     return Array.isArray(this.trigger) && this.trigger.includes(trigger);
   }
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -134,8 +134,8 @@ class Popover extends PopoverPositionMixin(
     this.__onGlobalClick = this.__onGlobalClick.bind(this);
     this.__onTargetClick = this.__onTargetClick.bind(this);
     this.__onTargetKeydown = this.__onTargetKeydown.bind(this);
-    this.__onTargetFocusin = this.__onTargetFocusin.bind(this);
-    this.__onTargetFocusout = this.__onTargetFocusout.bind(this);
+    this.__onTargetFocusIn = this.__onTargetFocusIn.bind(this);
+    this.__onTargetFocusOut = this.__onTargetFocusOut.bind(this);
     this.__onTargetMouseEnter = this.__onTargetMouseEnter.bind(this);
     this.__onTargetMouseLeave = this.__onTargetMouseLeave.bind(this);
   }
@@ -161,8 +161,8 @@ class Popover extends PopoverPositionMixin(
         .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
         @mouseenter="${this.__onOverlayMouseEnter}"
         @mouseleave="${this.__onOverlayMouseLeave}"
-        @focusin="${this.__onOverlayFocusin}"
-        @focusout="${this.__onOverlayFocusout}"
+        @focusin="${this.__onOverlayFocusIn}"
+        @focusout="${this.__onOverlayFocusOut}"
         @opened-changed="${this.__onOpenedChanged}"
         .restoreFocusNode="${this.target}"
         @vaadin-overlay-escape-press="${this.__onEscapePress}"
@@ -218,8 +218,8 @@ class Popover extends PopoverPositionMixin(
     target.addEventListener('keydown', this.__onTargetKeydown);
     target.addEventListener('mouseenter', this.__onTargetMouseEnter);
     target.addEventListener('mouseleave', this.__onTargetMouseLeave);
-    target.addEventListener('focusin', this.__onTargetFocusin);
-    target.addEventListener('focusout', this.__onTargetFocusout);
+    target.addEventListener('focusin', this.__onTargetFocusIn);
+    target.addEventListener('focusout', this.__onTargetFocusOut);
   }
 
   /**
@@ -232,8 +232,8 @@ class Popover extends PopoverPositionMixin(
     target.removeEventListener('keydown', this.__onTargetKeydown);
     target.removeEventListener('mouseenter', this.__onTargetMouseEnter);
     target.removeEventListener('mouseleave', this.__onTargetMouseLeave);
-    target.removeEventListener('focusin', this.__onTargetFocusin);
-    target.removeEventListener('focusout', this.__onTargetFocusout);
+    target.removeEventListener('focusin', this.__onTargetFocusIn);
+    target.removeEventListener('focusout', this.__onTargetFocusOut);
   }
 
   /**
@@ -270,7 +270,7 @@ class Popover extends PopoverPositionMixin(
   }
 
   /** @private */
-  __onTargetFocusin() {
+  __onTargetFocusIn() {
     this.__focusInside = true;
 
     if (this.__hasTrigger('focus')) {
@@ -279,7 +279,7 @@ class Popover extends PopoverPositionMixin(
   }
 
   /** @private */
-  __onTargetFocusout(event) {
+  __onTargetFocusOut(event) {
     if (this._overlayElement.contains(event.relatedTarget)) {
       return;
     }
@@ -306,12 +306,12 @@ class Popover extends PopoverPositionMixin(
   }
 
   /** @private */
-  __onOverlayFocusin() {
+  __onOverlayFocusIn() {
     this.__focusInside = true;
   }
 
   /** @private */
-  __onOverlayFocusout(event) {
+  __onOverlayFocusOut(event) {
     if (event.relatedTarget === this.target || this._overlayElement.contains(event.relatedTarget)) {
       return;
     }

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -152,10 +152,6 @@ describe('popover', () => {
       await nextUpdate(popover);
       expect(overlay.withBackdrop).to.be.false;
     });
-
-    it('should set restoreFocusOnClose on the overlay to true', () => {
-      expect(overlay.restoreFocusOnClose).to.be.true;
-    });
   });
 
   describe('interactions', () => {

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -1,0 +1,235 @@
+import { expect } from '@esm-bundle/chai';
+import { aTimeout, esc, fire, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '../vaadin-popover.js';
+
+describe('trigger', () => {
+  let popover, target, overlay;
+
+  function mouseenter(target) {
+    fire(target, 'mouseenter');
+  }
+
+  function mouseleave(target, relatedTarget) {
+    const eventProps = relatedTarget ? { relatedTarget } : {};
+    fire(target, 'mouseleave', undefined, eventProps);
+  }
+
+  beforeEach(async () => {
+    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
+    target = fixtureSync('<button>Target</button>');
+    popover.target = target;
+    await nextRender();
+    overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+  });
+
+  describe('click', () => {
+    beforeEach(() => {
+      popover.trigger = 'click';
+    });
+
+    it('should open on target click', async () => {
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on target click', async () => {
+      target.click();
+      await nextRender();
+
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not open on target mouseenter', async () => {
+      mouseenter(target);
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close on target mouseleave', async () => {
+      target.click();
+      await nextRender();
+
+      mouseenter(target);
+      mouseleave(target);
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('hover-or-click', () => {
+    beforeEach(() => {
+      popover.trigger = 'hover-or-click';
+    });
+
+    it('should open on target mouseenter', async () => {
+      mouseenter(target);
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on target mouseleave after a timeout', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mouseleave(target);
+      await aTimeout(50);
+
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close on mouseleave from target to overlay', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mouseleave(target, overlay);
+      await aTimeout(50);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on target mouseleave followed by overlay mouseenter', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mouseleave(target);
+      mouseenter(overlay);
+      await aTimeout(50);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on overlay mouseleave after a timeout', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mouseenter(overlay);
+      mouseleave(overlay);
+      await aTimeout(50);
+
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close on mouseleave from overlay back to target', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mouseleave(target, overlay);
+      mouseleave(overlay, target);
+      await aTimeout(50);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on overlay mouseleave followed by target mouseenter', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mouseenter(overlay);
+      mouseleave(overlay);
+      mouseenter(target);
+      await aTimeout(50);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open on target click', async () => {
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on target click', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      target.click();
+      await nextRender();
+
+      expect(overlay.opened).to.be.false;
+    });
+  });
+
+  describe('manual', () => {
+    beforeEach(() => {
+      popover.trigger = 'manual';
+    });
+
+    it('should not open on target click', async () => {
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not open on target mouseenter', async () => {
+      mouseenter(target);
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open on setting opened to true', async () => {
+      popover.opened = true;
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on global Escape press', async () => {
+      popover.opened = true;
+      await nextRender();
+
+      esc(document.body);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on target Escape press', async () => {
+      popover.opened = true;
+      await nextRender();
+
+      esc(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on global Escape press when modal', async () => {
+      popover.modal = true;
+      popover.opened = true;
+      await nextRender();
+
+      esc(document.body);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on outside click when not modal', async () => {
+      popover.opened = true;
+      await nextRender();
+
+      outsideClick();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on outside click when modal', async () => {
+      popover.modal = true;
+      popover.opened = true;
+      await nextRender();
+
+      outsideClick();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close when setting opened to false', async () => {
+      popover.opened = true;
+      await nextRender();
+
+      popover.opened = false;
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+  });
+});

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -41,7 +41,7 @@ describe('trigger', () => {
 
   describe('click', () => {
     beforeEach(() => {
-      popover.trigger = 'click';
+      popover.trigger = ['click'];
     });
 
     it('should open on target click', async () => {
@@ -76,9 +76,9 @@ describe('trigger', () => {
     });
   });
 
-  describe('hover-or-click', () => {
+  describe('hover', () => {
     beforeEach(async () => {
-      popover.trigger = 'hover-or-click';
+      popover.trigger = ['hover'];
       await nextUpdate(popover);
     });
 
@@ -133,59 +133,16 @@ describe('trigger', () => {
 
       expect(overlay.opened).to.be.true;
     });
-
-    it('should not open on target click from mouse', async () => {
-      mousedown(target);
-      enter(target);
-      target.click();
-      await nextRender();
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should open on target click from keyboard', async () => {
-      enter(target);
-      target.click();
-      await nextRender();
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should not close on target click from mouse', async () => {
-      mouseenter(target);
-      await nextRender();
-
-      mousedown(target);
-      target.click();
-      await nextRender();
-
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should close on target click from keyboard', async () => {
-      mouseenter(target);
-      await nextRender();
-
-      enter(target);
-      target.click();
-      await nextRender();
-
-      expect(overlay.opened).to.be.false;
-    });
   });
 
-  describe('hover-or-focus', () => {
+  describe('focus', () => {
     beforeEach(async () => {
-      popover.trigger = 'hover-or-focus';
+      popover.trigger = ['focus'];
       await nextUpdate(popover);
     });
 
     it('should set restoreFocusOnClose to false', () => {
       expect(overlay.restoreFocusOnClose).to.be.false;
-    });
-
-    it('should open on target mouseenter', async () => {
-      mouseenter(target);
-      await nextRender();
-      expect(overlay.opened).to.be.true;
     });
 
     it('should open on target focusin', async () => {
@@ -201,6 +158,63 @@ describe('trigger', () => {
       focusout(target);
       await nextUpdate(popover);
       expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close on target focusout to the overlay', async () => {
+      focusin(target);
+      await nextRender();
+
+      focusout(target, overlay);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on overlay focusout', async () => {
+      focusin(target);
+      await nextRender();
+
+      focusout(target, overlay);
+      focusout(overlay);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close on overlay focusout to the overlay content', async () => {
+      focusin(target);
+      await nextRender();
+
+      focusout(overlay, overlay.firstElementChild);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on overlay focusout back to the target', async () => {
+      focusin(target);
+      await nextRender();
+
+      focusout(target, overlay);
+      focusout(overlay, target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('hover and focus', () => {
+    beforeEach(async () => {
+      popover.trigger = ['hover', 'focus'];
+      await nextUpdate(popover);
+    });
+
+    it('should open on target mouseenter', async () => {
+      mouseenter(target);
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open on target focusin', async () => {
+      focusin(target);
+      await nextRender();
+      expect(overlay.opened).to.be.true;
     });
 
     it('should not close on target focusout if target has hover', async () => {
@@ -245,44 +259,6 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.false;
     });
 
-    it('should not close on target focusout to the overlay', async () => {
-      focusin(target);
-      await nextRender();
-
-      focusout(target, overlay);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should close on overlay focusout', async () => {
-      focusin(target);
-      await nextRender();
-
-      focusout(target, overlay);
-      focusout(overlay);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.false;
-    });
-
-    it('should not close on overlay focusout to the overlay content', async () => {
-      focusin(target);
-      await nextRender();
-
-      focusout(overlay, overlay.firstElementChild);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should not close on overlay focusout back to the target', async () => {
-      focusin(target);
-      await nextRender();
-
-      focusout(target, overlay);
-      focusout(overlay, target);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
-
     it('should not close on target mouseleave if target has focus', async () => {
       mouseenter(target);
       await nextRender();
@@ -316,87 +292,99 @@ describe('trigger', () => {
   });
 
   describe('manual', () => {
-    beforeEach(async () => {
-      popover.trigger = 'manual';
-      await nextUpdate(popover);
-    });
+    [null, undefined, []].forEach((value) => {
+      const trigger = Array.isArray(value) ? 'empty array' : value;
 
-    it('should set restoreFocusOnClose to false', () => {
-      expect(overlay.restoreFocusOnClose).to.be.false;
-    });
+      describe(`trigger set to ${trigger}`, () => {
+        beforeEach(async () => {
+          popover.trigger = value;
+          await nextUpdate(popover);
+        });
 
-    it('should not open on target click', async () => {
-      target.click();
-      await nextRender();
-      expect(overlay.opened).to.be.false;
-    });
+        it(`should set restoreFocusOnClose to false with trigger set to ${trigger}`, () => {
+          expect(overlay.restoreFocusOnClose).to.be.false;
+        });
 
-    it('should not open on target mouseenter', async () => {
-      mouseenter(target);
-      await nextRender();
-      expect(overlay.opened).to.be.false;
-    });
+        it(`should not open on target click with trigger set to ${trigger}`, async () => {
+          target.click();
+          await nextRender();
+          expect(overlay.opened).to.be.false;
+        });
 
-    it('should open on setting opened to true', async () => {
-      popover.opened = true;
-      await nextRender();
-      expect(overlay.opened).to.be.true;
-    });
+        it(`should not open on target mouseenter with trigger set to ${trigger}`, async () => {
+          mouseenter(target);
+          await nextRender();
+          expect(overlay.opened).to.be.false;
+        });
 
-    it('should not close on global Escape press', async () => {
-      popover.opened = true;
-      await nextRender();
+        it(`should not open on target focusin with trigger set to ${trigger}`, async () => {
+          focusin(target);
+          await nextRender();
+          expect(overlay.opened).to.be.false;
+        });
 
-      esc(document.body);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
+        it(`should open on setting opened to true with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
+          expect(overlay.opened).to.be.true;
+        });
 
-    it('should not close on target Escape press', async () => {
-      popover.opened = true;
-      await nextRender();
+        it(`should not close on global Escape press with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
 
-      esc(target);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
+          esc(document.body);
+          await nextUpdate(popover);
+          expect(overlay.opened).to.be.true;
+        });
 
-    it('should not close on global Escape press when modal', async () => {
-      popover.modal = true;
-      popover.opened = true;
-      await nextRender();
+        it(`should not close on target Escape press with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
 
-      esc(document.body);
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
+          esc(target);
+          await nextUpdate(popover);
+          expect(overlay.opened).to.be.true;
+        });
 
-    it('should not close on outside click when not modal', async () => {
-      popover.opened = true;
-      await nextRender();
+        it(`should not close on global Escape press when modal with trigger set to ${trigger}`, async () => {
+          popover.modal = true;
+          popover.opened = true;
+          await nextRender();
 
-      outsideClick();
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
+          esc(document.body);
+          await nextUpdate(popover);
+          expect(overlay.opened).to.be.true;
+        });
 
-    it('should not close on outside click when modal', async () => {
-      popover.modal = true;
-      popover.opened = true;
-      await nextRender();
+        it(`should not close on outside click when not modal with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
 
-      outsideClick();
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.true;
-    });
+          outsideClick();
+          await nextUpdate(popover);
+          expect(overlay.opened).to.be.true;
+        });
 
-    it('should close when setting opened to false', async () => {
-      popover.opened = true;
-      await nextRender();
+        it(`should not close on outside click when modal with trigger set to ${trigger}`, async () => {
+          popover.modal = true;
+          popover.opened = true;
+          await nextRender();
 
-      popover.opened = false;
-      await nextUpdate(popover);
-      expect(overlay.opened).to.be.false;
+          outsideClick();
+          await nextUpdate(popover);
+          expect(overlay.opened).to.be.true;
+        });
+
+        it(`should close when setting opened to false with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
+
+          popover.opened = false;
+          await nextUpdate(popover);
+          expect(overlay.opened).to.be.false;
+        });
+      });
     });
   });
 });

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -190,6 +190,17 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.true;
     });
 
+    it('should close on target focusout if target has lost hover', async () => {
+      focusin(target);
+      await nextRender();
+
+      mouseenter(target);
+      mouseleave(target);
+      focusout(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
     it('should not close on target focusout if overlay has hover', async () => {
       focusin(target);
       await nextRender();
@@ -198,6 +209,17 @@ describe('trigger', () => {
       focusout(target);
       await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on target focusout if overlay has lost hover', async () => {
+      focusin(target);
+      await nextRender();
+
+      mouseenter(overlay);
+      mouseleave(overlay);
+      focusout(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
     });
 
     it('should not close on target focusout to the overlay', async () => {
@@ -224,6 +246,16 @@ describe('trigger', () => {
       await nextRender();
 
       focusout(overlay, overlay.firstElementChild);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on overlay focusout back to the target', async () => {
+      focusin(target);
+      await nextRender();
+
+      focusout(target, overlay);
+      focusout(overlay, target);
       await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -281,6 +281,30 @@ describe('trigger', () => {
     });
   });
 
+  describe('focus and click', () => {
+    beforeEach(async () => {
+      popover.trigger = ['click', 'focus'];
+      await nextUpdate(popover);
+    });
+
+    it('should not immediately close on target click when opened on focusin', async () => {
+      target.focus();
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on target click after a delay when opened on focusin', async () => {
+      target.focus();
+      target.click();
+      await nextRender();
+
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+  });
+
   describe('manual', () => {
     [null, undefined, []].forEach((value) => {
       const trigger = Array.isArray(value) ? 'empty array' : value;

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  aTimeout,
   esc,
   fire,
   fixtureSync,
@@ -91,12 +90,12 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should close on target mouseleave after a timeout', async () => {
+    it('should close on target mouseleave', async () => {
       mouseenter(target);
       await nextRender();
 
       mouseleave(target);
-      await aTimeout(50);
+      await nextUpdate(popover);
 
       expect(overlay.opened).to.be.false;
     });
@@ -106,29 +105,18 @@ describe('trigger', () => {
       await nextRender();
 
       mouseleave(target, overlay);
-      await aTimeout(50);
+      await nextUpdate(popover);
 
       expect(overlay.opened).to.be.true;
     });
 
-    it('should not close on target mouseleave followed by overlay mouseenter', async () => {
-      mouseenter(target);
-      await nextRender();
-
-      mouseleave(target);
-      mouseenter(overlay);
-      await aTimeout(50);
-
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should close on overlay mouseleave after a timeout', async () => {
+    it('should close on overlay mouseleave', async () => {
       mouseenter(target);
       await nextRender();
 
       mouseenter(overlay);
       mouseleave(overlay);
-      await aTimeout(50);
+      await nextUpdate(popover);
 
       expect(overlay.opened).to.be.false;
     });
@@ -139,19 +127,7 @@ describe('trigger', () => {
 
       mouseleave(target, overlay);
       mouseleave(overlay, target);
-      await aTimeout(50);
-
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should not close on overlay mouseleave followed by target mouseenter', async () => {
-      mouseenter(target);
-      await nextRender();
-
-      mouseenter(overlay);
-      mouseleave(overlay);
-      mouseenter(target);
-      await aTimeout(50);
+      await nextUpdate(popover);
 
       expect(overlay.opened).to.be.true;
     });
@@ -258,7 +234,7 @@ describe('trigger', () => {
 
       focusin(target);
       mouseleave(target);
-      await aTimeout(50);
+      await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });
 
@@ -268,7 +244,7 @@ describe('trigger', () => {
 
       focusin(overlay);
       mouseleave(target);
-      await aTimeout(50);
+      await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });
 
@@ -279,7 +255,7 @@ describe('trigger', () => {
       focusin(overlay);
       mouseenter(overlay);
       mouseleave(overlay);
-      await aTimeout(50);
+      await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });
   });

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -82,10 +82,6 @@ describe('trigger', () => {
       await nextUpdate(popover);
     });
 
-    it('should set restoreFocusOnClose to false', () => {
-      expect(overlay.restoreFocusOnClose).to.be.false;
-    });
-
     it('should open on target mouseenter', async () => {
       mouseenter(target);
       await nextRender();
@@ -139,10 +135,6 @@ describe('trigger', () => {
     beforeEach(async () => {
       popover.trigger = ['focus'];
       await nextUpdate(popover);
-    });
-
-    it('should set restoreFocusOnClose to false', () => {
-      expect(overlay.restoreFocusOnClose).to.be.false;
     });
 
     it('should open on target focusin', async () => {
@@ -299,10 +291,6 @@ describe('trigger', () => {
         beforeEach(async () => {
           popover.trigger = value;
           await nextUpdate(popover);
-        });
-
-        it(`should set restoreFocusOnClose to false with trigger set to ${trigger}`, () => {
-          expect(overlay.restoreFocusOnClose).to.be.false;
         });
 
         it(`should not open on target click with trigger set to ${trigger}`, async () => {

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -1,10 +1,12 @@
 import { expect } from '@esm-bundle/chai';
 import {
+  enter,
   esc,
   fire,
   fixtureSync,
   focusin,
   focusout,
+  mousedown,
   nextRender,
   nextUpdate,
   outsideClick,
@@ -132,16 +134,37 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should open on target click', async () => {
+    it('should not open on target click from mouse', async () => {
+      mousedown(target);
+      enter(target);
       target.click();
       await nextRender();
       expect(overlay.opened).to.be.true;
     });
 
-    it('should close on target click', async () => {
+    it('should open on target click from keyboard', async () => {
+      enter(target);
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on target click from mouse', async () => {
       mouseenter(target);
       await nextRender();
 
+      mousedown(target);
+      target.click();
+      await nextRender();
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close on target click from keyboard', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      enter(target);
       target.click();
       await nextRender();
 

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -1,12 +1,10 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  enter,
   esc,
   fire,
   fixtureSync,
   focusin,
   focusout,
-  mousedown,
   nextRender,
   nextUpdate,
   outsideClick,

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -187,6 +187,20 @@ describe('trigger', () => {
       await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });
+
+    it('should open on target focusin followed by click when modal', async () => {
+      popover.modal = true;
+      await nextUpdate(popover);
+
+      target.focus();
+      // Wait for open focus trap
+      await nextRender();
+
+      // Emulate click without focus change
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
   });
 
   describe('hover and focus', () => {

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -317,6 +317,26 @@ describe('trigger', () => {
           expect(overlay.opened).to.be.true;
         });
 
+        it(`should not close on target mouseleave with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
+
+          mouseenter(target);
+          mouseleave(target);
+          await nextRender();
+          expect(overlay.opened).to.be.true;
+        });
+
+        it(`should not close on target focusout with trigger set to ${trigger}`, async () => {
+          popover.opened = true;
+          await nextRender();
+
+          focusin(target);
+          focusout(target);
+          await nextRender();
+          expect(overlay.opened).to.be.true;
+        });
+
         it(`should not close on global Escape press with trigger set to ${trigger}`, async () => {
           popover.opened = true;
           await nextRender();

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -4,7 +4,12 @@ import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { PopoverPositionMixinClass } from '../../src/vaadin-popover-position-mixin.js';
 import type { PopoverTargetMixinClass } from '../../src/vaadin-popover-target-mixin.js';
-import type { PopoverPosition, PopoverRenderer, PopoverTrigger } from '../../vaadin-popover.js';
+import type {
+  PopoverOpenedChangedEvent,
+  PopoverPosition,
+  PopoverRenderer,
+  PopoverTrigger,
+} from '../../vaadin-popover.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -29,3 +34,9 @@ assertType<boolean>(popover.modal);
 assertType<boolean>(popover.withBackdrop);
 assertType<boolean>(popover.noCloseOnEsc);
 assertType<boolean>(popover.noCloseOnOutsideClick);
+
+// Events
+popover.addEventListener('opened-changed', (event) => {
+  assertType<PopoverOpenedChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -4,7 +4,7 @@ import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { PopoverPositionMixinClass } from '../../src/vaadin-popover-position-mixin.js';
 import type { PopoverTargetMixinClass } from '../../src/vaadin-popover-target-mixin.js';
-import type { PopoverPosition, PopoverRenderer } from '../../vaadin-popover.js';
+import type { PopoverPosition, PopoverRenderer, PopoverTrigger } from '../../vaadin-popover.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -22,7 +22,9 @@ assertType<string | undefined>(popover.for);
 assertType<HTMLElement | undefined>(popover.target);
 assertType<PopoverPosition>(popover.position);
 assertType<PopoverRenderer | null | undefined>(popover.renderer);
+assertType<PopoverTrigger>(popover.trigger);
 assertType<string>(popover.overlayClass);
+assertType<boolean>(popover.opened);
 assertType<boolean>(popover.modal);
 assertType<boolean>(popover.withBackdrop);
 assertType<boolean>(popover.noCloseOnEsc);

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -27,7 +27,7 @@ assertType<string | undefined>(popover.for);
 assertType<HTMLElement | undefined>(popover.target);
 assertType<PopoverPosition>(popover.position);
 assertType<PopoverRenderer | null | undefined>(popover.renderer);
-assertType<PopoverTrigger>(popover.trigger);
+assertType<PopoverTrigger[] | null | undefined>(popover.trigger);
 assertType<string>(popover.overlayClass);
 assertType<boolean>(popover.opened);
 assertType<boolean>(popover.modal);


### PR DESCRIPTION
## Description

- Added the `trigger` property for setting how popover opens and closes.
- Changed `opened` property to be public (especially for `manual` trigger).

## Type of change

- Feature