### PR TITLE
docs: update spacing related jsdocs

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-layout.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-layout.d.ts
@@ -30,12 +30,12 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * The following custom properties are available:
  *
  * Custom Property                     | Description
- * ----------------------------------- |-------------
+ * ------------------------------------|-------------
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the layout
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the layout
- * `--vaadin-dashboard-row-min-height` | maximum column count of the layout
- * `--vaadin-dashboard-spacing`        | spacing between the cells of the layout
+ * `--vaadin-dashboard-row-min-height` | minimum row height of the layout
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the layout
+ * `--vaadin-dashboard-spacing`        | spacing between child elements and space around its outer edges
  *
  * The following state attributes are available for styling:
  *

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -33,12 +33,12 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * The following custom properties are available:
  *
  * Custom Property                     | Description
- * ----------------------------------- |-------------
+ * ------------------------------------|-------------
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the layout
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the layout
- * `--vaadin-dashboard-row-min-height` | maximum column count of the layout
- * `--vaadin-dashboard-spacing`        | spacing between the cells of the layout
+ * `--vaadin-dashboard-row-min-height` | minimum row height of the layout
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the layout
+ * `--vaadin-dashboard-spacing`        | spacing between child elements and space around its outer edges
  *
  * The following state attributes are available for styling:
  *

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -193,9 +193,9 @@ export interface DashboardI18n {
  * ------------------------------------|-------------
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the dashboard
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the dashboard
- * `--vaadin-dashboard-row-min-height` | maximum column count of the dashboard
- * `--vaadin-dashboard-spacing`        | spacing between the cells of the dashboard
+ * `--vaadin-dashboard-row-min-height` | minimum row height of the dashboard
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the dashboard
+ * `--vaadin-dashboard-spacing`        | spacing between child elements and space around its outer edges
  *
  * The following state attributes are available for styling:
  *

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -75,9 +75,9 @@ import { WidgetResizeController } from './widget-resize-controller.js';
  * ------------------------------------|-------------
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the dashboard
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the dashboard
- * `--vaadin-dashboard-row-min-height` | maximum column count of the dashboard
- * `--vaadin-dashboard-spacing`        | spacing between the cells of the dashboard
+ * `--vaadin-dashboard-row-min-height` | minimum row height of the dashboard
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the dashboard
+ * `--vaadin-dashboard-spacing`        | spacing between child elements and space around its outer edges
  *
  * The following state attributes are available for styling:
  *

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -111,7 +111,7 @@ export function setRowspan(element: HTMLElement, rowspan?: number): void {
 }
 
 /**
- * Sets the spacing between the cells of the dashboard.
+ * Sets the spacing of the dashboard. This value adjusts the spacing between elements within the dashboard and the space around its outer edges.
  */
 export function setSpacing(dashboard: HTMLElement, spacing?: number): void {
   dashboard.style.setProperty('--vaadin-dashboard-spacing', spacing !== undefined ? `${spacing}px` : null);


### PR DESCRIPTION
## Description

This PR

- updates the dashboard spacing related JSDocs to further clarify what it does 
- fixes the incorrect description for `--vaadin-dashboard-row-min-height`

Part of https://github.com/vaadin/platform/issues/6626

## Type of change

Docs / chore