### PR TITLE
fix: delay parsing htmlValue when RTE is attached but not rendered

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -806,8 +806,8 @@ export const RichTextEditorMixin = (superClass) =>
       // with the viewport before trying to set the value again.
       if (!getComputedStyle(this).display) {
         this.__savePendingHtmlValue(htmlValue);
-        const observer = new IntersectionObserver(([rte]) => {
-          if ((rte && rte.isIntersecting) || getComputedStyle(this).display) {
+        const observer = new IntersectionObserver(() => {
+          if (getComputedStyle(this).display) {
             this.__flushPendingHtmlValue();
             observer.disconnect();
           }

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -793,10 +793,26 @@ export const RichTextEditorMixin = (superClass) =>
      */
     dangerouslySetHtmlValue(htmlValue) {
       if (!this._editor) {
-        // The editor isn't ready yet, store the value for later
-        this.__pendingHtmlValue = htmlValue;
-        // Clear a possible value to prevent it from clearing the pending htmlValue once the editor property is set
-        this.value = '';
+        this.__savePendingHtmlValue(htmlValue);
+
+        return;
+      }
+
+      // In Firefox, the styles are not properly computed when the element is placed
+      // in a Lit component, as the element is first attached to the DOM and then
+      // the shadowRoot is initialized. This causes the `hmlValue` to not be correctly
+      // parsed into the delta format used by Quill. To work around this, we check
+      // if the display property is set and if not, we wait for the element to intersect
+      // with the viewport before trying to set the value again.
+      if (!getComputedStyle(this).display) {
+        this.__savePendingHtmlValue(htmlValue);
+        const observer = new IntersectionObserver(([rte]) => {
+          if ((rte && rte.isIntersecting) || getComputedStyle(this).display) {
+            this.__flushPendingHtmlValue();
+            observer.disconnect();
+          }
+        });
+        observer.observe(this);
         return;
       }
 
@@ -821,6 +837,14 @@ export const RichTextEditorMixin = (superClass) =>
       });
 
       this._editor.setContents(deltaFromHtml, SOURCE.API);
+    }
+
+    /** @private */
+    __savePendingHtmlValue(htmlValue) {
+      // The editor isn't ready yet, store the value for later
+      this.__pendingHtmlValue = htmlValue;
+      // Clear a possible value to prevent it from clearing the pending htmlValue once the editor property is set
+      this.value = '';
     }
 
     /** @private */

--- a/packages/rich-text-editor/test/attach-lit.test.js
+++ b/packages/rich-text-editor/test/attach-lit.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-rich-text-editor-styles.js';
+import '../src/vaadin-lit-rich-text-editor.js';
+import './attach.common.js';

--- a/packages/rich-text-editor/test/attach-polymer.test.js
+++ b/packages/rich-text-editor/test/attach-polymer.test.js
@@ -1,0 +1,3 @@
+import '../theme/lumo/vaadin-rich-text-editor-styles.js';
+import '../src/vaadin-rich-text-editor.js';
+import './attach.common.js';

--- a/packages/rich-text-editor/test/attach.common.js
+++ b/packages/rich-text-editor/test/attach.common.js
@@ -1,0 +1,90 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+
+describe('attach/detach', () => {
+  let rte, editor;
+
+  const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
+
+  async function attach(shadow = false) {
+    const parent = fixtureSync('<div></div>');
+    if (shadow) {
+      parent.attachShadow({ mode: 'open' });
+    }
+    parent.appendChild(rte);
+    await nextRender();
+    flushValueDebouncer();
+  }
+
+  beforeEach(async () => {
+    rte = fixtureSync('<vaadin-rich-text-editor></vaaddin-rich-text-editor>');
+    await nextRender();
+    flushValueDebouncer();
+    editor = rte._editor;
+  });
+
+  describe('detach and re-attach', () => {
+    it('should disconnect the emitter when detached', () => {
+      const spy = sinon.spy(editor.emitter, 'disconnect');
+
+      rte.parentNode.removeChild(rte);
+
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should re-connect the emitter when detached and re-attached', async () => {
+      const parent = rte.parentNode;
+      parent.removeChild(rte);
+
+      const spy = sinon.spy(editor.emitter, 'connect');
+
+      parent.appendChild(rte);
+      await nextUpdate(rte);
+
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should parse htmlValue correctly when element is attached but not rendered', async () => {
+      await attach(true);
+      rte.dangerouslySetHtmlValue('<p>Foo</p><ul><li>Bar</li><li>Baz</li></ul>');
+      rte.parentNode.shadowRoot.innerHTML = '<slot></slot>';
+      await nextRender();
+      flushValueDebouncer();
+      expect(rte.htmlValue).to.equal('<p>Foo</p><ul><li>Bar</li><li>Baz</li></ul>');
+    });
+  });
+
+  describe('unattached rich text editor', () => {
+    beforeEach(() => {
+      rte = document.createElement('vaadin-rich-text-editor');
+    });
+
+    it('should not throw when setting html value', () => {
+      expect(() => rte.dangerouslySetHtmlValue('<h1>Foo</h1>')).to.not.throw(Error);
+    });
+
+    it('should have the html value once attached', async () => {
+      rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
+      await attach();
+
+      expect(rte.htmlValue).to.equal('<h1>Foo</h1>');
+    });
+
+    it('should override the htmlValue', async () => {
+      rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
+      rte.value = JSON.stringify([{ insert: 'Vaadin' }]);
+      await attach();
+
+      expect(rte.htmlValue).to.equal('<p>Vaadin</p>');
+    });
+
+    it('should override the value', async () => {
+      rte.value = JSON.stringify([{ insert: 'Vaadin' }]);
+      rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
+      await attach();
+
+      expect(rte.htmlValue).to.equal('<h1>Foo</h1>');
+    });
+  });
+});

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -9,16 +9,6 @@ describe('rich text editor', () => {
 
   const getButton = (fmt) => rte.shadowRoot.querySelector(`[part~="toolbar-button-${fmt}"]`);
 
-  async function attach(shadow = false) {
-    const parent = fixtureSync('<div></div>');
-    if (shadow) {
-      parent.attachShadow({ mode: 'open' });
-    }
-    parent.appendChild(rte);
-    await nextRender();
-    flushValueDebouncer();
-  }
-
   beforeEach(async () => {
     rte = fixtureSync('<vaadin-rich-text-editor></vaadin-rich-text-editor>');
     await nextRender();
@@ -464,15 +454,6 @@ describe('rich text editor', () => {
         });
       });
     });
-
-    it('should parse htmlValue correctly when element is attached but not rendered', async () => {
-      await attach(true);
-      rte.dangerouslySetHtmlValue('<p>Foo</p><ul><li>Bar</li><li>Baz</li></ul>');
-      rte.parentNode.shadowRoot.innerHTML = '<slot></slot>';
-      await nextRender();
-      flushValueDebouncer();
-      expect(rte.htmlValue).to.equal('<p>Foo</p><ul><li>Bar</li><li>Baz</li></ul>');
-    });
   });
 
   describe('disabled', () => {
@@ -591,71 +572,5 @@ describe('rich text editor', () => {
         ]),
       );
     });
-  });
-
-  describe('detach and re-attach', () => {
-    it('should disconnect the emitter when detached', () => {
-      const spy = sinon.spy(editor.emitter, 'disconnect');
-
-      rte.parentNode.removeChild(rte);
-
-      expect(spy).to.be.calledOnce;
-    });
-
-    it('should re-connect the emitter when detached and re-attached', async () => {
-      const parent = rte.parentNode;
-      parent.removeChild(rte);
-
-      const spy = sinon.spy(editor.emitter, 'connect');
-
-      parent.appendChild(rte);
-      await nextUpdate(rte);
-
-      expect(spy).to.be.calledOnce;
-    });
-  });
-});
-
-describe('unattached rich text editor', () => {
-  let rte;
-
-  beforeEach(() => {
-    rte = document.createElement('vaadin-rich-text-editor');
-  });
-
-  const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
-
-  async function attach() {
-    const parent = fixtureSync('<div></div>');
-    parent.appendChild(rte);
-    await nextRender();
-    flushValueDebouncer();
-  }
-
-  it('should not throw when setting html value', () => {
-    expect(() => rte.dangerouslySetHtmlValue('<h1>Foo</h1>')).to.not.throw(Error);
-  });
-
-  it('should have the html value once attached', async () => {
-    rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
-    await attach();
-
-    expect(rte.htmlValue).to.equal('<h1>Foo</h1>');
-  });
-
-  it('should override the htmlValue', async () => {
-    rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
-    rte.value = JSON.stringify([{ insert: 'Vaadin' }]);
-    await attach();
-
-    expect(rte.htmlValue).to.equal('<p>Vaadin</p>');
-  });
-
-  it('should override the value', async () => {
-    rte.value = JSON.stringify([{ insert: 'Vaadin' }]);
-    rte.dangerouslySetHtmlValue('<h1>Foo</h1>');
-    await attach();
-
-    expect(rte.htmlValue).to.equal('<h1>Foo</h1>');
   });
 });

