### PR TITLE
fix: implement custom toolbar formats click logic

### DIFF
--- a/packages/rich-text-editor/src/vaadin-lit-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-lit-rich-text-editor.js
@@ -47,7 +47,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
     return html`
       <div class="vaadin-rich-text-editor-container">
         <!-- Create toolbar container -->
-        <div part="toolbar" role="toolbar">
+        <div part="toolbar" role="toolbar" @click="${this._onToolbarClick}">
           <span part="toolbar-group toolbar-group-history">
             <!-- Undo and Redo -->
             <button
@@ -69,19 +69,19 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
 
           <span part="toolbar-group toolbar-group-emphasis">
             <!-- Bold -->
-            <button id="btn-bold" class="ql-bold" part="toolbar-button toolbar-button-bold"></button>
+            <button id="btn-bold" class="format-bold" part="toolbar-button toolbar-button-bold"></button>
             <vaadin-tooltip for="btn-bold" .text="${this.i18n.bold}"></vaadin-tooltip>
 
             <!-- Italic -->
-            <button id="btn-italic" class="ql-italic" part="toolbar-button toolbar-button-italic"></button>
+            <button id="btn-italic" class="format-italic" part="toolbar-button toolbar-button-italic"></button>
             <vaadin-tooltip for="btn-italic" .text="${this.i18n.italic}"></vaadin-tooltip>
 
             <!-- Underline -->
-            <button id="btn-underline" class="ql-underline" part="toolbar-button toolbar-button-underline"></button>
+            <button id="btn-underline" class="format-underline" part="toolbar-button toolbar-button-underline"></button>
             <vaadin-tooltip for="btn-underline" .text="${this.i18n.underline}"></vaadin-tooltip>
 
             <!-- Strike -->
-            <button id="btn-strike" class="ql-strike" part="toolbar-button toolbar-button-strike"></button>
+            <button id="btn-strike" class="format-strike" part="toolbar-button toolbar-button-strike"></button>
             <vaadin-tooltip for="btn-strike" .text="${this.i18n.strike}"></vaadin-tooltip>
           </span>
 
@@ -109,7 +109,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-h1"
               type="button"
-              class="ql-header"
+              class="format-header"
               value="1"
               part="toolbar-button toolbar-button-h1"
             ></button>
@@ -117,7 +117,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-h2"
               type="button"
-              class="ql-header"
+              class="format-header"
               value="2"
               part="toolbar-button toolbar-button-h2"
             ></button>
@@ -125,7 +125,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-h3"
               type="button"
-              class="ql-header"
+              class="format-header"
               value="3"
               part="toolbar-button toolbar-button-h3"
             ></button>
@@ -136,14 +136,14 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <!-- Subscript and superscript -->
             <button
               id="btn-subscript"
-              class="ql-script"
+              class="format-script"
               value="sub"
               part="toolbar-button toolbar-button-subscript"
             ></button>
             <vaadin-tooltip for="btn-subscript" .text="${this.i18n.subscript}"></vaadin-tooltip>
             <button
               id="btn-superscript"
-              class="ql-script"
+              class="format-script"
               value="super"
               part="toolbar-button toolbar-button-superscript"
             ></button>
@@ -155,7 +155,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-ol"
               type="button"
-              class="ql-list"
+              class="format-list"
               value="ordered"
               part="toolbar-button toolbar-button-list-ordered"
             ></button>
@@ -163,7 +163,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-ul"
               type="button"
-              class="ql-list"
+              class="format-list"
               value="bullet"
               part="toolbar-button toolbar-button-list-bullet"
             ></button>
@@ -175,7 +175,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-left"
               type="button"
-              class="ql-align"
+              class="format-align"
               value=""
               part="toolbar-button toolbar-button-align-left"
             ></button>
@@ -183,7 +183,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-center"
               type="button"
-              class="ql-align"
+              class="format-align"
               value="center"
               part="toolbar-button toolbar-button-align-center"
             ></button>
@@ -191,7 +191,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-right"
               type="button"
-              class="ql-align"
+              class="format-align"
               value="right"
               part="toolbar-button toolbar-button-align-right"
             ></button>
@@ -223,7 +223,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-blockquote"
               type="button"
-              class="ql-blockquote"
+              class="format-blockquote"
               part="toolbar-button toolbar-button-blockquote"
             ></button>
             <vaadin-tooltip for="btn-blockquote" .text="${this.i18n.blockquote}"></vaadin-tooltip>
@@ -231,7 +231,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-code"
               type="button"
-              class="ql-code-block"
+              class="format-code-block"
               part="toolbar-button toolbar-button-code-block"
             ></button>
             <vaadin-tooltip for="btn-code" .text="${this.i18n.codeBlock}"></vaadin-tooltip>
@@ -239,7 +239,12 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
 
           <span part="toolbar-group toolbar-group-format">
             <!-- Clean -->
-            <button id="btn-clean" type="button" class="ql-clean" part="toolbar-button toolbar-button-clean"></button>
+            <button
+              id="btn-clean"
+              type="button"
+              class="format-clean"
+              part="toolbar-button toolbar-button-clean"
+            ></button>
             <vaadin-tooltip for="btn-clean" .text="${this.i18n.clean}"></vaadin-tooltip>
           </span>
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -106,7 +106,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
     return html`
       <div class="vaadin-rich-text-editor-container">
         <!-- Create toolbar container -->
