### PR TITLE
fix: only close combo-box overlay on blur from keyboard

### DIFF
--- a/integration/tests/dialog-combo-box.test.js
+++ b/integration/tests/dialog-combo-box.test.js
@@ -1,5 +1,13 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, mousedown, nextFrame, nextUpdate, oneEvent, touchstart } from '@vaadin/testing-helpers';
+import {
+  fixtureSync,
+  mousedown,
+  nextFrame,
+  nextUpdate,
+  oneEvent,
+  outsideClick,
+  touchstart,
+} from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '@vaadin/combo-box';
@@ -27,19 +35,26 @@ describe('combo-box in dialog', () => {
       await nextUpdate(comboBox);
     });
 
-    it('should not close the dialog when closing time-picker on input element Escape', async () => {
+    it('should not close the dialog when closing combo-box on input element Escape', async () => {
       await sendKeys({ press: 'Escape' });
 
       expect(comboBox.opened).to.be.false;
       expect(dialog.opened).to.be.true;
     });
 
-    it('should close the dialog on subsequent Escape after the time-picker is closed', async () => {
+    it('should close the dialog on subsequent Escape after the combo-box is closed', async () => {
       await sendKeys({ press: 'Escape' });
 
       await sendKeys({ press: 'Escape' });
 
       expect(dialog.opened).to.be.false;
+    });
+
+    it('should not close the dialog when closing combo-box on outside click', () => {
+      outsideClick();
+
+      expect(comboBox.opened).to.be.false;
+      expect(dialog.opened).to.be.true;
     });
   });
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -5,7 +5,7 @@
  */
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
@@ -1358,7 +1358,19 @@ export const ComboBoxMixin = (subclass) =>
           return;
         }
 
-        this._closeOrCommit();
+        if (isKeyboardActive()) {
+          // Close on Tab key causing blur. With mouse, close on outside click instead.
+          this._closeOrCommit();
+          return;
+        }
+
+        if (!this.opened) {
+          this._commitValue();
+        } else if (!this._overlayOpened) {
+          // Combo-box is opened, but overlay is not visible -> custom value was entered.
+          // Make sure we close here as there won't be an "outside click" in this case.
+          this.close();
+        }
       }
     }
 

--- a/packages/combo-box/test/interactions.common.js
+++ b/packages/combo-box/test/interactions.common.js
@@ -9,6 +9,7 @@ import {
   nextRender,
   nextUpdate,
   outsideClick,
+  tabKeyDown,
   tap,
   touchstart,
 } from '@vaadin/testing-helpers';
@@ -58,7 +59,8 @@ describe('interactions', () => {
       expect(comboBox.opened).to.be.false;
     });
 
-    it('should close the when focus is lost', () => {
+    it('should close when focus is lost from keyboard', () => {
+      tabKeyDown(input);
       focusout(input);
 
       expect(comboBox.opened).to.be.false;

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -6,6 +6,7 @@
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import './vaadin-time-picker-combo-box.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -459,7 +460,10 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     super._setFocused(focused);
 
     if (!focused) {
-      this.__commitValueChange();
+      if (!this.opened || isKeyboardActive()) {
+        // Do not commit value change on blur when closing on outside click.
+        this.__commitValueChange();
+      }
 
       // Do not validate when focusout is caused by document
       // losing focus, which happens on browser tab switch.

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -6,7 +6,6 @@
 import '@vaadin/input-container/src/vaadin-input-container.js';
 import './vaadin-time-picker-combo-box.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -460,11 +459,6 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     super._setFocused(focused);
 
     if (!focused) {
-      if (!this.opened || isKeyboardActive()) {
-        // Do not commit value change on blur when closing on outside click.
-        this.__commitValueChange();
-      }
-
       // Do not validate when focusout is caused by document
       // losing focus, which happens on browser tab switch.
       if (document.hasFocus()) {


### PR DESCRIPTION
## Description

Fixes #7552

Changed the blur logic of `vaadin-combo-box` to only close when losing focus from keyboard, or if the `opened` is set to `true` but the overlay is not actually open (which is the case if no dropdown items match the filter).

This way we make sure that closing an opened combo-box happens on outside click (vs `focusout`) and therefore avoid closing of the parent `vaadin-dialog` (or `vaadin-popover`) - this is covered by new test in `integration` folder.

Also updated `vaadin-time-picker` to remove unnecessary value commit from `focusout` - in fact it was triggered twice in this case: first from `focusout` and then from combo-box `change` event. Now only the latter is used.

## Type of change

- Bugfix