### PR TITLE
test: use playwright for chrome tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Install Playwright
-        run: npx playwright install-deps chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Test
         run: yarn test
@@ -46,7 +46,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Install Playwright
-        run: npx playwright install-deps firefox
+        run: npx playwright install --with-deps firefox
 
       - name: Test
         run: yarn test:firefox
@@ -68,7 +68,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Install Playwright
-        run: npx playwright install-deps webkit
+        run: npx playwright install --with-deps webkit
 
       - name: Test
         run: yarn test:webkit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
+      - name: Install Playwright
+        run: npx playwright install-deps chromium
+
       - name: Test
         run: yarn test
   firefox:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
+      - name: Install Playwright
+        run: npx playwright install-deps chromium
+
       - name: Test
         run: yarn test:snapshots
   integration:
@@ -64,6 +67,9 @@ jobs:
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
+
+      - name: Install Playwright
+        run: npx playwright install-deps chromium
 
       - name: Test
         run: yarn test:it

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Install Playwright
-        run: npx playwright install-deps chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Test
         run: yarn test:snapshots
@@ -69,7 +69,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Install Playwright
-        run: npx playwright install-deps chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Test
         run: yarn test:it

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     "stylelint-config-vaadin": "^1.0.0-alpha.1",
     "typescript": "^5.5.2"
   },
+  "resolutions": {
+    "playwright": "^1.46.1"
+  },
   "lint-staged": {
     "*.{js,ts}": [
       "eslint --fix",

--- a/web-test-runner-it.config.js
+++ b/web-test-runner-it.config.js
@@ -1,16 +1,10 @@
 /* eslint-env node */
-const { chromeLauncher } = require('@web/test-runner-chrome');
+const { playwrightLauncher } = require('@web/test-runner-playwright');
 const { createIntegrationTestsConfig } = require('./wtr-utils.js');
 const devServerConfig = require('./web-dev-server.config.js');
 
 const unitTestsConfig = createIntegrationTestsConfig({
-  browsers: [
-    chromeLauncher({
-      launchOptions: {
-        headless: 'shell',
-      },
-    }),
-  ],
+  browsers: [playwrightLauncher({ product: 'chromium' })],
 });
 
 module.exports = {

--- a/web-test-runner-snapshots.config.js
+++ b/web-test-runner-snapshots.config.js
@@ -1,13 +1,7 @@
 /* eslint-env node */
-const { chromeLauncher } = require('@web/test-runner-chrome');
+const { playwrightLauncher } = require('@web/test-runner-playwright');
 const { createSnapshotTestsConfig } = require('./wtr-utils.js');
 
 module.exports = createSnapshotTestsConfig({
-  browsers: [
-    chromeLauncher({
-      launchOptions: {
-        headless: 'shell',
-      },
-    }),
-  ],
+  browsers: [playwrightLauncher({ product: 'chromium' })],
 });

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,16 +1,10 @@
 /* eslint-env node */
-const { chromeLauncher } = require('@web/test-runner-chrome');
+const { playwrightLauncher } = require('@web/test-runner-playwright');
 const { createUnitTestsConfig } = require('./wtr-utils.js');
 const devServerConfig = require('./web-dev-server.config.js');
 
 const unitTestsConfig = createUnitTestsConfig({
-  browsers: [
-    chromeLauncher({
-      launchOptions: {
-        headless: 'shell',
-      },
-    }),
-  ],
+  browsers: [playwrightLauncher({ product: 'chromium' })],
   coverageConfig: {
     include: ['packages/**/src/**/*', 'packages/*/*.js'],
     threshold: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6209,6 +6209,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2, fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -6216,11 +6221,6 @@ fsevents@^1.2.7:
   dependencies:
     bindings "^1.5.0"
     nan "^2.12.1"
-
-fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1, function-bind@^1.1.2:
   version "1.1.2"
@@ -10392,17 +10392,19 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.24.2.tgz#47bc5adf3dcfcc297a5a7a332449c9009987db26"
-  integrity sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==
+playwright-core@1.46.1:
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.46.1.tgz#28f3ab35312135dda75b0c92a3e5c0e7edb9cc8b"
+  integrity sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==
 
-playwright@^1.22.2:
-  version "1.24.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.24.2.tgz#51e60f128b386023e5ee83deca23453aaf73ba6d"
-  integrity sha512-iMWDLgaFRT+7dXsNeYwgl8nhLHsUrzFyaRVC+ftr++P1dVs70mPrFKBZrGp1fOKigHV9d1syC03IpPbqLKlPsg==
+playwright@1.46.1, playwright@^1.22.2:
+  version "1.46.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.46.1.tgz#ea562bc48373648e10420a10c16842f0b227c218"
+  integrity sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==
   dependencies:
-    playwright-core "1.24.2"
+    playwright-core "1.46.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 plexer@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Using the latest Chrome version (128) together with `@web/test-runner-chrome`, which uses puppeteer under the hood, results in a number of test failures related to focus handling, native key presses and timeouts for certain actions.

For now switch to `@web/test-runner-playwright` for Chrome, Snapshot and IT tests, which seems to work fine.