### PR TITLE
fix: allow helper disallowed char patterns set for input

### DIFF
--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -166,10 +166,6 @@ export const InputControlMixin = (superclass) =>
       input.addEventListener('beforeinput', this._boundOnBeforeInput);
     }
 
-    __targetIsInput(event) {
-      return event.target === this.inputElement;
-    }
-
     /**
      * Override a method from `InputMixin`.
      * @param {!HTMLElement} input
@@ -192,7 +188,7 @@ export const InputControlMixin = (superclass) =>
      */
     _onKeyDown(event) {
       super._onKeyDown(event);
-      if (this.allowedCharPattern && !this.__shouldAcceptKey(event) && this.__targetIsInput(event)) {
+      if (this.allowedCharPattern && !this.__shouldAcceptKey(event) && event.target === this.inputElement) {
         event.preventDefault();
         this._markInputPrevented();
       }

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -166,6 +166,10 @@ export const InputControlMixin = (superclass) =>
       input.addEventListener('beforeinput', this._boundOnBeforeInput);
     }
 
+    __targetIsHelper(event) {
+      return event.target.assignedSlot.getRootNode().host.getAttribute('slot') === 'helper';
+    }
+
     /**
      * Override a method from `InputMixin`.
      * @param {!HTMLElement} input
@@ -188,8 +192,7 @@ export const InputControlMixin = (superclass) =>
      */
     _onKeyDown(event) {
       super._onKeyDown(event);
-
-      if (this.allowedCharPattern && !this.__shouldAcceptKey(event)) {
+      if (this.allowedCharPattern && !this.__shouldAcceptKey(event) && !this.__targetIsHelper(event)) {
         event.preventDefault();
         this._markInputPrevented();
       }
@@ -219,7 +222,7 @@ export const InputControlMixin = (superclass) =>
     _onPaste(e) {
       if (this.allowedCharPattern) {
         const pastedText = e.clipboardData.getData('text');
-        if (!this.__allowedTextRegExp.test(pastedText)) {
+        if (!this.__allowedTextRegExp.test(pastedText) && !this.__targetIsHelper(e)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -230,7 +233,7 @@ export const InputControlMixin = (superclass) =>
     _onDrop(e) {
       if (this.allowedCharPattern) {
         const draggedText = e.dataTransfer.getData('text');
-        if (!this.__allowedTextRegExp.test(draggedText)) {
+        if (!this.__allowedTextRegExp.test(draggedText) && !this.__targetIsHelper(e)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -243,7 +246,8 @@ export const InputControlMixin = (superclass) =>
       // but it is still experimental technology so we can't rely on it. It's used here just as an additional check,
       // because it seems to be the only way to detect and prevent specific keys on mobile devices.
       // See https://github.com/vaadin/vaadin-text-field/issues/429
-      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data)) {
+
+      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data) && !this.__targetIsHelper(e)) {
         e.preventDefault();
         this._markInputPrevented();
       }

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -222,7 +222,7 @@ export const InputControlMixin = (superclass) =>
     _onPaste(e) {
       if (this.allowedCharPattern) {
         const pastedText = e.clipboardData.getData('text');
-        if (!this.__allowedTextRegExp.test(pastedText) && this.__targetIsInput(e)) {
+        if (!this.__allowedTextRegExp.test(pastedText)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -233,7 +233,7 @@ export const InputControlMixin = (superclass) =>
     _onDrop(e) {
       if (this.allowedCharPattern) {
         const draggedText = e.dataTransfer.getData('text');
-        if (!this.__allowedTextRegExp.test(draggedText) && this.__targetIsInput(e)) {
+        if (!this.__allowedTextRegExp.test(draggedText)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -246,8 +246,7 @@ export const InputControlMixin = (superclass) =>
       // but it is still experimental technology so we can't rely on it. It's used here just as an additional check,
       // because it seems to be the only way to detect and prevent specific keys on mobile devices.
       // See https://github.com/vaadin/vaadin-text-field/issues/429
-
-      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data) && this.__targetIsInput(e)) {
+      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data)) {
         e.preventDefault();
         this._markInputPrevented();
       }

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -188,6 +188,7 @@ export const InputControlMixin = (superclass) =>
      */
     _onKeyDown(event) {
       super._onKeyDown(event);
+
       if (this.allowedCharPattern && !this.__shouldAcceptKey(event) && event.target === this.inputElement) {
         event.preventDefault();
         this._markInputPrevented();

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -166,8 +166,8 @@ export const InputControlMixin = (superclass) =>
       input.addEventListener('beforeinput', this._boundOnBeforeInput);
     }
 
-    __targetIsHelper(event) {
-      return event.target.assignedSlot.getRootNode().host.getAttribute('slot') === 'helper';
+    __targetIsInput(event) {
+      return event.target === this.inputElement;
     }
 
     /**
@@ -192,7 +192,7 @@ export const InputControlMixin = (superclass) =>
      */
     _onKeyDown(event) {
       super._onKeyDown(event);
-      if (this.allowedCharPattern && !this.__shouldAcceptKey(event) && !this.__targetIsHelper(event)) {
+      if (this.allowedCharPattern && !this.__shouldAcceptKey(event) && this.__targetIsInput(event)) {
         event.preventDefault();
         this._markInputPrevented();
       }
@@ -222,7 +222,7 @@ export const InputControlMixin = (superclass) =>
     _onPaste(e) {
       if (this.allowedCharPattern) {
         const pastedText = e.clipboardData.getData('text');
-        if (!this.__allowedTextRegExp.test(pastedText) && !this.__targetIsHelper(e)) {
+        if (!this.__allowedTextRegExp.test(pastedText) && this.__targetIsInput(e)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -233,7 +233,7 @@ export const InputControlMixin = (superclass) =>
     _onDrop(e) {
       if (this.allowedCharPattern) {
         const draggedText = e.dataTransfer.getData('text');
-        if (!this.__allowedTextRegExp.test(draggedText) && !this.__targetIsHelper(e)) {
+        if (!this.__allowedTextRegExp.test(draggedText) && this.__targetIsInput(e)) {
           e.preventDefault();
           this._markInputPrevented();
         }
@@ -247,7 +247,7 @@ export const InputControlMixin = (superclass) =>
       // because it seems to be the only way to detect and prevent specific keys on mobile devices.
       // See https://github.com/vaadin/vaadin-text-field/issues/429
 
-      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data) && !this.__targetIsHelper(e)) {
+      if (this.allowedCharPattern && e.data && !this.__allowedTextRegExp.test(e.data) && this.__targetIsInput(e)) {
         e.preventDefault();
         this._markInputPrevented();
       }

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -10,6 +10,7 @@ import {
   nextRender,
   nextUpdate,
 } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -368,6 +369,18 @@ const runTests = (defineHelper, baseMixin) => {
 
         element._preventInputDebouncer.flush();
         expect(element.hasAttribute('input-prevented')).to.be.false;
+      });
+
+      it('should check the helper checkbox', async () => {
+        element.allowedCharPattern = '';
+        const helperCheckbox = fixtureSync(`<input id="helper-checkbox" type="checkbox" slot="helper"/>`);
+        element.appendChild(helperCheckbox);
+        helperCheckbox.focus();
+
+        await sendKeys({ down: 'Space' });
+        await sendKeys({ up: 'Space' });
+
+        expect(helperCheckbox.checked).to.be.true;
       });
     });
 

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -371,7 +371,7 @@ const runTests = (defineHelper, baseMixin) => {
         expect(element.hasAttribute('input-prevented')).to.be.false;
       });
 
-      it('should check the helper checkbox', async () => {
+      it('should not prevent input for other slotted inputs', async () => {
         element.allowedCharPattern = '';
         const helperCheckbox = fixtureSync(`<input id="helper-checkbox" type="checkbox" slot="helper"/>`);
         element.appendChild(helperCheckbox);

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -373,9 +373,9 @@ const runTests = (defineHelper, baseMixin) => {
 
       it('should not prevent input for other slotted inputs', async () => {
         element.allowedCharPattern = '';
-        const helperCheckbox = fixtureSync(`<input id="helper-checkbox" type="checkbox" slot="helper"/>`);
-        element.appendChild(helperCheckbox);
-        helperCheckbox.focus();
+        const checkbox = fixtureSync(`<input type="checkbox" slot="helper"/>`);
+        element.appendChild(checkbox);
+        checkbox.focus();
 
         await sendKeys({ press: 'Space' });
 

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -372,7 +372,6 @@ const runTests = (defineHelper, baseMixin) => {
       });
 
       it('should not prevent input for other slotted inputs', async () => {
-        element.allowedCharPattern = 'a';
         const checkbox = fixtureSync(`<input type="checkbox" slot="helper"/>`);
         element.appendChild(checkbox);
         checkbox.focus();

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -377,8 +377,7 @@ const runTests = (defineHelper, baseMixin) => {
         element.appendChild(helperCheckbox);
         helperCheckbox.focus();
 
-        await sendKeys({ down: 'Space' });
-        await sendKeys({ up: 'Space' });
+        await sendKeys({ press: 'Space' });
 
         expect(helperCheckbox.checked).to.be.true;
       });

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -372,14 +372,14 @@ const runTests = (defineHelper, baseMixin) => {
       });
 
       it('should not prevent input for other slotted inputs', async () => {
-        element.allowedCharPattern = '';
+        element.allowedCharPattern = 'a';
         const checkbox = fixtureSync(`<input type="checkbox" slot="helper"/>`);
         element.appendChild(checkbox);
         checkbox.focus();
 
         await sendKeys({ press: 'Space' });
 
-        expect(helperCheckbox.checked).to.be.true;
+        expect(checkbox.checked).to.be.true;
       });
     });
 


### PR DESCRIPTION
## Description

Currently helpers are also disallowed the char patterns as set for the main input. The issue mentions the very real problem of not being able to check a helper checkbox with keyboard navigation if the input disallows spaces, like it should for a lot of inputs.

This PR checks that the event target is the main input of the input-field. 

Fixes https://github.com/vaadin/flow-components/issues/6391

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have added tests to ensure my change is effective and works as intended.
- [x] Existing tests are passing locally with my change.