### PR TITLE
feat: fire closed event when Dialog overlay is closed

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -65,6 +65,7 @@ export const DialogBaseMixin = (superClass) =>
       this._overlayElement = overlay;
     }
 
+    /** @private */
     __handleOverlayClosed() {
       this.dispatchEvent(new CustomEvent('closed'));
     }

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -60,8 +60,13 @@ export const DialogBaseMixin = (superClass) =>
 
       overlay.addEventListener('vaadin-overlay-outside-click', this._handleOutsideClick.bind(this));
       overlay.addEventListener('vaadin-overlay-escape-press', this._handleEscPress.bind(this));
+      overlay.addEventListener('vaadin-overlay-closed', this.__handleOverlayClosed.bind(this));
 
       this._overlayElement = overlay;
+    }
+
+    __handleOverlayClosed() {
+      this.dispatchEvent(new CustomEvent('closed'));
     }
 
     /** @protected */

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -34,8 +34,15 @@ export type DialogOpenedChangedEvent = CustomEvent<{ value: boolean }>;
  */
 export type DialogResizeEvent = CustomEvent<DialogResizeDimensions>;
 
+/**
+ * Fired when the dialog is closed.
+ */
+export type DialogClosedEvent = CustomEvent;
+
 export interface DialogCustomEventMap {
   'opened-changed': DialogOpenedChangedEvent;
+
+  closed: DialogClosedEvent;
 
   resize: DialogResizeEvent;
 }
@@ -102,6 +109,7 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} vaadin-overlay-closed - Fired after the overlay is closed.
  */
 declare class Dialog extends DialogDraggableMixin(
   DialogResizableMixin(

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -109,7 +109,7 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
- * @fires {CustomEvent} vaadin-overlay-closed - Fired after the overlay is closed.
+ * @fires {CustomEvent} closed - Fired when the overlay is closed.
  */
 declare class Dialog extends DialogDraggableMixin(
   DialogResizableMixin(

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -109,7 +109,7 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
- * @fires {CustomEvent} closed - Fired when the overlay is closed.
+ * @fires {CustomEvent} closed - Fired when the dialog is closed.
  */
 declare class Dialog extends DialogDraggableMixin(
   DialogResizableMixin(

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -77,6 +77,7 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} closed - Fired when the dialog is closed.
  *
  * @customElement
  * @extends HTMLElement

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, click, esc, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, click, esc, fixtureSync, listenOnce, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
@@ -186,6 +186,29 @@ describe('vaadin-dialog', () => {
         await nextUpdate(dialog);
         expect(overlay.modeless).to.be.true;
         expect(backdrop.hidden).to.be.true;
+      });
+    });
+
+    describe('closed event', () => {
+      it('should dispatch closed event when closed', async () => {
+        const closedSpy = sinon.spy();
+        listenOnce(dialog, 'closed', closedSpy);
+        dialog.opened = false;
+        await nextRender();
+        expect(closedSpy.calledOnce).to.be.true;
+      });
+
+      it('closed event should be called after overlay is closed', async () => {
+        const closedPromise = new Promise((resolve) => {
+          const closedListener = () => {
+            expect(dialog._overlayElement.parentElement).to.be.not.ok;
+            resolve();
+          };
+          listenOnce(dialog, 'closed', closedListener);
+        });
+        dialog.opened = false;
+        await nextRender();
+        await closedPromise;
       });
     });
   });

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -192,10 +192,11 @@ describe('vaadin-dialog', () => {
     describe('closed event', () => {
       it('should dispatch closed event when closed', async () => {
         const closedSpy = sinon.spy();
-        listenOnce(dialog, 'closed', closedSpy);
+        dialog.addEventListener('closed', closedSpy);
         dialog.opened = false;
         await nextRender();
         expect(closedSpy.calledOnce).to.be.true;
+        dialog.removeEventListener('closed', closedSpy);
       });
 
       it('closed event should be called after overlay is closed', async () => {

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -6,6 +6,7 @@ import type { DialogDraggableMixinClass } from '../../src/vaadin-dialog-draggabl
 import type { DialogResizableMixinClass } from '../../src/vaadin-dialog-resizable-mixin.js';
 import type {
   Dialog,
+  DialogClosedEvent,
   DialogOpenedChangedEvent,
   DialogRenderer,
   DialogResizeDimensions,
@@ -32,6 +33,10 @@ dialog.addEventListener('opened-changed', (event) => {
 dialog.addEventListener('resize', (event) => {
   assertType<DialogResizeEvent>(event);
   assertType<DialogResizeDimensions>(event.detail);
+});
+
+dialog.addEventListener('closed', (event) => {
+  assertType<DialogClosedEvent>(event);
 });
 
 // Properties


### PR DESCRIPTION
## Description

Add a new `closed` event that is triggered after the overlay is closed

Part of #7422

## Type of change

- [ ] Bugfix
- [X] Feature
