### PR TITLE
feat: dashboard i18n

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
@@ -11,6 +11,12 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export interface DashboardItemI18n {
+  widget: {
+    selectTitleForEditing: string;
+  };
+  section: {
+    selectTitleForEditing: string;
+  };
   remove: {
     title: string;
   };
@@ -19,6 +25,14 @@ export interface DashboardItemI18n {
     apply: string;
     forward: string;
     backward: string;
+  };
+  resize: {
+    title: string;
+    apply: string;
+    shrinkWidth: string;
+    growWidth: string;
+    shrinkHeight: string;
+    growHeight: string;
   };
 }
 

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
@@ -10,6 +10,18 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
+export interface DashboardItemI18n {
+  remove: {
+    title: string;
+  };
+  move: {
+    title: string;
+    apply: string;
+    forward: string;
+    backward: string;
+  };
+}
+
 /**
  * Shared functionality between widgets and sections
  */

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
@@ -11,29 +11,19 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
 export interface DashboardItemI18n {
-  widget: {
-    selectTitleForEditing: string;
-  };
-  section: {
-    selectTitleForEditing: string;
-  };
-  remove: {
-    title: string;
-  };
-  move: {
-    title: string;
-    apply: string;
-    forward: string;
-    backward: string;
-  };
-  resize: {
-    title: string;
-    apply: string;
-    shrinkWidth: string;
-    growWidth: string;
-    shrinkHeight: string;
-    growHeight: string;
-  };
+  selectWidgetTitleForEditing: string;
+  selectSectionTitleForEditing: string;
+  remove: string;
+  move: string;
+  moveApply: string;
+  moveForward: string;
+  moveBackward: string;
+  resize: string;
+  resizeApply: string;
+  resizeShrinkWidth: string;
+  resizeGrowWidth: string;
+  resizeShrinkHeight: string;
+  resizeGrowHeight: string;
 }
 
 /**

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -26,7 +26,7 @@ const DEFAULT_I18N = {
   resize: 'Resize',
   resizeApply: 'Apply',
   resizeShrinkWidth: 'Shrink width',
-  resizegrowWidth: 'Grow width',
+  resizeGrowWidth: 'Grow width',
   resizeShrinkHeight: 'Shrink height',
   resizeGrowHeight: 'Grow height',
 };

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -16,36 +16,26 @@ import { fireMove, fireRemove, fireResize } from './vaadin-dashboard-helpers.js'
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-styles.js';
 
 const DEFAULT_I18N = {
-  widget: {
-    selectTitleForEditing: 'Select widget title for editing',
-  },
-  section: {
-    selectTitleForEditing: 'Select section title for editing',
-  },
-  remove: {
-    title: 'Remove',
-  },
-  move: {
-    title: 'Move',
-    apply: 'Apply',
-    forward: 'Move Forward',
-    backward: 'Move Backward',
-  },
-  resize: {
-    title: 'Resize',
-    apply: 'Apply',
-    shrinkWidth: 'Shrink width',
-    growWidth: 'Grow width',
-    shrinkHeight: 'Shrink height',
-    growHeight: 'Grow height',
-  },
+  selectWidgetTitleForEditing: 'Select widget title for editing',
+  selectSectionTitleForEditing: 'Select section title for editing',
+  remove: 'Remove',
+  move: 'Move',
+  moveApply: 'Apply',
+  moveForward: 'Move Forward',
+  moveBackward: 'Move Backward',
+  resize: 'Resize',
+  resizeApply: 'Apply',
+  resizeShrinkWidth: 'Shrink width',
+  resizegrowWidth: 'Grow width',
+  resizeShrinkHeight: 'Shrink height',
+  resizeGrowHeight: 'Grow height',
 };
 
 /**
  * Returns a new object with the default i18n values
  */
 export function getDefaultI18n() {
-  return JSON.parse(JSON.stringify(DEFAULT_I18N));
+  return { ...DEFAULT_I18N };
 }
 
 /**
@@ -65,19 +55,6 @@ export const DashboardItemMixin = (superClass) =>
         /** @protected */
         i18n: {
           type: Object,
-          value: () => {
-            return {
-              remove: {
-                title: 'Remove',
-              },
-              move: {
-                title: 'Move',
-                apply: 'Apply',
-                forward: 'Move Forward',
-                backward: 'Move Backward',
-              },
-            };
-          },
         },
 
         /** @private */
@@ -114,7 +91,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderDragHandle() {
       return html`<button
-        title="${this.i18n.move.title}"
+        title="${this.i18n.move}"
         id="drag-handle"
         draggable="true"
         class="drag-handle"
@@ -126,7 +103,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderRemoveButton() {
       return html`<button
-        title="${this.i18n.remove.title}"
+        title="${this.i18n.remove}"
         id="remove-button"
         tabindex="${this.__selected ? 0 : -1}"
         @click="${() => fireRemove(this)}"
@@ -134,9 +111,9 @@ export const DashboardItemMixin = (superClass) =>
     }
 
     /** @private */
