### PR TITLE
fix: always define custom element class version getter

### DIFF
--- a/packages/component-base/src/define.d.ts
+++ b/packages/component-base/src/define.d.ts
@@ -7,4 +7,4 @@ export interface CustomElementType extends CustomElementConstructor {
   is: string;
 }
 
-export declare function defineCustomElement(CustomElement: CustomElementConstructor): void;
+export declare function defineCustomElement(CustomElement: CustomElementConstructor, version?: string): void;

--- a/packages/component-base/src/define.js
+++ b/packages/component-base/src/define.js
@@ -4,15 +4,15 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-export function defineCustomElement(CustomElement) {
+export function defineCustomElement(CustomElement, version = '24.6.0-alpha0') {
+  Object.defineProperty(CustomElement, 'version', {
+    get() {
+      return version;
+    },
+  });
+
   const defined = customElements.get(CustomElement.is);
   if (!defined) {
-    Object.defineProperty(CustomElement, 'version', {
-      get() {
-        return '24.6.0-alpha0';
-      },
-    });
-
     customElements.define(CustomElement.is, CustomElement);
   } else {
     const definedVersion = defined.version;

--- a/test/integration/define.test.js
+++ b/test/integration/define.test.js
@@ -15,7 +15,7 @@ describe('define', () => {
     });
 
     it('should warn when component with same version is loaded twice', () => {
-      defineCustomElement({ is: 'vaadin-button', version: Button.version });
+      defineCustomElement({ is: 'vaadin-button' });
       expect(console.warn.calledOnce).to.be.true;
       expect(console.warn.firstCall.args[0]).to.equal('The component vaadin-button has been loaded twice');
     });
@@ -31,7 +31,7 @@ describe('define', () => {
     });
 
     it('should log an error when two components with different versions are loaded', () => {
-      defineCustomElement({ is: 'vaadin-button', version: '0.0.1' });
+      defineCustomElement({ is: 'vaadin-button' }, '0.0.1');
       expect(console.error.calledOnce).to.be.true;
       expect(console.error.firstCall.args[0]).to.equal(
         `Tried to define vaadin-button version 0.0.1 when version ${Button.version} is already in use. Something will probably break.`,


### PR DESCRIPTION
## Description

This fixes an error with version listed as `undefined` when trying to re-define the same class with a different version:

```
Tried to define vaadin-iconset version undefined when version 24.5.0-alpha11 is already in use. Something will probably break.
console.error @ (index):5
defineCustomElement @ define.js:23
```

The issue is a regression from #6568 where I moved the version number from `static get version()` (always available) to be hardcoded in the `defineCustomElement` (only available for the first custom element definition).

The fix is to always define a version getter, regardless of whether the custom element is already defined or not.

## Type of change

- Bugfix