### PR TITLE
fix: do not close popover when focus moves to nested overlay

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -692,7 +692,7 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetFocusOut(event) {
-    if (this._overlayElement.contains(event.relatedTarget)) {
+    if (this._overlayElement.contains(event.relatedTarget) || this.__isInsideNestedOverlay(event.relatedTarget)) {
       return;
     }
 
@@ -734,11 +734,32 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onOverlayFocusOut(event) {
-    if (event.relatedTarget === this.target || this._overlayElement.contains(event.relatedTarget)) {
+    const { relatedTarget } = event;
+
+    if (
+      relatedTarget === this.target ||
+      this._overlayElement.contains(relatedTarget) ||
+      this.__isInsideNestedOverlay(relatedTarget)
+    ) {
       return;
     }
 
     this.__handleFocusout();
+  }
+
+  /** @private */
+  __isInsideNestedOverlay(element) {
+    let node = element;
+    while (node) {
+      // Check if the element is placed in an overlay whose host is a popover overlay child.
+      if (node._hasOverlayStackMixin && node.owner && this._overlayElement._deepContains(node.owner)) {
+        return true;
+      }
+
+      node = node.parentNode;
+    }
+
+    return false;
   }
 
   /** @private */

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -269,66 +269,6 @@ describe('popover', () => {
       });
     });
 
-    describe('nested popovers', () => {
-      let secondPopover, secondTarget;
-
-      function nestedRenderer(root) {
-        root.innerHTML = `
-          <button id="second-target">Second target</button>
-          <vaadin-popover for="second-target"></vaadin-popover>
-        `;
-        [secondTarget, secondPopover] = root.children;
-      }
-
-      beforeEach(async () => {
-        popover.renderer = nestedRenderer;
-
-        // Open the first popover
-        target.click();
-        await nextRender();
-
-        // Open the second popover
-        secondTarget.click();
-        await nextRender();
-
-        // Expect both popovers to be opened
-        expect(popover.opened).to.be.true;
-        expect(secondPopover.opened).to.be.true;
-      });
-
-      it('should close the topmost overlay on global Escape press', async () => {
-        esc(document.body);
-        await nextRender();
-
-        // Expect only the second popover to be closed
-        expect(popover.opened).to.be.true;
-        expect(secondPopover.opened).to.be.false;
-
-        esc(document.body);
-        await nextRender();
-
-        // Expect both popovers to be closed
-        expect(popover.opened).to.be.false;
-        expect(secondPopover.opened).to.be.false;
-      });
-
-      it('should close the topmost overlay on outside click', async () => {
-        outsideClick();
-        await nextRender();
-
-        // Expect only the second popover to be closed
-        expect(popover.opened).to.be.true;
-        expect(secondPopover.opened).to.be.false;
-
-        outsideClick();
-        await nextRender();
-
-        // Expect both popovers to be closed
-        expect(popover.opened).to.be.false;
-        expect(secondPopover.opened).to.be.false;
-      });
-    });
-
     describe('backdrop', () => {
       beforeEach(async () => {
         popover.withBackdrop = true;

--- a/packages/popover/test/nested.test.js
+++ b/packages/popover/test/nested.test.js
@@ -1,0 +1,129 @@
+import { expect } from '@vaadin/chai-plugins';
+import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '../vaadin-popover.js';
+
+describe('nested popover', () => {
+  let popover, target, secondPopover, secondTarget;
+
+  beforeEach(async () => {
+    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
+    target = fixtureSync('<button>Target</button>');
+    popover.target = target;
+    popover.renderer = (root) => {
+      if (root.firstChild) {
+        return;
+      }
+      root.innerHTML = `
+        <button id="second-target">Second target</button>
+        <vaadin-popover for="second-target"></vaadin-popover>
+      `;
+      [secondTarget, secondPopover] = root.children;
+      secondPopover.renderer = (root2) => {
+        root2.textContent = 'Nested';
+      };
+    };
+    await nextRender();
+  });
+
+  describe('closing', () => {
+    beforeEach(async () => {
+      // Open the first popover
+      target.click();
+      await nextRender();
+
+      // Open the second popover
+      secondTarget.click();
+      await nextRender();
+
+      // Expect both popovers to be opened
+      expect(popover.opened).to.be.true;
+      expect(secondPopover.opened).to.be.true;
+    });
+
+    it('should close the topmost overlay on global Escape press', async () => {
+      esc(document.body);
+      await nextRender();
+
+      // Expect only the second popover to be closed
+      expect(popover.opened).to.be.true;
+      expect(secondPopover.opened).to.be.false;
+
+      esc(document.body);
+      await nextRender();
+
+      // Expect both popovers to be closed
+      expect(popover.opened).to.be.false;
+      expect(secondPopover.opened).to.be.false;
+    });
+
+    it('should close the topmost overlay on outside click', async () => {
+      outsideClick();
+      await nextRender();
+
+      // Expect only the second popover to be closed
+      expect(popover.opened).to.be.true;
+      expect(secondPopover.opened).to.be.false;
+
+      outsideClick();
+      await nextRender();
+
+      // Expect both popovers to be closed
+      expect(popover.opened).to.be.false;
+      expect(secondPopover.opened).to.be.false;
+    });
+  });
+
+  describe('focus', () => {
+    beforeEach(async () => {
+      popover.trigger = ['focus'];
+      await nextUpdate(popover);
+    });
+
+    it('should not close when focus moves from the target to the nested popover', async () => {
+      target.focus();
+      await nextRender();
+
+      secondPopover.modal = true;
+      await nextUpdate(secondPopover);
+
+      secondTarget.click();
+      await nextRender();
+
+      expect(popover.opened).to.be.true;
+    });
+
+    it('should not close when focus moves from the overlay to the nested popover', async () => {
+      target.focus();
+      await nextRender();
+
+      secondPopover.modal = true;
+      await nextUpdate(secondPopover);
+
+      secondTarget.focus();
+      secondTarget.click();
+      await nextRender();
+
+      expect(popover.opened).to.be.true;
+    });
+
+    it('should properly detect nested popover if its owner is in the shadow root', async () => {
+      target.focus();
+      await nextRender();
+
+      secondPopover.modal = true;
+      await nextUpdate(secondPopover);
+
+      // Wrap second popover with shadow root
+      const div = document.createElement('div');
+      div.attachShadow({ mode: 'open' });
+      secondPopover.parentNode.appendChild(div);
+      div.shadowRoot.appendChild(secondPopover);
+
+      secondTarget.click();
+      await nextRender();
+
+      expect(popover.opened).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/7652

Added logic to detect if the `event.relatedTarget` of the `focusout` event is an element placed in the overlay whose `host` is a child of the `vaadin-popover-overlay` to avoid issue with closing parent popover using `focus` trigger.

Note: some components need tweaks to set `owner` property, I'll handle this in separate PRs and add integration tests.

## Type of change

- Bugfix