### PR TITLE
refactor: drop usage of deprecated constant() function

### DIFF
--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -138,33 +138,23 @@ const loginOverlayWrapper = css`
   /* Handle iPhone X notch */
   @media only screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) {
     [part='card'] {
-      padding-right: constant(safe-area-inset-right);
       padding-right: env(safe-area-inset-right);
-
-      padding-left: constant(safe-area-inset-left);
       padding-left: env(safe-area-inset-left);
     }
 
     [part='brand'] {
-      margin-left: calc(constant(safe-area-inset-left) * -1);
       margin-left: calc(env(safe-area-inset-left) * -1);
-
-      padding-left: calc(var(--lumo-space-l) + constant(safe-area-inset-left));
       padding-left: calc(var(--lumo-space-l) + env(safe-area-inset-left));
     }
 
     /* RTL styles */
     :host([dir='rtl']) [part='card'] {
-      padding-left: constant(safe-area-inset-right);
       padding-left: env(safe-area-inset-right);
-      padding-right: constant(safe-area-inset-left);
       padding-right: env(safe-area-inset-left);
     }
 
     :host([dir='rtl']) [part='brand'] {
-      margin-right: calc(constant(safe-area-inset-left) * -1);
       margin-right: calc(env(safe-area-inset-left) * -1);
-      padding-right: calc(var(--lumo-space-l) + constant(safe-area-inset-left));
       padding-right: calc(var(--lumo-space-l) + env(safe-area-inset-left));
     }
   }

--- a/packages/login/theme/material/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/material/vaadin-login-overlay-styles.js
@@ -280,21 +280,18 @@ const loginOverlayWrapper = css`
   /* Handle iPhone X notch */
   @media only screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) {
     [part='card'] {
-      padding: 0 constant(safe-area-inset-bottom);
       padding: 0 env(safe-area-inset-bottom);
     }
 
     :host(:not([dir='rtl'])) [part='brand'] {
-      margin-left: calc(constant(safe-area-inset-bottom) * -1);
       margin-left: calc(env(safe-area-inset-bottom) * -1);
-      padding-left: calc(1.5rem + constant(safe-area-inset-bottom));
+      padding-left: calc(1.5rem + env(safe-area-inset-bottom));
     }
 
     /* RTL styles */
     :host([dir='rtl']) [part='brand'] {
-      margin-right: calc(constant(safe-area-inset-bottom) * -1);
       margin-right: calc(env(safe-area-inset-bottom) * -1);
-      padding-right: calc(1.5rem + constant(safe-area-inset-bottom));
+      padding-right: calc(1.5rem + env(safe-area-inset-bottom));
     }
   }
 `;


### PR DESCRIPTION
## Description

The `constant()` was an old version of [`env()`](https://caniuse.com/css-env-function) function supported only in Safari 11. 
As we dropped support for that version long ago, it's safe to only use `env`.

Note: discovered when trying to upgrade to Stylelint 16 and `stylelint-config-recommended`:

```
packages/login/theme/lumo/vaadin-login-overlay-styles.js
  141:22  ✖  Unexpected unknown function "constant"  function-no-unknown
```

## Type of change

- Refactor