### PR TITLE
chore: fix contributing guide links in packages README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 *There are many ways to contribute to the Vaadin Web Components project. You can ask questions and participate in discussions in the [Vaadin Forum](https://vaadin.com/forum/), [create issues](https://github.com/vaadin/web-components/issues/new/choose) to file bug reports and enhancement suggestions, or contribute code.*
 
-The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/pr
+The contributing docs have moved to: https://vaadin.com/docs/latest/contributing

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Fixes # (issue)
 
 ## Checklist
 
-- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/overview
+- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
 - [ ] I have added a description following the guideline.
 - [ ] The issue is created in the corresponding repository and I have referenced it.
 - [ ] I have added tests to ensure my change is effective and works as intended.

--- a/packages/a11y-base/README.md
+++ b/packages/a11y-base/README.md
@@ -4,7 +4,7 @@ A set of accessibility helpers, mixins and controllers used by Vaadin components
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -60,7 +60,7 @@ import '@vaadin/accordion/src/vaadin-accordion.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/app-layout/README.md
+++ b/packages/app-layout/README.md
@@ -75,7 +75,7 @@ import '@vaadin/app-layout/src/vaadin-drawer-toggle.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/avatar-group/README.md
+++ b/packages/avatar-group/README.md
@@ -59,7 +59,7 @@ import '@vaadin/avatar-group/src/vaadin-avatar-group.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -53,7 +53,7 @@ import '@vaadin/avatar/src/vaadin-avatar.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/board/README.md
+++ b/packages/board/README.md
@@ -48,7 +48,7 @@ import '@vaadin/board';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -53,7 +53,7 @@ import '@vaadin/button/src/vaadin-button.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -41,7 +41,7 @@ import '@vaadin/charts';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/checkbox-group/README.md
+++ b/packages/checkbox-group/README.md
@@ -54,7 +54,7 @@ import '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -53,7 +53,7 @@ import '@vaadin/checkbox/src/vaadin-checkbox.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/combo-box/README.md
+++ b/packages/combo-box/README.md
@@ -64,7 +64,7 @@ import '@vaadin/combo-box/src/vaadin-combo-box.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/component-base/README.md
+++ b/packages/component-base/README.md
@@ -4,7 +4,7 @@ A set of helpers and mixins used by Vaadin components.
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/confirm-dialog/README.md
+++ b/packages/confirm-dialog/README.md
@@ -53,7 +53,7 @@ import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -30,7 +30,7 @@ import '@vaadin/cookie-consent';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/crud/README.md
+++ b/packages/crud/README.md
@@ -53,7 +53,7 @@ import '@vaadin/crud/src/vaadin-crud.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/custom-field/README.md
+++ b/packages/custom-field/README.md
@@ -55,7 +55,7 @@ import '@vaadin/custom-field/src/vaadin-custom-field.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -51,7 +51,7 @@ import '@vaadin/date-picker/src/vaadin-date-picker.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/date-time-picker/README.md
+++ b/packages/date-time-picker/README.md
@@ -49,7 +49,7 @@ import '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/details/README.md
+++ b/packages/details/README.md
@@ -54,7 +54,7 @@ import '@vaadin/details/src/vaadin-details.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -58,7 +58,7 @@ import '@vaadin/dialog/src/vaadin-dialog.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/email-field/README.md
+++ b/packages/email-field/README.md
@@ -49,7 +49,7 @@ import '@vaadin/email-field/src/vaadin-email-field.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/field-base/README.md
+++ b/packages/field-base/README.md
@@ -4,7 +4,7 @@ A set of mixins and controllers used by Vaadin field components.
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/field-highlighter/README.md
+++ b/packages/field-highlighter/README.md
@@ -4,7 +4,7 @@ A set of field helpers used by [Vaadin Collaboration Engine](https://vaadin.com/
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/form-layout/README.md
+++ b/packages/form-layout/README.md
@@ -55,7 +55,7 @@ import '@vaadin/form-layout/src/vaadin-form-layout.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/grid-pro/README.md
+++ b/packages/grid-pro/README.md
@@ -68,7 +68,7 @@ import '@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -87,7 +87,7 @@ import '@vaadin/grid/src/vaadin-grid-tree-column.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/horizontal-layout/README.md
+++ b/packages/horizontal-layout/README.md
@@ -52,7 +52,7 @@ import '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -49,7 +49,7 @@ import '@vaadin/icon/src/vaadin-icon.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/input-container/README.md
+++ b/packages/input-container/README.md
@@ -4,7 +4,7 @@ A web component used internally by Vaadin field components.
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/integer-field/README.md
+++ b/packages/integer-field/README.md
@@ -49,7 +49,7 @@ import '@vaadin/integer-field/src/vaadin-integer-field.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/item/README.md
+++ b/packages/item/README.md
@@ -51,7 +51,7 @@ import '@vaadin/item/src/vaadin-item.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/list-box/README.md
+++ b/packages/list-box/README.md
@@ -58,7 +58,7 @@ import '@vaadin/list-box/src/vaadin-list-box.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/login/README.md
+++ b/packages/login/README.md
@@ -54,7 +54,7 @@ import '@vaadin/login/src/vaadin-login-form.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/map/README.md
+++ b/packages/map/README.md
@@ -30,7 +30,7 @@ import '@vaadin/map';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/menu-bar/README.md
+++ b/packages/menu-bar/README.md
@@ -63,7 +63,7 @@ import '@vaadin/menu-bar/src/vaadin-menu-bar.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/message-input/README.md
+++ b/packages/message-input/README.md
@@ -49,7 +49,7 @@ import '@vaadin/message-input/src/vaadin-message-input.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/message-list/README.md
+++ b/packages/message-list/README.md
@@ -57,7 +57,7 @@ import '@vaadin/message-list/src/vaadin-message-list.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/multi-select-combo-box/README.md
+++ b/packages/multi-select-combo-box/README.md
@@ -54,7 +54,7 @@ import '@vaadin/multi-select-combo-box/src/vaadin-multi-select-combo-box.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/notification/README.md
+++ b/packages/notification/README.md
@@ -59,7 +59,7 @@ import '@vaadin/notification/src/vaadin-notification.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -49,7 +49,7 @@ import '@vaadin/number-field/src/vaadin-number-field.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/password-field/README.md
+++ b/packages/password-field/README.md
@@ -49,7 +49,7 @@ import '@vaadin/password-field/src/vaadin-password-field.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -43,7 +43,7 @@ import '@vaadin/popover/src/vaadin-popover.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -53,7 +53,7 @@ import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/radio-group/README.md
+++ b/packages/radio-group/README.md
@@ -53,7 +53,7 @@ import '@vaadin/radio-group/src/vaadin-radio-group.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/rich-text-editor/README.md
+++ b/packages/rich-text-editor/README.md
@@ -53,7 +53,7 @@ import '@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/scroller/README.md
+++ b/packages/scroller/README.md
@@ -59,7 +59,7 @@ import '@vaadin/scroller/src/vaadin-scroller.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -70,7 +70,7 @@ import '@vaadin/select/src/vaadin-select.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -20,13 +20,9 @@ A web component for navigation menus.
     <vaadin-icon icon="vaadin:folder-open" slot="prefix"></vaadin-icon>
     Parent
 
-    <vaadin-side-nav-item path="/child1" slot="children">
-      Child 1
-    </vaadin-side-nav-item>
+    <vaadin-side-nav-item path="/child1" slot="children"> Child 1 </vaadin-side-nav-item>
 
-    <vaadin-side-nav-item path="/child2" slot="children">
-      Child 2
-    </vaadin-side-nav-item>
+    <vaadin-side-nav-item path="/child2" slot="children"> Child 2 </vaadin-side-nav-item>
   </vaadin-side-nav-item>
 </vaadin-side-nav>
 ```
@@ -70,7 +66,7 @@ import '@vaadin/side-nav/src/vaadin-side-nav.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/split-layout/README.md
+++ b/packages/split-layout/README.md
@@ -60,7 +60,7 @@ import '@vaadin/split-layout/src/vaadin-split-layout.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -56,7 +56,7 @@ import '@vaadin/tabs/src/vaadin-tabs.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/tabsheet/README.md
+++ b/packages/tabsheet/README.md
@@ -61,7 +61,7 @@ import '@vaadin/tabsheet/src/vaadin-tabsheet.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/text-area/README.md
+++ b/packages/text-area/README.md
@@ -49,7 +49,7 @@ import '@vaadin/text-area/src/vaadin-text-area.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/text-field/README.md
+++ b/packages/text-field/README.md
@@ -49,7 +49,7 @@ import '@vaadin/text-field/src/vaadin-text-field.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/time-picker/README.md
+++ b/packages/time-picker/README.md
@@ -51,7 +51,7 @@ import '@vaadin/time-picker/src/vaadin-time-picker.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -50,7 +50,7 @@ import '@vaadin/tooltip/src/vaadin-tooltip.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -53,7 +53,7 @@ import '@vaadin/upload/src/vaadin-upload.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/vertical-layout/README.md
+++ b/packages/vertical-layout/README.md
@@ -52,7 +52,7 @@ import '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 

--- a/packages/virtual-list/README.md
+++ b/packages/virtual-list/README.md
@@ -57,7 +57,7 @@ import '@vaadin/virtual-list/src/vaadin-virtual-list.js';
 
 ## Contributing
 
-Read the [contributing guide](https://vaadin.com/docs/latest/contributing/overview) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
+Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.
 
 ## License
 


### PR DESCRIPTION
## Description

The current link points to the page that says that it has moved. It was only fixed in #7223 for root level README.

<img width="572" alt="Screenshot 2024-03-15 at 16 14 16" src="https://github.com/vaadin/web-components/assets/10589913/529763c5-54f4-48c1-8ae6-b4203142d3d6">

This PR fixes that for READMEs in `packages` folder and also for the PR template.

## Type of change

- Internal change