### PR TITLE
refactor: repurpose dashboard-gap as dashboard-spacing

### DIFF
--- a/dev/dashboard-layout.html
+++ b/dev/dashboard-layout.html
@@ -25,7 +25,6 @@
         --vaadin-dashboard-col-min-width: 300px;
         --vaadin-dashboard-col-max-width: 500px;
         --vaadin-dashboard-row-min-height: 300px;
-        --vaadin-dashboard-gap: 20px;
         --vaadin-dashboard-col-max-count: 3;
       }
 

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -18,7 +18,6 @@
         --vaadin-dashboard-col-min-width: 300px;
         --vaadin-dashboard-col-max-width: 500px;
         --vaadin-dashboard-row-min-height: 300px;
-        --vaadin-dashboard-gap: 20px;
         --vaadin-dashboard-col-max-count: 3;
       }
 

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -36,7 +36,12 @@ export const DashboardLayoutMixin = (superClass) =>
 
         #grid {
           box-sizing: border-box;
-          padding: 20px;
+          --_vaadin-dashboard-default-spacing: 1rem;
+          --_vaadin-dashboard-spacing: max(
+            0px,
+            var(--vaadin-dashboard-spacing, var(--_vaadin-dashboard-default-spacing))
+          );
+          padding: var(--_vaadin-dashboard-spacing);
 
           /* Default min and max column widths */
           --_vaadin-dashboard-default-col-min-width: 25rem;
@@ -75,7 +80,7 @@ export const DashboardLayoutMixin = (superClass) =>
 
           grid-auto-rows: var(--_vaadin-dashboard-row-height);
 
