### PR TITLE
fix: set the right globals

### DIFF
--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -62,8 +62,8 @@ const globals = css`
     --vaadin-checkbox-label-font-size: var(--lumo-font-size-m);
     --vaadin-checkbox-label-padding: var(--lumo-space-xs) var(--lumo-space-s) var(--lumo-space-xs) var(--lumo-space-xs);
     --vaadin-checkbox-size: calc(var(--lumo-size-m) / 2);
-    --vaadin-checkbox-disabled-checkmark-color: var(--lumo-contrast-10pct);
-    --vaadin-checkbox-disabled-background: var(--lumo-contrast-30pct);
+    --vaadin-checkbox-disabled-checkmark-color: var(--lumo-contrast-30pct);
+    --vaadin-checkbox-disabled-background: var(--lumo-contrast-10pct);
     /* Radio button */
     --vaadin-radio-button-background: var(--lumo-contrast-20pct);
     --vaadin-radio-button-background-hover: var(--lumo-contrast-30pct);


### PR DESCRIPTION
## Description

Follow up to https://github.com/vaadin/web-components/pull/7615
Mistakenly had switched up the two new global defaults.

## Type of change

- [X] Bugfix
