### PR TITLE
test: do not use Array constructor in unit tests

### DIFF
--- a/packages/combo-box/test/data-provider-dynamic-size.common.js
+++ b/packages/combo-box/test/data-provider-dynamic-size.common.js
@@ -23,7 +23,7 @@ const TEMPLATES = {
       const ACTUAL_SIZE = 500;
 
       function dataProvider(params, callback) {
-        const items = Array(...new Array(params.pageSize)).map((_, i) => {
+        const items = new Array(params.pageSize).fill().map((_, i) => {
           return {
             label: `Item ${params.pageSize * params.page + i}`,
           };

--- a/packages/combo-box/test/data-provider.common.js
+++ b/packages/combo-box/test/data-provider.common.js
@@ -57,7 +57,7 @@ const TEMPLATES = {
     const objectDataProvider = (params, callback) => {
       const offset = params.page * params.pageSize;
       const n = Math.min(offset + params.pageSize, SIZE) - offset;
-      dataProviderItems = Array(...new Array(n)).map((_, i) => {
+      dataProviderItems = new Array(n).fill().map((_, i) => {
         return { id: i, value: `value ${i}`, label: `label ${i}` };
       });
       callback(dataProviderItems, SIZE);

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -228,9 +228,7 @@ describe('resizable', () => {
     container.style.height = '100%';
     container.style.width = '100%';
     container.style.overflow = 'auto';
-    container.textContent = Array(...new Array(10000))
-      .map(() => 'foo')
-      .join(' ');
+    container.textContent = new Array(10000).fill('foo').join(' ');
 
     const resizeContainer = dialog.$.overlay.$.resizerContainer;
     expect(container.offsetHeight).to.equal(resizeContainer.offsetHeight);
@@ -238,9 +236,7 @@ describe('resizable', () => {
 
   it('should scroll if the content overflows', () => {
     // Fill the content with a lot of text so that it overflows the viewport
-    dialog.$.overlay.firstElementChild.textContent = Array(...new Array(10000))
-      .map(() => 'foo')
-      .join(' ');
+    dialog.$.overlay.firstElementChild.textContent = new Array(10000).fill('foo').join(' ');
 
     const resizeContainer = dialog.$.overlay.$.resizerContainer;
     resizeContainer.scrollTop = 1;

--- a/packages/grid/test/accessibility.common.js
+++ b/packages/grid/test/accessibility.common.js
@@ -307,7 +307,7 @@ describe('accessibility', () => {
     });
 
     it('should update aria-rowcount on after size change', () => {
-      grid.items = Array(...new Array(10)).map(() => 'foo');
+      grid.items = new Array(10).fill('foo');
 
       // 10 item rows + header row + footer row = 12 in total
       expect(grid.$.table.getAttribute('aria-rowcount')).to.equal('12');

--- a/packages/grid/test/scroll-to-index.common.js
+++ b/packages/grid/test/scroll-to-index.common.js
@@ -137,7 +137,7 @@ describe('scroll to index', () => {
       grid.dataProvider = ({ parentItem }, cb) => {
         setTimeout(() => {
           const scope = parentItem || '';
-          cb(Array(...new Array(grid.pageSize)).map((_, index) => `${scope}foo${index}`));
+          cb(new Array(grid.pageSize).fill().map((_, index) => `${scope}foo${index}`));
           if (parentItem) {
             expect(getFirstVisibleItem(grid).index).to.be.above(75);
             done();
@@ -177,7 +177,7 @@ describe('scroll to index', () => {
           // Still in loading state, this will end up as pending scroll to index
           grid.scrollToIndex(100);
           // Resolve the request, no longer in loading state after this
-          cb(Array(...new Array(grid.pageSize)).map((_, index) => `foo${index}`));
+          cb(new Array(grid.pageSize).fill().map((_, index) => `foo${index}`));
           flushGrid(grid);
 
           // Scroll to a new location (new data will get loaded)
@@ -186,7 +186,7 @@ describe('scroll to index', () => {
           expect(getFirstVisibleItem(grid).index).to.be.above(150);
           done();
         } else {
-          cb(Array(...new Array(grid.pageSize)).map((_, index) => `foo${index}`));
+          cb(new Array(grid.pageSize).fill().map((_, index) => `foo${index}`));
         }
       };
     });
@@ -197,7 +197,7 @@ describe('scroll to index', () => {
 
     beforeEach(() => {
       grid = fixtures.large();
-      data = Array(...new Array(10)).map((_, i) => {
+      data = new Array(10).fill().map((_, i) => {
         return { index: i };
       });
 


### PR DESCRIPTION
## Description

This fixes some warnings reported by [no-array-constructor](https://eslint.org/docs/latest/rules/no-array-constructor) rule in the latest `eslint-config-vaadin` alpha.

## Type of change

- Tests