### PR TITLE
docs: remove unneeded JSDoc annotations from typings

### DIFF
--- a/packages/virtual-list/src/vaadin-virtual-list.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list.d.ts
@@ -36,11 +36,6 @@ export { VirtualListDefaultItem, VirtualListItemModel, VirtualListRenderer };
  * `overflow`       | Set to `top`, `bottom`, both, or none.
  *
  * See [Virtual List](https://vaadin.com/docs/latest/components/virtual-list) documentation.
- *
- * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes VirtualListMixin
  */
 declare class VirtualList<TItem = VirtualListDefaultItem> extends ThemableMixin(ElementMixin(HTMLElement)) {}
 


### PR DESCRIPTION
## Description

Both `@extends` and `@mixes` annotations are only needed in `.js` files used by Polymer Analyzer, but not in `.d.ts`.

## Type of change

- Documentation