### PR TITLE
refactor: use the shared _getGridEventLocation method

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -208,8 +208,7 @@ export const InlineEditingMixin = (superClass) =>
         const edited = this.__edited;
 
         if (context.item && this._isEditColumn(column)) {
-          const path = e.composedPath();
-          const cell = path[path.indexOf(this.$.table) - 3];
+          const { cell } = this._getGridEventLocation(e);
 
           if (!cell || cell.getAttribute('part').indexOf('details-cell') > -1) {
             return;
@@ -278,8 +277,7 @@ export const InlineEditingMixin = (superClass) =>
       const edited = this.__edited;
 
       if (context.item && this._isEditColumn(column)) {
-        const path = e.composedPath();
-        const cell = path[path.indexOf(this.$.table) - 3];
+        const { cell } = this._getGridEventLocation(e);
 
         if (!cell || cell.getAttribute('part').indexOf('details-cell') > -1) {
           return;

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -81,8 +81,7 @@ export const ActiveItemMixin = (superClass) =>
         return;
       }
 
-      const path = e.composedPath();
-      const cell = path[path.indexOf(this.$.table) - 3];
+      const { cell } = this._getGridEventLocation(e);
       if (!cell || cell.getAttribute('part').indexOf('details-cell') > -1 || cell === this.$.emptystatecell) {
         return;
       }

--- a/packages/grid/src/vaadin-grid-event-context-mixin.js
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.js
@@ -33,10 +33,7 @@ export const EventContextMixin = (superClass) =>
     getEventContext(event) {
       const context = {};
 
-      // Use `composedPath()` stored by vaadin-context-menu gesture
-      // to avoid problem when accessing it after a timeout on iOS
-      const path = event.__composedPath || event.composedPath();
-      const cell = path[path.indexOf(this.$.table) - 3];
+      const { cell } = this._getGridEventLocation(event);
 
       if (!cell) {
         return context;

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -1072,7 +1072,9 @@ export const KeyboardNavigationMixin = (superClass) =>
      * @private
      */
     _getGridEventLocation(e) {
-      const path = e.composedPath();
+      // Use `composedPath()` stored by vaadin-context-menu gesture
+      // to avoid problem when accessing it after a timeout on iOS
+      const path = e.__composedPath || e.composedPath();
       const tableIndex = path.indexOf(this.$.table);
       // Assuming ascending path to table is: [...,] th|td, tr, thead|tbody, table [,...]
       const section = tableIndex >= 1 ? path[tableIndex - 1] : null;

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -1069,7 +1069,7 @@ export const KeyboardNavigationMixin = (superClass) =>
      * The event may either target table section, a row, a cell or contents of a cell.
      * @param {Event} e
      * @returns {GridEventLocation}
-     * @private
+     * @protected
      */
     _getGridEventLocation(e) {
       // Use `composedPath()` stored by vaadin-context-menu gesture


### PR DESCRIPTION
## Description

Refactor instances of:

```js
const path = e.composedPath();
const cell = path[path.indexOf(this.$.table) - 3];
```

in grid and grid-pro to instead use the shared `_getGridEventLocation` helper.

## Type of change

Refactor