### PR TITLE
fix: remove not working vaadin-lit-date-picker-light entrypoint

### DIFF
--- a/packages/date-picker/vaadin-lit-date-picker-light.d.ts
+++ b/packages/date-picker/vaadin-lit-date-picker-light.d.ts
@@ -1,1 +1,0 @@
-export * from './src/vaadin-date-picker-light.js';

--- a/packages/date-picker/vaadin-lit-date-picker-light.js
+++ b/packages/date-picker/vaadin-lit-date-picker-light.js
@@ -1,2 +1,0 @@
-import './theme/lumo/vaadin-lit-date-picker-light.js';
-export * from './src/vaadin-lit-date-picker-light.js';


### PR DESCRIPTION
## Description

These files were added in https://github.com/vaadin/web-components/pull/6801 with the regular `vaadin-lit-date-picker.js`
However, there is no Lit based version of `vaadin-date-picker-light` yet.

Removed these as importing them would simply cause applications to break.

## Type of change

- Bugfix