### PR TITLE
feat: add colspan support to dashboard

### DIFF
--- a/dev/dashboard-layout.html
+++ b/dev/dashboard-layout.html
@@ -33,7 +33,7 @@
   <body>
     <vaadin-dashboard-layout>
       <div>Item 0</div>
-      <div>Item 1</div>
+      <div style="--vaadin-dashboard-item-colspan: 2">Item 1</div>
       <div>Item 2</div>
       <div>Item 3</div>
       <div>Item 4</div>

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.d.ts
@@ -9,12 +9,13 @@
  * license.
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
 /**
  * A mixin to enable the dashboard layout functionality.
  */
 export declare function DashboardLayoutMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<DashboardLayoutMixinClass> & T;
+): Constructor<DashboardLayoutMixinClass> & Constructor<ResizeMixinClass> & T;
 
 export declare class DashboardLayoutMixinClass {}

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -8,15 +8,17 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
+import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
  * A mixin to enable the dashboard layout functionality
  *
  * @polymerMixin
+ * @mixes ResizeMixin
  */
 export const DashboardLayoutMixin = (superClass) =>
-  class DashboardLayoutMixinClass extends superClass {
+  class DashboardLayoutMixinClass extends ResizeMixin(superClass) {
     static get styles() {
       return css`
         :host {
@@ -39,6 +41,30 @@ export const DashboardLayoutMixin = (superClass) =>
             minmax(var(--_vaadin-dashboard-col-min-width), var(--_vaadin-dashboard-col-max-width))
           );
         }
+
+        ::slotted(*) {
+          grid-column: span min(var(--vaadin-dashboard-item-colspan, 1), var(--_vaadin-dashboard-item-max-colspan));
+        }
       `;
+    }
+
+    /**
+     * @protected
+     * @override
+     */
+    _onResize() {
+      this.__updateItemMaxColspan();
+    }
+
+    /**
+     * @private
+     */
+    __updateItemMaxColspan() {
+      // Temporarily set max colspan to 1
+      this.style.setProperty('--_vaadin-dashboard-item-max-colspan', 1);
+      // Get the effective column count with no colspans
+      const columnCount = getComputedStyle(this).gridTemplateColumns.split(' ').length;
+      // ...and set it as the new max colspan value
+      this.style.setProperty('--_vaadin-dashboard-item-max-colspan', columnCount);
     }
   };

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -45,6 +45,13 @@ export function setMaximumColumnWidth(dashboard: HTMLElement, width?: number): v
 }
 
 /**
+ * Sets the column span of the element
+ */
+export function setColspan(element: HTMLElement, colspan?: number): void {
+  element.style.setProperty('--vaadin-dashboard-item-colspan', colspan !== undefined ? `${colspan}` : null);
+}
+
+/**
  * Sets the gap between the cells of the dashboard.
  */
 export function setGap(dashboard: HTMLElement, gap: number): void {


### PR DESCRIPTION
## Description

Add column spanning support for `<vaadin-dashboard-layout>`

- Items can span multiple columns
- Actual column span is capped to currently available columns

https://github.com/user-attachments/assets/77486810-f586-460a-9a09-29962dd2a439

Added API:
`--vaadin-dashboard-item-colspan`: Applied to a child element of a dashboard layout. Affects its column span in the layout grid.

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=74625129

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature