### PR TITLE
refactor: use attributes for widget/section state

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-helpers.js
+++ b/packages/dashboard/src/vaadin-dashboard-helpers.js
@@ -6,6 +6,9 @@
 
 export const WRAPPER_LOCAL_NAME = 'vaadin-dashboard-widget-wrapper';
 
+// The attributes that should be synchronized between the wrapper and the widget/section
+export const SYNCHRONIZED_ATTRIBUTES = ['editable', 'dragging'];
+
 /**
  * Returns the array of items that contains the given item.
  * Might be the dashboard items or the items of a section.

--- a/packages/dashboard/src/vaadin-dashboard-helpers.js
+++ b/packages/dashboard/src/vaadin-dashboard-helpers.js
@@ -6,7 +6,7 @@
 
 export const WRAPPER_LOCAL_NAME = 'vaadin-dashboard-widget-wrapper';
 
-// The attributes that should be synchronized between the wrapper and the widget/section
+// The attributes that should be synchronized from the wrapper to widget/section
 export const SYNCHRONIZED_ATTRIBUTES = ['editable', 'dragging'];
 
 /**

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -15,7 +15,6 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
-import { SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { dashboardWidgetAndSectionStyles, hasWidgetWrappers } from './vaadin-dashboard-styles.js';
 
 /**
@@ -119,16 +118,6 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
         this.setAttribute('aria-labelledby', node.id);
       }
     });
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    const wrapper = this.closest(WRAPPER_LOCAL_NAME);
-    if (wrapper) {
-      SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
-        this.toggleAttribute(attr, wrapper.hasAttribute(attr));
-      });
-    }
   }
 
   /** @protected */

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -15,6 +15,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
+import { SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { dashboardWidgetAndSectionStyles, hasWidgetWrappers } from './vaadin-dashboard-styles.js';
 
 /**
@@ -118,6 +119,16 @@ class DashboardSection extends ControllerMixin(ElementMixin(PolylitMixin(LitElem
         this.setAttribute('aria-labelledby', node.id);
       }
     });
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    const wrapper = this.closest(WRAPPER_LOCAL_NAME);
+    if (wrapper) {
+      SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
+        this.toggleAttribute(attr, wrapper.hasAttribute(attr));
+      });
+    }
   }
 
   /** @protected */

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -7,6 +7,10 @@ export const hasWidgetWrappers = css`
 `;
 
 export const dashboardWidgetAndSectionStyles = css`
+  :host {
+    box-sizing: border-box;
+  }
+
   :host([dragging]) {
     border: 3px dashed black !important;
   }

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -7,16 +7,12 @@ export const hasWidgetWrappers = css`
 `;
 
 export const dashboardWidgetAndSectionStyles = css`
-  /* Placeholder shown while the widget or section is dragged */
-  :host::before {
-    content: '';
-    z-index: 1;
-    position: absolute;
-    display: var(--_vaadin-dashboard-item-placeholder-display, none);
-    inset: 0;
-    border: 3px dashed black;
-    border-radius: 5px;
-    background-color: #fff;
+  :host([dragging]) {
+    border: 3px dashed black !important;
+  }
+
+  :host([dragging]) * {
+    visibility: hidden;
   }
 
   :host(:not([editable])) #drag-handle,

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -19,6 +19,11 @@ export const dashboardWidgetAndSectionStyles = css`
     background-color: #fff;
   }
 
+  :host(:not([editable])) #drag-handle,
+  :host(:not([editable])) #remove-button {
+    display: none;
+  }
+
   header {
     display: flex;
     justify-content: space-between;
@@ -26,7 +31,6 @@ export const dashboardWidgetAndSectionStyles = css`
   }
 
   #drag-handle {
-    display: var(--_vaadin-dashboard-widget-actions-display, none);
     font-size: 30px;
     cursor: grab;
   }
