### PR TITLE
docs: add past and future to the list of date-picker parts

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -142,6 +142,8 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * `focused`             | Focused date element
  * `selected`            | Selected date element
  * `today`               | Date element corresponding to the current day
+ * `past`                | Date element corresponding to the date in the past
+ * `future`              | Date element corresponding to the date in the future
  *
  * In order to style year scroller elements, use `<vaadin-date-picker-year>` shadow DOM parts:
  *

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -105,6 +105,8 @@ registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { mod
  * `focused`             | Focused date element
  * `selected`            | Selected date element
  * `today`               | Date element corresponding to the current day
+ * `past`                | Date element corresponding to the date in the past
+ * `future`              | Date element corresponding to the date in the future
  *
  * In order to style year scroller elements, use `<vaadin-date-picker-year>` shadow DOM parts:
  *


### PR DESCRIPTION
## Description

Follow-up to #7691

Added `past` and `future` shadow parts to the tables in JSDoc.

## Type of change

- Documentation