### PR TITLE
fix: add missing export for SelectListBox element class

### DIFF
--- a/packages/select/src/vaadin-lit-select-list-box.js
+++ b/packages/select/src/vaadin-lit-select-list-box.js
@@ -81,3 +81,5 @@ class SelectListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LitEle
 }
 
 defineCustomElement(SelectListBox);
+
+export { SelectListBox };

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -79,3 +79,5 @@ class SelectListBox extends ListMixin(ThemableMixin(DirMixin(ControllerMixin(Pol
 }
 
 defineCustomElement(SelectListBox);
+
+export { SelectListBox };


### PR DESCRIPTION
## Description

When changing `vaadin-select-list-box` to not extend `vaadin-list-box` I added the export to the `.d.ts` file.
However, the corresponding JS class isn't exported, unlike `SelectItem` and e.g. `ContextMenuListBox`.

Added the export to make importing the component possible and align with other similar components.

## Type of change

- Bugfix