### PR TITLE
fix: prevent opening select on click or keydown when disabled

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -304,6 +304,10 @@ export const SelectBaseMixin = (superClass) =>
      * @private
      */
     _onClick(event) {
+      if (this.disabled) {
+        return;
+      }
+
       // Prevent parent components such as `vaadin-grid`
       // from handling the click event after it bubbles.
       event.preventDefault();
@@ -324,7 +328,7 @@ export const SelectBaseMixin = (superClass) =>
      * @override
      */
     _onKeyDown(e) {
-      if (e.target === this.focusElement && !this.readonly && !this.opened) {
+      if (e.target === this.focusElement && !this.readonly && !this.disabled && !this.opened) {
         if (/^(Enter|SpaceBar|\s|ArrowDown|Down|ArrowUp|Up)$/u.test(e.key)) {
           e.preventDefault();
           this.opened = true;

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -499,15 +499,24 @@ describe('vaadin-select', () => {
     });
 
     describe('disabled', () => {
-      it('should disable the button and disable opening if select is disabled', async () => {
+      beforeEach(async () => {
         select.disabled = true;
         await nextUpdate(select);
+      });
+
+      it('should disable the value button element when disabled', () => {
         expect(valueButton.disabled).to.be.true;
+      });
 
+      it('should not open on value button Enter when disabled', () => {
         enterKeyDown(valueButton);
+        expect(select.opened).to.be.false;
         expect(select._overlayElement.opened).to.be.false;
+      });
 
+      it('should not open on value button click when disabled', () => {
         click(valueButton);
+        expect(select.opened).to.be.false;
         expect(select._overlayElement.opened).to.be.false;
       });
     });


### PR DESCRIPTION
## Description

Fixes #7873

By setting `pointer-events: auto` it is currently possible to make `vaadin-select` flash opening on click since we don't check for `disabled` property in click listener. After adding the check, I also noticed that `vaadin-select-value-button` still receives focus which also means the same problem can happen on pressing <kbd>Enter</kbd> so I updated `keydown` listener too.

## Type of change

- Bugfix

## Note

I think it's weird that `focused` is set on the select and value button when setting `pointer-events: auto` on the host.
Disabled component shouldn't receive focus in any case. I'll make a separate PR to address that problem.