### PR TITLE
chore: add missing mocha types

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@fontsource/roboto": "^4.5.1",
     "@polymer/iron-component-page": "^4.0.1",
     "@rollup/plugin-terser": "^0.4.4",
+    "@types/mocha": "^10.0.7",
     "@types/sinon": "^17.0.3",
     "@vaadin/testing-helpers": "^1.0.0",
     "@web/dev-server": "^0.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2088,6 +2088,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/mocha@^10.0.7":
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.7.tgz#4c620090f28ca7f905a94b706f74dc5b57b44f2f"
+  integrity sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==
+
 "@types/node@*", "@types/node@^20.1.0":
   version "20.2.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.5.tgz#26d295f3570323b2837d322180dfbf1ba156fefb"


### PR DESCRIPTION
## Description

Add missing `@types/mocha` dev dependency to fix ts test errors

<img width="970" alt="Screenshot 2024-08-13 at 13 22 31" src="https://github.com/user-attachments/assets/f8d0f4cd-3f8c-4032-b346-a97ecd7faaad">
