### PR TITLE
test: ensure chip min-width custom CSS property to be set

### DIFF
--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -222,6 +222,7 @@ describe('chips', () => {
 
         const chips = getChips(comboBox);
         const minWidth = getComputedStyle(comboBox).getPropertyValue('--_chip-min-width');
+        expect(minWidth).to.be.ok;
         expect(chips[1].style.maxWidth).to.equal(minWidth);
       });
     });


### PR DESCRIPTION
## Description

Added an assertion to the test since current it is unreliable - after removing the following line, it still passes:

https://github.com/vaadin/web-components/blob/5c59e40013bdaa9add262222678858cd2014821e/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js#L26

This is because when custom property is not set, `max-width` isn't set either and the equality check returns `true`.

## Type of change

- Test