### PR TITLE
feat: include popover content in Tab order after the target

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -610,8 +610,7 @@ class Popover extends PopoverPositionMixin(
     if (lastFocusable && isElementFocused(lastFocusable)) {
       const focusable = this.__getNextBodyFocusable(this.target);
       if (focusable && focusable !== overlayPart) {
-        event.preventDefault();
-        focusable.focus();
+        this.target.focus();
         return;
       }
     }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -610,7 +610,8 @@ class Popover extends PopoverPositionMixin(
     if (lastFocusable && isElementFocused(lastFocusable)) {
       const focusable = this.__getNextBodyFocusable(this.target);
       if (focusable && focusable !== overlayPart) {
-        this.target.focus();
+        event.preventDefault();
+        focusable.focus();
         return;
       }
     }

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -351,10 +351,12 @@ describe('a11y', () => {
       // Move focus to the input inside the overlay
       await sendKeys({ press: 'Tab' });
 
+      const spy = sinon.spy(input, 'focus');
+
       // Move focus to the input after the overlay
       await sendKeys({ press: 'Tab' });
 
-      expect(document.activeElement).to.equal(input);
+      expect(spy).to.be.calledOnce;
     });
 
     it('should focus the last overlay child on the next element Shift Tab', async () => {

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -351,12 +351,10 @@ describe('a11y', () => {
       // Move focus to the input inside the overlay
       await sendKeys({ press: 'Tab' });
 
-      const spy = sinon.spy(input, 'focus');
-
       // Move focus to the input after the overlay
       await sendKeys({ press: 'Tab' });
 
-      expect(spy).to.be.calledOnce;
+      expect(document.activeElement).to.equal(input);
     });
 
     it('should focus the last overlay child on the next element Shift Tab', async () => {


### PR DESCRIPTION
## Description

Fixes #7607

Implemented the <kbd>Tab</kbd> order for `vaadin-popover` overlay content. See the video:

https://github.com/user-attachments/assets/b1ede21f-0b46-40c9-bfed-97d7b4135e5b

## Type of change

- A11y feature

## Note

As it's now impossible to close the popover on target <kbd>Tab</kbd> (the focus will move to the overlay when it's non modal, and the focus will be trapped inside the overlay when modal), corresponding listener and test has been removed.