@@ -36,7 +40,6 @@ export const dashboardWidgetAndSectionStyles = css`
   }
 
   #remove-button {
-    display: var(--_vaadin-dashboard-widget-actions-display, none);
     font-size: 30px;
     cursor: pointer;
   }

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -134,7 +134,11 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
     super.connectedCallback();
 
     const wrapper = this.closest(WRAPPER_LOCAL_NAME);
-    this.toggleAttribute('editable', wrapper && wrapper.hasAttribute('editable'));
+    if (wrapper) {
+      ['editable', 'dragging'].forEach((attr) => {
+        this.toggleAttribute(attr, wrapper.hasAttribute(attr));
+      });
+    }
 
     const undefinedAncestor = this.closest('*:not(:defined)');
     if (undefinedAncestor) {

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -15,7 +15,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
-import { WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
+import { SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-styles.js';
 
 /**
@@ -135,7 +135,7 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
 
     const wrapper = this.closest(WRAPPER_LOCAL_NAME);
     if (wrapper) {
-      ['editable', 'dragging'].forEach((attr) => {
+      SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
         this.toggleAttribute(attr, wrapper.hasAttribute(attr));
       });
     }

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -15,6 +15,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
+import { WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-styles.js';
 
 /**
@@ -45,13 +46,16 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
           display: none !important;
         }
 
+        :host(:not([editable])) #resize-handle {
+          display: none;
+        }
+
         #content {
           flex: 1;
           min-height: 100px;
         }
 
         #resize-handle {
-          display: var(--_vaadin-dashboard-widget-actions-display, none);
           position: absolute;
           bottom: 0;
           inset-inline-end: 0;
@@ -128,6 +132,9 @@ class DashboardWidget extends ControllerMixin(ElementMixin(PolylitMixin(LitEleme
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
+
+    const wrapper = this.closest(WRAPPER_LOCAL_NAME);
+    this.toggleAttribute('editable', wrapper && wrapper.hasAttribute('editable'));
 
     const undefinedAncestor = this.closest('*:not(:defined)');
     if (undefinedAncestor) {

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -208,7 +208,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     `.trim();
 
     wrapper.setAttribute('style', style);
-    wrapper.toggleAttribute('editable', this.editable);
+    wrapper.toggleAttribute('editable', !!this.editable);
     wrapper.toggleAttribute('dragging', this.__widgetReorderController.draggedItem === item);
   }
 

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -16,7 +16,12 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { getElementItem, getItemsArrayOfItem, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
+import {
+  getElementItem,
+  getItemsArrayOfItem,
+  SYNCHRONIZED_ATTRIBUTES,
+  WRAPPER_LOCAL_NAME,
+} from './vaadin-dashboard-helpers.js';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 import { DashboardSection } from './vaadin-dashboard-section.js';
 import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
@@ -141,7 +146,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       }
 
       if (cell.firstElementChild) {
-        ['editable', 'dragging'].forEach((attr) => {
+        SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
           cell.firstElementChild.toggleAttribute(attr, cell.hasAttribute(attr));
         });
       }
@@ -183,7 +188,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
         }
 
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
-        ['editable', 'dragging'].forEach((attr) => section.toggleAttribute(attr, wrapper.hasAttribute(attr)));
+        SYNCHRONIZED_ATTRIBUTES.forEach((attr) => section.toggleAttribute(attr, wrapper.hasAttribute(attr)));
         // Render the subitems
         this.__renderItemWrappers(item.items, section);
       }

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -53,10 +53,6 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     return [
       super.styles,
       css`
-        :host([editable]) {
-          --_vaadin-dashboard-widget-actions-display: block;
-        }
-
         #grid[resizing] {
           -webkit-user-select: none;
           user-select: none;
@@ -98,13 +94,12 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
        */
       editable: {
         type: Boolean,
-        reflectToAttribute: true,
       },
     };
   }
 
   static get observers() {
-    return ['__itemsOrRendererChanged(items, renderer)'];
+    return ['__itemsOrRendererChanged(items, renderer, editable)'];
   }
 
   constructor() {
@@ -143,6 +138,10 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
         renderer(cell, this, { item: cell.__item });
       } else {
         cell.innerHTML = '';
+      }
+
+      if (cell.firstElementChild) {
+        cell.firstElementChild.toggleAttribute('editable', this.editable);
       }
     });
   }
@@ -209,6 +208,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     `.trim();
 
     wrapper.setAttribute('style', style);
+    wrapper.toggleAttribute('editable', this.editable);
   }
 
   /** @private */

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -141,7 +141,9 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       }
 
       if (cell.firstElementChild) {
-        cell.firstElementChild.toggleAttribute('editable', this.editable);
+        ['editable', 'dragging'].forEach((attr) => {
+          cell.firstElementChild.toggleAttribute(attr, cell.hasAttribute(attr));
+        });
       }
     });
   }
