### PR TITLE
chore: add missing overlay dependency to rich-text-editor

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -44,6 +44,7 @@
     "@vaadin/button": "24.5.0-alpha7",
     "@vaadin/component-base": "24.5.0-alpha7",
     "@vaadin/confirm-dialog": "24.5.0-alpha7",
+    "@vaadin/overlay": "24.5.0-alpha7",
     "@vaadin/text-field": "24.5.0-alpha7",
     "@vaadin/tooltip": "24.5.0-alpha7",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha7",


### PR DESCRIPTION
## Description

Looks like I missed to add this dependency when implementing color pickers in #7392. This PR fixes that.

## Type of change

- Internal change