### PR TITLE
feat: fire closed event when popover overlay is closed

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -22,6 +22,8 @@ export type PopoverOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 
 export interface PopoverCustomEventMap {
   'opened-changed': PopoverOpenedChangedEvent;
+
+  closed: Event;
 }
 
 export type PopoverEventMap = HTMLElementEventMap & PopoverCustomEventMap;
@@ -34,6 +36,7 @@ export type PopoverEventMap = HTMLElementEventMap & PopoverCustomEventMap;
  * that can be provided by using `renderer` function.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} closed - Fired when the popover is closed.
  */
 declare class Popover extends PopoverPositionMixin(
   PopoverTargetMixin(OverlayClassMixin(ThemePropertyMixin(ElementMixin(HTMLElement)))),

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -132,6 +132,7 @@ class PopoverOpenedStateController {
  * that can be provided by using `renderer` function.
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} closed - Fired when the popover is closed.
  *
  * @customElement
  * @extends HTMLElement
@@ -685,6 +686,8 @@ class Popover extends PopoverPositionMixin(
     if (this.modal && this.target.style.pointerEvents) {
       this.target.style.pointerEvents = '';
     }
+
+    this.dispatchEvent(new CustomEvent('closed'));
   }
 
   /**
@@ -741,6 +744,12 @@ class Popover extends PopoverPositionMixin(
       this.__updateDimension(overlay, 'width', width);
     }
   }
+
+  /**
+   * Fired when the popover is closed.
+   *
+   * @event closed
+   */
 }
 
 defineCustomElement(Popover);

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -399,4 +399,32 @@ describe('popover', () => {
       expect(overlay.getAttribute('style')).to.be.not.ok;
     });
   });
+
+  describe('closed event', () => {
+    beforeEach(async () => {
+      popover.opened = true;
+      await nextRender();
+    });
+
+    it('should dispatch closed event when closed', async () => {
+      const closedSpy = sinon.spy();
+      popover.addEventListener('closed', closedSpy);
+      popover.opened = false;
+      await nextRender();
+      expect(closedSpy).to.be.calledOnce;
+    });
+
+    it('should dispatch closed event after overlay is closed', async () => {
+      const closedPromise = new Promise((resolve) => {
+        const closedListener = () => {
+          expect(overlay.parentElement).to.be.not.ok;
+          resolve();
+        };
+        popover.addEventListener('closed', closedListener, { once: true });
+      });
+      popover.opened = false;
+      await nextRender();
+      await closedPromise;
+    });
+  });
 });

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -48,3 +48,7 @@ popover.addEventListener('opened-changed', (event) => {
   assertType<PopoverOpenedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
+
+popover.addEventListener('closed', (event) => {
+  assertType<Event>(event);
+});


### PR DESCRIPTION
## Description

Related to #7422

Implemented `closed` event similar to what was added to `vaadin-dialog` in #7471

## Type of change

- Feature