### PR TITLE
fix: primarily reorder with the dragged over dashboard item

### DIFF
--- a/packages/dashboard/src/widget-reorder-controller.js
+++ b/packages/dashboard/src/widget-reorder-controller.js
@@ -72,18 +72,22 @@ export class WidgetReorderController {
       return;
     }
 
-    // Find the element closest to the x and y coordinates of the drag event
-    const closestElement = this.__getClosestElement(otherElements, e.clientX, e.clientY);
+    // Find the element that is being dragged over
+    let targetElement = otherElements.find((other) => other.contains(e.target));
+    if (!targetElement) {
+      // Find the element closest to the x and y coordinates of the drag event
+      targetElement = this.__getClosestElement(otherElements, e.clientX, e.clientY);
+    }
 
-    // Check if the dragged element is dragged enough over the element closest to the drag event coordinates
-    if (!this.__reordering && this.__isDraggedOver(draggedElement, closestElement, e.clientX, e.clientY)) {
+    // Check if the dragged element is dragged enough over the target element
+    if (!this.__reordering && this.__isDraggedOver(draggedElement, targetElement, e.clientX, e.clientY)) {
       // Prevent reordering multiple times in quick succession
       this.__reordering = true;
       setTimeout(() => {
         this.__reordering = false;
       }, REORDER_EVENT_TIMEOUT);
 
-      const targetItem = getElementItem(closestElement);
+      const targetItem = getElementItem(targetElement);
       const targetItems = getItemsArrayOfItem(targetItem, this.host.items);
       const targetIndex = targetItems.indexOf(targetItem);
 

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -389,6 +389,33 @@ describe('dashboard - widget reordering', () => {
       expect(reorderEndSpy).to.not.have.been.called;
     });
 
+    it('should primarily reorder the dragged over element', async () => {
+      // Add a third widget
+      dashboard.style.width = `${columnWidth * 4}px`;
+      (dashboard.items[1] as TestDashboardItem).colspan = 2;
+      dashboard.items = [...dashboard.items, { id: 2 }];
+      await onceResized(dashboard);
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1, 1, 2],
+      ]);
+
+      // Start dragging the first widget
+      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      // Drag the first widget over the end edge of the second one
+      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'end');
+      await nextFrame();
+
+      // Expect the widgets to be reordered
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 1, 0, 2],
+      ]);
+    });
+
     it('should reorder the element closest to the drag event coordinates', async () => {
       // Add a third widget
       dashboard.style.width = `${columnWidth * 3}px`;
@@ -411,6 +438,38 @@ describe('dashboard - widget reordering', () => {
       // prettier-ignore
       expectLayout(dashboard, [
         [1, 2, 0],
+      ]);
+    });
+
+    it('should reorder the element closest to the empty area under drag event coordinates', async () => {
+      // Add a third widget
+      dashboard.style.width = `${columnWidth * 2}px`;
+      dashboard.items = [...dashboard.items, { id: 2 }];
+      await onceResized(dashboard);
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2]
+      ]);
+
+      // Start dragging the first widget
+      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      // Drag the first over the second row but not over any widget
+      const dashboardRect = dashboard.getBoundingClientRect();
+      const dragOverEvent = createDragEvent('dragover', {
+        x: dashboardRect.left + dashboardRect.width / 2 + 1,
+        y: dashboardRect.bottom,
+      });
+      dashboard.dispatchEvent(dragOverEvent);
+      await nextFrame();
+
+      // Expect the widgets to be reordered
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [1, 2],
+        [0]
       ]);
     });
 


### PR DESCRIPTION
## Description

There's an issue where the dragged widget doesn't always switch places with the widget under the drag coordinates.

https://github.com/user-attachments/assets/7d5a9cf0-f17a-44e0-bb1e-1a53a8190896

Currently, only the closest widget to the drag coordinates (based on its center point) is considered for switching during a drag event. This PR fixes the issue by prioritizing the widget directly under the drag coordinates as the primary candidate for switching. The closest widget is only treated as a secondary candidate (when dragging over empty space).

## Type of change

Bugfix