### PR TITLE
fix: do not apply disabled value color to prefix and suffix

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -87,7 +87,7 @@ registerStyles(
       background: var(--_disabled-background);
     }
 
-    :host([disabled]) ::slotted(*) {
+    :host([disabled]) ::slotted(:not([slot$='fix'])) {
       -webkit-text-fill-color: var(--_disabled-value-color);
       color: var(--_disabled-value-color);
     }

--- a/packages/vaadin-lumo-styles/mixins/field-button.js
+++ b/packages/vaadin-lumo-styles/mixins/field-button.js
@@ -28,7 +28,7 @@ const fieldButton = css`
 
   :host([disabled]) [part$='button'],
   :host([readonly]) [part$='button'] {
-    color: var(--lumo-disabled-text-color);
+    color: var(--lumo-contrast-20pct);
     cursor: default;
   }
 

--- a/packages/vaadin-lumo-styles/mixins/field-button.js
+++ b/packages/vaadin-lumo-styles/mixins/field-button.js
@@ -28,7 +28,7 @@ const fieldButton = css`
 
   :host([disabled]) [part$='button'],
   :host([readonly]) [part$='button'] {
-    color: var(--lumo-contrast-20pct);
+    color: var(--lumo-disabled-text-color);
     cursor: default;
   }
 

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -90,7 +90,8 @@ const inputField = css`
     --vaadin-input-field-border-color: var(--lumo-contrast-20pct);
   }
 
-  :host([disabled]) [part='label'] {
+  :host([disabled]) [part='label'],
+  :host([disabled]) [part='input-field'] ::slotted([slot$='fix']) {
     color: var(--lumo-disabled-text-color);
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -95,7 +95,7 @@ const inputField = css`
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }
 
-  :host([disabled]) [part='input-field'] ::slotted(*) {
+  :host([disabled]) [part='input-field'] ::slotted(:not([slot$='fix'])) {
     color: var(--_disabled-value-color);
     -webkit-text-fill-color: var(--_disabled-value-color);
   }


### PR DESCRIPTION
## Description

The recently added custom CSS property `--vaadin-input-field-disabled-value-color` is only supposed to affect the value of the `<input>` element (or, in case of `vaadin-select`, of the selected item). But it also applies to prefix and suffix:

<img width="405" alt="Screenshot 2024-09-05 at 15 57 40" src="https://github.com/user-attachments/assets/4c09346a-3e71-4c03-a86d-41b5ce0b0922">

So I updated `::slotted(*)` to be `::slotted(:not([slot$='fix']))` (which covers both `prefix` and `suffix` slots).

Note: some users might expect `--lumo-disabled-text-color` to be applied to their custom `prefix` icons etc, so I figured out we can use it still for backwards compatibility with `24.4` which uses this CSS:

https://github.com/vaadin/web-components/blob/fb99836f8969f84e50c93356028cc7f7552ca7cf/packages/vaadin-lumo-styles/mixins/input-field-shared.js#L93-L96

## Type of change

- Bugfix
