### PR TITLE
fix: use correct element for popover global click listener

### DIFF
--- a/integration/tests/dialog-popover.test.js
+++ b/integration/tests/dialog-popover.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import './not-animated-styles.js';
 import '@vaadin/dialog';
 import '@vaadin/popover';
@@ -54,6 +54,10 @@ describe('popover in dialog', () => {
         await nextRender();
       });
 
+      afterEach(async () => {
+        await resetMouse();
+      });
+
       it(`should not close the dialog when closing ${type} popover on Escape`, async () => {
         await sendKeys({ press: 'Escape' });
 
@@ -67,6 +71,17 @@ describe('popover in dialog', () => {
         await sendKeys({ press: 'Escape' });
 
         expect(dialog.opened).to.be.false;
+      });
+
+      it(`should not close the dialog when closing ${type} popover on outside click`, async () => {
+        // Use proper mouse click instead of the "outsideClick" helper because
+        // clicking programmatically calls all click listeners synchronously,
+        // and that would break this test by making it false-positive (so as
+        // the dialog remains open, while the real user click would close it).
+        await sendMouse({ type: 'click', position: [10, 10] });
+
+        expect(overlay.opened).to.be.false;
+        expect(dialog.opened).to.be.true;
       });
     });
   });

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -445,14 +445,14 @@ class Popover extends PopoverPositionMixin(
   connectedCallback() {
     super.connectedCallback();
 
-    document.addEventListener('click', this.__onGlobalClick, true);
+    document.documentElement.addEventListener('click', this.__onGlobalClick, true);
   }
 
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
 
-    document.removeEventListener('click', this.__onGlobalClick, true);
+    document.documentElement.removeEventListener('click', this.__onGlobalClick, true);
 
     this._openedStateController.close(true);
   }

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -221,7 +221,7 @@ describe('popover', () => {
     });
 
     it('should remove document click listener when popover is detached', async () => {
-      const spy = sinon.spy(document, 'removeEventListener');
+      const spy = sinon.spy(document.documentElement, 'removeEventListener');
       popover.remove();
       await nextRender();
       expect(spy).to.be.called;


### PR DESCRIPTION
## Description

Fixes #7481

This issue turned out to be caused by the fact that I used different elements for global `click` listeners:

- `vaadin-popover` uses `doument.addEventListener('click')`
- `vaadin-dialog-overlay` uses `document.documentElement`

This is a problem especially for modeless `vaadin-popover` (the one that uses its own click listener).

The fix might not be very intuitive (ideally we would instead implement something like https://github.com/vaadin/web-components/issues/7481#issuecomment-2180098804 to avoid having a separate listener in the first place). But I do think that it makes sense to align elements used for adding click listener.

### Before

The listener on the `document` is called first, then the one on `document.documentElement`:

1. click listener from `vaadin-popover` is called and it closes `vaadin-popover-overlay`
2. click listener from `vaadin-dialog-overlay` is called, its `_last` returns `true` and it also closes

### After

The listeners are called in the order they were added:

1. click listener from `vaadin-dialog-overlay` is called, its `_last` returns `false` and it stays open
2. click listener from `vaadin-popover` is called and it closes `vaadin-popover-overlay`

## Type of change

- Bugfix

## Note

Testing this is only possible using real click events via `sendPointer()` API - see comment in the new integration test.