### PR TITLE
refactor: remove not needed backslash in css literals

### DIFF
--- a/packages/notification/theme/lumo/vaadin-notification-styles.js
+++ b/packages/notification/theme/lumo/vaadin-notification-styles.js
@@ -46,25 +46,25 @@ registerStyles(
       margin: var(--lumo-space-s) auto;
     }
 
-    :host([slot\$='stretch']) {
+    :host([slot$='stretch']) {
       margin: 0;
     }
 
-    :host([slot\$='stretch']) [part='overlay'] {
+    :host([slot$='stretch']) [part='overlay'] {
       border-radius: 0;
     }
 
     @media (min-width: 421px) {
-      :host(:not([slot\$='stretch'])) {
+      :host(:not([slot$='stretch'])) {
         display: flex;
       }
 
-      :host([slot\$='end']) {
+      :host([slot$='end']) {
         justify-content: flex-end;
       }
 
       :host([slot^='middle']),
-      :host([slot\$='center']) {
+      :host([slot$='center']) {
         display: flex;
         justify-content: center;
       }

--- a/packages/notification/theme/material/vaadin-notification-styles.js
+++ b/packages/notification/theme/material/vaadin-notification-styles.js
@@ -30,7 +30,6 @@ const notificationCard = css`
     background-color: var(--material-background-color);
     border-radius: 4px;
     box-shadow: var(--material-shadow-elevation-6dp);
-
     padding: 14px 16px;
     justify-content: stretch;
   }
@@ -53,11 +52,11 @@ const notificationCard = css`
     margin: -8px 0;
   }
 
-  :host([slot\$='stretch']) {
+  :host([slot$='stretch']) {
     margin: 0 -4px;
   }
 
-  :host([slot\$='stretch']) [part='overlay'] {
+  :host([slot$='stretch']) [part='overlay'] {
     border-radius: 0;
   }
 
@@ -71,7 +70,7 @@ const notificationCard = css`
       margin: auto;
     }
 
-    :host([slot\$='stretch']) {
+    :host([slot$='stretch']) {
       margin: 0 -12px;
     }
   }

--- a/packages/number-field/theme/lumo/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/lumo/vaadin-number-field-styles.js
@@ -22,14 +22,14 @@ const numberField = css`
     padding: 0;
   }
 
-  [part\$='button'] {
+  [part$='button'] {
     cursor: pointer;
     font-size: var(--lumo-icon-size-s);
     width: 1.6em;
     height: 1.6em;
   }
 
-  [part\$='button']::before {
+  [part$='button']::before {
     margin-top: 0.3em;
   }
 


### PR DESCRIPTION
## Description

Replaced `\$` with `$` in tagged css literals. Backslash was added by `polymer-modulizer` when converting to Polymer 3, in fact this character isn't needed. We have already removed it from most of theme files, this PR covers remaining ones.

## Type of change

- Refactor