### PR TITLE
fix: restore default node correctly when using helperText

### DIFF
--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -111,12 +111,12 @@ export class SlotController extends EventTarget {
         if (slotName !== '') {
           node.setAttribute('slot', slotName);
         }
-        this.node = node;
         this.defaultNode = node;
       }
     }
 
     if (node) {
+      this.node = node;
       host.appendChild(node);
     }
 

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -592,6 +592,17 @@ const runTests = (defineHelper, baseMixin) => {
           expect(element._helperNode).to.equal(defaultHelper);
         });
 
+        it('should restore the default helper when restoring helperText immediately', async () => {
+          element.helperText = null;
+          element.appendChild(helper);
+          await nextRender();
+
+          element.removeChild(helper);
+          element.helperText = 'Updated helper';
+          await nextRender();
+          expect(element._helperNode.textContent).to.equal('Updated helper');
+        });
+
         it('should keep has-helper attribute when the default helper is restored', async () => {
           element.appendChild(helper);
           await nextRender();


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6323

Currently, there is a timing issue in the `SlotController` related to how `this.node` reference is updated:

- when creating default node first time in `attachDefaultNode()`, it is set immediately;
- when restoring default node, it is only updated after a delay in the slot observer.

This leads to a problem in `HelperController` which checks for `this.node` immediately after restoring:

https://github.com/vaadin/web-components/blob/66675ccdf6a23090f14079eb6c6874f68274cd2b/packages/field-base/src/helper-controller.js#L26-L34

While there is an existing test for restoring `helperText`, it uses `await` and does not catch this case.

Updated to set `this.node` before calling `appendChild()` for consistency, and added a test for the original helper issue.

## Type of change

- Bugfix