### PR TITLE
feat: support drag-reordering of dashboard items

### DIFF
--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -50,48 +50,20 @@
           colspan: 2,
         },
         {
-          title: 'Sales closed this month',
-          content: '54 000€',
-          type: 'kpi',
-        },
-        {
-          title: 'Just some number',
-          content: '1234',
-          type: 'kpi',
-          header: '2014-2024',
-        },
-        {
-          title: 'Activity since 2023',
-          type: 'chart',
-        },
-        {
-          title: 'Total cost',
-          content: '+203%',
-          type: 'kpi',
-          header: '2023-2024',
-          colspan: 2,
-        },
-        {
           title: 'Section',
           items: [
-            {
-              title: 'Sales',
-              type: 'chart',
-              header: '2023-2024',
-              colspan: 2,
-            },
             {
               title: 'Sales closed this month',
               content: '54 000€',
               type: 'kpi',
             },
+            {
+              title: 'Just some number',
+              content: '1234',
+              type: 'kpi',
+              header: '2014-2024',
+            },
           ],
-        },
-        {
-          title: 'Just some number',
-          content: '1234',
-          type: 'kpi',
-          header: '2014-2024',
         },
         {
           title: 'Activity since 2023',
@@ -100,7 +72,6 @@
       ];
 
       dashboard.renderer = (root, _dashboard, { item }) => {
-        // TODO: This is why the element gets removed from the DOM and dragend doesn't fire
         root.innerHTML = `
           <vaadin-dashboard-widget widget-title="${item.title}">
             <span slot="header">${item.header || ''}</span>
@@ -120,6 +91,7 @@
 
       dashboard.addEventListener('dashboard-item-reorder-end', (e) => {
         console.log('dashboard-item-reorder-end');
+        console.log('items after reorder', e.target.items);
       });
     </script>
   </head>

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -15,6 +15,10 @@
         padding: 10px;
       }
 
+      vaadin-dashboard {
+        --vaadin-dashboard-col-min-width: 300px;
+      }
+
       .kpi-number {
         font-size: 80px;
         font-weight: bold;

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -15,13 +15,6 @@
         padding: 10px;
       }
 
-      vaadin-dashboard {
-        --vaadin-dashboard-col-min-width: 300px;
-        --vaadin-dashboard-col-max-width: 500px;
-        --vaadin-dashboard-gap: 20px;
-        --vaadin-dashboard-col-max-count: 3;
-      }
-
       .kpi-number {
         font-size: 80px;
         font-weight: bold;

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -57,20 +57,47 @@
           colspan: 2,
         },
         {
+          title: 'Sales closed this month',
+          content: '54 000€',
+          type: 'kpi',
+        },
+        {
+          title: 'Just some number',
+          content: '1234',
+          type: 'kpi',
+          header: '2014-2024',
+        },
+        {
+          title: 'Activity since 2023',
+          type: 'chart',
+        },
+        {
+          title: 'Total cost',
+          content: '+203%',
+          type: 'kpi',
+          header: '2023-2024',
+        },
+        {
           title: 'Section',
           items: [
+            {
+              title: 'Sales',
+              type: 'chart',
+              header: '2023-2024',
+              colspan: 2,
+            },
             {
               title: 'Sales closed this month',
               content: '54 000€',
               type: 'kpi',
             },
-            {
-              title: 'Just some number',
-              content: '1234',
-              type: 'kpi',
-              header: '2014-2024',
-            },
           ],
+        },
+        {
+          title: 'Just some number',
+          content: '1234',
+          type: 'kpi',
+          header: '2014-2024',
         },
         {
           title: 'Activity since 2023',
@@ -79,6 +106,7 @@
       ];
 
       dashboard.renderer = (root, _dashboard, { item }) => {
+        // TODO: This is why the element gets removed from the DOM and dragend doesn't fire
         root.innerHTML = `
           <vaadin-dashboard-widget widget-title="${item.title}">
             <span slot="header">${item.header || ''}</span>
@@ -86,10 +114,23 @@
           </vaadin-dashboard-widget>
         `;
       };
+
+      dashboard.addEventListener('dashboard-item-reorder-start', (e) => {
+        console.log('dashboard-item-reorder-start');
+      });
+
+      dashboard.addEventListener('dashboard-item-drag-reorder', (e) => {
+        console.log('dashboard-item-drag-reorder', e.detail);
+        // e.preventDefault();
+      });
+
+      dashboard.addEventListener('dashboard-item-reorder-end', (e) => {
+        console.log('dashboard-item-reorder-end');
+      });
     </script>
   </head>
 
   <body>
-    <vaadin-dashboard></vaadin-dashboard>
+    <vaadin-dashboard editable></vaadin-dashboard>
   </body>
 </html>

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -69,6 +69,7 @@
           content: '+203%',
           type: 'kpi',
           header: '2023-2024',
+          colspan: 2,
         },
         {
           title: 'Section',

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -17,6 +17,9 @@
 
       vaadin-dashboard {
         --vaadin-dashboard-col-min-width: 300px;
+        --vaadin-dashboard-col-max-width: 500px;
+        --vaadin-dashboard-gap: 20px;
+        --vaadin-dashboard-col-max-count: 3;
       }
 
       .kpi-number {

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -63,6 +63,10 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
         header {
           grid-column: var(--_vaadin-dashboard-section-column);
         }
+
+        :host::before {
+          z-index: 2 !important;
+        }
       `,
       hasWidgetWrappers,
       dashboardWidgetAndSectionStyles,

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -15,6 +15,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
+import { dashboardWidgetAndSectionStyles, hasWidgetWrappers } from './vaadin-dashboard-styles.js';
 
 /**
  * A section component for use with the Dashboard component
@@ -30,40 +31,38 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: grid;
-        grid-template-columns: subgrid;
-        --_vaadin-dashboard-section-column: 1 / calc(var(--_vaadin-dashboard-effective-col-count) + 1);
-        grid-column: var(--_vaadin-dashboard-section-column) !important;
-        gap: var(--vaadin-dashboard-gap, 1rem);
-      }
+    return [
+      css`
+        :host {
+          display: grid;
+          position: relative;
+          grid-template-columns: subgrid;
+          --_vaadin-dashboard-section-column: 1 / calc(var(--_vaadin-dashboard-effective-col-count) + 1);
+          grid-column: var(--_vaadin-dashboard-section-column) !important;
+          gap: var(--vaadin-dashboard-gap, 1rem);
+        }
 
-      :host([hidden]) {
-        display: none !important;
-      }
+        :host([hidden]) {
+          display: none !important;
+        }
 
-      ::slotted(*) {
-        --_vaadin-dashboard-item-column: span
-          min(
-            var(--vaadin-dashboard-item-colspan, 1),
-            var(--_vaadin-dashboard-effective-col-count, var(--_vaadin-dashboard-col-count))
-          );
+        ::slotted(*) {
+          --_vaadin-dashboard-item-column: span
+            min(
+              var(--vaadin-dashboard-item-colspan, 1),
+              var(--_vaadin-dashboard-effective-col-count, var(--_vaadin-dashboard-col-count))
+            );
 
-        grid-column: var(--_vaadin-dashboard-item-column);
-      }
+          grid-column: var(--_vaadin-dashboard-item-column);
+        }
 
-      ::slotted(vaadin-dashboard-widget-wrapper) {
-        display: contents;
-      }
-
-      header {
-        display: flex;
-        grid-column: var(--_vaadin-dashboard-section-column);
-        justify-content: space-between;
-        align-items: center;
-      }
-    `;
+        header {
+          grid-column: var(--_vaadin-dashboard-section-column);
+        }
+      `,
+      hasWidgetWrappers,
+      dashboardWidgetAndSectionStyles,
+    ];
   }
 
   static get properties() {
@@ -84,7 +83,9 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
     return html`
       <header>
         <slot name="title" @slotchange="${this.__onTitleSlotChange}"></slot>
-        <div id="header-actions"></div>
+        <div id="header-actions">
+          <span id="drag-handle" draggable="true" class="drag-handle"></span>
+        </div>
       </header>
 
       <slot></slot>

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -46,6 +46,10 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
           display: none !important;
         }
 
+        :host([highlight]) {
+          background-color: #f5f5f5;
+        }
+
         ::slotted(*) {
           --_vaadin-dashboard-item-column: span
             min(

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -7,6 +7,7 @@ export const hasWidgetWrappers = css`
 `;
 
 export const dashboardWidgetAndSectionStyles = css`
+  /* Placeholder shown while the widget or section is dragged */
   :host::before {
     content: '';
     z-index: 1;

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -29,6 +29,7 @@ export const dashboardWidgetAndSectionStyles = css`
   }
 
   #drag-handle::before {
+    font-size: 30px;
     content: '☰';
     cursor: grab;
   }

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -25,7 +25,7 @@ export const dashboardWidgetAndSectionStyles = css`
   }
 
   #header-actions {
-    visibility: var(--_vaadin-dashboard-widget-actions-visibility, hidden);
+    display: var(--_vaadin-dashboard-widget-actions-display, none);
   }
 
   #drag-handle::before {

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -1,0 +1,35 @@
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const hasWidgetWrappers = css`
+  ::slotted(vaadin-dashboard-widget-wrapper) {
+    display: contents;
+  }
+`;
+
+export const dashboardWidgetAndSectionStyles = css`
+  :host::before {
+    content: '';
+    z-index: 1;
+    position: absolute;
+    display: var(--_vaadin-dashboard-item-placeholder-display, none);
+    inset: 0;
+    border: 3px dashed black;
+    border-radius: 5px;
+    background-color: #fff;
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  #header-actions {
+    visibility: var(--_vaadin-dashboard-widget-actions-visibility, hidden);
+  }
+
+  #drag-handle::before {
+    content: '☰';
+    cursor: grab;
+  }
+`;

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -15,6 +15,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
+import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-styles.js';
 
 /**
  * A Widget component for use with the Dashboard component
@@ -30,27 +31,25 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: flex;
-        flex-direction: column;
-        grid-column: var(--_vaadin-dashboard-item-column);
-      }
+    return [
+      css`
+        :host {
+          display: flex;
+          flex-direction: column;
+          grid-column: var(--_vaadin-dashboard-item-column);
+          position: relative;
+        }
 
-      :host([hidden]) {
-        display: none !important;
-      }
+        :host([hidden]) {
+          display: none !important;
+        }
 
-      header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-
-      #content {
-        flex: 1;
-      }
-    `;
+        #content {
+          flex: 1;
+        }
+      `,
+      dashboardWidgetAndSectionStyles,
+    ];
   }
 
   static get properties() {
@@ -72,7 +71,9 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
       <header>
         <slot name="title" @slotchange="${this.__onTitleSlotChange}"></slot>
         <slot name="header"></slot>
-        <div id="header-actions"></div>
+        <div id="header-actions">
+          <span id="drag-handle" draggable="true" class="drag-handle"></span>
+        </div>
       </header>
 
       <div id="content">

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -65,6 +65,11 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
    *   - `model.item` The item.
    */
   renderer: DashboardRenderer<TItem> | null | undefined;
