### PR TITLE
fix: only focus parent item if sub-menu contained focus

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -361,6 +361,10 @@ export const ItemsMixin = (superClass) =>
       if (item) {
         const { children } = item._item;
 
+        // Check if the sub-menu was focused before closing it.
+        const child = subMenu._overlayElement.getFirstChild();
+        const isSubmenuFocused = child && child.focused;
+
         if (subMenu.items !== children) {
           subMenu.close();
         }
@@ -374,8 +378,12 @@ export const ItemsMixin = (superClass) =>
           // Forward parent overlay class
           const { overlayClass } = this;
           this.__openSubMenu(subMenu, item, overlayClass);
-        } else {
+        } else if (isSubmenuFocused) {
+          // If the sub-menu item was focused, focus its parent item.
           subMenu.listenOn.focus();
+        } else if (!this._listBox.focused) {
+          // Otherwise, focus the overlay part to handle arrow keys.
+          this._overlayElement.$.overlay.focus();
         }
       }
     }

--- a/packages/context-menu/test/items.common.js
+++ b/packages/context-menu/test/items.common.js
@@ -261,6 +261,22 @@ describe('items', () => {
     expect(focusSpy.called).to.be.true;
   });
 
+  (isTouch ? it.skip : it)('should focus overlay part on closing sub-menu without focused item', async () => {
+    const parent = getMenuItems(rootMenu)[3];
+    await openMenu(parent);
+    const nonParent = getMenuItems(rootMenu)[1];
+    const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
+    await openMenu(nonParent);
+    expect(focusSpy.called).to.be.true;
+  });
+
+  (isTouch ? it.skip : it)('should not focus overlay part if the parent menu list-box has focus', async () => {
+    await openMenu(getMenuItems(rootMenu)[1]);
+    const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
+    await openMenu(getMenuItems(rootMenu)[2]);
+    expect(focusSpy.called).to.be.false;
+  });
+
   it('should not close the menu if root item has keep open', () => {
     getMenuItems(rootMenu)[2].click();
     expect(rootMenu.opened).to.be.true;


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6386

Updated the context-menu to check if the sub-menu contained a focused item before closing it:
- If that's true, the focus is moved to the corresponding parent item (and the outline is preserved).
- Otherwise, the overlay part receives focus, so that we can still handle `keydown` for arrow keys.

I think this makes more sense than a workaround with focusing the item without showing outline.

## Type of change

- Bugfix

## Note

See video below for the updated behavior:

### Hover

Parent / child item is not focused when opening / closing sub-menu on hover:

https://github.com/vaadin/web-components/assets/10589913/7434555c-8d0e-4086-9060-47f574c1e1d7

### Keyboard

Parent item is focused after closing a sub-menu with a focused child item:

https://github.com/vaadin/web-components/assets/10589913/2304d7ee-5d2d-4ecf-89cd-70507af18146



