### PR TITLE
fix: use correct class name in confirm-dialog typings

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-base-mixin.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-base-mixin.d.ts
@@ -9,7 +9,7 @@ export declare function ConfirmDialogBaseMixin<T extends Constructor<HTMLElement
   base: T,
 ): Constructor<ConfirmDialogBaseMixinClass> & T;
 
-export declare class ConfirmDialogBaseMixin {
+export declare class ConfirmDialogBaseMixinClass {
   /**
    * Set the `aria-label` attribute for assistive technologies like
    * screen readers. An empty string value for this property (the


### PR DESCRIPTION
## Description

Found this issue when testing `vaadin/imports` preset from `eslint-config-vaadin`.

Note: this is an internal mixin used by `vaadin-confirm-dialog-dialog` which doesn't have its own typings.

## Type of change

- Bugfix