### PR TITLE
chore: enable no-unused-vars ESLint rule and fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
     "@typescript-eslint/max-params": ["error", { "max": 5 }],
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-unused-expressions": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "no-only-tests/no-only-tests": "error",
     "simple-import-sort/imports": [
       "error",
@@ -71,7 +70,7 @@
     {
       "files": ["packages/*/src/**/*.d.ts"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^TItem" }]
+        "@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^TItem" }]
       }
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/max-params": ["error", { "max": 5 }],
     "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-unused-expressions": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "no-only-tests/no-only-tests": "error",
     "simple-import-sort/imports": [
       "error",
@@ -65,6 +66,12 @@
       "files": ["packages/*/src/**/*.js"],
       "rules": {
         "es/no-optional-chaining": "error"
+      }
+    },
+    {
+      "files": ["packages/*/src/**/*.d.ts"],
+      "rules": {
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^TItem" }]
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "axios": "^1.4.0",
     "dotenv": "^16.0.3",
     "eslint": "^8.57.0",
-    "eslint-config-vaadin": "^1.0.0-alpha.25",
+    "eslint-config-vaadin": "^1.0.0-alpha.27",
     "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^5.1.3",

--- a/packages/app-layout/test/keyboard-desktop.test.js
+++ b/packages/app-layout/test/keyboard-desktop.test.js
@@ -6,7 +6,7 @@ import '../vaadin-drawer-toggle.js';
 import { tab } from './helpers.js';
 
 describe('desktop navigation', () => {
-  let layout, toggle, drawer, drawerInput, contentInput, outerInput;
+  let layout, toggle, drawerInput, contentInput, outerInput;
 
   before(async () => {
     await setViewport({ width: 1000, height: 1000 });
@@ -30,7 +30,6 @@ describe('desktop navigation', () => {
     [layout, outerInput] = wrapper.children;
     await nextRender();
     toggle = layout.querySelector('[slot=navbar]');
-    drawer = layout.shadowRoot.querySelector('[part=drawer]');
     drawerInput = layout.querySelector('[slot=drawer] > input');
     contentInput = layout.querySelector(':not([slot]) > input');
   });

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -159,7 +159,7 @@ export const AvatarMixin = (superClass) =>
     }
 
     /** @private */
-    __imgOrAbbrOrNameChanged(img, abbr, name) {
+    __imgOrAbbrOrNameChanged(_img, abbr, name) {
       this.__updateVisibility();
 
       if (abbr && abbr !== this.__generatedAbbr) {

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -168,13 +168,13 @@ class BoardRow extends ResizeMixin(ElementMixin(PolymerElement)) {
 
     let spaceLeft = 4;
     let returnBoardCols = [];
-    nodes.forEach((node, i) => {
+    nodes.forEach((_node, i) => {
       spaceLeft -= boardCols[i];
     });
 
     if (spaceLeft < 0) {
       this._reportError();
-      boardCols.forEach((node, i) => {
+      boardCols.forEach((_node, i) => {
         returnBoardCols[i] = 1;
       });
     } else {

--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -16,7 +16,7 @@ export function inflateFunctions(config) {
       try {
         // eslint-disable-next-line no-eval
         config[attr.substr(4)] = eval(`(${targetProperty})`);
-      } catch (e) {
+      } catch (_) {
         // eslint-disable-next-line no-eval
         config[attr.substr(4)] = eval(`(function(){${targetProperty}})`);
       }

--- a/packages/charts/src/vaadin-chart-series.js
+++ b/packages/charts/src/vaadin-chart-series.js
@@ -304,7 +304,7 @@ class ChartSeries extends PolymerElement {
   }
 
   /** @private */
-  __valuesObserver(splices, series) {
+  __valuesObserver(_splices, series) {
     if (series) {
       series.setData(this.values);
     }

--- a/packages/checkbox/test/validation.common.js
+++ b/packages/checkbox/test/validation.common.js
@@ -117,8 +117,6 @@ describe('validation', () => {
   });
 
   describe('required', () => {
-    let checkboxes;
-
     beforeEach(async () => {
       checkbox = fixtureSync('<vaadin-checkbox label="Checkbox" required></vaadin-checkbox>');
       await nextFrame();

--- a/packages/checkbox/test/validation.common.js
+++ b/packages/checkbox/test/validation.common.js
@@ -120,7 +120,6 @@ describe('validation', () => {
     beforeEach(async () => {
       checkbox = fixtureSync('<vaadin-checkbox label="Checkbox" required></vaadin-checkbox>');
       await nextFrame();
-      validateSpy = sinon.spy(checkbox, 'validate');
     });
 
     it('should fail validation with checked set to false', () => {

--- a/packages/combo-box/test/data-provider.common.js
+++ b/packages/combo-box/test/data-provider.common.js
@@ -239,7 +239,7 @@ const TEMPLATES = {
 
       it('should toggle loading', (done) => {
         expect(comboBox.loading).to.be.false;
-        comboBox.dataProvider = (params, callback) => {
+        comboBox.dataProvider = (_params, callback) => {
           expect(comboBox.loading).to.be.true;
           callback([], 0);
           expect(comboBox.loading).to.be.false;
@@ -266,7 +266,7 @@ const TEMPLATES = {
 
       it('should render all visible items after delayed response', (done) => {
         const items = [...Array(10)].map((_, i) => `item ${i}`);
-        comboBox.dataProvider = (params, callback) => {
+        comboBox.dataProvider = (_params, callback) => {
           setTimeout(() => {
             callback(items, 10);
             setTimeout(() => {
@@ -489,12 +489,12 @@ const TEMPLATES = {
 
     describe('changing dataProvider', () => {
       it('should have correct items after changing dataProvider to return less items', () => {
-        comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 2);
+        comboBox.dataProvider = (_, callback) => callback(['foo', 'bar'], 2);
         comboBox.open();
         comboBox.close();
 
         comboBox.clearCache();
-        comboBox.dataProvider = (params, callback) => callback(['baz'], 1);
+        comboBox.dataProvider = (_, callback) => callback(['baz'], 1);
         comboBox.open();
 
         expect(comboBox.filteredItems).to.eql(['baz']);
@@ -584,7 +584,7 @@ const TEMPLATES = {
 
       it('should be 0 after dataProvider returns size 0', () => {
         comboBox.opened = true;
-        comboBox.dataProvider = (params, callback) => callback([], 0);
+        comboBox.dataProvider = (_, callback) => callback([], 0);
         expect(comboBox.size).to.equal(0);
       });
 
@@ -592,24 +592,24 @@ const TEMPLATES = {
         comboBox.opened = true;
         comboBox.dataProvider = spyDataProvider;
         expect(comboBox.size).to.equal(SIZE);
-        comboBox.dataProvider = (params, callback) => callback([], undefined);
+        comboBox.dataProvider = (_, callback) => callback([], undefined);
         expect(comboBox.size).to.equal(SIZE);
       });
 
       it('should not add items exceeding the size returned by dataProvider', () => {
-        comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 1);
+        comboBox.dataProvider = (_, callback) => callback(['foo', 'bar'], 1);
         comboBox.opened = true;
         expect(comboBox.filteredItems).to.eql(['foo']);
       });
 
       it('should add items when dataProvider return size undefined', () => {
-        comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], undefined);
+        comboBox.dataProvider = (_, callback) => callback(['foo', 'bar'], undefined);
         comboBox.opened = true;
         expect(comboBox.filteredItems).to.eql(['foo', 'bar']);
       });
 
       it('should remove extra filteredItems when decreasing size', () => {
-        comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 2);
+        comboBox.dataProvider = (_, callback) => callback(['foo', 'bar'], 2);
         comboBox.open();
 
         comboBox.size = 1;
@@ -618,7 +618,7 @@ const TEMPLATES = {
 
       it('should not reset when dataProvider callback has undefined size', () => {
         comboBox.size = SIZE;
-        comboBox.dataProvider = (params, callback) => {
+        comboBox.dataProvider = (_, callback) => {
           callback(allItems);
         };
         comboBox.opened = true;
@@ -793,7 +793,7 @@ const TEMPLATES = {
 
       it('should not mark placeholders selected when items are loading', () => {
         comboBox.itemIdPath = 'key';
-        comboBox.dataProvider = (p, c) => {
+        comboBox.dataProvider = (_, c) => {
           if (!comboBox.dataProvider.__jammed) {
             c([{ key: 0, label: 'foo' }], 1);
           }
@@ -1023,7 +1023,7 @@ const TEMPLATES = {
 
       it('should clear old pending requests', () => {
         let slowCallback;
-        comboBox.dataProvider = (params, callback) => {
+        comboBox.dataProvider = (_, callback) => {
           if (!slowCallback) {
             slowCallback = callback;
           }
@@ -1073,7 +1073,7 @@ const TEMPLATES = {
     describe('lost focus before data is returned', () => {
       let returnedItems;
 
-      const bluringDataProvider = (params, callback) => {
+      const bluringDataProvider = (_, callback) => {
         comboBox.inputElement.blur();
         callback(returnedItems, returnedItems.length);
       };

--- a/packages/combo-box/test/item-renderer.common.js
+++ b/packages/combo-box/test/item-renderer.common.js
@@ -49,7 +49,7 @@ describe('item renderer', () => {
   });
 
   it('should use renderer when it is defined', () => {
-    comboBox.renderer = (root, comboBox, model) => {
+    comboBox.renderer = (root, _comboBox, model) => {
       const textNode = document.createTextNode(`${model.item} ${model.index}`);
       root.appendChild(textNode);
     };

--- a/packages/combo-box/test/lit.common.js
+++ b/packages/combo-box/test/lit.common.js
@@ -13,7 +13,7 @@ describe('lit', () => {
 
       const size = 100;
 
-      comboBox.items = new Array(size).fill().map((e, i) => {
+      comboBox.items = new Array(size).fill().map((_, i) => {
         return { value: `value-${i}` };
       });
 

--- a/packages/component-base/src/browser-utils.js
+++ b/packages/component-base/src/browser-utils.js
@@ -29,7 +29,7 @@ export const isTouch = (() => {
   try {
     document.createEvent('TouchEvent');
     return true;
-  } catch (e) {
+  } catch (_) {
     return false;
   }
 })();

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -45,7 +45,7 @@ const MOUSE_WHICH_TO_BUTTONS = [0, 1, 4, 2];
 const MOUSE_HAS_BUTTONS = (function () {
   try {
     return new MouseEvent('test', { buttons: 1 }).buttons === 1;
-  } catch (e) {
+  } catch (_) {
     return false;
   }
 })();
@@ -71,7 +71,7 @@ let supportsPassive = false;
     });
     window.addEventListener('test', null, opts);
     window.removeEventListener('test', null, opts);
-  } catch (e) {}
+  } catch (_) {}
 })();
 
 /**

--- a/packages/component-base/src/overflow-controller.js
+++ b/packages/component-base/src/overflow-controller.js
@@ -48,7 +48,7 @@ export class OverflowController {
   observe() {
     const { host } = this;
 
-    this.__resizeObserver = new ResizeObserver((entries) => {
+    this.__resizeObserver = new ResizeObserver(() => {
       this.__debounceOverflow = Debouncer.debounce(this.__debounceOverflow, animationFrame, () => {
         this.__updateOverflow();
       });

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -56,7 +56,7 @@ export class IronListAdapter {
     this.scrollTarget.addEventListener('wheel', (e) => this.__onWheel(e));
 
     this.scrollTarget.addEventListener('virtualizer-element-focused', (e) => this.__onElementFocused(e));
-    this.elementsContainer.addEventListener('focusin', (e) => {
+    this.elementsContainer.addEventListener('focusin', () => {
       this.scrollTarget.dispatchEvent(
         new CustomEvent('virtualizer-element-focused', { detail: { element: this.__getFocusedElement() } }),
       );

--- a/packages/component-base/test/data-provider-controller-cache.test.js
+++ b/packages/component-base/test/data-provider-controller-cache.test.js
@@ -137,6 +137,7 @@ describe('DataProviderController - Cache', () => {
     });
 
     it('should remove the sub-cache for the given item index', () => {
+      expect(cache.subCaches[0]).to.equal(subCache0);
       cache.removeSubCache(0);
       expect(cache.subCaches).to.have.lengthOf(1);
       expect(cache.subCaches[0]).to.equal(subCache1);

--- a/packages/component-base/test/data-provider-controller.test.js
+++ b/packages/component-base/test/data-provider-controller.test.js
@@ -5,8 +5,6 @@ import { Cache } from '../src/data-provider-controller/cache.js';
 import { DataProviderController } from '../src/data-provider-controller/data-provider-controller.js';
 import { createDataProvider } from './data-provider-controller-helpers.js';
 
-const PLACEHOLDER = Symbol('PLACEHOLDER');
-
 describe('DataProviderController', () => {
   let host, controller;
 

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, mousedown, mouseup, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, mouseup, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -435,7 +435,7 @@ export const ItemsMixin = (superClass) =>
     }
 
     /** @private */
-    __initMenu(root, menu) {
+    __initMenu(root, _menu) {
       // NOTE: in this method, `menu` and `this` reference the same element,
       // so we can use either of those. Original implementation used `menu`.
       if (!root.firstElementChild) {

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -1200,7 +1200,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
       return;
     }
     this.__setHighlightedItem(item);
-    this.__openEditor('edit', item);
+    this.__openEditor(item);
   }
 
   /** @private */
@@ -1211,7 +1211,7 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(PolymerElement))) 
   }
 
   /** @private */
-  __openEditor(type, item) {
+  __openEditor(item) {
     this.__focusRestorationController.saveFocus();
 
     this.__isDirty = false;

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, change, fire, fixtureSync, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, change, fire, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import '../src/vaadin-crud.js';

--- a/packages/date-picker/test/basic.common.js
+++ b/packages/date-picker/test/basic.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { click, escKeyDown, fixtureSync, keyboardEventFor, nextRender, oneEvent, tap } from '@vaadin/testing-helpers';
+import { click, fixtureSync, keyboardEventFor, nextRender, oneEvent, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { parseDate } from '../src/vaadin-date-picker-helper.js';

--- a/packages/date-picker/test/validation.common.js
+++ b/packages/date-picker/test/validation.common.js
@@ -1,8 +1,7 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { enter, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { close, open, setInputValue, waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
+import { close, open, setInputValue, waitForOverlayRender } from './helpers.js';
 
 class DatePicker2016 extends customElements.get('vaadin-date-picker') {
   checkValidity() {
@@ -11,19 +10,6 @@ class DatePicker2016 extends customElements.get('vaadin-date-picker') {
 }
 
 customElements.define('vaadin-date-picker-2016', DatePicker2016);
-
-function waitForValueChange(datePicker, callback) {
-  let stub;
-
-  return new Promise((resolve) => {
-    stub = sinon.stub().callsFake((e) => {
-      resolve(stub);
-    });
-
-    datePicker.addEventListener('value-changed', stub);
-    callback();
-  });
-}
 
 describe('validation', () => {
   let datePicker;

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
-import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DelegateFocusMixin } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -65,7 +65,7 @@ customElements.define(
 function getParsedWidth(el) {
   const width = el.style.getPropertyValue('width');
   const components = width.replace(/^calc\((.*)\)$/u, '$1').split(/ [+-] /u);
-  const [percentage, spacing] = components.sort((a, b) => b.indexOf('%'));
+  const [percentage, spacing] = components.sort((_a, b) => b.indexOf('%'));
   return { percentage, spacing };
 }
 

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -143,7 +143,7 @@ export const GridProEditColumnMixin = (superClass) =>
     }
 
     /** @private */
-    _isCellEditableChanged(newValue, oldValue) {
+    _isCellEditableChanged() {
       // Re-render grid to update editable-cell part names
       this._grid.requestContentUpdate();
     }

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -200,7 +200,7 @@ export const InlineEditingMixin = (superClass) =>
     }
 
     /** @private */
-    _applyEdit({ path, value, index, item }) {
+    _applyEdit({ path, value, item }) {
       set(path, value, item);
       this.requestContentUpdate();
     }

--- a/packages/grid-pro/test/edit-column-renderer.common.js
+++ b/packages/grid-pro/test/edit-column-renderer.common.js
@@ -51,7 +51,7 @@ describe('edit column renderer', () => {
       column = grid.firstElementChild;
       grid.items = createItems();
 
-      column.renderer = function (root, owner, model) {
+      column.renderer = function (root, _owner, model) {
         root.innerHTML = '';
         const wrapper = document.createElement('div');
         const text = document.createTextNode(`${model.index} ${model.item.name}`);

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -269,7 +269,7 @@ export const DataProviderMixin = (superClass) =>
     }
 
     /** @private */
-    __computeExpandedKeys(itemIdPath, expandedItems) {
+    __computeExpandedKeys(_itemIdPath, expandedItems) {
       const expanded = expandedItems || [];
       const expandedKeys = new Set();
       expanded.forEach((item) => {

--- a/packages/grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.js
@@ -94,7 +94,7 @@ export const RowDetailsMixin = (superClass) =>
     }
 
     /** @private */
-    _detailsOpenedItemsChanged(detailsOpenedItems, rowDetailsRenderer) {
+    _detailsOpenedItemsChanged(_detailsOpenedItems, rowDetailsRenderer) {
       iterateChildren(this.$.items, (row) => {
         // Re-renders the row to possibly close the previously opened details.
         if (row.hasAttribute('details-opened')) {

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -349,14 +349,14 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      * @param {Object} item the item to select
      * @protected
      */
-    _selectItem(item) {}
+    _selectItem(_item) {}
 
     /**
      * Override to handle the user deselecting an item.
      * @param {Object} item the item to deselect
      * @protected
      */
-    _deselectItem(item) {}
+    _deselectItem(_item) {}
 
     /**
      * IOS needs indeterminate + checked at the same time

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -91,7 +91,7 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @private */
-    __computeSelectedKeys(itemIdPath, selectedItems) {
+    __computeSelectedKeys(_itemIdPath, selectedItems) {
       const selected = selectedItems || [];
       const selectedKeys = new Set();
       selected.forEach((item) => {

--- a/packages/grid/test/accessibility.common.js
+++ b/packages/grid/test/accessibility.common.js
@@ -35,10 +35,10 @@ describe('accessibility', () => {
     col1.footerRenderer = col2.footerRenderer = (root) => {
       root.textContent = 'footer';
     };
-    col1.renderer = (root, col, model) => {
+    col1.renderer = (root, _col, model) => {
       root.textContent = model.index;
     };
-    col2.renderer = (root, col, model) => {
+    col2.renderer = (root, _col, model) => {
       root.textContent = model.item;
     };
     grid.items = ['foo', 'bar'];

--- a/packages/grid/test/array-data-provider.common.js
+++ b/packages/grid/test/array-data-provider.common.js
@@ -226,7 +226,7 @@ describe('invalid paths', () => {
 
 describe('items with a custom data provider', () => {
   let grid;
-  const dataProvider = (params, callback) => callback([{ value: 'foo' }], 1);
+  const dataProvider = (_, callback) => callback([{ value: 'foo' }], 1);
   const items = [{ value: 'bar' }];
 
   beforeEach(async () => {

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -136,10 +136,10 @@ describe('column auto-width', () => {
   });
 
   it('should have correct column widths when using renderers', async () => {
-    columns[0].renderer = function (root, column, model) {
+    columns[0].renderer = function (root, _column, model) {
       root.textContent = model.index;
     };
-    columns[1].renderer = function (root, column, model) {
+    columns[1].renderer = function (root, _column, model) {
       root.innerHTML = `<div style="width: ${10 + 10 * model.index}px; height: 25px; outline: 1px solid green;">`;
     };
     grid.items = testItems;

--- a/packages/grid/test/column-observer.test.js
+++ b/packages/grid/test/column-observer.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ColumnObserver } from '../src/vaadin-grid-helpers.js';
 

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -117,7 +117,7 @@ import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './
       grid.items = [{ name: 'Item 1' }, { name: 'Item 2' }];
       grid.items = [{ name: 'Item 1' }];
       const renderedItems = [];
-      columns[0].renderer = (root, _, model) => {
+      columns[0].renderer = (_root, _, model) => {
         renderedItems.push(model.item.name);
       };
       await nextFrame();

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -37,7 +37,7 @@ function getVisualHeaderCellContent(grid, row, col) {
 function getVisualColumnCellContents(grid, col) {
   const headerContent = getVisualCellContent(grid.$.header, getRows(grid.$.header).length - 1, col);
   const footerContent = getVisualCellContent(grid.$.footer, 0, col);
-  const bodyContent = Array.from(grid.$.items.children).map((row, rowIndex) =>
+  const bodyContent = Array.from(grid.$.items.children).map((_row, rowIndex) =>
     getVisualCellContent(grid.$.items, rowIndex, col),
   );
   return bodyContent.concat(headerContent).concat(footerContent);

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -38,7 +38,7 @@ class WrappedGrid extends PolymerElement {
     this.$.col.headerRenderer = (root) => {
       root.textContent = 'Header';
     };
-    this.$.col.renderer = (root, col, model) => {
+    this.$.col.renderer = (root, _col, model) => {
       root.textContent = model.item.value;
     };
   }
@@ -716,7 +716,7 @@ describe('attached', () => {
     grid.appendChild(col);
 
     grid.size = 1;
-    grid.dataProvider = function (params, callback) {
+    grid.dataProvider = function (_params, callback) {
       callback([{ item: 'A' }]);
     };
 
@@ -845,7 +845,7 @@ describe('wrapped grid', () => {
     it('should update sub properties on clearCache', () => {
       const data = [{ value: 'foo' }];
       grid.size = 1;
-      container.dataProvider = (params, cb) => cb(data);
+      container.dataProvider = (_, cb) => cb(data);
       expect(getCellContent(getFirstCell(grid)).textContent.trim()).to.equal('foo');
       data[0].value = 'bar';
       grid.clearCache();
@@ -891,7 +891,7 @@ describe('wrapped grid', () => {
 
     it('should be in loading state when cache is cleared', () => {
       let cb;
-      container.dataProvider = (params, callback) => {
+      container.dataProvider = (_, callback) => {
         cb = callback;
       };
       cb(Array(25));
@@ -914,14 +914,14 @@ describe('wrapped grid', () => {
     });
 
     it('should clear loading attribute from rows when data received', () => {
-      container.dataProvider = (params, callback) => {
+      container.dataProvider = (_, callback) => {
         callback([{}]);
       };
       expect(getRows(grid.$.items)[0].hasAttribute('loading')).to.be.false;
     });
 
     it('should remove loading from cells part attribute when data received', () => {
-      container.dataProvider = (params, callback) => {
+      container.dataProvider = (_, callback) => {
         callback([{}]);
       };
       const row = getRows(grid.$.items)[0];

--- a/packages/grid/test/deprecated-api.common.js
+++ b/packages/grid/test/deprecated-api.common.js
@@ -52,7 +52,7 @@ describe('deprecated API', () => {
     });
 
     it('should warn about the property being deprecated', () => {
-      const result = grid._effectiveSize;
+      const result = grid._effectiveSize; // eslint-disable-line @typescript-eslint/no-unused-vars
       expect(console.warn).to.be.calledOnce;
       expect(console.warn).to.be.calledWith(
         '<vaadin-grid> The `_effectiveSize` property is deprecated and will be removed in Vaadin 25.',
@@ -66,7 +66,7 @@ describe('deprecated API', () => {
     });
 
     it('should warn about the property being deprecated', () => {
-      const result = grid._cache;
+      const result = grid._cache; // eslint-disable-line @typescript-eslint/no-unused-vars
       expect(console.warn).to.be.calledOnce;
       expect(console.warn).to.be.calledWith(
         '<vaadin-grid> The `_cache` property is deprecated and will be removed in Vaadin 25.',
@@ -80,7 +80,7 @@ describe('deprecated API', () => {
     });
 
     it('should warn about the property being deprecated', () => {
-      const result = grid._cache.effectiveSize;
+      const result = grid._cache.effectiveSize; // eslint-disable-line @typescript-eslint/no-unused-vars
       expect(console.warn).to.be.calledTwice;
       expect(console.warn.lastCall).to.be.calledWith(
         '<vaadin-grid> The `effectiveSize` property of ItemCache is deprecated and will be removed in Vaadin 25.',
@@ -157,7 +157,7 @@ describe('deprecated API', () => {
     });
 
     it('should warn about the property being deprecated', () => {
-      const result = grid._cache.grid;
+      const result = grid._cache.grid; // eslint-disable-line @typescript-eslint/no-unused-vars
       expect(console.warn).to.be.calledTwice;
       expect(console.warn.lastCall).to.be.calledWith(
         '<vaadin-grid> The `grid` property of ItemCache is deprecated and will be removed in Vaadin 25.',
@@ -172,7 +172,7 @@ describe('deprecated API', () => {
     });
 
     it('should warn about the property being deprecated', () => {
-      const result = grid._cache.itemCaches;
+      const result = grid._cache.itemCaches; // eslint-disable-line @typescript-eslint/no-unused-vars
       expect(console.warn).to.be.calledTwice;
       expect(console.warn.lastCall).to.be.calledWith(
         '<vaadin-grid> The `itemCaches` property of ItemCache is deprecated and will be removed in Vaadin 25.',

--- a/packages/grid/test/renderers.common.js
+++ b/packages/grid/test/renderers.common.js
@@ -26,7 +26,7 @@ describe('renderers', () => {
 
   describe('column cells', () => {
     beforeEach(() => {
-      column.renderer = function (root, owner, model) {
+      column.renderer = function (root, _owner, model) {
         root.innerHTML = '';
         const text = document.createTextNode(`${model.index} ${model.item.foo}`);
         root.appendChild(text);
@@ -47,14 +47,14 @@ describe('renderers', () => {
     });
 
     it('should pass column as `owner` and `this` to the renderer', () => {
-      column.renderer = function (root, owner) {
+      column.renderer = function (_root, owner) {
         expect(this).to.eql(owner);
         expect(owner.localName).to.eql('vaadin-grid-column');
       };
     });
 
     it('should allow to change the renderer', () => {
-      column.renderer = function (root, owner, model) {
+      column.renderer = function (root, _owner, model) {
         root.innerHTML = `${model.index} test`;
       };
       expect(getCell(grid, 0)._content.innerHTML).to.eql('0 test');
@@ -69,7 +69,7 @@ describe('renderers', () => {
     });
 
     it('should initialize with instance properties', () => {
-      column.renderer = function (root, owner, model) {
+      column.renderer = function (_root, _owner, model) {
         expect(model.selected).to.be.false;
         expect(model.expanded).to.be.false;
         expect(model.detailsOpened).to.be.false;
@@ -116,7 +116,7 @@ describe('renderers', () => {
 
       it('should allow to change the renderer', () => {
         grid.detailsOpenedItems = grid.items;
-        grid.rowDetailsRenderer = function (root, owner, model) {
+        grid.rowDetailsRenderer = function (root, _owner, model) {
           root.innerHTML = `${model.index} test`;
         };
         flushGrid(grid);

--- a/packages/grid/test/row-details.common.js
+++ b/packages/grid/test/row-details.common.js
@@ -274,7 +274,7 @@ describe('row details', () => {
     it('should have correct height', () => {
       grid.openItemDetails(items[0]);
 
-      grid.dataProvider = (params, callback) => callback(items);
+      grid.dataProvider = (_, callback) => callback(items);
       flushGrid(grid);
 
       const row = getRows(grid.$.items)[0];
@@ -284,7 +284,7 @@ describe('row details', () => {
 
   describe('details opened attribute', () => {
     let dataset = [];
-    const dataProvider = (params, callback) => callback(dataset);
+    const dataProvider = (_, callback) => callback(dataset);
 
     const countRowsMarkedAsDetailsOpened = (grid) => {
       return grid.$.items.querySelectorAll('tr[details-opened]').length;

--- a/packages/grid/test/row-details.common.js
+++ b/packages/grid/test/row-details.common.js
@@ -414,7 +414,7 @@ describe('row details', () => {
           <vaadin-grid-column path="name"></vaadin-grid-column>
         </vaadin-grid>
       `);
-      grid.rowDetailsRenderer = (root, _, { item }) => {
+      grid.rowDetailsRenderer = (root) => {
         // Render the details cell with a height of 100px
         root.innerHTML = `<div style="height: 100px; background: yellow;">Details</div>`;
         // Increase the details cell height to 200px in a microtask

--- a/packages/grid/test/scroll-to-index.common.js
+++ b/packages/grid/test/scroll-to-index.common.js
@@ -202,7 +202,7 @@ describe('scroll to index', () => {
       });
 
       grid.size = 10;
-      grid.dataProvider = function (params, callback) {
+      grid.dataProvider = function (_, callback) {
         callback(data);
       };
 

--- a/packages/grid/test/tree-toggle.common.js
+++ b/packages/grid/test/tree-toggle.common.js
@@ -137,7 +137,7 @@ describe('tree toggle', () => {
         </vaadin-grid>
       `);
       column = grid.querySelector('vaadin-grid-tree-column');
-      grid.dataProvider = (params, cb) => {
+      grid.dataProvider = (_, cb) => {
         cb([{ name: 'foo', hasChildren: true }], 1);
       };
       flushGrid(grid);

--- a/packages/icon/src/vaadin-lit-iconset.js
+++ b/packages/icon/src/vaadin-lit-iconset.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { html, LitElement } from 'lit';
+import { LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';

--- a/packages/list-box/src/vaadin-multi-select-list-mixin.js
+++ b/packages/list-box/src/vaadin-multi-select-list-mixin.js
@@ -51,7 +51,7 @@ export const MultiSelectListMixin = (superClass) =>
     }
 
     /** @private */
-    _enhanceMultipleItems(items, multiple, selected, disabled, selectedValues) {
+    _enhanceMultipleItems(items, multiple, _selected, _disabled, selectedValues) {
       if (!items || !multiple) {
         return;
       }

--- a/packages/menu-bar/test/menu-bar.common.js
+++ b/packages/menu-bar/test/menu-bar.common.js
@@ -296,7 +296,7 @@ describe('root menu layout', () => {
 });
 
 describe('item components', () => {
-  let menu, buttons, overflow;
+  let menu, buttons;
 
   function makeComponent(id) {
     const div = document.createElement('div');
@@ -317,7 +317,6 @@ describe('item components', () => {
     ];
     await nextRender(menu);
     buttons = menu._buttons;
-    overflow = buttons[buttons.length - 1];
   });
 
   it('should render the component inside the menu-bar item', () => {

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -5,7 +5,7 @@ import './not-animated-styles.js';
 import '../vaadin-multi-select-combo-box.js';
 
 describe('chips', () => {
-  let comboBox, internal, inputElement;
+  let comboBox, inputElement;
 
   const getChips = (combo) => combo.querySelectorAll('vaadin-multi-select-combo-box-chip');
 
@@ -20,7 +20,6 @@ describe('chips', () => {
   beforeEach(async () => {
     comboBox = fixtureSync(`<vaadin-multi-select-combo-box></vaadin-multi-select-combo-box>`);
     comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
-    internal = comboBox.$.comboBox;
     inputElement = comboBox.inputElement;
 
     comboBox.selectedItems = ['orange'];

--- a/packages/notification/test/renderer.test.js
+++ b/packages/notification/test/renderer.test.js
@@ -41,7 +41,7 @@ describe('renderer', () => {
     });
 
     it('renderer should receive notification when defined', () => {
-      notification.renderer = (root, notification) => {
+      notification.renderer = (_root, notification) => {
         expect(notification).to.eql(notification);
       };
     });

--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -7,15 +7,10 @@ describe('validation', () => {
   let field, input;
 
   describe('basic', () => {
-    let validateSpy, changeSpy;
-
     beforeEach(async () => {
       field = fixtureSync('<vaadin-number-field></vaadin-number-field>');
       await nextRender();
       input = field.inputElement;
-      validateSpy = sinon.spy(field, 'validate');
-      changeSpy = sinon.spy().named('changeSpy');
-      field.addEventListener('change', changeSpy);
     });
 
     it('should pass validation by default', () => {

--- a/packages/polymer-legacy-adapter/test/grid-body.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-body.test.js
@@ -154,7 +154,7 @@ describe('grid body template', () => {
 
     beforeEach(() => {
       // Expanding items only works with custom data providers.
-      grid.dataProvider = (params, cb) => {
+      grid.dataProvider = (_, cb) => {
         const items = [
           { title: 'item1', hasChildren: true },
           { title: 'item2', hasChildren: true },

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -1,14 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import {
-  esc,
-  fire,
-  fixtureSync,
-  focusin,
-  focusout,
-  nextRender,
-  nextUpdate,
-  outsideClick,
-} from '@vaadin/testing-helpers';
+import { esc, fixtureSync, focusin, focusout, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';

--- a/packages/radio-group/test/radio-button.common.js
+++ b/packages/radio-group/test/radio-button.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fire, fixtureSync, mousedown, mouseup, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, mousedown, mouseup, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -759,7 +759,7 @@ export const RichTextEditorMixin = (superClass) =>
       let content = editor.innerHTML;
 
       // Remove Quill classes, e.g. ql-syntax, except for align
-      content = content.replace(/class="([^"]*)"/gu, (match, group1) => {
+      content = content.replace(/class="([^"]*)"/gu, (_match, group1) => {
         const classes = group1.split(' ').filter((className) => {
           return !className.startsWith('ql-') || className.startsWith('ql-align');
         });

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -273,11 +273,10 @@ describe('vaadin-select', () => {
     });
 
     describe('opening the overlay', () => {
-      let overlay, menu;
+      let overlay;
 
       beforeEach(() => {
         overlay = select._overlayElement;
-        menu = select._menuElement;
       });
 
       it('should keep synchronized opened properties in overlay and select', async () => {

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -614,7 +614,7 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
   }
 
   /** @private */
-  __updateDropdownItems(i8n, min, max, step) {
+  __updateDropdownItems(_i18n, min, max, step) {
     const minTimeObj = this.__validateTime(this.__parseISO(min || MIN_ALLOWED_TIME));
     const minSec = this.__getSec(minTimeObj);
 

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { arrowDown, arrowUp, esc, fixtureSync } from '@vaadin/testing-helpers';
+import { arrowDown, arrowUp, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-time-picker.js';

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { enter, fixtureSync, nextFrame, outsideClick } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { enter, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-time-picker.js';

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -68,7 +68,7 @@ describe('validation', () => {
   });
 
   describe('basic', () => {
-    let validateSpy, changeSpy, valueChangedSpy, input;
+    let validateSpy, changeSpy, valueChangedSpy;
 
     beforeEach(() => {
       timePicker = fixtureSync(`<vaadin-time-picker></vaadin-time-picker>`);
@@ -77,7 +77,6 @@ describe('validation', () => {
       timePicker.addEventListener('change', changeSpy);
       valueChangedSpy = sinon.spy();
       timePicker.addEventListener('value-changed', valueChangedSpy);
-      input = timePicker.inputElement;
     });
 
     it('should pass validation by default', () => {

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -576,7 +576,7 @@ export const UploadMixin = (superClass) =>
       if (typeof this.headers === 'string') {
         try {
           this.headers = JSON.parse(this.headers);
-        } catch (e) {
+        } catch (_) {
           this.headers = undefined;
         }
       }

--- a/packages/upload/test/helpers.js
+++ b/packages/upload/test/helpers.js
@@ -4,7 +4,7 @@ export const touchDevice = (function () {
   try {
     document.createEvent('TouchEvent');
     return true;
-  } catch (e) {
+  } catch (_) {
     return false;
   }
 })();

--- a/packages/upload/test/mock-http-request.js
+++ b/packages/upload/test/mock-http-request.js
@@ -283,7 +283,7 @@ MockHttpRequest.prototype = {
           xmlDoc.async = 'false';
           xmlDoc.loadXML(data);
         }
-      } catch (e) {
+      } catch (_) {
         // According to specs from point 3.7.5:
         // '3. Let document be a cookie-free Document object that
         // represents the result of parsing the response entity body
@@ -421,7 +421,7 @@ MockHttpRequest.prototype = {
     }
 
     uri.queryKey = {};
-    uri[key[12]].replace(querypattern, ($0, $1, $2) => {
+    uri[key[12]].replace(querypattern, (_, $1, $2) => {
       if ($1) {
         uri.queryKey[$1] = $2;
       }

--- a/packages/vaadin-themable-mixin/test/post-finalize-styles.common.ts
+++ b/packages/vaadin-themable-mixin/test/post-finalize-styles.common.ts
@@ -167,7 +167,7 @@ describe('ThemableMixin - post-finalize styles', () => {
   it('should not include duplicate styles', async () => {
     const parentTagName = uniqueTagName();
     defineComponent(parentTagName);
-    const parent = fixtureSync(`<${parentTagName}></${parentTagName}>`);
+    fixtureSync(`<${parentTagName}></${parentTagName}>`);
     await nextFrame();
     registerStyles(
       parentTagName,

--- a/packages/virtual-list/test/lit.common.js
+++ b/packages/virtual-list/test/lit.common.js
@@ -12,7 +12,7 @@ describe('lit', () => {
 
       const size = 100;
 
-      list.items = new Array(size).fill().map((e, i) => {
+      list.items = new Array(size).fill().map((_, i) => {
         return { value: `value-${i}` };
       });
 

--- a/packages/virtual-list/test/virtual-list.common.js
+++ b/packages/virtual-list/test/virtual-list.common.js
@@ -40,11 +40,11 @@ describe('virtual-list', () => {
     beforeEach(async () => {
       const size = 100;
 
-      list.items = new Array(size).fill().map((e, i) => {
+      list.items = new Array(size).fill().map((_, i) => {
         return { value: `value-${i}` };
       });
 
-      list.renderer = (el, list, model) => {
+      list.renderer = (el, _list, model) => {
         el.textContent = model.item.value;
       };
 
@@ -67,14 +67,14 @@ describe('virtual-list', () => {
     });
 
     it('should change the items to an array of same size', () => {
-      list.items = new Array(list.items.length).fill().map((e, i) => {
+      list.items = new Array(list.items.length).fill().map((_, i) => {
         return { value: `text-${i}` };
       });
       expect(list.children[0].textContent.trim()).to.equal('text-0');
     });
 
     it('should change the items to a shorter array', () => {
-      list.items = new Array(list.items.length - 1).fill().map((e, i) => {
+      list.items = new Array(list.items.length - 1).fill().map((_, i) => {
         return { value: `text-${i}` };
       });
       expect(list.children[0].textContent.trim()).to.equal('text-0');

--- a/scripts/buildWebtypes.js
+++ b/scripts/buildWebtypes.js
@@ -44,7 +44,7 @@ function loadAnalysis() {
   const analysisPath = path.resolve('./analysis.json');
   try {
     return JSON.parse(fs.readFileSync(analysisPath, 'utf8'));
-  } catch (e) {
+  } catch (_) {
     throw new Error(
       `Could not read output of the Polymer Analyzer from: ${analysisPath}. Make sure to run the Polymer Analyzer before generating web-types.`,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5426,10 +5426,10 @@ eslint-config-prettier@^9.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
   integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
 
-eslint-config-vaadin@^1.0.0-alpha.25:
-  version "1.0.0-alpha.25"
-  resolved "https://registry.yarnpkg.com/eslint-config-vaadin/-/eslint-config-vaadin-1.0.0-alpha.25.tgz#fa2cd741ddbc7fcd867c93617198c97d3fd535d5"
-  integrity sha512-zkfIH9+cQR2iLJiRwFkSI5lghzNwGvGi/CHYgJw7iyMFJ3wqR4QilaVBMJpy8sufks/o7IEy1z7gAGzCoXwh5g==
+eslint-config-vaadin@^1.0.0-alpha.27:
+  version "1.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/eslint-config-vaadin/-/eslint-config-vaadin-1.0.0-alpha.27.tgz#d9ab5865ec88fc401c2c034d1bc71201ac653cee"
+  integrity sha512-kqtlhgHTL32fw2cLu5h+KKkZadFaKkwHJRYsZ01jnzXq23+B8oA5+oZmNhAWLVci1psVImRAvekNBH9OfcfDwQ==
   dependencies:
     "@babel/core" "^7.24.7"
     "@babel/eslint-parser" "^7.24.7"


### PR DESCRIPTION
## Description

This rule is currently disabled in `eslint-config-vaadin` due to some old issue which is now fixed.

I enabled it and added an override to `d.ts` files to avoid reporting `TItem` generic parameters.

## Type of change

- Internal change