### PR TITLE
fix: remove custom part names from loading grid rows

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -234,6 +234,12 @@ export const DataProviderMixin = (superClass) =>
 
       // Cells part attribute
       updateCellsPart(cells, 'loading-row-cell', loading);
+
+      if (loading) {
+        // Run style generators for the loading row to have custom names cleared
+        this._generateCellClassNames(row);
+        this._generateCellPartNames(row);
+      }
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -89,7 +89,7 @@ export const StylingMixin = (superClass) =>
      */
     generateCellClassNames() {
       iterateChildren(this.$.items, (row) => {
-        if (!row.hidden && !row.hasAttribute('loading')) {
+        if (!row.hidden) {
           this._generateCellClassNames(row, this.__getRowModel(row));
         }
       });
@@ -103,7 +103,7 @@ export const StylingMixin = (superClass) =>
      */
     generateCellPartNames() {
       iterateChildren(this.$.items, (row) => {
-        if (!row.hidden && !row.hasAttribute('loading')) {
+        if (!row.hidden) {
           this._generateCellPartNames(row, this.__getRowModel(row));
         }
       });
@@ -115,7 +115,7 @@ export const StylingMixin = (superClass) =>
         if (cell.__generatedClasses) {
           cell.__generatedClasses.forEach((className) => cell.classList.remove(className));
         }
-        if (this.cellClassNameGenerator) {
+        if (this.cellClassNameGenerator && !row.hasAttribute('loading')) {
           const result = this.cellClassNameGenerator(cell._column, model);
           cell.__generatedClasses = result && result.split(' ').filter((className) => className.length > 0);
           if (cell.__generatedClasses) {
@@ -134,7 +134,7 @@ export const StylingMixin = (superClass) =>
             updatePart(cell, null, partName);
           });
         }
-        if (this.cellPartNameGenerator) {
+        if (this.cellPartNameGenerator && !row.hasAttribute('loading')) {
           const result = this.cellPartNameGenerator(cell._column, model);
           cell.__generatedParts = result && result.split(' ').filter((partName) => partName.length > 0);
           if (cell.__generatedParts) {

--- a/packages/grid/test/styling.common.js
+++ b/packages/grid/test/styling.common.js
@@ -155,6 +155,20 @@ describe('styling', () => {
         clock.tick(10);
         grid[requestFn]();
         expect(spy.called).to.be.true;
+        expect(spy.getCalls().filter((call) => call.args[1].index === 0).length).to.be.lessThan(5);
+      });
+
+      it(`should remove custom ${entries} for rows that enter loading state`, () => {
+        grid[generatorFn] = () => 'foo';
+        clock.tick(10);
+
+        expect(grid._getRenderedRows()[0].hasAttribute('loading')).to.be.false;
+        assertCallback(['foo']);
+
+        grid.clearCache();
+
+        expect(grid._getRenderedRows()[0].hasAttribute('loading')).to.be.true;
+        assertCallback([]);
       });
     });
   }
@@ -183,7 +197,9 @@ describe('styling', () => {
 
     const assertPartNames = (expectedParts, row = 0, col = 0) => {
       const cell = getContainerCell(grid.$.items, row, col);
-      const actualPart = cell.getAttribute('part');
+      let actualPart = cell.getAttribute('part');
+      // Remove "loading-row-cell" since initialCellPart doesn't include it and it's irrelevant for the test
+      actualPart = actualPart.replace('loading-row-cell', '').trim();
       const customParts = expectedParts.length ? ` ${expectedParts.join(' ')}` : '';
 
       if (row === 0 && col === 0) {


### PR DESCRIPTION
## Description

Clear custom part (and class) names from grid rows that enter `loading` state.

Fixes #7447

## Type of change

Bugfix