@@ -181,6 +183,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
         }
 
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
+        ['editable', 'dragging'].forEach((attr) => section.toggleAttribute(attr, wrapper.hasAttribute(attr)));
         // Render the subitems
         this.__renderItemWrappers(item.items, section);
       }
@@ -199,16 +202,14 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
   /** @private */
   __updateWrapper(wrapper, item) {
-    const itemDragged = this.__widgetReorderController.draggedItem === item;
-
     const style = `
       ${item.colspan ? `--vaadin-dashboard-item-colspan: ${item.colspan};` : ''}
       ${item.rowspan ? `--vaadin-dashboard-item-rowspan: ${item.rowspan};` : ''}
-      ${itemDragged ? '--_vaadin-dashboard-item-placeholder-display: block;' : ''}
     `.trim();
 
     wrapper.setAttribute('style', style);
     wrapper.toggleAttribute('editable', this.editable);
+    wrapper.toggleAttribute('dragging', this.__widgetReorderController.draggedItem === item);
   }
 
   /** @private */

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -553,6 +553,9 @@ describe('dashboard - widget reordering', () => {
         fireDragOver(getElementFromCell(dashboard, 0, 0)!, 'top');
         await nextFrame();
 
+        fireDragEnd(dashboard);
+        await nextFrame();
+
         // prettier-ignore
         expectLayout(dashboard, [
           [2, 3],

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -429,5 +429,18 @@ describe('dashboard', () => {
       const resizeHandle = getResizeHandle(widget);
       expect(resizeHandle.getBoundingClientRect().height).to.be.above(0);
     });
+
+    it('should unhide remove button of a section when editable', async () => {
+      dashboard.items = [{ title: 'Section', items: [{ id: 'Item 0' }] }, { id: 'Item 1' }];
+      await nextFrame();
+      getElementFromCell(dashboard, 0, 0)!.focus();
+      await nextFrame();
+      dashboard.editable = true;
+      await nextFrame();
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+      const removeButton = getRemoveButton(section);
+      expect(removeButton.getBoundingClientRect().height).to.be.above(0);
+    });
   });
 });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -24,7 +24,7 @@ describe('dashboard', () => {
 
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');
-    dashboard.style.width = `${columnWidth * 100}px`;
+    dashboard.style.width = `${columnWidth * 2}px`;
     setMinimumColumnWidth(dashboard, columnWidth);
     setMaximumColumnWidth(dashboard, columnWidth);
     setGap(dashboard, 0);
@@ -52,7 +52,7 @@ describe('dashboard', () => {
     dashboard.items = [...dashboard.items, { id: 'Item 2' }];
     await nextFrame();
 
-    const newWidget = getElementFromCell(dashboard, 0, 2);
+    const newWidget = getElementFromCell(dashboard, 1, 0);
     expect(newWidget).to.be.ok;
     expect(newWidget?.localName).to.equal('vaadin-dashboard-widget');
     expect(newWidget).to.have.property('widgetTitle', 'Item 2 title');
@@ -249,6 +249,49 @@ describe('dashboard', () => {
       const resizeHandle = getResizeHandle(widget);
       expect(resizeHandle.getBoundingClientRect().height).to.be.above(0);
     });
+
+    describe('section', () => {
+      beforeEach(async () => {
+        dashboard.items = [
+          { id: 'Item 0' },
+          { id: 'Item 1' },
+          { title: 'Section', items: [{ id: 'Item 2' }, { id: 'Item 3' }] },
+        ];
+        await nextFrame();
+      });
+
+      it('should hide draggable handle by default', () => {
+        const widget = getElementFromCell(dashboard, 1, 0)!;
+        const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+        const draggable = getDraggable(section);
+        expect(draggable.getBoundingClientRect().height).to.equal(0);
+      });
+
+      it('should unhide draggable handle when editable', async () => {
+        dashboard.editable = true;
+        await nextFrame();
+        const widget = getElementFromCell(dashboard, 1, 0)!;
+        const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+        const draggable = getDraggable(section);
+        expect(draggable.getBoundingClientRect().height).to.be.above(0);
+      });
+
+      it('should hide remove button by default', () => {
+        const widget = getElementFromCell(dashboard, 1, 0) as DashboardSection;
+        const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+        const removeButton = getRemoveButton(section);
+        expect(removeButton.getBoundingClientRect().height).to.equal(0);
+      });
+
+      it('should unhide remove button when editable', async () => {
+        dashboard.editable = true;
+        await nextFrame();
+        const widget = getElementFromCell(dashboard, 1, 0) as DashboardSection;
+        const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+        const removeButton = getRemoveButton(section);
+        expect(removeButton.getBoundingClientRect().height).to.be.above(0);
+      });
+    });
   });
 
   describe('item components', () => {
@@ -375,6 +418,16 @@ describe('dashboard', () => {
       dashboard.items = [...dashboard.items];
       await nextFrame();
       expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
+    });
+
+    it('should unhide resize handle when editable', async () => {
+      getElementFromCell(dashboard, 0, 0)!.focus();
+      await nextFrame();
+      dashboard.editable = true;
+      await nextFrame();
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const resizeHandle = getResizeHandle(widget);
+      expect(resizeHandle.getBoundingClientRect().height).to.be.above(0);
     });
   });
 });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -250,6 +250,24 @@ describe('dashboard', () => {
       expect(resizeHandle.getBoundingClientRect().height).to.be.above(0);
     });
 
