### PR TITLE
test: remove no longer needed custom-style import

### DIFF
--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@polymer/polymer/lib/elements/custom-style.js';
 import '@vaadin/custom-field';
 import '@vaadin/text-field';
 import '../vaadin-form-item.js';


### PR DESCRIPTION
## Description

This import was there because of #499 (tests related to `updateStyle()` didn't pass without it).
The method and related tests were removed in #4993 but we missed to also remove this import.

## Type of change

- Test