### PR TITLE
fix: keep combo-box focused state when restoring focus

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -1397,6 +1397,11 @@ export const ComboBoxMixin = (subclass) =>
         return false;
       }
 
+      // Do not remove focused state if focus should be restored after closing on outside click.
+      if (this._overlayOpened && this._overlayElement.restoreFocusOnClose) {
+        return false;
+      }
+
       return true;
     }
 

--- a/packages/combo-box/test/combo-box-light-validation.common.js
+++ b/packages/combo-box/test/combo-box-light-validation.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 
@@ -35,10 +35,19 @@ describe('vaadin-combo-box-light - validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate before change event on blur', async () => {
+    it('should validate before change event on keyboard blur', async () => {
       input.focus();
       await sendKeys({ type: 'foo' });
-      input.blur();
+      await sendKeys({ press: 'Tab' });
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(validateSpy.calledBefore(changeSpy)).to.be.true;
+    });
+
+    it('should validate before change event on outside click', async () => {
+      input.focus();
+      await sendKeys({ type: 'foo' });
+      outsideClick();
       expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;

--- a/packages/combo-box/test/data-provider.common.js
+++ b/packages/combo-box/test/data-provider.common.js
@@ -1,5 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import {
+  arrowDownKeyDown,
+  aTimeout,
+  enterKeyDown,
+  fixtureSync,
+  nextFrame,
+  nextRender,
+  tabKeyDown,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
@@ -1074,6 +1082,8 @@ const TEMPLATES = {
       let returnedItems;
 
       const bluringDataProvider = (_, callback) => {
+        // Keyboard blur before data is returned
+        tabKeyDown(comboBox.inputElement);
         comboBox.inputElement.blur();
         callback(returnedItems, returnedItems.length);
       };

--- a/packages/combo-box/test/interactions.common.js
+++ b/packages/combo-box/test/interactions.common.js
@@ -217,6 +217,13 @@ describe('interactions', () => {
       expect(comboBox.hasAttribute('focused')).to.be.true;
     });
 
+    it('should not remove focused attribute after closing with outside click', () => {
+      comboBox.focus();
+      comboBox.open();
+      outsideClick();
+      expect(comboBox.hasAttribute('focused')).to.be.true;
+    });
+
     it('should keep focus-ring attribute after closing with Escape', () => {
       comboBox.focus();
       comboBox.setAttribute('focus-ring', '');
@@ -225,14 +232,12 @@ describe('interactions', () => {
       expect(comboBox.hasAttribute('focus-ring')).to.be.true;
     });
 
-    it('should not keep focus-ring attribute after closing with outside click', () => {
+    it('should not remove focus-ring attribute after closing with outside click', () => {
       comboBox.focus();
       comboBox.setAttribute('focus-ring', '');
       comboBox.open();
       outsideClick();
-      expect(comboBox.hasAttribute('focus-ring')).to.be.false;
-      // FIXME: see https://github.com/vaadin/web-components/issues/4148
-      // expect(comboBox.hasAttribute('focus-ring')).to.be.true;
+      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
     });
   });
 

--- a/packages/combo-box/test/validation.common.js
+++ b/packages/combo-box/test/validation.common.js
@@ -48,10 +48,10 @@ describe('validation', () => {
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;
     });
 
-    it('should validate before change event on blur', async () => {
+    it('should validate before change event on keyboard blur', async () => {
       input.focus();
       await sendKeys({ type: 'foo' });
-      input.blur();
+      await sendKeys({ press: 'Tab' });
       expect(changeSpy.calledOnce).to.be.true;
       expect(validateSpy.calledOnce).to.be.true;
       expect(validateSpy.calledBefore(changeSpy)).to.be.true;


### PR DESCRIPTION
## Description

Fixes #4148

Updated the `_shouldRemoveFocus()` logic to check on `focusout` that `restoreFocusOnClose` is `true`, which is the case when closing overlay on outside click, or e.g. toggle button click but not keyboard blur with <kbd>Tab</kbd>.

This should align the behavior with the `vaadin-date-picker` and therefore make it easier to provide a common solution for both components used as custom editors in `vaadin-grid-pro` to not discard value on outside click, see #7796

As a result of this change, the `focus-ring` attribute is also preserved (see the issue referenced above).

## Type of change

- [ ] Bugfix
- [ ] Feature

## Note

Previously, I updated the combo-box to only close on blur from keyboard in #7554. However, some tests were still calling `inputElement.blur()` without outside click or <kbd>Tab</kbd> key. Updated these to use keyboard blur instead.

Some data-provider tests about losing focus could probably be refactored but IMO it's better to do in a separate PR.
