### PR TITLE
feat: add dashboard item mode changed events

### DIFF
--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -102,6 +102,18 @@
       dashboard.addEventListener('dashboard-item-removed', (e) => {
         console.log('dashboard-item-removed', e.detail);
       });
+
+      dashboard.addEventListener('dashboard-item-selected-changed', (e) => {
+        console.log('dashboard-item-selected-changed', e.detail);
+      });
+
+      dashboard.addEventListener('dashboard-item-move-mode-changed', (e) => {
+        console.log('dashboard-item-move-mode-changed', e.detail);
+      });
+
+      dashboard.addEventListener('dashboard-item-resize-mode-changed', (e) => {
+        console.log('dashboard-item-resize-mode-changed', e.detail);
+      });
     </script>
   </head>
 

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -77,6 +77,7 @@ export const DashboardItemMixin = (superClass) =>
           type: Boolean,
           reflectToAttribute: true,
           attribute: 'move-mode',
+          observer: '__moveModeChanged',
         },
 
         /** @private */
@@ -84,6 +85,7 @@ export const DashboardItemMixin = (superClass) =>
           type: Boolean,
           reflectToAttribute: true,
           attribute: 'resize-mode',
+          observer: '__resizeModeChanged',
         },
       };
     }
@@ -227,6 +229,9 @@ export const DashboardItemMixin = (superClass) =>
 
     /** @private */
     __selectedChanged(selected) {
+      this.dispatchEvent(
+        new CustomEvent('item-selected-changed', { bubbles: true, composed: true, detail: { value: selected } }),
+      );
       if (selected) {
         this.__focusTrapController.trapFocus(this.$.focustrap);
       } else {
@@ -282,5 +287,19 @@ export const DashboardItemMixin = (superClass) =>
       requestAnimationFrame(() => {
         this.__focusTrapController.trapFocus(this.$['resize-controls']);
       });
+    }
+
+    /** @private */
+    __moveModeChanged(moveMode) {
+      this.dispatchEvent(
+        new CustomEvent('item-move-mode-changed', { bubbles: true, composed: true, detail: { value: moveMode } }),
+      );
+    }
+
+    /** @private */
+    __resizeModeChanged(resizeMode) {
+      this.dispatchEvent(
+        new CustomEvent('item-resize-mode-changed', { bubbles: true, composed: true, detail: { value: resizeMode } }),
+      );
     }
   };

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -76,12 +76,42 @@ export type DashboardItemRemovedEvent<TItem extends DashboardItem> = CustomEvent
   items: Array<TItem | DashboardSectionItem<TItem>>;
 }>;
 
+/**
+ * Fired when an item selected state changed
+ */
+export type DashboardItemSeletedChangedEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem;
+  value: boolean;
+}>;
+
+/**
+ * Fired when an item move mode changed
+ */
+export type DashboardItemMoveModeChangedEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem;
+  value: boolean;
+}>;
+
+/**
+ * Fired when an item resize mode changed
+ */
+export type DashboardItemResizeModeChangedEvent<TItem extends DashboardItem> = CustomEvent<{
+  item: TItem;
+  value: boolean;
+}>;
+
 export interface DashboardCustomEventMap<TItem extends DashboardItem> {
   'dashboard-item-moved': DashboardItemMovedEvent<TItem>;
 
   'dashboard-item-resized': DashboardItemResizedEvent<TItem>;
 
   'dashboard-item-removed': DashboardItemRemovedEvent<TItem>;
+
+  'dashboard-item-selected-changed': DashboardItemSeletedChangedEvent<TItem>;
+
+  'dashboard-item-move-mode-changed': DashboardItemMoveModeChangedEvent<TItem>;
+
+  'dashboard-item-resize-mode-changed': DashboardItemResizeModeChangedEvent<TItem>;
 }
 
 export type DashboardEventMap<TItem extends DashboardItem> = DashboardCustomEventMap<TItem> & HTMLElementEventMap;

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -273,45 +273,34 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
   }
 
   /** @private */
