### PR TITLE
feat: support elements in dashboard items

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -89,7 +89,12 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
     render(this.__renderItemCells(items || []), this);
 
     this.querySelectorAll('vaadin-dashboard-widget-wrapper').forEach((cell) => {
-      if (renderer) {
+      if (cell.__item.component instanceof HTMLElement) {
+        if (cell.__item.component.parentElement !== cell) {
+          cell.textContent = '';
+          cell.appendChild(cell.__item.component);
+        }
+      } else if (renderer) {
         renderer(cell, this, { item: cell.__item });
       } else {
         cell.innerHTML = '';
@@ -101,6 +106,11 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
   __renderItemCells(items) {
     return items.map((item) => {
       if (item.items) {
+        if (item.component instanceof HTMLElement) {
+          render(this.__renderItemCells(item.items), item.component);
+          return item.component;
+        }
+
         return html`<vaadin-dashboard-section
           .__item="${item}"
           .sectionTitle="${item.title || ''}"

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -1,11 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../vaadin-dashboard.js';
 import type { CustomElementType } from '@vaadin/component-base/src/define.js';
 import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
 import { getElementFromCell, setGap, setMaximumColumnWidth, setMinimumColumnWidth } from './helpers.js';
 
-type TestDashboardItem = DashboardItem & { id: string };
+type TestDashboardItem = DashboardItem & { id: string; component?: Element | string };
 
 describe('dashboard', () => {
   let dashboard: Dashboard<TestDashboardItem>;
@@ -142,6 +143,65 @@ describe('dashboard', () => {
       expect(widget3).to.be.ok;
       expect(widget3?.localName).to.equal('vaadin-dashboard-widget');
       expect(widget3).to.have.property('widgetTitle', 'Item 3 title');
+    });
+  });
+
+  describe('item components', () => {
+    it('should use the item component as widget', async () => {
+      const widget = fixtureSync('<vaadin-dashboard-widget widget-title="Component 0"></vaadin-dashboard-widget>');
+      dashboard.items = [{ id: 'Item 0', component: widget }];
+      await nextFrame();
+
+      expect(getElementFromCell(dashboard, 0, 0)).to.equal(widget);
+    });
+
+    it('should render default widgets if component is not an element', async () => {
+      dashboard.items = [{ id: 'Item 0', component: 'not-an-element' }];
+      await nextFrame();
+
+      const widget = getElementFromCell(dashboard, 0, 0);
+      expect(widget).to.be.ok;
+      expect(widget?.localName).to.equal('vaadin-dashboard-widget');
+      expect(widget).to.have.property('widgetTitle', 'Item 0 title');
+    });
+
+    it('should not call renderer for item components', async () => {
+      const renderer = sinon.spy();
+      dashboard.renderer = renderer;
+      const widget = fixtureSync('<vaadin-dashboard-widget widget-title="Component 0"></vaadin-dashboard-widget>');
+      dashboard.items = [{ id: 'Item 0', component: widget }];
+      await nextFrame();
+
+      expect(renderer).to.not.be.called;
+    });
+
+    it('should use the item component as section', async () => {
+      const section = fixtureSync(`<vaadin-dashboard-section section-title="Section"></vaadin-dashboard-section>`);
+      const widget = fixtureSync('<vaadin-dashboard-widget widget-title="Component 0"></vaadin-dashboard-widget>');
+      (dashboard as any).items = [
+        {
+          component: section,
+          items: [{ id: 'Item 0', component: widget }],
+        },
+      ];
+      await nextFrame();
+
+      expect(getElementFromCell(dashboard, 0, 0)).to.equal(widget);
+      expect(section.contains(widget)).to.be.true;
+    });
+
+    it('should render default section if component is not an element', async () => {
+      (dashboard as any).items = [{ component: 'not-an-element', title: 'Section', items: [{ id: 'Item 0' }] }];
+      await nextFrame();
+
+      const widget = getElementFromCell(dashboard, 0, 0);
+      expect(widget).to.be.ok;
+      expect(widget?.localName).to.equal('vaadin-dashboard-widget');
+      expect(widget).to.have.property('widgetTitle', 'Item 0 title');
+
+      const section = widget?.closest('vaadin-dashboard-section');
+      expect(section).to.be.ok;
+      expect(section?.sectionTitle).to.equal('Section');
     });
   });
 });


### PR DESCRIPTION
## Description

Support providing element instances in `<vaadin-dashboard>` `items`.

If an `HTMLElement` instance is passed as `item.component`
- Widget items: a `renderer` call for the item is skipped in favor of using the provided element as the widget.
- Section items: generating a `<vaadin-dashboard-section>` element internally is skipped in favor of using the provided element as the section.

This feature is added exclusively for the `Dashboard` Flow component's purposes, specifically to enable `DashboardSection` to extend `Component`, and thus doesn't include type definitions.

## Type of change

Feature