### PR TITLE
fix: apply initially set custom field value to inputs

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -257,7 +257,7 @@ export const CustomFieldMixin = (superClass) =>
       if (inputs.length === 0) {
         return;
       }
-      
+
       // When inputs are first initialized, apply value set with property.
       if (this.value && this.value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
         this.__applyInputsValue(this.value);

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -65,6 +65,7 @@ export const CustomFieldMixin = (superClass) =>
         inputs: {
           type: Array,
           readOnly: true,
+          observer: '__inputsChanged',
         },
 
         /**
@@ -106,10 +107,6 @@ export const CustomFieldMixin = (superClass) =>
           type: Function,
         },
       };
-    }
-
-    static get observers() {
-      return ['__inputsOrValueChanged(inputs, value)'];
     }
 
     /** @protected */
@@ -256,19 +253,15 @@ export const CustomFieldMixin = (superClass) =>
     }
 
     /** @private */
-    __inputsOrValueChanged(inputs, value) {
-      const oldInputs = this.__oldInputs;
-
-      if (inputs && inputs !== oldInputs && inputs.length > 0) {
+    __inputsChanged(inputs, oldInputs) {
+      if (inputs.length > 0) {
         // When inputs are first initialized, apply value set with property.
-        if (value && value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
-          this.__applyInputsValue(value);
+        if (this.value && this.value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
+          this.__applyInputsValue(this.value);
         } else {
           this.__setValue();
         }
       }
-
-      this.__oldInputs = inputs;
     }
 
     /** @private */

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -254,13 +254,15 @@ export const CustomFieldMixin = (superClass) =>
 
     /** @private */
     __inputsChanged(inputs, oldInputs) {
-      if (inputs.length > 0) {
-        // When inputs are first initialized, apply value set with property.
-        if (this.value && this.value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
-          this.__applyInputsValue(this.value);
-        } else {
-          this.__setValue();
-        }
+      if (inputs.length === 0) {
+        return;
+      }
+      
+      // When inputs are first initialized, apply value set with property.
+      if (this.value && this.value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
+        this.__applyInputsValue(this.value);
+      } else {
+        this.__setValue();
       }
     }
 

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -79,6 +79,27 @@ describe('custom field', () => {
     });
   });
 
+  describe('value set with attribute', () => {
+    beforeEach(async () => {
+      customField = fixtureSync(`
+        <vaadin-custom-field value="01\t25">
+          <input type="number" />
+          <input type="number" />
+        </vaadin-custom-field>
+      `);
+      await nextRender();
+    });
+
+    it('should not reset value set using attribute', () => {
+      expect(customField.value).to.equal('01\t25');
+    });
+
+    it('should apply value set using attribute to inputs', () => {
+      expect(customField.inputs[0].value).to.equal('01');
+      expect(customField.inputs[1].value).to.equal('25');
+    });
+  });
+
   describe('aria-required', () => {
     it('should toggle aria-required attribute on required property change', async () => {
       customField.required = true;

--- a/test/integration/custom-field-lazy-inputs.test.js
+++ b/test/integration/custom-field-lazy-inputs.test.js
@@ -1,0 +1,24 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '@vaadin/custom-field';
+
+describe('custom-field inputs', () => {
+  let customField;
+
+  beforeEach(async () => {
+    customField = fixtureSync(`
+      <vaadin-custom-field value="01\t25">
+        <vaadin-integer-field></vaadin-integer-field>
+        <vaadin-integer-field></vaadin-integer-field>
+      </vaadin-custom-field>
+    `);
+
+    // Ensure lazy custom element upgrade for slotted inputs.
+    await import('@vaadin/integer-field');
+  });
+
+  it('should apply value set using attribute to inputs', () => {
+    expect(customField.inputs[0].value).to.equal('01');
+    expect(customField.inputs[1].value).to.equal('25');
+  });
+});


### PR DESCRIPTION
## Description

Fixes #7871

Added logic to store the `value` property set initially and apply it to inputs after they are populated.

Also added integration tests to cover the case when inputs are not yet upgraded (only happens for Vaadin web components but works with native `<input>` elements, see the issue description).

## Type of change

- Bugfix