### PR TITLE
refactor: move dashboard CSS grid inside shadow root

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -22,6 +22,15 @@ export const DashboardLayoutMixin = (superClass) =>
     static get styles() {
       return css`
         :host {
+          display: block;
+          overflow: auto;
+        }
+
+        :host([hidden]) {
+          display: none !important;
+        }
+
+        #grid {
           /* Default min and max column widths */
           --_vaadin-dashboard-default-col-min-width: 25rem;
           --_vaadin-dashboard-default-col-max-width: 1fr;
@@ -46,7 +55,6 @@ export const DashboardLayoutMixin = (superClass) =>
           );
 
           display: grid;
-          overflow: auto;
 
           grid-template-columns: repeat(
             var(--_vaadin-dashboard-effective-col-count, auto-fill),
@@ -54,10 +62,6 @@ export const DashboardLayoutMixin = (superClass) =>
           );
 
           gap: var(--vaadin-dashboard-gap, 1rem);
-        }
-
-        :host([hidden]) {
-          display: none !important;
         }
 
         ::slotted(*) {
@@ -77,6 +81,9 @@ export const DashboardLayoutMixin = (superClass) =>
      * @override
      */
     _onResize() {
+      // Update the grid width to match the host width. This is done programmatically to avoid
+      // flickering due to the asynchronous nature of ResizeObserver.
+      this.$.grid.style.width = `${this.offsetWidth}px`;
       this.__updateColumnCount();
     }
 
@@ -87,7 +94,7 @@ export const DashboardLayoutMixin = (superClass) =>
       // Clear the previously computed column count
       this.style.removeProperty('--_vaadin-dashboard-col-count');
       // Get the column count (with no colspans etc in effect)...
-      const columnCount = getComputedStyle(this).gridTemplateColumns.split(' ').length;
+      const columnCount = getComputedStyle(this.$.grid).gridTemplateColumns.split(' ').length;
       // ...and set it as the new value
       this.style.setProperty('--_vaadin-dashboard-col-count', columnCount);
     }

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -23,6 +23,7 @@ export const DashboardLayoutMixin = (superClass) =>
       return css`
         :host {
           display: block;
+          overflow: hidden;
         }
 
         :host([hidden]) {
@@ -30,9 +31,6 @@ export const DashboardLayoutMixin = (superClass) =>
         }
 
         #grid {
-          overflow: hidden auto;
-          height: 100%;
-
           /* Default min and max column widths */
           --_vaadin-dashboard-default-col-min-width: 25rem;
           --_vaadin-dashboard-default-col-max-width: 1fr;
@@ -57,6 +55,8 @@ export const DashboardLayoutMixin = (superClass) =>
           );
 
           display: grid;
+          overflow: auto;
+          height: 100%;
 
           grid-template-columns: repeat(
             var(--_vaadin-dashboard-effective-col-count, auto-fill),
@@ -64,10 +64,6 @@ export const DashboardLayoutMixin = (superClass) =>
           );
 
           gap: var(--vaadin-dashboard-gap, 1rem);
-        }
-
-        #grid[overflow] {
-          overflow: auto;
         }
 
         ::slotted(*) {
@@ -91,9 +87,6 @@ export const DashboardLayoutMixin = (superClass) =>
       // flickering due to the asynchronous nature of ResizeObserver.
       this.$.grid.style.width = `${this.offsetWidth}px`;
       this.__updateColumnCount();
-
-      const overflow = Math.ceil(this.$.grid.scrollWidth - this.$.grid.clientWidth) > 0;
-      this.$.grid.toggleAttribute('overflow', overflow);
     }
 
     /**

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -23,6 +23,10 @@ export const DashboardLayoutMixin = (superClass) =>
       return css`
         :host {
           display: block;
+          overflow: hidden auto;
+        }
+
+        :host([overflow]) {
           overflow: auto;
         }
 
@@ -85,6 +89,9 @@ export const DashboardLayoutMixin = (superClass) =>
       // flickering due to the asynchronous nature of ResizeObserver.
       this.$.grid.style.width = `${this.offsetWidth}px`;
       this.__updateColumnCount();
+
+      const overflow = Math.ceil(this.scrollWidth - this.clientWidth) > 0;
+      this.toggleAttribute('overflow', overflow);
     }
 
     /**

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -23,11 +23,6 @@ export const DashboardLayoutMixin = (superClass) =>
       return css`
         :host {
           display: block;
-          overflow: hidden auto;
-        }
-
-        :host([overflow]) {
-          overflow: auto;
         }
 
         :host([hidden]) {
@@ -35,6 +30,9 @@ export const DashboardLayoutMixin = (superClass) =>
         }
 
         #grid {
+          overflow: hidden auto;
+          height: 100%;
+
           /* Default min and max column widths */
           --_vaadin-dashboard-default-col-min-width: 25rem;
           --_vaadin-dashboard-default-col-max-width: 1fr;
