### PR TITLE
chore: update sinon dev dependency to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@fontsource/roboto": "^4.5.1",
     "@polymer/iron-component-page": "^4.0.1",
     "@rollup/plugin-terser": "^0.4.4",
-    "@types/sinon": "^17.0.2",
+    "@types/sinon": "^17.0.3",
     "@vaadin/testing-helpers": "^1.0.0",
     "@web/dev-server": "^0.4.3",
     "@web/dev-server-esbuild": "^1.0.2",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -38,6 +38,6 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-board",
   "web-types": [

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -47,7 +47,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-chart",
   "web-types": [

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -56,7 +56,7 @@
     "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-field": "24.5.0-alpha7",
     "lit": "^3.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -40,6 +40,6 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -50,7 +50,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-crud",
   "web-types": [

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -59,7 +59,7 @@
     "@vaadin/text-area": "24.5.0-alpha7",
     "@vaadin/text-field": "24.5.0-alpha7",
     "@vaadin/time-picker": "24.5.0-alpha7",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -52,7 +52,7 @@
     "@vaadin/a11y-base": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-area": "24.5.0-alpha7",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -39,6 +39,6 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -57,6 +57,6 @@
     "@vaadin/text-area": "24.5.0-alpha7",
     "@vaadin/text-field": "24.5.0-alpha7",
     "@vaadin/time-picker": "24.5.0-alpha7",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -46,7 +46,7 @@
     "@vaadin/custom-field": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
     "@vaadin/text-field": "24.5.0-alpha7",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-grid-pro",
   "web-types": [

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -43,6 +43,6 @@
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/icons": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -35,6 +35,6 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-map",
   "web-types": [

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -55,7 +55,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/icon": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -54,7 +54,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
     "lit": "^3.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -49,7 +49,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/button": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -46,6 +46,6 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -41,6 +41,6 @@
     "@vaadin/grid": "24.5.0-alpha7",
     "@vaadin/grid-pro": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -59,7 +59,7 @@
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "gulp-iconfont": "^11.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-rich-text-editor",
   "web-types": [

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -46,7 +46,7 @@
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
     "lit": "^3.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -38,6 +38,6 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "24.5.0-alpha7",
     "@vaadin/testing-helpers": "^1.0.0",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -44,6 +44,6 @@
     "@vaadin/time-picker": "24.5.0-alpha7",
     "@vaadin/tooltip": "24.5.0-alpha7",
     "@vaadin/vaadin-themable-mixin": "24.5.0-alpha7",
-    "sinon": "^13.0.2"
+    "sinon": "^18.0.0"
   }
 }

--- a/test/plugins/package.json
+++ b/test/plugins/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "dependencies": {
     "@open-wc/semantic-dom-diff": "^0.20.1",
-    "@vaadin/testing-helpers": "^1.0.0",
     "chai": "^5.1.1",
+    "sinon": "^18.0.0",
     "sinon-chai": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,30 +1821,37 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.4.0.tgz#b1bfbd6024311ade045093b424536cefcc8e3a42"
   integrity sha512-Ggh6E9AnMpiNXlbXfFUcWE9qm408rL8jDi7+PMBBx7TMbwEmiqAiSmZ+zydYwxcJLqPGNDoLc9mXDuMDBZg0sA==
 
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
-  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@>=5", "@sinonjs/fake-timers@^9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
-  integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
+"@sinonjs/commons@^3.0.0", "@sinonjs/commons@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
+    type-detect "4.0.8"
 
-"@sinonjs/samsam@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.1.tgz#627f7f4cbdb56e6419fa2c1a3e4751ce4f6a00b1"
-  integrity sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==
+"@sinonjs/fake-timers@^11.2.2":
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz#50063cc3574f4a27bd8453180a04171c85cc9699"
+  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
   dependencies:
-    "@sinonjs/commons" "^1.6.0"
+    "@sinonjs/commons" "^3.0.0"
+
+"@sinonjs/samsam@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.0.tgz#0d488c91efb3fa1442e26abea81759dfc8b5ac60"
+  integrity sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
     lodash.get "^4.4.2"
     type-detect "^4.0.8"
 
-"@sinonjs/text-encoding@^0.7.1":
+"@sinonjs/text-encoding@^0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
@@ -2145,10 +2152,10 @@
     "@types/mime" "*"
     "@types/node" "*"
 
-"@types/sinon@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-17.0.2.tgz#9a769f67e62b45b7233f1fe01cb1f231d2393e1c"
-  integrity sha512-Zt6heIGsdqERkxctIpvN5Pv3edgBrhoeb3yHyxffd4InN0AX2SVNKSrhdDZKGQICVOxWP/q4DyhpfPNMSrpIiA==
+"@types/sinon@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-17.0.3.tgz#9aa7e62f0a323b9ead177ed23a36ea757141a5fa"
+  integrity sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 
@@ -4854,10 +4861,10 @@ dezalgo@^1.0.0:
     asap "^2.0.0"
     wrappy "1"
 
-diff@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
-  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
+diff@^5.0.0, diff@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
+  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -7989,10 +7996,10 @@ just-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.1.0.tgz#2f81a3ad4121a76bc7cb45dbf704c0d76a8e5ddf"
   integrity sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==
 
-just-extend@^4.0.2:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
-  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+just-extend@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-6.2.0.tgz#b816abfb3d67ee860482e7401564672558163947"
+  integrity sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -9207,16 +9214,16 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nise@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.1.tgz#ac4237e0d785ecfcb83e20f389185975da5c31f3"
-  integrity sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==
+nise@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-6.0.0.tgz#ae56fccb5d912037363c3b3f29ebbfa28bde8b48"
+  integrity sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==
   dependencies:
-    "@sinonjs/commons" "^1.8.3"
-    "@sinonjs/fake-timers" ">=5"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    path-to-regexp "^1.7.0"
+    "@sinonjs/commons" "^3.0.0"
+    "@sinonjs/fake-timers" "^11.2.2"
+    "@sinonjs/text-encoding" "^0.7.2"
+    just-extend "^6.2.0"
+    path-to-regexp "^6.2.1"
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -10199,12 +10206,10 @@ path-scurry@^1.7.0:
     lru-cache "^9.1.1"
     minipass "^5.0.0 || ^6.0.2"
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
+path-to-regexp@^6.2.1:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.2.tgz#324377a83e5049cbecadc5554d6a63a9a4866b36"
+  integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -11458,17 +11463,17 @@ sinon-chai@^4.0.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-4.0.0.tgz#77d59d9f4a833f0d3a88249b4637acc72656fdfa"
   integrity sha512-cWqO7O2I4XfJDWyWElAQ9D/dtdh5Mo0RHndsfiiYyjWnlPzBJdIvjCVURO4EjyYaC3BjV+ISNXCfTXPXTEIEWA==
 
-sinon@^13.0.2:
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-13.0.2.tgz#c6a8ddd655dc1415bbdc5ebf0e5b287806850c3a"
-  integrity sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==
+sinon@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-18.0.0.tgz#69ca293dbc3e82590a8b0d46c97f63ebc1e5fc01"
+  integrity sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==
   dependencies:
-    "@sinonjs/commons" "^1.8.3"
-    "@sinonjs/fake-timers" "^9.1.2"
-    "@sinonjs/samsam" "^6.1.1"
-    diff "^5.0.0"
-    nise "^5.1.1"
-    supports-color "^7.2.0"
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^11.2.2"
+    "@sinonjs/samsam" "^8.0.0"
+    diff "^5.2.0"
+    nise "^6.0.0"
+    supports-color "^7"
 
 slash@^2.0.0:
   version "2.0.0"
@@ -12123,7 +12128,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7, supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==


### PR DESCRIPTION
## Description

Upgraded `sinon` to v18 and also added it to `@vaadin/chai-plugins` to fix missing peer dependency warning:

```
@vaadin/chai-plugins > sinon-chai@4.0.0" has unmet peer dependency "sinon@>=4.0.0"
```

## Type of change

- Internal change