### PR TITLE
feat: add parts to drag source row cells

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -181,6 +181,9 @@ export const DragAndDropMixin = (superClass) =>
           updateBooleanRowStates(row, { dragstart: false });
           this.style.setProperty('--_grid-drag-start-x', '');
           this.style.setProperty('--_grid-drag-start-y', '');
+          rows.forEach((row) => {
+            updateBooleanRowStates(row, { 'drag-source': true });
+          });
         });
 
         const event = new CustomEvent('grid-dragstart', {
@@ -192,12 +195,6 @@ export const DragAndDropMixin = (superClass) =>
         });
         event.originalEvent = e;
         this.dispatchEvent(event);
-
-        requestAnimationFrame(() => {
-          rows.forEach((row) => {
-            updateBooleanRowStates(row, { 'drag-source': true });
-          });
-        });
       }
     }
 

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -197,7 +197,7 @@ export const DragAndDropMixin = (superClass) =>
 
         requestAnimationFrame(() => {
           rows.forEach((row) => {
-            updateCellsPart(getBodyRowCells(row), 'dragstart-source-row-cell', true);
+            updateBooleanRowStates(row, { 'drag-source': true });
           });
         });
       }
@@ -212,7 +212,7 @@ export const DragAndDropMixin = (superClass) =>
       this.dispatchEvent(event);
 
       iterateChildren(this.$.items, (row) => {
-        updateCellsPart(getBodyRowCells(row), 'dragstart-source-row-cell', false);
+        updateBooleanRowStates(row, { 'drag-source': false });
       });
     }
 

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -192,7 +192,6 @@ export const DragAndDropMixin = (superClass) =>
             setDraggedItemsCount: (count) => row.setAttribute('dragstart', count),
           },
         });
-
         event.originalEvent = e;
         this.dispatchEvent(event);
 

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -4,11 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import {
-  getBodyRowCells,
   iterateChildren,
   iterateRowCells,
   updateBooleanRowStates,
-  updateCellsPart,
   updateStringRowStates,
 } from './vaadin-grid-helpers.js';
 

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -4,9 +4,11 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import {
+  getBodyRowCells,
   iterateChildren,
   iterateRowCells,
   updateBooleanRowStates,
+  updateCellsPart,
   updateStringRowStates,
 } from './vaadin-grid-helpers.js';
 
@@ -190,8 +192,15 @@ export const DragAndDropMixin = (superClass) =>
             setDraggedItemsCount: (count) => row.setAttribute('dragstart', count),
           },
         });
+
         event.originalEvent = e;
         this.dispatchEvent(event);
+
+        requestAnimationFrame(() => {
+          rows.forEach((row) => {
+            updateCellsPart(getBodyRowCells(row), 'dragstart-source-row-cell', true);
+          });
+        });
       }
     }
 
@@ -202,6 +211,10 @@ export const DragAndDropMixin = (superClass) =>
       const event = new CustomEvent('grid-dragend');
       event.originalEvent = e;
       this.dispatchEvent(event);
+
+      iterateChildren(this.$.items, (row) => {
+        updateCellsPart(getBodyRowCells(row), 'dragstart-source-row-cell', false);
+      });
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -191,7 +191,7 @@ registerStyles('vaadin-grid', gridStyles, { moduleId: 'vaadin-grid-styles' });
  * `expanded-row-cell`        | Cell in an expanded row
  * `details-opened-row-cell`  | Cell in an row with details open
  * `dragstart-row-cell`       | Cell in a row that user started to drag (set for one frame)
- * `dragstart-source-row-cell`| Cell in the source row that user started to drag
+ * `drag-source-row-cell`     | Cell in the source row of row that is dragged
  * `dragover-above-row-cell`  | Cell in a row that has another row dragged over above
  * `dragover-below-row-cell`  | Cell in a row that has another row dragged over below
  * `dragover-on-top-row-cell` | Cell in a row that has another row dragged over on top

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -190,8 +190,8 @@ registerStyles('vaadin-grid', gridStyles, { moduleId: 'vaadin-grid-styles' });
  * `collapsed-row-cell`       | Cell in a collapsed row
  * `expanded-row-cell`        | Cell in an expanded row
  * `details-opened-row-cell`  | Cell in an row with details open
