### PR TITLE
refactor: update popover styles to use inset-inline shorthand

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -62,8 +62,7 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
           content: '';
           top: calc(var(--vaadin-popover-offset-top, 0) * -1);
           bottom: calc(var(--vaadin-popover-offset-bottom, 0) * -1);
-          inset-inline-start: calc(var(--vaadin-popover-offset-start, 0) * -1);
-          inset-inline-end: calc(var(--vaadin-popover-offset-end, 0) * -1);
+          inset-inline: calc(var(--vaadin-popover-offset-start, 0) * -1);
           z-index: -1;
           pointer-events: auto;
         }

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -62,7 +62,7 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
           content: '';
           top: calc(var(--vaadin-popover-offset-top, 0) * -1);
           bottom: calc(var(--vaadin-popover-offset-bottom, 0) * -1);
-          inset-inline: calc(var(--vaadin-popover-offset-start, 0) * -1);
+          inset-inline: calc(var(--vaadin-popover-offset-start, 0) * -1) calc(var(--vaadin-popover-offset-end, 0) * -1);
           z-index: -1;
           pointer-events: auto;
         }

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -60,8 +60,7 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
         [part='overlay']::before {
           position: absolute;
           content: '';
-          top: calc(var(--vaadin-popover-offset-top, 0) * -1);
-          bottom: calc(var(--vaadin-popover-offset-bottom, 0) * -1);
+          inset-block: calc(var(--vaadin-popover-offset-top, 0) * -1) calc(var(--vaadin-popover-offset-bottom, 0) * -1);
           inset-inline: calc(var(--vaadin-popover-offset-start, 0) * -1) calc(var(--vaadin-popover-offset-end, 0) * -1);
           z-index: -1;
           pointer-events: auto;


### PR DESCRIPTION
## Description

This is the only remaining error reported when upgrading to Stylelint 16:

```
packages/popover/src/vaadin-popover-overlay.js
  66:11  ✖  Expected shorthand property "inset-inline"  declaration-block-no-redundant-longhand-properties
```

## Type of change

- Refactor