### PR TITLE
feat: add overlayRole property to customize dialog role

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
@@ -31,4 +31,11 @@ export declare class DialogBaseMixinClass {
    * Set to true to remove backdrop and allow click events on background elements.
    */
   modeless: boolean;
+
+  /**
+   * The `role` attribute value to be set on the overlay. Defaults to "dialog".
+   *
+   * @attr {string} overlay-role
+   */
+  overlayRole: string;
 }

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -49,6 +49,16 @@ export const DialogBaseMixin = (superClass) =>
           type: Boolean,
           value: false,
         },
+
+        /**
+         * The `role` attribute value to be set on the overlay. Defaults to "dialog".
+         *
+         * @attr {string} overlay-role
+         */
+        overlayRole: {
+          type: String,
+          value: 'dialog',
+        },
       };
     }
 

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -104,7 +104,7 @@ class Dialog extends DialogDraggableMixin(
 
       <vaadin-dialog-overlay
         id="overlay"
-        role="dialog"
+        role$="[[overlayRole]]"
         header-title="[[headerTitle]]"
         on-opened-changed="_onOverlayOpened"
         on-mousedown="_bringOverlayToFront"

--- a/packages/dialog/src/vaadin-lit-dialog.js
+++ b/packages/dialog/src/vaadin-lit-dialog.js
@@ -72,7 +72,7 @@ class Dialog extends DialogDraggableMixin(
     return html`
       <vaadin-dialog-overlay
         id="overlay"
-        role="dialog"
+        role="${this.overlayRole}"
         .owner="${this}"
         .opened="${this.opened}"
         .headerTitle="${this.headerTitle}"

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -64,6 +64,12 @@ describe('vaadin-dialog', () => {
         expect(overlay.getAttribute('role')).to.be.eql('dialog');
       });
 
+      it('should change role attribute on the overlay based on overlayRole', async () => {
+        dialog.overlayRole = 'alertdialog';
+        await nextUpdate(dialog);
+        expect(overlay.getAttribute('role')).to.equal('alertdialog');
+      });
+
       it('overlay should have the `aria-label` attribute (if set)', async () => {
         dialog.ariaLabel = 'accessible';
         await nextUpdate(dialog);

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -40,7 +40,9 @@ describe('vaadin-dialog', () => {
     let dialog, backdrop, overlay;
 
     beforeEach(async () => {
-      dialog = fixtureSync('<vaadin-dialog opened></vaadin-dialog>');
+      dialog = fixtureSync(`
+        <vaadin-dialog opened theme="foo"></vaadin-dialog>
+      `);
       await nextRender();
 
       dialog.renderer = (root) => {
@@ -57,7 +59,11 @@ describe('vaadin-dialog', () => {
       await nextRender();
     });
 
-    describe('aria-label', () => {
+    describe('attributes', () => {
+      it('overlay should have the `dialog` role', () => {
+        expect(overlay.getAttribute('role')).to.be.eql('dialog');
+      });
+
       it('overlay should have the `aria-label` attribute (if set)', async () => {
         dialog.ariaLabel = 'accessible';
         await nextUpdate(dialog);
@@ -90,6 +96,10 @@ describe('vaadin-dialog', () => {
         dialog.ariaLabel = '';
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
+      });
+
+      it('should propagate theme attribute to the overlay', () => {
+        expect(overlay.getAttribute('theme')).to.be.eql(dialog.getAttribute('theme'));
       });
     });
 

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -40,9 +40,7 @@ describe('vaadin-dialog', () => {
     let dialog, backdrop, overlay;
 
     beforeEach(async () => {
-      dialog = fixtureSync(`
-        <vaadin-dialog opened theme="foo"></vaadin-dialog>
-      `);
+      dialog = fixtureSync('<vaadin-dialog opened></vaadin-dialog>');
       await nextRender();
 
       dialog.renderer = (root) => {
@@ -59,17 +57,7 @@ describe('vaadin-dialog', () => {
       await nextRender();
     });
 
-    describe('attributes', () => {
-      it('overlay should have the `dialog` role', () => {
-        expect(overlay.getAttribute('role')).to.be.eql('dialog');
-      });
-
-      it('should change role attribute on the overlay based on overlayRole', async () => {
-        dialog.overlayRole = 'alertdialog';
-        await nextUpdate(dialog);
-        expect(overlay.getAttribute('role')).to.equal('alertdialog');
-      });
-
+    describe('aria-label', () => {
       it('overlay should have the `aria-label` attribute (if set)', async () => {
         dialog.ariaLabel = 'accessible';
         await nextUpdate(dialog);
@@ -102,10 +90,6 @@ describe('vaadin-dialog', () => {
         dialog.ariaLabel = '';
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
-      });
-
-      it('should propagate theme attribute to the overlay', () => {
-        expect(overlay.getAttribute('theme')).to.be.eql(dialog.getAttribute('theme'));
       });
     });
 

--- a/packages/dialog/test/dom/__snapshots__/dialog.test.snap.js
+++ b/packages/dialog/test/dom/__snapshots__/dialog.test.snap.js
@@ -59,3 +59,17 @@ snapshots["vaadin-dialog overlay class"] =
 `;
 /* end snapshot vaadin-dialog overlay class */
 
+snapshots["vaadin-dialog overlay role"] = 
+`<vaadin-dialog-overlay
+  focus-trap=""
+  id="overlay"
+  opened=""
+  restore-focus-on-close=""
+  role="alertdialog"
+  with-backdrop=""
+>
+  content
+</vaadin-dialog-overlay>
+`;
+/* end snapshot vaadin-dialog overlay role */
+

--- a/packages/dialog/test/dom/dialog.test.js
+++ b/packages/dialog/test/dom/dialog.test.js
@@ -40,4 +40,9 @@ describe('vaadin-dialog', () => {
     dialog.overlayClass = 'custom dialog-overlay';
     await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
+
+  it('overlay role', async () => {
+    dialog.overlayRole = 'alertdialog';
+    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
 });

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -47,6 +47,7 @@ assertType<boolean>(dialog.resizable);
 assertType<boolean>(dialog.noCloseOnEsc);
 assertType<boolean>(dialog.noCloseOnOutsideClick);
 assertType<string>(dialog.overlayClass);
+assertType<string>(dialog.overlayRole);
 assertType<string | null | undefined>(dialog.headerTitle);
 assertType<DialogRenderer | null | undefined>(dialog.renderer);
 assertType<DialogRenderer | null | undefined>(dialog.headerRenderer);


### PR DESCRIPTION
## Description

Part of #4977

Added `overlayRole` property similar to the one we now have in `vaadin-popover` to customize the dialog role.

## Type of change

- Feature