### PR TITLE
fix: do not cancel edit column cell click events

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -120,15 +120,6 @@ export const InlineEditingMixin = (superClass) =>
       this.$.table.addEventListener('click', (e) => {
         const column = this.getEventContext(e).column;
         if (column && this._isEditColumn(column)) {
-          if (e.target.matches(':not([type=checkbox])')) {
-            // Prevents the `click` event from a column's cell in order to prevent making the cell's parent row active.
-            // Note, it should not prevent the `click` event from checkboxes. Otherwise, they will not respond to user interactions.
-            // Read more: https://github.com/vaadin/web-components/pull/2539#discussion_r712076433.
-            // TODO: Using `preventDefault()` for any other purpose than preventing the default browser's behavior is bad practice
-            // and therefore it would be great to refactor this part someday.
-            e.preventDefault();
-          }
-
           if (this.editOnClick) {
             this._enterEditFromEvent(e);
           }
@@ -164,6 +155,20 @@ export const InlineEditingMixin = (superClass) =>
           }
         });
       }
+    }
+
+    /**
+     * Prevents making an edit column cell's parent row active on click.
+     *
+     * @override
+     * @protected
+     */
+    _preventCellActivationOnClick(e) {
+      return (
+        super._preventCellActivationOnClick(e) ||
+        // The clicked cell is editable
+        this._isEditColumn(this.getEventContext(e).column)
+      );
     }
 
     /**

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -163,9 +163,9 @@ export const InlineEditingMixin = (superClass) =>
      * @override
      * @protected
      */
-    _preventCellActivationOnClick(e) {
+    _shouldPreventCellActivationOnClick(e) {
       return (
-        super._preventCellActivationOnClick(e) ||
+        super._shouldPreventCellActivationOnClick(e) ||
         // The clicked cell is editable
         this._isEditColumn(this.getEventContext(e).column)
       );

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -695,6 +695,22 @@ describe('edit column', () => {
         cell._content.click();
         expect(activeItemChangedSpy.called).to.be.true;
       });
+
+      it('should not fire the event on focusable content click in the not editable column', () => {
+        cell = getContainerCell(grid.$.items, 0, 3);
+        cell._content.append(document.createElement('button'));
+        cell._content.querySelector('button').click();
+        expect(activeItemChangedSpy.called).to.be.false;
+      });
+
+      it('should not cancel click events on editable column cells', () => {
+        const clickSpy = sinon.spy();
+        grid.addEventListener('click', clickSpy);
+        cell = getContainerCell(grid.$.items, 0, 1);
+        cell._content.click();
+        expect(clickSpy.called).to.be.true;
+        expect(clickSpy.getCall(0).args[0].defaultPrevented).to.be.false;
+      });
     });
   });
 

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -73,7 +73,7 @@ export const ActiveItemMixin = (superClass) =>
      *
      * @protected
      */
-    _preventCellActivationOnClick(e) {
+    _shouldPreventCellActivationOnClick(e) {
       const { cell } = this._getGridEventLocation(e);
       return (
         // Something has handled this click already, e. g., <vaadin-grid-sorter>
@@ -98,7 +98,7 @@ export const ActiveItemMixin = (superClass) =>
      * @protected
      */
     _onClick(e) {
-      if (this._preventCellActivationOnClick(e)) {
+      if (this._shouldPreventCellActivationOnClick(e)) {
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -69,27 +69,41 @@ export const ActiveItemMixin = (superClass) =>
     }
 
     /**
-     * We need to listen to click instead of tap because on mobile safari, the
-     * document.activeElement has not been updated (focus has not been shifted)
-     * yet at the point when tap event is being executed.
+     * Checks whether the click event should not activate the cell on which it occurred.
+     *
+     * @protected
+     */
+    _preventCellActivationOnClick(e) {
+      const { cell } = this._getGridEventLocation(e);
+      return (
+        // Something has handled this click already, e. g., <vaadin-grid-sorter>
+        e.defaultPrevented ||
+        // No clicked cell available
+        !cell ||
+        // Cell is a details cell
+        cell.getAttribute('part').includes('details-cell') ||
+        // Cell is the empty state cell
+        cell === this.$.emptystatecell ||
+        // Cell content is focused
+        cell._content.contains(this.getRootNode().activeElement) ||
+        // Clicked on a focusable element
+        this._isFocusable(e.target) ||
+        // Clicked on a label element
+        e.target instanceof HTMLLabelElement
+      );
+    }
+
+    /**
      * @param {!MouseEvent} e
      * @protected
      */
     _onClick(e) {
-      if (e.defaultPrevented) {
-        // Something has handled this click already, e. g., <vaadin-grid-sorter>
+      if (this._preventCellActivationOnClick(e)) {
         return;
       }
 
       const { cell } = this._getGridEventLocation(e);
-      if (!cell || cell.getAttribute('part').indexOf('details-cell') > -1 || cell === this.$.emptystatecell) {
-        return;
-      }
-      const cellContent = cell._content;
-
-      const activeElement = this.getRootNode().activeElement;
-      const cellContentHasFocus = cellContent.contains(activeElement);
-      if (!cellContentHasFocus && !this._isFocusable(e.target) && !(e.target instanceof HTMLLabelElement)) {
+      if (cell) {
         this.dispatchEvent(
           new CustomEvent('cell-activate', {
             detail: {


### PR DESCRIPTION
## Description

Update `vaadin-grid-pro-inline-editing-mixin.js` to not cancel click events that occur in edit column cells. Canceling the click events [blocks the grid connector](https://github.com/vaadin/flow-components/blob/5b937e811d7185bbaf6b00c977bb3054dcc6bdb1/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts#L1128-L1131) from dispatching `item-click` events which in turn results in the Flow Grid item click listeners not getting invoked.

Related to https://github.com/vaadin/web-components/issues/637

## Type of change

Bugfix