### PR TITLE
docs: fix broken link to styling docs in tabsheet JSDoc

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -64,7 +64,7 @@ export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEve
  * `loading` | Set when a tab without associated content is selected
  * `overflow`   | Set to `top`, `bottom`, `start`, `end`, all of them, or none.
  *
- * See [Styling Components](hhttps://vaadin.com/docs/latest/components/ds-resources/customization/styling-components) documentation.
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -48,7 +48,7 @@ import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
  * `loading` | Set when a tab without associated content is selected
  * `overflow`   | Set to `top`, `bottom`, `start`, `end`, all of them, or none.
  *
- * See [Styling Components](hhttps://vaadin.com/docs/latest/components/ds-resources/customization/styling-components) documentation.
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.


### PR DESCRIPTION
## Description

This link has `hhttps` which makes it broken (also the URL hasn't been updated due to that).

## Type of change

- Documentation