### PR TITLE
feat: add minimum row height to dashboard

### DIFF
--- a/dev/dashboard-layout.html
+++ b/dev/dashboard-layout.html
@@ -24,6 +24,7 @@
       vaadin-dashboard-layout {
         --vaadin-dashboard-col-min-width: 300px;
         --vaadin-dashboard-col-max-width: 500px;
+        --vaadin-dashboard-row-min-height: 300px;
         --vaadin-dashboard-gap: 20px;
         --vaadin-dashboard-col-max-count: 3;
       }

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -18,6 +18,7 @@
       vaadin-dashboard {
         --vaadin-dashboard-col-min-width: 300px;
         --vaadin-dashboard-col-max-width: 500px;
+        --vaadin-dashboard-row-min-height: 300px;
         --vaadin-dashboard-gap: 20px;
         --vaadin-dashboard-col-max-count: 3;
       }

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -54,6 +54,9 @@ export const DashboardLayoutMixin = (superClass) =>
             var(--_vaadin-dashboard-col-max-count)
           );
 
+          /* Effective row height */
+          --_vaadin-dashboard-row-height: minmax(var(--vaadin-dashboard-row-min-height, auto), auto);
+
           display: grid;
           overflow: auto;
           height: 100%;
@@ -62,6 +65,8 @@ export const DashboardLayoutMixin = (superClass) =>
             var(--_vaadin-dashboard-effective-col-count, auto-fill),
             minmax(var(--_vaadin-dashboard-col-min-width), var(--_vaadin-dashboard-col-max-width))
           );
+
+          grid-auto-rows: var(--_vaadin-dashboard-row-height);
 
           gap: var(--vaadin-dashboard-gap, 1rem);
         }

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -37,7 +37,7 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
         --_vaadin-dashboard-section-column: 1 / calc(var(--_vaadin-dashboard-effective-col-count) + 1);
         grid-column: var(--_vaadin-dashboard-section-column) !important;
         gap: var(--vaadin-dashboard-gap, 1rem);
-
+        /* Dashbaord section header height */
         --_vaadin-dashboard-section-header-height: minmax(0, auto);
         grid-template-rows: repeat(
           auto-fill,

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -37,6 +37,13 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
         --_vaadin-dashboard-section-column: 1 / calc(var(--_vaadin-dashboard-effective-col-count) + 1);
         grid-column: var(--_vaadin-dashboard-section-column) !important;
         gap: var(--vaadin-dashboard-gap, 1rem);
+
+        --_vaadin-dashboard-section-header-height: minmax(0, auto);
+        grid-template-rows: repeat(
+          auto-fill,
+          var(--_vaadin-dashboard-section-header-height) var(--_vaadin-dashboard-row-height)
+        );
+        grid-auto-rows: var(--_vaadin-dashboard-row-height);
       }
 
       :host([hidden]) {

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -39,10 +39,10 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
         gap: var(--vaadin-dashboard-gap, 1rem);
         /* Dashbaord section header height */
         --_vaadin-dashboard-section-header-height: minmax(0, auto);
-        grid-template-rows: repeat(
-          auto-fill,
-          var(--_vaadin-dashboard-section-header-height) var(--_vaadin-dashboard-row-height)
-        );
+        grid-template-rows: var(--_vaadin-dashboard-section-header-height) repeat(
+            auto-fill,
+            var(--_vaadin-dashboard-row-height)
+          );
         grid-auto-rows: var(--_vaadin-dashboard-row-height);
       }
 

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -3,10 +3,10 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-layout.js';
 import '../vaadin-dashboard-section.js';
 import type { DashboardLayout } from '../vaadin-dashboard-layout.js';
