### PR TITLE
fix: add and remove drag-source when scrolling

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -106,9 +106,7 @@ export const DragAndDropMixin = (superClass) =>
 
         /** @private  */
         __draggedItems: {
-          value() {
-            return [];
-          },
+          value: () => [],
         },
       };
     }

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -188,14 +188,12 @@ export const DragAndDropMixin = (superClass) =>
           updateBooleanRowStates(row, { dragstart: false });
           this.style.setProperty('--_grid-drag-start-x', '');
           this.style.setProperty('--_grid-drag-start-y', '');
-          rows.forEach((row) => {
-            updateBooleanRowStates(row, { 'drag-source': true });
-          });
+          this.requestContentUpdate();
         });
 
         const event = new CustomEvent('grid-dragstart', {
           detail: {
-            draggedItems: rows.map((row) => row._item),
+            draggedItems: [...this.__draggedItems],
             setDragData: (type, data) => e.dataTransfer.setData(type, data),
             setDraggedItemsCount: (count) => row.setAttribute('dragstart', count),
           },
@@ -213,11 +211,8 @@ export const DragAndDropMixin = (superClass) =>
       event.originalEvent = e;
       this.dispatchEvent(event);
 
-      iterateChildren(this.$.items, (row) => {
-        updateBooleanRowStates(row, { 'drag-source': false });
-      });
-
       this.__draggedItems = [];
+      this.requestContentUpdate();
     }
 
     /** @private */
@@ -348,12 +343,8 @@ export const DragAndDropMixin = (superClass) =>
     }
 
     /** @private */
-    _updateDragSourceParts(row, model) {
-      if (this.__draggedItems.includes(model.item)) {
-        updateBooleanRowStates(row, { 'drag-source': true });
-      } else {
-        updateBooleanRowStates(row, { 'drag-source': false });
-      }
+    __updateDragSourceParts(row, model) {
+      updateBooleanRowStates(row, { 'drag-source': this.__draggedItems.includes(model.item) });
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -106,7 +106,9 @@ export const DragAndDropMixin = (superClass) =>
 
         /** @private  */
         __draggedItems: {
-          value: [],
+          value() {
+            return [];
+          },
         },
       };
     }

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -103,6 +103,11 @@ export const DragAndDropMixin = (superClass) =>
         __dndAutoScrollThreshold: {
           value: 50,
         },
+
+        /** @private  */
+        __draggedItems: {
+          value: [],
+        },
       };
     }
 
@@ -170,6 +175,8 @@ export const DragAndDropMixin = (superClass) =>
             .filter((row) => !this.dragFilter || this.dragFilter(this.__getRowModel(row)));
         }
 
+        this.__draggedItems = rows.map((row) => row._item);
+
         // Set the default transfer data
         e.dataTransfer.setData('text', this.__formatDefaultTransferData(rows));
 
@@ -209,6 +216,8 @@ export const DragAndDropMixin = (superClass) =>
       iterateChildren(this.$.items, (row) => {
         updateBooleanRowStates(row, { 'drag-source': false });
       });
+
+      this.__draggedItems = [];
     }
 
     /** @private */
@@ -336,6 +345,15 @@ export const DragAndDropMixin = (superClass) =>
       iterateChildren(this.$.items, (row) => {
         updateStringRowStates(row, { dragover: null });
       });
