### PR TITLE
fix: make dashboard draggables work on firefox

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-helpers.js
+++ b/packages/dashboard/src/vaadin-dashboard-helpers.js
@@ -47,7 +47,8 @@ export function getItemsArrayOfItem(item, items) {
  * @param {HTMLElement} element the element
  */
 export function getElementItem(element) {
-  return element.closest(WRAPPER_LOCAL_NAME).__item;
+  const wrapper = element.closest(WRAPPER_LOCAL_NAME);
+  return wrapper && wrapper.__item;
 }
 
 /**

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -92,15 +92,16 @@ export const DashboardItemMixin = (superClass) =>
 
     /** @private */
     __renderDragHandle() {
-      return html`<button
-        aria-label="${this.__i18n.move}"
-        title="${this.__i18n.move}"
-        id="drag-handle"
-        draggable="true"
-        class="drag-handle"
-        tabindex="${this.__selected ? 0 : -1}"
-        @click="${() => this.__enterMoveMode()}"
-      ></button>`;
+      // To make the button draggable on Firefox, using a workaround from https://stackoverflow.com/a/55019027/3409629
+      return html`<label draggable="true" class="drag-handle" id="drag-handle-wrapper">
+        <button
+          id="drag-handle"
+          aria-label="${this.__i18n.move}"
+          title="${this.__i18n.move}"
+          tabindex="${this.__selected ? 0 : -1}"
+          @click="${() => this.__enterMoveMode()}"
+        ></button>
+      </label>`;
     }
 
     /** @private */
@@ -116,17 +117,18 @@ export const DashboardItemMixin = (superClass) =>
 
     /** @private */
     __renderFocusButton(i18nSelectTitleForEditingProperty) {
-      return html`<button
-        aria-label=${this.__i18n[i18nSelectTitleForEditingProperty]}
-        aria-describedby="title"
-        aria-pressed="${!!this.__selected}"
-        id="focus-button"
-        draggable="true"
-        class="drag-handle"
-        @click="${() => {
-          this.__selected = true;
-        }}"
-      ></button>`;
+      // To make the button draggable on Firefox, using a workaround from https://stackoverflow.com/a/55019027/3409629
+      return html`<label draggable="true" class="drag-handle" id="focus-button-wrapper">
+        <button
+          id="focus-button"
+          aria-label=${this.__i18n[i18nSelectTitleForEditingProperty]}
+          aria-describedby="title"
+          aria-pressed="${!!this.__selected}"
+          @click="${() => {
+            this.__selected = true;
+          }}"
+        ></button>
+      </label>`;
     }
 
     /** @private */

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -43,16 +43,28 @@ export const dashboardWidgetAndSectionStyles = css`
     align-items: center;
   }
 
+  #focus-button-wrapper,
   #focus-button {
     position: absolute;
     inset: 0;
     opacity: 0;
   }
 
+  #focus-button {
+    pointer-events: none;
+    padding: 0;
+    border: none;
+  }
+
+  #drag-handle-wrapper {
+    z-index: 1;
+    cursor: grab;
+  }
+
   #drag-handle {
     font-size: 30px;
-    cursor: grab;
     z-index: 1;
+    pointer-events: none;
   }
 
   #drag-handle::before {

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -349,6 +349,9 @@ class Dashboard extends ControllerMixin(DashboardLayoutMixin(ElementMixin(Themab
 
   /** @private */
   __dispatchCustomEvent(eventName, item, value) {
+    if (!item) {
+      return;
+    }
     this.dispatchEvent(
       new CustomEvent(eventName, {
         detail: {


### PR DESCRIPTION
## Description

Native DnD doesn't work with draggable `<button>` elements on Firefox which effectively makes the Dashboard widgets not mouse-draggable.

Use the workaround described [here](https://stackoverflow.com/a/55019027/3409629) to fix the issue.

## Type of change

Bugfix