### PR TITLE
test: use correct tag name in field highlighter visual tests

### DIFF
--- a/packages/field-highlighter/test/visual/common.js
+++ b/packages/field-highlighter/test/visual/common.js
@@ -33,7 +33,7 @@ registerStyles(
 
 /* Disable opacity transition */
 registerStyles(
-  'vaadin-user-tags',
+  'vaadin-user-tag',
   css`
     :host {
       transition: none !important;


### PR DESCRIPTION
## Description

Follow-up to #7831 - I used `vaadin-user-tags` instead of `vaadin-user-tag` 🤦‍♂️ 

This is also fixed in cherry-pick PRs so no need to backport this to `24.4` and `24.5`.

## Type of change

- Test