### PR TITLE
fix: validate custom-field when required is set to false

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -192,6 +192,21 @@ export const CustomFieldMixin = (superClass) =>
     }
 
     /**
+     * Override an observer from `FieldMixin`
+     * to validate when required is removed.
+     *
+     * @protected
+     * @override
+     */
+    _requiredChanged(required) {
+      super._requiredChanged(required);
+
+      if (required === false) {
+        this.validate();
+      }
+    }
+
+    /**
      * @param {KeyboardEvent} e
      * @protected
      * @override

--- a/packages/custom-field/test/validation.common.js
+++ b/packages/custom-field/test/validation.common.js
@@ -97,5 +97,12 @@ describe('validation', () => {
       fire(customField.inputs[0], 'change');
       expect(customField.invalid).to.be.true;
     });
+
+    it('should validate when setting required to false', async () => {
+      const validateSpy = sinon.spy(customField, 'validate');
+      customField.required = false;
+      await nextUpdate(customField);
+      expect(validateSpy).to.be.calledOnce;
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #7905 

Same as #7908 but for `vaadin-custom-field`.

## Type of change

- Bugfix