-    __renderFocusButton(i18n) {
+    __renderFocusButton(i18nSelectTitleForEditingProperty) {
       return html`<button
-        aria-label=${i18n ? i18n.selectTitleForEditing : ''}
+        aria-label=${this.i18n[i18nSelectTitleForEditingProperty]}
         id="focus-button"
         draggable="true"
         class="drag-handle"
@@ -149,7 +126,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderResizeHandle() {
       return html`<button
-        title="${this.i18n.resize.title}"
+        title="${this.i18n.resize}"
         id="resize-handle"
         class="resize-handle"
         tabindex="${this.__selected ? 0 : -1}"
@@ -165,9 +142,9 @@ export const DashboardItemMixin = (superClass) =>
         .hidden="${!this.__moveMode}"
         @pointerdown="${(e) => e.preventDefault()}"
       >
-        <button title="${this.i18n.move.backward}" @click="${() => fireMove(this, -1)}" id="move-backward"></button>
-        <button title="${this.i18n.move.apply}" @click="${() => this.__exitMode(true)}" id="move-apply"></button>
-        <button title="${this.i18n.move.forward}" @click="${() => fireMove(this, 1)}" id="move-forward"></button>
+        <button title="${this.i18n.moveBackward}" @click="${() => fireMove(this, -1)}" id="move-backward"></button>
+        <button title="${this.i18n.moveApply}" @click="${() => this.__exitMode(true)}" id="move-apply"></button>
+        <button title="${this.i18n.moveForward}" @click="${() => fireMove(this, 1)}" id="move-forward"></button>
       </div>`;
     }
 
@@ -181,25 +158,25 @@ export const DashboardItemMixin = (superClass) =>
         .hidden="${!this.__resizeMode}"
         @pointerdown="${(e) => e.preventDefault()}"
       >
-        <button title="${this.i18n.resize.apply}" @click="${() => this.__exitMode(true)}" id="resize-apply"></button>
+        <button title="${this.i18n.resizeApply}" @click="${() => this.__exitMode(true)}" id="resize-apply"></button>
         <button
-          title="${this.i18n.resize.shrinkWidth}"
+          title="${this.i18n.resizeShrinkWidth}"
           @click="${() => fireResize(this, -1, 0)}"
           id="resize-shrink-width"
         ></button>
         <button
-          title="${this.i18n.resize.growWidth}"
+          title="${this.i18n.resizeGrowWidth}"
           @click="${() => fireResize(this, 1, 0)}"
           id="resize-grow-width"
         ></button>
         <button
-          title="${this.i18n.resize.shrinkHeight}"
+          title="${this.i18n.resizeShrinkHeight}"
           @click="${() => fireResize(this, 0, -1)}"
           id="resize-shrink-height"
           .hidden="${!hasMinRowHeight}"
         ></button>
         <button
-          title="${this.i18n.resize.growHeight}"
+          title="${this.i18n.resizeGrowHeight}"
           @click="${() => fireResize(this, 0, 1)}"
           id="resize-grow-height"
           .hidden="${!hasMinRowHeight}"

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -15,6 +15,39 @@ import { KeyboardController } from './keyboard-controller.js';
 import { fireMove, fireRemove, fireResize } from './vaadin-dashboard-helpers.js';
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-styles.js';
 
+const DEFAULT_I18N = {
+  widget: {
+    selectTitleForEditing: 'Select widget title for editing',
+  },
+  section: {
+    selectTitleForEditing: 'Select section title for editing',
+  },
+  remove: {
+    title: 'Remove',
+  },
+  move: {
+    title: 'Move',
+    apply: 'Apply',
+    forward: 'Move Forward',
+    backward: 'Move Backward',
+  },
+  resize: {
+    title: 'Resize',
+    apply: 'Apply',
+    shrinkWidth: 'Shrink width',
+    growWidth: 'Grow width',
+    shrinkHeight: 'Shrink height',
+    growHeight: 'Grow height',
+  },
+};
+
+/**
+ * Returns a new object with the default i18n values
+ */
+export function getDefaultI18n() {
+  return JSON.parse(JSON.stringify(DEFAULT_I18N));
+}
+
 /**
  * Shared functionality between widgets and sections
  *
@@ -101,9 +134,9 @@ export const DashboardItemMixin = (superClass) =>
     }
 
     /** @private */
-    __renderFocusButton() {
+    __renderFocusButton(i18n) {
       return html`<button
-        aria-label=${this.i18n.selectTitleForEditing}
+        aria-label=${i18n ? i18n.selectTitleForEditing : ''}
         id="focus-button"
         draggable="true"
         class="drag-handle"

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -29,6 +29,24 @@ export const DashboardItemMixin = (superClass) =>
 
     static get properties() {
       return {
+        /** @protected */
+        i18n: {
+          type: Object,
+          value: () => {
+            return {
+              remove: {
+                title: 'Remove',
+              },
+              move: {
+                title: 'Move',
+                apply: 'Apply',
+                forward: 'Move Forward',
+                backward: 'Move Backward',
+              },
+            };
+          },
+        },
+
         /** @private */
         __selected: {
           type: Boolean,
@@ -63,6 +81,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderDragHandle() {
       return html`<button
+        title="${this.i18n.move.title}"
         id="drag-handle"
         draggable="true"
         class="drag-handle"
@@ -74,6 +93,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderRemoveButton() {
       return html`<button
+        title="${this.i18n.remove.title}"
         id="remove-button"
         tabindex="${this.__selected ? 0 : -1}"
         @click="${() => fireRemove(this)}"
@@ -83,7 +103,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderFocusButton() {
       return html`<button
-        aria-label="Select Title for editing"
+        aria-label=${this.i18n.selectTitleForEditing}
         id="focus-button"
         draggable="true"
         class="drag-handle"
@@ -96,6 +116,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderResizeHandle() {
       return html`<button
+        title="${this.i18n.resize.title}"
         id="resize-handle"
         class="resize-handle"
         tabindex="${this.__selected ? 0 : -1}"
@@ -104,16 +125,16 @@ export const DashboardItemMixin = (superClass) =>
     }
 
     /** @private */
-    __renderModeControls() {
+    __renderMoveControls() {
       return html`<div
         id="move-controls"
         class="mode-controls"
         .hidden="${!this.__moveMode}"
         @pointerdown="${(e) => e.preventDefault()}"
       >
-        <button title="Move backward" @click="${() => fireMove(this, -1)}" id="move-backward"></button>
-        <button title="Apply" @click="${() => this.__exitMode(true)}" id="move-apply"></button>
-        <button title="Move forward" @click="${() => fireMove(this, 1)}" id="move-forward"></button>
+        <button title="${this.i18n.move.backward}" @click="${() => fireMove(this, -1)}" id="move-backward"></button>
+        <button title="${this.i18n.move.apply}" @click="${() => this.__exitMode(true)}" id="move-apply"></button>
+        <button title="${this.i18n.move.forward}" @click="${() => fireMove(this, 1)}" id="move-forward"></button>
       </div>`;
     }
 
@@ -127,17 +148,25 @@ export const DashboardItemMixin = (superClass) =>
         .hidden="${!this.__resizeMode}"
         @pointerdown="${(e) => e.preventDefault()}"
       >
-        <button title="Apply" @click="${() => this.__exitMode(true)}" id="resize-apply"></button>
-        <button title="Shrink width" @click="${() => fireResize(this, -1, 0)}" id="resize-shrink-width"></button>
-        <button title="Grow width" @click="${() => fireResize(this, 1, 0)}" id="resize-grow-width"></button>
+        <button title="${this.i18n.resize.apply}" @click="${() => this.__exitMode(true)}" id="resize-apply"></button>
         <button
-          title="Shrink height"
+          title="${this.i18n.resize.shrinkWidth}"
+          @click="${() => fireResize(this, -1, 0)}"
+          id="resize-shrink-width"
+        ></button>
+        <button
+          title="${this.i18n.resize.growWidth}"
+          @click="${() => fireResize(this, 1, 0)}"
+          id="resize-grow-width"
+        ></button>
+        <button
+          title="${this.i18n.resize.shrinkHeight}"
           @click="${() => fireResize(this, 0, -1)}"
           id="resize-shrink-height"
           .hidden="${!hasMinRowHeight}"
         ></button>
         <button
-          title="Grow height"
+          title="${this.i18n.resize.growHeight}"
           @click="${() => fireResize(this, 0, 1)}"
           id="resize-grow-height"
           .hidden="${!hasMinRowHeight}"

--- a/packages/dashboard/src/vaadin-dashboard-section.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-section.d.ts
@@ -10,7 +10,11 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
+import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
+
+export interface DashboardSectionI18n extends DashboardItemI18n {
+  selectTitleForEditing: string;
+}
 
 /**
  * A Section component for use with the Dashboard component
@@ -20,6 +24,30 @@ declare class DashboardSection extends DashboardItemMixin(ControllerMixin(Elemen
    * The title of the section
    */
   sectionTitle: string | null | undefined;
+
+  /**
+   * The object used to localize this component.
+   *
+   * To change the default localization, replace the entire
+   * `i18n` object with a custom one.
+   *
+   * The object has the following structure and default values:
+   * ```
+   * {
+   *   selectTitleForEditing: 'Select Section Title for editing',
+   *   remove: {
+   *     title: 'Remove',
+   *   },
+   *   move: {
+   *     title: 'Move',
+   *     apply: 'Apply',
+   *     forward: 'Move Forward',
+   *     backward: 'Move Backward',
+   *   },
+   * }
+   * ```
+   */
+  i18n: DashboardSectionI18n;
 }
 
 declare global {

--- a/packages/dashboard/src/vaadin-dashboard-section.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-section.d.ts
@@ -12,9 +12,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 
-export interface DashboardSectionI18n extends DashboardItemI18n {
-  selectTitleForEditing: string;
-}
+export interface DashboardSectionI18n extends Omit<DashboardItemI18n, 'widget' | 'resize'> {}
 
 /**
  * A Section component for use with the Dashboard component
@@ -34,7 +32,9 @@ declare class DashboardSection extends DashboardItemMixin(ControllerMixin(Elemen
    * The object has the following structure and default values:
    * ```
    * {
-   *   selectTitleForEditing: 'Select Section Title for editing',
+   *   section: {
+   *     selectTitleForEditing: 'Select section title for editing',
+   *   },
    *   remove: {
    *     title: 'Remove',
    *   },

--- a/packages/dashboard/src/vaadin-dashboard-section.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-section.d.ts
@@ -12,7 +12,11 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 
-export interface DashboardSectionI18n extends Omit<DashboardItemI18n, 'widget' | 'resize'> {}
+export interface DashboardSectionI18n
+  extends Pick<
+    DashboardItemI18n,
+    'selectSectionTitleForEditing' | 'remove' | 'move' | 'moveApply' | 'moveForward' | 'moveBackward'
+  > {}
 
 /**
  * A Section component for use with the Dashboard component
@@ -32,18 +36,12 @@ declare class DashboardSection extends DashboardItemMixin(ControllerMixin(Elemen
    * The object has the following structure and default values:
    * ```
    * {
-   *   section: {
-   *     selectTitleForEditing: 'Select section title for editing',
-   *   },
-   *   remove: {
-   *     title: 'Remove',
-   *   },
-   *   move: {
-   *     title: 'Move',
-   *     apply: 'Apply',
-   *     forward: 'Move Forward',
-   *     backward: 'Move Backward',
-   *   },
+   *   selectSectionTitleForEditing: 'Select section title for editing',
+   *   remove: 'Remove',
+   *   move: 'Move',
+   *   moveApply: 'Apply',
+   *   moveForward: 'Move Forward',
+   *   moveBackward: 'Move Backward',
    * }
    * ```
    */

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -111,11 +111,12 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
         value: () => {
           const i18n = getDefaultI18n();
           return {
-            ...i18n.selectSectionTitleForEditing,
-            ...i18n.remove,
-            ...i18n.move,
-            ...i18n.moveApply,
-            ...i18n.moveForward,
+            selectSectionTitleForEditing: i18n.selectSectionTitleForEditing,
+            remove: i18n.remove,
+            move: i18n.move,
+            moveApply: i18n.moveApply,
+            moveForward: i18n.moveForward,
+            moveBackward: i18n.moveBackward,
           };
         },
       },

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -97,18 +97,12 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
        * The object has the following structure and default values:
        * ```
        * {
-       *   section: {
-       *     selectTitleForEditing: 'Select section title for editing',
-       *   },
-       *   remove: {
-       *     title: 'Remove',
-       *   },
-       *   move: {
-       *     title: 'Move',
-       *     apply: 'Apply',
-       *     forward: 'Move Forward',
-       *     backward: 'Move Backward',
-       *   },
+       *   selectSectionTitleForEditing: 'Select section title for editing',
+       *   remove: 'Remove',
+       *   move: 'Move',
+       *   moveApply: 'Apply',
+       *   moveForward: 'Move Forward',
+       *   moveBackward: 'Move Backward',
        * }
        * ```
        */
@@ -116,9 +110,13 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
         type: Object,
         value: () => {
           const i18n = getDefaultI18n();
-          delete i18n.widget;
-          delete i18n.resize;
-          return i18n;
+          return {
+            ...i18n.selectSectionTitleForEditing,
+            ...i18n.remove,
+            ...i18n.move,
+            ...i18n.moveApply,
+            ...i18n.moveForward,
+          };
         },
       },
 
@@ -136,7 +134,7 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
   /** @protected */
   render() {
     return html`
-      ${this.__renderFocusButton(this.i18n.section)} ${this.__renderMoveControls()}
+      ${this.__renderFocusButton('selectSectionTitleForEditing')} ${this.__renderMoveControls()}
 
       <div id="focustrap">
         <header>

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -88,6 +88,38 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
   static get properties() {
     return {
       /**
+       * The object used to localize this component.
+       *
+       * To change the default localization, replace the entire
+       * `i18n` object with a custom one.
+       *
+       * The object has the following structure and default values:
+       * ```
+       * {
+       *   selectTitleForEditing: 'Select Section Title for editing',
+       *   remove: {
+       *     title: 'Remove',
+       *   },
+       *   move: {
+       *     title: 'Move',
+       *     apply: 'Apply',
+       *     forward: 'Move Forward',
+       *     backward: 'Move Backward',
+       *   },
+       * }
+       * ```
+       */
+      i18n: {
+        type: Object,
+        value: () => {
+          return {
+            ...super.properties.i18n.value(),
+            selectTitleForEditing: 'Select Section Title for editing',
+          };
+        },
+      },
+
+      /**
        * The title of the section
        */
       sectionTitle: {
@@ -101,7 +133,7 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
   /** @protected */
   render() {
     return html`
-      ${this.__renderFocusButton()} ${this.__renderModeControls()}
+      ${this.__renderFocusButton()} ${this.__renderMoveControls()}
 
       <div id="focustrap">
         <header>

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -16,6 +16,7 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
 import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
+import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
 import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
 
 /**
@@ -96,7 +97,9 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
        * The object has the following structure and default values:
        * ```
        * {
-       *   selectTitleForEditing: 'Select Section Title for editing',
+       *   section: {
+       *     selectTitleForEditing: 'Select section title for editing',
+       *   },
        *   remove: {
        *     title: 'Remove',
        *   },
@@ -112,10 +115,10 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
       i18n: {
         type: Object,
         value: () => {
-          return {
-            ...super.properties.i18n.value(),
-            selectTitleForEditing: 'Select Section Title for editing',
-          };
+          const i18n = getDefaultI18n();
+          delete i18n.widget;
+          delete i18n.resize;
+          return i18n;
         },
       },
 
@@ -133,7 +136,7 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
   /** @protected */
   render() {
     return html`
-      ${this.__renderFocusButton()} ${this.__renderMoveControls()}
+      ${this.__renderFocusButton(this.i18n.section)} ${this.__renderMoveControls()}
 
       <div id="focustrap">
         <header>

--- a/packages/dashboard/src/vaadin-dashboard-widget.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-widget.d.ts
@@ -10,7 +10,19 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
+import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
+
+export interface DashboardWidgetI18n extends DashboardItemI18n {
+  selectTitleForEditing: string;
+  resize: {
+    title: string;
+    apply: string;
+    shrinkWidth: string;
+    growWidth: string;
+    shrinkHeight: string;
+    growHeight: string;
+  };
+}
 
 /**
  * A Widget component for use with the Dashboard component
@@ -20,6 +32,38 @@ declare class DashboardWidget extends DashboardItemMixin(ControllerMixin(Element
    * The title of the widget
    */
   widgetTitle: string | null | undefined;
+
+  /**
+   * The object used to localize this component.
+   *
+   * To change the default localization, replace the entire
+   * `i18n` object with a custom one.
+   *
+   * The object has the following structure and default values:
+   * ```
+   * {
+   *   selectTitleForEditing: 'Select Widget Title for editing',
+   *   remove: {
+   *     title: 'Remove',
+   *   },
+   *   resize: {
+   *     title: 'Resize',
+   *     apply: 'Apply',
+   *     shrinkWidth: 'Shrink width',
+   *     growWidth: 'Grow width',
+   *     shrinkHeight: 'Shrink height',
+   *     growHeight: 'Grow height',
+   *   },
+   *   move: {
+   *     title: 'Move',
+   *     apply: 'Apply',
+   *     forward: 'Move Forward',
+   *     backward: 'Move Backward',
+   *   },
+   * }
+   * ```
+   */
+  i18n: DashboardWidgetI18n;
 }
 
 declare global {

--- a/packages/dashboard/src/vaadin-dashboard-widget.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-widget.d.ts
@@ -12,17 +12,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 
-export interface DashboardWidgetI18n extends DashboardItemI18n {
-  selectTitleForEditing: string;
-  resize: {
-    title: string;
-    apply: string;
-    shrinkWidth: string;
-    growWidth: string;
-    shrinkHeight: string;
-    growHeight: string;
-  };
-}
+export interface DashboardWidgetI18n extends Omit<DashboardItemI18n, 'section'> {}
 
 /**
  * A Widget component for use with the Dashboard component
@@ -42,7 +32,9 @@ declare class DashboardWidget extends DashboardItemMixin(ControllerMixin(Element
    * The object has the following structure and default values:
    * ```
    * {
-   *   selectTitleForEditing: 'Select Widget Title for editing',
+   *   widget: {
+   *     selectTitleForEditing: 'Select widget title for editing',
+   *   },
    *   remove: {
    *     title: 'Remove',
    *   },

--- a/packages/dashboard/src/vaadin-dashboard-widget.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-widget.d.ts
@@ -12,7 +12,7 @@ import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js'
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 
-export interface DashboardWidgetI18n extends Omit<DashboardItemI18n, 'section'> {}
+export interface DashboardWidgetI18n extends Omit<DashboardItemI18n, 'selectSectionTitleForEditing'> {}
 
 /**
  * A Widget component for use with the Dashboard component
@@ -32,26 +32,18 @@ declare class DashboardWidget extends DashboardItemMixin(ControllerMixin(Element
    * The object has the following structure and default values:
    * ```
    * {
-   *   widget: {
-   *     selectTitleForEditing: 'Select widget title for editing',
-   *   },
-   *   remove: {
-   *     title: 'Remove',
-   *   },
-   *   resize: {
-   *     title: 'Resize',
-   *     apply: 'Apply',
-   *     shrinkWidth: 'Shrink width',
-   *     growWidth: 'Grow width',
-   *     shrinkHeight: 'Shrink height',
-   *     growHeight: 'Grow height',
-   *   },
-   *   move: {
-   *     title: 'Move',
-   *     apply: 'Apply',
-   *     forward: 'Move Forward',
-   *     backward: 'Move Backward',
-   *   },
+   *   selectWidgetTitleForEditing: 'Select widget title for editing',
+   *   remove: 'Remove',
+   *   resize: 'Resize',
+   *   resizeApply: 'Apply',
+   *   resizeShrinkWidth: 'Shrink width',
+   *   resizeGrowWidth: 'Grow width',
+   *   resizeShrinkHeight: 'Shrink height',
+   *   resizeGrowHeight: 'Grow height',
+   *   move: 'Move',
+   *   moveApply: 'Apply',
+   *   moveForward: 'Move Forward',
+   *   moveBackward: 'Move Backward',
    * }
    * ```
    */

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -101,26 +101,18 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
        * The object has the following structure and default values:
        * ```
        * {
-       *   widget: {
-       *     selectTitleForEditing: 'Select widget title for editing',
-       *   }
-       *   remove: {
-       *     title: 'Remove',
-       *   },
-       *   resize: {
-       *     title: 'Resize',
-       *     apply: 'Apply',
-       *     shrinkWidth: 'Shrink width',
-       *     growWidth: 'Grow width',
-       *     shrinkHeight: 'Shrink height',
-       *     growHeight: 'Grow height',
-       *   },
-       *   move: {
-       *     title: 'Move',
-       *     apply: 'Apply',
-       *     forward: 'Move Forward',
-       *     backward: 'Move Backward',
-       *   },
+       *   selectWidgetTitleForEditing: 'Select widget title for editing',
+       *   remove: 'Remove',
+       *   resize: 'Resize',
+       *   resizeApply: 'Apply',
+       *   resizeShrinkWidth: 'Shrink width',
+       *   resizeGrowWidth: 'Grow width',
+       *   resizeShrinkHeight: 'Shrink height',
+       *   resizeGrowHeight: 'Grow height',
+       *   move: 'Move',
+       *   moveApply: 'Apply',
+       *   moveForward: 'Move Forward',
+       *   moveBackward: 'Move Backward',
        * }
        * ```
        */
@@ -128,7 +120,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
         type: Object,
         value: () => {
           const i18n = getDefaultI18n();
-          delete i18n.section;
+          delete i18n.selectSectionTitleForEditing;
           return i18n;
         },
       },
@@ -147,7 +139,8 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
   /** @protected */
   render() {
     return html`
-      ${this.__renderFocusButton(this.i18n.widget)} ${this.__renderMoveControls()} ${this.__renderResizeControls()}
+      ${this.__renderFocusButton('selectWidgetTitleForEditing')} ${this.__renderMoveControls()}
+      ${this.__renderResizeControls()}
 
       <div id="focustrap">
         <header>

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -92,6 +92,54 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
   static get properties() {
     return {
       /**
+       * The object used to localize this component.
+       *
+       * To change the default localization, replace the entire
+       * `i18n` object with a custom one.
+       *
+       * The object has the following structure and default values:
+       * ```
+       * {
+       *   selectTitleForEditing: 'Select Widget Title for editing',
+       *   remove: {
+       *     title: 'Remove',
+       *   },
+       *   resize: {
+       *     title: 'Resize',
+       *     apply: 'Apply',
+       *     shrinkWidth: 'Shrink width',
+       *     growWidth: 'Grow width',
+       *     shrinkHeight: 'Shrink height',
+       *     growHeight: 'Grow height',
+       *   },
+       *   move: {
+       *     title: 'Move',
+       *     apply: 'Apply',
+       *     forward: 'Move Forward',
+       *     backward: 'Move Backward',
+       *   },
+       * }
+       * ```
+       */
+      i18n: {
+        type: Object,
+        value: () => {
+          return {
+            ...super.properties.i18n.value(),
+            selectTitleForEditing: 'Select Widget Title for editing',
+            resize: {
+              title: 'Resize',
+              apply: 'Apply',
+              shrinkWidth: 'Shrink width',
+              growWidth: 'Grow width',
+              shrinkHeight: 'Shrink height',
+              growHeight: 'Grow height',
+            },
+          };
+        },
+      },
+
+      /**
        * The title of the widget.
        */
       widgetTitle: {
@@ -105,7 +153,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
   /** @protected */
   render() {
     return html`
-      ${this.__renderFocusButton()} ${this.__renderModeControls()} ${this.__renderResizeControls()}
+      ${this.__renderFocusButton()} ${this.__renderMoveControls()} ${this.__renderResizeControls()}
 
       <div id="focustrap">
         <header>

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -17,6 +17,7 @@ import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { TitleController } from './title-controller.js';
 import { SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
+import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
 
 /**
  * A Widget component for use with the Dashboard component
@@ -100,7 +101,9 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
        * The object has the following structure and default values:
        * ```
        * {
-       *   selectTitleForEditing: 'Select Widget Title for editing',
+       *   widget: {
+       *     selectTitleForEditing: 'Select widget title for editing',
+       *   }
        *   remove: {
        *     title: 'Remove',
        *   },
@@ -124,18 +127,9 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
       i18n: {
         type: Object,
         value: () => {
-          return {
-            ...super.properties.i18n.value(),
-            selectTitleForEditing: 'Select Widget Title for editing',
-            resize: {
-              title: 'Resize',
-              apply: 'Apply',
-              shrinkWidth: 'Shrink width',
-              growWidth: 'Grow width',
-              shrinkHeight: 'Shrink height',
-              growHeight: 'Grow height',
-            },
-          };
+          const i18n = getDefaultI18n();
+          delete i18n.section;
+          return i18n;
         },
       },
 
@@ -153,7 +147,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
   /** @protected */
   render() {
     return html`
-      ${this.__renderFocusButton()} ${this.__renderMoveControls()} ${this.__renderResizeControls()}
+      ${this.__renderFocusButton(this.i18n.widget)} ${this.__renderMoveControls()} ${this.__renderResizeControls()}
 
       <div id="focustrap">
         <header>
@@ -192,6 +186,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
       SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
         this.toggleAttribute(attr, wrapper.hasAttribute(attr));
       });
+      this.i18n = wrapper.i18n;
     }
 
     const undefinedAncestor = this.closest('*:not(:defined)');

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -11,6 +11,7 @@
 import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-section.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import type { DashboardItemI18n } from './vaadin-dashboard-item-mixin.js';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 
 export interface DashboardItem {
@@ -86,6 +87,8 @@ export interface DashboardCustomEventMap<TItem extends DashboardItem> {
 
 export type DashboardEventMap<TItem extends DashboardItem> = DashboardCustomEventMap<TItem> & HTMLElementEventMap;
 
+export interface DashboardI18n extends DashboardItemI18n {}
+
 /**
  * A responsive, grid-based dashboard layout component
  */
@@ -114,6 +117,43 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
    * Whether the dashboard is editable.
    */
   editable: boolean;
+
+  /**
+   * The object used to localize this component.
+   *
+   * To change the default localization, replace the entire
+   * `i18n` object with a custom one.
+   *
+   * The object has the following structure and default values:
+   * ```
+   * {
+   *   widget: {
+   *     selectTitleForEditing: 'Select widget title for editing',
+   *   },
+   *   section: {
+   *     selectTitleForEditing: 'Select section title for editing',
+   *   },
+   *   remove: {
+   *     title: 'Remove',
+   *   },
+   *   resize: {
+   *     title: 'Resize',
+   *     apply: 'Apply',
+   *     shrinkWidth: 'Shrink width',
+   *     growWidth: 'Grow width',
+   *     shrinkHeight: 'Shrink height',
+   *     growHeight: 'Grow height',
+   *   },
+   *   move: {
+   *     title: 'Move',
+   *     apply: 'Apply',
+   *     forward: 'Move Forward',
+   *     backward: 'Move Backward',
+   *   },
+   * }
+   * ```
+   */
+  i18n: DashboardI18n;
 
   addEventListener<K extends keyof DashboardEventMap<TItem>>(
     type: K,

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -127,29 +127,19 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
    * The object has the following structure and default values:
    * ```
    * {
-   *   widget: {
-   *     selectTitleForEditing: 'Select widget title for editing',
-   *   },
-   *   section: {
-   *     selectTitleForEditing: 'Select section title for editing',
-   *   },
-   *   remove: {
-   *     title: 'Remove',
-   *   },
-   *   resize: {
-   *     title: 'Resize',
-   *     apply: 'Apply',
-   *     shrinkWidth: 'Shrink width',
-   *     growWidth: 'Grow width',
-   *     shrinkHeight: 'Shrink height',
-   *     growHeight: 'Grow height',
-   *   },
-   *   move: {
-   *     title: 'Move',
-   *     apply: 'Apply',
-   *     forward: 'Move Forward',
-   *     backward: 'Move Backward',
-   *   },
+   *   selectSectionTitleForEditing: 'Select section title for editing',
+   *   selectWidgetTitleForEditing: 'Select widget title for editing',
+   *   remove: 'Remove',
+   *   resize: 'Resize',
+   *   resizeApply: 'Apply',
+   *   resizeShrinkWidth: 'Shrink width',
+   *   resizeGrowWidth: 'Grow width',
+   *   resizeShrinkHeight: 'Shrink height',
+   *   resizeGrowHeight: 'Grow height',
+   *   move: 'Move',
+   *   moveApply: 'Apply',
+   *   moveForward: 'Move Forward',
+   *   moveBackward: 'Move Backward',
    * }
    * ```
    */

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -98,6 +98,31 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
         type: Boolean,
       },
 
+      /**
+       * The object used to localize this component.
+       *
+       * To change the default localization, replace the entire
+       * `i18n` object with a custom one.
+       *
+       * The object has the following structure and default values:
+       * ```
+       * {
+       *   selectSectionTitleForEditing: 'Select section title for editing',
+       *   selectWidgetTitleForEditing: 'Select widget title for editing',
+       *   remove: 'Remove',
+       *   resize: 'Resize',
+       *   resizeApply: 'Apply',
+       *   resizeShrinkWidth: 'Shrink width',
+       *   resizeGrowWidth: 'Grow width',
+       *   resizeShrinkHeight: 'Shrink height',
+       *   resizeGrowHeight: 'Grow height',
+       *   move: 'Move',
+       *   moveApply: 'Apply',
+       *   moveForward: 'Move Forward',
+       *   moveBackward: 'Move Backward',
+       * }
+       * ```
+       */
       i18n: {
         type: Object,
         value: () => {

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -22,6 +22,7 @@ import {
   SYNCHRONIZED_ATTRIBUTES,
   WRAPPER_LOCAL_NAME,
 } from './vaadin-dashboard-helpers.js';
+import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 import { DashboardSection } from './vaadin-dashboard-section.js';
 import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
@@ -96,11 +97,20 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       editable: {
         type: Boolean,
       },
+
+      i18n: {
+        type: Object,
+        value: () => {
+          return {
+            ...getDefaultI18n(),
+          };
+        },
+      },
     };
   }
 
   static get observers() {
-    return ['__itemsOrRendererChanged(items, renderer, editable)'];
+    return ['__itemsOrRendererChanged(items, renderer, editable, i18n)'];
   }
 
   constructor() {
@@ -145,6 +155,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
         SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
           wrapper.firstElementChild.toggleAttribute(attr, wrapper.hasAttribute(attr));
         });
+        wrapper.firstElementChild.i18n = this.i18n;
       }
     });
   }
@@ -185,6 +196,8 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
         SYNCHRONIZED_ATTRIBUTES.forEach((attr) => section.toggleAttribute(attr, wrapper.hasAttribute(attr)));
+        section.i18n = this.i18n;
+
         // Render the subitems
         this.__renderItemWrappers(item.items, section);
       }
@@ -213,6 +226,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     wrapper.toggleAttribute('dragging', this.__widgetReorderController.draggedItem === item);
     wrapper.toggleAttribute('first-child', item === getItemsArrayOfItem(item, this.items)[0]);
     wrapper.toggleAttribute('last-child', item === getItemsArrayOfItem(item, this.items).slice(-1)[0]);
+    wrapper.i18n = this.i18n;
   }
 
   /** @private */

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -109,7 +109,7 @@ describe('dashboard section', () => {
 
   describe('i18n', () => {
     it('should localize focus button aria-label', async () => {
-      section.i18n = { ...section.i18n, selectTitleForEditing: 'foo' };
+      section.i18n = { ...section.i18n, section: { selectTitleForEditing: 'foo' } };
       await nextFrame();
 
       const focusButton = section.shadowRoot?.querySelector('#focus-button');

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -109,7 +109,7 @@ describe('dashboard section', () => {
 
   describe('i18n', () => {
     it('should localize focus button aria-label', async () => {
-      section.i18n = { ...section.i18n, section: { selectTitleForEditing: 'foo' } };
+      section.i18n = { ...section.i18n, selectSectionTitleForEditing: 'foo' };
       await nextFrame();
 
       const focusButton = section.shadowRoot?.querySelector('#focus-button');
@@ -117,7 +117,7 @@ describe('dashboard section', () => {
     });
 
     it('should localize remove button title', async () => {
-      section.i18n = { ...section.i18n, remove: { title: 'foo' } };
+      section.i18n = { ...section.i18n, remove: 'foo' };
       await nextFrame();
 
       const removeButton = getRemoveButton(section);
@@ -125,7 +125,7 @@ describe('dashboard section', () => {
     });
 
     it('should localize drag handle title', async () => {
-      section.i18n = { ...section.i18n, move: { ...section.i18n.move, title: 'foo' } };
+      section.i18n = { ...section.i18n, move: 'foo' };
       await nextFrame();
 
       const dragHandle = getDraggable(section);
@@ -135,12 +135,9 @@ describe('dashboard section', () => {
     it('should localize move mode buttons', async () => {
       section.i18n = {
         ...section.i18n,
-        move: {
-          ...section.i18n.move,
-          apply: 'foo',
-          forward: 'bar',
-          backward: 'baz',
-        },
+        moveApply: 'foo',
+        moveForward: 'bar',
+        moveBackward: 'baz',
       };
 
       await nextFrame();

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -109,30 +109,40 @@ describe('dashboard section', () => {
 
   describe('i18n', () => {
     it('should localize focus button aria-label', async () => {
+      const focusButton = section.shadowRoot?.querySelector('#focus-button');
+      expect(focusButton?.getAttribute('aria-label')).to.eql('Select section title for editing');
+
       section.i18n = { ...section.i18n, selectSectionTitleForEditing: 'foo' };
       await nextFrame();
 
-      const focusButton = section.shadowRoot?.querySelector('#focus-button');
       expect(focusButton?.getAttribute('aria-label')).to.eql('foo');
     });
 
     it('should localize remove button title', async () => {
+      const removeButton = getRemoveButton(section);
+      expect(removeButton?.getAttribute('title')).to.eql('Remove');
+
       section.i18n = { ...section.i18n, remove: 'foo' };
       await nextFrame();
 
-      const removeButton = getRemoveButton(section);
       expect(removeButton?.getAttribute('title')).to.eql('foo');
     });
 
     it('should localize drag handle title', async () => {
+      const dragHandle = getDraggable(section);
+      expect(dragHandle?.getAttribute('title')).to.eql('Move');
+
       section.i18n = { ...section.i18n, move: 'foo' };
       await nextFrame();
 
-      const dragHandle = getDraggable(section);
       expect(dragHandle?.getAttribute('title')).to.eql('foo');
     });
 
     it('should localize move mode buttons', async () => {
+      expect(getMoveApplyButton(section)?.getAttribute('title')).to.eql('Apply');
+      expect(getMoveForwardButton(section)?.getAttribute('title')).to.eql('Move Forward');
+      expect(getMoveBackwardButton(section)?.getAttribute('title')).to.eql('Move Backward');
+
       section.i18n = {
         ...section.i18n,
         moveApply: 'foo',

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -2,6 +2,13 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-section.js';
 import type { DashboardSection } from '../vaadin-dashboard-section.js';
+import {
+  getDraggable,
+  getMoveApplyButton,
+  getMoveBackwardButton,
+  getMoveForwardButton,
+  getRemoveButton,
+} from './helpers.js';
 
 describe('dashboard section', () => {
   let section: DashboardSection;
@@ -97,6 +104,50 @@ describe('dashboard section', () => {
 
       const title = section.querySelector('[slot="title"]');
       expect(title?.textContent).to.eql('');
+    });
+  });
+
+  describe('i18n', () => {
+    it('should localize focus button aria-label', async () => {
+      section.i18n = { ...section.i18n, selectTitleForEditing: 'foo' };
+      await nextFrame();
+
+      const focusButton = section.shadowRoot?.querySelector('#focus-button');
+      expect(focusButton?.getAttribute('aria-label')).to.eql('foo');
+    });
+
+    it('should localize remove button title', async () => {
+      section.i18n = { ...section.i18n, remove: { title: 'foo' } };
+      await nextFrame();
+
+      const removeButton = getRemoveButton(section);
+      expect(removeButton?.getAttribute('title')).to.eql('foo');
+    });
+
+    it('should localize drag handle title', async () => {
+      section.i18n = { ...section.i18n, move: { ...section.i18n.move, title: 'foo' } };
+      await nextFrame();
+
+      const dragHandle = getDraggable(section);
+      expect(dragHandle?.getAttribute('title')).to.eql('foo');
+    });
+
+    it('should localize move mode buttons', async () => {
+      section.i18n = {
+        ...section.i18n,
+        move: {
+          ...section.i18n.move,
+          apply: 'foo',
+          forward: 'bar',
+          backward: 'baz',
+        },
+      };
+
+      await nextFrame();
+
+      expect(getMoveApplyButton(section)?.getAttribute('title')).to.eql('foo');
+      expect(getMoveForwardButton(section)?.getAttribute('title')).to.eql('bar');
+      expect(getMoveBackwardButton(section)?.getAttribute('title')).to.eql('baz');
     });
   });
 });

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -111,7 +111,7 @@ describe('dashboard widget', () => {
 
   describe('i18n', () => {
     it('should localize focus button aria-label', async () => {
-      widget.i18n = { ...widget.i18n, widget: { selectTitleForEditing: 'foo' } };
+      widget.i18n = { ...widget.i18n, selectWidgetTitleForEditing: 'foo' };
       await nextFrame();
 
       const focusButton = widget.shadowRoot?.querySelector('#focus-button');
@@ -119,7 +119,7 @@ describe('dashboard widget', () => {
     });
 
     it('should localize remove button title', async () => {
-      widget.i18n = { ...widget.i18n, remove: { title: 'foo' } };
+      widget.i18n = { ...widget.i18n, remove: 'foo' };
       await nextFrame();
 
       const removeButton = getRemoveButton(widget);
@@ -127,7 +127,7 @@ describe('dashboard widget', () => {
     });
 
     it('should localize drag handle title', async () => {
-      widget.i18n = { ...widget.i18n, move: { ...widget.i18n.move, title: 'foo' } };
+      widget.i18n = { ...widget.i18n, move: 'foo' };
       await nextFrame();
 
       const dragHandle = getDraggable(widget);
@@ -135,7 +135,7 @@ describe('dashboard widget', () => {
     });
 
     it('should localize resize handle title', async () => {
-      widget.i18n = { ...widget.i18n, resize: { ...widget.i18n.resize, title: 'foo' } };
+      widget.i18n = { ...widget.i18n, resize: 'foo' };
       await nextFrame();
 
       const resizeHandle = getResizeHandle(widget);
@@ -145,14 +145,11 @@ describe('dashboard widget', () => {
     it('should localize resize mode buttons', async () => {
       widget.i18n = {
         ...widget.i18n,
-        resize: {
-          ...widget.i18n.resize,
-          apply: 'foo',
-          shrinkHeight: 'bar',
-          shrinkWidth: 'baz',
-          growHeight: 'qux',
-          growWidth: 'quux',
-        },
+        resizeApply: 'foo',
+        resizeShrinkHeight: 'bar',
+        resizeShrinkWidth: 'baz',
+        resizeGrowHeight: 'qux',
+        resizeGrowWidth: 'quux',
       };
 
       await nextFrame();
@@ -167,12 +164,9 @@ describe('dashboard widget', () => {
     it('should localize move mode buttons', async () => {
       widget.i18n = {
         ...widget.i18n,
-        move: {
-          ...widget.i18n.move,
-          apply: 'foo',
-          forward: 'bar',
-          backward: 'baz',
-        },
+        moveApply: 'foo',
+        moveForward: 'bar',
+        moveBackward: 'baz',
       };
 
       await nextFrame();

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -111,38 +111,52 @@ describe('dashboard widget', () => {
 
   describe('i18n', () => {
     it('should localize focus button aria-label', async () => {
+      const focusButton = widget.shadowRoot?.querySelector('#focus-button');
+      expect(focusButton?.getAttribute('aria-label')).to.eql('Select widget title for editing');
+
       widget.i18n = { ...widget.i18n, selectWidgetTitleForEditing: 'foo' };
       await nextFrame();
 
-      const focusButton = widget.shadowRoot?.querySelector('#focus-button');
       expect(focusButton?.getAttribute('aria-label')).to.eql('foo');
     });
 
     it('should localize remove button title', async () => {
+      const removeButton = getRemoveButton(widget);
+      expect(removeButton?.getAttribute('title')).to.eql('Remove');
+
       widget.i18n = { ...widget.i18n, remove: 'foo' };
       await nextFrame();
 
-      const removeButton = getRemoveButton(widget);
       expect(removeButton?.getAttribute('title')).to.eql('foo');
     });
 
     it('should localize drag handle title', async () => {
+      const dragHandle = getDraggable(widget);
+      expect(dragHandle?.getAttribute('title')).to.eql('Move');
+
       widget.i18n = { ...widget.i18n, move: 'foo' };
       await nextFrame();
 
-      const dragHandle = getDraggable(widget);
       expect(dragHandle?.getAttribute('title')).to.eql('foo');
     });
 
     it('should localize resize handle title', async () => {
+      const resizeHandle = getResizeHandle(widget);
+      expect(resizeHandle?.getAttribute('title')).to.eql('Resize');
+
       widget.i18n = { ...widget.i18n, resize: 'foo' };
       await nextFrame();
 
-      const resizeHandle = getResizeHandle(widget);
       expect(resizeHandle?.getAttribute('title')).to.eql('foo');
     });
 
     it('should localize resize mode buttons', async () => {
+      expect(getResizeApplyButton(widget)?.getAttribute('title')).to.eql('Apply');
+      expect(getResizeShrinkHeightButton(widget)?.getAttribute('title')).to.eql('Shrink height');
+      expect(getResizeShrinkWidthButton(widget)?.getAttribute('title')).to.eql('Shrink width');
+      expect(getResizeGrowHeightButton(widget)?.getAttribute('title')).to.eql('Grow height');
+      expect(getResizeGrowWidthButton(widget)?.getAttribute('title')).to.eql('Grow width');
+
       widget.i18n = {
         ...widget.i18n,
         resizeApply: 'foo',
@@ -162,6 +176,10 @@ describe('dashboard widget', () => {
     });
 
     it('should localize move mode buttons', async () => {
+      expect(getMoveApplyButton(widget)?.getAttribute('title')).to.eql('Apply');
+      expect(getMoveForwardButton(widget)?.getAttribute('title')).to.eql('Move Forward');
+      expect(getMoveBackwardButton(widget)?.getAttribute('title')).to.eql('Move Backward');
+
       widget.i18n = {
         ...widget.i18n,
         moveApply: 'foo',

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -3,6 +3,19 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-widget.js';
 import { DashboardSection } from '../vaadin-dashboard-section.js';
 import { DashboardWidget } from '../vaadin-dashboard-widget.js';
+import {
+  getDraggable,
+  getMoveApplyButton,
+  getMoveBackwardButton,
+  getMoveForwardButton,
+  getRemoveButton,
+  getResizeApplyButton,
+  getResizeGrowHeightButton,
+  getResizeGrowWidthButton,
+  getResizeHandle,
+  getResizeShrinkHeightButton,
+  getResizeShrinkWidthButton,
+} from './helpers.js';
 
 describe('dashboard widget', () => {
   let widget: DashboardWidget;
@@ -93,6 +106,80 @@ describe('dashboard widget', () => {
 
       const title = widget.querySelector('[slot="title"]');
       expect(title?.textContent).to.eql('');
+    });
+  });
+
+  describe('i18n', () => {
+    it('should localize focus button aria-label', async () => {
+      widget.i18n = { ...widget.i18n, selectTitleForEditing: 'foo' };
+      await nextFrame();
+
+      const focusButton = widget.shadowRoot?.querySelector('#focus-button');
+      expect(focusButton?.getAttribute('aria-label')).to.eql('foo');
+    });
+
+    it('should localize remove button title', async () => {
+      widget.i18n = { ...widget.i18n, remove: { title: 'foo' } };
+      await nextFrame();
+
+      const removeButton = getRemoveButton(widget);
+      expect(removeButton?.getAttribute('title')).to.eql('foo');
+    });
+
+    it('should localize drag handle title', async () => {
+      widget.i18n = { ...widget.i18n, move: { ...widget.i18n.move, title: 'foo' } };
+      await nextFrame();
+
+      const dragHandle = getDraggable(widget);
+      expect(dragHandle?.getAttribute('title')).to.eql('foo');
+    });
+
+    it('should localize resize handle title', async () => {
+      widget.i18n = { ...widget.i18n, resize: { ...widget.i18n.resize, title: 'foo' } };
+      await nextFrame();
+
+      const resizeHandle = getResizeHandle(widget);
+      expect(resizeHandle?.getAttribute('title')).to.eql('foo');
+    });
+
+    it('should localize resize mode buttons', async () => {
+      widget.i18n = {
+        ...widget.i18n,
+        resize: {
+          ...widget.i18n.resize,
+          apply: 'foo',
+          shrinkHeight: 'bar',
+          shrinkWidth: 'baz',
+          growHeight: 'qux',
+          growWidth: 'quux',
+        },
+      };
+
+      await nextFrame();
+
+      expect(getResizeApplyButton(widget)?.getAttribute('title')).to.eql('foo');
+      expect(getResizeShrinkHeightButton(widget)?.getAttribute('title')).to.eql('bar');
+      expect(getResizeShrinkWidthButton(widget)?.getAttribute('title')).to.eql('baz');
+      expect(getResizeGrowHeightButton(widget)?.getAttribute('title')).to.eql('qux');
+      expect(getResizeGrowWidthButton(widget)?.getAttribute('title')).to.eql('quux');
+    });
+
+    it('should localize move mode buttons', async () => {
+      widget.i18n = {
+        ...widget.i18n,
+        move: {
+          ...widget.i18n.move,
+          apply: 'foo',
+          forward: 'bar',
+          backward: 'baz',
+        },
+      };
+
+      await nextFrame();
+
+      expect(getMoveApplyButton(widget)?.getAttribute('title')).to.eql('foo');
+      expect(getMoveForwardButton(widget)?.getAttribute('title')).to.eql('bar');
+      expect(getMoveBackwardButton(widget)?.getAttribute('title')).to.eql('baz');
     });
   });
 });

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -111,7 +111,7 @@ describe('dashboard widget', () => {
 
   describe('i18n', () => {
     it('should localize focus button aria-label', async () => {
-      widget.i18n = { ...widget.i18n, selectTitleForEditing: 'foo' };
+      widget.i18n = { ...widget.i18n, widget: { selectTitleForEditing: 'foo' } };
       await nextFrame();
 
       const focusButton = widget.shadowRoot?.querySelector('#focus-button');

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -170,6 +170,24 @@ describe('dashboard', () => {
   });
 
   describe('i18n', () => {
+    it('should have default values', () => {
+      expect(dashboard.i18n).to.eql({
+        selectSectionTitleForEditing: 'Select section title for editing',
+        selectWidgetTitleForEditing: 'Select widget title for editing',
+        remove: 'Remove',
+        resize: 'Resize',
+        resizeApply: 'Apply',
+        resizeShrinkWidth: 'Shrink width',
+        resizeGrowWidth: 'Grow width',
+        resizeShrinkHeight: 'Shrink height',
+        resizeGrowHeight: 'Grow height',
+        move: 'Move',
+        moveApply: 'Apply',
+        moveForward: 'Move Forward',
+        moveBackward: 'Move Backward',
+      });
+    });
+
     it('should localize widget', async () => {
       dashboard.i18n = {
         ...dashboard.i18n,

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -173,20 +173,16 @@ describe('dashboard', () => {
     it('should localize widget', async () => {
       dashboard.i18n = {
         ...dashboard.i18n,
-        widget: {
-          selectTitleForEditing: 'foo',
-        },
+        selectWidgetTitleForEditing: 'foo',
       };
 
       await nextFrame();
 
       const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
-      expect(widget.i18n.widget.selectTitleForEditing).to.equal('foo');
+      expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
       expect(widget.i18n).to.eql({
         ...dashboard.i18n,
-        widget: {
-          selectTitleForEditing: 'foo',
-        },
+        selectWidgetTitleForEditing: 'foo',
       });
     });
 
@@ -210,13 +206,11 @@ describe('dashboard', () => {
 
       dashboard.i18n = {
         ...dashboard.i18n,
-        widget: {
-          selectTitleForEditing: 'foo',
-        },
+        selectWidgetTitleForEditing: 'foo',
       };
       await nextFrame();
 
-      expect(widget.i18n.widget.selectTitleForEditing).to.equal('foo');
+      expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
     });
 
     it('should localize a lazily rendered widget', async () => {
@@ -232,14 +226,12 @@ describe('dashboard', () => {
 
       dashboard.i18n = {
         ...dashboard.i18n,
-        widget: {
-          selectTitleForEditing: 'foo',
-        },
+        selectWidgetTitleForEditing: 'foo',
       };
       await nextFrame();
 
       const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
-      expect(widget.i18n.widget.selectTitleForEditing).to.equal('foo');
+      expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
     });
   });
 
@@ -392,21 +384,17 @@ describe('dashboard', () => {
         it('should localize section', async () => {
           dashboard.i18n = {
             ...dashboard.i18n,
-            section: {
-              selectTitleForEditing: 'foo',
-            },
+            selectSectionTitleForEditing: 'foo',
           };
 
           await nextFrame();
 
           const widget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
           const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
-          expect(section.i18n.section.selectTitleForEditing).to.equal('foo');
+          expect(section.i18n.selectSectionTitleForEditing).to.equal('foo');
           expect(section.i18n).to.eql({
             ...dashboard.i18n,
-            section: {
-              selectTitleForEditing: 'foo',
-            },
+            selectSectionTitleForEditing: 'foo',
           });
         });
       });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -198,10 +198,7 @@ describe('dashboard', () => {
 
       const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
       expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
-      expect(widget.i18n).to.eql({
-        ...dashboard.i18n,
-        selectWidgetTitleForEditing: 'foo',
-      });
+      expect(widget.i18n).to.eql(dashboard.i18n);
     });
 
     it('should localize focused widget', async () => {
@@ -410,10 +407,7 @@ describe('dashboard', () => {
           const widget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
           const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
           expect(section.i18n.selectSectionTitleForEditing).to.equal('foo');
-          expect(section.i18n).to.eql({
-            ...dashboard.i18n,
-            selectSectionTitleForEditing: 'foo',
-          });
+          expect(section.i18n).to.eql(dashboard.i18n);
         });
       });
     });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -169,6 +169,80 @@ describe('dashboard', () => {
     });
   });
 
+  describe('i18n', () => {
+    it('should localize widget', async () => {
+      dashboard.i18n = {
+        ...dashboard.i18n,
+        widget: {
+          selectTitleForEditing: 'foo',
+        },
+      };
+
+      await nextFrame();
+
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      expect(widget.i18n.widget.selectTitleForEditing).to.equal('foo');
+      expect(widget.i18n).to.eql({
+        ...dashboard.i18n,
+        widget: {
+          selectTitleForEditing: 'foo',
+        },
+      });
+    });
+
+    it('should localize focused widget', async () => {
+      dashboard.editable = true;
+      // Use a custom renderer that reuses the same widget instance
+      dashboard.renderer = (root, _, model) => {
+        let widget = root.querySelector('vaadin-dashboard-widget');
+        if (!widget || widget.tabIndex !== 0) {
+          root.textContent = '';
+          widget = document.createElement('vaadin-dashboard-widget');
+          widget.tabIndex = 0;
+          root.appendChild(widget);
+        }
+        widget.widgetTitle = `${model.item.id} title`;
+      };
+      await nextFrame();
+
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      widget.focus();
+
+      dashboard.i18n = {
+        ...dashboard.i18n,
+        widget: {
+          selectTitleForEditing: 'foo',
+        },
+      };
+      await nextFrame();
+
+      expect(widget.i18n.widget.selectTitleForEditing).to.equal('foo');
+    });
+
+    it('should localize a lazily rendered widget', async () => {
+      // Assign a renderer that initially renders nothing
+      const syncRenderer = dashboard.renderer!;
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        requestAnimationFrame(() => {
+          syncRenderer(root, _, model);
+        });
+      };
+      await nextFrame();
+
+      dashboard.i18n = {
+        ...dashboard.i18n,
+        widget: {
+          selectTitleForEditing: 'foo',
+        },
+      };
+      await nextFrame();
+
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      expect(widget.i18n.widget.selectTitleForEditing).to.equal('foo');
+    });
+  });
+
   describe('section', () => {
     beforeEach(async () => {
       dashboard.items = [
@@ -299,7 +373,7 @@ describe('dashboard', () => {
       });
 
       it('should hide remove button by default', () => {
-        const widget = getElementFromCell(dashboard, 1, 0) as DashboardSection;
+        const widget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
         const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
         const removeButton = getRemoveButton(section);
         expect(removeButton.getBoundingClientRect().height).to.equal(0);
@@ -308,10 +382,33 @@ describe('dashboard', () => {
       it('should unhide remove button when editable', async () => {
         dashboard.editable = true;
         await nextFrame();
-        const widget = getElementFromCell(dashboard, 1, 0) as DashboardSection;
+        const widget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
         const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
         const removeButton = getRemoveButton(section);
         expect(removeButton.getBoundingClientRect().height).to.be.above(0);
+      });
+
+      describe('i18n', () => {
+        it('should localize section', async () => {
+          dashboard.i18n = {
+            ...dashboard.i18n,
+            section: {
+              selectTitleForEditing: 'foo',
+            },
+          };
+
+          await nextFrame();
+
+          const widget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
+          const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+          expect(section.i18n.section.selectTitleForEditing).to.equal('foo');
+          expect(section.i18n).to.eql({
+            ...dashboard.i18n,
+            section: {
+              selectTitleForEditing: 'foo',
+            },
+          });
+        });
       });
     });
   });

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -10,8 +10,8 @@ import type {
   DashboardSectionItem,
 } from '../../vaadin-dashboard.js';
 import type { DashboardLayout } from '../../vaadin-dashboard-layout.js';
-import type { DashboardSection } from '../../vaadin-dashboard-section.js';
-import type { DashboardWidget } from '../../vaadin-dashboard-widget.js';
+import type { DashboardSection, DashboardSectionI18n } from '../../vaadin-dashboard-section.js';
+import type { DashboardWidget, DashboardWidgetI18n } from '../../vaadin-dashboard-widget.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -74,8 +74,44 @@ assertType<DashboardWidget>(widget);
 
 assertType<string | null | undefined>(widget.widgetTitle);
 
+assertType<DashboardWidgetI18n>(widget.i18n);
+assertType<{
+  selectTitleForEditing: string;
+  remove: {
+    title: string;
+  };
+  resize: {
+    title: string;
+    apply: string;
+    shrinkWidth: string;
+    growWidth: string;
+    shrinkHeight: string;
+    growHeight: string;
+  };
+  move: {
+    title: string;
+    apply: string;
+    forward: string;
+    backward: string;
+  };
+}>(widget.i18n);
+
 /* DashboardSection */
 const section = document.createElement('vaadin-dashboard-section');
 assertType<DashboardSection>(section);
 
 assertType<string | null | undefined>(section.sectionTitle);
+
+assertType<DashboardSectionI18n>(section.i18n);
+assertType<{
+  selectTitleForEditing: string;
+  remove: {
+    title: string;
+  };
+  move: {
+    title: string;
+    apply: string;
+    forward: string;
+    backward: string;
+  };
+}>(section.i18n);

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -76,26 +76,18 @@ assertType<string | null | undefined>(widget.widgetTitle);
 
 assertType<DashboardWidgetI18n>(widget.i18n);
 assertType<{
-  widget: {
-    selectTitleForEditing: string;
-  };
-  remove: {
-    title: string;
-  };
-  resize: {
-    title: string;
-    apply: string;
-    shrinkWidth: string;
-    growWidth: string;
-    shrinkHeight: string;
-    growHeight: string;
-  };
-  move: {
-    title: string;
-    apply: string;
-    forward: string;
-    backward: string;
-  };
+  selectWidgetTitleForEditing: string;
+  remove: string;
+  move: string;
+  moveApply: string;
+  moveForward: string;
+  moveBackward: string;
+  resize: string;
+  resizeApply: string;
+  resizeShrinkWidth: string;
+  resizeGrowWidth: string;
+  resizeShrinkHeight: string;
+  resizeGrowHeight: string;
 }>(widget.i18n);
 
 /* DashboardSection */
@@ -106,16 +98,10 @@ assertType<string | null | undefined>(section.sectionTitle);
 
 assertType<DashboardSectionI18n>(section.i18n);
 assertType<{
-  section: {
-    selectTitleForEditing: string;
-  };
-  remove: {
-    title: string;
-  };
-  move: {
-    title: string;
-    apply: string;
-    forward: string;
-    backward: string;
-  };
+  selectSectionTitleForEditing: string;
+  remove: string;
+  move: string;
+  moveApply: string;
+  moveForward: string;
+  moveBackward: string;
 }>(section.i18n);

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -76,7 +76,9 @@ assertType<string | null | undefined>(widget.widgetTitle);
 
 assertType<DashboardWidgetI18n>(widget.i18n);
 assertType<{
-  selectTitleForEditing: string;
+  widget: {
+    selectTitleForEditing: string;
+  };
   remove: {
     title: string;
   };
@@ -104,7 +106,9 @@ assertType<string | null | undefined>(section.sectionTitle);
 
 assertType<DashboardSectionI18n>(section.i18n);
 assertType<{
-  selectTitleForEditing: string;
+  section: {
+    selectTitleForEditing: string;
+  };
   remove: {
     title: string;
   };


### PR DESCRIPTION
## Description

Add dashboard i18n object

Fixes https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=80724405

Added API:
```js
dashboard.i18n: {
  selectWidgetTitleForEditing: string;
  selectSectionTitleForEditing: string;
  remove: string;
  move: string;
  moveApply: string;
  moveForward: string;
  moveBackward: string;
  resize: string;
  resizeApply: string;
  resizeShrinkWidth: string;
  resizeGrowWidth: string;
  resizeShrinkHeight: string;
  resizeGrowHeight: string;
}
```

## Type of change

Feature