-  __itemSelectedChanged(e) {
-    e.stopImmediatePropagation();
+  __dispatchCustomEvent(eventName, item, value) {
     this.dispatchEvent(
-      new CustomEvent('dashboard-item-selected-changed', {
+      new CustomEvent(eventName, {
         bubbles: true,
         detail: {
-          item: getElementItem(e.target),
-          value: e.detail.value,
+          item,
+          value,
         },
       }),
     );
+  }
+
+  /** @private */
+  __itemSelectedChanged(e) {
+    e.stopImmediatePropagation();
+    this.__dispatchCustomEvent('dashboard-item-selected-changed', getElementItem(e.target), e.detail.value);
   }
 
   /** @private */
   __itemMoveModeChanged(e) {
     e.stopImmediatePropagation();
-    this.dispatchEvent(
-      new CustomEvent('dashboard-item-move-mode-changed', {
-        bubbles: true,
-        detail: {
-          item: getElementItem(e.target),
-          value: e.detail.value,
-        },
-      }),
-    );
+    this.__dispatchCustomEvent('dashboard-item-move-mode-changed', getElementItem(e.target), e.detail.value);
   }
 
   /** @private */
   __itemResizeModeChanged(e) {
     e.stopImmediatePropagation();
-    this.dispatchEvent(
-      new CustomEvent('dashboard-item-resize-mode-changed', {
-        bubbles: true,
-        detail: {
-          item: getElementItem(e.target),
-          value: e.detail.value,
-        },
-      }),
-    );
+    this.__dispatchCustomEvent('dashboard-item-resize-mode-changed', getElementItem(e.target), e.detail.value);
   }
 
   /**

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -35,6 +35,9 @@ import { WidgetResizeController } from './widget-resize-controller.js';
  * @fires {CustomEvent} dashboard-item-moved - Fired when an item was moved
  * @fires {CustomEvent} dashboard-item-resized - Fired when an item was resized
  * @fires {CustomEvent} dashboard-item-removed - Fired when an item was removed
+ * @fires {CustomEvent} dashboard-item-selected-changed - Fired when an item selected state changed
+ * @fires {CustomEvent} dashboard-item-move-mode-changed - Fired when an item move mode changed
+ * @fires {CustomEvent} dashboard-item-resize-mode-changed - Fired when an item resize mode changed
  *
  * @customElement
  * @extends HTMLElement
@@ -143,6 +146,9 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
     this.__widgetReorderController = new WidgetReorderController(this);
     this.__widgetResizeController = new WidgetResizeController(this);
     this.addEventListener('item-remove', (e) => this.__itemRemove(e));
+    this.addEventListener('item-selected-changed', (e) => this.__itemSelectedChanged(e));
+    this.addEventListener('item-move-mode-changed', (e) => this.__itemMoveModeChanged(e));
+    this.addEventListener('item-resize-mode-changed', (e) => this.__itemResizeModeChanged(e));
   }
 
   /** @protected */
@@ -265,6 +271,66 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
       new CustomEvent('dashboard-item-removed', { cancelable: true, detail: { item, items: this.items } }),
     );
   }
+
+  /** @private */
+  __itemSelectedChanged(e) {
+    e.stopImmediatePropagation();
+    this.dispatchEvent(
+      new CustomEvent('dashboard-item-selected-changed', {
+        bubbles: true,
+        detail: {
+          item: getElementItem(e.target),
+          value: e.detail.value,
+        },
+      }),
+    );
+  }
+
+  /** @private */
+  __itemMoveModeChanged(e) {
+    e.stopImmediatePropagation();
+    this.dispatchEvent(
+      new CustomEvent('dashboard-item-move-mode-changed', {
+        bubbles: true,
+        detail: {
+          item: getElementItem(e.target),
+          value: e.detail.value,
+        },
+      }),
+    );
+  }
+
+  /** @private */
+  __itemResizeModeChanged(e) {
+    e.stopImmediatePropagation();
+    this.dispatchEvent(
+      new CustomEvent('dashboard-item-resize-mode-changed', {
+        bubbles: true,
+        detail: {
+          item: getElementItem(e.target),
+          value: e.detail.value,
+        },
+      }),
+    );
+  }
+
+  /**
+   * Fired when an item selected state changed
+   *
+   * @event dashboard-item-selected-changed
+   */
+
+  /**
+   * Fired when an item move mode changed
+   *
+   * @event dashboard-item-move-mode-changed
+   */
+
+  /**
+   * Fired when an item resize mode changed
+   *
+   * @event dashboard-item-resize-mode-changed
+   */
 
   /**
    * Fired when an item was moved

--- a/packages/dashboard/test/dashboard-keyboard.test.ts
+++ b/packages/dashboard/test/dashboard-keyboard.test.ts
@@ -81,6 +81,15 @@ describe('dashboard - keyboard interaction', () => {
     expect(widget.hasAttribute('selected')).to.be.true;
   });
 
+  it('should dispatch a selection event', async () => {
+    const spy = sinon.spy();
+    dashboard.addEventListener('dashboard-item-selected-changed', spy);
+    await sendKeys({ press: 'Tab' });
+    await sendKeys({ press: 'Space' });
+    expect(spy.calledOnce).to.be.true;
+    expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: true });
+  });
+
   it('should not remove the widget on backspace', async () => {
     await sendKeys({ press: 'Tab' });
     await sendKeys({ press: 'Backspace' });
@@ -116,6 +125,14 @@ describe('dashboard - keyboard interaction', () => {
       await sendKeys({ press: 'Escape' });
       expect(widget.hasAttribute('selected')).to.be.false;
       expect(widget.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should dispatch a selection event', async () => {
+      const spy = sinon.spy();
+      dashboard.addEventListener('dashboard-item-selected-changed', spy);
+      await sendKeys({ press: 'Escape' });
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: false });
     });
 
     it('should blur deselected widget on shift tab', async () => {
@@ -361,6 +378,14 @@ describe('dashboard - keyboard interaction', () => {
       expect(section.hasAttribute('focused')).to.be.true;
     });
 
+    it('should dispatch a selection event', async () => {
+      const spy = sinon.spy();
+      dashboard.addEventListener('dashboard-item-selected-changed', spy);
+      await sendKeys({ press: 'Escape' });
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0].detail).to.eql({ item: { items: [{ id: 2 }, { id: 3 }] }, value: false });
+    });
+
     it('should blur deselected selected on shift tab', async () => {
       await sendKeys({ press: 'Escape' });
       await sendKeys({ down: 'Shift' });
@@ -434,6 +459,16 @@ describe('dashboard - keyboard interaction', () => {
     expect(widget.hasAttribute('move-mode')).to.be.true;
   });
 
+  it('should dispatch a move mode event', async () => {
+    const spy = sinon.spy();
+    dashboard.addEventListener('dashboard-item-move-mode-changed', spy);
+    const widget = getElementFromCell(dashboard, 0, 0)!;
+    (getDraggable(widget) as HTMLElement).click();
+    await nextFrame();
+    expect(spy.calledOnce).to.be.true;
+    expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: true });
+  });
+
   describe('widget in move mode', () => {
     beforeEach(async () => {
       // Select
@@ -450,6 +485,15 @@ describe('dashboard - keyboard interaction', () => {
       expect(widget.hasAttribute('move-mode')).to.be.false;
       expect(widget.hasAttribute('selected')).to.be.true;
       expect(widget.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should dispatch a move mode event', async () => {
+      const spy = sinon.spy();
+      dashboard.addEventListener('dashboard-item-move-mode-changed', spy);
+      await sendKeys({ press: 'Escape' });
+      await nextFrame();
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: false });
     });
 
     it('should exit move mode on apply', async () => {
@@ -639,6 +683,16 @@ describe('dashboard - keyboard interaction', () => {
     expect(widget.hasAttribute('resize-mode')).to.be.true;
   });
 
+  it('should dispatch a resize mode event', async () => {
+    const spy = sinon.spy();
+    dashboard.addEventListener('dashboard-item-resize-mode-changed', spy);
+    const widget = getElementFromCell(dashboard, 0, 0)!;
+    (getResizeHandle(widget) as HTMLElement).click();
+    await nextFrame();
+    expect(spy.calledOnce).to.be.true;
+    expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: true });
+  });
+
   describe('widget in resize mode', () => {
     beforeEach(async () => {
       // Select
@@ -657,6 +711,14 @@ describe('dashboard - keyboard interaction', () => {
       expect(widget.hasAttribute('resize-mode')).to.be.false;
       expect(widget.hasAttribute('selected')).to.be.true;
       expect(widget.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should dispatch a resize mode event', async () => {
+      const spy = sinon.spy();
+      dashboard.addEventListener('dashboard-item-resize-mode-changed', spy);
+      await sendKeys({ press: 'Escape' });
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: false });
     });
 
     it('should exit resize mode on apply', async () => {

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -4,8 +4,11 @@ import type {
   Dashboard,
   DashboardItem,
   DashboardItemMovedEvent,
+  DashboardItemMoveModeChangedEvent,
   DashboardItemRemovedEvent,
   DashboardItemResizedEvent,
+  DashboardItemResizeModeChangedEvent,
+  DashboardItemSeletedChangedEvent,
   DashboardRenderer,
   DashboardSectionItem,
 } from '../../vaadin-dashboard.js';
@@ -75,6 +78,24 @@ narrowedDashboard.addEventListener('dashboard-item-removed', (event) => {
   assertType<DashboardItemRemovedEvent<TestDashboardItem>>(event);
   assertType<TestDashboardItem | DashboardSectionItem<TestDashboardItem>>(event.detail.item);
   assertType<Array<TestDashboardItem | DashboardSectionItem<TestDashboardItem>>>(event.detail.items);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-selected-changed', (event) => {
+  assertType<DashboardItemSeletedChangedEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem>(event.detail.item);
+  assertType<boolean>(event.detail.value);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-move-mode-changed', (event) => {
+  assertType<DashboardItemMoveModeChangedEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem>(event.detail.item);
+  assertType<boolean>(event.detail.value);
+});
+
+narrowedDashboard.addEventListener('dashboard-item-resize-mode-changed', (event) => {
+  assertType<DashboardItemResizeModeChangedEvent<TestDashboardItem>>(event);
+  assertType<TestDashboardItem>(event.detail.item);
+  assertType<boolean>(event.detail.value);
 });
 
 /* DashboardLayout */


### PR DESCRIPTION
## Description

Add selected, move mode and resize mode change events to dashboard.

Added events:

- 'dashboard-item-selected-changed': Fired when an item selected state changed
  - `event.detail.item`: The item
  - `event.detail.value`: The new selected state of the widget representing the item
- 'dashboard-item-move-mode-changed': Fired when an item move mode changed
  - `event.detail.item`: The item
  - `event.detail.value`: The new move mode state of the widget representing the item
- 'dashboard-item-resize-mode-changed': Fired when an item resize mode changed
  - `event.detail.item`: The item
  - `event.detail.value`: The new resize mode state of the widget representing the item

## Type of change

Feature