### PR TITLE
chore: add missing Lit dependency to tooltip

### DIFF
--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -42,7 +42,8 @@
     "@vaadin/popover": "24.5.0-alpha7",
     "@vaadin/vaadin-lumo-styles": "24.5.0-alpha7",
     "@vaadin/vaadin-material-styles": "24.5.0-alpha7",
-    "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7"
+    "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7",
+    "lit": "^3.0.0"
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",


### PR DESCRIPTION
## Description

Looks like I missed to add `lit` dependency when adding Lit based version of the component. This PR fixes that.

## Type of change

- Internal change