-          gap: var(--vaadin-dashboard-gap, 1rem);
+          gap: var(--_vaadin-dashboard-spacing);
         }
 
         ::slotted(*) {

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -42,7 +42,7 @@ class DashboardSection extends DashboardItemMixin(ControllerMixin(ElementMixin(P
           grid-template-columns: subgrid;
           --_vaadin-dashboard-section-column: 1 / calc(var(--_vaadin-dashboard-effective-col-count) + 1);
           grid-column: var(--_vaadin-dashboard-section-column) !important;
-          gap: var(--vaadin-dashboard-gap, 1rem);
+          gap: var(--_vaadin-dashboard-spacing, 1rem);
           /* Dashbaord section header height */
           --_vaadin-dashboard-section-header-height: minmax(0, auto);
           grid-template-rows: var(--_vaadin-dashboard-section-header-height) repeat(

--- a/packages/dashboard/test/dashboard-keyboard.test.ts
+++ b/packages/dashboard/test/dashboard-keyboard.test.ts
@@ -18,10 +18,10 @@ import {
   getResizeShrinkHeightButton,
   getResizeShrinkWidthButton,
   onceResized,
-  setGap,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
+  setSpacing,
 } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: number };
@@ -39,7 +39,7 @@ describe('dashboard - keyboard interaction', () => {
     dashboard.addEventListener('keydown', keydownSpy);
     setMinimumColumnWidth(dashboard, columnWidth);
     setMaximumColumnWidth(dashboard, columnWidth);
-    setGap(dashboard, 0);
+    setSpacing(dashboard, 0);
 
     dashboard.items = [{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }];
     dashboard.renderer = (root, _, model) => {
@@ -51,8 +51,6 @@ describe('dashboard - keyboard interaction', () => {
         root.appendChild(widget);
       }
     };
-    // @ts-expect-error Test without padding
-    dashboard.$.grid.style.padding = '0';
 
     dashboard.style.width = `${columnWidth * 2}px`;
     await onceResized(dashboard);

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-layout.js';
 import '../vaadin-dashboard-section.js';
+import '@vaadin/vaadin-lumo-styles/spacing.js';
 import type { DashboardLayout } from '../vaadin-dashboard-layout.js';
 import type { DashboardSection } from '../vaadin-dashboard-section.js';
 import {
@@ -11,19 +12,30 @@ import {
   getScrollingContainer,
   onceResized,
   setColspan,
-  setGap,
   setMaximumColumnCount,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
   setRowspan,
+  setSpacing,
 } from './helpers.js';
+
+const [defaultSpacing] = (() => {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  div.style.width = '1rem';
+  const width = getComputedStyle(div).width;
+  div.remove();
+  return [parseFloat(width)];
+})();
+
+// TODO: Fix the default minimum column width
+const defaultMinimumColumnWidth = 400;
 
 describe('dashboard layout', () => {
   let dashboard: DashboardLayout;
   let childElements: HTMLElement[];
   const columnWidth = 100;
-  const remValue = parseFloat(getComputedStyle(document.documentElement).fontSize);
 
   beforeEach(async () => {
     dashboard = fixtureSync(`
@@ -34,13 +46,11 @@ describe('dashboard layout', () => {
     `);
     childElements = [...dashboard.children] as HTMLElement[];
     await nextFrame();
-    // Disable gap between items in these tests
-    setGap(dashboard, 0);
+    // Disable spacing between items in these tests
+    setSpacing(dashboard, 0);
     // Set the column width to a fixed value
     setMinimumColumnWidth(dashboard, columnWidth);
     setMaximumColumnWidth(dashboard, columnWidth);
-    // @ts-expect-error Test without padding
-    dashboard.$.grid.style.padding = '0';
     // Make the dashboard wide enough to fit all items on a single row
     dashboard.style.width = `${columnWidth * dashboard.childElementCount}px`;
 
@@ -109,7 +119,7 @@ describe('dashboard layout', () => {
       dashboard.style.width = '0';
       await onceResized(dashboard);
       // Expect the column width to equal the default minimum column width
-      expect(getColumnWidths(dashboard)).to.eql([remValue * 25]);
+      expect(getColumnWidths(dashboard)).to.eql([defaultMinimumColumnWidth]);
     });
 
     it('should have one overflown column if narrowed below minimum column width', async () => {
@@ -307,43 +317,43 @@ describe('dashboard layout', () => {
     });
   });
 
-  describe('gap', () => {
-    it('should have a default gap', async () => {
-      // Clear the gap used in the tests
-      setGap(dashboard, undefined);
-      // Increase the width of the dashboard to fit two items and a gap
-      dashboard.style.width = `${columnWidth * 2 + remValue}px`;
+  describe('spacing', () => {
+    it('should have default spacing', async () => {
+      // Clear the spacing used in the tests
+      setSpacing(dashboard, undefined);
+      // Increase the width of the dashboard to fit two items, paddings and a gap
+      dashboard.style.width = `calc(${columnWidth}px * 2 + ${defaultSpacing * 3}px)`;
       await onceResized(dashboard);
 
       const { right: item0Right } = childElements[0].getBoundingClientRect();
       const { left: item1Left } = childElements[1].getBoundingClientRect();
       // Expect the items to have a gap of 1rem
-      expect(item1Left - item0Right).to.eql(remValue);
+      expect(item1Left - item0Right).to.eql(defaultSpacing);
     });
 
-    it('should have a custom gap between items horizontally', async () => {
-      const customGap = 10;
-      setGap(dashboard, customGap);
-      // Increase the width of the dashboard to fit two items and a gap
-      dashboard.style.width = `${columnWidth * 2 + customGap}px`;
+    it('should have custom spacing between items horizontally', async () => {
+      const customSpacing = 10;
+      setSpacing(dashboard, customSpacing);
+      // Increase the width of the dashboard to fit two items, paddings and a gap
+      dashboard.style.width = `${columnWidth * 2 + customSpacing * 3}px`;
       await onceResized(dashboard);
 
       const { right: item0Right } = childElements[0].getBoundingClientRect();
       const { left: item1Left } = childElements[1].getBoundingClientRect();
       // Expect the items to have a gap of 10px
-      expect(item1Left - item0Right).to.eql(customGap);
+      expect(item1Left - item0Right).to.eql(customSpacing);
     });
 
-    it('should have a custom gap between items vertically', async () => {
-      const customGap = 10;
-      setGap(dashboard, customGap);
+    it('should have custom spacing between items vertically', async () => {
+      const customSpacing = 10;
+      setSpacing(dashboard, customSpacing);
       dashboard.style.width = `${columnWidth}px`;
       await onceResized(dashboard);
 
       const { bottom: item0Bottom } = childElements[0].getBoundingClientRect();
       const { top: item1Top } = childElements[1].getBoundingClientRect();
-      // Expect the items to have a gap of 10px
-      expect(item1Top - item0Bottom).to.eql(customGap);
+      // Expect the items to have spacing of 10px
+      expect(item1Top - item0Bottom).to.eql(customSpacing);
     });
   });
 
@@ -513,43 +523,43 @@ describe('dashboard layout', () => {
       expect(newTitleHeight).to.eql(titleHeight);
     });
 
-    describe('gap', () => {
-      it('should have a default gap', async () => {
-        // Clear the gap used in the tests
-        setGap(dashboard, undefined);
-        // Increase the width of the dashboard to fit two items and a gap
-        dashboard.style.width = `${columnWidth * 2 + remValue}px`;
+    describe('spacing', () => {
+      it('should have default spacing', async () => {
+        // Clear the spacing used in the tests
+        setSpacing(dashboard, undefined);
+        // Increase the width of the dashboard to fit two items, paddings and a gap
+        dashboard.style.width = `calc(${columnWidth}px * 2 + ${defaultSpacing * 3}px)`;
         await onceResized(dashboard);
 
         const { right: item2Right } = childElements[2].getBoundingClientRect();
         const { left: item3Left } = childElements[3].getBoundingClientRect();
         // Expect the items to have a gap of 1rem
-        expect(item3Left - item2Right).to.eql(remValue);
+        expect(item3Left - item2Right).to.eql(defaultSpacing);
       });
 
-      it('should have a custom gap between items horizontally', async () => {
-        const customGap = 10;
-        setGap(dashboard, customGap);
-        // Increase the width of the dashboard to fit two items and a gap
-        dashboard.style.width = `${columnWidth * 2 + customGap}px`;
+      it('should have a custom spacing between items horizontally', async () => {
+        const customSpacing = 10;
+        setSpacing(dashboard, customSpacing);
+        // Increase the width of the dashboard to fit two items, paddings and a gap
+        dashboard.style.width = `${columnWidth * 2 + customSpacing * 3}px`;
         await onceResized(dashboard);
 
         const { right: item2Right } = childElements[2].getBoundingClientRect();
         const { left: item3Left } = childElements[3].getBoundingClientRect();
         // Expect the items to have a gap of 10px
-        expect(item3Left - item2Right).to.eql(customGap);
+        expect(item3Left - item2Right).to.eql(customSpacing);
       });
 
-      it('should have a custom gap between items vertically', async () => {
-        const customGap = 10;
-        setGap(dashboard, customGap);
+      it('should have a custom spacing between items vertically', async () => {
+        const customSpacing = 10;
+        setSpacing(dashboard, customSpacing);
         dashboard.style.width = `${columnWidth}px`;
         await onceResized(dashboard);
 
         const { bottom: item2Bottom } = childElements[2].getBoundingClientRect();
         const { top: item3Top } = childElements[3].getBoundingClientRect();
         // Expect the items to have a gap of 10px
-        expect(item3Top - item2Bottom).to.eql(customGap);
+        expect(item3Top - item2Bottom).to.eql(customSpacing);
       });
     });
   });

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -17,9 +17,9 @@ import {
   getParentSection,
   onceResized,
   resetReorderTimeout,
-  setGap,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
+  setSpacing,
 } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: number };
@@ -31,12 +31,10 @@ describe('dashboard - widget reordering', () => {
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');
     await nextFrame();
-    // @ts-expect-error Test without padding
-    dashboard.$.grid.style.padding = '0';
 
     setMinimumColumnWidth(dashboard, columnWidth);
     setMaximumColumnWidth(dashboard, columnWidth);
-    setGap(dashboard, 0);
+    setSpacing(dashboard, 0);
 
     dashboard.editable = true;
 

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -12,10 +12,10 @@ import {
   fireResizeStart,
   getElementFromCell,
   onceResized,
-  setGap,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
+  setSpacing,
 } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: number };
@@ -28,11 +28,10 @@ describe('dashboard - widget resizing', () => {
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');
     await nextFrame();
-    // @ts-expect-error Test without padding
-    dashboard.$.grid.style.padding = '0';
+
     setMinimumColumnWidth(dashboard, columnWidth);
     setMaximumColumnWidth(dashboard, columnWidth);
-    setGap(dashboard, 0);
+    setSpacing(dashboard, 0);
     setMinimumRowHeight(dashboard, rowHeight);
 
     dashboard.editable = true;
@@ -434,7 +433,7 @@ describe('dashboard - widget resizing', () => {
 
     it('should take gap into account when resizing', async () => {
       dashboard.style.width = `${columnWidth * 3}px`;
-      setGap(dashboard, columnWidth / 2);
+      setSpacing(dashboard, 20);
       await onceResized(dashboard);
 
       // prettier-ignore
@@ -444,7 +443,18 @@ describe('dashboard - widget resizing', () => {
 
       fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
       await nextFrame();
-      fireResizeOver(getElementFromCell(dashboard, 0, 1)!, 'start');
+
+      const widget1Rect = getElementFromCell(dashboard, 0, 1)!.getBoundingClientRect();
+      const x = widget1Rect.left + widget1Rect.width / 2 - 10;
+      const y = widget1Rect.bottom;
+      const event = new MouseEvent('mousemove', {
+        bubbles: true,
+        composed: true,
+        clientX: x,
+        clientY: y,
+        buttons: 1,
+      });
+      dashboard.dispatchEvent(event);
       await nextFrame();
 
       // prettier-ignore

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -15,9 +15,9 @@ import {
   getResizeHandle,
   getScrollingContainer,
   onceResized,
-  setGap,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
+  setSpacing,
 } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: string; component?: Element | string };
@@ -29,13 +29,11 @@ describe('dashboard', () => {
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');
     await nextFrame();
-    // @ts-expect-error Test without padding
-    dashboard.$.grid.style.padding = '0';
 
     dashboard.style.width = `${columnWidth * 2}px`;
     setMinimumColumnWidth(dashboard, columnWidth);
     setMaximumColumnWidth(dashboard, columnWidth);
-    setGap(dashboard, 0);
+    setSpacing(dashboard, 0);
 
     dashboard.items = [{ id: '0' }, { id: '1' }];
     dashboard.renderer = (root, _, model) => {

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -111,10 +111,10 @@ export function setRowspan(element: HTMLElement, rowspan?: number): void {
 }
 
 /**
- * Sets the gap between the cells of the dashboard.
+ * Sets the specing between the cells of the dashboard.
  */
-export function setGap(dashboard: HTMLElement, gap?: number): void {
-  dashboard.style.setProperty('--vaadin-dashboard-gap', gap !== undefined ? `${gap}px` : null);
+export function setSpacing(dashboard: HTMLElement, spacing?: number): void {
+  dashboard.style.setProperty('--vaadin-dashboard-spacing', spacing !== undefined ? `${spacing}px` : null);
 }
 
 /**

--- a/packages/dashboard/theme/lumo/vaadin-dashboard-layout-styles.js
+++ b/packages/dashboard/theme/lumo/vaadin-dashboard-layout-styles.js
@@ -1,10 +1,6 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export const dashboardLayoutStyles = css`
-  :host {
-    --vaadin-dashboard-gap: var(--lumo-space-m);
-  }
-`;
+export const dashboardLayoutStyles = css``;
 
 registerStyles('vaadin-dashboard-layout', [dashboardLayoutStyles], {
   moduleId: 'lumo-dashboard-layout',

--- a/packages/dashboard/theme/material/vaadin-dashboard-layout-styles.js
+++ b/packages/dashboard/theme/material/vaadin-dashboard-layout-styles.js
@@ -1,10 +1,6 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-export const dashboardLayoutStyles = css`
-  :host {
-    --vaadin-dashboard-gap: 1rem;
-  }
-`;
+export const dashboardLayoutStyles = css``;
 
 registerStyles('vaadin-dashboard-layout', [dashboardLayoutStyles], {
   moduleId: 'material-dashboard-layout',


### PR DESCRIPTION
## Description

This PR renames `--vaadin-dashboard-gap` to `--vaadin-dashboard-spacing` and repurposes it to also affect the dashboard's padding.

Part of https://github.com/orgs/vaadin/projects/70/views/1?pane=issue&itemId=75293217

## Type of change

Refactor