### PR TITLE
feat: add autofocus property for non-modal popovers

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -92,6 +92,12 @@ declare class Popover extends PopoverPositionMixin(
   accessibleNameRef: string | null | undefined;
 
   /**
+   * When true, the popover content automatically receives focus after
+   * it is opened. Modal popovers use this behavior by default.
+   */
+  autofocus: boolean;
+
+  /**
    * Height to be set on the overlay content.
    *
    * @attr {string} content-height

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -211,6 +211,14 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
+       * When true, the popover content automatically receives focus after
+       * it is opened. Modal popovers use this behavior by default.
+       */
+      autofocus: {
+        type: Boolean,
+      },
+
+      /**
        * Height to be set on the overlay content.
        *
        * @attr {string} content-height
@@ -425,6 +433,7 @@ class Popover extends PopoverPositionMixin(
         .restoreFocusNode="${this.target}"
         @vaadin-overlay-escape-press="${this.__onEscapePress}"
         @vaadin-overlay-outside-click="${this.__onOutsideClick}"
+        @vaadin-overlay-open="${this.__onOverlayOpened}"
         @vaadin-overlay-closed="${this.__onOverlayClosed}"
       ></vaadin-popover-overlay>
     `;
@@ -780,6 +789,13 @@ class Popover extends PopoverPositionMixin(
   /** @private */
   __onOpenedChanged(event) {
     this.opened = event.detail.value;
+  }
+
+  /** @private */
+  __onOverlayOpened() {
+    if (this.autofocus && !this.modal) {
+      this._overlayElement.$.overlay.focus();
+    }
   }
 
   /** @private */

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -1,5 +1,14 @@
 import { expect } from '@esm-bundle/chai';
-import { esc, fixtureSync, focusout, nextRender, nextUpdate, outsideClick, tab } from '@vaadin/testing-helpers';
+import {
+  esc,
+  fixtureSync,
+  focusout,
+  nextRender,
+  nextUpdate,
+  oneEvent,
+  outsideClick,
+  tab,
+} from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import './not-animated-styles.js';
@@ -125,6 +134,27 @@ describe('a11y', () => {
       popover.accessibleNameRef = null;
       await nextUpdate(popover);
       expect(overlay.hasAttribute('aria-labelledby')).to.be.false;
+    });
+  });
+
+  describe('autofocus', () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = sinon.spy(overlay.$.overlay, 'focus');
+    });
+
+    it('should not move focus to the overlay content when opened by default', async () => {
+      target.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      expect(spy).to.not.be.called;
+    });
+
+    it('should move focus to the overlay content when opened if autofocus is true', async () => {
+      popover.autofocus = true;
+      target.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      expect(spy).to.be.calledOnce;
     });
   });
 

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -34,6 +34,7 @@ assertType<string>(popover.contentHeight);
 assertType<string>(popover.contentWidth);
 assertType<string>(popover.overlayClass);
 assertType<string>(popover.overlayRole);
+assertType<boolean>(popover.autofocus);
 assertType<boolean>(popover.opened);
 assertType<boolean>(popover.modal);
 assertType<boolean>(popover.withBackdrop);


### PR DESCRIPTION
## Description

Added API for setting automatically focusing the popover when opened.

## Type of change

- Feature