### PR TITLE
refactor: restore focus for popover click and focus triggers

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -321,7 +321,10 @@ class Popover extends PopoverPositionMixin(
     this.__hoverInside = true;
 
     if (this.__hasTrigger('hover') && !this.opened) {
-      this.__shouldRestoreFocus = false;
+      // Prevent closing due to `pointer-events: none` set on body.
+      if (this.modal) {
+        this.target.style.pointerEvents = 'auto';
+      }
       this.opened = true;
     }
   }
@@ -402,6 +405,11 @@ class Popover extends PopoverPositionMixin(
       setTimeout(() => {
         this.__shouldRestoreFocus = false;
       });
+    }
+
+    // Restore pointer-events set when opening on hover.
+    if (this.modal && this.target.style.pointerEvents) {
+      this.target.style.pointerEvents = '';
     }
   }
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -341,6 +341,12 @@ class Popover extends PopoverPositionMixin(
   /** @private */
   __onOverlayFocusIn() {
     this.__focusInside = true;
+
+    // When using Tab to move focus, restoring focus is reset. However, if pressing Tab
+    // causes focus to be moved inside the overlay, we should restore focus on close.
+    if ((this.__hasTrigger('focus') || this.__hasTrigger('click')) && !this.__shouldRestoreFocus) {
+      this.__shouldRestoreFocus = true;
+    }
   }
 
   /** @private */

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -344,7 +344,7 @@ class Popover extends PopoverPositionMixin(
 
     // When using Tab to move focus, restoring focus is reset. However, if pressing Tab
     // causes focus to be moved inside the overlay, we should restore focus on close.
-    if ((this.__hasTrigger('focus') || this.__hasTrigger('click')) && !this.__shouldRestoreFocus) {
+    if (this.__hasTrigger('focus') || this.__hasTrigger('click')) {
       this.__shouldRestoreFocus = true;
     }
   }

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -1,0 +1,163 @@
+import { expect } from '@esm-bundle/chai';
+import { esc, fixtureSync, focusout, nextRender, nextUpdate, outsideClick, tab } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './not-animated-styles.js';
+import '../vaadin-popover.js';
+import { mouseenter, mouseleave } from './helpers.js';
+
+describe('a11y', () => {
+  let popover, target, overlay;
+
+  beforeEach(async () => {
+    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
+    target = fixtureSync('<button>Target</button>');
+    popover.target = target;
+    popover.renderer = (root) => {
+      if (!root.firstChild) {
+        root.appendChild(document.createElement('input'));
+      }
+    };
+    await nextRender();
+    overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+  });
+
+  describe('focus restoration', () => {
+    describe('focus trigger', () => {
+      beforeEach(async () => {
+        popover.trigger = ['focus'];
+        await nextUpdate(popover);
+
+        target.focus();
+        await nextRender();
+      });
+
+      it('should restore focus on Esc with trigger set to focus', async () => {
+        const focusSpy = sinon.spy(target, 'focus');
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(focusSpy).to.be.calledOnce;
+      });
+
+      it('should not restore focus on Tab with trigger set to focus', async () => {
+        const focusSpy = sinon.spy(target, 'focus');
+        overlay.$.overlay.focus();
+        tab(target);
+        focusout(target);
+        await nextRender();
+
+        expect(focusSpy).to.not.be.called;
+      });
+
+      it('should not re-open when restoring focus on Esc with trigger set to focus', async () => {
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(popover.opened).to.be.false;
+      });
+
+      it('should not re-open when restoring focus on outside click with trigger set to focus', async () => {
+        overlay.$.overlay.focus();
+        outsideClick();
+        await nextRender();
+
+        expect(popover.opened).to.be.false;
+      });
+
+      it('should re-open when re-focusing after closing on outside click with trigger set to focus', async () => {
+        overlay.$.overlay.focus();
+        outsideClick();
+        await nextRender();
+
+        target.blur();
+        target.focus();
+        await nextRender();
+
+        expect(popover.opened).to.be.true;
+      });
+    });
+
+    describe('click trigger', () => {
+      beforeEach(async () => {
+        popover.trigger = ['click'];
+        await nextUpdate(popover);
+
+        target.click();
+        await nextRender();
+      });
+
+      it('should restore focus on Esc with trigger set to click', async () => {
+        const focusSpy = sinon.spy(target, 'focus');
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(focusSpy).to.be.calledOnce;
+      });
+
+      it('should restore focus on outside click with trigger set to click', async () => {
+        const focusSpy = sinon.spy(target, 'focus');
+        outsideClick();
+        await nextRender();
+
+        expect(focusSpy).to.be.calledOnce;
+      });
+    });
+
+    describe('hover trigger', () => {
+      it('should not restore focus on Esc with trigger set to hover', async () => {
+        popover.trigger = ['hover'];
+        await nextUpdate(popover);
+
+        mouseenter(target);
+        await nextRender();
+
+        const focusSpy = sinon.spy(target, 'focus');
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(focusSpy).to.not.be.called;
+      });
+    });
+
+    describe('hover and focus trigger', () => {
+      beforeEach(async () => {
+        popover.trigger = ['hover', 'focus'];
+        await nextUpdate(popover);
+
+        target.focus();
+        await nextRender();
+      });
+
+      it('should not restore focus when re-opening on hover after being restored', async () => {
+        outsideClick();
+        await nextRender();
+
+        // Re-open overlay
+        mouseenter(target);
+        await nextRender();
+
+        const focusSpy = sinon.spy(target, 'focus');
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(focusSpy).to.not.be.called;
+      });
+
+      it('should restore focus when hover occurs after opening on focus', async () => {
+        mouseenter(target);
+
+        const focusSpy = sinon.spy(target, 'focus');
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(focusSpy).to.be.calledOnce;
+      });
+    });
+  });
+});

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -107,10 +107,12 @@ describe('a11y', () => {
     });
 
     describe('hover trigger', () => {
-      it('should not restore focus on Esc with trigger set to hover', async () => {
+      beforeEach(async () => {
         popover.trigger = ['hover'];
         await nextUpdate(popover);
+      });
 
+      it('should not restore focus on Esc with trigger set to hover', async () => {
         mouseenter(target);
         await nextRender();
 
@@ -120,6 +122,29 @@ describe('a11y', () => {
         await nextRender();
 
         expect(focusSpy).to.not.be.called;
+      });
+
+      it('should set pointer-events: auto on the target when opened if modal', async () => {
+        popover.modal = true;
+        await nextUpdate(popover);
+
+        mouseenter(target);
+        await nextRender();
+
+        expect(target.style.pointerEvents).to.equal('auto');
+      });
+
+      it('should remove pointer-events on the target when closed if modal', async () => {
+        popover.modal = true;
+        await nextUpdate(popover);
+
+        mouseenter(target);
+        await nextRender();
+
+        mouseleave(target);
+        await nextRender();
+
+        expect(target.style.pointerEvents).to.equal('');
       });
     });
 

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -50,6 +50,17 @@ describe('a11y', () => {
         expect(focusSpy).to.not.be.called;
       });
 
+      it('should restore focus on close after Tab to overlay with trigger set to focus', async () => {
+        const focusSpy = sinon.spy(target, 'focus');
+        tab(target);
+        focusout(target, overlay);
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
+        await nextRender();
+
+        expect(focusSpy).to.be.calledOnce;
+      });
+
       it('should not re-open when restoring focus on Esc with trigger set to focus', async () => {
         overlay.$.overlay.focus();
         esc(overlay.$.overlay);
@@ -100,6 +111,17 @@ describe('a11y', () => {
       it('should restore focus on outside click with trigger set to click', async () => {
         const focusSpy = sinon.spy(target, 'focus');
         outsideClick();
+        await nextRender();
+
+        expect(focusSpy).to.be.calledOnce;
+      });
+
+      it('should restore focus on close after Tab to overlay with trigger set to click', async () => {
+        const focusSpy = sinon.spy(target, 'focus');
+        tab(target);
+        focusout(target, overlay);
+        overlay.$.overlay.focus();
+        esc(overlay.$.overlay);
         await nextRender();
 
         expect(focusSpy).to.be.calledOnce;

--- a/packages/popover/test/helpers.js
+++ b/packages/popover/test/helpers.js
@@ -1,0 +1,10 @@
+import { fire } from '@vaadin/testing-helpers';
+
+export function mouseenter(target) {
+  fire(target, 'mouseenter');
+}
+
+export function mouseleave(target, relatedTarget) {
+  const eventProps = relatedTarget ? { relatedTarget } : {};
+  fire(target, 'mouseleave', undefined, eventProps);
+}

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -11,18 +11,10 @@ import {
 } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-popover.js';
+import { mouseenter, mouseleave } from './helpers.js';
 
 describe('trigger', () => {
   let popover, target, overlay;
-
-  function mouseenter(target) {
-    fire(target, 'mouseenter');
-  }
-
-  function mouseleave(target, relatedTarget) {
-    const eventProps = relatedTarget ? { relatedTarget } : {};
-    fire(target, 'mouseleave', undefined, eventProps);
-  }
 
   beforeEach(async () => {
     popover = fixtureSync('<vaadin-popover></vaadin-popover>');


### PR DESCRIPTION
## Description

Re-enabled `restoreFocusOnClose` and changed the way how it is configured to work for `click` and `focus` triggers.
When using `trigger = ['hover', 'focus']`, the focus is still restored if opened on focus, but not if opened on hover.

## Type of change

- Refactor