@@ -68,6 +66,10 @@ export const DashboardLayoutMixin = (superClass) =>
           gap: var(--vaadin-dashboard-gap, 1rem);
         }
 
+        #grid[overflow] {
+          overflow: auto;
+        }
+
         ::slotted(*) {
           --_vaadin-dashboard-item-column: span
             min(
@@ -90,8 +92,8 @@ export const DashboardLayoutMixin = (superClass) =>
       this.$.grid.style.width = `${this.offsetWidth}px`;
       this.__updateColumnCount();
 
-      const overflow = Math.ceil(this.scrollWidth - this.clientWidth) > 0;
-      this.toggleAttribute('overflow', overflow);
+      const overflow = Math.ceil(this.$.grid.scrollWidth - this.$.grid.clientWidth) > 0;
+      this.$.grid.toggleAttribute('overflow', overflow);
     }
 
     /**
@@ -99,10 +101,10 @@ export const DashboardLayoutMixin = (superClass) =>
      */
     __updateColumnCount() {
       // Clear the previously computed column count
-      this.style.removeProperty('--_vaadin-dashboard-col-count');
+      this.$.grid.style.removeProperty('--_vaadin-dashboard-col-count');
       // Get the column count (with no colspans etc in effect)...
       const columnCount = getComputedStyle(this.$.grid).gridTemplateColumns.split(' ').length;
       // ...and set it as the new value
-      this.style.setProperty('--_vaadin-dashboard-col-count', columnCount);
+      this.$.grid.style.setProperty('--_vaadin-dashboard-col-count', columnCount);
     }
   };

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -31,7 +31,7 @@ class DashboardLayout extends DashboardLayoutMixin(ElementMixin(ThemableMixin(Po
 
   /** @protected */
   render() {
-    return html`<slot></slot>`;
+    return html`<div id="grid"><slot></slot></div>`;
   }
 }
 

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -81,7 +81,7 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
 
   /** @protected */
   render() {
-    return html`<slot></slot>`;
+    return html`<div id="grid"><slot></slot></div>`;
   }
 
   /** @private */

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -216,6 +216,36 @@ describe('dashboard layout', () => {
         [0, 0, 1],
       ]);
     });