+import type { DashboardSection } from '../vaadin-dashboard-section.js';
 import {
   getColumnWidths,
   getElementFromCell,
-  getParentSection,
   getRowHeights,
   getScrollingContainer,
   setColspan,
@@ -394,8 +394,10 @@ describe('dashboard layout', () => {
   });
 
   describe('section', () => {
+    let section: DashboardSection;
+
     beforeEach(async () => {
-      const section = fixtureSync(`
+      section = fixtureSync(`
         <vaadin-dashboard-section section-title="Section">
           <div id="item-2">Section item 2</div>
           <div id="item-3">Section item 3</div>
@@ -465,22 +467,23 @@ describe('dashboard layout', () => {
 
     it('should use minimum row height for all section rows', async () => {
       dashboard.style.width = `${columnWidth}px`;
-      const section = getParentSection(childElements[2])!;
       setMinimumRowHeight(dashboard, 300);
       await nextFrame();
 
-      const [_sectionHeaderHeight, ...rowHeights] = getComputedStyle(section).gridTemplateRows.split(' ');
-      expect(rowHeights).to.eql(['300px', '300px']);
+      expect(childElements[2].offsetHeight).to.eql(300);
+      expect(childElements[3].offsetHeight).to.eql(300);
     });
 
     it('should not use minimum row height for section header row', async () => {
-      const section = getParentSection(childElements[2])!;
-      const [sectionHeaderHeight] = getComputedStyle(section).gridTemplateRows.split(' ');
+      const title = section.querySelector<HTMLHeadingElement>('[slot="title"]')!;
+      title.style.height = '100%';
+
+      const titleHeight = title.offsetHeight;
       setMinimumRowHeight(dashboard, 300);
       await nextFrame();
 
-      const [newSectionHeaderHeight] = getComputedStyle(section).gridTemplateRows.split(' ');
-      expect(newSectionHeaderHeight).to.eql(sectionHeaderHeight);
+      const newTitleHeight = title.offsetHeight;
+      expect(newTitleHeight).to.eql(titleHeight);
     });
 
     describe('gap', () => {

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -10,16 +10,6 @@ export function getScrollingContainer(dashboard: Element): Element {
 }
 
 /**
- * Returns the parent section of the element.
- */
-export function getParentSection(element?: Element | null): Element | null {
-  if (!element) {
-    return null;
-  }
-  return element.closest('vaadin-dashboard-section');
-}
-
-/**
  * Returns the effective column widths of the dashboard as an array of numbers.
  */
 export function getColumnWidths(dashboard: Element): number[] {
@@ -34,7 +24,7 @@ function _getRowHeights(dashboard: Element): number[] {
     .map((height) => parseFloat(height));
 }
 
-function _getElementFromCell(dashboard: Element, rowIndex: number, columnIndex: number, rowHeights: number[]) {
+function _getElementFromCell(dashboard: HTMLElement, rowIndex: number, columnIndex: number, rowHeights: number[]) {
   const { top, left } = dashboard.getBoundingClientRect();
   const columnWidths = getColumnWidths(dashboard);
   const x = left + columnWidths.slice(0, columnIndex).reduce((sum, width) => sum + width, 0);
@@ -52,7 +42,7 @@ function _getElementFromCell(dashboard: Element, rowIndex: number, columnIndex: 
 /**
  * Returns the effective row heights with the row heights of nested sections flattened.
  */
-export function getRowHeights(dashboard: Element): number[] {
+export function getRowHeights(dashboard: HTMLElement): number[] {
   const dashboardRowHeights = _getRowHeights(dashboard);
   [...dashboardRowHeights].forEach((_height, index) => {
     const item = _getElementFromCell(dashboard, index, 0, dashboardRowHeights);

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -10,6 +10,16 @@ export function getScrollingContainer(dashboard: Element): Element {
 }
 
 /**
+ * Returns the parent section of the element.
+ */
+export function getParentSection(element?: Element | null): Element | null {
+  if (!element) {
+    return null;
+  }
+  return element.closest('vaadin-dashboard-section');
+}
+
+/**
  * Returns the effective column widths of the dashboard as an array of numbers.
  */
 export function getColumnWidths(dashboard: Element): number[] {
@@ -24,7 +34,7 @@ function _getRowHeights(dashboard: Element): number[] {
     .map((height) => parseFloat(height));
 }
 
-function _getElementFromCell(dashboard: HTMLElement, rowIndex: number, columnIndex: number, rowHeights: number[]) {
+function _getElementFromCell(dashboard: Element, rowIndex: number, columnIndex: number, rowHeights: number[]) {
   const { top, left } = dashboard.getBoundingClientRect();
   const columnWidths = getColumnWidths(dashboard);
   const x = left + columnWidths.slice(0, columnIndex).reduce((sum, width) => sum + width, 0);
@@ -42,7 +52,7 @@ function _getElementFromCell(dashboard: HTMLElement, rowIndex: number, columnInd
 /**
  * Returns the effective row heights with the row heights of nested sections flattened.
  */
-export function getRowHeights(dashboard: HTMLElement): number[] {
+export function getRowHeights(dashboard: Element): number[] {
   const dashboardRowHeights = _getRowHeights(dashboard);
   [...dashboardRowHeights].forEach((_height, index) => {
     const item = _getElementFromCell(dashboard, index, 0, dashboardRowHeights);
@@ -97,4 +107,11 @@ export function setGap(dashboard: HTMLElement, gap?: number): void {
  */
 export function setMaximumColumnCount(dashboard: HTMLElement, count?: number): void {
   dashboard.style.setProperty('--vaadin-dashboard-col-max-count', count !== undefined ? `${count}` : null);
+}
+
+/**
+ * Sets the minimum row height of the dashboard.
+ */
+export function setMinimumRowHeight(dashboard: HTMLElement, height?: number): void {
+  dashboard.style.setProperty('--vaadin-dashboard-row-min-height', height !== undefined ? `${height}px` : null);
 }


### PR DESCRIPTION
## Description

Add minimum row height to dashboard

- Added API:
   - `--vaadin-dashboard-row-min-height`: CSS variable that affects the minimum row height of the dashboard and dashboard section grid

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=78393622

Part of https://github.com/vaadin/platform/issues/6626

Feature