### PR TITLE
docs: fix tooltip JSDoc to use correct parameter name

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -381,7 +381,7 @@ export const TooltipMixin = (superClass) =>
      * Sets the default focus delay to be used by all tooltip instances,
      * except for those that have focus delay configured using property.
      *
-     * @param {number} delay
+     * @param {number} focusDelay
      */
     static setDefaultFocusDelay(focusDelay) {
       defaultFocusDelay = focusDelay != null && focusDelay >= 0 ? focusDelay : DEFAULT_DELAY;
@@ -401,7 +401,7 @@ export const TooltipMixin = (superClass) =>
      * Sets the default hover delay to be used by all tooltip instances,
      * except for those that have hover delay configured using property.
      *
-     * @param {number} delay
+     * @param {number} hoverDelay
      */
     static setDefaultHoverDelay(hoverDelay) {
       defaultHoverDelay = hoverDelay != null && hoverDelay >= 0 ? hoverDelay : DEFAULT_DELAY;

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -65,7 +65,7 @@ declare class Tooltip extends TooltipMixin(ThemePropertyMixin(ControllerMixin(El
    * Sets the default hover delay to be used by all tooltip instances,
    * except for those that have hover delay configured using property.
    */
-  static setDefaultHoverDelay(delay: number): void;
+  static setDefaultHoverDelay(hoverDelay: number): void;
 }
 
 declare global {


### PR DESCRIPTION
## Description

Same as #7938 but for `vaadin-tooltip`.

## Type of change

- Documentation