### PR TITLE
feat: add closed event when Notification is closed

### DIFF
--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -105,6 +105,7 @@ declare class NotificationCard extends ThemableMixin(HTMLElement) {}
  * propagated to the internal `<vaadin-notification-card>`.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} closed - Fired when the notification is closed.
  */
 declare class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement))) {
   /**

--- a/packages/notification/src/vaadin-notification.d.ts
+++ b/packages/notification/src/vaadin-notification.d.ts
@@ -27,8 +27,14 @@ export type NotificationRenderer = (root: HTMLElement, notification: Notificatio
  */
 export type NotificationOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
+/**
+ * Fired when the notification is closed.
+ */
+export type NotificationClosedEvent = CustomEvent;
+
 export interface NotificationCustomEventMap {
   'opened-changed': NotificationOpenedChangedEvent;
+  closed: NotificationClosedEvent;
 }
 
 export interface NotificationEventMap extends HTMLElementEventMap, NotificationCustomEventMap {}

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -257,6 +257,7 @@ class NotificationCard extends ThemableMixin(PolymerElement) {
  * propagated to the internal `<vaadin-notification-card>`.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} closed - Fired when the notification is closed.
  *
  * @customElement
  * @extends HTMLElement

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -532,6 +532,7 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
     }
     this._card.removeAttribute('closing');
     this._container.opened = Boolean(this._container.firstElementChild);
+    this.dispatchEvent(new CustomEvent('closed'));
   }
 
   /** @private */

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -53,6 +53,27 @@ describe('vaadin-notification', () => {
     expect(notification.opened).to.be.true;
   });
 
+  it('should dispatch closed event', async () => {
+    const spy = sinon.spy();
+    listenOnce(notification, 'closed', spy);
+    notification.opened = false;
+    await aTimeout(0);
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('closed event should be called after overlay is closed', async () => {
+    const closedPromise = new Promise((resolve) => {
+      const closedListener = () => {
+        expect(notification._container.parentElement).to.be.not.ok;
+        resolve();
+      };
+      listenOnce(notification, 'closed', closedListener);
+    });
+    notification.opened = false;
+    await aTimeout(0);
+    await closedPromise;
+  });
+
   describe('vaadin-notification-container', () => {
     it('should be in the body when notification opens', () => {
       expect(document.body.querySelectorAll('vaadin-notification-container').length).to.be.equal(1);

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -55,7 +55,7 @@ describe('vaadin-notification', () => {
 
   it('should dispatch closed event', async () => {
     const spy = sinon.spy();
-    listenOnce(notification, 'closed', spy);
+    notification.addEventListener('closed', spy);
     notification.opened = false;
     await aTimeout(0);
     expect(spy.calledOnce).to.be.true;

--- a/packages/notification/test/typings/notification.types.ts
+++ b/packages/notification/test/typings/notification.types.ts
@@ -3,6 +3,7 @@ import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type {
+  NotificationClosedEvent,
   NotificationOpenedChangedEvent,
   NotificationPosition,
   NotificationRenderer,
@@ -29,6 +30,10 @@ assertType<string>(notification.overlayClass);
 notification.addEventListener('opened-changed', (event) => {
   assertType<NotificationOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
+});
+
+notification.addEventListener('closed', (event) => {
+  assertType<NotificationClosedEvent>(event);
 });
 
 Notification.show('Hello world', { position: 'middle', duration: 7000, theme: 'error' });


### PR DESCRIPTION
## Description

Add a new `closed` event that is triggered after the notification is closed

Part of #7422

## Type of change

- [ ] Bugfix
- [X] Feature
