### PR TITLE
test: ensure popover opened property is updated when closed

### DIFF
--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -208,6 +208,7 @@ describe('popover', () => {
       outsideClick();
       await nextRender();
       expect(overlay.opened).to.be.false;
+      expect(popover.opened).to.be.false;
     });
 
     it('should not close on outside click if noCloseOnOutsideClick is true', async () => {
@@ -267,9 +268,10 @@ describe('popover', () => {
         esc(document.body);
         await nextRender();
         expect(overlay.opened).to.be.false;
+        expect(popover.opened).to.be.false;
       });
 
-      it('should not close on global Escape press if noCloseOnEsc is true when moodal', async () => {
+      it('should not close on global Escape press if noCloseOnEsc is true when modal', async () => {
         popover.modal = true;
         popover.noCloseOnEsc = true;
         await nextUpdate(popover);


### PR DESCRIPTION
## Description

The following logic is currently untested (when removing this line, tests still pass on `main` branch):

https://github.com/vaadin/web-components/blob/d8ae51196a1ded333c40e091ab07b184aa317d57/packages/popover/src/vaadin-popover.js#L900-L902

I added checks to `modal` tests as in that case, the `overlay` is closed internally and the `opened` property needs to be updated on the host accordingly (which is why we actually need this overlay `opened-change` listener).

## Type of change

- Test