### PR TITLE
fix: set display to none on the popover host element

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './vaadin-popover-overlay.js';
-import { html, LitElement } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import {
   getDeepActiveElement,
@@ -188,6 +188,14 @@ class Popover extends PopoverPositionMixin(
 ) {
   static get is() {
     return 'vaadin-popover';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: none !important;
+      }
+    `;
   }
 
   static get properties() {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -29,6 +29,17 @@ describe('popover', () => {
     });
   });
 
+  describe('host element', () => {
+    it('should set display: none on the host element by default', () => {
+      expect(getComputedStyle(popover).display).to.equal('none');
+    });
+
+    it('should enforce display: none to hide the host element', () => {
+      popover.style.display = 'block';
+      expect(getComputedStyle(popover).display).to.equal('none');
+    });
+  });
+
   describe('renderer', () => {
     let renderer;
 


### PR DESCRIPTION
## Description

This fixes a DX test finding related to extra gap when adding `vaadin-popover` to `vaadin-vertical-layout` with `spacing` theme variant. Also, this way we align behavior with other overlay based components like dialog, see #3597.

## Type of change

- Bugfix