### PR TITLE
chore: remove unnecessary event JSDoc from d.ts file

### DIFF
--- a/packages/field-base/src/validate-mixin.d.ts
+++ b/packages/field-base/src/validate-mixin.d.ts
@@ -30,12 +30,4 @@ export declare class ValidateMixinClass {
    * Returns true if the field value satisfies all constraints (if any).
    */
   checkValidity(): boolean;
-
-  /**
-   * Fired whenever the field is validated.
-   *
-   * @event validated
-   * @param {Object} detail
-   * @param {boolean} detail.valid the result of the validation.
-   */
 }


### PR DESCRIPTION
## Description

We only need `@event` annotation in `.js` files as Polymer Analyzer does not scan `.d.ts` files for it.
Removed this comment (there is a correct one in the corresponding `.js` file for this mixin.

## Type of change

- Documentation