### PR TITLE
fix: reintroduce disabled variable for slotted parts of input-field

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -28,6 +28,7 @@ const inputField = css`
     --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
     --_input-height: var(--vaadin-input-field-height, var(--lumo-text-field-size));
+    --_disabled-value-color: var(--vaadin-input-field-disabled-value-color, var(--lumo-disabled-text-color));
   }
 
   :host::before {
@@ -89,10 +90,13 @@ const inputField = css`
     --vaadin-input-field-border-color: var(--lumo-contrast-20pct);
   }
 
-  :host([disabled]) [part='label'],
-  :host([disabled]) [part='input-field'] ::slotted(*) {
+  :host([disabled]) [part='label'] {
     color: var(--lumo-disabled-text-color);
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
+  }
+  :host([disabled]) [part='input-field'] ::slotted(*) {
+    color: var(--_disabled-value-color);
+    -webkit-text-fill-color: var(--_disabled-value-color);
   }
 
   /* Invalid style */

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -94,6 +94,7 @@ const inputField = css`
     color: var(--lumo-disabled-text-color);
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }
+
   :host([disabled]) [part='input-field'] ::slotted(*) {
     color: var(--_disabled-value-color);
     -webkit-text-fill-color: var(--_disabled-value-color);


### PR DESCRIPTION
Rolf actually wanted to separate labels from the values of the input container