### PR TITLE
feat: allow matching navigation hierarchies with side nav item

### DIFF
--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -29,15 +29,15 @@ function containsQueryParams(actual, expected) {
  * @param {string} expected The expected URL to match.
  * @param {Object} matchOptions Options for path matching.
  */
-export function matchPaths(actual, expected, matchOptions = { exact: true }) {
+export function matchPaths(actual, expected, matchOptions = { matchNested: false }) {
   const base = document.baseURI;
   const actualUrl = new URL(actual, base);
   const expectedUrl = new URL(expected, base);
 
   const matchesOrigin = actualUrl.origin === expectedUrl.origin;
-  const matchesPath = matchOptions.exact
-    ? actualUrl.pathname === expectedUrl.pathname
-    : actualUrl.pathname === expectedUrl.pathname || actualUrl.pathname.startsWith(`${expectedUrl.pathname}/`);
+  const matchesPath = matchOptions.matchNested
+    ? actualUrl.pathname === expectedUrl.pathname || actualUrl.pathname.startsWith(`${expectedUrl.pathname}/`)
+    : actualUrl.pathname === expectedUrl.pathname;
 
   return matchesOrigin && matchesPath && containsQueryParams(actualUrl.searchParams, expectedUrl.searchParams);
 }

--- a/packages/component-base/src/url-utils.js
+++ b/packages/component-base/src/url-utils.js
@@ -27,15 +27,17 @@ function containsQueryParams(actual, expected) {
  *
  * @param {string} actual The actual URL to match.
  * @param {string} expected The expected URL to match.
+ * @param {Object} matchOptions Options for path matching.
  */
-export function matchPaths(actual, expected) {
+export function matchPaths(actual, expected, matchOptions = { exact: true }) {
   const base = document.baseURI;
   const actualUrl = new URL(actual, base);
   const expectedUrl = new URL(expected, base);
 
-  return (
-    actualUrl.origin === expectedUrl.origin &&
-    actualUrl.pathname === expectedUrl.pathname &&
-    containsQueryParams(actualUrl.searchParams, expectedUrl.searchParams)
-  );
+  const matchesOrigin = actualUrl.origin === expectedUrl.origin;
+  const matchesPath = matchOptions.exact
+    ? actualUrl.pathname === expectedUrl.pathname
+    : actualUrl.pathname === expectedUrl.pathname || actualUrl.pathname.startsWith(`${expectedUrl.pathname}/`);
+
+  return matchesOrigin && matchesPath && containsQueryParams(actualUrl.searchParams, expectedUrl.searchParams);
 }

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -50,6 +50,29 @@ describe('url-utils', () => {
       expect(matchPaths('https://vaadin.com/docs/components', 'components')).to.be.true;
     });
 
+    describe('exact option', () => {
+      it('should match the exact path by default', () => {
+        expect(matchPaths('/users', '/users')).to.be.true;
+        expect(matchPaths('/users/', '/users')).to.be.false;
+        expect(matchPaths('/users/john', '/users')).to.be.false;
+        expect(matchPaths('/usersessions', '/users')).to.be.false;
+      });
+
+      it('should match the exact path when exact is true', () => {
+        expect(matchPaths('/users', '/users', { exact: true })).to.be.true;
+        expect(matchPaths('/users/', '/users', { exact: true })).to.be.false;
+        expect(matchPaths('/users/john', '/users', { exact: true })).to.be.false;
+        expect(matchPaths('/usersessions', '/users', { exact: true })).to.be.false;
+      });
+
+      it('should match the path prefix when exact is false', () => {
+        expect(matchPaths('/users', '/users', { exact: false })).to.be.true;
+        expect(matchPaths('/users/', '/users', { exact: false })).to.be.true;
+        expect(matchPaths('/users/john', '/users', { exact: false })).to.be.true;
+        expect(matchPaths('/usersessions', '/users', { exact: false })).to.be.false;
+      });
+    });
+
     describe('query params', () => {
       it('should return true when query params match', () => {
         expect(matchPaths('/products', '/products')).to.be.true;

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -69,7 +69,7 @@ describe('url-utils', () => {
         expect(matchPaths('/users', '/users', { matchNested: true })).to.be.true;
         expect(matchPaths('/users/', '/users', { matchNested: true })).to.be.true;
         expect(matchPaths('/users/john', '/users', { matchNested: true })).to.be.true;
-        expect(matchPaths('/usersessions', '/users', { matchNested: false })).to.be.false;
+        expect(matchPaths('/usersessions', '/users', { matchNested: true })).to.be.false;
       });
     });
 

--- a/packages/component-base/test/url-utils.test.js
+++ b/packages/component-base/test/url-utils.test.js
@@ -50,7 +50,7 @@ describe('url-utils', () => {
       expect(matchPaths('https://vaadin.com/docs/components', 'components')).to.be.true;
     });
 
-    describe('exact option', () => {
+    describe('matchNested option', () => {
       it('should match the exact path by default', () => {
         expect(matchPaths('/users', '/users')).to.be.true;
         expect(matchPaths('/users/', '/users')).to.be.false;
@@ -58,18 +58,18 @@ describe('url-utils', () => {
         expect(matchPaths('/usersessions', '/users')).to.be.false;
       });
 
-      it('should match the exact path when exact is true', () => {
-        expect(matchPaths('/users', '/users', { exact: true })).to.be.true;
-        expect(matchPaths('/users/', '/users', { exact: true })).to.be.false;
-        expect(matchPaths('/users/john', '/users', { exact: true })).to.be.false;
-        expect(matchPaths('/usersessions', '/users', { exact: true })).to.be.false;
+      it('should match the exact path when matchNested is false', () => {
+        expect(matchPaths('/users', '/users', { matchNested: false })).to.be.true;
+        expect(matchPaths('/users/', '/users', { matchNested: false })).to.be.false;
+        expect(matchPaths('/users/john', '/users', { matchNested: false })).to.be.false;
+        expect(matchPaths('/usersessions', '/users', { matchNested: false })).to.be.false;
       });
 
-      it('should match the path prefix when exact is false', () => {
-        expect(matchPaths('/users', '/users', { exact: false })).to.be.true;
-        expect(matchPaths('/users/', '/users', { exact: false })).to.be.true;
-        expect(matchPaths('/users/john', '/users', { exact: false })).to.be.true;
-        expect(matchPaths('/usersessions', '/users', { exact: false })).to.be.false;
+      it('should match nested paths when matchNested is true', () => {
+        expect(matchPaths('/users', '/users', { matchNested: true })).to.be.true;
+        expect(matchPaths('/users/', '/users', { matchNested: true })).to.be.true;
+        expect(matchPaths('/users/john', '/users', { matchNested: true })).to.be.true;
+        expect(matchPaths('/usersessions', '/users', { matchNested: false })).to.be.false;
       });
     });
 

--- a/packages/side-nav/src/location.js
+++ b/packages/side-nav/src/location.js
@@ -1,8 +1,13 @@
 /**
+ * @license
+ * Copyright (c) 2023 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
  * Facade for `document.location`, can be stubbed for testing.
  *
  * For internal use only.
- *
  */
 export const location = {
   get pathname() {

--- a/packages/side-nav/src/location.js
+++ b/packages/side-nav/src/location.js
@@ -1,0 +1,14 @@
+/**
+ * Facade for `document.location`, can be stubbed for testing.
+ *
+ * For internal use only.
+ *
+ */
+export const location = {
+  get pathname() {
+    return document.location.pathname;
+  },
+  get search() {
+    return document.location.search;
+  },
+};

--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -94,29 +94,27 @@ declare class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixi
   expanded: boolean;
 
   /**
-   * Whether to use exact matching when comparing the item's path with the
-   * current browser URL, or not. `true` by default.
+   * Whether to also match nested paths / routes. `false` by default.
    *
-   * With exact matching, the item is considered current only when the paths
-   * are exactly the same. With non-exact matching, the item is considered
-   * current when the item's path is a prefix of the pathname of the current
-   * browser URL. For example, with exact matching, an item with the path
-   * `/path` is considered current only when the browser URL is `/path`.
-   * With non-exact matching, an item with the path `/path` is considered
-   * current when the browser URL is `/path`, `/path/child`,
-   * `/path/child/grandchild`, etc.
+   * When enabled, an item with the path `/path` is considered current when
+   * the browser URL is `/path`, `/path/child`, `/path/child/grandchild`,
+   * etc.
    *
    * Note that this only affects matching of the URLs path, not the base
    * origin or query parameters.
+   *
+   * @attr {boolean} match-nested
    */
-  matchExact: boolean;
+  matchNested: boolean;
 
   /**
    * Whether the item's path matches the current browser URL.
    *
    * A match occurs when both share the same base origin (like https://example.com),
-   * the same path (like /path/to/page), and the browser URL contains all
-   * the query parameters with the same values from the item's path.
+   * the same path (like /path/to/page), and the browser URL contains at least
+   * all the query parameters with the same values from the item's path.
+   *
+   * See [`matchNested`](#/elements/vaadin-side-nav-item#property-matchNested) for how to change the path matching behavior.
    *
    * The state is updated when the item is added to the DOM or when the browser
    * navigates to a new page.

--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -109,7 +109,7 @@ declare class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixi
    * Note that this only affects matching of the URLs path, not the base
    * origin or query parameters.
    */
-  exact: boolean;
+  matchExact: boolean;
 
   /**
    * Whether the item's path matches the current browser URL.

--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -94,6 +94,24 @@ declare class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixi
   expanded: boolean;
 
   /**
+   * Whether to use exact matching when comparing the item's path with the
+   * current browser URL, or not. `true` by default.
+   *
+   * With exact matching, the item is considered current only when the paths
+   * are exactly the same. With non-exact matching, the item is considered
+   * current when the item's path is a prefix of the pathname of the current
+   * browser URL. For example, with exact matching, an item with the path
+   * `/path` is considered current only when the browser URL is `/path`.
+   * With non-exact matching, an item with the path `/path` is considered
+   * current when the browser URL is `/path`, `/path/child`,
+   * `/path/child/grandchild`, etc.
+   *
+   * Note that this only affects matching of the URLs path, not the base
+   * origin or query parameters.
+   */
+  exact: boolean;
+
+  /**
    * Whether the item's path matches the current browser URL.
    *
    * A match occurs when both share the same base origin (like https://example.com),

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -133,7 +133,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
        *
        * @type {boolean}
        */
-      exact: {
+      matchExact: {
         type: Boolean,
         value: true,
       },
@@ -331,7 +331,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
     }
 
     const browserPath = `${location.pathname}${location.search}`;
-    const matchOptions = { exact: this.exact };
+    const matchOptions = { exact: this.matchExact };
     return (
       matchPaths(browserPath, this.path, matchOptions) ||
       this.pathAliases.some((alias) => matchPaths(browserPath, alias, matchOptions))

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -116,26 +116,21 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
       },
 
       /**
-       * Whether to use exact matching when comparing the item's path with the
-       * current browser URL, or not. `true` by default.
+       * Whether to also match nested paths / routes. `false` by default.
        *
-       * With exact matching, the item is considered current only when the paths
-       * are exactly the same. With non-exact matching, the item is considered
-       * current when the item's path is a prefix of the pathname of the current
-       * browser URL. For example, with exact matching, an item with the path
-       * `/path` is considered current only when the browser URL is `/path`.
-       * With non-exact matching, an item with the path `/path` is considered
-       * current when the browser URL is `/path`, `/path/child`,
-       * `/path/child/grandchild`, etc.
+       * When enabled, an item with the path `/path` is considered current when
+       * the browser URL is `/path`, `/path/child`, `/path/child/grandchild`,
+       * etc.
        *
        * Note that this only affects matching of the URLs path, not the base
        * origin or query parameters.
        *
        * @type {boolean}
+       * @attr {boolean} match-nested
        */
-      matchExact: {
+      matchNested: {
         type: Boolean,
-        value: true,
+        value: false,
       },
 
       /**
@@ -145,7 +140,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
        * the same path (like /path/to/page), and the browser URL contains at least
        * all the query parameters with the same values from the item's path.
        *
-       * See the `exact` property for how to change the path matching behavior.
+       * See [`matchNested`](#/elements/vaadin-side-nav-item#property-matchNested) for how to change the path matching behavior.
        *
        * The state is updated when the item is added to the DOM or when the browser
        * navigates to a new page.
@@ -216,7 +211,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
   updated(props) {
     super.updated(props);
 
-    if (props.has('path') || props.has('pathAliases') || props.has('exact')) {
+    if (props.has('path') || props.has('pathAliases') || props.has('matchNested')) {
       this.__updateCurrent();
     }
 
@@ -331,7 +326,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
     }
 
     const browserPath = `${location.pathname}${location.search}`;
-    const matchOptions = { exact: this.matchExact };
+    const matchOptions = { matchNested: this.matchNested };
     return (
       matchPaths(browserPath, this.path, matchOptions) ||
       this.pathAliases.some((alias) => matchPaths(browserPath, alias, matchOptions))

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -284,7 +284,7 @@ describe('side-nav-item', () => {
     });
   });
 
-  describe('exact', () => {
+  describe('matchExact', () => {
     let currentPath = '/';
     let pathnameStub;
 
@@ -297,7 +297,7 @@ describe('side-nav-item', () => {
 
     it('should be true by default', () => {
       item = fixtureSync('<vaadin-side-nav-item></vaadin-side-nav-item>');
-      expect(item.exact).to.be.true;
+      expect(item.matchExact).to.be.true;
     });
 
     it('it should match exact path when exact is true', () => {
@@ -313,13 +313,13 @@ describe('side-nav-item', () => {
     it('should match path prefix when exact is false', async () => {
       currentPath = '/users';
       item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
-      item.exact = false;
+      item.matchExact = false;
       await item.updateComplete;
       expect(item.current).to.be.true;
 
       currentPath = '/users/john';
       item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
-      item.exact = false;
+      item.matchExact = false;
       await item.updateComplete;
       expect(item.current).to.be.true;
     });

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -284,23 +284,24 @@ describe('side-nav-item', () => {
     });
   });
 
-  describe('matchExact', () => {
+  describe('matchNested', () => {
     let currentPath = '/';
     let pathnameStub;
 
     beforeEach(() => {
       pathnameStub = sinon.stub(location, 'pathname').get(() => currentPath);
     });
+
     afterEach(() => {
       pathnameStub.restore();
     });
 
-    it('should be true by default', () => {
+    it('should be false by default', () => {
       item = fixtureSync('<vaadin-side-nav-item></vaadin-side-nav-item>');
-      expect(item.matchExact).to.be.true;
+      expect(item.matchNested).to.be.false;
     });
 
-    it('it should match exact path when exact is true', () => {
+    it('should match exact path when matchNested is false', () => {
       currentPath = '/users';
       item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
       expect(item.current).to.be.true;
@@ -310,16 +311,23 @@ describe('side-nav-item', () => {
       expect(item.current).to.be.false;
     });
 
-    it('should match path prefix when exact is false', async () => {
+    it('should match nested paths when matchNested is true', () => {
       currentPath = '/users';
-      item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
-      item.matchExact = false;
-      await item.updateComplete;
+      item = fixtureSync('<vaadin-side-nav-item path="/users" match-nested></vaadin-side-nav-item>');
       expect(item.current).to.be.true;
 
       currentPath = '/users/john';
+      item = fixtureSync('<vaadin-side-nav-item path="/users" match-nested></vaadin-side-nav-item>');
+      expect(item.current).to.be.true;
+    });
+
+    it('should update when toggling matchNested', async () => {
+      currentPath = '/users/john';
       item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
-      item.matchExact = false;
+      await item.updateComplete;
+      expect(item.current).to.be.false;
+
+      item.matchNested = true;
       await item.updateComplete;
       expect(item.current).to.be.true;
     });

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -2,6 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-side-nav-item.js';
+import { location } from '../src/location.js';
 
 describe('side-nav-item', () => {
   let item, documentBaseURI;
@@ -280,6 +281,47 @@ describe('side-nav-item', () => {
         content.click();
         expect(spy.called).to.be.false;
       });
+    });
+  });
+
+  describe('exact', () => {
+    let currentPath = '/';
+    let pathnameStub;
+
+    beforeEach(() => {
+      pathnameStub = sinon.stub(location, 'pathname').get(() => currentPath);
+    });
+    afterEach(() => {
+      pathnameStub.restore();
+    });
+
+    it('should be true by default', () => {
+      item = fixtureSync('<vaadin-side-nav-item></vaadin-side-nav-item>');
+      expect(item.exact).to.be.true;
+    });
+
+    it('it should match exact path when exact is true', () => {
+      currentPath = '/users';
+      item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
+      expect(item.current).to.be.true;
+
+      currentPath = '/users/john';
+      item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
+      expect(item.current).to.be.false;
+    });
+
+    it('should match path prefix when exact is false', async () => {
+      currentPath = '/users';
+      item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
+      item.exact = false;
+      await item.updateComplete;
+      expect(item.current).to.be.true;
+
+      currentPath = '/users/john';
+      item = fixtureSync('<vaadin-side-nav-item path="/users"></vaadin-side-nav-item>');
+      item.exact = false;
+      await item.updateComplete;
+      expect(item.current).to.be.true;
     });
   });
 


### PR DESCRIPTION
Adds a `matchNested` property to `vaadin-side-nav-item` that allows an item to match nested paths. When enabled, then an item with the path `/users` does not only match `/users`, but also `/users/1`, `/users/1/permissions`, etc.

For context, the Flow `RouterLink` and React Router `NavLink` have similar options:
- `RouterLink` allows setting a `HighlightCondition` that determines whether the link is considered active or not. The most useful default implementations are `HighlightConditions.sameLocation` (exact match) and `HighlightConditions.locationPrefix` (match prefix).
- `NavLink` has an `end` property to force exact matching, otherwise it matches by prefix.

Note that both `RouterLink` and `NavLink` use prefix matching by default, while side nav item would keep using exact matching by default. For now we keep the default behavior to avoid breaking changes. We can consider aligning the defaults in a future major.

Closes https://github.com/vaadin/flow-components/issues/5227