### PR TITLE
feat: add properties to set popover content width and height

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -31,6 +31,11 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
     return [
       overlayStyles,
       css`
+        :host {
+          --_vaadin-popover-content-width: auto;
+          --_vaadin-popover-content-height: auto;
+        }
+
         :host([modeless][with-backdrop]) [part='backdrop'] {
           pointer-events: none;
         }
@@ -47,6 +52,8 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
 
         [part='content'] {
           overflow: auto;
+          width: var(--_vaadin-popover-content-width);
+          height: var(--_vaadin-popover-content-height);
         }
 
         /* Increase the area of the popover so the pointer can go from the target directly to it. */

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -39,6 +39,20 @@ declare class Popover extends PopoverPositionMixin(
   PopoverTargetMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement)))),
 ) {
   /**
+   * Height to be set on the overlay content.
+   *
+   * @attr {string} content-height
+   */
+  contentHeight: string;
+
+  /**
+   * Width to be set on the overlay content.
+   *
+   * @attr {string} content-width
+   */
+  contentWidth: string;
+
+  /**
    * True if the popover overlay is opened, false otherwise.
    */
   opened: boolean;

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -129,6 +129,22 @@ class Popover extends PopoverPositionMixin(
         value: false,
       },
 
+      /**
+       * Height to be set on the overlay content.
+       * @protected
+       */
+      _contentHeight: {
+        type: String,
+      },
+
+      /**
+       * Width to be set on the overlay content.
+       * @protected
+       */
+      _contentWidth: {
+        type: String,
+      },
+
       /** @private */
       __shouldRestoreFocus: {
         type: Boolean,
@@ -136,6 +152,13 @@ class Popover extends PopoverPositionMixin(
         sync: true,
       },
     };
+  }
+
+  static get observers() {
+    return [
+      '__updateContentHeight(_contentHeight, _overlayElement)',
+      '__updateContentWidth(_contentWidth, _overlayElement)',
+    ];
   }
 
   constructor() {
@@ -465,6 +488,31 @@ class Popover extends PopoverPositionMixin(
   /** @private */
   get __isManual() {
     return this.trigger == null || (Array.isArray(this.trigger) && this.trigger.length === 0);
+  }
+
+  /** @private */
+  __updateDimension(overlay, dimension, value) {
+    const prop = `--_vaadin-popover-content-${dimension}`;
+
+    if (value) {
+      overlay.style.setProperty(prop, value);
+    } else {
+      overlay.style.removeProperty(prop);
+    }
+  }
+
+  /** @private */
+  __updateContentHeight(height, overlay) {
+    if (overlay) {
+      this.__updateDimension(overlay, 'height', height);
+    }
+  }
+
+  /** @private */
+  __updateContentWidth(width, overlay) {
+    if (overlay) {
+      this.__updateDimension(overlay, 'width', width);
+    }
   }
 }
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -42,6 +42,24 @@ class Popover extends PopoverPositionMixin(
   static get properties() {
     return {
       /**
+       * Height to be set on the overlay content.
+       *
+       * @attr {string} content-height
+       */
+      contentHeight: {
+        type: String,
+      },
+
+      /**
+       * Width to be set on the overlay content.
+       *
+       * @attr {string} content-width
+       */
+      contentWidth: {
+        type: String,
+      },
+
+      /**
        * True if the popover overlay is opened, false otherwise.
        */
       opened: {
@@ -129,22 +147,6 @@ class Popover extends PopoverPositionMixin(
         value: false,
       },
 
-      /**
-       * Height to be set on the overlay content.
-       * @protected
-       */
-      _contentHeight: {
-        type: String,
-      },
-
-      /**
-       * Width to be set on the overlay content.
-       * @protected
-       */
-      _contentWidth: {
-        type: String,
-      },
-
       /** @private */
       __shouldRestoreFocus: {
         type: Boolean,
@@ -156,8 +158,8 @@ class Popover extends PopoverPositionMixin(
 
   static get observers() {
     return [
-      '__updateContentHeight(_contentHeight, _overlayElement)',
-      '__updateContentWidth(_contentWidth, _overlayElement)',
+      '__updateContentHeight(contentHeight, _overlayElement)',
+      '__updateContentWidth(contentWidth, _overlayElement)',
     ];
   }
 

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -289,4 +289,54 @@ describe('popover', () => {
       });
     });
   });
+
+  describe('dimensions', () => {
+    function getStyleValue(element) {
+      return element
+        .getAttribute('style')
+        .split(':')
+        .map((str) => str.trim().replace(';', ''));
+    }
+
+    beforeEach(async () => {
+      popover.opened = true;
+      await nextRender();
+    });
+
+    it('should update width after opening the popover', async () => {
+      popover._contentWidth = '300px';
+      await nextUpdate(popover);
+      expect(getComputedStyle(overlay.$.content).width).to.be.equal('300px');
+    });
+
+    it('should update height after opening the popover', async () => {
+      popover._contentHeight = '500px';
+      await nextUpdate(popover);
+      expect(getComputedStyle(overlay.$.content).height).to.equal('500px');
+    });
+
+    it('should reset style after setting width to null', async () => {
+      const prop = '--_vaadin-popover-content-width';
+
+      popover._contentWidth = '500px';
+      await nextUpdate(popover);
+      expect(getStyleValue(overlay)).to.eql([prop, '500px']);
+
+      popover._contentWidth = null;
+      await nextUpdate(popover);
+      expect(overlay.getAttribute('style')).to.be.not.ok;
+    });
+
+    it('should reset style after setting height to null', async () => {
+      const prop = '--_vaadin-popover-content-height';
+
+      popover._contentHeight = '500px';
+      await nextUpdate(popover);
+      expect(getStyleValue(overlay)).to.eql([prop, '500px']);
+
+      popover._contentHeight = null;
+      await nextUpdate(popover);
+      expect(overlay.getAttribute('style')).to.be.not.ok;
+    });
+  });
 });

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -304,13 +304,13 @@ describe('popover', () => {
     });
 
     it('should update width after opening the popover', async () => {
-      popover._contentWidth = '300px';
+      popover.contentWidth = '300px';
       await nextUpdate(popover);
       expect(getComputedStyle(overlay.$.content).width).to.be.equal('300px');
     });
 
     it('should update height after opening the popover', async () => {
-      popover._contentHeight = '500px';
+      popover.contentHeight = '500px';
       await nextUpdate(popover);
       expect(getComputedStyle(overlay.$.content).height).to.equal('500px');
     });
@@ -318,11 +318,11 @@ describe('popover', () => {
     it('should reset style after setting width to null', async () => {
       const prop = '--_vaadin-popover-content-width';
 
-      popover._contentWidth = '500px';
+      popover.contentWidth = '500px';
       await nextUpdate(popover);
       expect(getStyleValue(overlay)).to.eql([prop, '500px']);
 
-      popover._contentWidth = null;
+      popover.contentWidth = null;
       await nextUpdate(popover);
       expect(overlay.getAttribute('style')).to.be.not.ok;
     });
@@ -330,11 +330,11 @@ describe('popover', () => {
     it('should reset style after setting height to null', async () => {
       const prop = '--_vaadin-popover-content-height';
 
-      popover._contentHeight = '500px';
+      popover.contentHeight = '500px';
       await nextUpdate(popover);
       expect(getStyleValue(overlay)).to.eql([prop, '500px']);
 
-      popover._contentHeight = null;
+      popover.contentHeight = null;
       await nextUpdate(popover);
       expect(overlay.getAttribute('style')).to.be.not.ok;
     });

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -28,6 +28,8 @@ assertType<HTMLElement | undefined>(popover.target);
 assertType<PopoverPosition>(popover.position);
 assertType<PopoverRenderer | null | undefined>(popover.renderer);
 assertType<PopoverTrigger[] | null | undefined>(popover.trigger);
+assertType<string>(popover.contentHeight);
+assertType<string>(popover.contentWidth);
 assertType<string>(popover.overlayClass);
 assertType<boolean>(popover.opened);
 assertType<boolean>(popover.modal);


### PR DESCRIPTION
## Description

Based on #5187

Added API to set `vaadin-popover` overlay content width and height: `_contentWidth` and `_contentHeight` properties.
These are marked as protected to align with `vaadin-confirm-dialog` - see how the [Flow counterpart](https://github.com/vaadin/flow-components/blob/2757a87931252f551798b355a08c8b08994cb9a4/vaadin-confirm-dialog-flow-parent/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java#L124-L131) uses them.

## Type of change

- Feature