### PR TITLE
fix menu bar item focus

### DIFF
--- a/packages/a11y-base/src/keyboard-direction-mixin.js
+++ b/packages/a11y-base/src/keyboard-direction-mixin.js
@@ -137,14 +137,14 @@ export const KeyboardDirectionMixin = (superclass) =>
      * @param {boolean} navigating
      * @protected
      */
-    _focusItem(item) {
+    _focusItem(item, navigating) {
       if (item) {
         item.focus();
 
         // Generally, the items are expected to implement `FocusMixin`
         // that would set this attribute based on the `keydown` event.
         // We set it manually to handle programmatic focus() calls.
-        item.setAttribute('focus-ring', '');
+        if (navigating) item.setAttribute('focus-ring', '');
       }
     }
 

--- a/packages/a11y-base/test/keyboard-direction-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-direction-mixin.test.js
@@ -4,10 +4,12 @@ import {
   arrowLeftKeyDown,
   arrowRightKeyDown,
   arrowUpKeyDown,
+  aTimeout,
   endKeyDown,
   fire,
   fixtureSync,
   homeKeyDown,
+  nextRender,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../../menu-bar/vaadin-menu-bar.js';
@@ -194,7 +196,7 @@ describe('keyboard-direction-mixin', () => {
 
   describe('non-keyboard navigation', () => {
     describe('menu bar', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         element = fixtureSync(`<vaadin-menu-bar>`);
         element.openOnHover = true;
         element.items = [
@@ -209,16 +211,24 @@ describe('keyboard-direction-mixin', () => {
             ],
           },
         ];
+        await nextRender();
       });
-      it('should not apply focus-ring to menu bar items ', () => {
+      it('should not apply focus-ring to menu bar items ', async () => {
         const button = document.querySelector('vaadin-menu-bar-button');
         fire(button, 'mouseover');
+        await nextRender();
 
-        document.querySelectorAll('vaadin-menu-bar-item');
-        fire(button.item.children[1], 'mouseover');
-        fire(button.item.children[0], 'mouseover');
+        const itemsElements = document.querySelectorAll('vaadin-menu-bar-item');
 
-        expect(document.querySelectorAll('vaadin-menu-bar-item')[2].hasAttribute('focus-ring')).to.be.true;
+        fire(itemsElements[1], 'mouseover');
+        await nextRender();
+
+        fire(itemsElements[0], 'mouseover');
+        await nextRender();
+
+        await aTimeout(500);
+
+        expect(document.querySelectorAll('vaadin-menu-bar-item')[2].hasAttribute('focus-ring')).to.be.false;
       });
     });
   });

--- a/packages/a11y-base/test/keyboard-direction-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-direction-mixin.test.js
@@ -5,10 +5,12 @@ import {
   arrowRightKeyDown,
   arrowUpKeyDown,
   endKeyDown,
+  fire,
   fixtureSync,
   homeKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import '../../menu-bar/vaadin-menu-bar.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { KeyboardDirectionMixin } from '../src/keyboard-direction-mixin.js';
 
@@ -186,6 +188,37 @@ describe('keyboard-direction-mixin', () => {
         items[1].style.display = 'none';
         arrowRightKeyDown(items[0]);
         expect(element.focused).to.be.equal(items[3]);
+      });
+    });
+  });
+
+  describe('non-keyboard navigation', () => {
+    describe('menu bar', () => {
+      beforeEach(() => {
+        element = fixtureSync(`<vaadin-menu-bar>`);
+        element.openOnHover = true;
+        element.items = [
+          {
+            text: 'Share',
+            children: [
+              {
+                text: 'On social media',
+                children: [{ text: 'Facebook' }],
+              },
+              { text: 'By email' },
+            ],
+          },
+        ];
+      });
+      it('should not apply focus-ring to menu bar items ', () => {
+        const button = document.querySelector('vaadin-menu-bar-button');
+        fire(button, 'mouseover');
+
+        document.querySelectorAll('vaadin-menu-bar-item');
+        fire(button.item.children[1], 'mouseover');
+        fire(button.item.children[0], 'mouseover');
+
+        expect(document.querySelectorAll('vaadin-menu-bar-item')[2].hasAttribute('focus-ring')).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Description

Console.trace revealed that the menubar overriden _focusItem is never triggered. The focus comes through list-mixin

Reintroduce the navigating parameter to _focusItem in keyboard-direction-mixin. No idea why this was missing because every call to this function has 2 arguments and the JS docs mention 2 params. Based on what arguments are set for calls, I changed the function to add focus-ring only if navigating is true. 


Fixes 
vaadin/flow-components#6386

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.