+    it('should unhide resize handle when editable with a lazy renderer', async () => {
+      // Assign a renderer that initially renders nothing
+      const syncRenderer = dashboard.renderer!;
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        requestAnimationFrame(() => {
+          syncRenderer(root, _, model);
+        });
+      };
+      await nextFrame();
+
+      dashboard.editable = true;
+      await nextFrame();
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const resizeHandle = getResizeHandle(widget);
+      expect(resizeHandle.getBoundingClientRect().height).to.be.above(0);
+    });
+
     describe('section', () => {
       beforeEach(async () => {
         dashboard.items = [

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -19,7 +19,7 @@ type TestDashboardItem = DashboardItem & { id: string; component?: Element | str
 
 describe('dashboard', () => {
   let dashboard: Dashboard<TestDashboardItem>;
-  const columnWidth = 100;
+  const columnWidth = 200;
 
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -10,6 +10,7 @@ import {
   getDraggable,
   getElementFromCell,
   getRemoveButton,
+  getResizeHandle,
   setGap,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
@@ -219,6 +220,34 @@ describe('dashboard', () => {
       const widget = getElementFromCell(dashboard, 0, 0)!;
       const draggable = getDraggable(widget);
       expect(draggable.getBoundingClientRect().height).to.be.above(0);
+    });
+
+    it('should hide remove button by default', () => {
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const removeButton = getRemoveButton(widget);
+      expect(removeButton.getBoundingClientRect().height).to.equal(0);
+    });
+
+    it('should unhide remove button when editable', async () => {
+      dashboard.editable = true;
+      await nextFrame();
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const removeButton = getRemoveButton(widget);
+      expect(removeButton.getBoundingClientRect().height).to.be.above(0);
+    });
+
+    it('should hide resize handle by default', () => {
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const resizeHandle = getResizeHandle(widget);
+      expect(resizeHandle.getBoundingClientRect().height).to.equal(0);
+    });
+
+    it('should unhide resize handle when editable', async () => {
+      dashboard.editable = true;
+      await nextFrame();
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const resizeHandle = getResizeHandle(widget);
+      expect(resizeHandle.getBoundingClientRect().height).to.be.above(0);
     });
   });
 

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -263,8 +263,12 @@ export function fireResizeOver(dragOverTarget: Element, location: 'top' | 'botto
   dragOverTarget.dispatchEvent(event);
 }
 
+export function getResizeHandle(resizedWidget: Element): Element {
+  return resizedWidget.shadowRoot!.querySelector('.resize-handle')!;
+}
+
 export function fireResizeStart(resizedWidget: Element): void {
-  let handle = resizedWidget.shadowRoot!.querySelector('.resize-handle');
+  let handle = getResizeHandle(resizedWidget);
   if (!handle) {
     handle = resizedWidget;
   }


### PR DESCRIPTION
## Description

This PR refactors the dashboard to synchronize the widget/section state (`editable` / `dragging` for now) via wrapper attributes instead of using the clunky CSS property approach.

Part of https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=79678587

## Type of change

Refactor