### PR TITLE
fix: only show tooltip if the target cell is fully visible

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -1028,7 +1028,15 @@ export const GridMixin = (superClass) =>
       // Check if there is a slotted vaadin-tooltip element.
       const tooltip = this._tooltipController.node;
       if (tooltip && tooltip.isConnected) {
-        this._tooltipController.setTarget(event.target);
+        const target = event.target;
+        const targetRect = target.getBoundingClientRect();
+
+        if (targetRect.left < 0 || targetRect.right > this.getBoundingClientRect().right) {
+          // If the target cell is not fully in the viewport, do not show tooltip.
+          return;
+        }
+
+        this._tooltipController.setTarget(target);
         this._tooltipController.setContext(this.getEventContext(event));
 
         // Trigger opening using the corresponding delay.

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -1030,8 +1030,9 @@ export const GridMixin = (superClass) =>
       if (tooltip && tooltip.isConnected) {
         const target = event.target;
         const targetRect = target.getBoundingClientRect();
+        const gridRect = this.getBoundingClientRect();
 
-        if (targetRect.left < 0 || targetRect.right > this.getBoundingClientRect().right) {
+        if (targetRect.left < gridRect.left || targetRect.right > gridRect.right) {
           // If the target cell is not fully in the viewport, do not show tooltip.
           return;
         }

--- a/test/integration/grid-tooltip.test.js
+++ b/test/integration/grid-tooltip.test.js
@@ -32,6 +32,7 @@ describe('tooltip', () => {
       <vaadin-grid>
         <vaadin-grid-column path="firstName"></vaadin-grid-column>
         <vaadin-grid-column path="lastName"></vaadin-grid-column>
+        <vaadin-grid-column path="lastName"></vaadin-grid-column>
         <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
       </vaadin-grid>
     `);
@@ -292,6 +293,30 @@ describe('tooltip', () => {
         });
 
         it('should not show tooltip when cell not fully visible at the end', () => {
+          mouseenter(getCell(grid, 1));
+          expect(tooltip.opened).to.be.false;
+        });
+
+        it('should not show tooltip when cell is partially covered by frozen cell', async () => {
+          grid.querySelector('vaadin-grid-column').frozen = true;
+          await nextRender();
+
+          grid.$.table.scrollLeft = isRTL ? -100 : 100;
+          await nextRender();
+          flushGrid(grid);
+
+          mouseenter(getCell(grid, 1));
+          expect(tooltip.opened).to.be.false;
+        });
+
+        it('should not show tooltip when cell is partially covered by frozen to end cell', async () => {
+          grid.querySelectorAll('vaadin-grid-column')[2].frozenToEnd = true;
+          await nextRender();
+
+          grid.$.table.scrollLeft = isRTL ? -100 : 100;
+          await nextRender();
+          flushGrid(grid);
+
           mouseenter(getCell(grid, 1));
           expect(tooltip.opened).to.be.false;
         });

--- a/test/integration/grid-tooltip.test.js
+++ b/test/integration/grid-tooltip.test.js
@@ -263,23 +263,39 @@ describe('tooltip', () => {
   });
 
   describe('cell not fully visible', () => {
-    beforeEach(() => {
-      tooltip.hoverDelay = 0;
-      grid.style.width = '150px';
-    });
+    ['ltr', 'rtl'].forEach((direction) => {
+      describe(`${direction}`, () => {
+        const isRTL = direction === 'rtl';
 
-    it('should not show tooltip when cell not fully visible at the start', async () => {
-      grid.$.table.scrollLeft = 150;
-      await nextRender();
-      flushGrid(grid);
+        before(() => {
+          document.documentElement.setAttribute('dir', direction);
+        });
 
-      mouseenter(getCell(grid, 0));
-      expect(tooltip.opened).to.be.false;
-    });
+        after(() => {
+          document.documentElement.removeAttribute('dir');
+        });
 
-    it('should not show tooltip when cell not fully visible at the end', () => {
-      mouseenter(getCell(grid, 1));
-      expect(tooltip.opened).to.be.false;
+        beforeEach(async () => {
+          tooltip.hoverDelay = 0;
+          grid.style.width = '150px';
+          flushGrid(grid);
+          await nextRender();
+        });
+
+        it('should not show tooltip when cell not fully visible at the start', async () => {
+          grid.$.table.scrollLeft = isRTL ? -150 : 150;
+          await nextRender();
+          flushGrid(grid);
+
+          mouseenter(getCell(grid, 0));
+          expect(tooltip.opened).to.be.false;
+        });
+
+        it('should not show tooltip when cell not fully visible at the end', () => {
+          mouseenter(getCell(grid, 1));
+          expect(tooltip.opened).to.be.false;
+        });
+      });
     });
   });
 

--- a/test/integration/grid-tooltip.test.js
+++ b/test/integration/grid-tooltip.test.js
@@ -262,6 +262,27 @@ describe('tooltip', () => {
     });
   });
 
+  describe('cell not fully visible', () => {
+    beforeEach(() => {
+      tooltip.hoverDelay = 0;
+      grid.style.width = '150px';
+    });
+
+    it('should not show tooltip when cell not fully visible at the start', async () => {
+      grid.$.table.scrollLeft = 150;
+      await nextRender();
+      flushGrid(grid);
+
+      mouseenter(getCell(grid, 0));
+      expect(tooltip.opened).to.be.false;
+    });
+
+    it('should not show tooltip when cell not fully visible at the end', () => {
+      mouseenter(getCell(grid, 1));
+      expect(tooltip.opened).to.be.false;
+    });
+  });
+
   describe('delay', () => {
     before(() => {
       Tooltip.setDefaultFocusDelay(0);


### PR DESCRIPTION
## Description

Fixes #7744

In grids with many columns it's quite common to have cases where certain cell is not fully in the viewport due to horizontal scrolling. IMO we shouldn't show cell tooltip in this case as it might be positioned incorrectly.

Note: there is still a chance that the `vaadin-tooltip` using `bottom` or `top` position will not be fully visible as there is a more general issue: https://github.com/vaadin/web-components/issues/7744#issuecomment-2326353872. IMO that's worth extracting to the separate ticket as it needs more thinking.

## Type of change

- Bugfix