### PR TITLE
fix: use proper selector for input container disabled color

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -85,6 +85,9 @@ registerStyles(
     /* Disabled */
     :host([disabled]) {
       background: var(--_disabled-background);
+    }
+
+    :host([disabled]) ::slotted(*) {
       -webkit-text-fill-color: var(--_disabled-value-color);
       color: var(--_disabled-value-color);
     }


### PR DESCRIPTION
## Description

Follow-up to #7553

Restored the incorrectly changed CSS selector for input container color to apply to slotted `input`.

## Type of change

- Bugfix