### PR TITLE
fix: filter out undefined instances when redrawing all charts (#7779) (CP: 24.4)

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -488,7 +488,14 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
       args.forEach((arg) => inflateFunctions(arg));
       functionToCall.apply(this.configuration, args);
       if (redrawCharts) {
-        Highcharts.charts.forEach((c) => c.redraw());
+        Highcharts.charts.forEach((c) => {
+          // Ignore `undefined` values that are preserved in the array
+          // after their corresponding chart instances are destroyed.
+          // See https://github.com/vaadin/flow-components/issues/6607
+          if (c !== undefined) {
+            c.redraw();
+          }
+        });
       }
     }
   }

--- a/packages/charts/test/private-api.test.js
+++ b/packages/charts/test/private-api.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import '../vaadin-chart.js';
 import { inflateFunctions } from '../src/helpers.js';
 
@@ -192,6 +192,19 @@ describe('vaadin-chart private API', () => {
     it('should inflate functions passed as string', () => {
       const legend = chart.$.chart.querySelector('.highcharts-legend-item > text').textContent;
       expect(legend).to.be.equal('value');
+    });
+
+    it('should not throw when calling after a chart is destroyed', async () => {
+      chart.updateConfiguration({}, true);
+      await nextFrame();
+
+      expect(() => {
+        chart.constructor.__callHighchartsFunction('setOptions', true, {
+          lang: {
+            shortWeekdays: ['su', 'ma', 'ti', 'ke', 'to', 'pe', 'la'],
+          },
+        });
+      }).to.not.throw(Error);
     });
   });
 });


### PR DESCRIPTION
## Description

Manual cherry-pick of #7779 to `24.4` branch (there was a conflict in the test file due to the import change on `main`).

## Type of change

- Cherry-pick