### PR TITLE
docs: add missing mixes JSDoc annotation to popover

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -178,7 +178,7 @@ class PopoverOpenedStateController {
  * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin
- * @mixes ElementMixin
+ * @mixes OverlayClassMixin
  * @mixes PopoverPositionMixin
  * @mixes PopoverTargetMixin
  * @mixes ThemePropertyMixin


### PR DESCRIPTION
## Description

The `@mixes` annotation for `ElementMixin` is specified twice while `OverlayClassMixin` is missing. This PR fixes that.

## Type of change

- Documentation