### PR TITLE
docs: remove incorrect JSDoc annotation from typings

### DIFF
--- a/packages/component-base/src/media-query-controller.d.ts
+++ b/packages/component-base/src/media-query-controller.d.ts
@@ -19,9 +19,6 @@ export class MediaQueryController implements ReactiveController {
    */
   protected callback: (matches: boolean) => void;
 
-  /**
-   * @param {HTMLElement} host
-   */
   constructor(query: string, callback: (matches: boolean) => void);
 
   hostConnected(): void;


### PR DESCRIPTION
## Description

This annotation was added when creating `MediaQueryController` in #3426. 
However, its constructor doesn't actually accept `host`, so it's likely a copy-paste from elsewhere.

## Type of change

- Documentation