### PR TITLE
refactor: remove duplicate fieldButton styles usage from number-field

### DIFF
--- a/packages/number-field/theme/lumo/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/lumo/vaadin-number-field-styles.js
@@ -5,7 +5,6 @@
  */
 import '@vaadin/input-container/theme/lumo/vaadin-input-container-styles.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
-import { fieldButton } from '@vaadin/vaadin-lumo-styles/mixins/field-button.js';
 import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -47,6 +46,6 @@ const numberField = css`
   }
 `;
 
-registerStyles('vaadin-number-field', [inputFieldShared, fieldButton, numberField], {
+registerStyles('vaadin-number-field', [inputFieldShared, numberField], {
   moduleId: 'lumo-number-field',
 });

--- a/packages/number-field/theme/material/vaadin-number-field-styles.js
+++ b/packages/number-field/theme/material/vaadin-number-field-styles.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/input-container/theme/material/vaadin-input-container-styles.js';
-import { fieldButton } from '@vaadin/vaadin-material-styles/mixins/field-button.js';
 import { inputFieldShared } from '@vaadin/vaadin-material-styles/mixins/input-field-shared.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -24,6 +23,6 @@ const numberField = css`
   }
 `;
 
-registerStyles('vaadin-number-field', [inputFieldShared, fieldButton, numberField], {
+registerStyles('vaadin-number-field', [inputFieldShared, numberField], {
   moduleId: 'material-number-field',
 });


### PR DESCRIPTION
## Description

I noticed that we have `fieldButton` styles applied twice in case of `vaadin-number-field` as the `inputFieldShared` already contains them for both Lumo and Material themes:

https://github.com/vaadin/web-components/blob/6f3ad57baff3a5d4c51126151bfaf98301c68539/packages/vaadin-lumo-styles/mixins/input-field-shared.js#L150

https://github.com/vaadin/web-components/blob/6f3ad57baff3a5d4c51126151bfaf98301c68539/packages/vaadin-material-styles/mixins/input-field-shared.js#L198

While it should be deduped by `ThemableMixin`, we should remove this unnecessary style.

## Type of change

- Refactor