### PR TITLE
fix!: destroy chart instance when disconnected from the DOM

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -33,6 +33,7 @@ import Pointer from 'highcharts/es-modules/Core/Pointer.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { get } from '@vaadin/component-base/src/path-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { inflateFunctions } from './helpers.js';
@@ -923,9 +924,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
         return;
       }
 
-      const options = { ...this.options, ...this._jsonConfigurationBuffer };
-      this._jsonConfigurationBuffer = null;
-      this.__initChart(options);
+      this.__resetChart();
       this.__addChildObserver();
       this.__checkTurboMode();
     });
@@ -1078,9 +1077,22 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
+
+    if (this.configuration) {
+      this.configuration.destroy();
+      this.configuration = undefined;
+    }
+
     if (this._childObserver) {
       this._childObserver.disconnect();
     }
+  }
+
+  /** @private */
+  __resetChart() {
+    const initialOptions = { ...this.options, ...this._jsonConfigurationBuffer };
+    this.__initChart(initialOptions);
+    this._jsonConfigurationBuffer = null;
   }
 
   /**
@@ -1179,11 +1191,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
       }
 
       if (resetConfiguration) {
-        const initialOptions = { ...this.options, ...this._jsonConfigurationBuffer };
-
-        this.__initChart(initialOptions);
-
-        this._jsonConfigurationBuffer = null;
+        this.__resetChart();
         return;
       }
 
@@ -1394,6 +1402,11 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   }
 
   /** @private */
