### PR TITLE
docs: add missing JSDoc annotations for closed event

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -449,4 +449,10 @@ export const ConfirmDialogMixin = (superClass) =>
     _getAriaLabel(header) {
       return header || 'confirmation';
     }
+
+    /**
+     * Fired when the confirm dialog is closed.
+     *
+     * @event closed
+     */
   };

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -126,4 +126,10 @@ export const DialogBaseMixin = (superClass) =>
         this._overlayElement.bringToFront();
       }
     }
+
+    /**
+     * Fired when the dialog is closed.
+     *
+     * @event closed
+     */
   };

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -577,6 +577,12 @@ class Notification extends OverlayClassMixin(ThemePropertyMixin(ElementMixin(Pol
       }
     }
   }
+
+  /**
+   * Fired when the notification is closed.
+   *
+   * @event closed
+   */
 }
 
 defineCustomElement(NotificationContainer);


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/7422

While reviewing PRs related to the above change, I missed that we need to annotate this event using `@event` for Polymer Analyzer, which then generates `web-types.json` used by React components, so we could use `onClosed` in React.

This PR adds missing annotations. I will check if there are more events like these and if so, fix them separately.

## Type of change

- Documentation fix