### PR TITLE
test: update custom-field validation tests to also use Lit

### DIFF
--- a/packages/custom-field/test/validation-lit.test.js
+++ b/packages/custom-field/test/validation-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-custom-field.js';
+import './validation.common.js';

--- a/packages/custom-field/test/validation-polymer.test.js
+++ b/packages/custom-field/test/validation-polymer.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-custom-field.js';
+import './validation.common.js';

--- a/packages/custom-field/test/validation.common.js
+++ b/packages/custom-field/test/validation.common.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-custom-field.js';
 
 describe('validation', () => {
   let customField;
@@ -37,8 +36,9 @@ describe('validation', () => {
       expect(validateSpy.calledOnce).to.be.true;
     });
 
-    it('should validate on value change', () => {
+    it('should validate on value change', async () => {
       customField.value = 'foo,1';
+      await nextUpdate(customField);
       expect(validateSpy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Description

For some reason there was no Lit version of `validation.test.js` for `vaadin-custom-field`. This PR fixes that.

## Type of change

- Test