### PR TITLE
fix: allow focus rings on pointer coarse devices

### DIFF
--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -136,8 +136,8 @@ registerStyles(
     }
 
     @media (pointer: coarse) {
-      :host(:not([focus-ring])) [part~='focused']:not([part~='selected'])::before,
       [part~='date']:hover:not([part~='selected'])::before {
+        :host(: not([focus-ring])) [part~='focused']:not([part~='selected'])::before,
         display: none;
       }
 

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -136,17 +136,12 @@ registerStyles(
     }
 
     @media (pointer: coarse) {
-      [part~='date']:hover:not([part~='selected'])::before,
-      [part~='focused']:not([part~='selected'])::before {
+      [part~='date']:hover:not([part~='selected'])::before {
         display: none;
       }
 
       [part~='date']:not(:empty):not([part~='disabled']):active::before {
         display: block;
-      }
-
-      [part~='date'][part~='selected']::before {
-        box-shadow: none;
       }
     }
 

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -136,6 +136,7 @@ registerStyles(
     }
 
     @media (pointer: coarse) {
+      :host(:not([focus-ring])) [part~='focused']:not([part~='selected'])::before,
       [part~='date']:hover:not([part~='selected'])::before {
         display: none;
       }
@@ -143,8 +144,11 @@ registerStyles(
       [part~='date']:not(:empty):not([part~='disabled']):active::before {
         display: block;
       }
-    }
 
+      :host(:not([focus-ring])) [part~='date'][part~='selected']::before {
+        box-shadow: none;
+      }
+    }
     /* Disabled */
 
     :host([disabled]) * {

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -136,8 +136,8 @@ registerStyles(
     }
 
     @media (pointer: coarse) {
-      [part~='date']:hover:not([part~='selected'])::before {
-        :host(: not([focus-ring])) [part~='focused']:not([part~='selected'])::before,
+      [part~='date']:hover:not([part~='selected'])::before,
+      :host(:not([focus-ring])) [part~='focused']:not([part~='selected'])::before {
         display: none;
       }
 


### PR DESCRIPTION
## Description

Basically just changes the CSS selectors that remove focus related styles on pointer: coarse to only work when the parent month-calendar does not have the focus-ring attribute. In other words, do not hide the focus ring when the user is keyboard navigating on a touch device.

Fixes #6381 

## Type of change

- [X] Bugfix
