### PR TITLE
fix: remove no longer needed z-index for root menu-bar items

### DIFF
--- a/packages/menu-bar/src/vaadin-lit-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-lit-menu-bar-button.js
@@ -30,11 +30,6 @@ class MenuBarButton extends Button {
         :host([slot='overflow']) {
           margin-inline-end: 0;
         }
-
-        [part='label'] ::slotted(vaadin-menu-bar-item) {
-          position: relative;
-          z-index: 1;
-        }
       `,
     ];
   }

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -17,11 +17,6 @@ registerStyles(
     :host([slot='overflow']) {
       margin-inline-end: 0;
     }
-
-    [part='label'] ::slotted(vaadin-menu-bar-item) {
-      position: relative;
-      z-index: 1;
-    }
   `,
   { moduleId: 'vaadin-menu-bar-button-styles' },
 );

--- a/packages/menu-bar/test/menu-bar.common.js
+++ b/packages/menu-bar/test/menu-bar.common.js
@@ -406,13 +406,6 @@ describe('item components', () => {
     expect(buttons[4].item.component.children.length).to.equal(0);
     expect(buttons[4].item.component.textContent).to.equal('Item 5');
   });
-
-  it('should set position and z-index on the item component to allow clicks', () => {
-    const item = buttons[2].firstChild;
-    const style = getComputedStyle(item);
-    expect(style.position).to.equal('relative');
-    expect(Number(style.zIndex)).to.equal(1);
-  });
 });
 
 describe('menu-bar in flex', () => {


### PR DESCRIPTION
## Description

Fixes #7489

The code related to `z-index` was originally added when creating `vaadin-menu-bar` for Vaadin 14 due to the problem of handling clicks on root level menu items - see https://github.com/vaadin/vaadin-menu-bar/pull/69. The issue about `vaadin-menu-bar-button` consuming clicks was apparently caused by native `<button>` with `position: absolute` used by [V14 `vaadin-button`](https://github.com/vaadin/vaadin-button/blob/43d48864fd9abcd1b579d610644f29e669007d74/src/vaadin-button.html#L59-L60).

However, since in Vaadin 22 we changed `<vaadin-button>` to not use native `<button>` internally, these styles are no longer needed. Furthermore, removing them resolves the Firefox issue (which unfortunately can only be tested manually at the moment), so it seems like this rendering bug is a combination of `container-type: size` and `z-index` properties.

## Type of change

- Bugfix

## Note


I confirmed that `z-index: 1` is still needed in V14 to allow clicks on root level items with the following example:

```html
<vaadin-menu-bar></vaadin-menu-bar>

<script type="module">
  import '@vaadin/menu-bar';

  const anchor = document.createElement('a');
  anchor.setAttribute('href', 'https://example.com');
  anchor.textContent = 'Example';

  document.querySelector('vaadin-menu-bar').items = [
    {
      component: anchor,
    },
  ];
</script>
```