### PR TITLE
fix: remove default outline from the popover overlay part

### DIFF
--- a/packages/popover/theme/lumo/vaadin-popover-styles.js
+++ b/packages/popover/theme/lumo/vaadin-popover-styles.js
@@ -15,6 +15,10 @@ const popoverOverlay = css`
     --_vaadin-popover-default-offset: var(--lumo-space-xs);
   }
 
+  [part='overlay'] {
+    outline: none;
+  }
+
   [part='content'] {
     padding: var(--lumo-space-xs) var(--lumo-space-s);
   }

--- a/packages/popover/theme/material/vaadin-popover-styles.js
+++ b/packages/popover/theme/material/vaadin-popover-styles.js
@@ -12,6 +12,10 @@ const popoverOverlay = css`
     --_vaadin-popover-default-offset: 0.25rem;
   }
 
+  [part='overlay'] {
+    outline: none;
+  }
+
   [part='content'] {
     padding: 0.25rem 0.5rem;
   }


### PR DESCRIPTION
## Description

Fixes #7667

This aligns the appearance with `vaadin-dialog` which was introduced https://github.com/vaadin/vaadin-dialog/pull/63

## Type of change

- Bugfix