### PR TITLE
fix: delay setting error message on focusout until click

### DIFF
--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
+    "@vaadin/a11y-base": "24.6.0-alpha0",
     "@vaadin/button": "24.6.0-alpha0",
     "@vaadin/component-base": "24.6.0-alpha0",
     "@vaadin/overlay": "24.6.0-alpha0",

--- a/packages/login/src/vaadin-lit-login-form.js
+++ b/packages/login/src/vaadin-lit-login-form.js
@@ -56,10 +56,10 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
           <vaadin-text-field
             name="username"
             label="${this.i18n.form.username}"
-            .errorMessage="${this.i18n.errorMessage.username}"
             id="vaadinLoginUsername"
             required
             @keydown="${this._handleInputKeydown}"
+            @focusout="${this._handleInputFocusOut}"
             autocapitalize="none"
             autocorrect="off"
             spellcheck="false"
@@ -71,10 +71,10 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
           <vaadin-password-field
             name="password"
             .label="${this.i18n.form.password}"
-            .errorMessage="${this.i18n.errorMessage.password}"
             id="vaadinLoginPassword"
             required
             @keydown="${this._handleInputKeydown}"
+            @focusout="${this._handleInputFocusOut}"
             spellcheck="false"
             autocomplete="current-password"
           >

--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -51,7 +51,10 @@ export const LoginFormMixin = (superClass) =>
       this.__setErrorMessage(userName);
       this.__setErrorMessage(password);
 
-      if (this.disabled || !(userName.validate() && password.validate())) {
+      userName.validate();
+      password.validate();
+
+      if (this.disabled || userName.invalid || password.invalid) {
         return;
       }
 

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -67,10 +67,10 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
           <vaadin-text-field
             name="username"
             label="[[i18n.form.username]]"
-            error-message="[[i18n.errorMessage.username]]"
             id="vaadinLoginUsername"
             required
             on-keydown="_handleInputKeydown"
+            on-focusout="_handleInputFocusOut"
             autocapitalize="none"
             autocorrect="off"
             spellcheck="false"
@@ -82,9 +82,9 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
           <vaadin-password-field
             name="password"
             label="[[i18n.form.password]]"
-            error-message="[[i18n.errorMessage.password]]"
             id="vaadinLoginPassword"
             required
+            on-focusout="_handleInputFocusOut"
             on-keydown="_handleInputKeydown"
             spellcheck="false"
             autocomplete="current-password"

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -135,6 +135,7 @@ snapshots["vaadin-login-form host required"] =
         spellcheck="false"
       >
         <input
+          aria-describedby="error-message-vaadin-text-field-2"
           aria-invalid="true"
           aria-labelledby="label-vaadin-text-field-0"
           autocapitalize="none"
@@ -173,6 +174,7 @@ snapshots["vaadin-login-form host required"] =
         spellcheck="false"
       >
         <input
+          aria-describedby="error-message-vaadin-password-field-5"
           aria-invalid="true"
           aria-labelledby="label-vaadin-password-field-3"
           autocomplete="current-password"
@@ -362,6 +364,7 @@ snapshots["vaadin-login-form host i18n-required"] =
         spellcheck="false"
       >
         <input
+          aria-describedby="error-message-vaadin-text-field-2"
           aria-invalid="true"
           aria-labelledby="label-vaadin-text-field-0"
           autocapitalize="none"
@@ -400,6 +403,7 @@ snapshots["vaadin-login-form host i18n-required"] =
         spellcheck="false"
       >
         <input
+          aria-describedby="error-message-vaadin-password-field-5"
           aria-invalid="true"
           aria-labelledby="label-vaadin-password-field-3"
           autocomplete="current-password"

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -35,9 +35,8 @@ describe('vaadin-login-form', () => {
     });
 
     it('required', async () => {
-      form.querySelectorAll('[required]').forEach((el) => {
-        el.invalid = true;
-      });
+      form.submit();
+      await nextRender();
       await expect(form).dom.to.equalSnapshot();
     });
 
@@ -48,9 +47,8 @@ describe('vaadin-login-form', () => {
 
     it('i18n-required', async () => {
       form.i18n = I18N_FINNISH;
-      form.querySelectorAll('[required]').forEach((el) => {
-        el.invalid = true;
-      });
+      form.submit();
+      await nextRender();
       await expect(form).dom.to.equalSnapshot();
     });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6667

This is a somewhat hacky workaround (which is why I don't want to include it to `ErrorController` by default):

- By default, the error message on username / password fields is not set (like it was before Vaadin 24.1)
- On `focusout` with <kbd>Tab</kbd> or pressing <kbd>Enter</kbd> we set the proper error message immediately to show it
- Otherwise we wait until the global `click` to allow click to be handled and then set error message
- After typing in the field we clear error message to ensure the above fix works on subsequent clicks
- On "Submit" button click (or programmatic submit) we ensure error message is set on both fields

## Type of change

- Bugfix

## How to test

Use the following code example in the dev page:

```html
<vaadin-login-form></vaadin-login-form>

<a href="https://example.com">Example</a>

<script type="module">
  import '@vaadin/login/vaadin-login-form.js';

  document.querySelector('vaadin-login-form').addEventListener('forgot-password', (e) => {
    console.llog(e);
  });
</script>
```

- Click "forgot password" while "username" is focused -> there should be `forgot-password` event in the console.
- Click the link while "username" is focused -> the click should be handled and navigate to example.com

## Note

In the second commit, I also added the logic to validate both fields on `submit()` - currently, if username is empty, there is no error shown for the password field and it remains valid. Maybe we could extract this logic to separate PR.