### PR TITLE
refactor: remove unnecessary theme styles covered by src

### DIFF
--- a/packages/combo-box/theme/lumo/vaadin-combo-box-styles.js
+++ b/packages/combo-box/theme/lumo/vaadin-combo-box-styles.js
@@ -4,10 +4,6 @@ import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const comboBox = css`
-  :host {
-    outline: none;
-  }
-
   [part='toggle-button']::before {
     content: var(--lumo-icons-dropdown);
   }

--- a/packages/combo-box/theme/material/vaadin-combo-box-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-styles.js
@@ -6,8 +6,6 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 
 const comboBox = css`
   :host {
-    display: inline-flex;
-    outline: none;
     -webkit-tap-highlight-color: transparent;
   }
 

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-styles.js
@@ -4,10 +4,6 @@ import { inputFieldShared } from '@vaadin/vaadin-lumo-styles/mixins/input-field-
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 const datePicker = css`
-  :host {
-    outline: none;
-  }
-
   [part='toggle-button']::before {
     content: var(--lumo-icons-calendar);
   }

--- a/packages/select/theme/material/vaadin-select-styles.js
+++ b/packages/select/theme/material/vaadin-select-styles.js
@@ -17,7 +17,6 @@ registerStyles('vaadin-select-list-box', listBox, { moduleId: 'material-select-l
 
 const select = css`
   :host {
-    display: inline-flex;
     -webkit-tap-highlight-color: transparent;
   }
 

--- a/packages/vaadin-material-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-material-styles/mixins/input-field-shared.js
@@ -13,11 +13,9 @@ import { requiredField } from './required-field.js';
 
 const inputField = css`
   :host {
-    display: inline-flex;
     position: relative;
     padding-top: 8px;
     margin-bottom: 8px;
-    outline: none;
     color: var(--material-body-text-color);
     font-size: var(--material-body-font-size);
     line-height: 24px;


### PR DESCRIPTION
## Description

The following styles are no longer needed in themes as they are covered by `fieldShared` styles in `src`:

https://github.com/vaadin/web-components/blob/d665940d99599dc6005aecff2107687e4aeb1430/packages/field-base/src/styles/field-shared-styles.js#L8-L12

Updated themes for some components and Material input field styles to remove them.

## Type of change

- Refactor