### PR TITLE
Add a traffic light theme for checkbox component

### DIFF
--- a/packages/checkbox/test/visual/lumo/checkbox.test.js
+++ b/packages/checkbox/test/visual/lumo/checkbox.test.js
@@ -211,4 +211,64 @@ describe('checkbox', () => {
       await visualDiff(div, 'bordered-dark');
     });
   });
+
+  describe('traffic-light theme', () => {
+    beforeEach(() => {
+      element.setAttribute('theme', 'traffic-light');
+    });
+
+    it('basic', async () => {
+      await visualDiff(div, 'theme-traffic-light');
+    });
+
+    it('checked', async () => {
+      element.checked = true;
+      await visualDiff(div, 'theme-traffic-light-disabled');
+    });
+
+    it('indeterminate', async () => {
+      element.indeterminate = true;
+      await visualDiff(div, 'theme-traffic-light-indeterminate');
+    });
+
+    describe('disabled', () => {
+      beforeEach(() => {
+        element.disabled = true;
+      });
+
+      it('basic', async () => {
+        await visualDiff(div, 'theme-traffic-light-disabled');
+      });
+
+      it('checked', async () => {
+        element.checked = true;
+        await visualDiff(div, 'theme-traffic-light-disabled-checked');
+      });
+
+      it('indeterminate', async () => {
+        element.indeterminate = true;
+        await visualDiff(div, 'theme-traffic-light-disabled-indeterminate');
+      });
+    });
+
+    describe('readonly', () => {
+      beforeEach(() => {
+        element.readonly = true;
+      });
+
+      it('basic', async () => {
+        await visualDiff(div, 'theme-traffic-light-readonly');
+      });
+
+      it('checked', async () => {
+        element.checked = true;
+        await visualDiff(div, 'theme-traffic-light-readonly-checked');
+      });
+
+      it('indeterminate', async () => {
+        element.indeterminate = true;
+        await visualDiff(div, 'theme-traffic-light-readonly-indeterminate');
+      });
+    });
+  });
 });

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -205,6 +205,63 @@ registerStyles(
       }
     }
 
+    /* Traffic light colors */
+    :host([theme~='traffic-light']) [part='checkbox']::after {
+      opacity: 1;
+      color: var(--lumo-primary-contrast-color);
+    }
+
+    :host([theme~='traffic-light'][disabled]) [part='checkbox']::after {
+      color: var(--_disabled-checkmark-color);
+    }
+
+    :host([theme~='traffic-light']:not([checked]):not([indeterminate])) [part='checkbox']::after {
+      content: var(--lumo-icons-cross);
+    }
+
+    :host([theme~='traffic-light']:not([readonly])) [part='checkbox'] {
+      background: var(--lumo-error-color);
+    }
+
+    :host([theme~='traffic-light']:not([readonly])[disabled]) [part='checkbox'] {
+      background: var(--lumo-error-color-10pct);
+    }
+
+    :host(
+        [theme~='traffic-light']:not([checked]):not([indeterminate]):not([disabled]):not([readonly]):not(
+            [invalid]
+          ):hover
+      )
+    [part='checkbox'] {
+      background: var(--lumo-error-color);
+    }
+
+    :host([theme~='traffic-light']:not([readonly])[indeterminate]) [part='checkbox'] {
+      background: var(--lumo-warning-color);
+    }
+
+    :host([theme~='traffic-light']:not([readonly])[indeterminate][disabled]) [part='checkbox'] {
+      background: var(--lumo-warning-color-10pct);
+    }
+
+    :host([theme~='traffic-light']:not([readonly])[checked]) [part='checkbox'] {
+      background: var(--lumo-success-color);
+    }
+
+    :host([theme~='traffic-light']:not([readonly])[checked][disabled]) [part='checkbox'] {
+      background: var(--lumo-success-color-10pct);
+    }
+
+    :host([theme~='traffic-light'][readonly]:not([checked]):not([indeterminate])) [part='checkbox'] {
+      background: var(--lumo-contrast-70pct);
+    }
+
+    :host([theme~='traffic-light'][readonly]:not([checked]):not([indeterminate])) [part='checkbox']::after {
+      top: -1px;
+      left: -1px;
+      border: none;
+    }
+
     /* Active */
     :host([active]) [part='checkbox'] {
       transform: scale(0.9);

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -232,7 +232,7 @@ registerStyles(
             [invalid]
           ):hover
       )
-    [part='checkbox'] {
+      [part='checkbox'] {
       background: var(--lumo-error-color);
     }
 


### PR DESCRIPTION
## Description

This adds a new color theme to the checkbox component so that it works like a traffic light - red for unchecked, yellow for indeterminate and green for checked. Disabled and readonly variants are also taken into account. 

Normal/light components:
![image](https://github.com/user-attachments/assets/6519a878-c115-4913-85a6-c2680f045c7c)

Dark theme variants:
![image](https://github.com/user-attachments/assets/d805a8b3-9508-49f7-a01f-ea04e84fa5d1)

Fixes #7736 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
