### PR TITLE
fix: prevent scroll when restoring focus not from keyboard

### DIFF
--- a/packages/a11y-base/src/focus-restoration-controller.js
+++ b/packages/a11y-base/src/focus-restoration-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getDeepActiveElement } from './focus-utils.js';
+import { getDeepActiveElement, isKeyboardActive } from './focus-utils.js';
 
 /**
  * A controller for saving a focused node and restoring focus to it later.
@@ -29,14 +29,16 @@ export class FocusRestorationController {
       return;
     }
 
+    const preventScroll = isKeyboardActive() === false;
+
     if (getDeepActiveElement() === document.body) {
       // In Firefox and Safari, focusing the node synchronously
       // doesn't work as expected when the overlay is closing on outside click.
       // These browsers force focus to move to the body element and retain it
       // there until the next event loop iteration.
-      setTimeout(() => focusNode.focus());
+      setTimeout(() => focusNode.focus({ preventScroll }));
     } else {
-      focusNode.focus();
+      focusNode.focus({ preventScroll });
     }
 
     this.focusNode = null;

--- a/packages/a11y-base/src/focus-restoration-controller.js
+++ b/packages/a11y-base/src/focus-restoration-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getDeepActiveElement, isKeyboardActive } from './focus-utils.js';
+import { getDeepActiveElement } from './focus-utils.js';
 
 /**
  * A controller for saving a focused node and restoring focus to it later.
@@ -23,13 +23,13 @@ export class FocusRestorationController {
   /**
    * Restores focus to the target node that was saved previously with `saveFocus()`.
    */
-  restoreFocus() {
+  restoreFocus(options) {
     const focusNode = this.focusNode;
     if (!focusNode) {
       return;
     }
 
-    const preventScroll = isKeyboardActive() === false;
+    const preventScroll = options ? options.preventScroll : false;
 
     if (getDeepActiveElement() === document.body) {
       // In Firefox and Safari, focusing the node synchronously

--- a/packages/a11y-base/test/focus-restoration-controller.test.js
+++ b/packages/a11y-base/test/focus-restoration-controller.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { aTimeout, escKeyDown, fixtureSync, mousedown, outsideClick } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { FocusRestorationController } from '../src/focus-restoration-controller.js';
 import { getDeepActiveElement } from '../src/focus-utils.js';
@@ -60,27 +60,25 @@ describe('focus-restoration-controller', () => {
     expect(getDeepActiveElement()).to.equal(button2);
   });
 
-  it('should prevent scroll when restoring focus synchronously after mousedown', () => {
+  it('should not prevent scroll when restoring focus synchronously by default', () => {
     button1.focus();
     const spy = sinon.spy(button2, 'focus');
     controller.saveFocus(button2);
-    mousedown(document.body);
-    controller.restoreFocus();
-    expect(spy).to.be.calledOnce;
-    expect(spy.firstCall.args[0]).to.eql({ preventScroll: true });
-  });
-
-  it('should not prevent scroll when restoring focus synchronously after keydown', () => {
-    button1.focus();
-    const spy = sinon.spy(button2, 'focus');
-    controller.saveFocus(button2);
-    escKeyDown(document.body);
     controller.restoreFocus();
     expect(spy).to.be.calledOnce;
     expect(spy.firstCall.args[0]).to.eql({ preventScroll: false });
   });
 
-  it('should prevent scroll when restoring focus asynchronously after outside click', async () => {
+  it('should prevent scroll when restoring focus synchronously with preventScroll', () => {
+    button1.focus();
+    const spy = sinon.spy(button2, 'focus');
+    controller.saveFocus(button2);
+    controller.restoreFocus({ preventScroll: true });
+    expect(spy).to.be.calledOnce;
+    expect(spy.firstCall.args[0]).to.eql({ preventScroll: true });
+  });
+
+  it('should not prevent scroll when restoring focus asynchronously by default', async () => {
     button1.focus();
     const spy = sinon.spy(button2, 'focus');
     controller.saveFocus(button2);
@@ -88,18 +86,17 @@ describe('focus-restoration-controller', () => {
     controller.restoreFocus();
     await aTimeout(0);
     expect(spy).to.be.calledOnce;
-    expect(spy.firstCall.args[0]).to.eql({ preventScroll: true });
+    expect(spy.firstCall.args[0]).to.eql({ preventScroll: false });
   });
 
-  it('should not prevent scroll when restoring focus asynchronously after keydown', async () => {
+  it('should prevent scroll when restoring focus asynchronously with preventScroll', async () => {
     button1.focus();
     const spy = sinon.spy(button2, 'focus');
     controller.saveFocus(button2);
-    escKeyDown(document.body);
-    document.body.focus();
-    controller.restoreFocus();
+    outsideClick();
+    controller.restoreFocus({ preventScroll: true });
     await aTimeout(0);
     expect(spy).to.be.calledOnce;
-    expect(spy.firstCall.args[0]).to.eql({ preventScroll: false });
+    expect(spy.firstCall.args[0]).to.eql({ preventScroll: true });
   });
 });

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -6,7 +6,7 @@
 import { AriaModalController } from '@vaadin/a11y-base/src/aria-modal-controller.js';
 import { FocusRestorationController } from '@vaadin/a11y-base/src/focus-restoration-controller.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
-import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 
 /**
@@ -76,7 +76,8 @@ export const OverlayFocusMixin = (superClass) =>
       }
 
       if (this.restoreFocusOnClose && this._shouldRestoreFocus()) {
-        this.__focusRestorationController.restoreFocus();
+        const preventScroll = !isKeyboardActive();
+        this.__focusRestorationController.restoreFocus({ preventScroll });
       }
     }
 

--- a/packages/overlay/test/restore-focus.common.js
+++ b/packages/overlay/test/restore-focus.common.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, mousedown, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
@@ -140,6 +141,32 @@ describe('restore focus', () => {
           overlay.opened = false;
           await nextRender();
           expect(getDeepActiveElement()).to.equal(focusInput);
+        });
+      });
+
+      describe('prevent scroll', () => {
+        it('should prevent scroll when restoring focus on close after mousedown', async () => {
+          focusable.focus();
+          overlay.opened = true;
+          await nextRender();
+          const spy = sinon.spy(focusable, 'focus');
+          mousedown(document.body);
+          overlay.opened = false;
+          await nextRender();
+          expect(spy).to.be.calledOnce;
+          expect(spy.firstCall.args[0]).to.eql({ preventScroll: true });
+        });
+
+        it('should not prevent scroll when restoring focus on close after keydown', async () => {
+          focusable.focus();
+          overlay.opened = true;
+          await nextRender();
+          const spy = sinon.spy(focusable, 'focus');
+          escKeyDown(document.body);
+          overlay.opened = false;
+          await nextRender();
+          expect(spy).to.be.calledOnce;
+          expect(spy.firstCall.args[0]).to.eql({ preventScroll: false });
         });
       });
     });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6483

Changed the restoring focus logic to prevent page scroll when it's done not from keyboard.
This should prevent unexpected page scroll change after closing overlays on outside click.

## Type of change

- Bugfix