### PR TITLE
test: remove no longer needed dom-repeat import

### DIFF
--- a/packages/grid/test/row-details.common.js
+++ b/packages/grid/test/row-details.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   buildDataSet,


### PR DESCRIPTION
## Description

Usage of `dom-repeat` was removed in #5473 so this import is no longer needed.

## Type of change

- Test