### PR TITLE
fix: add missing extension to Lit directive import

### DIFF
--- a/packages/grid-pro/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid-pro/src/lit/column-renderer-directives.d.ts
@@ -8,7 +8,7 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import type { DirectiveResult } from 'lit/directive';
+import type { DirectiveResult } from 'lit/directive.js';
 import type { GridItemModel } from '@vaadin/grid';
 import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';

--- a/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid-pro/test/typings/lit-renderer-directives.types.ts
@@ -1,4 +1,4 @@
-import type { DirectiveResult } from 'lit/directive';
+import type { DirectiveResult } from 'lit/directive.js';
 import type { GridProColumnEditModeLitRenderer, GridProColumnEditModeRendererDirective } from '../../lit.js';
 import { columnEditModeRenderer } from '../../lit.js';
 

--- a/packages/grid/src/lit/column-renderer-directives.d.ts
+++ b/packages/grid/src/lit/column-renderer-directives.d.ts
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 /* eslint-disable max-classes-per-file */
-import type { DirectiveResult } from 'lit/directive';
+import type { DirectiveResult } from 'lit/directive.js';
 import type { LitRenderer, LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { GridItemModel } from '../vaadin-grid.js';

--- a/packages/grid/src/lit/renderer-directives.d.ts
+++ b/packages/grid/src/lit/renderer-directives.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { DirectiveResult } from 'lit/directive';
+import type { DirectiveResult } from 'lit/directive.js';
 import type { LitRendererResult } from '@vaadin/lit-renderer';
 import { LitRendererDirective } from '@vaadin/lit-renderer';
 import type { Grid, GridItemModel } from '../vaadin-grid.js';

--- a/packages/grid/test/typings/lit-renderer-directives.types.ts
+++ b/packages/grid/test/typings/lit-renderer-directives.types.ts
@@ -1,4 +1,4 @@
-import type { DirectiveResult } from 'lit/directive';
+import type { DirectiveResult } from 'lit/directive.js';
 import type {
   GridColumnBodyLitRenderer,
   GridColumnBodyRendererDirective,


### PR DESCRIPTION
## Description

Fixes #7780

Looks like the return type of some renderer directives was not properly evaluated since Lit enforces using `.js` extension and it was missing from several imports in `grid` and `grid-pro` packages. Adding it fixes the Lit plugin warning.

## Type of change

- Bugfix