+
+    it('should not flicker on resize', async () => {
+      setMinimumColumnWidth(dashboard, columnWidth / 2);
+      setColspan(childElements[0], 2);
+      await nextFrame();
+
+      /* prettier-ignore */
+      expectLayout(dashboard, [
+        [0, 0],
+        [1],
+      ]);
+
+      const widget1Width = childElements[1].offsetWidth;
+
+      // Narrow down the dashboard
+      dashboard.style.width = `${columnWidth}px`;
+      // Expect widget 1 to still have the same width
+      expect(childElements[1].offsetWidth).to.eql(widget1Width);
+
+      await nextFrame();
+
+      /* prettier-ignore */
+      expectLayout(dashboard, [
+        [0],
+        [1],
+      ]);
+
+      // Expect widget 1 to still have the same width after the layout has been recalculated
+      expect(childElements[1].offsetWidth).to.eql(widget1Width);
+    });
   });
 
   describe('gap', () => {

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -103,10 +103,11 @@ describe('dashboard layout', () => {
     dashboard.style.width = `${columnWidth}px`;
     const rowHeight = Math.ceil(getRowHeights(dashboard)[0]);
     dashboard.style.height = `${rowHeight}px`;
-    expect(dashboard.scrollTop).to.eql(0);
+    const scrollingContainer = (dashboard as any).$.grid;
+    expect(scrollingContainer.scrollTop).to.eql(0);
 
-    dashboard.scrollTop = 1;
-    expect(dashboard.scrollTop).to.eql(1);
+    scrollingContainer.scrollTop = 1;
+    expect(scrollingContainer.scrollTop).to.eql(1);
   });
 
   describe('minimum column width', () => {

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -126,6 +126,10 @@ describe('dashboard layout', () => {
     expect(scrollingContainer.scrollLeft).to.eql(1);
   });
 
+  it('should hide content overflowing the host', () => {
+    expect(getComputedStyle(dashboard).overflow).to.eql('hidden');
+  });
+
   describe('minimum column width', () => {
     it('should have a default minimum column width', () => {
       // Clear the minimum column width used in the tests

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -7,6 +7,7 @@ import {
   getColumnWidths,
   getElementFromCell,
   getRowHeights,
+  getScrollingContainer,
   setColspan,
   setGap,
   setMaximumColumnCount,
@@ -99,15 +100,30 @@ describe('dashboard layout', () => {
     ]);
   });
 
-  it('should scroll when content overflows', () => {
+  it('should scroll vertically when content overflows', async () => {
     dashboard.style.width = `${columnWidth}px`;
     const rowHeight = Math.ceil(getRowHeights(dashboard)[0]);
     dashboard.style.height = `${rowHeight}px`;
-    const scrollingContainer = (dashboard as any).$.grid;
+    await nextFrame();
+
+    const scrollingContainer = getScrollingContainer(dashboard);
+    expect(getComputedStyle(scrollingContainer).overflowY).to.eql('auto');
     expect(scrollingContainer.scrollTop).to.eql(0);
 
     scrollingContainer.scrollTop = 1;
     expect(scrollingContainer.scrollTop).to.eql(1);
+  });
+
+  it('should scroll horizontally when content overflows', async () => {
+    dashboard.style.width = `${columnWidth / 2}px`;
+    await nextFrame();
+
+    const scrollingContainer = getScrollingContainer(dashboard);
+    expect(getComputedStyle(scrollingContainer).overflowX).to.eql('auto');
+    expect(scrollingContainer.scrollLeft).to.eql(0);
+
+    scrollingContainer.scrollLeft = 1;
+    expect(scrollingContainer.scrollLeft).to.eql(1);
   });
 
   describe('minimum column width', () => {

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -2,8 +2,11 @@ function getCssGrid(element: Element): Element {
   return (element as any).$?.grid || element;
 }
 
+/**
+ * Returns the scrolling container of the dashboard.
+ */
 export function getScrollingContainer(dashboard: Element): Element {
-  return (dashboard as any).$.grid;
+  return getCssGrid(dashboard);
 }
 
 /**

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -1,14 +1,18 @@
+function getCssGrid(element: Element): Element {
+  return (element as any).$?.grid || element;
+}
+
 /**
  * Returns the effective column widths of the dashboard as an array of numbers.
  */
-export function getColumnWidths(dashboard: HTMLElement): number[] {
-  return getComputedStyle(dashboard)
+export function getColumnWidths(dashboard: Element): number[] {
+  return getComputedStyle(getCssGrid(dashboard))
     .gridTemplateColumns.split(' ')
     .map((width) => parseFloat(width));
 }
 
-function _getRowHeights(dashboard: HTMLElement): number[] {
-  return getComputedStyle(dashboard)
+function _getRowHeights(dashboard: Element): number[] {
+  return getComputedStyle(getCssGrid(dashboard))
     .gridTemplateRows.split(' ')
     .map((height) => parseFloat(height));
 }

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -2,6 +2,10 @@ function getCssGrid(element: Element): Element {
   return (element as any).$?.grid || element;
 }
 
+export function getScrollingContainer(dashboard: Element): Element {
+  return (dashboard as any).$.grid;
+}
+
 /**
  * Returns the effective column widths of the dashboard as an array of numbers.
  */


### PR DESCRIPTION
## Description

Move the dashboard CSS grid inside the host's shadow root. This enables us to resize the grid programmatically when the `ResizeMixin`'s `ResizeObserver` invokes on host size change. The change aims to eliminate flickering that might occur on component resize.

Before (CPU slowdown in use to highlight the flickering):

https://github.com/user-attachments/assets/0749e472-c6dc-4985-a4e1-c55efb7e7f59

After:

https://github.com/user-attachments/assets/ddb798a5-21f8-4a95-94a1-601ab64b7f62


Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=75035546

## Type of change

Refactor/bugfix