### PR TITLE
docs: add note about `em` unit in the column `width` jsdoc

### DIFF
--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -118,6 +118,11 @@ export declare class GridColumnMixinClass<
 > extends ColumnBaseMixinClass<TItem, Column> {
   /**
    * Width of the cells for this column.
+   *
+   * Please note that using the `em` length unit is discouraged as
+   * it might lead to misalignment issues if the header, body, and footer
+   * cells have different font sizes. Instead, use `rem` if you need
+   * a length unit relative to the font size.
    */
   width: string | null | undefined;
 

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -852,6 +852,11 @@ export const GridColumnMixin = (superClass) =>
       return {
         /**
          * Width of the cells for this column.
+         *
+         * Please note that using the `em` length unit is discouraged as
+         * it might lead to misalignment issues if the header, body, and footer
+         * cells have different font sizes. Instead, use `rem` if you need
+         * a length unit relative to the font size.
          */
         width: {
           type: String,


### PR DESCRIPTION
## Description

Add a new paragraph to mention the issue of using em length unit in columns width.

Part of https://github.com/vaadin/flow-components/issues/6260