### PR TITLE
docs: fix popover JSDoc to use correct parameter name

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -93,7 +93,7 @@ declare class Popover extends PopoverPositionMixin(
    * Sets the default hover delay to be used by all popover instances,
    * except for those that have hover delay configured using property.
    */
-  static setDefaultHoverDelay(delay: number): void;
+  static setDefaultHoverDelay(hoverDelay: number): void;
 
   /**
    * String used to label the overlay to screen reader users.

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -415,7 +415,7 @@ class Popover extends PopoverPositionMixin(
    * Sets the default focus delay to be used by all popover instances,
    * except for those that have focus delay configured using property.
    *
-   * @param {number} delay
+   * @param {number} focusDelay
    */
   static setDefaultFocusDelay(focusDelay) {
     defaultFocusDelay = focusDelay != null && focusDelay >= 0 ? focusDelay : DEFAULT_DELAY;
@@ -435,7 +435,7 @@ class Popover extends PopoverPositionMixin(
    * Sets the default hover delay to be used by all popover instances,
    * except for those that have hover delay configured using property.
    *
-   * @param {number} delay
+   * @param {number} hoverDelay
    */
   static setDefaultHoverDelay(hoverDelay) {
     defaultHoverDelay = hoverDelay != null && hoverDelay >= 0 ? hoverDelay : DEFAULT_DELAY;


### PR DESCRIPTION
## Description

Fixed some incorrect JSDoc (which was actually a copy-paste from Tooltip, will cover that in a separate PR).

## Type of change

- Documentation