### PR TITLE
fix!: prevent Safari AutoFill to avoid click issues

### DIFF
--- a/packages/component-base/src/slot-controller.d.ts
+++ b/packages/component-base/src/slot-controller.d.ts
@@ -38,6 +38,7 @@ export class SlotController extends EventTarget implements ReactiveController {
       multiple?: boolean;
       observe?: boolean;
       useUniqueId?: boolean;
+      uniqueIdPrefix?: string;
       initializer?(host: HTMLElement, node: HTMLElement): void;
     },
   );

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -19,15 +19,14 @@ export class SlotController extends EventTarget {
    * @return {string}
    * @protected
    */
-  static generateId(host, slotName) {
-    const prefix = slotName || 'default';
+  static generateId(host, prefix = 'default') {
     return `${prefix}-${host.localName}-${generateUniqueId()}`;
   }
 
   constructor(host, slotName, tagName, config = {}) {
     super();
 
-    const { initializer, multiple, observe, useUniqueId } = config;
+    const { initializer, multiple, observe, useUniqueId, uniqueIdPrefix } = config;
 
     this.host = host;
     this.slotName = slotName;
@@ -42,7 +41,7 @@ export class SlotController extends EventTarget {
 
     // Only generate the default ID if requested by the controller.
     if (useUniqueId) {
-      this.defaultId = this.constructor.generateId(host, slotName);
+      this.defaultId = this.constructor.generateId(host, uniqueIdPrefix || slotName);
     }
   }
 

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -222,8 +222,8 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
           this.ariaTarget = input;
         },
         {
-          // The "search" prefix is a trick to disable Safari's AutoFill,
-          // which can be causing click issues otherwise:
+          // The "search" word is a trick to prevent Safari from enabling AutoFill,
+          // which is causing click issues:
           // https://github.com/vaadin/web-components/issues/6817#issuecomment-2268229567
           uniqueIdPrefix: 'search-input',
         },

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -213,12 +213,21 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
     super.ready();
 
     this.addController(
-      new InputController(this, (input) => {
-        this._setInputElement(input);
-        this._setFocusElement(input);
-        this.stateTarget = input;
-        this.ariaTarget = input;
-      }),
+      new InputController(
+        this,
+        (input) => {
+          this._setInputElement(input);
+          this._setFocusElement(input);
+          this.stateTarget = input;
+          this.ariaTarget = input;
+        },
+        {
+          // The "search" prefix is a trick to disable Safari's AutoFill,
+          // which can be causing click issues otherwise:
+          // https://github.com/vaadin/web-components/issues/6817#issuecomment-2268229567
+          uniqueIdPrefix: 'search-input',
+        },
+      ),
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
 

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-date-picker host default"] = 
 `<vaadin-date-picker>
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -19,7 +19,7 @@ snapshots["vaadin-date-picker host default"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     role="combobox"
     slot="input"
   >
@@ -33,7 +33,7 @@ snapshots["vaadin-date-picker host disabled"] =
   disabled=""
 >
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -49,7 +49,7 @@ snapshots["vaadin-date-picker host disabled"] =
     aria-haspopup="dialog"
     autocomplete="off"
     disabled=""
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     role="combobox"
     slot="input"
     tabindex="-1"
@@ -61,7 +61,7 @@ snapshots["vaadin-date-picker host disabled"] =
 snapshots["vaadin-date-picker host placeholder"] = 
 `<vaadin-date-picker placeholder="Placeholder">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -76,7 +76,7 @@ snapshots["vaadin-date-picker host placeholder"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     placeholder="Placeholder"
     role="combobox"
     slot="input"
@@ -88,7 +88,7 @@ snapshots["vaadin-date-picker host placeholder"] =
 snapshots["vaadin-date-picker host readonly"] = 
 `<vaadin-date-picker readonly="">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -103,7 +103,7 @@ snapshots["vaadin-date-picker host readonly"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     readonly=""
     role="combobox"
     slot="input"
@@ -115,7 +115,7 @@ snapshots["vaadin-date-picker host readonly"] =
 snapshots["vaadin-date-picker host required"] = 
 `<vaadin-date-picker required="">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -130,7 +130,7 @@ snapshots["vaadin-date-picker host required"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     required=""
     role="combobox"
     slot="input"
@@ -142,7 +142,7 @@ snapshots["vaadin-date-picker host required"] =
 snapshots["vaadin-date-picker host label"] = 
 `<vaadin-date-picker has-label="">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -159,7 +159,7 @@ snapshots["vaadin-date-picker host label"] =
     aria-haspopup="dialog"
     aria-labelledby="label-vaadin-date-picker-0"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     role="combobox"
     slot="input"
   >
@@ -170,7 +170,7 @@ snapshots["vaadin-date-picker host label"] =
 snapshots["vaadin-date-picker host helper"] = 
 `<vaadin-date-picker has-helper="">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -186,7 +186,7 @@ snapshots["vaadin-date-picker host helper"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     role="combobox"
     slot="input"
   >
@@ -206,7 +206,7 @@ snapshots["vaadin-date-picker host error"] =
   invalid=""
 >
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -224,7 +224,7 @@ snapshots["vaadin-date-picker host error"] =
     aria-haspopup="dialog"
     aria-invalid="true"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     invalid=""
     role="combobox"
     slot="input"
@@ -236,7 +236,7 @@ snapshots["vaadin-date-picker host error"] =
 snapshots["vaadin-date-picker host name"] = 
 `<vaadin-date-picker name="Field Name">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -251,7 +251,7 @@ snapshots["vaadin-date-picker host name"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     name="Field Name"
     role="combobox"
     slot="input"
@@ -263,7 +263,7 @@ snapshots["vaadin-date-picker host name"] =
 snapshots["vaadin-date-picker host value"] = 
 `<vaadin-date-picker has-value="">
   <label
-    for="input-vaadin-date-picker-3"
+    for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
@@ -278,7 +278,7 @@ snapshots["vaadin-date-picker host value"] =
     aria-expanded="false"
     aria-haspopup="dialog"
     autocomplete="off"
-    id="input-vaadin-date-picker-3"
+    id="search-input-vaadin-date-picker-3"
     role="combobox"
     slot="input"
   >

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -16,7 +16,7 @@ snapshots["vaadin-date-time-picker host default"] =
   </div>
   <vaadin-date-picker slot="date-picker">
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -31,14 +31,14 @@ snapshots["vaadin-date-time-picker host default"] =
       aria-expanded="false"
       aria-haspopup="dialog"
       autocomplete="off"
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       role="combobox"
       slot="input"
     >
   </vaadin-date-picker>
   <vaadin-time-picker slot="time-picker">
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -55,7 +55,7 @@ snapshots["vaadin-date-time-picker host default"] =
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       role="combobox"
       slot="input"
       spellcheck="false"
@@ -88,7 +88,7 @@ snapshots["vaadin-date-time-picker host disabled"] =
     slot="date-picker"
   >
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -104,7 +104,7 @@ snapshots["vaadin-date-time-picker host disabled"] =
       aria-haspopup="dialog"
       autocomplete="off"
       disabled=""
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       role="combobox"
       slot="input"
       tabindex="-1"
@@ -116,7 +116,7 @@ snapshots["vaadin-date-time-picker host disabled"] =
     slot="time-picker"
   >
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -134,7 +134,7 @@ snapshots["vaadin-date-time-picker host disabled"] =
       autocomplete="off"
       autocorrect="off"
       disabled=""
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       role="combobox"
       slot="input"
       spellcheck="false"
@@ -166,7 +166,7 @@ snapshots["vaadin-date-time-picker host readonly"] =
     slot="date-picker"
   >
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -181,7 +181,7 @@ snapshots["vaadin-date-time-picker host readonly"] =
       aria-expanded="false"
       aria-haspopup="dialog"
       autocomplete="off"
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       readonly=""
       role="combobox"
       slot="input"
@@ -192,7 +192,7 @@ snapshots["vaadin-date-time-picker host readonly"] =
     slot="time-picker"
   >
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -209,7 +209,7 @@ snapshots["vaadin-date-time-picker host readonly"] =
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       readonly=""
       role="combobox"
       slot="input"
@@ -242,7 +242,7 @@ snapshots["vaadin-date-time-picker host required"] =
     slot="date-picker"
   >
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -257,7 +257,7 @@ snapshots["vaadin-date-time-picker host required"] =
       aria-expanded="false"
       aria-haspopup="dialog"
       autocomplete="off"
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       required=""
       role="combobox"
       slot="input"
@@ -268,7 +268,7 @@ snapshots["vaadin-date-time-picker host required"] =
     slot="time-picker"
   >
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -285,7 +285,7 @@ snapshots["vaadin-date-time-picker host required"] =
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       required=""
       role="combobox"
       slot="input"
@@ -316,7 +316,7 @@ snapshots["vaadin-date-time-picker host label"] =
   </div>
   <vaadin-date-picker slot="date-picker">
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -332,14 +332,14 @@ snapshots["vaadin-date-time-picker host label"] =
       aria-haspopup="dialog"
       aria-label="Label"
       autocomplete="off"
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       role="combobox"
       slot="input"
     >
   </vaadin-date-picker>
   <vaadin-time-picker slot="time-picker">
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -357,7 +357,7 @@ snapshots["vaadin-date-time-picker host label"] =
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       role="combobox"
       slot="input"
       spellcheck="false"
@@ -386,7 +386,7 @@ snapshots["vaadin-date-time-picker host helper"] =
   </div>
   <vaadin-date-picker slot="date-picker">
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -401,14 +401,14 @@ snapshots["vaadin-date-time-picker host helper"] =
       aria-expanded="false"
       aria-haspopup="dialog"
       autocomplete="off"
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       role="combobox"
       slot="input"
     >
   </vaadin-date-picker>
   <vaadin-time-picker slot="time-picker">
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -425,7 +425,7 @@ snapshots["vaadin-date-time-picker host helper"] =
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       role="combobox"
       slot="input"
       spellcheck="false"
@@ -465,7 +465,7 @@ snapshots["vaadin-date-time-picker host error"] =
     slot="date-picker"
   >
     <label
-      for="input-vaadin-date-picker-6"
+      for="search-input-vaadin-date-picker-6"
       id="label-vaadin-date-picker-3"
       slot="label"
     >
@@ -482,7 +482,7 @@ snapshots["vaadin-date-time-picker host error"] =
       aria-haspopup="dialog"
       aria-invalid="true"
       autocomplete="off"
-      id="input-vaadin-date-picker-6"
+      id="search-input-vaadin-date-picker-6"
       invalid=""
       role="combobox"
       slot="input"
@@ -493,7 +493,7 @@ snapshots["vaadin-date-time-picker host error"] =
     slot="time-picker"
   >
     <label
-      for="input-vaadin-time-picker-11"
+      for="search-input-vaadin-time-picker-11"
       id="label-vaadin-time-picker-7"
       slot="label"
     >
@@ -512,7 +512,7 @@ snapshots["vaadin-date-time-picker host error"] =
       autocapitalize="off"
       autocomplete="off"
       autocorrect="off"
-      id="input-vaadin-time-picker-11"
+      id="search-input-vaadin-time-picker-11"
       invalid=""
       role="combobox"
       slot="input"

--- a/packages/field-base/src/input-controller.js
+++ b/packages/field-base/src/input-controller.js
@@ -9,7 +9,9 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
  * A controller to create and initialize slotted `<input>` element.
  */
 export class InputController extends SlotController {
-  constructor(host, callback) {
+  constructor(host, callback, options = {}) {
+    const { uniqueIdPrefix } = options;
+
     super(host, 'input', 'input', {
       initializer: (node, host) => {
         if (host.value) {
@@ -27,6 +29,7 @@ export class InputController extends SlotController {
         }
       },
       useUniqueId: true,
+      uniqueIdPrefix,
     });
   }
 }

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -402,8 +402,8 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
           this.ariaTarget = input;
         },
         {
-          // The "search" prefix is a trick to disable Safari's AutoFill,
-          // which can be causing click issues otherwise:
+          // The "search" word is a trick to prevent Safari from enabling AutoFill,
+          // which is causing click issues:
           // https://github.com/vaadin/web-components/issues/6817#issuecomment-2268229567
           uniqueIdPrefix: 'search-input',
         },

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -393,12 +393,21 @@ class TimePicker extends PatternMixin(InputControlMixin(ThemableMixin(ElementMix
     super.ready();
 
     this.addController(
-      new InputController(this, (input) => {
-        this._setInputElement(input);
-        this._setFocusElement(input);
-        this.stateTarget = input;
-        this.ariaTarget = input;
-      }),
+      new InputController(
+        this,
+        (input) => {
+          this._setInputElement(input);
+          this._setFocusElement(input);
+          this.stateTarget = input;
+          this.ariaTarget = input;
+        },
+        {
+          // The "search" prefix is a trick to disable Safari's AutoFill,
+          // which can be causing click issues otherwise:
+          // https://github.com/vaadin/web-components/issues/6817#issuecomment-2268229567
+          uniqueIdPrefix: 'search-input',
+        },
+      ),
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
     this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-time-picker host default"] = 
 `<vaadin-time-picker>
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -21,7 +21,7 @@ snapshots["vaadin-time-picker host default"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     role="combobox"
     slot="input"
     spellcheck="false"
@@ -33,7 +33,7 @@ snapshots["vaadin-time-picker host default"] =
 snapshots["vaadin-time-picker host label"] = 
 `<vaadin-time-picker has-label="">
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -52,7 +52,7 @@ snapshots["vaadin-time-picker host label"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     role="combobox"
     slot="input"
     spellcheck="false"
@@ -64,7 +64,7 @@ snapshots["vaadin-time-picker host label"] =
 snapshots["vaadin-time-picker host helper"] = 
 `<vaadin-time-picker has-helper="">
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -82,7 +82,7 @@ snapshots["vaadin-time-picker host helper"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     role="combobox"
     slot="input"
     spellcheck="false"
@@ -103,7 +103,7 @@ snapshots["vaadin-time-picker host error"] =
   invalid=""
 >
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -123,7 +123,7 @@ snapshots["vaadin-time-picker host error"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     invalid=""
     role="combobox"
     slot="input"
@@ -136,7 +136,7 @@ snapshots["vaadin-time-picker host error"] =
 snapshots["vaadin-time-picker host required"] = 
 `<vaadin-time-picker required="">
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -153,7 +153,7 @@ snapshots["vaadin-time-picker host required"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     required=""
     role="combobox"
     slot="input"
@@ -169,7 +169,7 @@ snapshots["vaadin-time-picker host disabled"] =
   disabled=""
 >
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -187,7 +187,7 @@ snapshots["vaadin-time-picker host disabled"] =
     autocomplete="off"
     autocorrect="off"
     disabled=""
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     role="combobox"
     slot="input"
     spellcheck="false"
@@ -200,7 +200,7 @@ snapshots["vaadin-time-picker host disabled"] =
 snapshots["vaadin-time-picker host readonly"] = 
 `<vaadin-time-picker readonly="">
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -217,7 +217,7 @@ snapshots["vaadin-time-picker host readonly"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     readonly=""
     role="combobox"
     slot="input"
@@ -230,7 +230,7 @@ snapshots["vaadin-time-picker host readonly"] =
 snapshots["vaadin-time-picker host placeholder"] = 
 `<vaadin-time-picker placeholder="Placeholder">
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -247,7 +247,7 @@ snapshots["vaadin-time-picker host placeholder"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     placeholder="Placeholder"
     role="combobox"
     slot="input"
@@ -260,7 +260,7 @@ snapshots["vaadin-time-picker host placeholder"] =
 snapshots["vaadin-time-picker host pattern"] = 
 `<vaadin-time-picker>
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -277,7 +277,7 @@ snapshots["vaadin-time-picker host pattern"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     pattern="[0-9]*"
     role="combobox"
     slot="input"
@@ -290,7 +290,7 @@ snapshots["vaadin-time-picker host pattern"] =
 snapshots["vaadin-time-picker host name"] = 
 `<vaadin-time-picker name="Field Name">
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -307,7 +307,7 @@ snapshots["vaadin-time-picker host name"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     name="Field Name"
     role="combobox"
     slot="input"
@@ -323,7 +323,7 @@ snapshots["vaadin-time-picker host opened default"] =
   opened=""
 >
   <label
-    for="input-vaadin-time-picker-4"
+    for="search-input-vaadin-time-picker-4"
     id="label-vaadin-time-picker-0"
     slot="label"
   >
@@ -341,7 +341,7 @@ snapshots["vaadin-time-picker host opened default"] =
     autocapitalize="off"
     autocomplete="off"
     autocorrect="off"
-    id="input-vaadin-time-picker-4"
+    id="search-input-vaadin-time-picker-4"
     role="combobox"
     slot="input"
     spellcheck="false"


### PR DESCRIPTION
## Description

The PR adds the "search" prefix to the date and time picker's id attribute. This is a trick to prevent Safari from enabling AutoFill, which is causing click issues. See the referenced ticket for more details.

> [!WARNING]
> @web-padawan: could be considered behavior altering fix due to the fact of changing ID attributes which can be unexpected by some users in terms of testing.

Fixes #6817 

## Type of change

- [x] Bugfix
