### PR TITLE
docs!: deprecate internal-tab event and remove it from JSDoc

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -33,6 +33,7 @@ export type CustomFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 /**
  * Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
+ * @deprecated
  */
 export type CustomFieldInternalTabEvent = Event & {
   target: CustomField;
@@ -91,7 +92,6 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
- * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -51,7 +51,6 @@ registerStyles('vaadin-custom-field', customFieldStyles, { moduleId: 'vaadin-cus
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change for any of the internal inputs.
- * @fires {Event} internal-tab - Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.


### PR DESCRIPTION
## Description

The `internal-tab` event was originally designed to be used by `vaadin-date-time-picker` (which no longer depends on `vaadin-custom-field` since V22) and inside `vaadin-grid-pro` (this was removed in #7870).

Marked this event tab as deprecated and removed `@fires` annotations to avoid code completion in VSCode Lit plugin.
Note, there is no `@event` annotation for it which means this event is not exposed in API docs / React wrappers.

## Type of change

- Deprecation