### PR TITLE
chore: update all tests to use new chai-plugins package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -94,7 +94,7 @@
             "groups": [
               [
                 // Testing tools group
-                "^(@esm-bundle|@web|@vaadin/chai-plugins|@vaadin/testing-helpers|sinon)",
+                "^(@web|@vaadin/chai-plugins|@vaadin/testing-helpers|sinon)",
                 // Side-effects group
                 "^\\u0000",
                 // External group

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@polymer/iron-component-page": "^4.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/sinon": "^17.0.2",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@web/dev-server": "^0.4.3",
     "@web/dev-server-esbuild": "^1.0.2",
     "@web/rollup-plugin-html": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "update:snapshots": "web-test-runner --config web-test-runner-snapshots.config.js --update-snapshots"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
     "@fontsource/roboto": "^4.5.1",
     "@polymer/iron-component-page": "^4.0.1",
     "@rollup/plugin-terser": "^0.4.4",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -45,7 +45,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   esc,

--- a/packages/app-layout/test/dom/app-layout.test.js
+++ b/packages/app-layout/test/dom/app-layout.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import '../../src/vaadin-app-layout.js';

--- a/packages/app-layout/test/dom/drawer-toggle.test.js
+++ b/packages/app-layout/test/dom/drawer-toggle.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-drawer-toggle.js';
 

--- a/packages/app-layout/test/drawer-toggle.test.js
+++ b/packages/app-layout/test/drawer-toggle.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextFrame, space } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-drawer-toggle.js';

--- a/packages/app-layout/test/keyboard-desktop.test.js
+++ b/packages/app-layout/test/keyboard-desktop.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import '../vaadin-app-layout.js';

--- a/packages/app-layout/test/keyboard-mobile.test.js
+++ b/packages/app-layout/test/keyboard-mobile.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import '../vaadin-app-layout.js';

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -49,7 +49,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   enterKeyDown,
   escKeyDown,

--- a/packages/avatar-group/test/dom/avatar-group.test.js
+++ b/packages/avatar-group/test/dom/avatar-group.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-avatar-group.js';
 

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -49,7 +49,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/avatar/test/avatar.common.js
+++ b/packages/avatar/test/avatar.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusin, focusout, mousedown, nextUpdate, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/tooltip/vaadin-tooltip.js';

--- a/packages/avatar/test/dom/avatar.test.js
+++ b/packages/avatar/test/dom/avatar.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-avatar.js';
 

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -43,7 +43,7 @@
     "@vaadin/component-base": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-board",

--- a/packages/board/test/basic.test.js
+++ b/packages/board/test/basic.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 

--- a/packages/board/test/board-cols.test.js
+++ b/packages/board/test/board-cols.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-board-row.js';

--- a/packages/board/test/board-row.test.js
+++ b/packages/board/test/board-row.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 

--- a/packages/board/test/light-dom.test.js
+++ b/packages/board/test/light-dom.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-board-row.js';
 

--- a/packages/board/test/redraw.test.js
+++ b/packages/board/test/redraw.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 import { allResized, onceResized } from './helpers.js';

--- a/packages/board/test/size.test.js
+++ b/packages/board/test/size.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-board.js';
 import { allResized } from './helpers.js';

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -44,7 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/button/test/button.common.ts
+++ b/packages/button/test/button.common.ts
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/button/test/dom/button.test.js
+++ b/packages/button/test/dom/button.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../../src/vaadin-button.js';

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-chart",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -43,7 +43,7 @@
     "highcharts": "9.2.2"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';

--- a/packages/charts/test/chart-properties.test.js
+++ b/packages/charts/test/chart-properties.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';

--- a/packages/charts/test/dom-repeat.test.js
+++ b/packages/charts/test/dom-repeat.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '../vaadin-chart.js';

--- a/packages/charts/test/events.test.js
+++ b/packages/charts/test/events.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';

--- a/packages/charts/test/private-api.test.js
+++ b/packages/charts/test/private-api.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 import { inflateFunctions } from '../src/helpers.js';

--- a/packages/charts/test/styling.test.js
+++ b/packages/charts/test/styling.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-chart.js';

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -49,7 +49,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/checkbox-group/test/checkbox-group.common.js
+++ b/packages/checkbox-group/test/checkbox-group.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/checkbox-group/test/dom/checkbox-group.test.js
+++ b/packages/checkbox-group/test/dom/checkbox-group.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../vaadin-checkbox-group.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/checkbox-group/test/validation.common.js
+++ b/packages/checkbox-group/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -46,7 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/checkbox/test/checkbox.common.js
+++ b/packages/checkbox/test/checkbox.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, mousedown, mouseup, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/checkbox/test/dom/checkbox.test.js
+++ b/packages/checkbox/test/dom/checkbox.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../vaadin-checkbox.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/checkbox/test/validation.common.js
+++ b/packages/checkbox/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -52,7 +52,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-field": "24.5.0-alpha7",
     "lit": "^3.0.0",

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-field": "24.5.0-alpha7",
     "lit": "^3.0.0",
     "sinon": "^13.0.2"

--- a/packages/combo-box/test/aria.common.js
+++ b/packages/combo-box/test/aria.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { getAllItems } from './helpers.js';
 

--- a/packages/combo-box/test/basic.common.js
+++ b/packages/combo-box/test/basic.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getViewportItems, setInputValue } from './helpers.js';

--- a/packages/combo-box/test/combo-box-light-validation.common.js
+++ b/packages/combo-box/test/combo-box-light-validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/combo-box/test/combo-box-light.common.js
+++ b/packages/combo-box/test/combo-box-light.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDownKeyDown,
   click,

--- a/packages/combo-box/test/data-provider-dynamic-size.common.js
+++ b/packages/combo-box/test/data-provider-dynamic-size.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import { flushComboBox, getViewportItems, getVisibleItemsCount, makeItems, scrollToIndex } from './helpers.js';

--- a/packages/combo-box/test/data-provider-filtering.common.js
+++ b/packages/combo-box/test/data-provider-filtering.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { setInputValue } from './helpers.js';

--- a/packages/combo-box/test/data-provider.common.js
+++ b/packages/combo-box/test/data-provider.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';

--- a/packages/combo-box/test/dom/combo-box.test.js
+++ b/packages/combo-box/test/dom/combo-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-combo-box.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/combo-box/test/events.common.js
+++ b/packages/combo-box/test/events.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusout, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { clickItem, setInputValue } from './helpers.js';

--- a/packages/combo-box/test/external-filtering.common.js
+++ b/packages/combo-box/test/external-filtering.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { getAllItems, getFocusedItemIndex, setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/interactions.common.js
+++ b/packages/combo-box/test/interactions.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   click,

--- a/packages/combo-box/test/internal-filtering.common.js
+++ b/packages/combo-box/test/internal-filtering.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';

--- a/packages/combo-box/test/item-class-name-generator.common.js
+++ b/packages/combo-box/test/item-class-name-generator.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { getAllItems } from './helpers.js';
 

--- a/packages/combo-box/test/item-renderer.common.js
+++ b/packages/combo-box/test/item-renderer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getAllItems, getFirstItem, setInputValue } from './helpers.js';

--- a/packages/combo-box/test/keyboard.common.js
+++ b/packages/combo-box/test/keyboard.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDownKeyDown,
   arrowUpKeyDown,

--- a/packages/combo-box/test/lit-renderer-directives.common.js
+++ b/packages/combo-box/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/combo-box/test/lit.common.js
+++ b/packages/combo-box/test/lit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { html, LitElement, render } from 'lit';
 import { getViewportItems } from './helpers.js';

--- a/packages/combo-box/test/object-values.common.js
+++ b/packages/combo-box/test/object-values.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { clickItem, getFirstItem, getViewportItems } from './helpers.js';

--- a/packages/combo-box/test/overlay-opening.common.js
+++ b/packages/combo-box/test/overlay-opening.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, arrowUpKeyDown, click, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/overlay-position.common.js
+++ b/packages/combo-box/test/overlay-position.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { makeItems, setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/selecting-items.common.js
+++ b/packages/combo-box/test/selecting-items.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fire, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { clickItem, getAllItems, getFirstItem, onceScrolled, scrollToIndex, setInputValue } from './helpers.js';

--- a/packages/combo-box/test/validation.common.js
+++ b/packages/combo-box/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -38,7 +38,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }

--- a/packages/component-base/test/controller-mixin.test.js
+++ b/packages/component-base/test/controller-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { LitElement } from 'lit';

--- a/packages/component-base/test/data-provider-controller-cache.test.js
+++ b/packages/component-base/test/data-provider-controller-cache.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { Cache } from '../src/data-provider-controller/cache.js';
 
 const PLACEHOLDER = Symbol('PLACEHOLDER');