--- a/packages/rich-text-editor/test/basic.common.js
+++ b/packages/rich-text-editor/test/basic.common.js
@@ -1,11 +1,25 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusout, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import { html, LitElement } from 'lit';
+
+class TestLitElement extends LitElement {
+  static properties = {
+    toggleSlot: { type: Boolean },
+  };
+  render() {
+    if (!this.toggleSlot) {
+      return html``;
+    }
+    return html`<slot></slot>`;
+  }
+}
+customElements.define('test-lit-element', TestLitElement);
 
 describe('rich text editor', () => {
   let rte, editor;
 
-  const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
+  const flushValueDebouncer = (el = rte) => el.__debounceSetValue && el.__debounceSetValue.flush();
 
   const getButton = (fmt) => rte.shadowRoot.querySelector(`[part~="toolbar-button-${fmt}"]`);
 
@@ -453,6 +467,19 @@ describe('rich text editor', () => {
           rte.removeAttribute('dir');
         });
       });
+    });
+
+    it('should parse htmlValue correctly when element is attached but not rendered', async () => {
+      const parent = fixtureSync(
+        '<test-lit-element><vaadin-rich-text-editor></vaadin-rich-text-editor></test-lit-element>',
+      );
+      await nextRender();
+      const rte = parent.querySelector('vaadin-rich-text-editor');
+      rte.dangerouslySetHtmlValue('<p>Foo</p><ul><li>Bar</li><li>Baz</li></ul>');
+      parent.toggleSlot = true;
+      await nextRender();
+      flushValueDebouncer(rte);
+      expect(rte.htmlValue).to.equal('<p>Foo</p><ul><li>Bar</li><li>Baz</li></ul>');
     });
   });
 


### PR DESCRIPTION
## Description

In Firefox, the styles won't be computed properly if an element is attached to the DOM, but not rendered (e.g., it's placed as a child element of another element that does not define a slot). That leads to an issue with RTE if the component is added as a child of a Lit element. The reason is that a `LitElement` renders its DOM asynchronously, so for a brief moment, their children are attached while the template is not yet ready.

That's problematic for RTE while using `dangerouslySetHtmlValue` before the element is fully rendered in the page because this method uses the clipboard `Quill` feature, that in turn, uses `getComputedStyle` to parse the `HTML` snipped provided into the delta format used by `Quill`. Since `getComputedStyle` won't return the correct styles in the mentioned scenario, the parsed HTML will return unexpected results.

This fix aims to work around this issue, by checking whether the `getComputedStyle` returns empty and, if so, creates an `IntersectionObserver` that will be triggered once the element is visible and in the viewport to then proceed with the `HTML` parsing.

One downside of this approach is that in cases like the one described, the setting of the `value` property will happen asynchronously.

Fixes vaadin/flow-components#6653

## Type of change

- [X] Bugfix
- [ ] Feature
