### PR TITLE
fix: do not throw on drag when dashboard has one widget

### DIFF
--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -67,6 +67,10 @@ export class WidgetReorderController extends EventTarget {
     }
     // Get all elements except the dragged element from the drag context
     const otherElements = dragContextElements.filter((element) => element !== draggedElement);
+    if (otherElements.length === 0) {
+      return;
+    }
+
     // Find the element closest to the x and y coordinates of the drag event
     const closestElement = this.__getClosestElement(otherElements, e.clientX, e.clientY);
 

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -487,6 +487,23 @@ describe('dashboard - widget reordering', () => {
       ]);
     });
 
+    it('should throw when dragging when there is only one widget', async () => {
+      dashboard.items = [{ id: 0 }];
+      await nextFrame();
+      // Start dragging the first widget
+      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      expect(() => {
+        const dashboardRect = dashboard.getBoundingClientRect();
+        const dragOverEvent = createDragEvent('dragover', {
+          x: dashboardRect.right - dashboardRect.width / 4,
+          y: dashboardRect.top + dashboardRect.height / 2,
+        });
+        dashboard.dispatchEvent(dragOverEvent);
+      }).to.not.throw();
+    });
+
     describe('sections', () => {
       beforeEach(async () => {
         dashboard.items = [{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }];


### PR DESCRIPTION
## Description

Avoid an error when dragging a widget while there are no other widgets in the dashboard

## Type of change

Bugfix