--- a/packages/component-base/test/data-provider-controller-data-callbacks.test.js
+++ b/packages/component-base/test/data-provider-controller-data-callbacks.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import '@vaadin/testing-helpers';
 import { DataProviderController } from '../src/data-provider-controller/data-provider-controller.js';
 

--- a/packages/component-base/test/data-provider-controller-data-loading.test.js
+++ b/packages/component-base/test/data-provider-controller-data-loading.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/testing-helpers';

--- a/packages/component-base/test/data-provider-controller-events.test.js
+++ b/packages/component-base/test/data-provider-controller-events.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { DataProviderController } from '../src/data-provider-controller/data-provider-controller.js';

--- a/packages/component-base/test/data-provider-controller-placeholder.test.js
+++ b/packages/component-base/test/data-provider-controller-placeholder.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import '@vaadin/testing-helpers';
 import { DataProviderController } from '../src/data-provider-controller/data-provider-controller.js';

--- a/packages/component-base/test/data-provider-controller.test.js
+++ b/packages/component-base/test/data-provider-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import '@vaadin/testing-helpers';
 import { Cache } from '../src/data-provider-controller/cache.js';

--- a/packages/component-base/test/define.test.js
+++ b/packages/component-base/test/define.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineCustomElement } from '../src/define.js';
 
 describe('define', () => {

--- a/packages/component-base/test/delegate-state-mixin.test.js
+++ b/packages/component-base/test/delegate-state-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { DelegateStateMixin } from '../src/delegate-state-mixin.js';

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineCE, fixtureSync } from '@vaadin/testing-helpers';
 import {
   addValueToAttribute,

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { flush } from '../src/debounce.js';

--- a/packages/component-base/test/media-query-controller.test.js
+++ b/packages/component-base/test/media-query-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/overflow-controller.test.js
+++ b/packages/component-base/test/overflow-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { OverlayClassMixin } from '../src/overlay-class-mixin.js';

--- a/packages/component-base/test/path-utils.test.js
+++ b/packages/component-base/test/path-utils.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { get, set } from '../src/path-utils.js';
 
 describe('path-utils', () => {

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineCE, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, LitElement } from 'lit';

--- a/packages/component-base/test/resize-mixin.test.js
+++ b/packages/component-base/test/resize-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html as legacyHtml, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import { SlotObserver } from '../src/slot-observer.js';
 

--- a/packages/component-base/test/slot-styles-mixin.test.js
+++ b/packages/component-base/test/slot-styles-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';

--- a/packages/component-base/test/templates.test.js
+++ b/packages/component-base/test/templates.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/component-base/test/unique-id-utils.test.js
+++ b/packages/component-base/test/unique-id-utils.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { generateUniqueId, resetUniqueId } from '../src/unique-id-utils.js';
 
 describe('unique-id-utils', () => {

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import { matchPaths } from '../src/url-utils.js';
 

--- a/packages/component-base/test/virtualizer-item-height.test.js
+++ b/packages/component-base/test/virtualizer-item-height.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, mousedown, mouseup, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/component-base/test/virtualizer-scrolling.test.js
+++ b/packages/component-base/test/virtualizer-scrolling.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import Sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { Virtualizer } from '../src/virtualizer.js';
 

--- a/packages/component-base/test/virtualizer-update-range.test.js
+++ b/packages/component-base/test/virtualizer-update-range.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { Virtualizer } from '../src/virtualizer.js';
 

--- a/packages/component-base/test/virtualizer-variable-row-height.test.js
+++ b/packages/component-base/test/virtualizer-variable-row-height.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -47,7 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/confirm-dialog/test/confirm-dialog.common.js
+++ b/packages/confirm-dialog/test/confirm-dialog.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   esc,

--- a/packages/confirm-dialog/test/dom/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/dom/confirm-dialog.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-confirm-dialog.js';
 

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -53,7 +53,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/context-menu/test/a11y.common.js
+++ b/packages/context-menu/test/a11y.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';

--- a/packages/context-menu/test/context.common.js
+++ b/packages/context-menu/test/context.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';

--- a/packages/context-menu/test/dom/context-menu.test.js
+++ b/packages/context-menu/test/dom/context-menu.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-context-menu.js';
 import '../not-animated-styles.js';

--- a/packages/context-menu/test/integration.common.js
+++ b/packages/context-menu/test/integration.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 

--- a/packages/context-menu/test/items-theme.common.js
+++ b/packages/context-menu/test/items-theme.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/item/vaadin-item.js';
 import '@vaadin/list-box/vaadin-list-box.js';

--- a/packages/context-menu/test/items.common.js
+++ b/packages/context-menu/test/items.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDownKeyDown,
   arrowLeftKeyDown,

--- a/packages/context-menu/test/lit-renderer-directives.common.js
+++ b/packages/context-menu/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, nothing, render } from 'lit';

--- a/packages/context-menu/test/overlay.common.js
+++ b/packages/context-menu/test/overlay.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { esc, fire, fixtureSync, isIOS, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/context-menu/test/properties.common.js
+++ b/packages/context-menu/test/properties.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 
 describe('properties', () => {

--- a/packages/context-menu/test/renderer.common.js
+++ b/packages/context-menu/test/renderer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/context-menu/test/selection.common.js
+++ b/packages/context-menu/test/selection.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';

--- a/packages/context-menu/test/touch.common.js
+++ b/packages/context-menu/test/touch.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   fire,
   fixtureSync,

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -42,7 +42,7 @@
     "cookieconsent": "^3.0.6"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0"
   },
   "cvdlName": "vaadin-cookie-consent",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0"
+    "@vaadin/testing-helpers": "^1.0.0"
   },
   "cvdlName": "vaadin-cookie-consent",
   "web-types": [

--- a/packages/cookie-consent/test/cookie-consent.test.js
+++ b/packages/cookie-consent/test/cookie-consent.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, keyboardEventFor } from '@vaadin/testing-helpers';
 import '../vaadin-cookie-consent.js';
 

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -51,7 +51,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-crud",

--- a/packages/crud/test/a11y.test.js
+++ b/packages/crud/test/a11y.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import { sendKeys } from '@web/test-runner-commands';

--- a/packages/crud/test/crud-buttons.test.js
+++ b/packages/crud/test/crud-buttons.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, change, fire, fixtureSync, listenOnce, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import '../vaadin-crud.js';

--- a/packages/crud/test/crud-form.test.js
+++ b/packages/crud/test/crud-form.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-crud-form.js';
 

--- a/packages/crud/test/crud-grid-properties.test.js
+++ b/packages/crud/test/crud-grid-properties.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-crud.js';
 import { getHeaderCellContent } from './helpers.js';

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-crud-grid.js';
 import { flushGrid, getBodyCellContent, getHeaderCellContent } from './helpers.js';

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, change, fire, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/crud/test/dom/crud.test.js
+++ b/packages/crud/test/dom/crud.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 import '../../vaadin-crud.js';

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -47,7 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/combo-box": "24.5.0-alpha7",
     "@vaadin/date-picker": "24.5.0-alpha7",
     "@vaadin/email-field": "24.5.0-alpha7",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -55,7 +55,7 @@
     "@vaadin/number-field": "24.5.0-alpha7",
     "@vaadin/password-field": "24.5.0-alpha7",
     "@vaadin/select": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-area": "24.5.0-alpha7",
     "@vaadin/text-field": "24.5.0-alpha7",
     "@vaadin/time-picker": "24.5.0-alpha7",

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, focusin, focusout, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/custom-field/test/dom/custom-field.test.js
+++ b/packages/custom-field/test/dom/custom-field.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-custom-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/custom-field/test/keyboard.common.js
+++ b/packages/custom-field/test/keyboard.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/custom-field/test/slot-wrapper.common.js
+++ b/packages/custom-field/test/slot-wrapper.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 

--- a/packages/custom-field/test/validation.test.js
+++ b/packages/custom-field/test/validation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-custom-field.js';

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -48,7 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/date-picker/test/basic.common.js
+++ b/packages/date-picker/test/basic.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, keyboardEventFor, nextRender, oneEvent, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, oneEvent, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/date-picker/test/dom/date-picker.test.js
+++ b/packages/date-picker/test/dom/date-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-date-picker.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/date-picker/test/dom/month-calendar.test.js
+++ b/packages/date-picker/test/dom/month-calendar.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../src/vaadin-month-calendar.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/date-picker/test/dropdown.common.js
+++ b/packages/date-picker/test/dropdown.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   fire,

--- a/packages/date-picker/test/events.common.js
+++ b/packages/date-picker/test/events.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/fullscreen.common.js
+++ b/packages/date-picker/test/fullscreen.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender, nextUpdate, outsideClick, tabKeyDown, tap } from '@vaadin/testing-helpers';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/keyboard-input.common.js
+++ b/packages/date-picker/test/keyboard-input.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, enter, fixtureSync, nextRender, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/keyboard-navigation.common.js
+++ b/packages/date-picker/test/keyboard-navigation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/month-calendar.common.js
+++ b/packages/date-picker/test/month-calendar.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, makeSoloTouchEvent, nextFrame, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getDefaultI18n } from './helpers.js';

--- a/packages/date-picker/test/overlay-content.common.js
+++ b/packages/date-picker/test/overlay-content.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, listenOnce, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getDefaultI18n, getFirstVisibleItem, monthsEqual, waitForScrollToFinish } from './helpers.js';

--- a/packages/date-picker/test/scroller.test.js
+++ b/packages/date-picker/test/scroller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, listenOnce } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { InfiniteScroller } from '../src/vaadin-infinite-scroller.js';

--- a/packages/date-picker/test/theme-propagation.common.js
+++ b/packages/date-picker/test/theme-propagation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { open, waitForScrollToFinish } from './helpers.js';
 

--- a/packages/date-picker/test/validation.common.js
+++ b/packages/date-picker/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { close, open, setInputValue, waitForOverlayRender } from './helpers.js';

--- a/packages/date-picker/test/value-commit-auto-open-disabled.common.js
+++ b/packages/date-picker/test/value-commit-auto-open-disabled.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/value-commit.common.js
+++ b/packages/date-picker/test/value-commit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick, tap } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/date-picker/test/wai-aria.common.js
+++ b/packages/date-picker/test/wai-aria.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { activateScroller, close, getDefaultI18n, open } from './helpers.js';
 

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -47,7 +47,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/date-time-picker/test/aria.test.js
+++ b/packages/date-time-picker/test/aria.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, focusin, focusout, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';

