### PR TITLE
refactor: update side-nav styles to use margin shorthand

### DIFF
--- a/packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
@@ -46,8 +46,7 @@ export const sideNavStyles = css`
     justify-content: center;
     width: var(--lumo-size-s);
     height: var(--lumo-size-s);
-    margin-inline-start: auto;
-    margin-inline-end: var(--lumo-space-xs);
+    margin-inline: auto var(--lumo-space-xs);
     font-size: var(--lumo-icon-size-m);
     line-height: 1;
     color: var(--lumo-contrast-60pct);

--- a/packages/side-nav/theme/material/vaadin-side-nav-styles.js
+++ b/packages/side-nav/theme/material/vaadin-side-nav-styles.js
@@ -37,8 +37,7 @@ export const sideNavStyles = css`
     width: 24px;
     height: 24px;
     padding: 4px;
-    margin-inline-start: auto;
-    margin-inline-end: -4px;
+    margin-inline: auto -4px;
     font-size: var(--material-icon-font-size);
     line-height: 1;
     color: var(--material-secondary-text-color);


### PR DESCRIPTION
## Description

Fixed two more warnings reported by upgrading to Stylelint 16:

```
packages/side-nav/theme/lumo/vaadin-side-nav-styles.js
  50:5  ✖  Expected shorthand property "margin-inline"  declaration-block-no-redundant-longhand-properties

packages/side-nav/theme/material/vaadin-side-nav-styles.js
  41:5  ✖  Expected shorthand property "margin-inline"  declaration-block-no-redundant-longhand-properties
```

## Type of change

- Refactor