### PR TITLE
refactor: rename header slot to header content

### DIFF
--- a/dev/dashboard-layout.html
+++ b/dev/dashboard-layout.html
@@ -49,12 +49,12 @@
   <body>
     <vaadin-dashboard-layout>
       <vaadin-dashboard-widget widget-title="Total cost">
-        <span slot="header">2023-2024</span>
+        <span slot="header-content">2023-2024</span>
         <div class="kpi-number">+203%</div>
       </vaadin-dashboard-widget>
 
       <vaadin-dashboard-widget style="--vaadin-dashboard-item-colspan: 2" widget-title="Sales">
-        <span slot="header">2023-2024</span>
+        <span slot="header-content">2023-2024</span>
         <div class="chart"></div>
       </vaadin-dashboard-widget>
 
@@ -64,7 +64,7 @@
         </vaadin-dashboard-widget>
 
         <vaadin-dashboard-widget widget-title="Just some number">
-          <span slot="header">2014-2024</span>
+          <span slot="header-content">2014-2024</span>
           <div class="kpi-number">1234</div>
         </vaadin-dashboard-widget>
       </vaadin-dashboard-section>

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -86,7 +86,7 @@
         }
         root.firstElementChild.widgetTitle = item.title;
         root.firstElementChild.innerHTML = `
-          <span slot="header">${item.header || ''}</span>
+          <span slot="header-content">${item.header || ''}</span>
           ${item.type === 'chart' ? '<div class="chart"></div>' : `<div class="kpi-number">${item.content}</div>`}
         `;
       };

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -147,7 +147,7 @@ class DashboardWidget extends DashboardItemMixin(ControllerMixin(ElementMixin(Po
         <header>
           ${this.__renderDragHandle()}
           <slot name="title" id="title" @slotchange="${this.__onTitleSlotChange}"></slot>
-          <slot name="header"></slot>
+          <slot name="header-content"></slot>
           ${this.__renderRemoveButton()}
         </header>
 


### PR DESCRIPTION
## Description

This PR renames the `header` slot to `header-content`.

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Refactor