--- a/packages/date-time-picker/test/dom/date-time-picker.test.js
+++ b/packages/date-time-picker/test/dom/date-time-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-date-time-picker.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-date-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/date-time-picker/test/properties.test.js
+++ b/packages/date-time-picker/test/properties.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-date-time-picker.js';

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -50,7 +50,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/details/test/details.common.js
+++ b/packages/details/test/details.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/details/test/dom/details.test.js
+++ b/packages/details/test/dom/details.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../vaadin-details.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -48,7 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-area": "24.5.0-alpha7",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-area": "24.5.0-alpha7",
     "sinon": "^13.0.2"
   },

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, esc, fixtureSync, listenOnce, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';

--- a/packages/dialog/test/dom/dialog.test.js
+++ b/packages/dialog/test/dom/dialog.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dialog.js';
 

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-area/vaadin-text-area.js';

--- a/packages/dialog/test/header-footer.common.js
+++ b/packages/dialog/test/header-footer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createRenderer } from './helpers.js';

--- a/packages/dialog/test/lit-renderer-directives.common.js
+++ b/packages/dialog/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/dialog/test/renderer.common.js
+++ b/packages/dialog/test/renderer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -45,7 +45,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/email-field/test/dom/email-field.test.js
+++ b/packages/email-field/test/dom/email-field.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-email-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/email-field/test/validation.common.js
+++ b/packages/email-field/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -37,7 +37,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DelegateFocusMixin } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   defineLit,
   definePolymer,

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   defineLit,
   definePolymer,

--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';

--- a/packages/field-base/test/labelled-input-controller.test.js
+++ b/packages/field-base/test/labelled-input-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/field-base/test/text-area-controller.test.js
+++ b/packages/field-base/test/text-area-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -43,7 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/checkbox": "24.5.0-alpha7",
     "@vaadin/checkbox-group": "24.5.0-alpha7",
     "@vaadin/combo-box": "24.5.0-alpha7",

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -53,7 +53,7 @@
     "@vaadin/list-box": "24.5.0-alpha7",
     "@vaadin/radio-group": "24.5.0-alpha7",
     "@vaadin/select": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-area": "24.5.0-alpha7",
     "@vaadin/text-field": "24.5.0-alpha7",
     "@vaadin/time-picker": "24.5.0-alpha7",

--- a/packages/field-highlighter/test/field-components.test.js
+++ b/packages/field-highlighter/test/field-components.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, fixtureSync, nextFrame, nextRender, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/field-highlighter/test/field-highlighter.test.js
+++ b/packages/field-highlighter/test/field-highlighter.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field';

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field';

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/custom-field": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-field": "24.5.0-alpha7",
     "sinon": "^13.0.2"
   },

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -42,7 +42,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/custom-field": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "@vaadin/text-field": "24.5.0-alpha7",

--- a/packages/form-layout/test/dom/form-item.test.js
+++ b/packages/form-layout/test/dom/form-item.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-form-item.js';
 

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/custom-style.js';

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-repeat.js';

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -51,7 +51,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-grid-pro",

--- a/packages/grid-pro/test/edit-column-renderer.common.js
+++ b/packages/grid-pro/test/edit-column-renderer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, esc, fixtureSync, focusout, nextFrame, space } from '@vaadin/testing-helpers';
 import { sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/grid-pro/test/edit-column-type.common.js
+++ b/packages/grid-pro/test/edit-column-type.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDown,
   arrowUp,

--- a/packages/grid-pro/test/edit-column.common.js
+++ b/packages/grid-pro/test/edit-column.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, esc, fixtureSync, focusin, focusout, isIOS, nextFrame, tab } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import {
@@ -386,7 +386,7 @@ describe('edit column', () => {
         /* prettier-ignore */
         grid.dataProvider = ({ page, pageSize }, callback) => { // NOSONAR
           const items = [...Array(pageSize).keys()].map((i) => {
-            return { 
+            return {
               id: page * pageSize + i,
               status: 'draft',
               amount: 100,

--- a/packages/grid-pro/test/grid-pro.common.js
+++ b/packages/grid-pro/test/grid-pro.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, infiniteDataProvider } from './helpers.js';

--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, esc, fixtureSync, nextFrame, tab } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createItems, dblclick, dragAndDropOver, flushGrid, getCellEditor, getContainerCell } from './helpers.js';

--- a/packages/grid-pro/test/lit-renderer-directives.common.js
+++ b/packages/grid-pro/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/grid-pro/test/lit.common.js
+++ b/packages/grid-pro/test/lit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextFrame, tab } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -57,7 +57,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/grid/test/accessibility.common.js
+++ b/packages/grid/test/accessibility.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { flushGrid } from './helpers.js';
 

--- a/packages/grid/test/array-data-provider.common.js
+++ b/packages/grid/test/array-data-provider.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getBodyCellContent, getRows } from './helpers.js';

--- a/packages/grid/test/basic.common.js
+++ b/packages/grid/test/basic.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import {

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getContainerCell } from './helpers.js';

--- a/packages/grid/test/column-group.common.js
+++ b/packages/grid/test/column-group.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getContainerCell } from './helpers.js';

--- a/packages/grid/test/column-groups.common.js
+++ b/packages/grid/test/column-groups.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import {

--- a/packages/grid/test/column-observer.test.js
+++ b/packages/grid/test/column-observer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ColumnObserver } from '../src/vaadin-grid-helpers.js';

--- a/packages/grid/test/column-rendering.common.js
+++ b/packages/grid/test/column-rendering.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, keyDownOn, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import Sinon from 'sinon';
 import { flushGrid, getCellContent, getHeaderCellContent, onceResized } from './helpers.js';

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';

--- a/packages/grid/test/column-resizing.common.js
+++ b/packages/grid/test/column-resizing.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, listenOnce, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import {

--- a/packages/grid/test/column.common.js
+++ b/packages/grid/test/column.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/grid/test/deprecated-api.common.js
+++ b/packages/grid/test/deprecated-api.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid } from './helpers.js';

--- a/packages/grid/test/disabled.common.js
+++ b/packages/grid/test/disabled.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { flushGrid } from './helpers.js';

--- a/packages/grid/test/dom/grid.test.js
+++ b/packages/grid/test/dom/grid.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../vaadin-grid.js';
 import { users } from '../visual/users.js';

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getBodyCellContent, getFirstCell, getRowBodyCells, getRows } from './helpers.js';

--- a/packages/grid/test/dynamic-item-size.common.js
+++ b/packages/grid/test/dynamic-item-size.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { css } from 'lit';
 import { flushGrid, getFirstVisibleItem, infiniteDataProvider } from './helpers.js';

--- a/packages/grid/test/event-context.common.js
+++ b/packages/grid/test/event-context.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync } from '@vaadin/testing-helpers';
 import { flushGrid, getContainerCell } from './helpers.js';
 

