### PR TITLE
fix: ensure has-value attribute is set on custom-value

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -259,11 +259,11 @@ export const CustomFieldMixin = (superClass) =>
 
     /** @private */
     __valueChanged(value, oldValue) {
+      this.__toggleHasValue(value);
+
       if (this.__settingValue || !this.inputs) {
         return;
       }
-
-      this.__toggleHasValue(value);
 
       const parseFn = this.parseValue || defaultParseValue;
       const valuesArray = parseFn.apply(this, [value]);

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -68,6 +68,15 @@ describe('custom field', () => {
         expect(el.value).to.equal('1');
       });
     });
+
+    it('should set has-value when updating values', async () => {
+      customField.inputs.forEach((el) => {
+        el.value = '1';
+        fire(el, 'change');
+      });
+      await nextUpdate(customField);
+      expect(customField.hasAttribute('has-value')).to.be.true;
+    });
   });
 
   describe('aria-required', () => {


### PR DESCRIPTION
## Description

Currently, in the Polymer version the `has-value` isn't set due to `__settingValue` check in the observer. This PR fixes that.

## Type of change

- Bugfix