### PR TITLE
fix: propagate checkbox required attribute to input

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -86,7 +86,7 @@ export const CheckboxMixin = (superclass) =>
 
     /** @override */
     static get delegateAttrs() {
-      return [...super.delegateAttrs, 'name', 'invalid'];
+      return [...super.delegateAttrs, 'name', 'invalid', 'required'];
     }
 
     constructor() {

--- a/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
+++ b/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
@@ -195,6 +195,7 @@ snapshots["vaadin-checkbox host required"] =
   </div>
   <input
     id="input-vaadin-checkbox-3"
+    required=""
     slot="input"
     tabindex="0"
     type="checkbox"


### PR DESCRIPTION
## Description

When implementing `required` state in #7285 for some reason I didn't add `required` attribute propagation.

Tested this with VoiceOver on Chrome and Safari and the `required` state is now announced:

<img width="372" alt="Screenshot 2024-08-19 at 16 14 54" src="https://github.com/user-attachments/assets/d0a89ab8-db6d-4757-91dd-7f8b90ff74f7">
<img width="376" alt="Screenshot 2024-08-19 at 16 15 10" src="https://github.com/user-attachments/assets/fa5cf388-fcc3-4511-b6eb-8a832d4851da">

## Type of change

- Bugfix