### PR TITLE
test: move a11y test suite to the appropriate file

### DIFF
--- a/packages/menu-bar/test/a11y.common.js
+++ b/packages/menu-bar/test/a11y.common.js
@@ -3,6 +3,62 @@ import { arrowDown, arrowRight, enter, fixtureSync, nextRender, outsideClick } f
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('a11y', () => {
+  describe('ARIA attributes', () => {
+    let menu, buttons, subMenu, overflow;
+
+    beforeEach(async () => {
+      menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+      menu.items = [
+        {
+          text: 'Menu Item 1',
+          children: [{ text: 'Menu Item 1 1' }, { text: 'Menu Item 1 2' }],
+        },
+        { text: 'Menu Item 2' },
+        {
+          text: 'Menu Item 3',
+          children: [{ text: 'Menu Item 3 1' }, { text: 'Menu Item 3 2' }],
+        },
+      ];
+      await nextRender(menu);
+      subMenu = menu._subMenu;
+      buttons = menu._buttons;
+      overflow = menu._overflow;
+    });
+
+    it('should set role attribute on host element', () => {
+      expect(menu.getAttribute('role')).to.equal('menubar');
+    });
+
+    it('should set role attribute on menu bar buttons', () => {
+      buttons.forEach((btn) => {
+        expect(btn.getAttribute('role')).to.equal('menuitem');
+      });
+    });
+
+    it('should set aria-haspopup attribute on buttons with nested items', () => {
+      buttons.forEach((btn) => {
+        const hasPopup = btn === overflow || btn.item.children ? 'true' : null;
+        expect(btn.getAttribute('aria-haspopup')).to.equal(hasPopup);
+      });
+    });
+
+    it('should set aria-expanded attribute on buttons with nested items', () => {
+      buttons.forEach((btn) => {
+        const expanded = btn === overflow || btn.item.children ? 'false' : null;
+        expect(btn.getAttribute('aria-expanded')).to.equal(expanded);
+      });
+    });
+
+    it('should toggle aria-expanded attribute on submenu open / close', async () => {
+      buttons[0].click();
+      await nextRender(subMenu);
+      expect(buttons[0].getAttribute('aria-expanded')).to.equal('true');
+
+      buttons[0].click();
+      expect(buttons[0].getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+
   describe('focus restoration', () => {
     let menuBar, overlay, buttons;
 

--- a/packages/menu-bar/test/sub-menu.common.js
+++ b/packages/menu-bar/test/sub-menu.common.js
@@ -575,62 +575,6 @@ describe('open on hover', () => {
   });
 });
 
-describe('accessibility', () => {
-  let menu, buttons, subMenu, overflow;
-
-  beforeEach(async () => {
-    menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
-    menu.items = [
-      {
-        text: 'Menu Item 1',
-        children: [{ text: 'Menu Item 1 1' }, { text: 'Menu Item 1 2' }],
-      },
-      { text: 'Menu Item 2' },
-      {
-        text: 'Menu Item 3',
-        children: [{ text: 'Menu Item 3 1' }, { text: 'Menu Item 3 2' }],
-      },
-    ];
-    await nextRender(menu);
-    subMenu = menu._subMenu;
-    buttons = menu._buttons;
-    overflow = menu._overflow;
-  });
-
-  it('should set role attribute on host element', () => {
-    expect(menu.getAttribute('role')).to.equal('menubar');
-  });
-
-  it('should set role attribute on menu bar buttons', () => {
-    buttons.forEach((btn) => {
-      expect(btn.getAttribute('role')).to.equal('menuitem');
-    });
-  });
-
-  it('should set aria-haspopup attribute on buttons with nested items', () => {
-    buttons.forEach((btn) => {
-      const hasPopup = btn === overflow || btn.item.children ? 'true' : null;
-      expect(btn.getAttribute('aria-haspopup')).to.equal(hasPopup);
-    });
-  });
-
-  it('should set aria-expanded attribute on buttons with nested items', () => {
-    buttons.forEach((btn) => {
-      const expanded = btn === overflow || btn.item.children ? 'false' : null;
-      expect(btn.getAttribute('aria-expanded')).to.equal(expanded);
-    });
-  });
-
-  it('should toggle aria-expanded attribute on submenu open / close', async () => {
-    buttons[0].click();
-    await nextRender(subMenu);
-    expect(buttons[0].getAttribute('aria-expanded')).to.equal('true');
-
-    buttons[0].click();
-    expect(buttons[0].getAttribute('aria-expanded')).to.equal('false');
-  });
-});
-
 describe('theme attribute', () => {
   let menu, subMenu, subMenuOverlay, buttons;
 


### PR DESCRIPTION
## Description

While reviewing #7525, I noticed that for the "accessibility" test suite is confusingly placed in `sub-menu` test file.
This is a leftover from the V14 version. Now when we have `a11y` test file, it makes sense to move the suite there.

## Type of change

- Test