### PR TITLE
fix: reset overlay position target to avoid closing after items change

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -937,6 +937,13 @@ export const MenuBarMixin = (superClass) =>
       this._expandedButton = button;
 
       requestAnimationFrame(async () => {
+        // After changing items, buttons are recreated so the old button is
+        // no longer in the DOM. Reset position target to null to prevent
+        // overlay from closing due to target width / height equal to 0.
+        if (overlay.positionTarget && !overlay.positionTarget.isConnected) {
+          overlay.positionTarget = null;
+        }
+
         button.dispatchEvent(
           new CustomEvent('opensubmenu', {
             detail: {

--- a/packages/menu-bar/test/sub-menu.common.js
+++ b/packages/menu-bar/test/sub-menu.common.js
@@ -412,6 +412,22 @@ describe('sub-menu', () => {
     expect(subMenu.opened).to.be.true;
   });
 
+  it('should reopen sub-menu after updating items', async () => {
+    buttons[0].click();
+    await nextRender();
+
+    document.body.click();
+    await nextRender();
+
+    menu.items = [menu.items[0]];
+    await nextRender();
+
+    buttons = menu._buttons;
+    buttons[0].click();
+    await nextRender();
+    expect(subMenu.opened).to.be.true;
+  });
+
   it('should dispatch item-selected event on leaf button click', () => {
     const spy = sinon.spy();
     menu.addEventListener('item-selected', spy);


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6580
Fixes https://github.com/vaadin/flow-components/issues/6577

The issue is caused by the fact that I removed setting `positionTarget` to `undefined` in #7524 and therefore by the first time `_updatePosition()` is called, the `positionTarget` still contains a reference to the old menu-bar button which is no longer in the DOM. And then `getBoundingClientRect().width` for this button is `0` and that closes overlay since #7454.

## Type of change

- Bugfix