### PR TITLE
refactor: remove duplicate CSS selectors from themes

### DIFF
--- a/packages/app-layout/theme/material/vaadin-app-layout-styles.js
+++ b/packages/app-layout/theme/material/vaadin-app-layout-styles.js
@@ -18,9 +18,6 @@ registerStyles(
 
     [part='drawer'] {
       background: var(--material-background-color);
-    }
-
-    [part='drawer'] {
       border-inline-end: 1px solid var(--material-secondary-background-color);
     }
 

--- a/packages/app-layout/theme/material/vaadin-drawer-toggle-styles.js
+++ b/packages/app-layout/theme/material/vaadin-drawer-toggle-styles.js
@@ -12,12 +12,6 @@ const drawerToggle = css`
     margin-inline-end: 1em;
   }
 
-  [part='icon'],
-  [part='icon']::after,
-  [part='icon']::before {
-    background-color: currentColor;
-  }
-
   [part='icon'] {
     top: 18px;
     left: 15px;
@@ -26,6 +20,7 @@ const drawerToggle = css`
   [part='icon'],
   [part='icon']::after,
   [part='icon']::before {
+    background-color: currentColor;
     height: 2px;
     width: 18px;
   }

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
@@ -22,9 +22,6 @@ const datePickerOverlay = css`
     max-height: calc(var(--lumo-size-m) * 14);
     overflow: hidden;
     -webkit-tap-highlight-color: transparent;
-  }
-
-  [part='overlay'] {
     flex-direction: column;
   }
 

--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -14,21 +14,12 @@ const loginOverlayWrapper = css`
     background: var(--lumo-base-color) linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
   }
 
-  [part='content'] {
-    padding: 0;
-  }
-
   [part='overlay'] {
     background: none;
     border-radius: 0;
     box-shadow: none;
     width: 100%;
     height: 100%;
-  }
-
-  [part='card'] {
-    width: calc(var(--lumo-size-m) * 10);
-    background: var(--lumo-base-color) linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
   }
 
   [part='brand'] {
@@ -49,9 +40,12 @@ const loginOverlayWrapper = css`
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 0;
   }
 
   [part='card'] {
+    width: calc(var(--lumo-size-m) * 10);
+    background: var(--lumo-base-color) linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
     border-radius: var(--lumo-border-radius-l);
     box-shadow: var(--lumo-box-shadow-s);
     margin: var(--lumo-space-s);

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -94,11 +94,6 @@ registerStyles(
       will-change: transform;
     }
 
-    :host([selected])::before,
-    :host([selected])::after {
-      background-color: var(--_selection-color);
-    }
-
     :host([orientation='vertical'])::before,
     :host([orientation='vertical'])::after {
       left: 0;
@@ -120,6 +115,7 @@ registerStyles(
 
     :host([selected])::before,
     :host([selected])::after {
+      background-color: var(--_selection-color);
       transform: translateX(-50%) scale(1);
       transition-timing-function: cubic-bezier(0.12, 0.32, 0.54, 1.5);
     }

--- a/packages/tabs/theme/material/vaadin-tabs-styles.js
+++ b/packages/tabs/theme/material/vaadin-tabs-styles.js
@@ -7,9 +7,6 @@ registerStyles(
   css`
     :host {
       -webkit-tap-highlight-color: transparent;
-    }
-
-    :host {
       display: flex;
       flex-shrink: 0;
     }


### PR DESCRIPTION
## Description

Fixed a few warnings about duplicate CSS selectors reported after enabling `no-duplicate-selectors` Stylelint rule.

## Type of change

- Refactor