### PR TITLE
test: disable animation in confirm-dialog and CRUD tests

### DIFF
--- a/packages/crud/test/not-animated-styles.js
+++ b/packages/crud/test/not-animated-styles.js
@@ -1,7 +1,7 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-confirm-dialog-overlay',
+  'vaadin-crud-dialog-overlay',
   css`
     :host([opening]),
     :host([closing]),

--- a/packages/crud/test/visual/lumo/crud.test.js
+++ b/packages/crud/test/visual/lumo/crud.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.js';
 import '../../../theme/lumo/vaadin-crud.js';
 
 describe('crud', () => {

--- a/packages/crud/test/visual/material/crud.test.js
+++ b/packages/crud/test/visual/material/crud.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.js';
 import '../../../theme/material/vaadin-crud.js';
 
 describe('crud', () => {


### PR DESCRIPTION
## Description

Part of #7823

Turned out that `vaadin-confirm-dialog` visual tests were still using `vaadin-dialog-overlay` in `not-animated-styles` which needed to be updated since #6141. And `vaadin-crud` visual tests didn't have this file to disable animations at all 😕 

## Type of change

- Tests