### PR TITLE
fix: do not scroll when clicking cells

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -618,8 +618,8 @@ export const GridMixin = (superClass) =>
 
         // Patch `focus()` to use the button
         cell._focusButton = div;
-        cell.focus = function () {
-          cell._focusButton.focus();
+        cell.focus = function (options) {
+          cell._focusButton.focus(options);
         };
 
         div.appendChild(slot);
@@ -642,7 +642,7 @@ export const GridMixin = (superClass) =>
             // Only focus if mouse is released on cell content itself
             const mouseUpWithinCell = event.composedPath().includes(cellContent);
             if (!contentContainsFocusedElement && mouseUpWithinCell) {
-              cell.focus();
+              cell.focus({ preventScroll: true });
             }
             document.removeEventListener('mouseup', mouseUpListener, true);
           };
@@ -652,7 +652,7 @@ export const GridMixin = (superClass) =>
           // Watch out sync focus removal issue, only async focus works here.
           setTimeout(() => {
             if (!cellContent.contains(this.getRootNode().activeElement)) {
-              cell.focus();
+              cell.focus({ preventScroll: true });
             }
           });
         }

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -126,7 +126,10 @@ export const ScrollMixin = (superClass) =>
 
         if (this._rowWithFocusedElement) {
           // Make sure the row with the focused element is fully inside the visible viewport
-          this.__scrollIntoViewport(this._rowWithFocusedElement.index);
+          // Don't change scroll position if the user is interacting with the mouse
+          if (!this._isMousedown) {
+            this.__scrollIntoViewport(this._rowWithFocusedElement.index);
+          }
 
           if (!this.$.table.contains(e.relatedTarget)) {
             // Virtualizer can't catch the event because if orginates from the light DOM.

--- a/packages/grid/test/scroll-into-view-lit.test.js
+++ b/packages/grid/test/scroll-into-view-lit.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/lit-all-imports.js';
+import '../src/lit-all-imports.js';
+import './scroll-into-view.common.js';

--- a/packages/grid/test/scroll-into-view-polymer.test.js
+++ b/packages/grid/test/scroll-into-view-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-grid.js';
+import './scroll-into-view.common.js';

--- a/packages/grid/test/scroll-into-view.common.js
+++ b/packages/grid/test/scroll-into-view.common.js
@@ -25,9 +25,9 @@ describe('scroll into view', () => {
 
   beforeEach(async () => {
     grid = fixtureSync(`
-        <vaadin-grid style="height: 150px">
-          <vaadin-grid-column></vaadin-grid-column>
-        </vaadin-grid>
+      <vaadin-grid style="height: 150px">
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
     `);
     const column = grid.querySelector('vaadin-grid-column');
     column.renderer = (root, _, model) => {

--- a/packages/grid/test/scroll-into-view.common.js
+++ b/packages/grid/test/scroll-into-view.common.js
@@ -1,0 +1,114 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
+import { flushGrid, getContainerCell, getLastVisibleItem } from './helpers.js';
+
+describe('scroll into view', () => {
+  let grid, firstCell, secondCell;
+
+  function verifyCellFullyVisible(grid, cell) {
+    const scrollerBounds = grid.$.scroller.getBoundingClientRect();
+    const cellBounds = cell.getBoundingClientRect();
+    expect(cellBounds.top).to.be.greaterThanOrEqual(scrollerBounds.top);
+    expect(cellBounds.bottom).to.be.lessThanOrEqual(scrollerBounds.bottom);
+  }
+
+  function verifyCellNotFullyVisible(grid, cell) {
+    const scrollerBounds = grid.$.scroller.getBoundingClientRect();
+    const cellBounds = cell.getBoundingClientRect();
+    const isTopInvisible = cellBounds.top < scrollerBounds.top;
+    const isBottomInvisible = cellBounds.bottom > scrollerBounds.bottom;
+    expect(isTopInvisible || isBottomInvisible).to.be.true;
+  }
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+        <vaadin-grid style="height: 150px">
+          <vaadin-grid-column></vaadin-grid-column>
+        </vaadin-grid>
+    `);
+    const column = grid.querySelector('vaadin-grid-column');
+    column.renderer = (root, _, model) => {
+      root.innerHTML = `<div style="height: 100px">${model.item}</div>`;
+    };
+    grid.items = [1, 2];
+    flushGrid(grid);
+    await nextFrame();
+
+    firstCell = getContainerCell(grid.$.items, 0, 0);
+    secondCell = getContainerCell(grid.$.items, 1, 0);
+  });
+
+  describe('body cells', () => {
+    it('should scroll cell into view when focusing programmatically', () => {
+      verifyCellNotFullyVisible(grid, secondCell);
+
+      secondCell.focus();
+
+      expect(grid.$.table.scrollTop).to.be.above(0);
+      verifyCellFullyVisible(grid, secondCell);
+    });
+
+    it('should scroll cell into view when focusing with keyboard navigation', async () => {
+      verifyCellNotFullyVisible(grid, secondCell);
+
+      firstCell.focus();
+      await sendKeys({ press: 'ArrowDown' });
+
+      expect(grid.$.table.scrollTop).to.be.above(0);
+      verifyCellFullyVisible(grid, secondCell);
+    });
+
+    it('should not change scroll position when focusing with click', async () => {
+      verifyCellNotFullyVisible(grid, secondCell);
+
+      const bounds = secondCell.getBoundingClientRect();
+      await sendMouse({ type: 'click', position: [bounds.x + 10, bounds.y + 10] });
+
+      expect(grid.$.table.scrollTop).to.equal(0);
+    });
+  });
+
+  describe('details cells', () => {
+    let detailsCell;
+
+    beforeEach(async () => {
+      grid.rowDetailsRenderer = (root, _, model) => {
+        root.innerHTML = `<div style="height: 50px">${model.item} details</div>`;
+      };
+      grid.detailsOpenedItems = [2];
+      flushGrid(grid);
+      await nextFrame();
+
+      detailsCell = getLastVisibleItem(grid).querySelector('[part~="details-cell"]');
+    });
+
+    it('should scroll details cell into view when focusing row cell programmatically', () => {
+      verifyCellNotFullyVisible(grid, detailsCell);
+
+      secondCell.focus();
+
+      expect(grid.$.table.scrollTop).to.be.above(0);
+      verifyCellFullyVisible(grid, detailsCell);
+    });
+
+    it('should scroll cell into view when focusing row cell with keyboard navigation', async () => {
+      verifyCellNotFullyVisible(grid, detailsCell);
+
+      firstCell.focus();
+      await sendKeys({ press: 'ArrowDown' });
+
+      expect(grid.$.table.scrollTop).to.be.above(0);
+      verifyCellFullyVisible(grid, detailsCell);
+    });
+
+    it('should not change scroll position when focusing details cell with click', async () => {
+      verifyCellNotFullyVisible(grid, detailsCell);
+
+      const bounds = detailsCell.getBoundingClientRect();
+      await sendMouse({ type: 'click', position: [bounds.x + 10, bounds.y + 10] });
+
+      expect(grid.$.table.scrollTop).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
Prevents scrolling when focusing a cell via click by:
- Updating the scroll logic in scroll mixin to only take effect when the mouse is not used
- Updating a Chrome + Webkit specific workaround for focusing on click to use `focus({ preventScroll: true })` to avoid automatic scrolling by the browser

Fixes https://github.com/vaadin/web-components/issues/7684