### PR TITLE
feat: restore focus on dashboard widget removal

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -65,6 +65,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
           cursor: grab;
           line-height: 1;
           z-index: 1;
+          overflow: hidden;
         }
 
         #resize-handle::before {

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -238,16 +238,15 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
     if (focusedWrapperWillBeRemoved) {
       // The wrapper containing the focused element was removed. Try to focus the element in the closest wrapper.
-      const targetWrapper = wrapperClosestToRemovedFocused || this.querySelector(WRAPPER_LOCAL_NAME);
-      if (targetWrapper) {
-        requestAnimationFrame(() => this.__focusWrapperContent(targetWrapper));
-      }
+      requestAnimationFrame(() =>
+        this.__focusWrapperContent(wrapperClosestToRemovedFocused || this.querySelector(WRAPPER_LOCAL_NAME)),
+      );
     }
   }
 
   /** @private */
   __focusWrapperContent(wrapper) {
-    if (wrapper.firstElementChild) {
+    if (wrapper && wrapper.firstElementChild) {
       wrapper.firstElementChild.focus();
     }
   }

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -191,6 +191,11 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     let wrappers = [...hostElement.children].filter((el) => el.localName === WRAPPER_LOCAL_NAME);
     let previousWrapper = null;
 
+    const focusedWrapper = wrappers.find((wrapper) => wrapper.querySelector('[focused]'));
+    const focusedWrapperWillBeRemoved = focusedWrapper && !this.__isActiveWrapper(focusedWrapper);
+    const wrapperClosestToRemovedFocused =
+      focusedWrapperWillBeRemoved && this.__getClosestActiveWrapper(focusedWrapper);
+
     items.forEach((item) => {
       // Find the wrapper for the item or create a new one
       const wrapper = wrappers.find((el) => el.__item === item) || this.__createWrapper(item);
@@ -230,6 +235,56 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
     // Remove the unused wrappers
     wrappers.forEach((wrapper) => wrapper.remove());
+
+    if (focusedWrapperWillBeRemoved) {
+      // The wrapper containing the focused element was removed. Try to focus the element in the closest wrapper.
+      const targetWrapper = wrapperClosestToRemovedFocused || this.querySelector(WRAPPER_LOCAL_NAME);
+      if (targetWrapper) {
+        requestAnimationFrame(() => this.__focusWrapperContent(targetWrapper));
+      }
+    }
+  }
+
+  /** @private */
+  __focusWrapperContent(wrapper) {
+    if (wrapper.firstElementChild) {
+      wrapper.firstElementChild.focus();
+    }
+  }
+
+  /**
+   * Checks if the wrapper represents an item that is part of the dashboard's items array
+   * @private
+   */
+  __isActiveWrapper(wrapper) {
+    if (!wrapper || wrapper.localName !== WRAPPER_LOCAL_NAME) {
+      return false;
+    }
+    return getItemsArrayOfItem(getElementItem(wrapper), this.items);
+  }
+
+  /** @private */
+  __getClosestActiveWrapper(wrapper) {
+    if (!wrapper || this.__isActiveWrapper(wrapper)) {
+      return wrapper;
+    }
+
+    // Starting from the given wrapper element, iterates through the siblings in the given direction
+    // to find the closest wrapper that represents an item in the dashboard's items array
+    const findSiblingWrapper = (wrapper, dir) => {
+      while (wrapper) {
+        if (this.__isActiveWrapper(wrapper)) {
+          return wrapper;
+        }
+        wrapper = dir === 1 ? wrapper.nextElementSibling : wrapper.previousElementSibling;
+      }
+    };
+
+    return (
+      findSiblingWrapper(wrapper, 1) ||
+      findSiblingWrapper(wrapper, -1) ||
+      this.__getClosestActiveWrapper(wrapper.parentElement.closest(WRAPPER_LOCAL_NAME))
+    );
   }
 
   /** @private */

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -10,6 +10,7 @@ import {
   expectLayout,
   getDraggable,
   getElementFromCell,
+  getParentSection,
   getRemoveButton,
   getResizeHandle,
   onceResized,
@@ -575,16 +576,13 @@ describe('dashboard', () => {
           { id: 'Item 0' },
           { id: 'Item 1' },
           { title: 'Section', items: [{ id: 'Item 2' }, { id: 'Item 3' }] },
-          { id: 'Item 4' },
-          { id: 'Item 5' },
         ];
         await nextFrame();
 
         /* prettier-ignore */
         expectLayout(dashboard, [
           [0, 1],
-          [2, 3],
-          [4, 5]
+          [2, 3]
         ]);
       });
 
@@ -603,14 +601,15 @@ describe('dashboard', () => {
       });
 
       it('should focus the previous widget on focused widget removal', async () => {
-        getElementFromCell(dashboard, 2, 1)!.focus();
-        dashboard.items = dashboard.items.slice(0, 4);
+        const sectionWidget = getElementFromCell(dashboard, 1, 1)!;
+        getParentSection(sectionWidget)!.focus();
+        dashboard.items = dashboard.items.slice(0, 2);
         await renderAndFocusRestore();
-        expect(document.activeElement).to.equal(getElementFromCell(dashboard, 2, 0)!);
+        expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 1)!);
       });
 
       it('should focus the first widget on focused widget removal', async () => {
-        getElementFromCell(dashboard, 2, 0)!.focus();
+        getElementFromCell(dashboard, 1, 0)!.focus();
         dashboard.items = [dashboard.items[0]];
         await renderAndFocusRestore();
         expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
@@ -618,21 +617,21 @@ describe('dashboard', () => {
 
       it('should focus the last widget on focused widget removal', async () => {
         getElementFromCell(dashboard, 0, 0)!.focus();
-        dashboard.items = [dashboard.items[4]];
+        dashboard.items = [dashboard.items[2]];
         await renderAndFocusRestore();
-        expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
+        expect(document.activeElement).to.equal(getParentSection(getElementFromCell(dashboard, 0, 0))!);
       });
 
       it('should focus a root level widget on focused section removal', async () => {
         getElementFromCell(dashboard, 1, 0)!.focus();
-        dashboard.items = [dashboard.items[0], dashboard.items[1], dashboard.items[3], dashboard.items[4]];
+        dashboard.items = dashboard.items.slice(0, 2);
         await renderAndFocusRestore();
-        expect(document.activeElement).to.equal(getElementFromCell(dashboard, 1, 0)!);
+        expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 1)!);
       });
 
       it('should focus the section on focused section widget removal', async () => {
         const widget = getElementFromCell(dashboard, 1, 0)!;
-        const section = widget.closest('vaadin-dashboard-section') as DashboardSection;
+        const section = getParentSection(widget)!;
         widget.focus();
         (dashboard.items[2] as DashboardSectionItem<TestDashboardItem>).items = [];
         dashboard.items = [...dashboard.items];

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -7,6 +7,7 @@ import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
 import type { Dashboard, DashboardItem, DashboardSectionItem } from '../vaadin-dashboard.js';
 import {
+  expectLayout,
   getDraggable,
   getElementFromCell,
   getRemoveButton,
@@ -503,6 +504,7 @@ describe('dashboard', () => {
         if (!widget || widget.tabIndex !== 0) {
           root.textContent = '';
           widget = document.createElement('vaadin-dashboard-widget');
+          widget.id = model.item.id;
           widget.tabIndex = 0;
           root.appendChild(widget);
         }
@@ -567,6 +569,8 @@ describe('dashboard', () => {
     describe('focus restore on focused item removal', () => {
       beforeEach(async () => {
         dashboard.editable = true;
+        await nextFrame();
+
         dashboard.items = [
           { id: 'Item 0' },
           { id: 'Item 1' },
@@ -575,6 +579,13 @@ describe('dashboard', () => {
           { id: 'Item 5' },
         ];
         await nextFrame();
+
+        /* prettier-ignore */
+        expectLayout(dashboard, [
+          [0, 1],
+          [2, 3],
+          [4, 5]
+        ]);
       });
 
       async function renderAndFocusRestore() {

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -14,11 +14,11 @@ export function getScrollingContainer(dashboard: Element): Element {
   return getCssGrid(dashboard);
 }
 
-export function getParentSection(element?: Element | null): Element | null {
+export function getParentSection(element?: Element | null): DashboardSection | null {
   if (!element) {
     return null;
   }
-  return element.closest('vaadin-dashboard-section');
+  return element.closest('vaadin-dashboard-section') as DashboardSection;
 }
 
 /**

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -165,7 +165,8 @@ export function expectLayout(dashboard: HTMLElement, layout: Array<Array<number 
       if (!element) {
         actualRow.push(null);
       } else {
-        actualRow.push(parseInt(element.id.replace('item-', '')));
+        // TODO: Just use a number for all test item IDs
+        actualRow.push(parseInt(element.id.replace('item-', '').replace('Item ', ''), 10));
       }
     });
   });

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -45,7 +45,7 @@ function _getElementFromCell(dashboard: HTMLElement, rowIndex: number, columnInd
   const y = top + rowHeights.slice(0, rowIndex).reduce((sum, height) => sum + height, 0);
 
   return document
-    .elementsFromPoint(x + (columnWidths[columnIndex] / 2) * (rtl ? -1 : 1), y + rowHeights[rowIndex] - 1)
+    .elementsFromPoint(x + (columnWidths[columnIndex] / 2) * (rtl ? -1 : 1), y + rowHeights[rowIndex] - 10)
     .reverse()
     .find(
       (element) =>


### PR DESCRIPTION
## Description

When the dashboard widget including focus gets removed (for any reason), restore the focus to the widget closest to the removed one.

https://github.com/user-attachments/assets/8ed06993-6881-4b28-afb5-35cd414eec92

## Type of change

Feature