### PR TITLE
fix: select date on Today click if today is max date

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -531,7 +531,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _onTodayTap() {
-      const today = new Date();
+      const today = this._getTodayMidnight();
 
       if (Math.abs(this._monthScroller.position - this._differenceInMonths(today, this._originDate)) < 0.001) {
         // Select today only if the month scroller is positioned approximately
@@ -1040,12 +1040,17 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _isTodayAllowed(min, max, isDateDisabled) {
+      return this._dateAllowed(this._getTodayMidnight(), min, max, isDateDisabled);
+    }
+
+    /** @private */
+    _getTodayMidnight() {
       const today = new Date();
       const todayMidnight = new Date(0, 0);
       todayMidnight.setFullYear(today.getFullYear());
       todayMidnight.setMonth(today.getMonth());
       todayMidnight.setDate(today.getDate());
-      return this._dateAllowed(todayMidnight, min, max, isDateDisabled);
+      return todayMidnight;
     }
 
     /**

--- a/packages/date-picker/test/overlay-content.common.js
+++ b/packages/date-picker/test/overlay-content.common.js
@@ -280,6 +280,18 @@ describe('overlay', () => {
             overlay.minDate = tomorrowMidnight;
             expect(overlay._todayButton.disabled).to.be.true;
           });
+
+          it('should select today if today is max', async () => {
+            overlay.maxDate = todayMidnight;
+            overlay.scrollToDate(todayMidnight);
+            await waitForScrollToFinish(overlay);
+
+            tap(overlay._todayButton);
+
+            expect(overlay.selectedDate.getFullYear()).to.equal(todayMidnight.getFullYear());
+            expect(overlay.selectedDate.getMonth()).to.equal(todayMidnight.getMonth());
+            expect(overlay.selectedDate.getDate()).to.equal(todayMidnight.getDate());
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

Fixes #7505

Updated the logic to use "today midnight" for comparing with `max`. Without this change, the actual time is used and `dateAllowed` returns `false` when clicking "Today" button, thus making selecting today in this case impossible.

## Type of change

- Bugfix