### PR TITLE
fix: do not close popover on focusout after mousedown inside

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -424,6 +424,7 @@ class Popover extends PopoverPositionMixin(
         ?no-vertical-overlap="${this.__computeNoVerticalOverlap(effectivePosition)}"
         .horizontalAlign="${this.__computeHorizontalAlign(effectivePosition)}"
         .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
+        @mousedown="${this.__onOverlayMouseDown}"
         @mouseenter="${this.__onOverlayMouseEnter}"
         @mouseleave="${this.__onOverlayMouseLeave}"
         @focusin="${this.__onOverlayFocusIn}"
@@ -692,7 +693,7 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetFocusOut(event) {
-    if (this._overlayElement.contains(event.relatedTarget)) {
+    if ((this.__hasTrigger('focus') && this.__mouseDownInside) || this._overlayElement.contains(event.relatedTarget)) {
       return;
     }
 
@@ -734,11 +735,30 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onOverlayFocusOut(event) {
-    if (event.relatedTarget === this.target || this._overlayElement.contains(event.relatedTarget)) {
+    if (
+      (this.__hasTrigger('focus') && this.__mouseDownInside) ||
+      event.relatedTarget === this.target ||
+      this._overlayElement.contains(event.relatedTarget)
+    ) {
       return;
     }
 
     this.__handleFocusout();
+  }
+
+  /** @private */
+  __onOverlayMouseDown() {
+    if (this.__hasTrigger('focus')) {
+      this.__mouseDownInside = true;
+
+      document.addEventListener(
+        'mouseup',
+        () => {
+          this.__mouseDownInside = false;
+        },
+        { once: true },
+      );
+    }
   }
 
   /** @private */


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/7652

Fixes the issue that happens on click inside the popover content when `focus` trigger is used. In this case, `focusout` event occurs and the overlay unexpectedly closes despite the fact that the click was inside the overlay. 

The solution is to use `mousedown` event listener and set a flag to ignore next `focusout` event, if any. 
The flag is then set back to `false` on `mouseup` using a global event listener.

Can be tested with the following HTML:

```html
<button id="button">Open</button>
<vaadin-popover for="button"></vaadin-popover>

<script type="module">
  import '@vaadin/popover';

  const popover = document.querySelector('vaadin-popover');
  popover.trigger = ['focus'];

  popover.renderer = (root) => {
    if (!root.firstChild) {
      // root.appendChild(document.createElement('input'));
      const div = document.createElement('div');
      div.textContent = 'Some text content';
      root.appendChild(div)
    }
  };
</script>
```

## Type of change

- Feature