### PR TITLE
feat: add focusDelay, hoverDelay and hideDelay to popover

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -53,6 +53,28 @@ declare class Popover extends PopoverPositionMixin(
   contentWidth: string;
 
   /**
+   * The delay in milliseconds before the popover is opened
+   * on focus when the corresponding trigger is used.
+   * @attr {number} focus-delay
+   */
+  focusDelay: number;
+
+  /**
+   * The delay in milliseconds before the popover is closed
+   * on losing hover, when the corresponding trigger is used.
+   * On blur, the popover is closed immediately.
+   * @attr {number} hide-delay
+   */
+  hideDelay: number;
+
+  /**
+   * The delay in milliseconds before the popover is opened
+   * on hover when the corresponding trigger is used.
+   * @attr {number} hover-delay
+   */
+  hoverDelay: number;
+
+  /**
    * True if the popover overlay is opened, false otherwise.
    */
   opened: boolean;

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -32,17 +32,17 @@ class PopoverOpenedStateController {
   }
 
   /** @private */
-  get focusDelay() {
+  get __focusDelay() {
     return this.host.focusDelay || 0;
   }
 
   /** @private */
-  get hoverDelay() {
+  get __hoverDelay() {
     return this.host.hoverDelay || 0;
   }
 
   /** @private */
-  get hideDelay() {
+  get __hideDelay() {
     return this.host.hideDelay || 0;
   }
 
@@ -52,8 +52,8 @@ class PopoverOpenedStateController {
    */
   open(options = { immediate: false }) {
     const { immediate, trigger } = options;
-    const shouldDelayHover = trigger === 'hover' && this.hoverDelay > 0;
-    const shouldDelayFocus = trigger === 'focus' && this.focusDelay > 0;
+    const shouldDelayHover = trigger === 'hover' && this.__hoverDelay > 0;
+    const shouldDelayFocus = trigger === 'focus' && this.__focusDelay > 0;
 
     if (!immediate && (shouldDelayHover || shouldDelayFocus) && !this.__closeTimeout) {
       this.__scheduleOpen(trigger);
@@ -67,7 +67,7 @@ class PopoverOpenedStateController {
    * @param {boolean} immediate
    */
   close(immediate) {
-    if (!immediate && this.hideDelay > 0) {
+    if (!immediate && this.__hideDelay > 0) {
       this.__scheduleClose();
     } else {
       this.__abortClose();
@@ -107,14 +107,14 @@ class PopoverOpenedStateController {
     this.__closeTimeout = setTimeout(() => {
       this.__closeTimeout = null;
       this.__setOpened(false);
-    }, this.hideDelay);
+    }, this.__hideDelay);
   }
 
   /** @private */
   __scheduleOpen(trigger) {
     this.__abortOpen();
 
-    const delay = trigger === 'focus' ? this.focusDelay : this.hoverDelay;
+    const delay = trigger === 'focus' ? this.__focusDelay : this.__hoverDelay;
     this.__openTimeout = setTimeout(() => {
       this.__openTimeout = null;
       this.__showPopover();
@@ -309,7 +309,7 @@ class Popover extends PopoverPositionMixin(
     this.__onTargetMouseEnter = this.__onTargetMouseEnter.bind(this);
     this.__onTargetMouseLeave = this.__onTargetMouseLeave.bind(this);
 
-    this._stateController = new PopoverOpenedStateController(this);
+    this._openedStateController = new PopoverOpenedStateController(this);
   }
 
   /** @protected */
@@ -379,7 +379,7 @@ class Popover extends PopoverPositionMixin(
 
     document.removeEventListener('click', this.__onGlobalClick, true);
 
-    this._stateController.close(true);
+    this._openedStateController.close(true);
   }
 
   /**
@@ -432,7 +432,7 @@ class Popover extends PopoverPositionMixin(
       !event.composedPath().some((el) => el === this._overlayElement || el === this.target) &&
       !this.noCloseOnOutsideClick
     ) {
-      this._stateController.close(true);
+      this._openedStateController.close(true);
     }
   }
 
@@ -443,9 +443,9 @@ class Popover extends PopoverPositionMixin(
         this.__shouldRestoreFocus = true;
       }
       if (this.opened) {
-        this._stateController.close(true);
+        this._openedStateController.close(true);
       } else {
-        this._stateController.open({ immediate: true });
+        this._openedStateController.open({ immediate: true });
       }
     }
   }
@@ -459,7 +459,7 @@ class Popover extends PopoverPositionMixin(
     if (event.key === 'Escape' && !this.modal && !this.noCloseOnEsc && this.opened && !this.__isManual) {
       // Prevent closing parent overlay (e.g. dialog)
       event.stopPropagation();
-      this._stateController.close(true);
+      this._openedStateController.close(true);
     }
   }
 
@@ -486,7 +486,7 @@ class Popover extends PopoverPositionMixin(
       // Prevent overlay re-opening when restoring focus on close.
       if (!this.__shouldRestoreFocus) {
         this.__shouldRestoreFocus = true;
-        this._stateController.open({ trigger: 'focus' });
+        this._openedStateController.open({ trigger: 'focus' });
       }
     }
   }
@@ -509,7 +509,7 @@ class Popover extends PopoverPositionMixin(
       if (this.modal) {
         this.target.style.pointerEvents = 'auto';
       }
-      this._stateController.open({ trigger: 'hover' });
+      this._openedStateController.open({ trigger: 'hover' });
     }
   }
 
@@ -547,8 +547,8 @@ class Popover extends PopoverPositionMixin(
     this.__hoverInside = true;
 
     // Prevent closing if cursor moves to the overlay during hide delay.
-    if (this.__hasTrigger('hover') && this._stateController.isClosing) {
-      this._stateController.open({ immediate: true });
+    if (this.__hasTrigger('hover') && this._openedStateController.isClosing) {
+      this._openedStateController.open({ immediate: true });
     }
   }
 
@@ -570,7 +570,7 @@ class Popover extends PopoverPositionMixin(
     }
 
     if (this.__hasTrigger('focus')) {
-      this._stateController.close(true);
+      this._openedStateController.close(true);
     }
   }
 
@@ -583,7 +583,7 @@ class Popover extends PopoverPositionMixin(
     }
 
     if (this.__hasTrigger('hover')) {
-      this._stateController.close();
+      this._openedStateController.close();
     }
   }
 

--- a/packages/popover/test/timers.test.js
+++ b/packages/popover/test/timers.test.js
@@ -1,0 +1,211 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  aTimeout,
+  esc,
+  fire,
+  fixtureSync,
+  focusout,
+  nextRender,
+  nextUpdate,
+  outsideClick,
+} from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '../src/vaadin-popover.js';
+
+describe('timers', () => {
+  let popover, target, overlay;
+
+  function mouseenter(target) {
+    fire(target, 'mouseenter');
+  }
+
+  function mouseleave(target, relatedTarget) {
+    const eventProps = relatedTarget ? { relatedTarget } : {};
+    fire(target, 'mouseleave', undefined, eventProps);
+  }
+
+  beforeEach(async () => {
+    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
+    popover.renderer = (root) => {
+      root.textContent = 'Content';
+    };
+    target = fixtureSync('<button>Target</button>');
+    popover.target = target;
+    await nextRender();
+    overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+  });
+
+  describe('hoverDelay', () => {
+    beforeEach(async () => {
+      popover.trigger = ['hover', 'focus'];
+      popover.hoverDelay = 5;
+      await nextUpdate(popover);
+    });
+
+    it('should open the overlay after a delay on mouseenter', async () => {
+      mouseenter(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+
+      await aTimeout(5);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on focus', async () => {
+      target.focus();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on click', async () => {
+      popover.trigger = ['click'];
+      await nextUpdate(popover);
+
+      target.click();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on click during hover delay', async () => {
+      popover.trigger = ['hover', 'click'];
+      await nextUpdate(popover);
+
+      mouseenter(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+
+      target.click();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('focusDelay', () => {
+    beforeEach(async () => {
+      popover.trigger = ['hover', 'focus'];
+      popover.focusDelay = 5;
+      await nextUpdate(popover);
+    });
+
+    it('should open the overlay after a delay on focus', async () => {
+      target.focus();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+
+      await aTimeout(5);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on mouseenter', async () => {
+      mouseenter(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on click', async () => {
+      popover.trigger = ['click'];
+      await nextUpdate(popover);
+
+      target.click();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should open the overlay immediately on click during focus delay', async () => {
+      popover.trigger = ['hover', 'click'];
+      await nextUpdate(popover);
+
+      target.focus();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+
+      target.click();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('hideDelay', () => {
+    beforeEach(async () => {
+      popover.trigger = ['hover', 'focus'];
+      popover.hideDelay = 5;
+      await nextUpdate(popover);
+    });
+
+    it('should close the overlay after a hide delay on mouseleave', async () => {
+      mouseenter(target);
+      await nextUpdate(popover);
+
+      mouseleave(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+
+      await aTimeout(5);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on focusout', async () => {
+      target.focus();
+      await nextUpdate(popover);
+
+      focusout(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on Esc keydown', async () => {
+      target.focus();
+      await nextUpdate(popover);
+
+      esc(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close on overlay mouseenter during hide delay', async () => {
+      mouseenter(target);
+      await nextUpdate(popover);
+
+      mouseleave(target, document.body);
+      mouseenter(overlay);
+
+      await aTimeout(5);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close the overlay immediately on outside click', async () => {
+      target.focus();
+      await nextUpdate(popover);
+
+      outsideClick();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on click', async () => {
+      popover.trigger = ['click'];
+      await nextUpdate(popover);
+
+      target.click();
+      await nextUpdate(popover);
+
+      target.click();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on click during hide delay', async () => {
+      popover.trigger = ['hover', 'click'];
+      await nextUpdate(popover);
+
+      mouseenter(target);
+      await nextUpdate(popover);
+
+      mouseleave(target);
+
+      target.click();
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+  });
+});

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -36,6 +36,9 @@ assertType<boolean>(popover.modal);
 assertType<boolean>(popover.withBackdrop);
 assertType<boolean>(popover.noCloseOnEsc);
 assertType<boolean>(popover.noCloseOnOutsideClick);
+assertType<number>(popover.focusDelay);
+assertType<number>(popover.hideDelay);
+assertType<number>(popover.hoverDelay);
 
 // Events
 popover.addEventListener('opened-changed', (event) => {


### PR DESCRIPTION
## Description

Added `focusDelay`, `hoverDelay` and `hideDelay` properties to the `vaadin-popover`. 
These are similar to `vaadin-tooltip` with the exception of the following differences:

- there is no common "warm up" and "cooldown" logic (we don't need to switch between popovers quickly)
- there is no global API to set default hover, focus and hide delay values (can be added if we want to have it)
- default hover, hide and focus delays in milliseconds are set to `0` (in `vaadin-tooltip` it's set to `500`)

## Type of change

- Feature