### PR TITLE
feat: keep widget focus on dashboard items change

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -150,8 +150,8 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
   __renderItemWrappers(items, hostElement = this) {
     // Get all the wrappers in the host element
     let wrappers = [...hostElement.children].filter((el) => el.localName === WRAPPER_LOCAL_NAME);
-
     let previousWrapper = null;
+
     items.forEach((item) => {
       // Find the wrapper for the item or create a new one
       const wrapper = wrappers.find((el) => el.__item === item) || this.__createWrapper(item);
@@ -162,27 +162,15 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
       if (!wrapper.contains(document.activeElement)) {
         // Insert the wrapper to the correct position inside the host element
-        // if it doesn't contain the focused element
-        if (previousWrapper) {
-          previousWrapper.after(wrapper);
-        } else if (hostElement.firstChild) {
-          hostElement.insertBefore(wrapper, hostElement.firstChild);
-        } else {
-          hostElement.appendChild(wrapper);
-        }
+        const insertBeforeElement = previousWrapper ? previousWrapper.nextSibling : hostElement.firstChild;
+        hostElement.insertBefore(wrapper, insertBeforeElement);
       }
       previousWrapper = wrapper;
 
       // Render section if the item has subitems
       if (item.items) {
-        let section = wrapper.firstElementChild;
-        if (!section) {
-          // Create a new section if it doesn't exist
-          section =
-            item.component instanceof HTMLElement ? item.component : document.createElement('vaadin-dashboard-section');
-          wrapper.appendChild(section);
-        }
-        // Update the section title
+        const section = wrapper.firstElementChild || this.__createSection(item);
+        wrapper.appendChild(section);
         section.sectionTitle = item.title;
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
         // Render the subitems
@@ -194,6 +182,10 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     wrappers.forEach((wrapper) => wrapper.remove());
   }
 
+  /** @private */
+  __createSection(item) {
+    return item.component instanceof HTMLElement ? item.component : document.createElement('vaadin-dashboard-section');
+  }
   /** @private */
   __createWrapper(item) {
     const wrapper = document.createElement(WRAPPER_LOCAL_NAME);

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -169,8 +169,13 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
       // Render section if the item has subitems
       if (item.items) {
-        const section = wrapper.firstElementChild || this.__createSection(item);
-        wrapper.appendChild(section);
+        let section = wrapper.firstElementChild;
+        if (!section) {
+          // Create a new section if it doesn't exist
+          section =
+            item.component instanceof HTMLElement ? item.component : document.createElement('vaadin-dashboard-section');
+          wrapper.appendChild(section);
+        }
         section.sectionTitle = item.title;
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
         // Render the subitems
@@ -182,10 +187,6 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     wrappers.forEach((wrapper) => wrapper.remove());
   }
 
-  /** @private */
-  __createSection(item) {
-    return item.component instanceof HTMLElement ? item.component : document.createElement('vaadin-dashboard-section');
-  }
   /** @private */
   __createWrapper(item) {
     const wrapper = document.createElement(WRAPPER_LOCAL_NAME);

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -18,6 +18,7 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { getElementItem, getItemsArrayOfItem, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
+import { DashboardSection } from './vaadin-dashboard-section.js';
 import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
 import { WidgetReorderController } from './widget-reorder-controller.js';
 import { WidgetResizeController } from './widget-resize-controller.js';
@@ -170,13 +171,16 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       // Render section if the item has subitems
       if (item.items) {
         let section = wrapper.firstElementChild;
-        if (!section) {
+        const isComponentSection = item.component instanceof DashboardSection;
+        if (!(section instanceof DashboardSection)) {
           // Create a new section if it doesn't exist
-          section =
-            item.component instanceof HTMLElement ? item.component : document.createElement('vaadin-dashboard-section');
+          section = isComponentSection ? item.component : document.createElement('vaadin-dashboard-section');
           wrapper.appendChild(section);
         }
-        section.sectionTitle = item.title;
+        if (!isComponentSection) {
+          section.sectionTitle = item.title;
+        }
+
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
         // Render the subitems
         this.__renderItemWrappers(item.items, section);

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -279,4 +279,43 @@ describe('dashboard', () => {
       expect(section?.sectionTitle).to.equal('Section');
     });
   });
+
+  describe('focus', () => {
+    beforeEach(async () => {
+      // Use a custom renderer that reuses the same widget instance
+      // with a tab index to test focus behavior
+      dashboard.renderer = (root, _, model) => {
+        let widget = root.querySelector('vaadin-dashboard-widget');
+        if (!widget || widget.tabIndex !== 0) {
+          root.textContent = '';
+          widget = document.createElement('vaadin-dashboard-widget');
+          widget.tabIndex = 0;
+          root.appendChild(widget);
+        }
+        widget.widgetTitle = `${model.item.id} title`;
+      };
+      await nextFrame();
+    });
+
+    it('should not lose focus when reassigning items', async () => {
+      getElementFromCell(dashboard, 0, 0)!.focus();
+      dashboard.items = [...dashboard.items];
+      await nextFrame();
+      expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
+    });
+
+    it('should not lose focus when prepending items', async () => {
+      getElementFromCell(dashboard, 0, 0)!.focus();
+      dashboard.items = [{ id: 'Item -1' }, ...dashboard.items];
+      await nextFrame();
+      expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 1)!);
+    });
+
+    it('should not lose focus when removing items', async () => {
+      getElementFromCell(dashboard, 0, 1)!.focus();
+      dashboard.items = [dashboard.items[1]];
+      await nextFrame();
+      expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
+    });
+  });
 });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -317,5 +317,14 @@ describe('dashboard', () => {
       await nextFrame();
       expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
     });
+
+    it('should not lose focus when reassigning section items', async () => {
+      dashboard.items = [{ title: 'Section', items: [{ id: 'Item 0' }] }, { id: 'Item 1' }];
+      await nextFrame();
+      getElementFromCell(dashboard, 0, 0)!.focus();
+      dashboard.items = [...dashboard.items];
+      await nextFrame();
+      expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
+    });
   });
 });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -3,6 +3,7 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-dashboard.js';
 import type { CustomElementType } from '@vaadin/component-base/src/define.js';
+import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
 import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
 import {
@@ -277,6 +278,26 @@ describe('dashboard', () => {
       const section = widget?.closest('vaadin-dashboard-section');
       expect(section).to.be.ok;
       expect(section?.sectionTitle).to.equal('Section');
+    });
+
+    it('should not override the component titles', async () => {
+      const section = fixtureSync(
+        `<vaadin-dashboard-section section-title="Section"></vaadin-dashboard-section>`,
+      ) as DashboardSection;
+      const widget = fixtureSync(
+        '<vaadin-dashboard-widget widget-title="Component 0"></vaadin-dashboard-widget>',
+      ) as DashboardWidget;
+
+      (dashboard as any).items = [
+        {
+          component: section,
+          items: [{ id: 'Item 0', component: widget }],
+        },
+      ];
+      await nextFrame();
+
+      expect(widget.widgetTitle).to.equal('Component 0');
+      expect(section.sectionTitle).to.equal('Section');
     });
   });
 


### PR DESCRIPTION
## Description

Update the dashboard widget wrapper rendering so that element focus never gets lost on re-render.

Part of https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=79678587

## Type of change

Feature