### PR TITLE
fix: Chips container needs to be 100 width to make large chips to shrink

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -35,6 +35,7 @@ const multiSelectComboBox = css`
   #chips {
     display: flex;
     align-items: center;
+    width: 100%;
   }
 
   ::slotted(input) {


### PR DESCRIPTION
I think this was missing from: https://github.com/vaadin/web-components/commit/37cd565e7d37c784e9d4155d28146a7055aa6d32
