### PR TITLE
fix: do not show placeholder when select item has child elements

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -550,7 +550,9 @@ export const SelectBaseMixin = (superClass) =>
       if (!item) {
         return false;
       }
-      return Boolean(item.hasAttribute('label') ? item.getAttribute('label') : item.textContent.trim());
+      const hasText = Boolean(item.hasAttribute('label') ? item.getAttribute('label') : item.textContent.trim());
+      const hasChildren = item.childElementCount > 0;
+      return hasText || hasChildren;
     }
 
     /** @private */

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -103,6 +103,8 @@ describe('vaadin-select', () => {
               <vaadin-item value="v4" disabled>Disabled</vaadin-item>
               <vaadin-item value="5">A number</vaadin-item>
               <vaadin-item value="false">A boolean</vaadin-item>
+              <vaadin-item label="foo"></vaadin-item>
+              <vaadin-item><img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" /></vaadin-item>
             </vaadin-list-box>
           `,
           root,
@@ -471,6 +473,19 @@ describe('vaadin-select', () => {
         click(select._items[3]);
         await nextUpdate(select);
         expect(valueButton.textContent).to.equal('Select an item');
+      });
+
+      it('should not show placeholder for items with label, text content or child elements', async () => {
+        const emptyItems = [select._items[3], select._items[4]];
+        const nonEmptyItems = select._items.filter((item) => !emptyItems.includes(item));
+
+        for (const item of nonEmptyItems) {
+          select.opened = true;
+          await nextRender();
+          click(item);
+          await nextUpdate(select);
+          expect(valueButton.textContent).not.to.equal('Select an item');
+        }
       });
     });
 


### PR DESCRIPTION
The current placeholder logic in vaadin-select shows the placeholder when the selected item has neither a label attribute value nor text content (see https://github.com/vaadin/web-components/pull/7303). That is problematic however when a custom rendered select item only contains an image, icon or similar element that does not result in text content - in that case it also shows the placeholder instead of the image for example.

This change adds a check for whether a select item has any child element, in which case the placeholder is not shown.

Fixes https://github.com/vaadin/web-components/issues/7497