### PR TITLE
chore: fix gulp tasks for generating font-icons files

### DIFF
--- a/packages/vaadin-lumo-styles/gulpfile.cjs
+++ b/packages/vaadin-lumo-styles/gulpfile.cjs
@@ -157,7 +157,8 @@ import { addLumoGlobalStyles } from './global.js';
 const fontIcons = css\`
   @font-face {
     font-family: 'lumo-icons';
-    src: url(data:application/font-woff;charset=utf-8;base64,${lumoIconsWoff.toString('base64')}) format('woff');
+    src: url(data:application/font-woff;charset=utf-8;base64,${lumoIconsWoff.toString('base64')})
+      format('woff');
     font-weight: normal;
     font-style: normal;
   }
@@ -167,7 +168,7 @@ const fontIcons = css\`
           glyphs.forEach((g) => {
             const name = g.name.replace(/\s/g, '-').toLowerCase();
             const unicode = `\\\\${g.unicode[0].charCodeAt(0).toString(16)}`;
-            output += `    --lumo-icons-${name}: "${unicode}";\n`;
+            output += `    --lumo-icons-${name}: '${unicode}';\n`;
           });
           output += `  }
 \`;

--- a/packages/vaadin-material-styles/gulpfile.cjs
+++ b/packages/vaadin-material-styles/gulpfile.cjs
@@ -89,30 +89,29 @@ gulp.task('icons', (done) => {
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './version.js';
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { addMaterialGlobalStyles } from './global.js';
 
-const template = document.createElement('template');
+const fontIcons = css\`
+  @font-face {
+    font-family: 'material-icons';
+    src: url(data:application/font-woff;charset=utf-8;base64,${materialIconsWoff.toString('base64')})
+      format('woff');
+    font-weight: normal;
+    font-style: normal;
+  }
 
-template.innerHTML = \`
-  <style>
-    @font-face {
-      font-family: 'material-icons';
-      src: url(data:application/font-woff;charset=utf-8;base64,${materialIconsWoff.toString('base64')}) format('woff');
-      font-weight: normal;
-      font-style: normal;
-    }
-
-    html {
+  html {
 `;
           glyphs.forEach((g) => {
             const name = g.name.replace(/\s/g, '-').toLowerCase();
             const unicode = `\\\\${g.unicode[0].charCodeAt(0).toString(16)}`;
-            output += `      --material-icons-${name}: "${unicode}";\n`;
+            output += `    --material-icons-${name}: '${unicode}';\n`;
           });
-          output += `    }
-  </style>
+          output += `  }
 \`;
 
-document.head.appendChild(template.content);
+addMaterialGlobalStyles('font-icons', fontIcons);
 `;
           fs.writeFile('font-icons.js', output, (err) => {
             if (err) {


### PR DESCRIPTION
## Description

Updated `gulpfile.js` for Material theme to match the file content (this should have been done in #5752).
Also fixed the formatting in the corresponding Lumo theme `gulpfile.js` to not cause Prettier warnings.

To test this, run `yarn icons` and check that there are no files changed shown by `git diff`.

## Type of change

- Internal change