--- a/packages/grid/test/extension.common.js
+++ b/packages/grid/test/extension.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 
 const Grid = customElements.get('vaadin-grid');

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, LitElement } from 'lit';

--- a/packages/grid/test/frozen-columns.common.js
+++ b/packages/grid/test/frozen-columns.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, listenOnce, nextRender } from '@vaadin/testing-helpers';
 import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/grid/test/grid-wrapper.common.js
+++ b/packages/grid/test/grid-wrapper.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { flushGrid, getBodyCellContent } from './helpers.js';
 

--- a/packages/grid/test/hidden-grid.common.js
+++ b/packages/grid/test/hidden-grid.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { fire, flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';

--- a/packages/grid/test/keyboard-navigation-cell-button.common.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowLeft, arrowRight, aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid } from './helpers.js';

--- a/packages/grid/test/keyboard-navigation-row-focus.common.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   down as mouseDown,
   fixtureSync,

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   down as mouseDown,

--- a/packages/grid/test/light-dom-observing.common.js
+++ b/packages/grid/test/light-dom-observing.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/grid/test/lit-renderer-directives.common.js
+++ b/packages/grid/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/grid/test/lit-renderers.common.js
+++ b/packages/grid/test/lit-renderers.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { html, render } from 'lit';
 import { flushGrid } from './helpers.js';

--- a/packages/grid/test/lit.common.js
+++ b/packages/grid/test/lit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { html, render } from 'lit';
 import { flush } from '@vaadin/component-base/src/debounce.js';

--- a/packages/grid/test/missing-imports.common.js
+++ b/packages/grid/test/missing-imports.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, infiniteDataProvider } from './helpers.js';

--- a/packages/grid/test/physical-count.common.js
+++ b/packages/grid/test/physical-count.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { css } from 'lit';
 import {

--- a/packages/grid/test/renderers.common.js
+++ b/packages/grid/test/renderers.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isIOS, keyDownOn, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getBodyCellContent, getCell, getContainerCell } from './helpers.js';

--- a/packages/grid/test/resizing-material.common.js
+++ b/packages/grid/test/resizing-material.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { flushGrid, infiniteDataProvider } from './helpers.js';
 

--- a/packages/grid/test/resizing.common.js
+++ b/packages/grid/test/resizing.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/grid/test/row-details.common.js
+++ b/packages/grid/test/row-details.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-repeat.js';

--- a/packages/grid/test/row-height.common.js
+++ b/packages/grid/test/row-height.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import { flushGrid, getRowCells, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
 

--- a/packages/grid/test/scroll-restoration.common.js
+++ b/packages/grid/test/scroll-restoration.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, isFirefox } from '@vaadin/testing-helpers';
 import { fire, flushGrid, infiniteDataProvider } from './helpers.js';
 

--- a/packages/grid/test/scroll-to-index.common.js
+++ b/packages/grid/test/scroll-to-index.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import {
   flushGrid,

--- a/packages/grid/test/scrolling-mode.common.js
+++ b/packages/grid/test/scrolling-mode.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isDesktopSafari, isFirefox, listenOnce, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { flushGrid, infiniteDataProvider, onceResized, scrollToEnd } from './helpers.js';
 

--- a/packages/grid/test/selection.common.js
+++ b/packages/grid/test/selection.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, listenOnce, mousedown, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/grid/test/sorting.common.js
+++ b/packages/grid/test/sorting.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, keyUpOn, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import {

--- a/packages/grid/test/styling.common.js
+++ b/packages/grid/test/styling.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getContainerCell, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';

--- a/packages/grid/test/tree-toggle.common.js
+++ b/packages/grid/test/tree-toggle.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { flushGrid, getBodyCellContent } from './helpers.js';

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -42,7 +42,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0"
+    "@vaadin/testing-helpers": "^1.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/horizontal-layout/test/horizontal-layout.test.js
+++ b/packages/horizontal-layout/test/horizontal-layout.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-horizontal-layout.js';
 import { getComputedCSSPropertyValue } from './helpers.js';

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -44,7 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/icon/test/icon-font.common.js
+++ b/packages/icon/test/icon-font.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isChrome, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { needsFontIconSizingFallback, supportsCQUnitsForPseudoElements } from '../src/vaadin-icon-helpers.js';

--- a/packages/icon/test/icon.common.js
+++ b/packages/icon/test/icon.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { unsafeSvgLiteral } from '../src/vaadin-icon-svg.js';

--- a/packages/icon/test/iconset.common.js
+++ b/packages/icon/test/iconset.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { isValidSvg } from '../src/vaadin-icon-svg.js';
 

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -42,7 +42,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/icons": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -39,7 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/icons": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",

--- a/packages/input-container/test/input-container.common.js
+++ b/packages/input-container/test/input-container.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -43,7 +43,7 @@
     "@vaadin/vaadin-material-styles": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/integer-field/test/dom/integer-field.test.js
+++ b/packages/integer-field/test/dom/integer-field.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-integer-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/integer-field/test/integer-field.common.js
+++ b/packages/integer-field/test/integer-field.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, arrowUp, fixtureSync, keyDownOn, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/integer-field/test/validation.common.js
+++ b/packages/integer-field/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/integer-field/test/value-commit.common.js
+++ b/packages/integer-field/test/value-commit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -44,7 +44,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/item/test/dom/item.test.js
+++ b/packages/item/test/dom/item.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-item.js';
 

--- a/packages/item/test/item-mixin.test.js
+++ b/packages/item/test/item-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   defineLit,
   definePolymer,

--- a/packages/item/test/item.test.js
+++ b/packages/item/test/item.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-item.js';
 

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -45,7 +45,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/list-box/test/dom/list-box.test.js
+++ b/packages/list-box/test/dom/list-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-list-box.js';
 

--- a/packages/list-box/test/list-box.test.js
+++ b/packages/list-box/test/list-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/item/vaadin-item.js';
 import '../vaadin-list-box.js';

--- a/packages/list-box/test/missing-import.test.js
+++ b/packages/list-box/test/missing-import.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-list-box.js';

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -33,7 +33,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }

--- a/packages/lit-renderer/test/lit-renderer.test.js
+++ b/packages/lit-renderer/test/lit-renderer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './fixtures/mock-component.js';

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -48,7 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../vaadin-login-form.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/login/test/dom/login-overlay.test.js
+++ b/packages/login/test/dom/login-overlay.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../vaadin-login-overlay.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/login/test/login-form.common.js
+++ b/packages/login/test/login-form.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { fillUsernameAndPassword } from './helpers.js';

--- a/packages/login/test/login-overlay.common.js
+++ b/packages/login/test/login-overlay.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, esc, fixtureSync, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { fillUsernameAndPassword } from './helpers.js';

--- a/packages/login/test/login-submit.common.js
+++ b/packages/login/test/login-submit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextRender, tabKeyUp } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { fillUsernameAndPassword } from './helpers.js';

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -44,7 +44,7 @@
     "ol": "6.13.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "cvdlName": "vaadin-map",

--- a/packages/map/test/map.test.js
+++ b/packages/map/test/map.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../vaadin-map.js';

--- a/packages/map/test/styles.test.js
+++ b/packages/map/test/styles.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-map.js';
 

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -52,7 +52,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"

--- a/packages/menu-bar/test/a11y.common.js
+++ b/packages/menu-bar/test/a11y.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, arrowRight, enter, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 

--- a/packages/menu-bar/test/dom/menu-bar.test.js
+++ b/packages/menu-bar/test/dom/menu-bar.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-menu-bar.js';
 import '../not-animated-styles.js';

--- a/packages/menu-bar/test/menu-bar.common.js
+++ b/packages/menu-bar/test/menu-bar.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowLeft,
   arrowRight,

--- a/packages/menu-bar/test/overflow.common.js
+++ b/packages/menu-bar/test/overflow.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowRight, fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/menu-bar/test/sub-menu.common.js
+++ b/packages/menu-bar/test/sub-menu.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDown,
   arrowLeft,

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -44,7 +44,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/message-input/test/dom/message-input.test.js
+++ b/packages/message-input/test/dom/message-input.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-message-input.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/message-input/test/message-input.test.js
+++ b/packages/message-input/test/message-input.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enterKeyDown, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-message-input.js';

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -47,7 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/message-list/test/dom/message-list.test.js
+++ b/packages/message-list/test/dom/message-list.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../src/vaadin-message-list.js';
 

--- a/packages/message-list/test/dom/message.test.js
+++ b/packages/message-list/test/dom/message.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-message.js';
 

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDown,
   arrowRight,

--- a/packages/message-list/test/message.test.js
+++ b/packages/message-list/test/message.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-message.js';
 

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -51,7 +51,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "lit": "^3.0.0",
     "sinon": "^13.0.2"

