### PR TITLE
fix: remove target listeners when popover is detached

### DIFF
--- a/packages/popover/src/vaadin-popover-target-mixin.js
+++ b/packages/popover/src/vaadin-popover-target-mixin.js
@@ -39,6 +39,24 @@ export const PopoverTargetMixin = (superClass) =>
       };
     }
 
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (this.target) {
+        this._addTargetListeners(this.target);
+      }
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      if (this.target) {
+        this._removeTargetListeners(this.target);
+      }
+    }
+
     /** @private */
     __forChanged(forId) {
       if (forId) {

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -61,6 +61,23 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.false;
     });
 
+    it('should not open on target click when detached', async () => {
+      popover.remove();
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open on target click when re-attached', async () => {
+      popover.remove();
+      await nextRender();
+      target.parentNode.appendChild(popover);
+
+      target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
     it('should not open on target mouseenter', async () => {
       mouseenter(target);
       await nextRender();
@@ -129,6 +146,23 @@ describe('trigger', () => {
       mouseleave(overlay, target);
       await nextUpdate(popover);
 
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not open on target mouseenter when detached', async () => {
+      popover.remove();
+      mouseenter(target);
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open on target mouseenter when re-attached', async () => {
+      popover.remove();
+      await nextRender();
+      target.parentNode.appendChild(popover);
+
+      mouseenter(target);
+      await nextRender();
       expect(overlay.opened).to.be.true;
     });
   });
@@ -202,6 +236,23 @@ describe('trigger', () => {
 
       // Emulate click without focus change
       target.click();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not open on target focusin when detached', async () => {
+      popover.remove();
+      focusin(target);
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open on target focusin when re-attached', async () => {
+      popover.remove();
+      await nextRender();
+      target.parentNode.appendChild(popover);
+
+      focusin(target);
       await nextRender();
       expect(overlay.opened).to.be.true;
     });


### PR DESCRIPTION
## Description

Fixes #7683

This removes `target` event listeners when `vaadin-popover` is disconnected from the DOM, and restores them in case it is re-connected later. 

## Type of change

- Bugfix

## Note

There might be a case when `target` is set before adding `vaadin-popover` to the DOM, causing event listeners to be added twice. According to the [spec](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget-addEventListener) this is not a problem as duplicate listeners are discarded:

> If multiple identical [EventListener](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventListener)s are registered on the same EventTarget with the same parameters the duplicate instances are discarded. They do not cause the [EventListener](https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventListener) to be called twice and since they are discarded they do not need to be removed with the removeEventListener method.

I tested this manually and confirmed this doesn't cause problems, so I think we don't need to have some flags to prevent it.