### PR TITLE
fix: validate date-time-picker when required is set to false

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -721,6 +721,12 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     if (timePicker) {
       timePicker.required = required;
     }
+
+    if (this.__oldRequired && !required) {
+      this.validate();
+    }
+
+    this.__oldRequired = required;
   }
 
   /** @private */

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -200,6 +200,11 @@ const fixtures = {
         dateTimePicker.validate();
         expect(dateTimePicker.invalid).to.be.true;
       });
+
+      it('should validate when setting required to false', () => {
+        dateTimePicker.required = false;
+        expect(validateSpy).to.be.calledOnce;
+      });
     });
 
     describe('document losing focus', () => {


### PR DESCRIPTION
## Description

Fixes #7906

Similar to the fix for `vaadin-select` previously implemented in #4201 - `vaadin-date-time-picker` also doesn't use `InputConstraintsMixin` and therefore needs to call `validate()` when setting `required` to `false`.

## Type of change

- Bugfix