### PR TITLE
fix: allow the content part of details summary the remainder of the width

### DIFF
--- a/packages/details/theme/lumo/vaadin-details-summary-styles.js
+++ b/packages/details/theme/lumo/vaadin-details-summary-styles.js
@@ -61,7 +61,7 @@ const detailsSummary = css`
     transform: rotate(90deg);
   }
 
-  :host [part='content'] {
+  [part='content'] {
     flex-grow: 1;
   }
 

--- a/packages/details/theme/lumo/vaadin-details-summary-styles.js
+++ b/packages/details/theme/lumo/vaadin-details-summary-styles.js
@@ -61,6 +61,10 @@ const detailsSummary = css`
     transform: rotate(90deg);
   }
 
+  :host [part='content'] {
+    flex-grow: 1;
+  }
+
   /* RTL styles */
   :host([dir='rtl']) [part='toggle'] {
     margin-left: var(--lumo-space-xs);


### PR DESCRIPTION
## Description

Even though it's now easy for the user to style the content part of the summary, this gives the content the remainder of the width by default.

Fixes #497

## Type of change

- [X] Bugfix