-        <div part="toolbar" role="toolbar">
+        <div part="toolbar" role="toolbar" on-click="_onToolbarClick">
           <span part="toolbar-group toolbar-group-history">
             <!-- Undo and Redo -->
             <button id="btn-undo" type="button" part="toolbar-button toolbar-button-undo" on-click="_undo"></button>
@@ -118,19 +118,19 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
 
           <span part="toolbar-group toolbar-group-emphasis">
             <!-- Bold -->
-            <button id="btn-bold" class="ql-bold" part="toolbar-button toolbar-button-bold"></button>
+            <button id="btn-bold" class="format-bold" part="toolbar-button toolbar-button-bold"></button>
             <vaadin-tooltip for="btn-bold" text="[[i18n.bold]]"></vaadin-tooltip>
 
             <!-- Italic -->
-            <button id="btn-italic" class="ql-italic" part="toolbar-button toolbar-button-italic"></button>
+            <button id="btn-italic" class="format-italic" part="toolbar-button toolbar-button-italic"></button>
             <vaadin-tooltip for="btn-italic" text="[[i18n.italic]]"></vaadin-tooltip>
 
             <!-- Underline -->
-            <button id="btn-underline" class="ql-underline" part="toolbar-button toolbar-button-underline"></button>
+            <button id="btn-underline" class="format-underline" part="toolbar-button toolbar-button-underline"></button>
             <vaadin-tooltip for="btn-underline" text="[[i18n.underline]]"></vaadin-tooltip>
 
             <!-- Strike -->
-            <button id="btn-strike" class="ql-strike" part="toolbar-button toolbar-button-strike"></button>
+            <button id="btn-strike" class="format-strike" part="toolbar-button toolbar-button-strike"></button>
             <vaadin-tooltip for="btn-strike" text="[[i18n.strike]]"></vaadin-tooltip>
           </span>
 
@@ -158,7 +158,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-h1"
               type="button"
-              class="ql-header"
+              class="format-header"
               value="1"
               part="toolbar-button toolbar-button-h1"
             ></button>
@@ -166,7 +166,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-h2"
               type="button"
-              class="ql-header"
+              class="format-header"
               value="2"
               part="toolbar-button toolbar-button-h2"
             ></button>
@@ -174,7 +174,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-h3"
               type="button"
-              class="ql-header"
+              class="format-header"
               value="3"
               part="toolbar-button toolbar-button-h3"
             ></button>
@@ -185,14 +185,14 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <!-- Subscript and superscript -->
             <button
               id="btn-subscript"
-              class="ql-script"
+              class="format-script"
               value="sub"
               part="toolbar-button toolbar-button-subscript"
             ></button>
             <vaadin-tooltip for="btn-subscript" text="[[i18n.subscript]]"></vaadin-tooltip>
             <button
               id="btn-superscript"
