### PR TITLE
refactor: remove duplicate change event listener override

### DIFF
--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -129,30 +129,6 @@ export const InputControlMixin = (superclass) =>
     }
 
     /**
-     * Override an event listener inherited from `InputMixin`
-     * to capture native `change` event and make sure that
-     * a new one is dispatched after validation runs.
-     * @param {Event} event
-     * @protected
-     * @override
-     */
-    _onChange(event) {
-      event.stopPropagation();
-
-      this.validate();
-
-      this.dispatchEvent(
-        new CustomEvent('change', {
-          detail: {
-            sourceEvent: event,
-          },
-          bubbles: event.bubbles,
-          cancelable: event.cancelable,
-        }),
-      );
-    }
-
-    /**
      * Override a method from `InputMixin`.
      * @param {!HTMLElement} input
      * @protected


### PR DESCRIPTION
## Description

Starting from #2519 the `_onChange` listener was moved to `InputConstraintsMixin` and its code is exactly the same in `InputControlMixin` which uses that mixin internally. So there is no point in overriding it anymore.

## Type of change

- Refactor