### PR TITLE
fix: select date on Today click if today is max date (#7516) (CP: 24.3)

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -508,7 +508,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _onTodayTap() {
-      const today = new Date();
+      const today = this._getTodayMidnight();
 
       if (Math.abs(this._monthScroller.position - this._differenceInMonths(today, this._originDate)) < 0.001) {
         // Select today only if the month scroller is positioned approximately
@@ -1015,12 +1015,17 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _isTodayAllowed(min, max) {
+      return this._dateAllowed(this._getTodayMidnight(), min, max);
+    }
+
+    /** @private */
+    _getTodayMidnight() {
       const today = new Date();
       const todayMidnight = new Date(0, 0);
       todayMidnight.setFullYear(today.getFullYear());
       todayMidnight.setMonth(today.getMonth());
       todayMidnight.setDate(today.getDate());
-      return this._dateAllowed(todayMidnight, min, max);
+      return todayMidnight;
     }
 
     /**

--- a/packages/date-picker/test/overlay-content.common.js
+++ b/packages/date-picker/test/overlay-content.common.js
@@ -280,6 +280,18 @@ describe('overlay', () => {
             overlay.minDate = tomorrowMidnight;
             expect(overlay._todayButton.disabled).to.be.true;
           });
+
+          it('should select today if today is max', async () => {
+            overlay.maxDate = todayMidnight;
+            overlay.scrollToDate(todayMidnight);
+            await waitForScrollToFinish(overlay);
+
+            tap(overlay._todayButton);
+
+            expect(overlay.selectedDate.getFullYear()).to.equal(todayMidnight.getFullYear());
+            expect(overlay.selectedDate.getMonth()).to.equal(todayMidnight.getMonth());
+            expect(overlay.selectedDate.getDate()).to.equal(todayMidnight.getDate());
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

Manual cherry-pick of #7516 to `24.3` branch. 

The automated cherry-pick failed due to `isDateDisabled` present in main / 24.4 but missing in 24.3 branch.

## Type of change

- Cherry-pick