-              class="ql-script"
+              class="format-script"
               value="super"
               part="toolbar-button toolbar-button-superscript"
             ></button>
@@ -204,7 +204,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-ol"
               type="button"
-              class="ql-list"
+              class="format-list"
               value="ordered"
               part="toolbar-button toolbar-button-list-ordered"
             ></button>
@@ -212,7 +212,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-ul"
               type="button"
-              class="ql-list"
+              class="format-list"
               value="bullet"
               part="toolbar-button toolbar-button-list-bullet"
             ></button>
@@ -224,7 +224,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-left"
               type="button"
-              class="ql-align"
+              class="format-align"
               value=""
               part="toolbar-button toolbar-button-align-left"
             ></button>
@@ -232,7 +232,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-center"
               type="button"
-              class="ql-align"
+              class="format-align"
               value="center"
               part="toolbar-button toolbar-button-align-center"
             ></button>
@@ -240,7 +240,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-right"
               type="button"
-              class="ql-align"
+              class="format-align"
               value="right"
               part="toolbar-button toolbar-button-align-right"
             ></button>
@@ -272,7 +272,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-blockquote"
               type="button"
-              class="ql-blockquote"
+              class="format-blockquote"
               part="toolbar-button toolbar-button-blockquote"
             ></button>
             <vaadin-tooltip for="btn-blockquote" text="[[i18n.blockquote]]"></vaadin-tooltip>
@@ -280,7 +280,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
             <button
               id="btn-code"
               type="button"
-              class="ql-code-block"
+              class="format-code-block"
               part="toolbar-button toolbar-button-code-block"
             ></button>
             <vaadin-tooltip for="btn-code" text="[[i18n.codeBlock]]"></vaadin-tooltip>
@@ -288,7 +288,12 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
 
           <span part="toolbar-group toolbar-group-format">
             <!-- Clean -->
-            <button id="btn-clean" type="button" class="ql-clean" part="toolbar-button toolbar-button-clean"></button>
+            <button
+              id="btn-clean"
+              type="button"
+              class="format-clean"
+              part="toolbar-button toolbar-button-clean"
+            ></button>
             <vaadin-tooltip for="btn-clean" text="[[i18n.clean]]"></vaadin-tooltip>
           </span>
 

--- a/packages/rich-text-editor/test/toolbar.common.js
+++ b/packages/rich-text-editor/test/toolbar.common.js
@@ -556,4 +556,40 @@ describe('toolbar controls', () => {
       expect(editor.getText()).to.equal('Foo\n');
     });
   });
+
+  describe('detach and re-attach', () => {
+    beforeEach(async () => {
+      const parent = rte.parentNode;
+      parent.removeChild(rte);
+      parent.appendChild(rte);
+      await nextUpdate(rte);
+    });
+
+    [
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'blockquote',
+      'code-block',
+      'subscript',
+      'superscript',
+      'list-ordered',
+      'list-bullet',
+      'h1',
+      'h2',
+      'align-center',
+      'align-right',
+      'blockquote',
+      'code-block',
+    ].forEach((format) => {
+      it(`should correctly toggle "on" attribute for ${format} button after detach and re-attach`, () => {
+        btn = getButton(format);
+        btn.click();
+        expect(btn.hasAttribute('on')).to.be.true;
+        btn.click();
+        expect(btn.hasAttribute('on')).to.be.false;
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #7543 

- Added a custom `click` listener for the `toolbar` part with a subset of the corresponding [Quill toolbar module logic](https://github.com/vaadin/quill/blob/1cfe24900a5b402616b93f4a6bcafc61608c4e02/modules/toolbar.js#L81-L107);
- Renamed `ql-` class names on buttons to use `format-` prefix instead, to avoid adding individual click listeners when re-initializing Quill on re-attach in `connectedCallback()` (e.g. when using RTE inside `vaadin-dialog`).

I couldn't find a better solution as Quill doesn't store event listeners anywhere. Also, I'd like to avoid patching our Quill fork even further and instead keep the code in the web component (as long as it's relatively simple).

## Type of change

- Bugfix