### PR TITLE
fix: remove no longer needed z-index for root menu-bar items (#7743) (CP: 24.3)

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -17,11 +17,6 @@ registerStyles(
     :host([slot='overflow']) {
       margin-inline-end: 0;
     }
-
-    [part='label'] ::slotted(vaadin-menu-bar-item) {
-      position: relative;
-      z-index: 1;
-    }
   `,
   { moduleId: 'vaadin-menu-bar-button-styles' },
 );

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -732,13 +732,6 @@ describe('item components', () => {
     expect(subMenu.opened).to.be.false;
   });
 
-  it('should set position and z-index on the item component to allow clicks', () => {
-    const item = buttons[2].firstChild;
-    const style = getComputedStyle(item);
-    expect(style.position).to.equal('relative');
-    expect(Number(style.zIndex)).to.equal(1);
-  });
-
   describe('overflow', () => {
     let subMenu;
 


### PR DESCRIPTION
## Description

Manual cherry-pick of #7743 to `24.3` branch which doesn't have Lit based version of the menu-bar.

## Type of change

- Cherry-pick