### PR TITLE
refactor: remove unused size property declaration

### DIFF
--- a/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
@@ -44,11 +44,6 @@ export class DataProviderController<TItem, TDataProviderParams extends Record<st
   dataProviderParams: () => TDataProviderParams;
 
   /**
-   * A number of items in the root cache.
-   */
-  size?: number;
-
-  /**
    * A number of items to display per page.
    */
   pageSize: number;

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -30,13 +30,6 @@ export class DataProviderController extends EventTarget {
   dataProviderParams;
 
   /**
-   * A number of items in the root cache.
-   *
-   * @type {number}
-   */
-  size;
-
-  /**
    * A number of items to display per page.
    *
    * @type {number}

--- a/packages/component-base/test/typings/data-provider-controller/data-provider-controller.types.ts
+++ b/packages/component-base/test/typings/data-provider-controller/data-provider-controller.types.ts
@@ -52,7 +52,6 @@ assertType<
 // Properties
 assertType<HTMLElement>(dataProviderController.host);
 assertType<Cache<TestItem>>(dataProviderController.rootCache);
-assertType<number | undefined>(dataProviderController.size);
 assertType<number>(dataProviderController.pageSize);
 assertType<(item: TestItem) => unknown>(dataProviderController.getItemId);
 assertType<(item: TestItem) => boolean>(dataProviderController.isExpanded);


### PR DESCRIPTION
## Description

The PR removes the size property declaration from DataProviderController because this property isn't used anywhere. It's apparently a leftover from https://github.com/vaadin/web-components/pull/6806.

## Type of change

- [x] Internal
