### PR TITLE
chore: update retry GitHub action to v3 using Node 20

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -63,7 +63,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
## Description

Updated the `nick-fields/retry` action to [v3](https://github.com/nick-fields/retry/releases/tag/v3.0.0) to get rid of the following warning:

```
The following actions use a deprecated Node.js version and will be forced to run on node20: nick-fields/retry@v2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

## Type of change

- Internal change