### PR TITLE
fix: do not set placeholder to empty string by default

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -814,7 +814,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       }
       this.__tmpA11yPlaceholder = tmpPlaceholder;
       this.placeholder = tmpPlaceholder;
-    } else if (this.__savedPlaceholder !== undefined) {
+    } else if (this.__tmpA11yPlaceholder !== undefined) {
       delete this.__tmpA11yPlaceholder;
       this.placeholder = this.__savedPlaceholder;
     }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -460,7 +460,6 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
        */
       placeholder: {
         type: String,
-        value: '',
         observer: '_placeholderChanged',
       },
 
@@ -812,7 +811,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
       const tmpPlaceholder = this._mergeItemLabels(selectedItems);
       this.__tmpA11yPlaceholder = tmpPlaceholder;
       this.placeholder = tmpPlaceholder;
-    } else {
+    } else if (this.__savedPlaceholder !== undefined) {
       delete this.__tmpA11yPlaceholder;
       this.placeholder = this.__savedPlaceholder;
     }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -809,7 +809,9 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     // Use placeholder for announcing items
     if (this._hasValue) {
       const tmpPlaceholder = this._mergeItemLabels(selectedItems);
-      this.__savedPlaceholder = this.placeholder;
+      if (this.__tmpA11yPlaceholder === undefined) {
+        this.__savedPlaceholder = this.placeholder;
+      }
       this.__tmpA11yPlaceholder = tmpPlaceholder;
       this.placeholder = tmpPlaceholder;
     } else if (this.__savedPlaceholder !== undefined) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -809,6 +809,7 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
     // Use placeholder for announcing items
     if (this._hasValue) {
       const tmpPlaceholder = this._mergeItemLabels(selectedItems);
+      this.__savedPlaceholder = this.placeholder;
       this.__tmpA11yPlaceholder = tmpPlaceholder;
       this.placeholder = tmpPlaceholder;
     } else if (this.__savedPlaceholder !== undefined) {

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -70,6 +70,12 @@ describe('accessibility', () => {
           expect(inputElement.getAttribute('placeholder')).to.equal('Options');
         });
 
+        it('should restore placeholder when selected items are updated and removed', () => {
+          comboBox.selectedItems = ['Apple'];
+          comboBox.selectedItems = [];
+          expect(inputElement.getAttribute('placeholder')).to.equal('Fruits');
+        });
+
         it('should restore empty placeholder when selected items are removed', () => {
           comboBox.placeholder = '';
           comboBox.selectedItems = [];

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -82,6 +82,13 @@ describe('accessibility', () => {
           expect(comboBox.placeholder).to.be.equal('');
           expect(inputElement.hasAttribute('placeholder')).to.be.false;
         });
+
+        it('should clear placeholder when set to undefined and selected items are removed', () => {
+          comboBox.placeholder = undefined;
+          comboBox.selectedItems = [];
+          expect(comboBox.placeholder).to.be.undefined;
+          expect(inputElement.hasAttribute('placeholder')).to.be.false;
+        });
       });
     });
 

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-multi-select-combo-box host default"] = 
-`<vaadin-multi-select-combo-box placeholder="">
+`<vaadin-multi-select-combo-box>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -38,10 +38,7 @@ snapshots["vaadin-multi-select-combo-box host default"] =
 /* end snapshot vaadin-multi-select-combo-box host default */
 
 snapshots["vaadin-multi-select-combo-box host label"] = 
-`<vaadin-multi-select-combo-box
-  has-label=""
-  placeholder=""
->
+`<vaadin-multi-select-combo-box has-label="">
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -79,10 +76,7 @@ snapshots["vaadin-multi-select-combo-box host label"] =
 /* end snapshot vaadin-multi-select-combo-box host label */
 
 snapshots["vaadin-multi-select-combo-box host helper"] = 
-`<vaadin-multi-select-combo-box
-  has-helper=""
-  placeholder=""
->
+`<vaadin-multi-select-combo-box has-helper="">
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -128,7 +122,6 @@ snapshots["vaadin-multi-select-combo-box host error"] =
 `<vaadin-multi-select-combo-box
   has-error-message=""
   invalid=""
-  placeholder=""
 >
   <label
     for="input-vaadin-multi-select-combo-box-4"
@@ -169,10 +162,7 @@ snapshots["vaadin-multi-select-combo-box host error"] =
 /* end snapshot vaadin-multi-select-combo-box host error */
 
 snapshots["vaadin-multi-select-combo-box host required"] = 
-`<vaadin-multi-select-combo-box
-  placeholder=""
-  required=""
->
+`<vaadin-multi-select-combo-box required="">
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -212,7 +202,6 @@ snapshots["vaadin-multi-select-combo-box host disabled"] =
 `<vaadin-multi-select-combo-box
   aria-disabled="true"
   disabled=""
-  placeholder=""
 >
   <label
     for="input-vaadin-multi-select-combo-box-4"
@@ -252,10 +241,7 @@ snapshots["vaadin-multi-select-combo-box host disabled"] =
 /* end snapshot vaadin-multi-select-combo-box host disabled */
 
 snapshots["vaadin-multi-select-combo-box host readonly"] = 
-`<vaadin-multi-select-combo-box
-  placeholder=""
-  readonly=""
->
+`<vaadin-multi-select-combo-box readonly="">
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -333,7 +319,6 @@ snapshots["vaadin-multi-select-combo-box host opened default"] =
 `<vaadin-multi-select-combo-box
   focused=""
   opened=""
-  placeholder=""
 >
   <label
     for="input-vaadin-multi-select-combo-box-4"


### PR DESCRIPTION
## Description

Fixes #7551

Changed to align with `InputControlMixin` by removing default empty string value, so that we don't have `placeholder` attribute set by default. Also fixed the logic for restoring placeholder property in selected items observer.

Note, the property has `reflectToAttribute` so technically setting empty string can still cause that to happen (which is the case for all input fields). I don't think we can easily fix that without a breaking change.

## Type of change

- Bugfix