### PR TITLE
fix: do not cancel edit column cell click events (#7453)

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -120,15 +120,6 @@ export const InlineEditingMixin = (superClass) =>
       this.$.table.addEventListener('click', (e) => {
         const column = this.getEventContext(e).column;
         if (column && this._isEditColumn(column)) {
-          if (e.target.matches(':not([type=checkbox])')) {
-            // Prevents the `click` event from a column's cell in order to prevent making the cell's parent row active.
-            // Note, it should not prevent the `click` event from checkboxes. Otherwise, they will not respond to user interactions.
-            // Read more: https://github.com/vaadin/web-components/pull/2539#discussion_r712076433.
-            // TODO: Using `preventDefault()` for any other purpose than preventing the default browser's behavior is bad practice
-            // and therefore it would be great to refactor this part someday.
-            e.preventDefault();
-          }
-
           if (this.editOnClick) {
             this._enterEditFromEvent(e);
           }
@@ -164,6 +155,20 @@ export const InlineEditingMixin = (superClass) =>
           }
         });
       }
+    }
+
+    /**
+     * Prevents making an edit column cell's parent row active on click.
+     *
+     * @override
+     * @protected
+     */
+    _shouldPreventCellActivationOnClick(e) {
+      return (
+        super._shouldPreventCellActivationOnClick(e) ||
+        // The clicked cell is editable
+        this._isEditColumn(this.getEventContext(e).column)
+      );
     }
 
     /**

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -695,6 +695,22 @@ describe('edit column', () => {
         cell._content.click();
         expect(activeItemChangedSpy.called).to.be.true;
       });
+
+      it('should not fire the event on focusable content click in the not editable column', () => {
+        cell = getContainerCell(grid.$.items, 0, 3);
+        cell._content.append(document.createElement('button'));
+        cell._content.querySelector('button').click();
+        expect(activeItemChangedSpy.called).to.be.false;
+      });
+
+      it('should not cancel click events on editable column cells', () => {
+        const clickSpy = sinon.spy();
+        grid.addEventListener('click', clickSpy);
+        cell = getContainerCell(grid.$.items, 0, 1);
+        cell._content.click();
+        expect(clickSpy.called).to.be.true;
+        expect(clickSpy.getCall(0).args[0].defaultPrevented).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Manually cherry-pick https://github.com/vaadin/web-components/pull/7453 to `24.4`

The merge conflict was due to 24.4 not having the `emptystatecell` element

## Type of change

Bugfix