--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';

--- a/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-multi-select-combo-box.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/multi-select-combo-box/test/lit-renderer-directives.test.js
+++ b/packages/multi-select-combo-box/test/lit-renderer-directives.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/button": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -46,7 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/button": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"

--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-notification.js';
 

--- a/packages/notification/test/dom/notification.test.js
+++ b/packages/notification/test/dom/notification.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '../../vaadin-notification.js';
 

--- a/packages/notification/test/lit-renderer-directives.test.js
+++ b/packages/notification/test/lit-renderer-directives.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-notification.js';

--- a/packages/notification/test/lit.test.js
+++ b/packages/notification/test/lit.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-notification.js';
 import { html, render } from 'lit';

--- a/packages/notification/test/multiple.test.js
+++ b/packages/notification/test/multiple.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-notification.js';

--- a/packages/notification/test/notification.test.js
+++ b/packages/notification/test/notification.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, isIOS, listenOnce } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-notification.js';

--- a/packages/notification/test/renderer.test.js
+++ b/packages/notification/test/renderer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-notification.js';

--- a/packages/notification/test/statichelper.test.js
+++ b/packages/notification/test/statichelper.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout } from '@vaadin/testing-helpers';
 import '../vaadin-notification.js';
 import { html } from 'lit';

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -48,7 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/number-field/test/dom/number-field.test.js
+++ b/packages/number-field/test/dom/number-field.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-number-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/number-field/test/number-field.common.js
+++ b/packages/number-field/test/number-field.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, arrowUp, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/number-field/test/validation.common.js
+++ b/packages/number-field/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/number-field/test/value-commit.common.js
+++ b/packages/number-field/test/value-commit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/number-field/test/value-control-buttons.common.js
+++ b/packages/number-field/test/value-control-buttons.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -44,7 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/overlay/test/animations.common.js
+++ b/packages/overlay/test/animations.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { escKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/overlay/test/basic.common.js
+++ b/packages/overlay/test/basic.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createOverlay } from './helpers.js';

--- a/packages/overlay/test/focus-trap.common.js
+++ b/packages/overlay/test/focus-trap.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 

--- a/packages/overlay/test/interactions.common.js
+++ b/packages/overlay/test/interactions.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   click,
   enterKeyDown,

--- a/packages/overlay/test/lit.test.js
+++ b/packages/overlay/test/lit.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-overlay.js';
 import { html, render } from 'lit';

--- a/packages/overlay/test/multiple.common.js
+++ b/packages/overlay/test/multiple.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createOverlay } from './helpers.js';

--- a/packages/overlay/test/position-mixin-listeners.test.js
+++ b/packages/overlay/test/position-mixin-listeners.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { Overlay } from '../src/vaadin-overlay.js';

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 

