### PR TITLE
test: add missing data provider tests

### DIFF
--- a/packages/combo-box/test/data-provider.common.js
+++ b/packages/combo-box/test/data-provider.common.js
@@ -570,6 +570,10 @@ const TEMPLATES = {
         await nextRender();
       });
 
+      afterEach(() => {
+        document.body.removeChild(comboBox);
+      });
+
       it('should have undefined size', () => {
         expect(comboBox.size).to.be.undefined;
       });
@@ -740,6 +744,10 @@ const TEMPLATES = {
         comboBox.size = SIZE;
         document.body.appendChild(comboBox);
         await nextRender();
+      });
+
+      afterEach(() => {
+        document.body.removeChild(comboBox);
       });
 
       it('should have size', () => {

--- a/packages/combo-box/test/data-provider.common.js
+++ b/packages/combo-box/test/data-provider.common.js
@@ -562,6 +562,23 @@ const TEMPLATES = {
       });
     });
 
+    describe('dataProvider is set before attach', () => {
+      beforeEach(async () => {
+        comboBox = document.createElement(tag);
+        comboBox.dataProvider = spyDataProvider;
+        document.body.appendChild(comboBox);
+        await nextRender();
+      });
+
+      it('should have undefined size', () => {
+        expect(comboBox.size).to.be.undefined;
+      });
+
+      it('should have empty filteredItems', () => {
+        expect(comboBox.filteredItems).to.have.lengthOf(0);
+      });
+    });
+
     describe('pageSize', () => {
       it('should have default value', () => {
         expect(typeof comboBox.pageSize).to.equal('number');
@@ -713,6 +730,24 @@ const TEMPLATES = {
         // Reduce the size and trigger pending queue cleanup
         comboBox.size = 50;
         expect(comboBox.loading).to.be.false;
+      });
+    });
+
+    describe('size is set before attach', () => {
+      beforeEach(async () => {
+        comboBox = document.createElement(tag);
+        comboBox.dataProvider = spyDataProvider;
+        comboBox.size = SIZE;
+        document.body.appendChild(comboBox);
+        await nextRender();
+      });
+
+      it('should have size', () => {
+        expect(comboBox.size).to.equal(SIZE);
+      });
+
+      it('should have filteredItems', () => {
+        expect(comboBox.filteredItems).to.have.lengthOf(SIZE);
       });
     });
 


### PR DESCRIPTION
## Description

The PR adds unit tests to verify that the combo-box's size and filteredItems have correct initial values when the data provider is set before the component is added to the DOM.

Related to https://github.com/vaadin/web-components/pull/7044

## Type of change

- [x] Internal
