### PR TITLE
test: disable error-message transition in visual tests

### DIFF
--- a/packages/checkbox-group/test/visual/common.js
+++ b/packages/checkbox-group/test/visual/common.js
@@ -1,13 +1,8 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-text-area',
+  'vaadin-checkbox-group',
   css`
-    /* Hide caret */
-    ::slotted(textarea) {
-      caret-color: transparent;
-    }
-
     /* Show error message immediately */
     [part='error-message'] {
       transition: none !important;

--- a/packages/checkbox-group/test/visual/lumo/checkbox-group.test.js
+++ b/packages/checkbox-group/test/visual/lumo/checkbox-group.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '../../../theme/lumo/vaadin-checkbox-group.js';
 
 describe('checkbox-group', () => {

--- a/packages/checkbox-group/test/visual/material/checkbox-group.test.js
+++ b/packages/checkbox-group/test/visual/material/checkbox-group.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '../../../theme/material/vaadin-checkbox-group.js';
 
 describe('checkbox-group', () => {

--- a/packages/checkbox/test/visual/common.js
+++ b/packages/checkbox/test/visual/common.js
@@ -1,13 +1,8 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-text-area',
+  'vaadin-checkbox',
   css`
-    /* Hide caret */
-    ::slotted(textarea) {
-      caret-color: transparent;
-    }
-
     /* Show error message immediately */
     [part='error-message'] {
       transition: none !important;

--- a/packages/checkbox/test/visual/lumo/checkbox.test.js
+++ b/packages/checkbox/test/visual/lumo/checkbox.test.js
@@ -2,6 +2,7 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/test/autoload.js';
+import '../common.js';
 import '../../../theme/lumo/vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/checkbox/test/visual/material/checkbox.test.js
+++ b/packages/checkbox/test/visual/material/checkbox.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '../../../theme/material/vaadin-checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -1,12 +1,17 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-combo-box',
   css`
+    /* Hide caret */
     :host([focus-ring]) ::slotted(input),
     :host([opened]) ::slotted(input) {
       caret-color: transparent;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );

--- a/packages/custom-field/test/visual/common.js
+++ b/packages/custom-field/test/visual/common.js
@@ -1,13 +1,8 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-text-area',
+  'vaadin-custom-field vaadin-date-picker vaadin-number-field vaadin-text-field',
   css`
-    /* Hide caret */
-    ::slotted(textarea) {
-      caret-color: transparent;
-    }
-
     /* Show error message immediately */
     [part='error-message'] {
       transition: none !important;

--- a/packages/custom-field/test/visual/lumo/custom-field.test.js
+++ b/packages/custom-field/test/visual/lumo/custom-field.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '@vaadin/combo-box/theme/lumo/vaadin-combo-box.js';
 import '@vaadin/date-picker/theme/lumo/vaadin-date-picker.js';
 import '@vaadin/email-field/theme/lumo/vaadin-email-field.js';

--- a/packages/custom-field/test/visual/material/custom-field.test.js
+++ b/packages/custom-field/test/visual/material/custom-field.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '@vaadin/combo-box/theme/material/vaadin-combo-box.js';
 import '@vaadin/date-picker/theme/material/vaadin-date-picker.js';
 import '@vaadin/form-layout/theme/material/vaadin-form-item.js';

--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -1,12 +1,17 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-date-picker',
   css`
+    /* Hide caret */
     :host([focus-ring]) ::slotted(input),
     :host([opened]) ::slotted(input) {
       caret-color: transparent;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );

--- a/packages/date-time-picker/test/visual/common.js
+++ b/packages/date-time-picker/test/visual/common.js
@@ -1,11 +1,16 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-date-picker',
   css`
+    /* Hide caret */
     :host([focused]) ::slotted(input) {
       caret-color: transparent;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );

--- a/packages/multi-select-combo-box/test/visual/common.js
+++ b/packages/multi-select-combo-box/test/visual/common.js
@@ -1,13 +1,18 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-multi-select-combo-box',
   css`
+    /* Hide caret */
     :host([focused][focus-ring]) ::slotted(input),
     :host([focused][has-value]) ::slotted(input),
     :host([focused][opened]) ::slotted(input) {
       caret-color: transparent !important;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );

--- a/packages/number-field/test/visual/common.js
+++ b/packages/number-field/test/visual/common.js
@@ -1,11 +1,16 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-number-field',
   css`
+    /* Hide caret */
     :host([focus-ring]) ::slotted(input) {
       caret-color: transparent;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );

--- a/packages/radio-group/test/visual/common.js
+++ b/packages/radio-group/test/visual/common.js
@@ -1,13 +1,8 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-text-area',
+  'vaadin-radio-group',
   css`
-    /* Hide caret */
-    ::slotted(textarea) {
-      caret-color: transparent;
-    }
-
     /* Show error message immediately */
     [part='error-message'] {
       transition: none !important;

--- a/packages/radio-group/test/visual/lumo/radio-group.test.js
+++ b/packages/radio-group/test/visual/lumo/radio-group.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '../../../theme/lumo/vaadin-radio-group.js';
 
 describe('radio-group', () => {

--- a/packages/radio-group/test/visual/material/radio-group.test.js
+++ b/packages/radio-group/test/visual/material/radio-group.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '../../../theme/material/vaadin-radio-group.js';
 
 describe('radio-group', () => {

--- a/packages/select/test/visual/common.js
+++ b/packages/select/test/visual/common.js
@@ -1,13 +1,8 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-text-area',
+  'vaadin-select',
   css`
-    /* Hide caret */
-    ::slotted(textarea) {
-      caret-color: transparent;
-    }
-
     /* Show error message immediately */
     [part='error-message'] {
       transition: none !important;

--- a/packages/select/test/visual/lumo/select.test.js
+++ b/packages/select/test/visual/lumo/select.test.js
@@ -4,6 +4,7 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/item/theme/lumo/vaadin-item.js';
 import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '../../not-animated-styles.js';
+import '../common.js';
 import '../../../theme/lumo/vaadin-select.js';
 
 describe('select', () => {

--- a/packages/select/test/visual/material/select.test.js
+++ b/packages/select/test/visual/material/select.test.js
@@ -4,6 +4,7 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/item/theme/material/vaadin-item.js';
 import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '../../not-animated-styles.js';
+import '../common.js';
 import '../../../theme/material/vaadin-select.js';
 
 describe('select', () => {

--- a/packages/text-field/test/visual/common.js
+++ b/packages/text-field/test/visual/common.js
@@ -1,11 +1,16 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-text-field',
   css`
+    /* Hide caret */
     :host([focus-ring]) ::slotted(input) {
       caret-color: transparent;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );

--- a/packages/time-picker/test/visual/common.js
+++ b/packages/time-picker/test/visual/common.js
@@ -1,12 +1,17 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-/* Hide caret */
 registerStyles(
   'vaadin-time-picker',
   css`
+    /* Hide caret */
     :host([focus-ring]) ::slotted(input),
     :host([opened]) ::slotted(input) {
       caret-color: transparent;
+    }
+
+    /* Show error message immediately */
+    [part='error-message'] {
+      transition: none !important;
     }
   `,
 );


### PR DESCRIPTION
## Description

Part of #7823 

This should fix the following errors where the screenshot seems to be taken while error message transition is in progress:

```
 ❌ multi-select-combo-box > error message
      Error: Screenshot is not the same width and height as the baseline. Baseline: { width: 212, height: 124 } Screenshot: { width: 212, height: 121 }
        at async Ka.<anonymous> (packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js:73:5)

 ❌ text-area > error message
      Error: Screenshot is not the same width and height as the baseline. Baseline: { width: 212, height: 146 } Screenshot: { width: 212, height: 138 }
        at async n.<anonymous> (packages/text-area/test/visual/lumo/text-area.test.js:74:5)
```

## Type of change

- Tests