### PR TITLE
test: add missing data provider filtering tests

### DIFF
--- a/packages/combo-box/test/data-provider-filtering.common.js
+++ b/packages/combo-box/test/data-provider-filtering.common.js
@@ -66,6 +66,17 @@ const TEMPLATES = {
         expect(params.filter).to.equal('');
       });
 
+      it('should clear filteredItems on filter change', () => {
+        setInputValue(comboBox, 'Item');
+        expect(comboBox.filteredItems).to.deep.equal([]);
+      });
+
+      it('should update filteredItems on filter request response', async () => {
+        setInputValue(comboBox, 'Item 1');
+        await aTimeout(0);
+        expect(comboBox.filteredItems).to.deep.equal(['Item 1']);
+      });
+
       it('should clear filter on value clear', async () => {
         setInputValue(comboBox, 'Item');
         await aTimeout(0);


### PR DESCRIPTION
## Description

The PR adds tests to cover the following line in combo-box, which was noted as lacking coverage in [this discussion](https://github.com/vaadin/web-components/pull/7044#discussion_r1611331945):

https://github.com/vaadin/web-components/blob/7f63f1dd26edc80f34c3a955d7d46790977f85b1/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js#L114

Related to https://github.com/vaadin/web-components/pull/7044

## Type of change

- [x] Internal
