### PR TITLE
refactor: use correct import in template-renderer entrypoint

### DIFF
--- a/packages/polymer-legacy-adapter/template-renderer.js
+++ b/packages/polymer-legacy-adapter/template-renderer.js
@@ -3,4 +3,4 @@
  * Copyright (c) 2021 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-export * from './src/template-renderer.js';
+import './src/template-renderer.js';


### PR DESCRIPTION
## Description

Updated this file to align with `index.js` and `style-modules.js` in the same package.
While current `export` seems to work with native ES modules the `eslint-plugin-import` reports a warning:

```
/Users/serhii/vaadin/web-components/packages/polymer-legacy-adapter/template-renderer.js
  6:15  error  No named exports found in module './src/template-renderer.js'
```

## Type of change

- Refactor