+    }
+
+    /** @private */
+    _updateDragSourceParts(row, model) {
+      if (this.__draggedItems.includes(model.item)) {
+        updateBooleanRowStates(row, { 'drag-source': true });
+      } else {
+        updateBooleanRowStates(row, { 'drag-source': false });
+      }
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -968,6 +968,7 @@ export const GridMixin = (superClass) =>
       this._generateCellClassNames(row, model);
       this._generateCellPartNames(row, model);
       this._filterDragAndDrop(row, model);
+      this._updateDragSourceParts(row, model);
 
       iterateChildren(row, (cell) => {
         if (cell._column && !cell._column.isConnected) {

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -968,7 +968,7 @@ export const GridMixin = (superClass) =>
       this._generateCellClassNames(row, model);
       this._generateCellPartNames(row, model);
       this._filterDragAndDrop(row, model);
-      this._updateDragSourceParts(row, model);
+      this.__updateDragSourceParts(row, model);
 
       iterateChildren(row, (cell) => {
         if (cell._column && !cell._column.isConnected) {

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -1081,7 +1081,6 @@ describe('drag and drop', () => {
 
       grid.scrollToIndex(0);
       expect(getFirstCell(grid).getAttribute('part')).to.contain('drag-source-row-cell');
-      grid.rowsDraggable = false;
     });
   });
 });

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -254,14 +254,6 @@ describe('drag and drop', () => {
         });
       });
 
-      it('should add drag-source- part to dragged rows', async () => {
-        fireDragStart();
-        await nextFrame();
-        for (const cell of getRowBodyCells(getRows(grid.$.items)[0])) {
-          expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
-        }
-      });
-
       it('should add drag-source- part to all dragged rows', async () => {
         grid.selectItem(grid.items[0]);
         grid.selectItem(grid.items[1]);
@@ -271,6 +263,14 @@ describe('drag and drop', () => {
           for (const cell of getRowBodyCells(row)) {
             expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
           }
+        }
+      });
+
+      it('should add drag-source- part to dragged rows', async () => {
+        fireDragStart();
+        await nextFrame();
+        for (const cell of getRowBodyCells(getRows(grid.$.items)[0])) {
+          expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
         }
       });
 

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -262,17 +262,6 @@ describe('drag and drop', () => {
         }
       });
 
-      it('should remove drag-source- part from dragged rows', async () => {
-        fireDragStart();
-        await nextFrame();
-
-        fireDragEnd();
-        await nextFrame();
-        for (const cell of getRowBodyCells(getRows(grid.$.items)[0])) {
-          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
-        }
-      });
-
       it('should add drag-source- part to all dragged rows', async () => {
         grid.selectItem(grid.items[0]);
         grid.selectItem(grid.items[1]);
@@ -282,6 +271,17 @@ describe('drag and drop', () => {
           for (const cell of getRowBodyCells(row)) {
             expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
           }
+        }
+      });
+
+      it('should remove drag-source- part from dragged rows', async () => {
+        fireDragStart();
+        await nextFrame();
+
+        fireDragEnd();
+        await nextFrame();
+        for (const cell of getRowBodyCells(getRows(grid.$.items)[0])) {
+          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
         }
       });
 
@@ -1072,11 +1072,12 @@ describe('drag and drop', () => {
     it('should add/remove drag-source- part when scrolling', () => {
       grid.rowsDraggable = true;
       grid.selectItem(grid.items[0]);
-      const renderedBufferCount = grid.$.items.childElementCount;
       fireDragStart();
 
-      grid.scrollToIndex(renderedBufferCount);
-      expect(getFirstCell(grid).getAttribute('part')).to.not.contain('drag-source-row-cell');
+      // Scroll down so that the drag source cell leaves the viewport
+      grid.scrollToIndex(50);
+      // Expect no cells with drag-source-row-cell part in the DOM
+      expect(grid.$.items.querySelector('tr:not([hidden]) [part~="drag-source-row-cell"]')).to.be.null;
 
       grid.scrollToIndex(0);
       expect(getFirstCell(grid).getAttribute('part')).to.contain('drag-source-row-cell');

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -290,6 +290,21 @@ describe('drag and drop', () => {
         }
       });
 
+      it('should add items to draggedItems array when drag starts', () => {
+        grid.selectItem(grid.items[0]);
+        grid.selectItem(grid.items[1]);
+        fireDragStart();
+
+        expect(grid.__draggedItems.length).to.equal(2);
+      });
+
+      it('should remove items from draggedItems array when drag ends', () => {
+        grid.selectItem(grid.items[0]);
+        fireDragStart();
+
+        fireDragEnd();
+        expect(grid.__draggedItems.length).to.equal(0);
+      });
       // The test only concerns Safari
       const isSafari = /^((?!chrome|android).)*safari/iu.test(navigator.userAgent);
       (isSafari ? it : it.skip)('should use top on Safari for drag image', async () => {

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -302,6 +302,8 @@ describe('drag and drop', () => {
         grid.selectItem(grid.items[0]);
         fireDragStart();
 
+        expect(grid.__draggedItems.length).to.equal(1);
+
         fireDragEnd();
         expect(grid.__draggedItems.length).to.equal(0);
       });

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -254,6 +254,25 @@ describe('drag and drop', () => {
         });
       });
 
+      it('should add drag-source- part to dragged rows', async () => {
+        fireDragStart();
+        await nextFrame();
+        for (const cell of getRowBodyCells(getRows(grid.$.items)[0])) {
+          expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
+        }
+      });
+
+      it('should remove drag-source- part from dragged rows', async () => {
+        fireDragStart();
+        await nextFrame();
+
+        fireDragEnd();
+        await nextFrame();
+        for (const cell of getRowBodyCells(getRows(grid.$.items)[0])) {
+          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
+        }
+      });
+
       it('should add drag-source- part to all dragged rows', async () => {
         grid.selectItem(grid.items[0]);
         grid.selectItem(grid.items[1]);
@@ -266,47 +285,6 @@ describe('drag and drop', () => {
         }
       });
 
-      it('should add drag-source- part only to dragged rows', async () => {
-        fireDragStart();
-        let cells = getRowBodyCells(getRows(grid.$.items)[0]);
-        await nextFrame();
-        for (const cell of cells) {
-          expect(cell.getAttribute('part')).to.contain('drag-source-row-cell');
-        }
-        cells = getRowBodyCells(getRows(grid.$.items)[1]);
-        for (const cell of cells) {
-          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
-        }
-      });
-
-      it('should remove drag-source- part from row when drag ends', async () => {
-        fireDragStart();
-        const row = getRows(grid.$.items)[0];
-        const cells = getRowBodyCells(row);
-        await nextFrame();
-        fireDragEnd();
-        for (const cell of cells) {
-          expect(cell.getAttribute('part')).to.not.contain('drag-source-row-cell');
-        }
-      });
-
-      it('should add items to draggedItems array when drag starts', () => {
-        grid.selectItem(grid.items[0]);
-        grid.selectItem(grid.items[1]);
-        fireDragStart();
-
-        expect(grid.__draggedItems.length).to.equal(2);
-      });
-
-      it('should remove items from draggedItems array when drag ends', () => {
-        grid.selectItem(grid.items[0]);
-        fireDragStart();
-
-        expect(grid.__draggedItems.length).to.equal(1);
-
-        fireDragEnd();
-        expect(grid.__draggedItems.length).to.equal(0);
-      });
       // The test only concerns Safari
       const isSafari = /^((?!chrome|android).)*safari/iu.test(navigator.userAgent);
       (isSafari ? it : it.skip)('should use top on Safari for drag image', async () => {
@@ -1089,6 +1067,20 @@ describe('drag and drop', () => {
       const scrollTop = grid.$.table.scrollTop;
       fireDragOver(grid.__getViewportRows()[0], 'above');
       expect(grid.$.table.scrollTop).to.be.within(scrollTop - 200, scrollTop - 100);
+    });
+
+    it('should add/remove drag-source- part when scrolling', () => {
+      grid.rowsDraggable = true;
+      grid.selectItem(grid.items[0]);
+      const renderedBufferCount = grid.$.items.childElementCount;
+      fireDragStart();
+
+      grid.scrollToIndex(renderedBufferCount);
+      expect(getFirstCell(grid).getAttribute('part')).to.not.contain('drag-source-row-cell');
+
+      grid.scrollToIndex(0);
+      expect(getFirstCell(grid).getAttribute('part')).to.contain('drag-source-row-cell');
+      grid.rowsDraggable = false;
     });
   });
 });

--- a/packages/grid/test/styling.common.js
+++ b/packages/grid/test/styling.common.js
@@ -315,16 +315,5 @@ describe('styling', () => {
       expect(newHeaderCell.getAttribute('part')).to.contain('foobar');
       expect(newFooterCell.getAttribute('part')).to.contain('bazqux');
     });
-
-    it('should add/remove drag-source- part when scrolling', () => {
-      const renderedBufferCount = grid.$.items.childElementCount;
-      grid.__draggedItems = [grid.__getRowModel(grid.$.items.firstElementChild).item];
-
-      grid.scrollToIndex(renderedBufferCount);
-      expect(firstCell.getAttribute('part')).to.not.contain('drag-source-row-cell');
-
-      grid.scrollToIndex(0);
-      expect(firstCell.getAttribute('part')).to.contain('drag-source-row-cell');
-    });
   });
 });

--- a/packages/grid/test/styling.common.js
+++ b/packages/grid/test/styling.common.js
@@ -315,5 +315,16 @@ describe('styling', () => {
       expect(newHeaderCell.getAttribute('part')).to.contain('foobar');
       expect(newFooterCell.getAttribute('part')).to.contain('bazqux');
     });
+
+    it('should add/remove drag-source- part when scrolling', () => {
+      const renderedBufferCount = grid.$.items.childElementCount;
+      grid.__draggedItems = [grid.__getRowModel(grid.$.items.firstElementChild).item];
+
+      grid.scrollToIndex(renderedBufferCount);
+      expect(firstCell.getAttribute('part')).to.not.contain('drag-source-row-cell');
+
+      grid.scrollToIndex(0);
+      expect(firstCell.getAttribute('part')).to.contain('drag-source-row-cell');
+    });
   });
 });


### PR DESCRIPTION
## Description

The drag-source-row-cell part was incorrectly applied and did not get updated by the grid's virtual scrolling. This PR mitigates that by having the grid check the rows against `__draggedItems` to see which should receive the part.

Fixes #7622.

## Type of change

- [X] Bugfix