### PR TITLE
fix: use correct ComboBoxScrollerMixin import in typings

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.d.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2015 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxScrollerMixin } from './vaadin-combo-box-overlay-mixin.js';
+import { ComboBoxScrollerMixin } from './vaadin-combo-box-scroller-mixin.js';
 
 /**
  * An element used internally by `<vaadin-combo-box>`. Not intended to be used separately.


### PR DESCRIPTION
## Description

Found this incorrect import when trying `vaadin/imports` preset for ESLint config locally.

## Type of change

- Bugfix