### PR TITLE
refactor: hide/show overlay based on element/ancestor visibility

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -232,10 +232,10 @@ export const PositionMixin = (superClass) =>
 
       const targetRect = this.positionTarget.getBoundingClientRect();
 
-      if (targetRect.width === 0 && targetRect.height === 0 && this.opened) {
+      if (targetRect.width === 0 && targetRect.height === 0) {
         this.style.display = 'none';
         return;
-      } else if (this.style.display === 'none' && this.opened) {
+      } else if (this.style.display === 'none') {
         this.style.display = '';
       }
 

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -232,11 +232,10 @@ export const PositionMixin = (superClass) =>
 
       const targetRect = this.positionTarget.getBoundingClientRect();
 
-      if (targetRect.width === 0 && targetRect.height === 0) {
-        this.style.display = 'none';
+      this.hidden = targetRect.width === 0 && targetRect.height === 0;
+
+      if (this.hidden) {
         return;
-      } else if (this.style.display === 'none') {
-        this.style.display = '';
       }
 
       // Detect the desired alignment and update the layout accordingly

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -233,8 +233,10 @@ export const PositionMixin = (superClass) =>
       const targetRect = this.positionTarget.getBoundingClientRect();
 
       if (targetRect.width === 0 && targetRect.height === 0 && this.opened) {
-        this.opened = false;
+        this.style.display = 'none';
         return;
+      } else if (this.style.display === 'none' && this.opened) {
+        this.style.display = '';
       }
 
       // Detect the desired alignment and update the layout accordingly

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -96,7 +96,7 @@ describe('position mixin', () => {
   it('should hide overlay if element is hidden', async () => {
     target.style.display = 'none';
     await nextRender();
-    expect(overlay.style.display).to.be.equal('none');
+    expect(overlay.hidden).to.be.true;
   });
 
   it('should show overlay after element is shown again', async () => {
@@ -104,13 +104,13 @@ describe('position mixin', () => {
     await nextRender();
     target.style.display = '';
     await nextRender();
-    expect(overlay.style.display).to.be.equal('');
+    expect(overlay.hidden).to.be.false;
   });
 
   it('should hide overlay if parent element is hidden', async () => {
     target.parentElement.style.display = 'none';
     await nextRender();
-    expect(overlay.style.display).to.be.equal('none');
+    expect(overlay.hidden).to.be.true;
   });
 
   it('should show overlay after parent element is shown again', async () => {
@@ -118,7 +118,7 @@ describe('position mixin', () => {
     await nextRender();
     target.parentElement.style.display = '';
     await nextRender();
-    expect(overlay.style.display).to.be.equal('');
+    expect(overlay.hidden).to.be.false;
   });
 
   describe('vertical align top', () => {

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -93,16 +93,32 @@ describe('position mixin', () => {
     expect(overlay.$.overlay.scrollTop).to.equal(100);
   });
 
-  it('should close overlay if element is hidden', async () => {
+  it('should hide overlay if element is hidden', async () => {
     target.style.display = 'none';
     await nextRender();
-    expect(overlay.opened).to.be.false;
+    expect(overlay.style.display).to.be.equal('none');
   });
 
-  it('should close overlay if parent element is hidden', async () => {
+  it('should show overlay after element is shown again', async () => {
+    target.style.display = 'none';
+    await nextRender();
+    target.style.display = '';
+    await nextRender();
+    expect(overlay.style.display).to.be.equal('');
+  });
+
+  it('should hide overlay if parent element is hidden', async () => {
     target.parentElement.style.display = 'none';
     await nextRender();
-    expect(overlay.opened).to.be.false;
+    expect(overlay.style.display).to.be.equal('none');
+  });
+
+  it('should show overlay after parent element is shown again', async () => {
+    target.parentElement.style.display = 'none';
+    await nextRender();
+    target.parentElement.style.display = '';
+    await nextRender();
+    expect(overlay.style.display).to.be.equal('');
   });
 
   describe('vertical align top', () => {


### PR DESCRIPTION
## Description

Changes the behavior introduced in https://github.com/vaadin/web-components/pull/7454 to hide/show the overlay element instead of closing it, in case the `targetPosition` element is hidden. 