### PR TITLE
chore: add missing Lit dependency to checkbox-group

### DIFF
--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -45,7 +45,8 @@
     "@vaadin/field-base": "24.5.0-alpha7",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha7",
     "@vaadin/vaadin-material-styles": "24.5.0-alpha7",
-    "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
+    "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4",


### PR DESCRIPTION
## Description

Looks like I missed to add `lit` dependency when adding Lit based version. This PR fixes that.

## Type of change

- Internal change