### PR TITLE
test: remove dialog unit tests covered by snapshots

### DIFF
--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -40,9 +40,7 @@ describe('vaadin-dialog', () => {
     let dialog, backdrop, overlay;
 
     beforeEach(async () => {
-      dialog = fixtureSync(`
-        <vaadin-dialog opened theme="foo"></vaadin-dialog>
-      `);
+      dialog = fixtureSync('<vaadin-dialog opened></vaadin-dialog>');
       await nextRender();
 
       dialog.renderer = (root) => {
@@ -59,19 +57,11 @@ describe('vaadin-dialog', () => {
       await nextRender();
     });
 
-    describe('attributes', () => {
-      it('overlay should have the `dialog` role', () => {
-        expect(overlay.getAttribute('role')).to.be.eql('dialog');
-      });
-
+    describe('aria-label', () => {
       it('overlay should have the `aria-label` attribute (if set)', async () => {
         dialog.ariaLabel = 'accessible';
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.eql('accessible');
-      });
-
-      it('overlay should not have the `aria-label` attribute (if not set)', () => {
-        expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
       it('overlay should not have `aria-label` attribute if set to undefined', async () => {
@@ -96,10 +86,6 @@ describe('vaadin-dialog', () => {
         dialog.ariaLabel = '';
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
-      });
-
-      it('should propagate theme attribute to the overlay', () => {
-        expect(overlay.getAttribute('theme')).to.be.eql(dialog.getAttribute('theme'));
       });
     });
 

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -58,31 +58,28 @@ describe('vaadin-dialog', () => {
     });
 
     describe('aria-label', () => {
-      it('overlay should have the `aria-label` attribute (if set)', async () => {
+      beforeEach(async () => {
         dialog.ariaLabel = 'accessible';
         await nextUpdate(dialog);
+      });
+
+      it('should set `aria-label` attribute on the overlay when ariaLabel is set', () => {
         expect(overlay.getAttribute('aria-label')).to.be.eql('accessible');
       });
 
-      it('overlay should not have `aria-label` attribute if set to undefined', async () => {
-        dialog.ariaLabel = 'accessible';
-        await nextUpdate(dialog);
+      it('should remove `aria-label` attribute from the overlay when set to undefined', async () => {
         dialog.ariaLabel = undefined;
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
-      it('overlay should not have `aria-label` attribute if set to null', async () => {
-        dialog.ariaLabel = 'accessible';
-        await nextUpdate(dialog);
+      it('should remove `aria-label` attribute from the overlay when set to null', async () => {
         dialog.ariaLabel = null;
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;
       });
 
-      it('overlay should not have `aria-label` attribute if set to empty string', async () => {
-        dialog.ariaLabel = 'accessible';
-        await nextUpdate(dialog);
+      it('should remove `aria-label` attribute from the overlay when set to empty string', async () => {
         dialog.ariaLabel = '';
         await nextUpdate(dialog);
         expect(overlay.getAttribute('aria-label')).to.be.null;


### PR DESCRIPTION
## Description

- Removed a few tests about default `role` and `theme` propagation as covered by snapshots
- Changed the "attributes" test suite to be about `aria-label` and added `beforeEach()` block

## Type of change

- Tests