### PR TITLE
docs: add link to vaadin.com docs to popover README

### DIFF
--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -2,6 +2,8 @@
 
 A web component for creating overlays that are positioned next to specified DOM element (target).
 
+[Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/popover)
+
 [![npm version](https://badgen.net/npm/v/@vaadin/popover)](https://www.npmjs.com/package/@vaadin/popover)
 
 ## Installation


### PR DESCRIPTION
## Description

Now when https://vaadin.com/docs/latest/components/popover is deployed, let's add the link to README.

## Type of change

- Documentation