### PR TITLE
refactor: update select to use overlay focus restoration logic

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -378,7 +378,6 @@ export const SelectBaseMixin = (superClass) =>
           this.removeAttribute('focus-ring');
         }
       } else if (wasOpened) {
-        this.focus();
         if (this._openedWithFocusRing) {
           this.setAttribute('focus-ring', '');
         }

--- a/packages/select/src/vaadin-select-overlay-mixin.js
+++ b/packages/select/src/vaadin-select-overlay-mixin.js
@@ -20,6 +20,13 @@ export const SelectOverlayMixin = (superClass) =>
     }
 
     /** @protected */
+    ready() {
+      super.ready();
+
+      this.restoreFocusOnClose = true;
+    }
+
+    /** @protected */
     _getMenuElement() {
       return Array.from(this.children).find((el) => el.localName !== 'style');
     }

--- a/packages/select/test/keyboard.common.js
+++ b/packages/select/test/keyboard.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -67,7 +67,7 @@ describe('keyboard', () => {
       });
     });
 
-    it('should focus value button element on overlay closing', async () => {
+    it('should focus value button element on overlay closing with Esc', async () => {
       await sendKeys({ press: 'Tab' });
 
       await sendKeys({ press: 'Enter' });
@@ -77,6 +77,21 @@ describe('keyboard', () => {
 
       await sendKeys({ press: 'Escape' });
       await nextUpdate(select);
+
+      expect(focusedSpy.calledOnce).to.be.true;
+    });
+
+    it('should focus value button element on overlay closing with outside click', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      const focusedSpy = sinon.spy(valueButton, 'focus');
+
+      outsideClick();
+      await nextUpdate(select);
+      await aTimeout(0);
 
       expect(focusedSpy.calledOnce).to.be.true;
     });


### PR DESCRIPTION
## Description

This aligns `vaadin-select` with e.g. `vaadin-date-picker` and ensures it also benefits from #7599

## Type of change

- Refactor