### PR TITLE
test: disable user tag opacity transition in visual tests

### DIFF
--- a/packages/field-highlighter/test/visual/common.js
+++ b/packages/field-highlighter/test/visual/common.js
@@ -30,3 +30,13 @@ registerStyles(
     }
   `,
 );
+
+/* Disable opacity transition */
+registerStyles(
+  'vaadin-user-tags',
+  css`
+    :host {
+      transition: none !important;
+    }
+  `,
+);


### PR DESCRIPTION
## Description

Part of #7823

This disables the following `opacity` transition which currently causes some visual tests to fail:

https://github.com/vaadin/web-components/blob/d930b7c50ef59df967f38ca2f9701571b23428e2/packages/field-highlighter/src/vaadin-user-tag.js#L34

| Baseline | Failed |
| -------- | -------|
| ![checkbox-group](https://github.com/user-attachments/assets/11c01c4b-e706-4c42-999e-7d571838981c) | ![checkbox-group](https://github.com/user-attachments/assets/7665427b-421a-4ff4-b82a-67bd19748b73) |

## Type of change

- Tests