--- a/packages/overlay/test/renderer.common.js
+++ b/packages/overlay/test/renderer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/overlay/test/restore-focus.common.js
+++ b/packages/overlay/test/restore-focus.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { escKeyDown, fixtureSync, mousedown, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -47,7 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/password-field/test/dom/password-field.test.js
+++ b/packages/password-field/test/dom/password-field.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-password-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/password-field/test/password-field.common.js
+++ b/packages/password-field/test/password-field.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, focusout, mousedown, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/password-field/test/validation.common.js
+++ b/packages/password-field/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -40,7 +40,7 @@
     "@vaadin/checkbox": "24.5.0-alpha7",
     "@vaadin/grid": "24.5.0-alpha7",
     "@vaadin/grid-pro": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -36,7 +36,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/checkbox": "24.5.0-alpha7",
     "@vaadin/grid": "24.5.0-alpha7",
     "@vaadin/grid-pro": "24.5.0-alpha7",

--- a/packages/polymer-legacy-adapter/test/grid-body.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-body.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';

--- a/packages/polymer-legacy-adapter/test/grid-editor.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-editor.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid-pro';

--- a/packages/polymer-legacy-adapter/test/grid-footer.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-footer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';

--- a/packages/polymer-legacy-adapter/test/grid-header.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-header.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';

--- a/packages/polymer-legacy-adapter/test/grid-row-details.test.js
+++ b/packages/polymer-legacy-adapter/test/grid-row-details.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';

--- a/packages/polymer-legacy-adapter/test/list.test.js
+++ b/packages/polymer-legacy-adapter/test/list.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../template-renderer.js';

--- a/packages/polymer-legacy-adapter/test/observer.test.js
+++ b/packages/polymer-legacy-adapter/test/observer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../template-renderer.js';
 import './fixtures/mock-component.js';

--- a/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
+++ b/packages/polymer-legacy-adapter/test/style-modules-lazy-import.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

--- a/packages/polymer-legacy-adapter/test/style-modules-lit.test.js
+++ b/packages/polymer-legacy-adapter/test/style-modules-lit.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 // Import the adapter
 import '../style-modules.js';
 // Use LitElement based custom elements in the tests

--- a/packages/polymer-legacy-adapter/test/style-modules.test.js
+++ b/packages/polymer-legacy-adapter/test/style-modules.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 // Import the adapter
 import '../style-modules.js';
 import './setup.js';

--- a/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
+++ b/packages/polymer-legacy-adapter/test/vaadin-template-renderer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fire, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../template-renderer.js';

--- a/packages/polymer-legacy-adapter/test/warning.test.js
+++ b/packages/polymer-legacy-adapter/test/warning.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../template-renderer.js';

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -47,7 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   esc,
   fixtureSync,

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/popover/test/lit-renderer-directives.test.js
+++ b/packages/popover/test/lit-renderer-directives.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/popover/test/position.test.js
+++ b/packages/popover/test/position.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../src/vaadin-popover.js';

--- a/packages/popover/test/timers.test.js
+++ b/packages/popover/test/timers.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   esc,

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { esc, fixtureSync, focusin, focusout, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-popover.js';

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0"
+    "@vaadin/testing-helpers": "^1.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -47,7 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [

--- a/packages/progress-bar/test/progress-bar.common.js
+++ b/packages/progress-bar/test/progress-bar.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 
 describe('progress bar', () => {

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -52,7 +52,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/radio-group/test/dom/radio-button.test.js
+++ b/packages/radio-group/test/dom/radio-button.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../vaadin-radio-button.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/radio-group/test/dom/radio-group.test.js
+++ b/packages/radio-group/test/dom/radio-group.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../vaadin-radio-group.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/radio-group/test/radio-button.common.js
+++ b/packages/radio-group/test/radio-button.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, mousedown, mouseup, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/radio-group/test/radio-group-keyboard-navigation.common.js
+++ b/packages/radio-group/test/radio-group-keyboard-navigation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isFirefox, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 describe('keyboard navigation', () => {

--- a/packages/radio-group/test/radio-group.common.js
+++ b/packages/radio-group/test/radio-group.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/radio-group/test/validation.common.js
+++ b/packages/radio-group/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "gulp-iconfont": "^11.0.0",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -52,7 +52,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "gulp": "^4.0.2",

--- a/packages/rich-text-editor/test/a11y.common.js
+++ b/packages/rich-text-editor/test/a11y.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   down,
   fixtureSync,

--- a/packages/rich-text-editor/test/auto-grow.common.js
+++ b/packages/rich-text-editor/test/auto-grow.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 
 describe('rich text editor', () => {

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusout, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/rich-text-editor/test/toolbar.common.js
+++ b/packages/rich-text-editor/test/toolbar.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   esc,
   fixtureSync,

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -43,7 +43,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0"
+    "@vaadin/testing-helpers": "^1.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/scroller/test/scroller.test.js
+++ b/packages/scroller/test/scroller.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../vaadin-scroller.js';

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -54,7 +54,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/select/test/accessibility.common.js
+++ b/packages/select/test/accessibility.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '@vaadin/item/vaadin-item.js';

--- a/packages/select/test/dom/select.test.js
+++ b/packages/select/test/dom/select.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-select.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/select/test/items.common.js
+++ b/packages/select/test/items.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 
 describe('items', () => {

--- a/packages/select/test/keyboard.common.js
+++ b/packages/select/test/keyboard.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/select/test/lit-renderer-directives.common.js
+++ b/packages/select/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/select/test/pre-opened-polymer.test.js
+++ b/packages/select/test/pre-opened-polymer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-select.js';
 

--- a/packages/select/test/renderer.common.js
+++ b/packages/select/test/renderer.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/item/vaadin-item.js';

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowUp,
   click,

--- a/packages/select/test/validation.common.js
+++ b/packages/select/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -43,7 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "lit": "^3.0.0",
     "sinon": "^13.0.2"

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "lit": "^3.0.0",
     "sinon": "^13.0.2"
   },

--- a/packages/side-nav/test/accessibility.test.js
+++ b/packages/side-nav/test/accessibility.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '../vaadin-side-nav-item.js';

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../../src/vaadin-side-nav-item.js';

--- a/packages/side-nav/test/dom/side-nav.test.js
+++ b/packages/side-nav/test/dom/side-nav.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-side-nav.js';
 

--- a/packages/side-nav/test/navigation-callback.test.js
+++ b/packages/side-nav/test/navigation-callback.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';

--- a/packages/side-nav/test/navigation.test.js
+++ b/packages/side-nav/test/navigation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-side-nav-item.js';
 import '../vaadin-side-nav.js';

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';

--- a/packages/side-nav/test/side-nav.test.js
+++ b/packages/side-nav/test/side-nav.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-side-nav.js';

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -45,7 +45,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/split-layout/test/split-layout.common.js
+++ b/packages/split-layout/test/split-layout.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextRender, track } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -48,7 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/tabs/test/dom/tab.test.js
+++ b/packages/tabs/test/dom/tab.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-tab.js';
 

--- a/packages/tabs/test/dom/tabs.test.js
+++ b/packages/tabs/test/dom/tabs.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-tabs.js';
 

--- a/packages/tabs/test/scroll.common.js
+++ b/packages/tabs/test/scroll.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, arrowLeft, arrowRight, arrowUp, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 
 describe('scrollable tabs', () => {

--- a/packages/tabs/test/tab.common.js
+++ b/packages/tabs/test/tab.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 
 describe('tab', () => {

--- a/packages/tabs/test/tabs.common.js
+++ b/packages/tabs/test/tabs.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowRight,
   aTimeout,

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -45,7 +45,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/tabsheet/test/dom/tabsheet.test.js
+++ b/packages/tabsheet/test/dom/tabsheet.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../vaadin-tabsheet.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-tabsheet.js';

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -48,7 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-text-area.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/text-area/test/text-area.common.js
+++ b/packages/text-area/test/text-area.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextFrame, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/text-area/test/validation.common.js
+++ b/packages/text-area/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -46,7 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/text-field/test/dom/text-field.test.js
+++ b/packages/text-field/test/dom/text-field.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-text-field.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/text-field/test/text-field.common.js
+++ b/packages/text-field/test/text-field.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/text-field/test/validation.common.js
+++ b/packages/text-field/test/validation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -47,7 +47,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/time-picker/test/aria.test.js
+++ b/packages/time-picker/test/aria.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../src/vaadin-time-picker.js';
 

--- a/packages/time-picker/test/combo-box.test.js
+++ b/packages/time-picker/test/combo-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-time-picker.js';

--- a/packages/time-picker/test/dom/time-picker.test.js
+++ b/packages/time-picker/test/dom/time-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-time-picker.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/time-picker/test/events.test.js
+++ b/packages/time-picker/test/events.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/time-picker/test/keyboard-navigation.test.js
+++ b/packages/time-picker/test/keyboard-navigation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, arrowUp, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/time-picker/test/time-picker.test.js
+++ b/packages/time-picker/test/time-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { TimePicker } from '../src/vaadin-time-picker.js';

--- a/packages/time-picker/test/value-commit.test.js
+++ b/packages/time-picker/test/value-commit.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -45,7 +45,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/tooltip/test/dom/tooltip.test.js
+++ b/packages/tooltip/test/dom/tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-tooltip.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';

--- a/packages/tooltip/test/tooltip-offset.common.js
+++ b/packages/tooltip/test/tooltip-offset.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 
 describe('offset', () => {

--- a/packages/tooltip/test/tooltip-position.common.js
+++ b/packages/tooltip/test/tooltip-position.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 
 describe('position', () => {

--- a/packages/tooltip/test/tooltip-timers.common.js
+++ b/packages/tooltip/test/tooltip-timers.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
   escKeyDown,

--- a/packages/tooltip/test/tooltip.common.js
+++ b/packages/tooltip/test/tooltip.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   escKeyDown,
   fixtureSync,

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -52,7 +52,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/upload/test/a11y.common.js
+++ b/packages/upload/test/a11y.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createFile } from './helpers.js';

--- a/packages/upload/test/adding-files.common.js
+++ b/packages/upload/test/adding-files.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { change, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createFile, createFiles, touchDevice, xhrCreator } from './helpers.js';

--- a/packages/upload/test/dom/vaadin-upload-file.test.js
+++ b/packages/upload/test/dom/vaadin-upload-file.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../../src/vaadin-upload-file.js';
 

--- a/packages/upload/test/dom/vaadin-upload.test.js
+++ b/packages/upload/test/dom/vaadin-upload.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../src/vaadin-upload.js';
 

--- a/packages/upload/test/file-list.common.js
+++ b/packages/upload/test/file-list.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { createFiles, removeFile, xhrCreator } from './helpers.js';
 

--- a/packages/upload/test/file.common.js
+++ b/packages/upload/test/file.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { createFile } from './helpers.js';

--- a/packages/upload/test/keyboard-navigation.common.js
+++ b/packages/upload/test/keyboard-navigation.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { createFile } from './helpers.js';

--- a/packages/upload/test/slots.common.js
+++ b/packages/upload/test/slots.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { click, fixtureSync, makeSoloTouchEvent, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createFile } from './helpers.js';

--- a/packages/upload/test/upload.common.js
+++ b/packages/upload/test/upload.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   }
 }

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -35,8 +35,8 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   }

--- a/packages/vaadin-themable-mixin/test/post-finalize-styles.common.ts
+++ b/packages/vaadin-themable-mixin/test/post-finalize-styles.common.ts
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { css, registerStyles, ThemableMixin } from '../vaadin-themable-mixin.js';

--- a/packages/vaadin-themable-mixin/test/register-styles-lit.test.js
+++ b/packages/vaadin-themable-mixin/test/register-styles-lit.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import './lit-setup.js';
 import './register-styles.test.js';
 import { LitElement } from 'lit';

--- a/packages/vaadin-themable-mixin/test/register-styles.test.js
+++ b/packages/vaadin-themable-mixin/test/register-styles.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { css, registerStyles, unsafeCSS } from '../register-styles.js';

--- a/packages/vaadin-themable-mixin/test/themable-mixin-lit.test.js
+++ b/packages/vaadin-themable-mixin/test/themable-mixin-lit.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import './lit-setup.js';
 import './themable-mixin.test.js';
 import { LitElement } from 'lit';

--- a/packages/vaadin-themable-mixin/test/themable-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/themable-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { css, registerStyles, ThemableMixin, unsafeCSS } from '../vaadin-themable-mixin.js';

--- a/packages/vaadin-themable-mixin/test/theme-property-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/theme-property-mixin.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ThemePropertyMixin } from '../vaadin-theme-property-mixin.js';

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -42,7 +42,7 @@
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0"
   },
   "web-types": [

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0"
+    "@vaadin/testing-helpers": "^1.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/vertical-layout/test/vertical-layout.test.js
+++ b/packages/vertical-layout/test/vertical-layout.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '../vaadin-vertical-layout.js';
 import { getComputedCSSPropertyValue } from './helpers.js';

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -49,7 +49,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "sinon": "^13.0.2"
   },
   "web-types": [

--- a/packages/virtual-list/test/lit-renderer-directives.common.js
+++ b/packages/virtual-list/test/lit-renderer-directives.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, render } from 'lit';

--- a/packages/virtual-list/test/lit.common.js
+++ b/packages/virtual-list/test/lit.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { html, render } from 'lit';
 

--- a/packages/virtual-list/test/virtual-list.common.js
+++ b/packages/virtual-list/test/virtual-list.common.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 
 describe('virtual-list', () => {

--- a/test/integration/checkbox-group-tooltip.test.js
+++ b/test/integration/checkbox-group-tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/checkbox-group';
 import '@vaadin/tooltip';

--- a/test/integration/combo-box-template.test.js
+++ b/test/integration/combo-box-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-repeat.js';

--- a/test/integration/component-relayout-page.test.js
+++ b/test/integration/component-relayout-page.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { ComboBox } from '@vaadin/combo-box';
 import { ContextMenu } from '@vaadin/context-menu';

--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
 import { Button } from '@vaadin/button';
 import { Checkbox } from '@vaadin/checkbox';

--- a/test/integration/confirm-dialog-fields.test.js
+++ b/test/integration/confirm-dialog-fields.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { nextRender } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/checkbox';

--- a/test/integration/context-menu-date-picker.test.js
+++ b/test/integration/context-menu-date-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/context-menu';
 import '@vaadin/date-picker';

--- a/test/integration/context-menu-grid.test.js
+++ b/test/integration/context-menu-grid.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { esc, fire, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';
@@ -36,7 +36,7 @@ describe('grid in context-menu', () => {
           <vaadin-grid-column path="firstName"></vaadin-grid-column>
           <vaadin-grid-column path="lastName"></vaadin-grid-column>
         </vaadin-grid>
-      </vaadin-context-menu>    
+      </vaadin-context-menu>
     `);
 
     contextMenu.items = [{ text: 'Item 1' }, { text: 'Item 2' }];

--- a/test/integration/context-menu-template.test.js
+++ b/test/integration/context-menu-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/context-menu';

--- a/test/integration/define.test.js
+++ b/test/integration/define.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
 import '@vaadin/button';
 import { Button } from '@vaadin/button';

--- a/test/integration/dialog-accordion.test.js
+++ b/test/integration/dialog-accordion.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';

--- a/test/integration/dialog-combo-box.test.js
+++ b/test/integration/dialog-combo-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   fixtureSync,
   mousedown,

--- a/test/integration/dialog-date-picker.test.js
+++ b/test/integration/dialog-date-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, touchstart } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';

--- a/test/integration/dialog-grid-pro.test.js
+++ b/test/integration/dialog-grid-pro.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, focusin, focusout, nextFrame, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import '@vaadin/date-picker';
 import '@vaadin/dialog';

--- a/test/integration/dialog-menu-bar.test.js
+++ b/test/integration/dialog-menu-bar.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '@vaadin/dialog';
 import '@vaadin/menu-bar';

--- a/test/integration/dialog-multi-select-combo-box.test.js
+++ b/test/integration/dialog-multi-select-combo-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';

--- a/test/integration/dialog-popover.test.js
+++ b/test/integration/dialog-popover.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import './not-animated-styles.js';

--- a/test/integration/dialog-template.test.js
+++ b/test/integration/dialog-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/dialog';

--- a/test/integration/dialog-time-picker.test.js
+++ b/test/integration/dialog-time-picker.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import './not-animated-styles.js';

--- a/test/integration/grid-combo-box.test.js
+++ b/test/integration/grid-combo-box.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/combo-box';

--- a/test/integration/grid-overlay-focus-trap.test.js
+++ b/test/integration/grid-overlay-focus-trap.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import '@vaadin/button';

--- a/test/integration/grid-pro-edit-column-template.test.js
+++ b/test/integration/grid-pro-edit-column-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { enter, esc, fixtureSync, space } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';

--- a/test/integration/grid-select.test.js
+++ b/test/integration/grid-select.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';

--- a/test/integration/grid-templates.test.js
+++ b/test/integration/grid-templates.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-bind.js';

--- a/test/integration/grid-tooltip.test.js
+++ b/test/integration/grid-tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDown,
   aTimeout,

--- a/test/integration/menu-bar-tooltip.test.js
+++ b/test/integration/menu-bar-tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import {
   arrowDown,
   arrowRight,

--- a/test/integration/notification-template.test.js
+++ b/test/integration/notification-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/notification';

--- a/test/integration/notification-tooltip.test.js
+++ b/test/integration/notification-tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/notification';
 import '@vaadin/tooltip';

--- a/test/integration/overlay-focus-trap.test.js
+++ b/test/integration/overlay-focus-trap.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/button/vaadin-button.js';

--- a/test/integration/overlay-template.test.js
+++ b/test/integration/overlay-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/overlay/vaadin-overlay.js';

--- a/test/integration/polymer.test.js
+++ b/test/integration/polymer.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import '@vaadin/multi-select-combo-box';
 import '@vaadin/combo-box';
 import { html } from '@polymer/polymer';

--- a/test/integration/radio-group-tooltip.test.js
+++ b/test/integration/radio-group-tooltip.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { nextRender } from '@vaadin/testing-helpers';
 import '@vaadin/radio-group';
 import '@vaadin/tooltip';

--- a/test/integration/select-template.test.js
+++ b/test/integration/select-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/item';

--- a/test/integration/virtual-list-template.test.js
+++ b/test/integration/virtual-list-template.test.js
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '@vaadin/virtual-list';

--- a/test/package.json
+++ b/test/package.json
@@ -6,10 +6,10 @@
   "license": "Apache-2.0",
   "author": "Vaadin Ltd",
   "devDependencies": {
-    "@esm-bundle/chai": "^4.3.4",
     "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/accordion": "24.5.0-alpha7",
     "@vaadin/button": "24.5.0-alpha7",
+    "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/checkbox": "24.5.0-alpha7",
     "@vaadin/checkbox-group": "24.5.0-alpha7",
     "@vaadin/combo-box": "24.5.0-alpha7",

--- a/test/package.json
+++ b/test/package.json
@@ -38,7 +38,7 @@
     "@vaadin/radio-group": "24.5.0-alpha7",
     "@vaadin/select": "24.5.0-alpha7",
     "@vaadin/tabs": "24.5.0-alpha7",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-area": "24.5.0-alpha7",
     "@vaadin/text-field": "24.5.0-alpha7",
     "@vaadin/time-picker": "24.5.0-alpha7",

--- a/test/plugins/index.js
+++ b/test/plugins/index.js
@@ -1,5 +1,5 @@
 import { chaiDomDiff } from '@open-wc/semantic-dom-diff';
-import * as chai from 'chai';
+import * as chai from 'chai/index.js';
 import sinonChai from 'sinon-chai';
 
 chai.use(chaiDomDiff);

--- a/test/plugins/package.json
+++ b/test/plugins/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "dependencies": {
     "@open-wc/semantic-dom-diff": "^0.20.1",
-    "@vaadin/testing-helpers": "^0.6.0",
+    "@vaadin/testing-helpers": "^1.0.0",
     "chai": "^5.1.1",
     "sinon-chai": "^4.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,13 +382,6 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@esm-bundle/chai@^4.3.1":
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4.tgz#74ed4a0794b3a9f9517ff235744ac6f4be0d34dc"
-  integrity sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==
-  dependencies:
-    "@types/chai" "^4.2.12"
-
 "@fontsource/roboto@^4.5.1":
   version "4.5.8"
   resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.8.tgz#56347764786079838faf43f0eeda22dd7328437f"
@@ -1412,14 +1405,6 @@
   resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.1.tgz#5c1a1eeb0386b344290ebe3f1fca0c4869933dbf"
   integrity sha512-ukowSvzpZQDUH0Y3znJTsY88HkiGk3Khc0WGpIPhap1xlerieYi27QBg6wx/nTurpWfU6XXXsx9ocxDYCdtw0Q==
 
-"@open-wc/semantic-dom-diff@^0.19.7":
-  version "0.19.7"
-  resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.19.7.tgz#92361f0d2dcb54a8d5cf11d5ea40b8e7ffa58eb4"
-  integrity sha512-ahwHb7arQXXnkIGCrOsM895FJQrU47VWZryCsSSzl5nB3tJKcJ8yjzQ3D/yqZn6v8atqOz61vaY05aNsqoz3oA==
-  dependencies:
-    "@types/chai" "^4.3.1"
-    "@web/test-runner-commands" "^0.6.1"
-
 "@open-wc/semantic-dom-diff@^0.20.1":
   version "0.20.1"
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.20.1.tgz#b1bb78be455bd99fb034d9baadbb959d7d124030"
@@ -1923,7 +1908,7 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/chai@^4.2.12", "@types/chai@^4.3.1":
+"@types/chai@^4.3.1":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
   integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
@@ -1952,11 +1937,6 @@
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.5.tgz#650820e95de346e1f84e30667d168c8fd25aa6e3"
   integrity sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==
-
-"@types/convert-source-map@^1.5.1":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@types/convert-source-map/-/convert-source-map-1.5.2.tgz#318dc22d476632a4855594c16970c6dc3ed086e7"
-  integrity sha512-tHs++ZeXer40kCF2JpE51Hg7t4HPa18B1b1Dzy96S0eCw8QKECNMYMfwa1edK/x8yCN0r4e6ewvLcc5CsVGkdg==
 
 "@types/convert-source-map@^2.0.0":
   version "2.0.0"
@@ -2289,16 +2269,13 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vaadin/testing-helpers@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-0.6.0.tgz#895f21394b8ee2cd078ca68645d1551346e650ef"
-  integrity sha512-yyA+JULu3/ZM98wrkioZPPEK6+jl4nOr2gGTq7GsqGWMO2Mdo22yk3S6Pa4Bu+nZuYORKZCPbz7a+l3xxuSKzA==
+"@vaadin/testing-helpers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-1.0.0.tgz#e63ca3d6c8e201177ae9a9a0b50dbbf71851ad29"
+  integrity sha512-khYSX4uBBpI2eX883jNiGWyQDAx+X29vKud0T1VyLgiXT4lwFwaqO8pOIDG2k2feOFRKAwbNPbbxl8HTGTU2Kw==
   dependencies:
-    "@esm-bundle/chai" "^4.3.1"
-    "@open-wc/semantic-dom-diff" "^0.19.7"
     "@polymer/polymer" "^3.5.1"
     lit "^3.0.0"
-    sinon-chai "3.7.0"
 
 "@vaadin/vaadin-development-mode-detector@^2.0.0":
   version "2.0.5"
@@ -2365,13 +2342,6 @@
     import-meta-resolve "^3.0.0"
     p-iteration "^1.1.8"
 
-"@web/browser-logs@^0.2.1":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@web/browser-logs/-/browser-logs-0.2.5.tgz#0895efb641eacb0fbc1138c6092bd18c01df2734"
-  integrity sha512-Qxo1wY/L7yILQqg0jjAaueh+tzdORXnZtxQgWH23SsTCunz9iq9FvsZa8Q5XlpjnZ3vLIsFEuEsCMqFeohJnEg==
-  dependencies:
-    errorstacks "^2.2.0"
-
 "@web/browser-logs@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@web/browser-logs/-/browser-logs-0.4.0.tgz#8c4adddac46be02dff1a605312132053b3737d0a"
@@ -2383,30 +2353,6 @@
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.3.1.tgz#0917fd549c264e565e75bd6c7d73acd7365df26b"
   integrity sha512-IYjHXUgSGGNpO3YJQ9foLcazbJlAWDdJGRe9be7aOhon0Nd6Na5JIOJAej7jsMu76fKHr4b4w2LfIdNQ4fJ8pA==
-
-"@web/dev-server-core@^0.3.18":
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.3.19.tgz#b61f9a0b92351371347a758b30ba19e683c72e94"
-  integrity sha512-Q/Xt4RMVebLWvALofz1C0KvP8qHbzU1EmdIA2Y1WMPJwiFJFhPxdr75p9YxK32P2t0hGs6aqqS5zE0HW9wYzYA==
-  dependencies:
-    "@types/koa" "^2.11.6"
-    "@types/ws" "^7.4.0"
-    "@web/parse5-utils" "^1.2.0"
-    chokidar "^3.4.3"
-    clone "^2.1.2"
-    es-module-lexer "^1.0.0"
-    get-stream "^6.0.0"
-    is-stream "^2.0.0"
-    isbinaryfile "^4.0.6"
-    koa "^2.13.0"
-    koa-etag "^4.0.0"
-    koa-send "^5.0.1"
-    koa-static "^5.0.0"
-    lru-cache "^6.0.0"
-    mime-types "^2.1.27"
-    parse5 "^6.0.1"
-    picomatch "^2.2.2"
-    ws "^7.4.2"
 
 "@web/dev-server-core@^0.7.0", "@web/dev-server-core@^0.7.1":
   version "0.7.1"
@@ -2476,14 +2422,6 @@
     open "^8.0.2"
     portfinder "^1.0.32"
 
-"@web/parse5-utils@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@web/parse5-utils/-/parse5-utils-1.3.0.tgz#e2e9e98b31a4ca948309f74891bda8d77399f6bd"
-  integrity sha512-Pgkx3ECc8EgXSlS5EyrgzSOoUbM6P8OKS471HLAyvOBcP1NCBn0to4RN/OaKASGq8qa3j+lPX9H14uA5AHEnQg==
-  dependencies:
-    "@types/parse5" "^6.0.1"
-    parse5 "^6.0.1"
-
 "@web/parse5-utils@^2.0.0", "@web/parse5-utils@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@web/parse5-utils/-/parse5-utils-2.1.0.tgz#3d33aca62c66773492f2fba89d23a45f8b57ba4a"
@@ -2513,14 +2451,6 @@
     chrome-launcher "^0.15.0"
     puppeteer-core "^22.0.0"
 
-"@web/test-runner-commands@^0.6.1":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-commands/-/test-runner-commands-0.6.5.tgz#69a2a06b52fd9d329f9cf1e172cd8fb1d5ffc521"
-  integrity sha512-W+wLg10jEAJY9N6tNWqG1daKmAzxGmTbO/H9fFfcgOgdxdn+hHiR4r2/x1iylKbFLujHUQlnjNQeu2d6eDPFqg==
-  dependencies:
-    "@web/test-runner-core" "^0.10.27"
-    mkdirp "^1.0.4"
-
 "@web/test-runner-commands@^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@web/test-runner-commands/-/test-runner-commands-0.9.0.tgz#ed15a021249948204bb27559eb437ff6ceeee067"
@@ -2528,38 +2458,6 @@
   dependencies:
     "@web/test-runner-core" "^0.13.0"
     mkdirp "^1.0.4"
-
-"@web/test-runner-core@^0.10.27":
-  version "0.10.27"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-core/-/test-runner-core-0.10.27.tgz#8d1430f2364fb36b3ac15b9b43034fae9d94e177"
-  integrity sha512-ClV/hSxs4wDm/ANFfQOdRRFb/c0sYywC1QfUXG/nS4vTp3nnt7x7mjydtMGGLmvK9f6Zkubkc1aa+7ryfmVwNA==
-  dependencies:
-    "@babel/code-frame" "^7.12.11"
-    "@types/babel__code-frame" "^7.0.2"
-    "@types/co-body" "^6.1.0"
-    "@types/convert-source-map" "^1.5.1"
-    "@types/debounce" "^1.2.0"
-    "@types/istanbul-lib-coverage" "^2.0.3"
-    "@types/istanbul-reports" "^3.0.0"
-    "@web/browser-logs" "^0.2.1"
-    "@web/dev-server-core" "^0.3.18"
-    chokidar "^3.4.3"
-    cli-cursor "^3.1.0"
-    co-body "^6.1.0"
-    convert-source-map "^1.7.0"
-    debounce "^1.2.0"
-    dependency-graph "^0.11.0"
-    globby "^11.0.1"
-    ip "^1.1.5"
-    istanbul-lib-coverage "^3.0.0"
-    istanbul-lib-report "^3.0.0"
-    istanbul-reports "^3.0.2"
-    log-update "^4.0.0"
-    nanocolors "^0.2.1"
-    nanoid "^3.1.25"
-    open "^8.0.2"
-    picomatch "^2.2.2"
-    source-map "^0.7.3"
 
 "@web/test-runner-core@^0.13.0":
   version "0.13.1"
@@ -4355,7 +4253,7 @@ conventional-recommended-bump@^6.1.0:
     meow "^8.0.0"
     q "^1.5.1"
 
-convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.5.0, convert-source-map@^1.6.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
@@ -7451,11 +7349,6 @@ ip-address@^9.0.5:
     jsbn "1.1.0"
     sprintf-js "^1.1.3"
 
-ip@^1.1.5:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
-  integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==
-
 ip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
@@ -7916,11 +7809,6 @@ isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
-
-isbinaryfile@^4.0.6:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
-  integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
 
 isbinaryfile@^5.0.0:
   version "5.0.0"
@@ -11609,11 +11497,6 @@ signal-exit@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.0.2.tgz#ff55bb1d9ff2114c13b400688fa544ac63c36967"
   integrity sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==
-
-sinon-chai@3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.7.0.tgz#cfb7dec1c50990ed18c153f1840721cf13139783"
-  integrity sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==
 
 sinon-chai@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,7 +382,7 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@esm-bundle/chai@^4.3.1", "@esm-bundle/chai@^4.3.4":
+"@esm-bundle/chai@^4.3.1":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@esm-bundle/chai/-/chai-4.3.4.tgz#74ed4a0794b3a9f9517ff235744ac6f4be0d34dc"
   integrity sha512-6Tx35wWiNw7X0nLY9RMx8v3EL8SacCFW+eEZOE9Hc+XxmU5HFE2AFEg+GehUZpiyDGwVvPH75ckGlqC7coIPnA==


### PR DESCRIPTION
## Description

Based on #7627

Removed `@esm-bundle/chai` in favor of the ES modules based versions:

- `chai` v5.1.1 - https://github.com/chaijs/chai/releases/tag/v5.1.1
- `sinon-chai` v4.0.0 - https://github.com/chaijs/sinon-chai/releases/tag/4.0.0

Also updated `@vaadin/testing-helpers` to v1.0.0 that no longer registers chai plugins: https://github.com/vaadin/testing-helpers/pull/12

## Type of change

- Internal change

## Note

For some reason WebKit fails with ` SyntaxError: Unexpected token '{'` using import from `'chai'` as it apparently uses bundled `chai.js` file rather than `index.js` which is the correct one. Fixed by importing the explicit file.