### PR TITLE
docs: add missing JSDoc annotation for resized event

### DIFF
--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -158,4 +158,10 @@ export const DialogResizableMixin = (superClass) =>
       this.$.overlay.$.resizerContainer.scrollTop = scrollPosition;
       return { width, height, contentWidth, contentHeight };
     }
+
+    /**
+     * Fired when the dialog resize is finished.
+     *
+     * @event resize
+     */
   };


### PR DESCRIPTION
## Description

Added missing `@event` annotation for using by Polymer Analyzer to make the `resize` event appear in API docs.
This will also add it to `web-types.json` and therefore will generate `onResize` listener for the React wrapper.

## Type of change

- Documentation