### PR TITLE
fix: make resize handle not overlap with column sorter

### DIFF
--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -283,7 +283,7 @@ registerStyles(
     }
 
     [part='resize-handle']::before {
-      transform: translateX(calc(-50% + var(--_resize-handle-width)));
+      transform: translateX(calc(-50% + var(--_resize-handle-width) / 2));
       width: var(--lumo-size-s);
     }
 

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -275,10 +275,16 @@ registerStyles(
     /* Column resizing */
 
     [part='resize-handle'] {
-      width: 3px;
+      --_resize-handle-width: 3px;
+      width: var(--_resize-handle-width);
       background-color: var(--lumo-primary-color-50pct);
       opacity: 0;
       transition: opacity 0.2s;
+    }
+
+    [part='resize-handle']::before {
+      transform: translateX(calc(-50% + var(--_resize-handle-width)));
+      width: var(--lumo-size-s);
     }
 
     :host(:not([reordering])) *:not([column-resizing]) [part~='cell']:hover [part='resize-handle'],


### PR DESCRIPTION
## Description

Decrease the resize handle area to use `--lumo-size-s` to avoid overlapping with the column sorter when the column width is reduced. It also uses the resize handle width to calculate the amount of translation in the X-axis to make it better center-aligned.

#### Before

![image](https://github.com/user-attachments/assets/7ecd91f2-6ada-47d3-9c0a-5576062a7cf7)

#### After

![image](https://github.com/user-attachments/assets/e764702d-3976-446e-b4e5-f88893894e4f)

----

To test it locally, the `grid.html` file can be modified to add/change the columns to something like:

```html
    <vaadin-grid-sort-column path="name" width="200px" resizable header="Long header"
      flex-shrink="0"></vaadin-grid-sort-column>
    <vaadin-grid-sort-column path="name" width="200px" resizable flex-shrink="0"></vaadin-grid-sort-column>
```
2Then, shrink one of the columns so it starts truncating the header title and see if the sorter can be hovered/clicked as expected.

Fixes #5637

## Type of change

- [X] Bugfix
- [ ] Feature
