### PR TITLE
refactor: update select to use overlay focus restoration logic (#7601) (CP: 24.3)

### DIFF
--- a/packages/select/src/vaadin-lit-select-overlay.js
+++ b/packages/select/src/vaadin-lit-select-overlay.js
@@ -58,6 +58,13 @@ class SelectOverlay extends PositionMixin(OverlayMixin(ThemableMixin(DirMixin(Po
   }
 
   /** @protected */
+  ready() {
+    super.ready();
+
+    this.restoreFocusOnClose = true;
+  }
+
+  /** @protected */
   updated(props) {
     super.updated(props);
 

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -367,7 +367,6 @@ export const SelectBaseMixin = (superClass) =>
           this.removeAttribute('focus-ring');
         }
       } else if (wasOpened) {
-        this.focus();
         if (this._openedWithFocusRing) {
           this.setAttribute('focus-ring', '');
         }

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -59,6 +59,8 @@ export class SelectOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableM
   ready() {
     super.ready();
 
+    this.restoreFocusOnClose = true;
+
     // When setting `opened` as an attribute, the overlay is already teleported to body
     // by the time when `ready()` callback of the `vaadin-select` is executed by Polymer,
     // so querySelector() would return null. So we use this workaround to set properties.

--- a/packages/select/test/keyboard.common.js
+++ b/packages/select/test/keyboard.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -67,7 +67,7 @@ describe('keyboard', () => {
       });
     });
 
-    it('should focus value button element on overlay closing', async () => {
+    it('should focus value button element on overlay closing with Esc', async () => {
       await sendKeys({ press: 'Tab' });
 
       await sendKeys({ press: 'Enter' });
@@ -77,6 +77,21 @@ describe('keyboard', () => {
 
       await sendKeys({ press: 'Escape' });
       await nextUpdate(select);
+
+      expect(focusedSpy.calledOnce).to.be.true;
+    });
+
+    it('should focus value button element on overlay closing with outside click', async () => {
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'Enter' });
+      await nextRender();
+
+      const focusedSpy = sinon.spy(valueButton, 'focus');
+
+      outsideClick();
+      await nextUpdate(select);
+      await aTimeout(0);
 
       expect(focusedSpy.calledOnce).to.be.true;
     });


### PR DESCRIPTION
## Description

Manual cherry-pick of #7601 to `24.3` branch. 

The automated cherry-pick failed due to `vaadin-select-overlay-mixin` only present in `main` but not in older branches.

## Type of change

- Cherry-pick