### PR TITLE
fix: do not restore focus on popover target Shift Tab

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -640,6 +640,12 @@ class Popover extends PopoverPositionMixin(
   __onGlobalShiftTab(event) {
     const overlayPart = this._overlayElement.$.overlay;
 
+    // Prevent restoring focus after target blur on Shift + Tab
+    if (this.target && isElementFocused(this.target) && this.__shouldRestoreFocus) {
+      this.__shouldRestoreFocus = false;
+      return;
+    }
+
     // Move focus back to the target on overlay content Shift + Tab
     if (this.target && isElementFocused(overlayPart)) {
       event.preventDefault();

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -410,5 +410,26 @@ describe('a11y', () => {
       const activeElement = getDeepActiveElement();
       expect(activeElement).to.not.equal(overlay.$.overlay);
     });
+
+    it('should focus previous element on target Shift Tab while opened', async () => {
+      target.parentElement.insertBefore(input, target);
+
+      // Make popover open on focus
+      popover.opened = false;
+      popover.trigger = ['focus'];
+      await nextUpdate(popover);
+
+      target.focus();
+      await nextRender();
+
+      // Move focus back from the target
+      await sendKeys({ down: 'Shift' });
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ up: 'Shift' });
+      await nextRender();
+
+      const activeElement = getDeepActiveElement();
+      expect(activeElement).to.equal(input);
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #7665

Restored logic which was incorrectly removed in #7609 and added a test for <kbd>Shift</kbd> + <kbd>Tab</kbd>.

## Type of change

- Bugfix