- * `dragstart-row-cell`       | Cell in a row that user started to drag (set for one frame)
- * `drag-source-row-cell`     | Cell in the source row of row that is dragged
+ * `dragstart-row-cell`       | Cell in the ghost image row, but not in for a source row
+ * `drag-source-row-cell`     | Cell in a source row, but not in the ghost image
  * `dragover-above-row-cell`  | Cell in a row that has another row dragged over above
  * `dragover-below-row-cell`  | Cell in a row that has another row dragged over below
  * `dragover-on-top-row-cell` | Cell in a row that has another row dragged over on top

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -191,6 +191,7 @@ registerStyles('vaadin-grid', gridStyles, { moduleId: 'vaadin-grid-styles' });
  * `expanded-row-cell`        | Cell in an expanded row
  * `details-opened-row-cell`  | Cell in an row with details open
  * `dragstart-row-cell`       | Cell in a row that user started to drag (set for one frame)
+ * `dragstart-source-row-cell`| Cell in the source row that user started to drag
  * `dragover-above-row-cell`  | Cell in a row that has another row dragged over above
  * `dragover-below-row-cell`  | Cell in a row that has another row dragged over below
  * `dragover-on-top-row-cell` | Cell in a row that has another row dragged over on top

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -190,7 +190,7 @@ registerStyles('vaadin-grid', gridStyles, { moduleId: 'vaadin-grid-styles' });
  * `collapsed-row-cell`       | Cell in a collapsed row
  * `expanded-row-cell`        | Cell in an expanded row
  * `details-opened-row-cell`  | Cell in an row with details open
- * `dragstart-row-cell`       | Cell in the ghost image row, but not in for a source row
+ * `dragstart-row-cell`       | Cell in the ghost image row, but not in a source row
  * `drag-source-row-cell`     | Cell in a source row, but not in the ghost image
  * `dragover-above-row-cell`  | Cell in a row that has another row dragged over above
  * `dragover-below-row-cell`  | Cell in a row that has another row dragged over below

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -279,6 +279,17 @@ describe('drag and drop', () => {
         }
       });
 
+      it('should remove drag-source- part from row when drag ends', async () => {
+        fireDragStart();
+        const row = getRows(grid.$.items)[0];
+        const cells = getRowBodyCells(row);
+        await nextFrame();
+        fireDragEnd();
+        for (const cell of cells) {
+          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
+        }
+      });
+
       // The test only concerns Safari
       const isSafari = /^((?!chrome|android).)*safari/iu.test(navigator.userAgent);
       (isSafari ? it : it.skip)('should use top on Safari for drag image', async () => {

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -254,30 +254,28 @@ describe('drag and drop', () => {
         });
       });
 
