### PR TITLE
fix: fix and test focus issues in vaadin upload

### DIFF
--- a/dev/upload.html
+++ b/dev/upload.html
@@ -31,7 +31,7 @@
           })();
         }
       };
-      
+
       const files = [
         { name: 'Annual Report.docx', complete: true },
         {
@@ -41,7 +41,7 @@
         },
         { name: 'Financials.xlsx', error: 'An error occurred' },
       ];
-      
+
       const blobs = createFiles(files.length, 1000, 'application/unknown');
 
       files.forEach((_, index) => {

--- a/dev/upload.html
+++ b/dev/upload.html
@@ -10,7 +10,7 @@
     <script type="module">
       import '@vaadin/upload';
       import '@vaadin/radio-group';
-      import { xhrCreator } from '@vaadin/upload/test/helpers.js';
+      import { xhrCreator, createFiles } from '@vaadin/upload/test/helpers.js';
 
       const nextUpload = document.querySelector('#next-upload');
 
@@ -31,8 +31,8 @@
           })();
         }
       };
-
-      upload.files = [
+      
+      const files = [
         { name: 'Annual Report.docx', complete: true },
         {
           name: 'Workflow.pdf',
@@ -41,6 +41,14 @@
         },
         { name: 'Financials.xlsx', error: 'An error occurred' },
       ];
+      
+      const blobs = createFiles(3, 1000, 'application/unknown');
+
+      files.forEach((_, index) => {
+        files[index] = Object.assign(blobs[index], files[index]);
+      });
+
+      upload.files = files;
     </script>
   </head>
 

--- a/dev/upload.html
+++ b/dev/upload.html
@@ -42,7 +42,7 @@
         { name: 'Financials.xlsx', error: 'An error occurred' },
       ];
       
