### PR TITLE
docs: add link to vaadin.com docs to tooltip README

### DIFF
--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -2,6 +2,8 @@
 
 A web component for creating tooltips.
 
+[Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/tooltip)
+
 [![npm version](https://badgen.net/npm/v/@vaadin/tooltip)](https://www.npmjs.com/package/@vaadin/tooltip)
 
 ```html


### PR DESCRIPTION
## Description

For some reason the tooltip README was lacking vaadin.com docs link so I added it.

## Type of change

- Documentation