### PR TITLE
fix: use custom CSS property for text-area readonly border

### DIFF
--- a/packages/text-area/theme/lumo/vaadin-text-area-styles.js
+++ b/packages/text-area/theme/lumo/vaadin-text-area-styles.js
@@ -30,7 +30,7 @@ const textArea = css`
   }
 
   :host([readonly]) [part='input-field'] {
-    border: 1px dashed var(--lumo-contrast-30pct);
+    border: var(--vaadin-input-field-readonly-border, 1px dashed var(--lumo-contrast-30pct));
   }
 
   :host([readonly]) [part='input-field']::after {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6503

## Type of change

- Bugfix