### PR TITLE
chore: remove unused tabs from devDependencies

### DIFF
--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",
-    "@vaadin/tabs": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^0.6.0",
     "sinon": "^13.0.2"
   },


### PR DESCRIPTION
## Description

The `@vaadin/app-layout` package does not use `@vaadin/tabs` so this dev dependency can be removed.
It is most likely a leftover from the V14 version which used to have `vaadin-tabs` in drawer visual tests.

## Type of change

- Internal change