### PR TITLE
fix: make first item focusable when selected is negative

### DIFF
--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -166,7 +166,8 @@ export const ListMixin = (superClass) =>
             }
           });
 
-          this._setFocusable(selected || 0);
+          // When selected is set to -1, focus the first available item.
+          this._setFocusable(selected < 0 || !selected ? 0 : selected);
 
           const itemToSelect = items[selected];
           items.forEach((item) => {

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -269,6 +269,12 @@ const runTests = (defineHelper, baseMixin) => {
       [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
     });
 
+    it('should have the first not disabled item focusable when selected set to -1', async () => {
+      list.selected = -1;
+      await nextUpdate(list);
+      [-1, -1, 0, -1].forEach((val, idx) => expect(list.items[idx].tabIndex).to.equal(val));
+    });
+
     it('should set a not disabled item focusable', async () => {
       list._setFocusable(3);
       await nextUpdate(list);


### PR DESCRIPTION
## Description

Fixes #6392

The issue is caused by`_getAvailableIndex` helper. Due to roving tabindex, it switches to the last item if the `idx` is less than 0. But in this particular case, it becomes a problem as the last item gets `tabindex="0"` (instead of the first one).

As we already have a call to `_setFocusable()` where we check if `selected` is non-empty, I figured out the easiest fix is to update it to pass `0` also for cases when `selected` is less than 0. This way the first available item gets `tabindex="0"`.


## Type of change

- Bugfix