### PR TITLE
refactor: simplify type imports in GridMixin typings

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-mixin.d.ts
@@ -7,11 +7,10 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ActiveItemMixinClass } from './vaadin-grid-active-item-mixin.js';
 import type { ArrayDataProviderMixinClass } from './vaadin-grid-array-data-provider-mixin.js';
-import type { GridColumn } from './vaadin-grid-column.js';
-import { GridBodyRenderer, GridHeaderFooterRenderer } from './vaadin-grid-column.js';
+import type { GridBodyRenderer, GridColumn, GridHeaderFooterRenderer } from './vaadin-grid-column.js';
 import type { ColumnReorderingMixinClass } from './vaadin-grid-column-reordering-mixin.js';
-import type { DataProviderMixinClass } from './vaadin-grid-data-provider-mixin.js';
-import {
+import type {
+  DataProviderMixinClass,
   GridDataProvider,
   GridDataProviderCallback,
   GridDataProviderParams,
@@ -19,12 +18,14 @@ import {
   GridSorterDefinition,
   GridSorterDirection,
 } from './vaadin-grid-data-provider-mixin.js';
-import type { DragAndDropMixinClass } from './vaadin-grid-drag-and-drop-mixin.js';
-import { GridDragAndDropFilter, GridDropLocation, GridDropMode } from './vaadin-grid-drag-and-drop-mixin.js';
-import type { EventContextMixinClass } from './vaadin-grid-event-context-mixin.js';
-import { GridEventContext } from './vaadin-grid-event-context-mixin.js';
-import type { RowDetailsMixinClass } from './vaadin-grid-row-details-mixin.js';
-import { GridRowDetailsRenderer } from './vaadin-grid-row-details-mixin.js';
+import type {
+  DragAndDropMixinClass,
+  GridDragAndDropFilter,
+  GridDropLocation,
+  GridDropMode,
+} from './vaadin-grid-drag-and-drop-mixin.js';
+import type { EventContextMixinClass, GridEventContext } from './vaadin-grid-event-context-mixin.js';
+import type { GridRowDetailsRenderer, RowDetailsMixinClass } from './vaadin-grid-row-details-mixin.js';
 import type { ScrollMixinClass } from './vaadin-grid-scroll-mixin.js';
 import type { SelectionMixinClass } from './vaadin-grid-selection-mixin.js';
 import type { SortMixinClass } from './vaadin-grid-sort-mixin.js';


### PR DESCRIPTION
## Description

Fixed some duplicate imports reported when trying `vaadin/imports` preset from `eslint-config-vaadin` locally.

## Type of change

- Refactor