### PR TITLE
docs: update time-picker custom CSS properties tables

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -77,10 +77,11 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  *
  * The following custom properties are available for styling:
  *
- * Custom property                         | Description                | Default
- * ----------------------------------------|----------------------------|---------
- * `--vaadin-field-default-width`          | Default width of the field | `12em`
- * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
+ * Custom property                          | Description                | Default
+ * -----------------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width`           | Default width of the field | `12em`
+ * `--vaadin-time-picker-overlay-width`     | Width of the overlay       | `auto`
+ * `--vaadin-time-picker-overlay-max-height`| Max height of the overlay  | `65vh`
  *
  * `<vaadin-time-picker>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
  * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -37,10 +37,11 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  *
  * The following custom properties are available for styling:
  *
- * Custom property                         | Description                | Default
- * ----------------------------------------|----------------------------|---------
- * `--vaadin-field-default-width`          | Default width of the field | `12em`
- * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
+ * Custom property                          | Description                | Default
+ * -----------------------------------------|----------------------------|---------
+ * `--vaadin-field-default-width`           | Default width of the field | `12em`
+ * `--vaadin-time-picker-overlay-width`     | Width of the overlay       | `auto`
+ * `--vaadin-time-picker-overlay-max-height`| Max height of the overlay  | `65vh`
  *
  * `<vaadin-time-picker>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
  * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.


### PR DESCRIPTION
## Description

The `vaadin-time-picker` JSDoc tables are using incorrect custom property from combo-box and lacks the property to set overlay width. Updated these to reflect the actual custom CSS properties used by the component.

## Type of change

- Documentation