### PR TITLE
fix: add min-width to MenuBar

### DIFF
--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
@@ -4,6 +4,9 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-menu-bar',
   css`
+    :host {
+      min-width: var(--lumo-size-m);
+    }
     :host([has-single-button]) ::slotted(vaadin-menu-bar-button) {
       border-radius: var(--lumo-border-radius-m);
     }

--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
@@ -7,6 +7,7 @@ registerStyles(
     :host {
       min-width: var(--lumo-size-m);
     }
+
     :host([has-single-button]) ::slotted(vaadin-menu-bar-button) {
       border-radius: var(--lumo-border-radius-m);
     }


### PR DESCRIPTION
## Description

Set the MenuBar's minimum width to --lumo-size-m which is the default size of the overflow button. This way, the MenuBar can not be shrunk down to the point where the overflow button is not visible anymore.

Fixes  #6876 

## Type of change

- [X] Bugfix
- [ ] Feature
