### PR TITLE
docs: add missing docs for expanded item state attribute

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -220,6 +220,13 @@ export interface ContextMenuEventMap extends HTMLElementEventMap, ContextMenuCus
  * - `<vaadin-context-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-context-menu-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  *
+ * The `<vaadin-context-menu-item>` sub-menu elements have the following additional state attributes
+ * on top of the built-in `<vaadin-item>` state attributes:
+ *
+ * Attribute  | Description
+ * ---------- |-------------
+ * `expanded` | Expanded parent item.
+ *
  * Note: the `theme` attribute value set on `<vaadin-context-menu>` is
  * propagated to the internal components listed above.
  *

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -192,6 +192,13 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  * - `<vaadin-context-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-context-menu-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  *
+ * The `<vaadin-context-menu-item>` sub-menu elements have the following additional state attributes
+ * on top of the built-in `<vaadin-item>` state attributes:
+ *
+ * Attribute  | Description
+ * ---------- |-------------
+ * `expanded` | Expanded parent item.
+ *
  * Note: the `theme` attribute value set on `<vaadin-context-menu>` is
  * propagated to the internal components listed above.
  *

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -55,16 +55,6 @@ export const ItemsMixin = (superClass) =>
          * ```
          *
          * @type {!Array<!ContextMenuItem> | undefined}
-         *
-         *
-         * ### Styling
-         *
-         * The `<vaadin-context-menu-item>` sub-menu elements have the following additional state attributes on top of
-         * the built-in `<vaadin-item>` state attributes (see `<vaadin-item>` documentation for full listing).
-         *
-         * Part name | Attribute | Description
-         * ----------------|----------------|----------------
-         * `:host` | expanded | Expanded parent item
          */
         items: {
           type: Array,

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -65,6 +65,16 @@ export interface MenuBarEventMap extends HTMLElementEventMap, MenuBarCustomEvent
  * - `<vaadin-menu-bar-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  * - `<vaadin-menu-bar-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  *
+ * The `<vaadin-menu-bar-item>` sub-menu elements have the following additional state attributes
+ * on top of the built-in `<vaadin-item>` state attributes:
+ *
+ * Attribute  | Description
+ * ---------- |-------------
+ * `expanded` | Expanded parent item.
+ *
+ * Note: the `theme` attribute value set on `<vaadin-menu-bar>` is
+ * propagated to the internal components listed above.
+ *
  * @fires {CustomEvent} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  */
 declare class MenuBar extends MenuBarMixin(DisabledMixin(ElementMixin(ThemableMixin(HTMLElement)))) {

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -56,6 +56,16 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  * - `<vaadin-menu-bar-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  * - `<vaadin-menu-bar-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  *
+ * The `<vaadin-menu-bar-item>` sub-menu elements have the following additional state attributes
+ * on top of the built-in `<vaadin-item>` state attributes:
+ *
+ * Attribute  | Description
+ * ---------- |-------------
+ * `expanded` | Expanded parent item.
+ *
+ * Note: the `theme` attribute value set on `<vaadin-menu-bar>` is
+ * propagated to the internal components listed above.
+ *
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *
  * @customElement


### PR DESCRIPTION
## Description

For some reason the `expanded` state attribute of `vaadin-context-menu-item` is mentioned in property rather than the component JSDoc, so I moved it to the right place. Also updated `vaadin-menu-bar` JSDoc accordingly.

## Type of change

- Documentation