### PR TITLE
refactor: hide dashboard widget and section i18n

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.d.ts
@@ -10,22 +10,6 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export interface DashboardItemI18n {
-  selectWidgetTitleForEditing: string;
-  selectSectionTitleForEditing: string;
-  remove: string;
-  move: string;
-  moveApply: string;
-  moveForward: string;
-  moveBackward: string;
-  resize: string;
-  resizeApply: string;
-  resizeShrinkWidth: string;
-  resizeGrowWidth: string;
-  resizeShrinkHeight: string;
-  resizeGrowHeight: string;
-}
-
 /**
  * Shared functionality between widgets and sections
  */

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -53,7 +53,7 @@ export const DashboardItemMixin = (superClass) =>
     static get properties() {
       return {
         /** @protected */
-        i18n: {
+        __i18n: {
           type: Object,
         },
 
@@ -91,7 +91,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderDragHandle() {
       return html`<button
-        title="${this.i18n.move}"
+        title="${this.__i18n.move}"
         id="drag-handle"
         draggable="true"
         class="drag-handle"
@@ -103,7 +103,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderRemoveButton() {
       return html`<button
-        title="${this.i18n.remove}"
+        title="${this.__i18n.remove}"
         id="remove-button"
         tabindex="${this.__selected ? 0 : -1}"
         @click="${() => fireRemove(this)}"
@@ -113,7 +113,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderFocusButton(i18nSelectTitleForEditingProperty) {
       return html`<button
-        aria-label=${this.i18n[i18nSelectTitleForEditingProperty]}
+        aria-label=${this.__i18n[i18nSelectTitleForEditingProperty]}
         id="focus-button"
         draggable="true"
         class="drag-handle"
@@ -126,7 +126,7 @@ export const DashboardItemMixin = (superClass) =>
     /** @private */
     __renderResizeHandle() {
       return html`<button
-        title="${this.i18n.resize}"
+        title="${this.__i18n.resize}"
         id="resize-handle"
         class="resize-handle"
         tabindex="${this.__selected ? 0 : -1}"
@@ -142,9 +142,9 @@ export const DashboardItemMixin = (superClass) =>
         .hidden="${!this.__moveMode}"
         @pointerdown="${(e) => e.preventDefault()}"
       >
-        <button title="${this.i18n.moveBackward}" @click="${() => fireMove(this, -1)}" id="move-backward"></button>
-        <button title="${this.i18n.moveApply}" @click="${() => this.__exitMode(true)}" id="move-apply"></button>
-        <button title="${this.i18n.moveForward}" @click="${() => fireMove(this, 1)}" id="move-forward"></button>
+        <button title="${this.__i18n.moveBackward}" @click="${() => fireMove(this, -1)}" id="move-backward"></button>
+        <button title="${this.__i18n.moveApply}" @click="${() => this.__exitMode(true)}" id="move-apply"></button>
+        <button title="${this.__i18n.moveForward}" @click="${() => fireMove(this, 1)}" id="move-forward"></button>
       </div>`;
     }
 
@@ -158,25 +158,25 @@ export const DashboardItemMixin = (superClass) =>
         .hidden="${!this.__resizeMode}"
         @pointerdown="${(e) => e.preventDefault()}"
       >
-        <button title="${this.i18n.resizeApply}" @click="${() => this.__exitMode(true)}" id="resize-apply"></button>
+        <button title="${this.__i18n.resizeApply}" @click="${() => this.__exitMode(true)}" id="resize-apply"></button>
         <button
-          title="${this.i18n.resizeShrinkWidth}"
+          title="${this.__i18n.resizeShrinkWidth}"
           @click="${() => fireResize(this, -1, 0)}"
           id="resize-shrink-width"
         ></button>
         <button
-          title="${this.i18n.resizeGrowWidth}"
+          title="${this.__i18n.resizeGrowWidth}"
           @click="${() => fireResize(this, 1, 0)}"
           id="resize-grow-width"
         ></button>
         <button
-          title="${this.i18n.resizeShrinkHeight}"
+          title="${this.__i18n.resizeShrinkHeight}"
           @click="${() => fireResize(this, 0, -1)}"
           id="resize-shrink-height"
           .hidden="${!hasMinRowHeight}"
         ></button>
         <button
-          title="${this.i18n.resizeGrowHeight}"
+          title="${this.__i18n.resizeGrowHeight}"
           @click="${() => fireResize(this, 0, 1)}"
           id="resize-grow-height"
           .hidden="${!hasMinRowHeight}"

--- a/packages/dashboard/src/vaadin-dashboard-section.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-section.d.ts
@@ -10,13 +10,7 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
-
-export interface DashboardSectionI18n
-  extends Pick<
-    DashboardItemI18n,
-    'selectSectionTitleForEditing' | 'remove' | 'move' | 'moveApply' | 'moveForward' | 'moveBackward'
-  > {}
+import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 
 /**
  * A Section component for use with the Dashboard component
@@ -26,26 +20,6 @@ declare class DashboardSection extends DashboardItemMixin(ControllerMixin(Elemen
    * The title of the section
    */
   sectionTitle: string | null | undefined;
-
-  /**
-   * The object used to localize this component.
-   *
-   * To change the default localization, replace the entire
-   * `i18n` object with a custom one.
-   *
-   * The object has the following structure and default values:
-   * ```
-   * {
-   *   selectSectionTitleForEditing: 'Select section title for editing',
-   *   remove: 'Remove',
-   *   move: 'Move',
-   *   moveApply: 'Apply',
-   *   moveForward: 'Move Forward',
-   *   moveBackward: 'Move Backward',
-   * }
-   * ```
-   */
-  i18n: DashboardSectionI18n;
 }
 
 declare global {

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -105,8 +105,9 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
        *   moveBackward: 'Move Backward',
        * }
        * ```
+       * @private
        */
-      i18n: {
+      __i18n: {
         type: Object,
         value: () => {
           const i18n = getDefaultI18n();

--- a/packages/dashboard/src/vaadin-dashboard-widget.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-widget.d.ts
@@ -10,9 +10,7 @@
  */
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { type DashboardItemI18n, DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
-
-export interface DashboardWidgetI18n extends Omit<DashboardItemI18n, 'selectSectionTitleForEditing'> {}
+import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 
 /**
  * A Widget component for use with the Dashboard component
@@ -22,32 +20,6 @@ declare class DashboardWidget extends DashboardItemMixin(ControllerMixin(Element
    * The title of the widget
    */
   widgetTitle: string | null | undefined;
-
-  /**
-   * The object used to localize this component.
-   *
-   * To change the default localization, replace the entire
-   * `i18n` object with a custom one.
-   *
-   * The object has the following structure and default values:
-   * ```
-   * {
-   *   selectWidgetTitleForEditing: 'Select widget title for editing',
-   *   remove: 'Remove',
-   *   resize: 'Resize',
-   *   resizeApply: 'Apply',
-   *   resizeShrinkWidth: 'Shrink width',
-   *   resizeGrowWidth: 'Grow width',
-   *   resizeShrinkHeight: 'Shrink height',
-   *   resizeGrowHeight: 'Grow height',
-   *   move: 'Move',
-   *   moveApply: 'Apply',
-   *   moveForward: 'Move Forward',
-   *   moveBackward: 'Move Backward',
-   * }
-   * ```
-   */
-  i18n: DashboardWidgetI18n;
 }
 
 declare global {

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -115,8 +115,9 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
        *   moveBackward: 'Move Backward',
        * }
        * ```
+       * @private
        */
-      i18n: {
+      __i18n: {
         type: Object,
         value: () => {
           const i18n = getDefaultI18n();
@@ -179,7 +180,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
       SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
         this.toggleAttribute(attr, wrapper.hasAttribute(attr));
       });
-      this.i18n = wrapper.i18n;
+      this.__i18n = wrapper.i18n;
     }
 
     const undefinedAncestor = this.closest('*:not(:defined)');

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -11,7 +11,6 @@
 import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-section.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import type { DashboardItemI18n } from './vaadin-dashboard-item-mixin.js';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 
 export interface DashboardItem {
@@ -87,7 +86,21 @@ export interface DashboardCustomEventMap<TItem extends DashboardItem> {
 
 export type DashboardEventMap<TItem extends DashboardItem> = DashboardCustomEventMap<TItem> & HTMLElementEventMap;
 
-export interface DashboardI18n extends DashboardItemI18n {}
+export interface DashboardI18n {
+  selectSectionTitleForEditing: string;
+  selectWidgetTitleForEditing: string;
+  remove: string;
+  resize: string;
+  resizeApply: string;
+  resizeShrinkWidth: string;
+  resizeGrowWidth: string;
+  resizeShrinkHeight: string;
+  resizeGrowHeight: string;
+  move: string;
+  moveApply: string;
+  moveForward: string;
+  moveBackward: string;
+}
 
 /**
  * A responsive, grid-based dashboard layout component

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -180,7 +180,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
         SYNCHRONIZED_ATTRIBUTES.forEach((attr) => {
           wrapper.firstElementChild.toggleAttribute(attr, wrapper.hasAttribute(attr));
         });
-        wrapper.firstElementChild.i18n = this.i18n;
+        wrapper.firstElementChild.__i18n = this.i18n;
       }
     });
   }
@@ -221,7 +221,7 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
         section.toggleAttribute('highlight', !!this.__widgetReorderController.draggedItem);
         SYNCHRONIZED_ATTRIBUTES.forEach((attr) => section.toggleAttribute(attr, wrapper.hasAttribute(attr)));
-        section.i18n = this.i18n;
+        section.__i18n = this.i18n;
 
         // Render the subitems
         this.__renderItemWrappers(item.items, section);

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -11,7 +11,7 @@ import {
 } from './helpers.js';
 
 describe('dashboard section', () => {
-  let section: DashboardSection;
+  let section: DashboardSection & { __i18n: { [key: string]: string } };
 
   beforeEach(async () => {
     section = fixtureSync(`
@@ -112,7 +112,7 @@ describe('dashboard section', () => {
       const focusButton = section.shadowRoot?.querySelector('#focus-button');
       expect(focusButton?.getAttribute('aria-label')).to.eql('Select section title for editing');
 
-      section.i18n = { ...section.i18n, selectSectionTitleForEditing: 'foo' };
+      section.__i18n = { ...section.__i18n, selectSectionTitleForEditing: 'foo' };
       await nextFrame();
 
       expect(focusButton?.getAttribute('aria-label')).to.eql('foo');
@@ -122,7 +122,7 @@ describe('dashboard section', () => {
       const removeButton = getRemoveButton(section);
       expect(removeButton?.getAttribute('title')).to.eql('Remove');
 
-      section.i18n = { ...section.i18n, remove: 'foo' };
+      section.__i18n = { ...section.__i18n, remove: 'foo' };
       await nextFrame();
 
       expect(removeButton?.getAttribute('title')).to.eql('foo');
@@ -132,7 +132,7 @@ describe('dashboard section', () => {
       const dragHandle = getDraggable(section);
       expect(dragHandle?.getAttribute('title')).to.eql('Move');
 
-      section.i18n = { ...section.i18n, move: 'foo' };
+      section.__i18n = { ...section.__i18n, move: 'foo' };
       await nextFrame();
 
       expect(dragHandle?.getAttribute('title')).to.eql('foo');
@@ -143,8 +143,8 @@ describe('dashboard section', () => {
       expect(getMoveForwardButton(section)?.getAttribute('title')).to.eql('Move Forward');
       expect(getMoveBackwardButton(section)?.getAttribute('title')).to.eql('Move Backward');
 
-      section.i18n = {
-        ...section.i18n,
+      section.__i18n = {
+        ...section.__i18n,
         moveApply: 'foo',
         moveForward: 'bar',
         moveBackward: 'baz',

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -18,7 +18,7 @@ import {
 } from './helpers.js';
 
 describe('dashboard widget', () => {
-  let widget: DashboardWidget;
+  let widget: DashboardWidget & { __i18n: { [key: string]: string } };
 
   beforeEach(async () => {
     widget = fixtureSync(`<vaadin-dashboard-widget>Widget content</vaadin-dashboard-widget>`);
@@ -114,7 +114,7 @@ describe('dashboard widget', () => {
       const focusButton = widget.shadowRoot?.querySelector('#focus-button');
       expect(focusButton?.getAttribute('aria-label')).to.eql('Select widget title for editing');
 
-      widget.i18n = { ...widget.i18n, selectWidgetTitleForEditing: 'foo' };
+      widget.__i18n = { ...widget.__i18n, selectWidgetTitleForEditing: 'foo' };
       await nextFrame();
 
       expect(focusButton?.getAttribute('aria-label')).to.eql('foo');
@@ -124,7 +124,7 @@ describe('dashboard widget', () => {
       const removeButton = getRemoveButton(widget);
       expect(removeButton?.getAttribute('title')).to.eql('Remove');
 
-      widget.i18n = { ...widget.i18n, remove: 'foo' };
+      widget.__i18n = { ...widget.__i18n, remove: 'foo' };
       await nextFrame();
 
       expect(removeButton?.getAttribute('title')).to.eql('foo');
@@ -134,7 +134,7 @@ describe('dashboard widget', () => {
       const dragHandle = getDraggable(widget);
       expect(dragHandle?.getAttribute('title')).to.eql('Move');
 
-      widget.i18n = { ...widget.i18n, move: 'foo' };
+      widget.__i18n = { ...widget.__i18n, move: 'foo' };
       await nextFrame();
 
       expect(dragHandle?.getAttribute('title')).to.eql('foo');
@@ -144,7 +144,7 @@ describe('dashboard widget', () => {
       const resizeHandle = getResizeHandle(widget);
       expect(resizeHandle?.getAttribute('title')).to.eql('Resize');
 
-      widget.i18n = { ...widget.i18n, resize: 'foo' };
+      widget.__i18n = { ...widget.__i18n, resize: 'foo' };
       await nextFrame();
 
       expect(resizeHandle?.getAttribute('title')).to.eql('foo');
@@ -157,8 +157,8 @@ describe('dashboard widget', () => {
       expect(getResizeGrowHeightButton(widget)?.getAttribute('title')).to.eql('Grow height');
       expect(getResizeGrowWidthButton(widget)?.getAttribute('title')).to.eql('Grow width');
 
-      widget.i18n = {
-        ...widget.i18n,
+      widget.__i18n = {
+        ...widget.__i18n,
         resizeApply: 'foo',
         resizeShrinkHeight: 'bar',
         resizeShrinkWidth: 'baz',
@@ -180,8 +180,8 @@ describe('dashboard widget', () => {
       expect(getMoveForwardButton(widget)?.getAttribute('title')).to.eql('Move Forward');
       expect(getMoveBackwardButton(widget)?.getAttribute('title')).to.eql('Move Backward');
 
-      widget.i18n = {
-        ...widget.i18n,
+      widget.__i18n = {
+        ...widget.__i18n,
         moveApply: 'foo',
         moveForward: 'bar',
         moveBackward: 'baz',

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -196,9 +196,9 @@ describe('dashboard', () => {
 
       await nextFrame();
 
-      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
-      expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
-      expect(widget.i18n).to.eql(dashboard.i18n);
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget & { __i18n: { [key: string]: string } };
+      expect(widget.__i18n.selectWidgetTitleForEditing).to.equal('foo');
+      expect(widget.__i18n).to.eql(dashboard.i18n);
     });
 
     it('should localize focused widget', async () => {
@@ -216,7 +216,7 @@ describe('dashboard', () => {
       };
       await nextFrame();
 
-      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget & { __i18n: { [key: string]: string } };
       widget.focus();
 
       dashboard.i18n = {
@@ -225,7 +225,7 @@ describe('dashboard', () => {
       };
       await nextFrame();
 
-      expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
+      expect(widget.__i18n.selectWidgetTitleForEditing).to.equal('foo');
     });
 
     it('should localize a lazily rendered widget', async () => {
@@ -245,8 +245,8 @@ describe('dashboard', () => {
       };
       await nextFrame();
 
-      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
-      expect(widget.i18n.selectWidgetTitleForEditing).to.equal('foo');
+      const widget = getElementFromCell(dashboard, 0, 0) as DashboardWidget & { __i18n: { [key: string]: string } };
+      expect(widget.__i18n.selectWidgetTitleForEditing).to.equal('foo');
     });
   });
 
@@ -405,9 +405,11 @@ describe('dashboard', () => {
           await nextFrame();
 
           const widget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
-          const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
-          expect(section.i18n.selectSectionTitleForEditing).to.equal('foo');
-          expect(section.i18n).to.eql(dashboard.i18n);
+          const section = widget.closest('vaadin-dashboard-section') as DashboardSection & {
+            __i18n: { [key: string]: string };
+          };
+          expect(section.__i18n.selectSectionTitleForEditing).to.equal('foo');
+          expect(section.__i18n).to.eql(dashboard.i18n);
         });
       });
     });

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -10,8 +10,8 @@ import type {
   DashboardSectionItem,
 } from '../../vaadin-dashboard.js';
 import type { DashboardLayout } from '../../vaadin-dashboard-layout.js';
-import type { DashboardSection, DashboardSectionI18n } from '../../vaadin-dashboard-section.js';
-import type { DashboardWidget, DashboardWidgetI18n } from '../../vaadin-dashboard-widget.js';
+import type { DashboardSection } from '../../vaadin-dashboard-section.js';
+import type { DashboardWidget } from '../../vaadin-dashboard-widget.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -32,6 +32,22 @@ assertType<ElementMixinClass>(genericDashboard);
 assertType<DashboardLayoutMixinClass>(genericDashboard);
 assertType<Array<DashboardItem | DashboardSectionItem<DashboardItem>> | null | undefined>(genericDashboard.items);
 assertType<boolean>(genericDashboard.editable);
+
+assertType<{
+  selectWidgetTitleForEditing: string;
+  selectSectionTitleForEditing: string;
+  remove: string;
+  resize: string;
+  move: string;
+  resizeApply: string;
+  resizeShrinkWidth: string;
+  resizeGrowWidth: string;
+  resizeShrinkHeight: string;
+  resizeGrowHeight: string;
+  moveApply: string;
+  moveForward: string;
+  moveBackward: string;
+}>(genericDashboard.i18n);
 
 const narrowedDashboard = document.createElement('vaadin-dashboard') as unknown as Dashboard<TestDashboardItem>;
 assertType<Dashboard<TestDashboardItem>>(narrowedDashboard);
@@ -74,34 +90,8 @@ assertType<DashboardWidget>(widget);
 
 assertType<string | null | undefined>(widget.widgetTitle);
 
-assertType<DashboardWidgetI18n>(widget.i18n);
-assertType<{
-  selectWidgetTitleForEditing: string;
-  remove: string;
-  move: string;
-  moveApply: string;
-  moveForward: string;
-  moveBackward: string;
-  resize: string;
-  resizeApply: string;
-  resizeShrinkWidth: string;
-  resizeGrowWidth: string;
-  resizeShrinkHeight: string;
-  resizeGrowHeight: string;
-}>(widget.i18n);
-
 /* DashboardSection */
 const section = document.createElement('vaadin-dashboard-section');
 assertType<DashboardSection>(section);
 
 assertType<string | null | undefined>(section.sectionTitle);
-
-assertType<DashboardSectionI18n>(section.i18n);
-assertType<{
-  selectSectionTitleForEditing: string;
-  remove: string;
-  move: string;
-  moveApply: string;
-  moveForward: string;
-  moveBackward: string;
-}>(section.i18n);


### PR DESCRIPTION
## Description

Hide `i18n`API from dashboard widget and section. For now, the dashboard should have the only user-facing API for localizing the widgets/sections.

## Type of change

Refactor