### PR TITLE
chore: move a11y-base to field-highlighter dependencies

### DIFF
--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/component-base": "24.5.0-alpha7",
     "@vaadin/overlay": "24.5.0-alpha7",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha7",
@@ -43,7 +44,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/checkbox": "24.5.0-alpha7",
     "@vaadin/checkbox-group": "24.5.0-alpha7",
     "@vaadin/combo-box": "24.5.0-alpha7",


### PR DESCRIPTION
## Description

The `announce` helpers is imported in the `src` folder so we need to use `"dependencies"`, not `"devDependencies"`.

https://github.com/vaadin/web-components/blob/19bcd2bc48a751ea061e2d845372abb3f2bb8f02/packages/field-highlighter/src/vaadin-field-highlighter.js#L8

## Type of change

- Internal change