### PR TITLE
feat: drag-resizing of dashboard items

### DIFF
--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -105,7 +105,7 @@
       });
 
       dashboard.addEventListener('dashboard-item-resize-start', (e) => {
-        console.log('dashboard-item-resize-start');
+        console.log('dashboard-item-resize-start', e.detail);
       });
 
       dashboard.addEventListener('dashboard-item-drag-resize', (e) => {

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -102,6 +102,20 @@
         console.log('dashboard-item-reorder-end');
         console.log('items after reorder', e.target.items);
       });
+
+      dashboard.addEventListener('dashboard-item-resize-start', (e) => {
+        console.log('dashboard-item-resize-start');
+      });
+
+      dashboard.addEventListener('dashboard-item-drag-resize', (e) => {
+        console.log('dashboard-item-drag-resize', e.detail);
+        // e.preventDefault();
+      });
+
+      dashboard.addEventListener('dashboard-item-resize-end', (e) => {
+        console.log('dashboard-item-resize-end');
+        console.log('item after resize', e.detail);
+      });
     </script>
   </head>
 

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -34,7 +34,8 @@
       }
 
       .chart {
-        height: 300px;
+        height: 100%;
+        min-height: 300px;
         background: repeating-linear-gradient(45deg, #e0e0e0, #e0e0e0 10px, #f5f5f5 10px, #f5f5f5 20px);
       }
     </style>

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -48,6 +48,27 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
         #content {
           flex: 1;
         }
+
+        #resize-handle::before {
+          position: absolute;
+          bottom: 0;
+          right: 0;
+          font-size: 30px;
+          content: '\\2921';
+          cursor: grab;
+          line-height: 1;
+        }
+
+        :host::after {
+          content: '';
+          z-index: 100;
+          position: absolute;
+          inset-inline-start: 0;
+          top: 0;
+          width: var(--_vaadin-dashboard-widget-resizer-width, 0);
+          height: var(--_vaadin-dashboard-widget-resizer-height, 0);
+          background: rgba(0, 0, 0, 0.1);
+        }
       `,
       dashboardWidgetAndSectionStyles,
     ];
@@ -80,6 +101,8 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
       <div id="content">
         <slot></slot>
       </div>
+
+      <div id="resize-handle" class="resize-handle"></div>
     `;
   }
 

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -49,6 +49,10 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
           flex: 1;
         }
 
+        #resize-handle {
+          display: var(--_vaadin-dashboard-widget-actions-display, none);
+        }
+
         #resize-handle::before {
           position: absolute;
           bottom: 0;

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -65,12 +65,41 @@ export type DashboardItemDragReorderEvent<TItem extends DashboardItem> = CustomE
   targetIndex: number;
 }>;
 
+/**
+ * Fired when item resizing starts
+ */
+export type DashboardItemResizeStartEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem;
+}>;
+
+/**
+ * Fired when item resizing ends
+ */
+export type DashboardItemResizeEndEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem;
+}>;
+
+/**
+ * Fired when an item will be resized by dragging
+ */
+export type DashboardItemDragResizeEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem;
+  colspan: number;
+  rowspan: number;
+}>;
+
 export interface DashboardCustomEventMap<TItem extends DashboardItem> {
   'dashboard-item-reorder-start': DashboardItemReorderStartEvent;
 
   'dashboard-item-reorder-end': DashboardItemReorderEndEvent;
 
   'dashboard-item-drag-reorder': DashboardItemDragReorderEvent<TItem>;
+
+  'dashboard-item-resize-start': DashboardItemResizeStartEvent<TItem>;
+
+  'dashboard-item-resize-end': DashboardItemResizeEndEvent<TItem>;
+
+  'dashboard-item-drag-resize': DashboardItemDragResizeEvent<TItem>;
 }
 
 export type DashboardEventMap<TItem extends DashboardItem> = DashboardCustomEventMap<TItem> & HTMLElementEventMap;

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -27,6 +27,9 @@ import { WidgetResizeController } from './widget-resize-controller.js';
  * @fires {CustomEvent} dashboard-item-drag-reorder - Fired when an items will be reordered by dragging
  * @fires {CustomEvent} dashboard-item-reorder-start - Fired when item reordering starts
  * @fires {CustomEvent} dashboard-item-reorder-end - Fired when item reordering ends
+ * @fires {CustomEvent} dashboard-item-drag-resize - Fired when an item will be resized by dragging
+ * @fires {CustomEvent} dashboard-item-resize-start - Fired when item resizing starts
+ * @fires {CustomEvent} dashboard-item-resize-end - Fired when item resizing ends
  *
  * @customElement
  * @extends HTMLElement
