### PR TITLE
fix: store last filter also on item click

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -399,6 +399,10 @@ class MultiSelectComboBoxInternal extends ComboBoxDataProviderMixin(ComboBoxMixi
     }
 
     if (this.opened) {
+      // Store filter value for checking if user input is matching
+      // an item which is already selected, to not un-select it.
+      this.lastFilter = this.filter;
+
       this.dispatchEvent(
         new CustomEvent('combo-box-item-selected', {
           detail: {

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -50,6 +50,14 @@ describe('selecting items', () => {
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 
+    it('should unselect item on click when it was selected on Enter', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ type: 'apple' });
+      await sendKeys({ down: 'Enter' });
+      getFirstItem(comboBox).click();
+      expect(comboBox.selectedItems).to.deep.equal([]);
+    });
+
     it('should not un-select item when typing its value manually', async () => {
       comboBox.selectedItems = ['orange'];
       await sendKeys({ down: 'ArrowDown' });


### PR DESCRIPTION
## Description

During a previous [fix](https://github.com/vaadin/web-components/pull/4075), a mechanism to avoid unwanted un-selections was added. This mechanism is based on keeping track of the last filter. However, the [update of this last filter](https://github.com/vaadin/web-components/blob/main/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js#L308-L310) is only done on `_commitValue()`, which is not called when the selection is done via a click. 

This PR adds this filter update to `_overlaySelectedItemChanged()`, which is another path which is used to update the selection. This does not break the previous fix.

Fixes #7621

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.