-      it('should add part to the sources of dragged rows', async () => {
-        fireDragStart();
-        let cells = getRowBodyCells(getRows(grid.$.items)[0]);
-        await nextFrame();
-
-        for (const cell of cells) {
-          expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
-        }
-
-        cells = getRowBodyCells(getRows(grid.$.items)[1]);
-
-        for (const cell of cells) {
-          expect(cell.getAttribute('part')).to.not.contain('dragstart-source-row-cell');
-        }
-
+      it('should add drag-source- part to all dragged rows', async () => {
         grid.selectItem(grid.items[0]);
         grid.selectItem(grid.items[1]);
         fireDragStart();
         await nextFrame();
-
         for (const row of [...grid.$.items.children]) {
           for (const cell of [...row.children]) {
-            expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
+            expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
           }
+        }
+      });
+
+      it('should add drag-source- part only to dragged rows', async () => {
+        fireDragStart();
+        let cells = getRowBodyCells(getRows(grid.$.items)[0]);
+        await nextFrame();
+        for (const cell of cells) {
+          expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
+        }
+        cells = getRowBodyCells(getRows(grid.$.items)[1]);
+        for (const cell of cells) {
+          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
         }
       });
 

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -260,28 +260,26 @@ describe('drag and drop', () => {
         let cells = getRowBodyCells(getRows(grid.$.items)[0]);
         await nextFrame();
 
-        // NOSONAR
-        cells.forEach((cell) => {
+        for (const cell of cells) {
           expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
-        });
+        }
 
         cells = getRowBodyCells(getRows(grid.$.items)[1]);
-        // NOSONAR
-        cells.forEach((cell) => {
+
+        for (const cell of cells) {
           expect(cell.getAttribute('part')).to.not.contain('dragstart-source-row-cell');
-        });
+        }
 
         grid.selectItem(grid.items[0]);
         grid.selectItem(grid.items[1]);
         fireDragStart();
         await nextFrame();
-        // NOSONAR
-        iterateChildren(grid.$.items, (row) => {
-          // NOSONAR
-          iterateChildren(row, (cell) => {
+
+        for (const row of [...grid.$.items.children]) {
+          for (const cell of [...row.children]) {
             expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
-          });
-        });
+          }
+        }
       });
 
       // The test only concerns Safari

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { iterateChildren } from '../src/vaadin-grid-helpers.js';
 import { flushGrid, getBodyCellContent, getFirstCell, getRowBodyCells, getRows } from './helpers.js';
 
 describe('drag and drop', () => {

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import { iterateChildren } from '../src/vaadin-grid-helpers.js';
 import { flushGrid, getBodyCellContent, getFirstCell, getRowBodyCells, getRows } from './helpers.js';
 
 describe('drag and drop', () => {
@@ -251,6 +252,31 @@ describe('drag and drop', () => {
         await nextFrame();
         cells.forEach((cell) => {
           expect(cell.getAttribute('part')).to.not.contain('dragstart-row-cell');
+        });
+      });
+
+      it('should add part to the sources of dragged rows', async () => {
+        fireDragStart();
+        let cells = getRowBodyCells(getRows(grid.$.items)[0]);
+        await nextFrame();
+
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
+        });
+
+        cells = getRowBodyCells(getRows(grid.$.items)[1]);
+        cells.forEach((cell) => {
+          expect(cell.getAttribute('part')).to.not.contain('dragstart-source-row-cell');
+        });
+
+        grid.selectItem(grid.items[0]);
+        grid.selectItem(grid.items[1]);
+        fireDragStart();
+        await nextFrame();
+        iterateChildren(grid.$.items, (row) => {
+          iterateChildren(row, (cell) => {
+            expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
+          });
         });
       });
 

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -261,11 +261,13 @@ describe('drag and drop', () => {
         await nextFrame();
 
         cells.forEach((cell) => {
+          // NOSONAR
           expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
         });
 
         cells = getRowBodyCells(getRows(grid.$.items)[1]);
         cells.forEach((cell) => {
+          // NOSONAR
           expect(cell.getAttribute('part')).to.not.contain('dragstart-source-row-cell');
         });
 
@@ -274,7 +276,9 @@ describe('drag and drop', () => {
         fireDragStart();
         await nextFrame();
         iterateChildren(grid.$.items, (row) => {
+          // NOSONAR
           iterateChildren(row, (cell) => {
+            // NOSONAR
             expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
           });
         });

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -259,8 +259,8 @@ describe('drag and drop', () => {
         grid.selectItem(grid.items[1]);
         fireDragStart();
         await nextFrame();
-        for (const row of [...grid.$.items.children]) {
-          for (const cell of [...row.children]) {
+        for (const row of getRows(grid.$.items)) {
+          for (const cell of getRowBodyCells(row)) {
             expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
           }
         }

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -260,14 +260,14 @@ describe('drag and drop', () => {
         let cells = getRowBodyCells(getRows(grid.$.items)[0]);
         await nextFrame();
 
+        // NOSONAR
         cells.forEach((cell) => {
-          // NOSONAR
           expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
         });
 
         cells = getRowBodyCells(getRows(grid.$.items)[1]);
+        // NOSONAR
         cells.forEach((cell) => {
-          // NOSONAR
           expect(cell.getAttribute('part')).to.not.contain('dragstart-source-row-cell');
         });
 
@@ -275,10 +275,10 @@ describe('drag and drop', () => {
         grid.selectItem(grid.items[1]);
         fireDragStart();
         await nextFrame();
+        // NOSONAR
         iterateChildren(grid.$.items, (row) => {
           // NOSONAR
           iterateChildren(row, (cell) => {
-            // NOSONAR
             expect(cell.getAttribute('part')).to.contain('dragstart-source-row-cell');
           });
         });


### PR DESCRIPTION
## Description

Adds part attributes to the cells that are to be dragged. The image that follows the cursor around is left unchanged, it can be styled using the existing `dragstart-row-cell` part. 

Styling the row itself cause issues, which is why it was intentionally left out. 

Fixes #5548
## Type of change
- [X] Feature

## Checklist

- [ ] I have performed self-review and corrected misspellings.