### PR TITLE
docs: add grid drag source shadow parts docs to .d.ts

### DIFF
--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -190,7 +190,8 @@ export type GridDefaultItem = any;
  * `collapsed-row-cell`       | Cell in a collapsed row
  * `expanded-row-cell`        | Cell in an expanded row
  * `details-opened-row-cell`  | Cell in an row with details open
- * `dragstart-row-cell`       | Cell in a row that user started to drag (set for one frame)
+ * `dragstart-row-cell`       | Cell in the ghost image row, but not in a source row
+ * `drag-source-row-cell`     | Cell in a source row, but not in the ghost image
  * `dragover-above-row-cell`  | Cell in a row that has another row dragged over above
  * `dragover-below-row-cell`  | Cell in a row that has another row dragged over below
  * `dragover-on-top-row-cell` | Cell in a row that has another row dragged over on top


### PR DESCRIPTION
## Description

Follow-up to #7593

The PR above only updated the list of shadow parts in `vaadin-grid.js`, so I updated `vaadin-grid.d.ts` to align with it.

## Type of change

- Documentation