### PR TITLE
experiment: add Lit based version of vaadin-list-box

### DIFF
--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -21,6 +21,8 @@
   "type": "module",
   "files": [
     "src",
+    "!src/vaadin-lit-list-box.d.ts",
+    "!src/vaadin-lit-list-box.js",
     "theme",
     "vaadin-*.d.ts",
     "vaadin-*.js",

--- a/packages/list-box/src/vaadin-lit-list-box.d.ts
+++ b/packages/list-box/src/vaadin-lit-list-box.d.ts
@@ -1,0 +1,1 @@
+export * from './vaadin-list-box.js';

--- a/packages/list-box/src/vaadin-lit-list-box.js
+++ b/packages/list-box/src/vaadin-lit-list-box.js
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css, html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
+
+/**
+ * LitElement based version of `<vaadin-list-box>` web component.
+ *
+ * ## Disclaimer
+ *
+ * This component is an experiment and not yet a part of Vaadin platform.
+ * There is no ETA regarding specific Vaadin version where it'll land.
+ * Feel free to try this code in your apps as per Apache 2.0 license.
+ */
+class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+  static get is() {
+    return 'vaadin-list-box';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: flex;
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+
+      [part='items'] {
+        height: 100%;
+        width: 100%;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+    `;
+  }
+
+  static get properties() {
+    return {
+      // We don't need to define this property since super default is vertical,
+      // but we don't want it to be modified, or be shown in the API docs.
+      /** @private */
+      orientation: {
+        readOnly: true,
+      },
+    };
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div part="items">
+        <slot></slot>
+      </div>
+
+      <slot name="tooltip"></slot>
+    `;
+  }
+
+  /**
+   * @return {!HTMLElement}
+   * @protected
+   * @override
+   */
+  get _scrollerElement() {
+    return this.shadowRoot.querySelector('[part="items"]');
+  }
+
+  /** @protected */
+  ready() {
+    super.ready();
+
+    this.setAttribute('role', 'listbox');
+
+    this._tooltipController = new TooltipController(this);
+    this.addController(this._tooltipController);
+  }
+}
+
+defineCustomElement(ListBox);
+
+export { ListBox };

--- a/packages/list-box/test/list-box-lit.test.js
+++ b/packages/list-box/test/list-box-lit.test.js
@@ -1,0 +1,2 @@
+import '../src/vaadin-lit-list-box.js';
+import './list-box.common.js';

--- a/packages/list-box/test/list-box-polymer.test.js
+++ b/packages/list-box/test/list-box-polymer.test.js
@@ -1,0 +1,3 @@
+import '@vaadin/item/vaadin-item.js';
+import '../vaadin-list-box.js';
+import './list-box.common.js';

--- a/packages/list-box/test/list-box.common.js
+++ b/packages/list-box/test/list-box.common.js
@@ -1,18 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import '@vaadin/item/vaadin-item.js';
-import '../vaadin-list-box.js';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 
 describe('vaadin-list-box', () => {
   let listBox, tagName;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     listBox = fixtureSync(`
       <vaadin-list-box>
         <vaadin-item>Foo</vaadin-item>
         <vaadin-item>Bar</vaadin-item>
       </vaadin-list-box>
     `);
+    await nextRender();
     tagName = listBox.tagName.toLowerCase();
   });
 
@@ -22,5 +21,9 @@ describe('vaadin-list-box', () => {
 
   it('should have a valid static "is" getter', () => {
     expect(customElements.get(tagName).is).to.equal(tagName);
+  });
+
+  it('should set role attribute to list-box', () => {
+    expect(listBox.getAttribute('role')).to.equal('listbox');
   });
 });


### PR DESCRIPTION
## Description

Added Lit based version of `vaadin-list-box` (note, the `MultiSelectListMixin` already has tests running with Lit).

## Type of change

- Experiment

## Note

I didn't add `_checkImport()` logic for now, could be done if we want to preserve it after #7936 is merged.