+
+  /**
+   * Whether the dashboard is editable.
+   */
+  editable: boolean;
 }
 
 declare global {

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -24,7 +24,7 @@ export interface DashboardSectionItem<TItem extends DashboardItem> {
   /**
    * The title of the section
    */
-  title: string | null | undefined;
+  title?: string | null;
 
   /**
    * The items of the section

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -43,6 +43,34 @@ export type DashboardRenderer<TItem extends DashboardItem> = (
 ) => void;
 
 /**
+ * Fired when item reordering starts
+ */
+export type DashboardItemReorderStartEvent = CustomEvent;
+
+/**
+ * Fired when item reordering ends
+ */
+export type DashboardItemReorderEndEvent = CustomEvent;
+
+/**
+ * Fired when an items will be reordered by dragging
+ */
+export type DashboardItemDragReorderEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem | DashboardSectionItem<TItem>;
+  targetIndex: number;
+}>;
+
+export interface DashboardCustomEventMap<TItem extends DashboardItem> {
+  'dashboard-item-reorder-start': DashboardItemReorderStartEvent;
+
+  'dashboard-item-reorder-end': DashboardItemReorderEndEvent;
+
+  'dashboard-item-drag-reorder': DashboardItemDragReorderEvent<TItem>;
+}
+
+export type DashboardEventMap<TItem extends DashboardItem> = DashboardCustomEventMap<TItem> & HTMLElementEventMap;
+
+/**
  * A responsive, grid-based dashboard layout component
  */
 declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends DashboardLayoutMixin(
@@ -70,6 +98,18 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
    * Whether the dashboard is editable.
    */
   editable: boolean;
+
+  addEventListener<K extends keyof DashboardEventMap<TItem>>(
+    type: K,
+    listener: (this: Dashboard, ev: DashboardEventMap<TItem>[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof DashboardEventMap<TItem>>(
+    type: K,
+    listener: (this: Dashboard, ev: DashboardEventMap<TItem>[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
 }
 
 declare global {

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -11,11 +11,14 @@
 import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-section.js';
 import { html, LitElement, render } from 'lit';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
+import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
+import { WidgetReorderController } from './widget-reorder-controller.js';
 
 /**
  * A responsive, grid-based dashboard layout component
@@ -26,7 +29,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * @mixes DashboardLayoutMixin
  * @mixes ThemableMixin
  */
-class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
   static get is() {
     return 'vaadin-dashboard';
   }
@@ -39,10 +42,11 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
     return [
       super.styles,
       css`
-        ::slotted(vaadin-dashboard-widget-wrapper) {
-          display: contents;
+        :host([editable]) {
+          --_vaadin-dashboard-widget-actions-visibility: visible;
         }
       `,
+      hasWidgetWrappers,
     ];
   }
 
@@ -72,11 +76,30 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
       renderer: {
         type: Function,
       },
+
+      /**
+       * Whether the dashboard is editable.
+       */
+      editable: {
+        type: Boolean,
+        reflectToAttribute: true,
+      },
     };
   }
 
   static get observers() {
     return ['__itemsOrRendererChanged(items, renderer)'];
+  }
+
+  constructor() {
+    super();
+    this.__widgetReorderController = new WidgetReorderController(this);
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+    this.addController(this.__widgetReorderController);
   }
 
   /** @protected */
@@ -89,6 +112,9 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
     render(this.__renderItemCells(items || []), this);
 
     this.querySelectorAll('vaadin-dashboard-widget-wrapper').forEach((cell) => {
+      if (cell.firstElementChild && cell.firstElementChild.localName === 'vaadin-dashboard-section') {
+        return;
+      }
       if (renderer) {
         renderer(cell, this, { item: cell.__item });
       } else {
@@ -100,20 +126,19 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
   /** @private */
   __renderItemCells(items) {
     return items.map((item) => {
+      const placeholderDisplay = this.__widgetReorderController.draggedItem === item ? 'block' : 'none';
+      const style = `--vaadin-dashboard-item-colspan: ${item.colspan}; --_vaadin-dashboard-item-placeholder-display: ${placeholderDisplay};`;
+
       if (item.items) {
-        return html`<vaadin-dashboard-section
-          .__item="${item}"
-          .sectionTitle="${item.title || ''}"
-          .items="${item.items}"
-        >
-          ${this.__renderItemCells(item.items)}
-        </vaadin-dashboard-section>`;
+        return html`<vaadin-dashboard-widget-wrapper .__item="${item}" style="${style}">
+          <vaadin-dashboard-section .sectionTitle="${item.title}">
+            ${this.__renderItemCells(item.items)}
+          </vaadin-dashboard-section>
+        </vaadin-dashboard-widget-wrapper>`;
       }
 
-      return html`<vaadin-dashboard-widget-wrapper
-        .__item="${item}"
-        style="--vaadin-dashboard-item-colspan: ${item.colspan};"
-      ></vaadin-dashboard-widget-wrapper>`;
+      return html`<vaadin-dashboard-widget-wrapper .__item="${item}" style="${style}">
+      </vaadin-dashboard-widget-wrapper>`;
     });
   }
 }

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -23,6 +23,10 @@ import { WidgetReorderController } from './widget-reorder-controller.js';
 /**
  * A responsive, grid-based dashboard layout component
  *
+ * @fires {CustomEvent} dashboard-item-drag-reorder - Fired when an items will be reordered by dragging
+ * @fires {CustomEvent} dashboard-item-reorder-start - Fired when item reordering starts
+ * @fires {CustomEvent} dashboard-item-reorder-end - Fired when item reordering ends
+ *
  * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin
@@ -147,6 +151,24 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       </vaadin-dashboard-widget-wrapper>`;
     });
   }
+
+  /**
+   * Fired when item reordering starts
+   *
+   * @event dashboard-item-reorder-start
+   */
+
+  /**
+   * Fired when item reordering ends
+   *
+   * @event dashboard-item-reorder-end
+   */
+
+  /**
+   * Fired when an items will be reordered by dragging
+   *
+   * @event dashboard-item-drag-reorder
+   */
 }
 
 defineCustomElement(Dashboard);

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -43,7 +43,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       super.styles,
       css`
         :host([editable]) {
-          --_vaadin-dashboard-widget-actions-visibility: visible;
+          --_vaadin-dashboard-widget-actions-display: block;
         }
       `,
       hasWidgetWrappers,
@@ -126,8 +126,11 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
   /** @private */
   __renderItemCells(items) {
     return items.map((item) => {
-      const placeholderDisplay = this.__widgetReorderController.draggedItem === item ? 'block' : 'none';
-      const style = `--vaadin-dashboard-item-colspan: ${item.colspan}; --_vaadin-dashboard-item-placeholder-display: ${placeholderDisplay};`;
+      const itemDragged = this.__widgetReorderController.draggedItem === item;
+      const style = `
+        ${item.colspan ? `--vaadin-dashboard-item-colspan: ${item.colspan};` : ''}
+        ${itemDragged ? '--_vaadin-dashboard-item-placeholder-display: block;' : ''}
+      `.trim();
 
       if (item.items) {
         return html`<vaadin-dashboard-widget-wrapper .__item="${item}" style="${style}">

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -131,7 +131,10 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
       if (item.items) {
         return html`<vaadin-dashboard-widget-wrapper .__item="${item}" style="${style}">
-          <vaadin-dashboard-section .sectionTitle="${item.title}">
+          <vaadin-dashboard-section
+            .sectionTitle="${item.title}"
+            ?highlight="${this.__widgetReorderController.draggedItem}"
+          >
             ${this.__renderItemCells(item.items)}
           </vaadin-dashboard-section>
         </vaadin-dashboard-widget-wrapper>`;

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A controller to widget reordering inside a dashboard.
+ */
+export class WidgetReorderController extends EventTarget {
+  constructor(host) {
+    super();
+    this.host = host;
+    this.draggedElementRemoveObserver = new MutationObserver(() => this.__restoreDraggedElement());
+
+    host.addEventListener('dragstart', (e) => this.__dragStart(e));
+    host.addEventListener('dragend', (e) => this.__dragEnd(e));
+    host.addEventListener('dragover', (e) => this.__dragOver(e));
+  }
+
+  /** @private */
+  __dragStart(e) {
+    if ([...e.composedPath()].some((el) => el.classList && el.classList.contains('drag-handle'))) {
+      if (!this.host.editable) {
+        e.preventDefault();
+        return;
+      }
+
+      this.__draggedElement = e.target;
+      this.draggedItem = this.__getElementItem(this.__draggedElement);
+
+      // Set the drag image to the dragged element
+      const draggedElementRect = this.__draggedElement.getBoundingClientRect();
+      e.dataTransfer.setDragImage(
+        this.__draggedElement,
+        e.clientX - draggedElementRect.left,
+        e.clientY - draggedElementRect.top,
+      );
+
+      // Observe the removal of the dragged element from the DOM
+      this.draggedElementRemoveObserver.observe(this.host, { childList: true, subtree: true });
+
+      this.host.dispatchEvent(new CustomEvent('dashboard-item-reorder-start'));
+
+      requestAnimationFrame(() => {
+        // Re-render to have the dragged element turn into a placeholder
+        this.host.items = [...this.host.items];
+      });
+    }
+  }
+
+  /** @private */
+  __dragOver(e) {
+    if (this.draggedItem) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+
+      // All the elements that are candidates for reordering with the dragged element
+      const dragContextElements = this.__getDragContextElements(this.__draggedElement);
+      // Up-to-date element instance representing the dragged item
+      const draggedElement = dragContextElements.find((element) => this.__getElementItem(element) === this.draggedItem);
+      // All but the dragged element from the drag context
+      const otherElements = dragContextElements.filter((element) => element !== draggedElement);
+      // The element that is the closest to the x and y coordinates of the drag event
+      const closestElement = this.__getClosestElement(otherElements, e.clientX, e.clientY);
+
+      // See if the dragged element is dragged enough over the element closest to the drag event coordinates
+      if (this.__isDraggedOver(draggedElement, closestElement, e.clientX, e.clientY)) {
+        const targetItem = this.__getElementItem(closestElement);
+        const reorderEvent = new CustomEvent('dashboard-item-drag-reorder', {
+          detail: { draggedItem: this.draggedItem, targetItem },
+          cancelable: true,
+        });
+        if (this.host.dispatchEvent(reorderEvent)) {
+          // If the event is not canceled, reorder the items and re-render
+          this.__reorderItems(this.draggedItem, targetItem);
+        }
+      }
+    }
+  }
+
+  /** @private */
+  __dragEnd() {
+    if (!this.draggedItem) {
+      return;
+    }
+
+    // If the originally dragged element is restored to the DOM (as a direct child of the host),
+    // to make sure "dragend" event gets dispatched, remove it to avoid duplicates
+    if (this.__draggedElement.parentElement === this.host) {
+      this.__draggedElement.remove();
+    }
+    this.__draggedElement = null;
+    this.draggedItem = null;
+    this.host.items = [...this.host.items];
+    this.draggedElementRemoveObserver.disconnect();
+
+    this.host.dispatchEvent(new CustomEvent('dashboard-item-reorder-end'));
+  }
+
+  /**
+   * Returns the closest element to the given coordinates.
+   * @private
+   */
+  __getClosestElement(elements, x, y) {
+    return elements.reduce(
+      (acc, element) => {
+        const rect = element.getBoundingClientRect();
+        const centerOfElement = {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        };
+        const distance = Math.sqrt((centerOfElement.x - x) ** 2 + (centerOfElement.y - y) ** 2);
+        if (distance < acc.distance) {
+          return { element, distance };
+        }
+        return acc;
+      },
+      { element: null, distance: Number.MAX_VALUE },
+    ).element;
+  }
+
+  /**
+   * Returns true if the dragged element is dragged enough over the target element in
+   * the direction relative to their positions where x and y are the coordinates
+   * of the drag event.
+   * @private
+   */
+  __isDraggedOver(draggedElement, targetElement, x, y) {
+    const draggedPos = draggedElement.getBoundingClientRect();
+    const targetPos = targetElement.getBoundingClientRect();
+    if (draggedPos.top >= targetPos.bottom) {
+      // target is on a row above the dragged widget
+      return y < targetPos.top + targetPos.height / 2;
+    } else if (draggedPos.bottom <= targetPos.top) {
+      // target is on a row below the dragged widget
+      return y > targetPos.top + targetPos.height / 2;
+    } else if (draggedPos.left >= targetPos.right) {
+      // target is on a column to the left of the dragged widget
+      return x < targetPos.left + targetPos.width / 2;
+    } else if (draggedPos.right <= targetPos.left) {
+      // target is on a column to the right of the dragged widget
+      return x > targetPos.left + targetPos.width / 2;
+    }
+  }
+
+  /** @private */
+  __getElementItem(element) {
+    const wrapper = this.__getWrapper(element);
+    if (wrapper) {
+      return wrapper.__item;
+    }
+  }
+
+  /** @private */
+  __getWrapper(element) {
+    return element.closest('vaadin-dashboard-widget-wrapper');
+  }
+
+  /**
+   * Returns the elements (widgets or sections) that are candidates for reordering with the
+   * currently dragged item.
+   * @private
+   */
+  __getDragContextElements() {
+    const draggedItemWrapper = [...this.host.querySelectorAll('vaadin-dashboard-widget-wrapper')].find(
+      (el) => el.__item === this.draggedItem,
+    );
+    const siblingWrappers = [...draggedItemWrapper.parentElement.children].filter(
+      (el) => el.localName === 'vaadin-dashboard-widget-wrapper',
+    );
+    return siblingWrappers.map((el) => el.firstElementChild);
+  }
+
+  /** @private */
+  __reorderItems(draggedItem, targetItem) {
+    const draggedItems = this.__getItemsArrayOfItem(draggedItem);
+    const targetItems = this.__getItemsArrayOfItem(targetItem);
+    const draggedIndex = draggedItems.indexOf(draggedItem);
+    const targetIndex = targetItems.indexOf(targetItem);
+    draggedItems.splice(draggedIndex, 1);
+    targetItems.splice(targetIndex, 0, draggedItem);
+    this.host.items = [...this.host.items];
+  }
+
+  /**
+   * Returns the array of items that contains the given item.
+   * Might be the host items or the items of a section.
+   * @private
+   */
+  __getItemsArrayOfItem(item, items = this.host.items) {
+    for (const i of items) {
+      if (i === item) {
+        return items;
+      } else if (i.items) {
+        const result = this.__getItemsArrayOfItem(item, i.items);
+        if (result) {
+          return result;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * The dragged element might be removed from the DOM during the drag operation if
+   * the widgets get re-rendered. This method restores the dragged element if it's not
+   * present in the DOM to ensure the dragend event is fired.
+   * @private
+   */
+  __restoreDraggedElement() {
+    if (!this.host.contains(this.__draggedElement)) {
+      this.__draggedElement.style.display = 'none';
+      this.host.appendChild(this.__draggedElement);
+    }
+  }
+}

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -70,14 +70,17 @@ export class WidgetReorderController extends EventTarget {
         }, REORDER_EVENT_TIMEOUT);
 
         const targetItem = this.__getElementItem(closestElement);
+        const targetItems = this.__getItemsArrayOfItem(targetItem);
+        const targetIndex = targetItems.indexOf(targetItem);
+
         const reorderEvent = new CustomEvent('dashboard-item-drag-reorder', {
-          detail: { item: this.draggedItem, target: targetItem },
+          detail: { item: this.draggedItem, targetIndex },
           cancelable: true,
         });
 
         // Dispatch the reorder event and reorder items if the event is not canceled
         if (this.host.dispatchEvent(reorderEvent)) {
-          this.__reorderItems(this.draggedItem, targetItem);
+          this.__reorderItems(this.draggedItem, targetIndex);
         }
       }
     }
@@ -180,13 +183,11 @@ export class WidgetReorderController extends EventTarget {
   }
 
   /** @private */
-  __reorderItems(draggedItem, targetItem) {
-    const draggedItems = this.__getItemsArrayOfItem(draggedItem);
-    const targetItems = this.__getItemsArrayOfItem(targetItem);
-    const draggedIndex = draggedItems.indexOf(draggedItem);
-    const targetIndex = targetItems.indexOf(targetItem);
-    draggedItems.splice(draggedIndex, 1);
-    targetItems.splice(targetIndex, 0, draggedItem);
+  __reorderItems(draggedItem, targetIndex) {
+    const items = this.__getItemsArrayOfItem(draggedItem);
+    const draggedIndex = items.indexOf(draggedItem);
+    items.splice(draggedIndex, 1);
+    items.splice(targetIndex, 0, draggedItem);
     this.host.items = [...this.host.items];
   }
 

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -19,6 +19,7 @@ export class WidgetReorderController extends EventTarget {
     host.addEventListener('dragstart', (e) => this.__dragStart(e));
     host.addEventListener('dragend', (e) => this.__dragEnd(e));
     host.addEventListener('dragover', (e) => this.__dragOver(e));
+    host.addEventListener('drop', (e) => this.__drop(e));
   }
 
   /** @private */
@@ -30,6 +31,8 @@ export class WidgetReorderController extends EventTarget {
       // Set the drag image to the dragged element
       const { left, top } = this.__draggedElement.getBoundingClientRect();
       e.dataTransfer.setDragImage(this.__draggedElement, e.clientX - left, e.clientY - top);
+      // Set the dragged item as text/plain data
+      e.dataTransfer.setData('text/plain', JSON.stringify(this.draggedItem));
 
       // Observe the removal of the dragged element from the DOM
       this.draggedElementRemoveObserver.observe(this.host, { childList: true, subtree: true });
@@ -102,6 +105,14 @@ export class WidgetReorderController extends EventTarget {
 
     // Dispatch the reorder end event
     this.host.dispatchEvent(new CustomEvent('dashboard-item-reorder-end'));
+  }
+
+  /** @private */
+  __drop(e) {
+    if (!this.draggedItem) {
+      return;
+    }
+    e.preventDefault();
   }
 
   /**

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -5,7 +5,7 @@
  */
 
 const WRAPPER_LOCAL_NAME = 'vaadin-dashboard-widget-wrapper';
-const REORDER_EVENT_TIMEOUT = 300;
+const REORDER_EVENT_TIMEOUT = 200;
 
 /**
  * A controller to widget reordering inside a dashboard.
@@ -170,7 +170,8 @@ export class WidgetReorderController extends EventTarget {
 
   /**
    * Returns the elements (widgets or sections) that are candidates for reordering with the
-   * currently dragged item.
+   * currently dragged item. Effectively, this is the list of child widgets or sections inside
+   * the same parent container (host or a section) as the dragged item.
    * @private
    */
   __getDragContextElements() {

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -31,8 +31,8 @@ export class WidgetReorderController extends EventTarget {
       // Set the drag image to the dragged element
       const { left, top } = this.__draggedElement.getBoundingClientRect();
       e.dataTransfer.setDragImage(this.__draggedElement, e.clientX - left, e.clientY - top);
-      // Set the dragged item as text/plain data
-      e.dataTransfer.setData('text/plain', JSON.stringify(this.draggedItem));
+      // Set the text/plain data to enable dragging on mobile devices
+      e.dataTransfer.setData('text/plain', 'item');
 
       // Observe the removal of the dragged element from the DOM
       this.draggedElementRemoveObserver.observe(this.host, { childList: true, subtree: true });

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -177,6 +177,9 @@ export class WidgetReorderController extends EventTarget {
     const draggedItemWrapper = [...this.host.querySelectorAll(WRAPPER_LOCAL_NAME)].find(
       (el) => el.__item === this.draggedItem,
     );
+    if (!draggedItemWrapper) {
+      return [];
+    }
 
     const siblingWrappers = [...draggedItemWrapper.parentElement.children].filter(
       (el) => el.localName === WRAPPER_LOCAL_NAME,

--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -56,6 +56,9 @@ export class WidgetReorderController extends EventTarget {
       const dragContextElements = this.__getDragContextElements(this.__draggedElement);
       // Find the up-to-date element instance representing the dragged item
       const draggedElement = dragContextElements.find((element) => this.__getElementItem(element) === this.draggedItem);
+      if (!draggedElement) {
+        return;
+      }
       // Get all elements except the dragged element from the drag context
       const otherElements = dragContextElements.filter((element) => element !== draggedElement);
       // Find the element closest to the x and y coordinates of the drag event
@@ -179,7 +182,7 @@ export class WidgetReorderController extends EventTarget {
       (el) => el.localName === WRAPPER_LOCAL_NAME,
     );
 
-    return siblingWrappers.map((el) => el.firstElementChild);
+    return siblingWrappers.map((el) => el.firstElementChild).filter((el) => el);
   }
 
   /** @private */

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -4,8 +4,8 @@ import '../vaadin-dashboard-layout.js';
 import '../vaadin-dashboard-section.js';
 import type { DashboardLayout } from '../vaadin-dashboard-layout.js';
 import {
+  expectLayout,
   getColumnWidths,
-  getElementFromCell,
   getRowHeights,
   setColspan,
   setGap,
@@ -13,43 +13,6 @@ import {
   setMaximumColumnWidth,
   setMinimumColumnWidth,
 } from './helpers.js';
-
-/**
- * Validates the given grid layout.
- *
- * This function iterates through a number matrix representing the IDs of
- * the items in the layout, and checks if the elements in the corresponding
- * cells of the grid match the expected IDs.
- *
- * For example, the following layout would expect a grid with two columns
- * and three rows, where the first row has one element with ID "item-0" spanning
- * two columns, and the second row has two elements with IDs "item-1" and "item-2"
- * where the first one spans two rows, and the last cell in the third row has
- * an element with ID "item-3":
- *
- * ```
- * [
- *  [0, 0],
- *  [1, 2],
- *  [1, 3]
- * ]
- * ```
- */
-function expectLayout(dashboard: DashboardLayout, layout: Array<Array<number | null>>) {
-  expect(getRowHeights(dashboard).length).to.eql(layout.length);
-  expect(getColumnWidths(dashboard).length).to.eql(layout[0].length);
-
-  layout.forEach((row, rowIndex) => {
-    row.forEach((itemId, columnIndex) => {
-      const element = getElementFromCell(dashboard, rowIndex, columnIndex);
-      if (!element) {
-        expect(itemId).to.be.null;
-      } else {
-        expect(element.id).to.equal(`item-${itemId}`);
-      }
-    });
-  });
-}
 
 describe('dashboard layout', () => {
   let dashboard: DashboardLayout;

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -261,7 +261,7 @@ describe('dashboard - widget reordering', () => {
       expect(event.dataTransfer.getData('text/plain')).to.be.ok;
     });
 
-    it('should should not throw when dragging something inside the widgets', () => {
+    it('should not throw when dragging something inside the widgets', () => {
       const widget = getElementFromCell(dashboard, 0, 0)!;
       const widgetContent = widget.querySelector('.content')!;
       expect(() =>

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -1,0 +1,127 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '../vaadin-dashboard.js';
+import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
+import {
+  expectLayout,
+  fireDragEnd,
+  fireDragOver,
+  fireDragStart,
+  getDraggable,
+  getElementFromCell,
+  setGap,
+  setMaximumColumnWidth,
+  setMinimumColumnWidth,
+} from './helpers.js';
+
+type TestDashboardItem = DashboardItem & { id: number };
+
+describe('dashboard - widget reordering', () => {
+  let dashboard: Dashboard<TestDashboardItem>;
+  const columnWidth = 100;
+
+  beforeEach(async () => {
+    dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');
+    dashboard.style.width = `${columnWidth * 2}px`;
+    setMinimumColumnWidth(dashboard, columnWidth);
+    setMaximumColumnWidth(dashboard, columnWidth);
+    setGap(dashboard, 0);
+
+    dashboard.editable = true;
+
+    dashboard.items = [{ id: 0 }, { id: 1 }];
+    dashboard.renderer = (root, _, model) => {
+      root.textContent = '';
+      const widget = fixtureSync(`
+        <vaadin-dashboard-widget id="item-${model.item.id}" widget-title="${model.item.id} title">
+          <div class="content">Widget content</div>
+        </vaadin-dashboard-widget>`);
+      root.appendChild(widget);
+    };
+    await nextFrame();
+
+    // prettier-ignore
+    expectLayout(dashboard, [
+      [0, 1],
+    ]);
+  });
+
+  describe('drag and drop', () => {
+    it('should reorder the widgets while dragging (start -> end)', async () => {
+      // Start dragging the first widget by its draggable header
+      fireDragStart(getDraggable(getElementFromCell(dashboard, 0, 0)!));
+      await nextFrame();
+
+      // Drag the first widget over the end edge of the second one
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+
+      // Expect the widgets to be reordered
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 0],
+      ]);
+    });
+
+    it('should not reorder if dragged barely over another widget (start -> end)', async () => {
+      fireDragStart(getDraggable(getElementFromCell(dashboard, 0, 0)!));
+      await nextFrame();
+
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'start');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+      ]);
+    });
+
+    // Make sure the original dragged element is restored in the host.
+    // Otherwise, "dragend" event would not be fired with native drag and drop.
+    describe('ensure dragend event', () => {
+      it('should restore the original dragged element in host', async () => {
+        const originalDraggedElement = getElementFromCell(dashboard, 0, 0)!;
+        fireDragStart(getDraggable(originalDraggedElement));
+        await nextFrame();
+        fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+        await nextFrame();
+
+        expect(dashboard.contains(originalDraggedElement)).to.be.true;
+      });
+
+      it('should remove duplicate elements once drag has ended', async () => {
+        fireDragStart(getDraggable(getElementFromCell(dashboard, 0, 0)!));
+        await nextFrame();
+        fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+        await nextFrame();
+
+        fireDragEnd(dashboard);
+        await nextFrame();
+
+        // Make sure the original dragged element is removed from the host if it was
+        // restored.
+        expect(dashboard.querySelectorAll(`vaadin-dashboard-widget[id='item-0']`).length).to.equal(1);
+      });
+
+      it('should not remove dragged element with a renderer that reuses same instances', async () => {
+        const reusedWidgets = [
+          fixtureSync('<vaadin-dashboard-widget id="item-0" widget-title="0 title"></vaadin-dashboard-widget>'),
+          fixtureSync('<vaadin-dashboard-widget id="item-1" widget-title="1 title"></vaadin-dashboard-widget>'),
+        ];
+        dashboard.renderer = (root, _, model) => {
+          root.textContent = '';
+          root.appendChild(reusedWidgets[model.item.id]);
+        };
+        await nextFrame();
+
+        fireDragStart(getDraggable(reusedWidgets[0]));
+        await nextFrame();
+        fireDragOver(reusedWidgets[1], 'end');
+        await nextFrame();
+
+        fireDragEnd(dashboard);
+        expect(reusedWidgets[0].isConnected).to.be.true;
+      });
+    });
+  });
+});

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -266,7 +266,7 @@ describe('dashboard - widget reordering', () => {
       expect(reorderSpy).to.have.been.calledOnce;
       expect(reorderSpy.getCall(0).args[0].detail).to.deep.equal({
         item: { id: 0 },
-        target: { id: 1 },
+        targetIndex: 1,
       });
     });
 
@@ -293,6 +293,23 @@ describe('dashboard - widget reordering', () => {
       await nextFrame();
 
       expect(reorderSpy).to.have.been.calledOnce;
+    });
+
+    it('should reorder in the app logic', async () => {
+      dashboard.addEventListener('dashboard-item-drag-reorder', (e) => {
+        const { item, targetIndex } = e.detail;
+        const items = dashboard.items.filter((i) => i !== item);
+        items.splice(targetIndex, 0, item);
+        dashboard.items = items;
+      });
+      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 0],
+      ]);
     });
 
     it('should not ignore subsequent dragover events after a short timeout', () => {
@@ -369,6 +386,12 @@ describe('dashboard - widget reordering', () => {
       await nextFrame();
 
       expect(event.defaultPrevented).to.be.false;
+    });
+
+    it('should allow changs to items while dragging', async () => {
+      // Remove some widget
+      // Add a widget after widfget x
+      // Remove the dragged widget
     });
 
     describe('sections', () => {

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -12,6 +12,7 @@ import {
   fireDrop,
   getDraggable,
   getElementFromCell,
+  resetReorderTimeout,
   setGap,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
@@ -424,9 +425,65 @@ describe('dashboard - widget reordering', () => {
     });
 
     it('should allow changs to items while dragging', async () => {
-      // Remove some widget
-      // Add a widget after widfget x
+      // Start dragging the first widget
+      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      // Drag over the second widget to reorder
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 0],
+      ]);
+
+      // Add a new widget after widget 1
+      dashboard.items = [dashboard.items[0], { id: 2 }, dashboard.items[1]];
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 2],
+        [0],
+      ]);
+
+      // Drag over the new widget 2
+      resetReorderTimeout(dashboard);
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'top');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 0],
+        [2],
+      ]);
+
       // Remove the dragged widget
+      dashboard.items = [dashboard.items[0], dashboard.items[2]];
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 2],
+      ]);
+
+      // Try dragging over the remaining widgets
+      resetReorderTimeout(dashboard);
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+
+      resetReorderTimeout(dashboard);
+      fireDragOver(getElementFromCell(dashboard, 0, 0)!, 'start');
+      await nextFrame();
+
+      fireDragEnd(dashboard);
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 2],
+      ]);
     });
 
     describe('sections', () => {

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -12,6 +12,7 @@ import {
   fireDrop,
   getDraggable,
   getElementFromCell,
+  getParentSection,
   resetReorderTimeout,
   setGap,
   setMaximumColumnWidth,
@@ -528,7 +529,7 @@ describe('dashboard - widget reordering', () => {
       });
 
       it('should reorder the sections and widgets', async () => {
-        const section = dashboard.querySelector('vaadin-dashboard-section')!;
+        const section = getParentSection(getElementFromCell(dashboard, 1, 0))!;
         fireDragStart(section);
         await nextFrame();
 

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -8,6 +8,7 @@ import {
   fireDragEnd,
   fireDragOver,
   fireDragStart,
+  fireDrop,
   getDraggable,
   getElementFromCell,
   setGap,
@@ -216,6 +217,13 @@ describe('dashboard - widget reordering', () => {
       expect(reorderStartSpy).to.have.been.calledOnce;
     });
 
+    it('should set data transfer data on drag start', async () => {
+      const event = fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      expect(JSON.parse(event.dataTransfer.getData('text/plain'))).to.eql(dashboard.items[0]);
+    });
+
     it('should should not throw when dragging something inside the widgets', () => {
       const widget = getElementFromCell(dashboard, 0, 0)!;
       const widgetContent = widget.querySelector('.content')!;
@@ -346,6 +354,21 @@ describe('dashboard - widget reordering', () => {
       expectLayout(dashboard, [
         [1, 2, 0],
       ]);
+    });
+
+    it('should cancel drop event', async () => {
+      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      const event = fireDrop(getElementFromCell(dashboard, 0, 1)!);
+      await nextFrame();
+
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should not cancel drop event if drag has not started', async () => {
+      const event = fireDrop(getElementFromCell(dashboard, 0, 1)!);
+      await nextFrame();
+
+      expect(event.defaultPrevented).to.be.false;
     });
 
     describe('sections', () => {

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -258,7 +258,7 @@ describe('dashboard - widget reordering', () => {
       const event = fireDragStart(getElementFromCell(dashboard, 0, 0)!);
       await nextFrame();
 
-      expect(JSON.parse(event.dataTransfer.getData('text/plain'))).to.eql(dashboard.items[0]);
+      expect(event.dataTransfer.getData('text/plain')).to.be.ok;
     });
 
     it('should should not throw when dragging something inside the widgets', () => {

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -3,7 +3,7 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard.js';
 import type { CustomElementType } from '@vaadin/component-base/src/define.js';
 import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
-import { getElementFromCell, setGap, setMaximumColumnWidth, setMinimumColumnWidth } from './helpers.js';
+import { getDraggable, getElementFromCell, setGap, setMaximumColumnWidth, setMinimumColumnWidth } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: string };
 
@@ -142,6 +142,22 @@ describe('dashboard', () => {
       expect(widget3).to.be.ok;
       expect(widget3?.localName).to.equal('vaadin-dashboard-widget');
       expect(widget3).to.have.property('widgetTitle', 'Item 3 title');
+    });
+  });
+
+  describe('editable', () => {
+    it('should hide draggable handle by default', () => {
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      const draggable = getDraggable(widget);
+      expect(draggable.getBoundingClientRect().height).to.equal(0);
+    });
+
+    it('should unhide draggable handle when editable', async () => {
+      dashboard.editable = true;
+      await nextFrame();
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      const draggable = getDraggable(widget);
+      expect(draggable.getBoundingClientRect().height).to.be.above(0);
     });
   });
 });

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -136,6 +136,7 @@ type TestDragEvent = Event & {
   clientX: number;
   clientY: number;
   dataTransfer: {
+    dropEffect?: string;
     setDragImage: sinon.SinonSpy;
     setData(type: string, data: string): void;
     getData(type: string): string;
@@ -164,7 +165,8 @@ function createDragEvent(type: string, { x, y }: { x: number; y: number }): Test
   return event;
 }
 
-export function fireDragStart(draggable: Element): TestDragEvent {
+export function fireDragStart(dragStartTarget: Element): TestDragEvent {
+  const draggable = getDraggable(dragStartTarget);
   const draggableRect = draggable.getBoundingClientRect();
   const event = createDragEvent('dragstart', {
     x: draggableRect.left + draggableRect.width / 2,
@@ -174,7 +176,7 @@ export function fireDragStart(draggable: Element): TestDragEvent {
   return event;
 }
 
-export function fireDragOver(dragOverTarget: Element, location: 'top' | 'botton' | 'start' | 'end'): TestDragEvent {
+export function fireDragOver(dragOverTarget: Element, location: 'top' | 'bottom' | 'start' | 'end'): TestDragEvent {
   const { top, bottom, left, right } = dragOverTarget.getBoundingClientRect();
   const y = location === 'top' ? top : bottom;
   const dir = document.dir;

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -197,3 +197,7 @@ export function fireDrop(dragOverTarget: Element): TestDragEvent {
   dragOverTarget.dispatchEvent(event);
   return event;
 }
+
+export function resetReorderTimeout(dashboard: HTMLElement): void {
+  (dashboard as any).__widgetReorderController.__reordering = false;
+}

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -191,3 +191,9 @@ export function fireDragEnd(dashboard: Element): TestDragEvent {
   dashboard.dispatchEvent(event);
   return event;
 }
+
+export function fireDrop(dragOverTarget: Element): TestDragEvent {
+  const event = createDragEvent('drop', { x: 0, y: 0 });
+  dragOverTarget.dispatchEvent(event);
+  return event;
+}

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -143,7 +143,7 @@ type TestDragEvent = Event & {
   };
 };
 
-function createDragEvent(type: string, { x, y }: { x: number; y: number }): TestDragEvent {
+export function createDragEvent(type: string, { x, y }: { x: number; y: number }): TestDragEvent {
   const event = new Event(type, {
     bubbles: true,
     cancelable: true,

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -1,3 +1,6 @@
+import { expect } from '@vaadin/chai-plugins';
+import sinon from 'sinon';
+
 /**
  * Returns the effective column widths of the dashboard as an array of numbers.
  */
@@ -86,4 +89,103 @@ export function setGap(dashboard: HTMLElement, gap?: number): void {
  */
 export function setMaximumColumnCount(dashboard: HTMLElement, count?: number): void {
   dashboard.style.setProperty('--vaadin-dashboard-col-max-count', count !== undefined ? `${count}` : null);
+}
+
+/**
+ * Validates the given grid layout.
+ *
+ * This function iterates through a number matrix representing the IDs of
+ * the items in the layout, and checks if the elements in the corresponding
+ * cells of the grid match the expected IDs.
+ *
+ * For example, the following layout would expect a grid with two columns
+ * and three rows, where the first row has one element with ID "item-0" spanning
+ * two columns, and the second row has two elements with IDs "item-1" and "item-2"
+ * where the first one spans two rows, and the last cell in the third row has
+ * an element with ID "item-3":
+ *
+ * ```
+ * [
+ *  [0, 0],
+ *  [1, 2],
+ *  [1, 3]
+ * ]
+ * ```
+ */
+export function expectLayout(dashboard: HTMLElement, layout: Array<Array<number | null>>): void {
+  expect(getRowHeights(dashboard).length).to.eql(layout.length);
+  expect(getColumnWidths(dashboard).length).to.eql(layout[0].length);
+
+  layout.forEach((row, rowIndex) => {
+    row.forEach((itemId, columnIndex) => {
+      const element = getElementFromCell(dashboard, rowIndex, columnIndex);
+      if (!element) {
+        expect(itemId).to.be.null;
+      } else {
+        expect(element.id).to.equal(`item-${itemId}`);
+      }
+    });
+  });
+}
+
+export function getDraggable(element: Element): Element {
+  return element.shadowRoot!.querySelector('[draggable]')!;
+}
+
+type TestDragEvent = Event & {
+  clientX: number;
+  clientY: number;
+  dataTransfer: {
+    setDragImage: sinon.SinonSpy;
+    setData(type: string, data: string): void;
+    getData(type: string): string;
+  };
+};
+
+function createDragEvent(type: string, { x, y }: { x: number; y: number }): TestDragEvent {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  }) as TestDragEvent;
+
+  event.clientX = x;
+  event.clientY = y;
+
+  const dragData: Record<string, string> = {};
+  event.dataTransfer = {
+    setDragImage: sinon.spy(),
+    setData: (type: string, data: string) => {
+      dragData[type] = data;
+    },
+    getData: (type: string) => dragData[type],
+  };
+
+  return event;
+}
+
+export function fireDragStart(draggable: Element): TestDragEvent {
+  const draggableRect = draggable.getBoundingClientRect();
+  const event = createDragEvent('dragstart', {
+    x: draggableRect.left + draggableRect.width / 2,
+    y: draggableRect.top + draggableRect.height / 2,
+  });
+  draggable.dispatchEvent(event);
+  return event;
+}
+
+export function fireDragOver(dragOverTarget: Element, location: 'top' | 'botton' | 'start' | 'end'): TestDragEvent {
+  const { top, bottom, left, right } = dragOverTarget.getBoundingClientRect();
+  const y = location === 'top' ? top : bottom;
+  const dir = document.dir;
+  const x = location === 'start' ? (dir === 'rtl' ? right : left) : dir === 'rtl' ? left : right;
+  const event = createDragEvent('dragover', { x, y });
+  dragOverTarget.dispatchEvent(event);
+  return event;
+}
+
+export function fireDragEnd(dashboard: Element): TestDragEvent {
+  const event = createDragEvent('dragend', { x: 0, y: 0 });
+  dashboard.dispatchEvent(event);
+  return event;
 }

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -4,13 +4,20 @@ import sinon from 'sinon';
 /**
  * Returns the effective column widths of the dashboard as an array of numbers.
  */
-export function getColumnWidths(dashboard: HTMLElement): number[] {
+export function getColumnWidths(dashboard: Element): number[] {
   return getComputedStyle(dashboard)
     .gridTemplateColumns.split(' ')
     .map((width) => parseFloat(width));
 }
 
-function _getRowHeights(dashboard: HTMLElement): number[] {
+export function getParentSection(element?: Element | null): Element | null {
+  if (!element) {
+    return null;
+  }
+  return element.closest('vaadin-dashboard-section');
+}
+
+function _getRowHeights(dashboard: Element): number[] {
   return getComputedStyle(dashboard)
     .gridTemplateRows.split(' ')
     .map((height) => parseFloat(height));
@@ -38,7 +45,7 @@ export function getRowHeights(dashboard: HTMLElement): number[] {
   const dashboardRowHeights = _getRowHeights(dashboard);
   [...dashboardRowHeights].forEach((_height, index) => {
     const item = _getElementFromCell(dashboard, index, 0, dashboardRowHeights);
-    const parentSection = item?.closest('vaadin-dashboard-section');
+    const parentSection = getParentSection(item);
     if (parentSection) {
       const [headerRowHeight, firstRowHeight, ...remainingRowHeights] = _getRowHeights(parentSection);
       // Merge the first two row heights of the section since the first one is the section header

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -1,7 +1,15 @@
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import { TitleController } from '../../src/title-controller.js';
 import type { DashboardLayoutMixinClass } from '../../src/vaadin-dashboard-layout-mixin.js';
-import type { Dashboard, DashboardItem, DashboardRenderer, DashboardSectionItem } from '../../vaadin-dashboard.js';
+import type {
+  Dashboard,
+  DashboardItem,
+  DashboardItemDragReorderEvent,
+  DashboardItemReorderEndEvent,
+  DashboardItemReorderStartEvent,
+  DashboardRenderer,
+  DashboardSectionItem,
+} from '../../vaadin-dashboard.js';
 import type { DashboardLayout } from '../../vaadin-dashboard-layout.js';
 import type { DashboardSection } from '../../vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../../vaadin-dashboard-widget.js';
@@ -29,6 +37,22 @@ assertType<
   | { colspan?: number; testProperty: string }
   | { title?: string | null; items: Array<{ colspan?: number; testProperty: string }> }
 >(narrowedDashboard.items[0]);
+
+narrowedDashboard.addEventListener('dashboard-item-reorder-start', (event) => {
+  assertType<DashboardItemReorderStartEvent>(event);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-reorder-end', (event) => {
+  assertType<DashboardItemReorderEndEvent>(event);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-drag-reorder', (event) => {
+  assertType<DashboardItemDragReorderEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem | DashboardSectionItem<TestDashboardItem>>(event.detail.item);
+  assertType<number>(event.detail.targetIndex);
+});
+
+/* DashboardLayout */
 const layout = document.createElement('vaadin-dashboard-layout');
 assertType<DashboardLayout>(layout);
 

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -19,6 +19,7 @@ assertType<Dashboard>(genericDashboard);
 assertType<ElementMixinClass>(genericDashboard);
 assertType<DashboardLayoutMixinClass>(genericDashboard);
 assertType<Array<DashboardItem | DashboardSectionItem<DashboardItem>> | null | undefined>(genericDashboard.items);
+assertType<boolean>(genericDashboard.editable);
 
 const narrowedDashboard = document.createElement('vaadin-dashboard') as unknown as Dashboard<TestDashboardItem>;
 assertType<Dashboard<TestDashboardItem>>(narrowedDashboard);
@@ -26,7 +27,7 @@ assertType<Array<TestDashboardItem | DashboardSectionItem<TestDashboardItem>>>(n
 assertType<DashboardRenderer<TestDashboardItem> | null | undefined>(narrowedDashboard.renderer);
 assertType<
   | { colspan?: number; testProperty: string }
-  | { title: string | null | undefined; items: Array<{ colspan?: number; testProperty: string }> }
+  | { title?: string | null; items: Array<{ colspan?: number; testProperty: string }> }
 >(narrowedDashboard.items[0]);
 const layout = document.createElement('vaadin-dashboard-layout');
 assertType<DashboardLayout>(layout);


### PR DESCRIPTION
## Description

Add support for DnD reordering of `<vaadin-dashboard>` widgets and sections

https://github.com/user-attachments/assets/d075811d-2713-4472-b151-d32d8c93fb09

Added API:
- `editable` if true, the widget/section header controls are visible
- Events:
  - `dashboard-item-reorder-start`: Fired when item reordering starts
  - `dashboard-item-reorder-end`: Fired when item reordering ends
  - `dashboard-item-drag-reorder`: Fired when an items will be reordered by dragging
    - `event.item`: The item being dragged
    - `event.targetIndex`: The new index of the item in its host `items` array

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=74625606

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature