### PR TITLE
fix: render at most 7 weekdays in datepicker

### DIFF
--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -199,12 +199,14 @@ export const MonthCalendarMixin = (superClass) =>
       const weekDayNamesShort = this._applyFirstDayOfWeek(weekdaysShort, firstDayOfWeek);
       const weekDayNames = this._applyFirstDayOfWeek(weekdays, firstDayOfWeek);
 
-      return weekDayNames.map((day, index) => {
-        return {
-          weekDay: day,
-          weekDayShort: weekDayNamesShort[index],
-        };
-      });
+      return weekDayNames
+        .map((day, index) => {
+          return {
+            weekDay: day,
+            weekDayShort: weekDayNamesShort[index],
+          };
+        })
+        .slice(0, 7);
     }
 
     /** @private */

--- a/packages/date-picker/test/month-calendar.common.js
+++ b/packages/date-picker/test/month-calendar.common.js
@@ -64,6 +64,18 @@ describe('vaadin-month-calendar', () => {
     expect(monthCalendar.shadowRoot.querySelector('[part="month-header"]').textContent).to.equal('January 2000');
   });
 
+  it('should render at most 7 weekdays', async () => {
+    monthCalendar.i18n = {
+      ...monthCalendar.i18n,
+      weekdays: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+      weekdaysShort: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+    };
+    await nextRender();
+
+    const weekdays = getWeekDayCells(monthCalendar);
+    expect(weekdays.length).to.equal(7);
+  });
+
   it('should fire value change on tap', () => {
     const dateElements = getDateCells(monthCalendar);
     tap(dateElements[10]);


### PR DESCRIPTION
## Description
Nothing stops the user from setting more than 7 weekdays, this PR renders only the first 7 of the given weekdays.

Weekday items are given a width of 100%/7 meaning that the are aligned even with less than 7 items, but when there are 8 or more, the width exceeds 100% and the parent container's flexbox squeezes them together, misaligning the weekdays from the dates.

Fixes part of https://github.com/vaadin/flow-components/issues/6353

Related PR: https://github.com/vaadin/flow-components/pull/6432

## Type of change
- [X] Bugfix