+  __hasConfigurationBuffer(path) {
+    return get(path, this._jsonConfigurationBuffer) !== undefined;
+  }
+
+  /** @private */
   __updateOrAddCredits(credits) {
     if (this.configuration.credits) {
       this.configuration.credits.update(credits);
@@ -1441,7 +1454,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateCategories(categories, config) {
-    if (categories === undefined || !config) {
+    if (categories === undefined || !config || this.__hasConfigurationBuffer('xAxis.categories')) {
       return;
     }
 
@@ -1450,7 +1463,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateCategoryMax(max, config) {
-    if (max === undefined || !config) {
+    if (max === undefined || !config || this.__hasConfigurationBuffer('xAxis.max')) {
       return;
     }
 
@@ -1464,7 +1477,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateCategoryMin(min, config) {
-    if (min === undefined || !config) {
+    if (min === undefined || !config || this.__hasConfigurationBuffer('xAxis.min')) {
       return;
     }
 
@@ -1499,7 +1512,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateCategoryPosition(categoryPosition, config) {
-    if (categoryPosition === undefined || !config) {
+    if (categoryPosition === undefined || !config || this.__hasConfigurationBuffer('chart.inverted')) {
       return;
     }
 
@@ -1525,7 +1538,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __hideLegend(noLegend, config) {
-    if (noLegend === undefined || !config) {
+    if (noLegend === undefined || !config || this.__hasConfigurationBuffer('legend')) {
       return;
     }
 
@@ -1538,7 +1551,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateTitle(title, config) {
-    if (title === undefined || !config) {
+    if (title === undefined || !config || this.__hasConfigurationBuffer('title')) {
       return;
     }
 
@@ -1549,7 +1562,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __tooltipObserver(tooltip, config) {
-    if (tooltip === undefined || !config) {
+    if (tooltip === undefined || !config || this.__hasConfigurationBuffer('tooltip')) {
       return;
     }
 
@@ -1558,7 +1571,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateType(type, config) {
-    if (type === undefined || !config) {
+    if (type === undefined || !config || this.__hasConfigurationBuffer('chart.type')) {
       return;
     }
 
@@ -1571,7 +1584,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __updateSubtitle(subtitle, config) {
-    if (subtitle === undefined || !config) {
+    if (subtitle === undefined || !config || this.__hasConfigurationBuffer('subtitle')) {
       return;
     }
 
@@ -1602,7 +1615,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __stackingObserver(stacking, config) {
-    if (stacking === undefined || !config) {
+    if (stacking === undefined || !config || this.__hasConfigurationBuffer('plotOptions.series.stacking')) {
       return;
     }
 
@@ -1620,7 +1633,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __chart3dObserver(chart3d, config) {
-    if (chart3d === undefined || !config) {
+    if (chart3d === undefined || !config || this.__hasConfigurationBuffer('chart.options3d')) {
       return;
     }
 
@@ -1647,7 +1660,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __polarObserver(polar, config) {
-    if (polar === undefined || !config) {
+    if (polar === undefined || !config || this.__hasConfigurationBuffer('chart.polar')) {
       return;
     }
 
@@ -1658,7 +1671,7 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
 
   /** @private */
   __emptyTextObserver(emptyText, config) {
-    if (emptyText === undefined || !config) {
+    if (emptyText === undefined || !config || this.__hasConfigurationBuffer('lang.noData')) {
       return;
     }
 

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -367,48 +367,6 @@ describe('vaadin-chart', () => {
     });
   });
 
-  describe('reattach', () => {
-    let wrapper, inner, chart;
-
-    beforeEach(async () => {
-      wrapper = fixtureSync(`
-        <div>
-          <vaadin-chart>
-            <vaadin-chart-series value="[0,1,2]"></vaadin-chart-series>
-            <vaadin-chart-series value="[3,2,1]"></vaadin-chart-series>
-          </vaadin-chart>
-          <div id="inner"></div>
-        </div>
-      `);
-      chart = wrapper.querySelector('vaadin-chart');
-      inner = wrapper.querySelector('#inner');
-      await oneEvent(chart, 'chart-load');
-    });
-
-    it('should keep chart configuration when attached to a new parent', async () => {
-      expect(chart.configuration.series.length).to.be.equal(chart.childElementCount);
-      inner.appendChild(chart);
-      await oneEvent(chart, 'chart-redraw');
-      expect(chart.configuration.series.length).to.be.equal(chart.childElementCount);
-    });
-
-    it('should apply configuration update when attached to a new parent', async () => {
-      chart.updateConfiguration({ title: { text: 'Awesome title' }, credits: { enabled: false } });
-      await oneEvent(chart, 'chart-redraw');
-      expect(chart.$.chart.querySelector('.highcharts-title').textContent).to.equal('Awesome title');
-      expect(chart.$.chart.querySelector('.highcharts-credits')).to.be.null;
-
-      wrapper.removeChild(chart);
-      chart.updateConfiguration({ subtitle: { text: 'Awesome subtitle' }, credits: { enabled: true, text: 'Vaadin' } });
-
-      inner.appendChild(chart);
-      await oneEvent(chart, 'chart-redraw');
-      expect(chart.$.chart.querySelector('.highcharts-title').textContent).to.equal('Awesome title');
-      expect(chart.$.chart.querySelector('.highcharts-subtitle').textContent).to.equal('Awesome subtitle');
-      expect(chart.$.chart.querySelector('.highcharts-credits').textContent).to.equal('Vaadin');
-    });
-  });
-
   describe('RTL', () => {
     let chart;
 

--- a/packages/charts/test/reattach.test.js
+++ b/packages/charts/test/reattach.test.js
@@ -1,0 +1,206 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../vaadin-chart.js';
+
+describe('reattach', () => {
+  let wrapper, inner, chart;
+
+  beforeEach(() => {
+    wrapper = fixtureSync(`
+      <div>
+        <vaadin-chart>
+          <vaadin-chart-series values="[0,1,2]"></vaadin-chart-series>
+          <vaadin-chart-series values="[3,2,1]"></vaadin-chart-series>
+        </vaadin-chart>
+        <div id="inner"></div>
+      </div>
+    `);
+    chart = wrapper.querySelector('vaadin-chart');
+    inner = wrapper.querySelector('#inner');
+  });
+
+  it('should destroy chart configuration when disconnected from the DOM', async () => {
+    await oneEvent(chart, 'chart-load');
+
+    const spy = sinon.spy(chart.configuration, 'destroy');
+    wrapper.removeChild(chart);
+    expect(spy).to.be.calledOnce;
+    expect(chart.configuration).to.be.undefined;
+  });
+
+  it('should re-create chart configuration when attached to a new parent', async () => {
+    await oneEvent(chart, 'chart-load');
+    wrapper.removeChild(chart);
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.series.length).to.be.equal(chart.childElementCount);
+  });
+
+  it('should apply title updated while detached after reattach', async () => {
+    chart.title = 'Title';
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ title: { text: 'New title' } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.$.chart.querySelector('.highcharts-title').textContent).to.equal('New title');
+  });
+
+  it('should apply subtitle updated while detached after reattach', async () => {
+    chart.subtitle = 'Subtitle';
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ subtitle: { text: 'New subtitle' } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.$.chart.querySelector('.highcharts-subtitle').textContent).to.equal('New subtitle');
+  });
+
+  it('should apply type updated while detached after reattach', async () => {
+    chart.type = 'area';
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ chart: { type: 'line' } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.types).to.be.eql(['line']);
+  });
+
+  it('should apply tooltip updated while detached after reattach', async () => {
+    chart.tooltip = true;
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ tooltip: { enabled: false } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.tooltip.options.enabled).to.be.false;
+  });
+
+  it('should apply legend updated while detached after reattach', async () => {
+    chart.noLegend = true;
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ legend: { enabled: true } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.legend.options.enabled).to.be.true;
+  });
+
+  it('should apply chart3d updated while detached after reattach', async () => {
+    chart.chart3d = true;
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ chart: { options3d: { enabled: false } } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.is3d()).to.be.false;
+  });
+
+  it('should apply polar updated while detached after reattach', async () => {
+    chart.polar = true;
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ chart: { polar: false } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.options.chart.polar).to.be.false;
+  });
+
+  it('should apply empty text updated while detached after reattach', async () => {
+    chart.emptyText = 'No data';
+    chart.innerHTML = '';
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ lang: { noData: 'Nothing' } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+
+    const message = chart.$.chart.querySelector('.highcharts-no-data > text');
+    expect(message.textContent).to.equal('Nothing');
+  });
+
+  it('should apply stacking updated while detached after reattach', async () => {
+    chart.stacking = 'normal';
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({
+      plotOptions: {
+        series: { stacking: 'percent' },
+      },
+    });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.options.plotOptions.series.stacking).to.be.equal('percent');
+  });
+
+  it('should apply categories updated while detached after reattach', async () => {
+    chart.categories = ['Jan', 'Feb', 'Mar'];
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ xAxis: { categories: ['Jun', 'Jul', 'Aug'] } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+
+    const textNodes = chart.$.chart.querySelectorAll('.highcharts-xaxis-labels > text');
+    const text = Array.from(textNodes).map((node) => node.textContent);
+    expect(text).to.eql(['Jun', 'Jul', 'Aug']);
+  });
+
+  it('should apply xAxis min updated while detached after reattach', async () => {
+    chart.categoryMin = 0;
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ xAxis: { min: 1 } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.xAxis[0].min).to.be.equal(1);
+  });
+
+  it('should apply xAxis max updated while detached after reattach', async () => {
+    chart.categoryMax = 2;
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ xAxis: { max: 3 } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.xAxis[0].max).to.be.equal(3);
+  });
+
+  it('should apply inverted updated while detached after reattach', async () => {
+    chart.categoryPosition = 'left';
+    await oneEvent(chart, 'chart-load');
+
+    wrapper.removeChild(chart);
+    chart.updateConfiguration({ chart: { inverted: false } });
+
+    inner.appendChild(chart);
+    await oneEvent(chart, 'chart-load');
+    expect(chart.configuration.inverted).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Description

Depends on #7779

Part of https://github.com/vaadin/flow-components/issues/6607

This is a potential fix for the second part of the issue:

>  Currently, detaching the chart from the DOM doesn't destroy it, and the gobal charts array will still reference it. This is a resource leak, and you can also reproduce this by switching back and forth between the two views 

## Type of change

- Behavior altering fix

## Note

We need to test if the Flow counterpart still works after the change (especially since there is a known issue in the Flow router where the view component moved within the DOM during initialization causing detach and re-attach).