### PR TITLE
fix: reset hidden state when removing panel from tabsheet

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.js
@@ -141,13 +141,25 @@ export const TabSheetMixin = (superClass) =>
 
       // Observe the panels slot for nodes. Set the assigned element nodes as the __panels array.
       const panelSlot = this.shadowRoot.querySelector('#panel-slot');
-      this.__panelsObserver = new SlotObserver(panelSlot, ({ removedNodes }) => {
+      this.__panelsObserver = new SlotObserver(panelSlot, ({ addedNodes, removedNodes }) => {
+        if (addedNodes.length) {
+          addedNodes.forEach((node) => {
+            // Preserve custom hidden attribute to not override it.
+            if (node.nodeType === Node.ELEMENT_NODE && node.hidden) {
+              node.__customHidden = true;
+            }
+          });
+        }
         if (removedNodes.length) {
           removedNodes.forEach((node) => {
             // Clear hidden attribute when removing node from the default slot,
             // e.g. when changing its slot to `prefix` or `suffix` dynamically.
             if (node.nodeType === Node.ELEMENT_NODE && node.hidden) {
-              node.hidden = false;
+              if (node.__customHidden) {
+                delete node.__customHidden;
+              } else {
+                node.hidden = false;
+              }
             }
           });
         }

--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.js
@@ -141,7 +141,16 @@ export const TabSheetMixin = (superClass) =>
 
       // Observe the panels slot for nodes. Set the assigned element nodes as the __panels array.
       const panelSlot = this.shadowRoot.querySelector('#panel-slot');
-      this.__panelsObserver = new SlotObserver(panelSlot, () => {
+      this.__panelsObserver = new SlotObserver(panelSlot, ({ removedNodes }) => {
+        if (removedNodes.length) {
+          removedNodes.forEach((node) => {
+            // Clear hidden attribute when removing node from the default slot,
+            // e.g. when changing its slot to `prefix` or `suffix` dynamically.
+            if (node.nodeType === Node.ELEMENT_NODE && node.hidden) {
+              node.hidden = false;
+            }
+          });
+        }
         this.__panels = Array.from(
           panelSlot.assignedNodes({
             flatten: true,

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -186,6 +186,17 @@ describe('tabsheet', () => {
 
       expect(panel.id).to.equal('custom-id');
     });
+
+    it('should reset hidden state when removing a panel', async () => {
+      const div = document.createElement('div');
+      tabsheet.appendChild(div);
+      await nextFrame();
+      expect(div.hidden).to.be.true;
+
+      div.setAttribute('slot', 'prefix');
+      await nextFrame();
+      expect(div.hidden).to.be.false;
+    });
   });
 
   describe('loading', () => {

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -197,6 +197,19 @@ describe('tabsheet', () => {
       await nextFrame();
       expect(div.hidden).to.be.false;
     });
+
+    it('should not remove explicit hidden state', async () => {
+      const div = document.createElement('div');
+      // Prefix component explicitly marked as hidden
+      div.hidden = true;
+      tabsheet.appendChild(div);
+      await nextFrame();
+
+      div.setAttribute('slot', 'prefix');
+      await nextFrame();
+
+      expect(div.hidden).to.be.true;
+    });
   });
 
   describe('loading', () => {


### PR DESCRIPTION
## Description

This fixes a finding with React component reported internally on Slack:

```jsx
<TabSheet>
  <Button>Close all</Button>
  <TabSheetTab label="One" />
  <TabSheetTab label="Two" />
  <TabSheetTab label="Three" />
</TabSheet>
```

> add the missing `slot="prefix"` to `<Button>` - how come the UI is not updated with HMR but requires a refresh?

The actual problem is that the web component treats any elements without `slot` attribute as panels and then doesn’t reset `hidden` attribute when the `slot` is set (or e.g. when the element is moved to the different parent).

## Type of change

- Bugfix

## Note

There is an edge case with `hidden` set initially on the panel before adding it to tabsheet - it will be reset to `false` on removing. I don't think it's a big problem