-      const blobs = createFiles(3, 1000, 'application/unknown');
+      const blobs = createFiles(files.length, 1000, 'application/unknown');
 
       files.forEach((_, index) => {
         files[index] = Object.assign(blobs[index], files[index]);

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -848,7 +848,7 @@ export const UploadMixin = (superClass) =>
      */
     _removeFile(file) {
       const fileIndex = this.files.indexOf(file);
-      if (fileIndex > -1) {
+      if (fileIndex >= 0) {
         this.files = this.files.filter((i) => i !== file);
 
         this.dispatchEvent(

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -753,6 +753,7 @@ export const UploadMixin = (superClass) =>
       );
       if (evt) {
         this._uploadFile(file);
+        this._updateFocus(this.files.indexOf(file));
       }
     }
 
@@ -827,13 +828,27 @@ export const UploadMixin = (superClass) =>
       }
     }
 
+    /** @private */
+    _updateFocus(fileIndex) {
+      if (this.files.length === 0) {
+        this._addButton.focus();
+        return;
+      }
+      const lastFileRemoved = fileIndex === this.files.length;
+      if (lastFileRemoved) {
+        fileIndex -= 1;
+      }
+      this._fileList.children[fileIndex].firstElementChild.focus();
+    }
+
     /**
      * Remove file from upload list. Called internally if file upload was canceled.
      * @param {!UploadFile} file File to remove
      * @protected
      */
     _removeFile(file) {
-      if (this.files.indexOf(file) > -1) {
+      const fileIndex = this.files.indexOf(file);
+      if (fileIndex > -1) {
         this.files = this.files.filter((i) => i !== file);
 
         this.dispatchEvent(
@@ -843,6 +858,8 @@ export const UploadMixin = (superClass) =>
             composed: true,
           }),
         );
+
+        this._updateFocus(fileIndex);
       }
     }
 

--- a/packages/upload/test/keyboard-navigation.common.js
+++ b/packages/upload/test/keyboard-navigation.common.js
@@ -64,7 +64,7 @@ describe('keyboard navigation', () => {
       uploadElement.files = fileList;
 
       await nextRender();
-      fileElements = document.querySelectorAll('vaadin-upload-file');
+      fileElements = uploadElement.querySelectorAll('vaadin-upload-file');
     });
 
     it('should focus on the start button', async () => {
@@ -112,8 +112,7 @@ describe('keyboard navigation', () => {
       removeButton.click();
       await nextFrame();
 
-      const activeElementFileName = document.activeElement.shadowRoot.querySelector('#name').innerText;
-      expect(activeElementFileName).to.equal('file-1');
+      expect(document.activeElement.file.name).to.equal('file-1');
     });
 
     it('should focus on previous when last file in list is removed', async () => {
@@ -122,8 +121,7 @@ describe('keyboard navigation', () => {
       removeButton.click();
       await nextFrame();
 
-      const activeElementFileName = document.activeElement.shadowRoot.querySelector('#name').innerText;
-      expect(activeElementFileName).to.equal('file-0');
+      expect(document.activeElement.file.name).to.equal('file-0');
     });
 
     it('should not change focus after upload', async () => {

--- a/packages/upload/test/keyboard-navigation.common.js
+++ b/packages/upload/test/keyboard-navigation.common.js
@@ -55,20 +55,13 @@ describe('keyboard navigation', () => {
 
   describe('file', () => {
     beforeEach(async () => {
-      uploadElement.files = [
-        {
-          ...FAKE_FILE,
-          held: true, // Show the start button
-          error: 'Error', // Show the retry button
-          name: 'file-0',
-        },
-        {
-          ...FAKE_FILE,
-          held: true,
-          error: 'Error',
-          name: 'file-1',
-        },
-      ];
+      const fileList = [];
+      for (let i = 0; i < 2; i++) {
+        const file = createFile(1000, 'application/uknown');
+        Object.assign(file, { name: `file-${i}`, held: true, error: 'Error' });
+        fileList.push(file);
+      }
+      uploadElement.files = fileList;
 
       await nextRender();
       fileElements = document.querySelectorAll('vaadin-upload-file');
@@ -78,6 +71,7 @@ describe('keyboard navigation', () => {
       const startButton = fileElements[0].shadowRoot.querySelector('[part=start-button]');
 
       await repeatTab(3);
+
       expect(fileElements[0].shadowRoot.activeElement).to.not.equal(null);
       expect(fileElements[0].shadowRoot.activeElement).to.equal(startButton);
     });
@@ -114,18 +108,31 @@ describe('keyboard navigation', () => {
 
     it('should focus the next file after removing a file', async () => {
       const removeButton = fileElements[0].shadowRoot.querySelector('[part=remove-button]');
+
       removeButton.click();
       await nextFrame();
+
       const activeElementFileName = document.activeElement.shadowRoot.querySelector('#name').innerText;
       expect(activeElementFileName).to.equal('file-1');
     });
 
     it('should focus on previous when last file in list is removed', async () => {
       const removeButton = fileElements[1].shadowRoot.querySelector('[part=remove-button]');
+
       removeButton.click();
       await nextFrame();
+
       const activeElementFileName = document.activeElement.shadowRoot.querySelector('#name').innerText;
       expect(activeElementFileName).to.equal('file-0');
+    });
+
+    it('should not change focus after upload', async () => {
+      // Programmatic upload does not actually set focus, so we first navigate to the button.
+      await repeatTab(1);
+
+      uploadElement._uploadFile(FAKE_FILE);
+
+      expect(document.activeElement).to.equal(uploadButton);
     });
   });
 });

--- a/packages/upload/test/keyboard-navigation.common.js
+++ b/packages/upload/test/keyboard-navigation.common.js
@@ -31,8 +31,8 @@ describe('keyboard navigation', () => {
     uploadElement.files = [FAKE_FILE];
 
     await nextRender();
-    uploadButton = document.querySelector('vaadin-button[slot=add-button]');
-    fileElements = uploadElement.querySelector('vaadin-upload-file');
+    uploadButton = uploadElement.querySelector('vaadin-button[slot=add-button]');
+    fileElements = uploadElement.querySelectorAll('vaadin-upload-file');
   });
 
   afterEach(() => {
@@ -49,7 +49,7 @@ describe('keyboard navigation', () => {
   it('should focus on the file', async () => {
     await repeatTab(2);
 
-    expect(document.activeElement).to.equal(fileElements);
+    expect(document.activeElement).to.equal(fileElements[0]);
     expect(document.activeElement).to.not.equal(null);
   });
 

--- a/packages/upload/test/keyboard-navigation.common.js
+++ b/packages/upload/test/keyboard-navigation.common.js
@@ -12,7 +12,7 @@ async function repeatTab(times) {
 }
 
 describe('keyboard navigation', () => {
-  let uploadElement, fileElements, button;
+  let uploadElement, fileElements, button, uploadButton;
 
   before(() => {
     // Firefox has an issue with focus stuck when an upload element
@@ -31,7 +31,7 @@ describe('keyboard navigation', () => {
     uploadElement.files = [FAKE_FILE];
 
     await nextRender();
-
+    uploadButton = document.querySelector('vaadin-button[slot=add-button]');
     fileElements = uploadElement.querySelector('vaadin-upload-file');
   });
 
@@ -40,17 +40,17 @@ describe('keyboard navigation', () => {
   });
 
   it('should focus on the upload button', async () => {
-    const uploadButton = uploadElement.shadowRoot.querySelector('[part=upload-button]');
-
     await repeatTab(1);
 
-    expect(uploadElement.shadowRoot.activeElement).to.equal(uploadButton);
+    expect(document.activeElement).to.not.equal(null);
+    expect(document.activeElement).to.equal(uploadButton);
   });
 
   it('should focus on the file', async () => {
     await repeatTab(2);
 
     expect(document.activeElement).to.equal(fileElements);
+    expect(document.activeElement).to.not.equal(null);
   });
 
   describe('file', () => {
@@ -78,7 +78,7 @@ describe('keyboard navigation', () => {
       const startButton = fileElements[0].shadowRoot.querySelector('[part=start-button]');
 
       await repeatTab(3);
-
+      expect(fileElements[0].shadowRoot.activeElement).to.not.equal(null);
       expect(fileElements[0].shadowRoot.activeElement).to.equal(startButton);
     });
 
@@ -87,6 +87,7 @@ describe('keyboard navigation', () => {
 
       await repeatTab(4);
 
+      expect(fileElements[0].shadowRoot.activeElement).to.not.equal(null);
       expect(fileElements[0].shadowRoot.activeElement).to.equal(retryButton);
     });
 
@@ -95,15 +96,20 @@ describe('keyboard navigation', () => {
 
       await repeatTab(5);
 
+      expect(fileElements[0].shadowRoot.activeElement).to.not.equal(null);
       expect(fileElements[0].shadowRoot.activeElement).to.equal(removeButton);
     });
 
     it('should focus on upload button when last remaining file is removed', async () => {
       const removeButton = fileElements[0].shadowRoot.querySelector('[part=remove-button]');
-      const uploadButton = uploadElement.shadowRoot.querySelector('[part=upload-button]');
+
       removeButton.click();
       await nextFrame();
-      expect(fileElements[0].shadowRoot.activeElement).to.equal(uploadButton);
+      removeButton.click();
+      await nextFrame();
+
+      expect(document.activeElement).to.not.equal(null);
+      expect(document.activeElement).to.equal(uploadButton);
     });
 
     it('should focus the next file after removing a file', async () => {


### PR DESCRIPTION
## Description
Keyboard navigation in the upload list was broken. This PR fixes that by:
- focus next when a file is removed
- focus previous when the last file is removed
- focus the upload button when the last remaining file is removed
- focus self on retry
- focus upload button after upload (or really, just don't move it elsewhere)

These choices for navigation have been discussed internally. This PR focuses on keyboard navigation, possible ARIA issues are not taken into account.

I noticed that some of the tests were false positives because `null === null` so I added to each test that compares two objects an additional check for null. Of course, as these aren't supposed to be null, I also changed the way some of the elements are query selected.

Updated dev/upload.html to have proper files, this allows retrying upload for failed files.

Fixes #6292

## Type of change

- [X] Bugfix
