### PR TITLE
refactor: close popover on global Escape press by default

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -143,6 +143,7 @@ class Popover extends PopoverPositionMixin(
     this.__onGlobalClick = this.__onGlobalClick.bind(this);
     this.__onGlobalKeyDown = this.__onGlobalKeyDown.bind(this);
     this.__onTargetClick = this.__onTargetClick.bind(this);
+    this.__onTargetKeydown = this.__onTargetKeydown.bind(this);
     this.__onTargetFocusIn = this.__onTargetFocusIn.bind(this);
     this.__onTargetFocusOut = this.__onTargetFocusOut.bind(this);
     this.__onTargetMouseEnter = this.__onTargetMouseEnter.bind(this);
@@ -226,6 +227,7 @@ class Popover extends PopoverPositionMixin(
    */
   _addTargetListeners(target) {
     target.addEventListener('click', this.__onTargetClick);
+    target.addEventListener('keydown', this.__onTargetKeydown);
     target.addEventListener('mouseenter', this.__onTargetMouseEnter);
     target.addEventListener('mouseleave', this.__onTargetMouseLeave);
     target.addEventListener('focusin', this.__onTargetFocusIn);
@@ -239,6 +241,7 @@ class Popover extends PopoverPositionMixin(
    */
   _removeTargetListeners(target) {
     target.removeEventListener('click', this.__onTargetClick);
+    target.removeEventListener('keydown', this.__onTargetKeydown);
     target.removeEventListener('mouseenter', this.__onTargetMouseEnter);
     target.removeEventListener('mouseleave', this.__onTargetMouseLeave);
     target.removeEventListener('focusin', this.__onTargetFocusIn);
@@ -292,7 +295,10 @@ class Popover extends PopoverPositionMixin(
       event.stopPropagation();
       this.opened = false;
     }
+  }
 
+  /** @private */
+  __onTargetKeydown(event) {
     // Prevent restoring focus after target blur on Tab key
     if (event.key === 'Tab' && this.__shouldRestoreFocus) {
       this.__shouldRestoreFocus = false;

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -234,7 +234,16 @@ describe('popover', () => {
         await nextRender();
       });
 
-      it('should not close overlay on global Escape press by default', async () => {
+      it('should close overlay on global Escape press by default', async () => {
+        esc(document.body);
+        await nextRender();
+        expect(overlay.opened).to.be.false;
+      });
+
+      it('should not close on global Escape press if noCloseOnEsc is true', async () => {
+        popover.noCloseOnEsc = true;
+        await nextUpdate(popover);
+
         esc(document.body);
         await nextRender();
         expect(overlay.opened).to.be.true;
@@ -249,42 +258,12 @@ describe('popover', () => {
         expect(overlay.opened).to.be.false;
       });
 
-      it('should close overlay on internal Escape press by default', async () => {
-        esc(overlay.$.overlay);
-        await nextRender();
-        expect(overlay.opened).to.be.false;
-      });
-
-      it('should close overlay on target Escape press by default', async () => {
-        esc(target);
-        await nextRender();
-        expect(overlay.opened).to.be.false;
-      });
-
-      it('should not close on global Escape press if noCloseOnEsc is true', async () => {
+      it('should not close on global Escape press if noCloseOnEsc is true when moodal', async () => {
         popover.modal = true;
         popover.noCloseOnEsc = true;
         await nextUpdate(popover);
 
         esc(document.body);
-        await nextRender();
-        expect(overlay.opened).to.be.true;
-      });
-
-      it('should not close overlay on internal Escape if noCloseOnEsc is true', async () => {
-        popover.noCloseOnEsc = true;
-        await nextUpdate(popover);
-
-        esc(overlay.$.overlay);
-        await nextRender();
-        expect(overlay.opened).to.be.true;
-      });
-
-      it('should not close overlay on target Escape if noCloseOnEsc is true', async () => {
-        popover.noCloseOnEsc = true;
-        await nextUpdate(popover);
-
-        esc(target);
         await nextRender();
         expect(overlay.opened).to.be.true;
       });


### PR DESCRIPTION
## Description

Depends on #7430 

Changed the logic to always close the popover on <kbd>Esc</kbd> using global listener like in `vaadin-tooltip`:

https://github.com/vaadin/web-components/blob/9f3ac555d5fef1845a1f98cc7e0b311be4094772/packages/tooltip/src/vaadin-tooltip-mixin.js#L476-L480

This is needed to align the behavior so that `vaadin-popover` opened on hover can also be dismissed by <kbd>Esc</kbd>.

## Type of change

- Refactor