### PR TITLE
refactor: remove no longer needed global keyframes declaration

### DIFF
--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -158,17 +158,3 @@ registerStyles(
   `,
   { moduleId: 'lumo-month-calendar' },
 );
-
-const template = document.createElement('template');
-
-template.innerHTML = `
-  <style>
-    @keyframes vaadin-date-picker-month-calendar-focus-date {
-      50% {
-        box-shadow: 0 0 0 var(--_focus-ring-width) transparent;
-      }
-    }
-  </style>
-`;
-
-document.head.appendChild(template.content);

--- a/packages/progress-bar/theme/lumo/vaadin-progress-bar-styles.js
+++ b/packages/progress-bar/theme/lumo/vaadin-progress-bar-styles.js
@@ -274,23 +274,3 @@ registerStyles(
   `,
   { moduleId: 'lumo-progress-bar' },
 );
-
-const template = document.createElement('template');
-
-/* Safari fails to declare animations for pseudo elements inside a shadow DOM */
-template.innerHTML = `
-  <style>
-    @keyframes vaadin-progress-pulse3 {
-      0% { opacity: 1; }
-      10% { opacity: 0; }
-      40% { opacity: 0; }
-      50% { opacity: 1; }
-      50.1% { opacity: 1; }
-      60% { opacity: 0; }
-      90% { opacity: 0; }
-      100% { opacity: 1; }
-    }
-  </style>
-`;
-
-document.head.appendChild(template.content);


### PR DESCRIPTION
## Description

These `@keyframes` are copied from corresponding shadow DOM styles due to the old [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=173027) with Safari not animating `::before` and `::after` correctly. The bug was fixed in 2020 which means the fix was available at least in Safari 14 released later that year, and in Safari 15 for sure. So we can safely drop these styles now. 

## Type of change

- Refactor