@@ -104,6 +107,12 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     super();
     this.__widgetReorderController = new WidgetReorderController(this);
     this.__widgetResizeController = new WidgetResizeController(this);
+  }
+
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.__widgetResizeController.cleanup();
   }
 
   /** @protected */
@@ -188,6 +197,24 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
    * Fired when an items will be reordered by dragging
    *
    * @event dashboard-item-drag-reorder
+   */
+
+  /**
+   * Fired when item resizing starts
+   *
+   * @event dashboard-item-resize-start
+   */
+
+  /**
+   * Fired when item resizing ends
+   *
+   * @event dashboard-item-resize-end
+   */
+
+  /**
+   * Fired when an item will be resized by dragging
+   *
+   * @event dashboard-item-drag-resize
    */
 }
 

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -51,7 +51,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
           --_vaadin-dashboard-widget-actions-display: block;
         }
 
-        :host([resizing]) {
+        #grid[resizing] {
           user-select: none;
         }
       `,

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -19,6 +19,7 @@ import { css, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themabl
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
 import { WidgetReorderController } from './widget-reorder-controller.js';
+import { WidgetResizeController } from './widget-resize-controller.js';
 
 /**
  * A responsive, grid-based dashboard layout component
@@ -48,6 +49,10 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       css`
         :host([editable]) {
           --_vaadin-dashboard-widget-actions-display: block;
+        }
+
+        :host([resizing]) {
+          user-select: none;
         }
       `,
       hasWidgetWrappers,
@@ -98,12 +103,14 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
   constructor() {
     super();
     this.__widgetReorderController = new WidgetReorderController(this);
+    this.__widgetResizeController = new WidgetResizeController(this);
   }
 
   /** @protected */
   ready() {
     super.ready();
     this.addController(this.__widgetReorderController);
+    this.addController(this.__widgetResizeController);
   }
 
   /** @protected */

--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -106,13 +106,18 @@ export class WidgetResizeController extends EventTarget {
     itemWrapper.style.removeProperty('--_vaadin-dashboard-widget-resizer-width');
     itemWrapper.style.removeProperty('--_vaadin-dashboard-widget-resizer-height');
 
-    this.resizedItem = null;
     this.host.$.grid.toggleAttribute('resizing', false);
 
     this.__resizedElementRemoveObserver.disconnect();
     this.cleanup();
 
-    this.host.dispatchEvent(new CustomEvent('dashboard-item-resize-end'));
+    this.host.dispatchEvent(
+      new CustomEvent('dashboard-item-resize-end', {
+        detail: { item: this.resizedItem },
+        cancelable: true,
+      }),
+    );
+    this.resizedItem = null;
   }
 
   /** @private */

--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -132,7 +132,7 @@ export class WidgetResizeController extends EventTarget {
 
   /** @private */
   __updateResizedItem(colspan = 1, rowspan = 1) {
-    if (this.resizedItem.colspan === colspan && this.resizedItem.rowspan === rowspan) {
+    if ((this.resizedItem.colspan || 1) === colspan && (this.resizedItem.rowspan || 1) === rowspan) {
       return;
     }
 

--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright (c) 2019 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+const WRAPPER_LOCAL_NAME = 'vaadin-dashboard-widget-wrapper';
+import { addListener } from '@vaadin/component-base/src/gestures.js';
+
+/**
+ * A controller to widget resizing inside a dashboard.
+ */
+export class WidgetResizeController extends EventTarget {
+  constructor(host) {
+    super();
+    this.host = host;
+    this.__resizedElementRemoveObserver = new MutationObserver(() => this.__restoreResizedElement());
+
+    addListener(host, 'track', (e) => this.__onTrack(e));
+  }
+
+  /** @private */
+  __onTrack(e) {
+    if (e.detail.state === 'start') {
+      this.__onResizeStart(e);
+    } else if (e.detail.state === 'track') {
+      this.__onResize(e);
+    } else if (e.detail.state === 'end') {
+      this.__onResizeEnd(e);
+    }
+  }
+
+  /** @private */
+  __onResizeStart(e) {
+    const handle = [...e.composedPath()].find((el) => el.classList && el.classList.contains('resize-handle'));
+    if (!handle) {
+      return;
+    }
+
+    this.host.toggleAttribute('resizing', true);
+    this.resizedItem = this.__getElementItem(e.target);
+
+    this.__resizeStartWidth = e.target.offsetWidth;
+    this.__resizeStartHeight = e.target.offsetHeight;
+    this.__resizeWidth = this.__resizeStartWidth + e.detail.dx;
+    this.__resizeHeight = this.__resizeStartHeight + e.detail.dy;
+    this.__updateWidgetStyles();
+
+    this.host.dispatchEvent(new CustomEvent('dashboard-item-resize-start'));
+
+    this.__resizedElement = e.target;
+    this.__resizedElementRemoveObserver.observe(this.host, { childList: true, subtree: true });
+  }
+
+  /** @private */
+  __onResize(e) {
+    if (!this.resizedItem) {
+      return;
+    }
+
+    this.__resizeWidth = this.__resizeStartWidth + e.detail.dx;
+    this.__resizeHeight = this.__resizeStartHeight + e.detail.dy;
+    this.__updateWidgetStyles();
+
+    const itemWrapper = this.__getItemWrapper(this.resizedItem);
+    if (!itemWrapper.firstElementChild) {
+      return;
+    }
+
+    const gridStyle = getComputedStyle(this.host.$.grid);
+    const gapSize = parseFloat(gridStyle.gap || 0);
+
+    const currentElementWidth = itemWrapper.firstElementChild.offsetWidth;
+    const columns = gridStyle.gridTemplateColumns.split(' ');
+    const columnWidth = parseFloat(columns[0]);
+    if (this.__resizeWidth > currentElementWidth + gapSize + columnWidth / 2) {
+      this.__updateResizedItem(Math.min((this.resizedItem.colspan || 1) + 1, columns.length), this.resizedItem.rowspan);
+    } else if (this.__resizeWidth < currentElementWidth - columnWidth / 2) {
+      this.__updateResizedItem(Math.max((this.resizedItem.colspan || 1) - 1, 1), this.resizedItem.rowspan);
+    }
+
+    const currentElementHeight = itemWrapper.firstElementChild.offsetHeight;
+    const rowMinHeight = Math.min(...gridStyle.gridTemplateRows.split(' ').map((height) => parseFloat(height)));
+    if (this.__resizeHeight > currentElementHeight + gapSize + rowMinHeight / 2) {
+      this.__updateResizedItem(this.resizedItem.colspan, (this.resizedItem.rowspan || 1) + 1);
+    } else if (this.__resizeHeight < currentElementHeight - rowMinHeight / 2) {
+      this.__updateResizedItem(this.resizedItem.colspan, Math.max((this.resizedItem.rowspan || 1) - 1, 1));
+    }
+  }
+
+  /** @private */
+  __onResizeEnd() {
+    if (!this.resizedItem) {
+      return;
+    }
+
+    const itemWrapper = this.__getItemWrapper(this.resizedItem);
+    itemWrapper.style.removeProperty('--_vaadin-dashboard-widget-resizer-width');
+    itemWrapper.style.removeProperty('--_vaadin-dashboard-widget-resizer-height');
+
+    this.resizedItem = null;
+    this.host.toggleAttribute('resizing', false);
+
+    this.__resizedElementRemoveObserver.disconnect();
+
+    this.host.dispatchEvent(new CustomEvent('dashboard-item-resize-end'));
+  }
+
+  /** @private */
+  __getElementItem(element) {
+    return element.closest(WRAPPER_LOCAL_NAME).__item;
+  }
+
+  /** @private */
+  __getItemWrapper(item) {
+    return [...this.host.querySelectorAll(WRAPPER_LOCAL_NAME)].find((el) => el.__item === item);
+  }
+
+  /** @private */
+  __updateResizedItem(colspan, rowspan) {
+    if (this.resizedItem.colspan !== colspan || this.resizedItem.rowspan !== rowspan) {
+      this.resizedItem.colspan = colspan;
+      this.resizedItem.rowspan = rowspan;
+      this.host.dispatchEvent(new CustomEvent('dashboard-item-resize', { detail: { item: this.resizedItem } }));
+      this.host.items = [...this.host.items];
+      requestAnimationFrame(() => this.__updateWidgetStyles());
+    }
+  }
+
+  /** @private */
+  __updateWidgetStyles() {
+    const itemWrapper = this.__getItemWrapper(this.resizedItem);
+    itemWrapper.style.setProperty('--_vaadin-dashboard-widget-resizer-width', `${this.__resizeWidth}px`);
+    itemWrapper.style.setProperty('--_vaadin-dashboard-widget-resizer-height', `${this.__resizeHeight}px`);
+  }
+
+  /** @private */
+  __restoreResizedElement() {
+    if (!this.host.contains(this.__resizedElement)) {
+      this.__resizedElement.style.display = 'none';
+      this.host.appendChild(this.__resizedElement);
+    }
+  }
+}

--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -46,7 +46,7 @@ export class WidgetResizeController extends EventTarget {
     this.__resizeHeight = this.__resizeStartHeight + e.detail.dy;
     this.__updateWidgetStyles();
 
-    this.host.dispatchEvent(new CustomEvent('dashboard-item-resize-start'));
+    this.host.dispatchEvent(new CustomEvent('dashboard-item-resize-start', { detail: { item: this.resizedItem } }));
 
     this.__resizedElement = e.target;
     // Observe the removal of the resized element from the DOM

--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -15,7 +15,7 @@ export class WidgetResizeController extends EventTarget {
     super();
     this.host = host;
     this.__resizedElementRemoveObserver = new MutationObserver(() => this.__restoreResizedElement());
-
+    this.__touchMoveCancelListener = (e) => e.preventDefault();
     addListener(host, 'track', (e) => this.__onTrack(e));
   }
 
@@ -50,6 +50,8 @@ export class WidgetResizeController extends EventTarget {
 
     this.__resizedElement = e.target;
     this.__resizedElementRemoveObserver.observe(this.host, { childList: true, subtree: true });
+
+    document.addEventListener('touchmove', this.__touchMoveCancelListener, { passive: false });
   }
 
   /** @private */
@@ -108,6 +110,7 @@ export class WidgetResizeController extends EventTarget {
     this.host.$.grid.toggleAttribute('resizing', false);
 
     this.__resizedElementRemoveObserver.disconnect();
+    document.removeEventListener('touchmove', this.__touchMoveCancelListener);
 
     this.host.dispatchEvent(new CustomEvent('dashboard-item-resize-end'));
   }

--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -37,7 +37,7 @@ export class WidgetResizeController extends EventTarget {
       return;
     }
 
-    this.host.toggleAttribute('resizing', true);
+    this.host.$.grid.toggleAttribute('resizing', true);
     this.resizedItem = this.__getElementItem(e.target);
 
     this.__resizeStartWidth = e.target.offsetWidth;
@@ -94,12 +94,18 @@ export class WidgetResizeController extends EventTarget {
       return;
     }
 
+    // If the originally resized element is restored to the DOM (as a direct child of the host),
+    // to make sure "track" event gets dispatched, remove it to avoid duplicates
+    if (this.__resizedElement.parentElement === this.host) {
+      this.__resizedElement.remove();
+    }
+
     const itemWrapper = this.__getItemWrapper(this.resizedItem);
     itemWrapper.style.removeProperty('--_vaadin-dashboard-widget-resizer-width');
     itemWrapper.style.removeProperty('--_vaadin-dashboard-widget-resizer-height');
 
     this.resizedItem = null;
-    this.host.toggleAttribute('resizing', false);
+    this.host.$.grid.toggleAttribute('resizing', false);
 
     this.__resizedElementRemoveObserver.disconnect();
 

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -211,6 +211,29 @@ describe('dashboard - widget resizing', () => {
       ]);
     });
 
+    it('should not resize vertically if minimum row height is not defined', async () => {
+      setMinimumRowHeight(dashboard, undefined);
+      dashboard.items = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 1, 0)!, 'bottom');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+    });
+
     it('should not resize a widget if not dragging by the resize handle', async () => {
       const widget = getElementFromCell(dashboard, 0, 0)!;
       widget.shadowRoot?.querySelector('.resize-handle')?.remove();

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -272,10 +272,15 @@ describe('dashboard - widget resizing', () => {
       dashboard.addEventListener('dashboard-item-resize-end', resizeEndSpy);
       fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
       await nextFrame();
+      fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
       fireResizeEnd(dashboard);
       await nextFrame();
 
       expect(resizeEndSpy).to.have.been.calledOnce;
+      expect(resizeEndSpy.getCall(0).args[0].detail).to.deep.equal({
+        item: { id: 0, colspan: 2, rowspan: 1 },
+      });
     });
 
     it('should cancel touchmove events while resizing', async () => {
@@ -296,6 +301,19 @@ describe('dashboard - widget resizing', () => {
       document.dispatchEvent(touchmove);
 
       expect(touchmove.defaultPrevented).to.be.false;
+    });
+
+    it('should prevent selection while resizing', async () => {
+      expect(getComputedStyle(getElementFromCell(dashboard, 0, 0)!).userSelect).not.to.equal('none');
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      expect(getComputedStyle(getElementFromCell(dashboard, 0, 0)!).userSelect).to.equal('none');
+
+      fireResizeEnd(dashboard);
+      await nextFrame();
+
+      expect(getComputedStyle(getElementFromCell(dashboard, 0, 0)!).userSelect).not.to.equal('none');
     });
 
     // Make sure the original resized element is restored in the host.

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -1,0 +1,279 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '../vaadin-dashboard.js';
+import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
+import {
+  expectLayout,
+  fireResizeEnd,
+  fireResizeOver,
+  fireResizeStart,
+  getElementFromCell,
+  setGap,
+  setMaximumColumnWidth,
+  setMinimumColumnWidth,
+  setMinimumRowHeight,
+} from './helpers.js';
+
+type TestDashboardItem = DashboardItem & { id: number };
+
+describe('dashboard - widget resizing', () => {
+  let dashboard: Dashboard<TestDashboardItem>;
+  const columnWidth = 100;
+  const rowHeight = 100;
+
+  beforeEach(async () => {
+    dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');
+    dashboard.style.width = `${columnWidth * 2}px`;
+    setMinimumColumnWidth(dashboard, columnWidth);
+    setMaximumColumnWidth(dashboard, columnWidth);
+    setGap(dashboard, 0);
+    setMinimumRowHeight(dashboard, rowHeight);
+
+    dashboard.editable = true;
+
+    dashboard.items = [{ id: 0 }, { id: 1 }];
+    dashboard.renderer = (root, _, model) => {
+      root.textContent = '';
+      const widget = fixtureSync(`
+        <vaadin-dashboard-widget id="item-${model.item.id}" widget-title="${model.item.id} title">
+          <div class="content">Widget content</div>
+        </vaadin-dashboard-widget>`);
+      root.appendChild(widget);
+    };
+    await nextFrame();
+
+    // prettier-ignore
+    expectLayout(dashboard, [
+      [0, 1],
+    ]);
+  });
+
+  describe('mouse drag', () => {
+    it('should resize a widget while dragging (start -> end)', async () => {
+      // Start dragging the first widget resize handle
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      // Drag over the end edge of the second one
+      fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+
+      // Expect the widgets to be reordered
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 0],
+        [1],
+      ]);
+    });
+
+    it('should not resize if dragged barely over another widget (start -> end)', async () => {
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'start');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+      ]);
+    });
+
+    it('should resize a widget while dragging (end -> start)', async () => {
+      dashboard.items = [{ id: 0, colspan: 2 }, { id: 1 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 0],
+        [1],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 0, 1)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 0, 0)!, 'start');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+      ]);
+    });
+
+    it('should not resize if dragged barely over another widget (end -> start)', async () => {
+      dashboard.items = [{ id: 0, colspan: 2 }, { id: 1 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 0],
+        [1],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 0, 1)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 0, 0)!, 'end');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 0],
+        [1],
+      ]);
+    });
+
+    it('should resize a widget while dragging (top -> bottom)', async () => {
+      dashboard.items = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 1, 0)!, 'bottom');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [0, 2],
+      ]);
+    });
+
+    it('should not resize if dragged barely over another widget (top -> bottom)', async () => {
+      dashboard.items = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 1, 0)!, 'top');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+    });
+
+    it('should resize a widget while dragging (bottom -> top)', async () => {
+      dashboard.items = [{ id: 0, rowspan: 2 }, { id: 1 }, { id: 2 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [0, 2],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 1, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 0, 0)!, 'top');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+    });
+
+    it('should not resize if dragged barely over another widget (bottom -> top)', async () => {
+      dashboard.items = [{ id: 0, rowspan: 2 }, { id: 1 }, { id: 2 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [0, 2],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 1, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 0, 0)!, 'bottom');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [0, 2],
+      ]);
+    });
+
+    it('should not resize a widget if not dragging by the resize handle', async () => {
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      widget.shadowRoot?.querySelector('.resize-handle')?.remove();
+
+      // Start dragging the first widget by somewhere else than the resize handle
+      fireResizeStart(widget);
+      await nextFrame();
+
+      // Drag over the end edge of the second one
+      fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+      ]);
+    });
+
+    // Make sure the original resized element is restored in the host.
+    // Otherwise, "track" event would stop working.
+    describe('ensure track event', () => {
+      it('should restore the original resized element in host', async () => {
+        const originalResizedElement = getElementFromCell(dashboard, 0, 0)!;
+        fireResizeStart(originalResizedElement);
+        await nextFrame();
+        fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+        await nextFrame();
+
+        expect(dashboard.contains(originalResizedElement)).to.be.true;
+      });
+
+      it('should remove duplicate elements once resize has ended', async () => {
+        fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+        await nextFrame();
+        fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+        await nextFrame();
+
+        fireResizeEnd(dashboard);
+        await nextFrame();
+
+        // Make sure the original dragged element is removed from the host if it was
+        // restored.
+        expect(dashboard.querySelectorAll(`vaadin-dashboard-widget[id='item-0']`).length).to.equal(1);
+      });
+
+      it('should not remove resized element with a renderer that reuses same instances', async () => {
+        const reusedWidgets = [
+          fixtureSync('<vaadin-dashboard-widget id="item-0" widget-title="0 title"></vaadin-dashboard-widget>'),
+          fixtureSync('<vaadin-dashboard-widget id="item-1" widget-title="1 title"></vaadin-dashboard-widget>'),
+        ];
+        dashboard.renderer = (root, _, model) => {
+          root.textContent = '';
+          root.appendChild(reusedWidgets[model.item.id]);
+        };
+        await nextFrame();
+
+        fireResizeStart(reusedWidgets[0]);
+        await nextFrame();
+        fireResizeOver(reusedWidgets[1], 'end');
+        await nextFrame();
+
+        fireResizeEnd(dashboard);
+        expect(reusedWidgets[0].isConnected).to.be.true;
+      });
+    });
+  });
+});

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -259,6 +259,9 @@ describe('dashboard - widget resizing', () => {
       await nextFrame();
 
       expect(resizeStartSpy).to.have.been.calledOnce;
+      expect(resizeStartSpy.getCall(0).args[0].detail).to.deep.equal({
+        item: { id: 0 },
+      });
     });
 
     it('should dispatch an item drag resize event', async () => {

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -5,8 +5,11 @@ import type {
   Dashboard,
   DashboardItem,
   DashboardItemDragReorderEvent,
+  DashboardItemDragResizeEvent,
   DashboardItemReorderEndEvent,
   DashboardItemReorderStartEvent,
+  DashboardItemResizeEndEvent,
+  DashboardItemResizeStartEvent,
   DashboardRenderer,
   DashboardSectionItem,
 } from '../../vaadin-dashboard.js';
@@ -55,6 +58,22 @@ narrowedDashboard.addEventListener('dashboard-item-drag-reorder', (event) => {
   assertType<DashboardItemDragReorderEvent<TestDashboardItem>>(event);
   assertType<TestDashboardItem | DashboardSectionItem<TestDashboardItem>>(event.detail.item);
   assertType<number>(event.detail.targetIndex);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-resize-start', (event) => {
+  assertType<DashboardItemResizeStartEvent<TestDashboardItem>>(event);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-resize-end', (event) => {
+  assertType<DashboardItemResizeEndEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem>(event.detail.item);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-drag-resize', (event) => {
+  assertType<DashboardItemDragResizeEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem>(event.detail.item);
+  assertType<number>(event.detail.colspan);
+  assertType<number>(event.detail.rowspan);
 });
 
 /* DashboardLayout */

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -62,6 +62,7 @@ narrowedDashboard.addEventListener('dashboard-item-drag-reorder', (event) => {
 
 narrowedDashboard.addEventListener('dashboard-item-resize-start', (event) => {
   assertType<DashboardItemResizeStartEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem>(event.detail.item);
 });
 
 narrowedDashboard.addEventListener('dashboard-item-resize-end', (event) => {


### PR DESCRIPTION
## Description

Add support for drag resizing of `<vaadin-dashboard>` widgets 

https://github.com/user-attachments/assets/f69921c2-a313-41d7-9a1b-7cd36c5e9492

Added API:
- Events:
  - `dashboard-item-resize-start`: Fired when item resizing starts
    - `event.item`: The item being resized
  - `dashboard-item-resize-end`: Fired when item resizing ends
    - `event.item`: The item being resized
  - `dashboard-item-drag-resize`: Fired when an item will be resized by dragging
    - `event.item`: The item being resized
    - `colspan`: The colspan to be assigned to the item
    - `rowspan`: The rowspan to be assigned to the item

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=74626094

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Feature