### PR TITLE
fix: ensure no focus outline when item is scrolled out of view

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -924,6 +924,10 @@ export const KeyboardNavigationMixin = (superClass) =>
 
     /** @protected */
     _preventScrollerRotatingCellFocus() {
+      if (this._activeRowGroup !== this.$.items) {
+        return;
+      }
+
       this.__preventScrollerRotatingCellFocusDebouncer = Debouncer.debounce(
         this.__preventScrollerRotatingCellFocusDebouncer,
         animationFrame,

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -506,8 +506,8 @@ export const KeyboardNavigationMixin = (superClass) =>
       // listener invocation gets updated _focusedItemIndex value.
       this._focusedItemIndex = dstRowIndex;
 
-      // This has to be set after scrolling, otherwise it can be removed by
-      // `_preventScrollerRotatingCellFocus(row, index)` during scrolling.
+      // Reapply navigating state in case it was removed due to previous item
+      // being focused with the mouse.
       this.toggleAttribute('navigating', true);
 
       return {

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -932,27 +932,25 @@ export const KeyboardNavigationMixin = (superClass) =>
           const isFocusedItemRendered = this._getRenderedRows().some((row) => row.index === this._focusedItemIndex);
           if (isFocusedItemRendered) {
             // Ensure the correct element is focused, as the virtualizer
-            // may render items using different elements.
+            // may have rendered the item using a different element.
             this.__updateItemsFocusable();
 
-            // Revert the cell focus outline if focus is still inside the body.
+            // if the focused item is visible, restore the cell focus outline
+            // and navigation mode.
             if (isItemsRowGroupActive && !this.__rowFocusMode) {
               this._focusedCell = this._itemsFocusable;
             }
 
-            // Restore navigation mode
             if (this._navigatingIsHidden) {
               this.toggleAttribute('navigating', true);
               this._navigatingIsHidden = false;
             }
-          } else {
-            // Focused item was scrolled out of view, remove the cell focus outline
-            if (isItemsRowGroupActive) {
-              this._focusedCell = null;
-            }
+          } else if (isItemsRowGroupActive) {
+            // If the focused item was scrolled out of view and focus is still inside body,
+            // remove the cell focus outline and hide navigation mode.
+            this._focusedCell = null;
 
-            // Hide navigation mode if focus is inside the body.
-            if (isItemsRowGroupActive && this.hasAttribute('navigating')) {
+            if (this.hasAttribute('navigating')) {
               this._navigatingIsHidden = true;
               this.toggleAttribute('navigating', false);
             }

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -936,10 +936,10 @@ export const KeyboardNavigationMixin = (superClass) =>
           const isFocusedItemRendered = this._getRenderedRows().some((row) => row.index === this._focusedItemIndex);
           if (isFocusedItemRendered) {
             // Ensure the correct element is focused, as the virtualizer
-            // may have rendered the item using a different element.
+            // may use different elements when re-rendering visible items.
             this.__updateItemsFocusable();
 
-            // if the focused item is visible, restore the cell focus outline
+            // The focused item is visible, so restore the cell focus outline
             // and navigation mode.
             if (isItemsRowGroupActive && !this.__rowFocusMode) {
               this._focusedCell = this._itemsFocusable;
@@ -950,8 +950,8 @@ export const KeyboardNavigationMixin = (superClass) =>
               this._navigatingIsHidden = false;
             }
           } else if (isItemsRowGroupActive) {
-            // If the focused item was scrolled out of view and focus is still inside body,
-            // remove the cell focus outline and hide navigation mode.
+            // The focused item was scrolled out of view and focus is still inside body,
+            // so remove the cell focus outline and hide navigation mode.
             this._focusedCell = null;
 
             if (this.hasAttribute('navigating')) {

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -3,7 +3,9 @@
  * Copyright (c) 2016 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { animationFrame } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 
@@ -920,26 +922,39 @@ export const KeyboardNavigationMixin = (superClass) =>
       focusTarget.tabIndex = isInteractingWithinActiveSection ? -1 : 0;
     }
 
-    /**
-     * @param {!HTMLTableRowElement} row
-     * @param {number} index
-     * @protected
-     */
-    _preventScrollerRotatingCellFocus(row, index) {
-      if (
-        row.index === this._focusedItemIndex &&
-        this.hasAttribute('navigating') &&
-        this._activeRowGroup === this.$.items
-      ) {
-        // Focused item has went, hide navigation mode
-        this._navigatingIsHidden = true;
-        this.toggleAttribute('navigating', false);
-      }
-      if (index === this._focusedItemIndex && this._navigatingIsHidden) {
-        // Focused item is back, restore navigation mode
-        this._navigatingIsHidden = false;
-        this.toggleAttribute('navigating', true);
-      }
+    /** @protected */
+    _preventScrollerRotatingCellFocus() {
+      this.__preventScrollerRotatingCellFocusDebouncer = Debouncer.debounce(
+        this.__preventScrollerRotatingCellFocusDebouncer,
+        animationFrame,
+        () => {
+          const isFocusedItemRendered = this._getRenderedRows().some((row) => row.index === this._focusedItemIndex);
+          if (isFocusedItemRendered) {
+            // Focused item was scrolled back to view, revert the focus outline
+            this.__updateItemsFocusable();
+
+            if (isElementFocused(this._itemsFocusable) && !this.__rowFocusMode) {
+              this._focusedCell = this._itemsFocusable;
+            }
+
+            if (this._navigatingIsHidden) {
+              // Focused item is back, restore navigation mode
+              this._navigatingIsHidden = false;
+              this.toggleAttribute('navigating', true);
+            }
+          } else {
+            // Focused item was scrolled out of view, remove the focus outline
+            if (isElementFocused(this._itemsFocusable)) {
+              this._focusedCell = null;
+            }
+
+            if (this.hasAttribute('navigating') && this._activeRowGroup) {
+              this._navigatingIsHidden = true;
+              this.toggleAttribute('navigating', false);
+            }
+          }
+        },
+      );
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -145,6 +145,10 @@ export const gridStyles = css`
     white-space: nowrap;
   }
 
+  [part~='cell'] {
+    outline: none;
+  }
+
   [part~='cell'] > [tabindex] {
     display: flex;
     align-items: inherit;

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -16,6 +16,7 @@ export const flushGrid = (grid) => {
   ].forEach((debouncer) => debouncer?.flush());
 
   grid.__virtualizer.flush();
+  grid.__preventScrollerRotatingCellFocusDebouncer?.flush();
   grid.performUpdate?.();
 };
 

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -1326,38 +1326,38 @@ describe('keyboard navigation', () => {
       });
 
       describe('rotating focus indicator prevention', () => {
-        it('should hide navigation mode when a focused row goes off screen', async () => {
+        it('should hide navigation mode when a focused row goes off screen', () => {
           focusItem(0);
           right();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
 
           grid.scrollToIndex(100);
-          await nextFrame();
+          flushGrid(grid);
 
           expect(grid.hasAttribute('navigating')).to.be.false;
         });
 
-        it('should reveal navigation mode when a focused row is back on screen', async () => {
+        it('should reveal navigation mode when a focused row is back on screen', () => {
           focusItem(0);
           right();
           grid.scrollToIndex(100);
-          await nextFrame();
+          flushGrid(grid);
 
           grid.scrollToIndex(0);
-          await nextFrame();
+          flushGrid(grid);
 
           expect(grid.hasAttribute('navigating')).to.be.true;
         });
 
-        it('should not hide navigation mode if a header cell is focused', async () => {
+        it('should not hide navigation mode if a header cell is focused', () => {
           tabToHeader();
           right();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
 
           grid.scrollToIndex(100);
-          await nextFrame();
+          flushGrid(grid);
 
           expect(grid.hasAttribute('navigating')).to.be.true;
         });
@@ -1601,56 +1601,53 @@ describe('keyboard navigation', () => {
       expect(cell.getAttribute('part')).to.not.contain('focused-cell');
     });
 
-    it('should keep the part when focused item is scrolled but still visible', async () => {
+    it('should keep the part when focused item is scrolled but still visible', () => {
       focusItem(5);
       grid.scrollToIndex(2);
-      await nextFrame();
+      flushGrid(grid);
       const cell = getPhysicalItems(grid)[5].firstChild;
       expect(cell.getAttribute('part')).to.contain('focused-cell');
     });
 
-    it('should remove the part when focused item is scrolled out of view', async () => {
+    it('should remove the part when focused item is scrolled out of view', () => {
       focusItem(5);
       grid.scrollToIndex(100);
-      await nextFrame();
+      flushGrid(grid);
       expect(grid.$.items.querySelector(':not([hidden]) [part~="focused-cell"')).to.be.null;
     });
 
-    it('should restore the part when focused item is scrolled back to view', async () => {
+    it('should restore the part when focused item is scrolled back to view', () => {
       focusItem(5);
       grid.scrollToIndex(100);
-      await nextFrame();
+      flushGrid(grid);
 
       // Simulate real scrolling to get the virtualizer to render
       // the focused item in a different element.
       grid.$.table.scrollTop = 0;
-      // Virtualizer scroll handler
-      await nextFrame();
-      // preventScrollerRotatingCellFocusDebouncer
-      await nextFrame();
+      flushGrid(grid);
 
       const cell = getPhysicalItems(grid)[5].firstChild;
       expect(cell.getAttribute('part')).to.contain('focused-cell');
     });
 
-    it('should not add the part to any element when focused item is scrolled back to view - row focus mode', async () => {
+    it('should not add the part to any element when focused item is scrolled back to view - row focus mode', () => {
       focusItem(5);
       left();
       grid.scrollToIndex(100);
-      await nextFrame();
+      flushGrid(grid);
       grid.scrollToIndex(0);
-      await nextFrame();
+      flushGrid(grid);
       expect(grid.$.items.querySelector(':not([hidden]) [part~="focused-cell"')).to.be.null;
     });
 
-    it('should not remove the part from header cell when scrolling items', async () => {
+    it('should not remove the part from header cell when scrolling items', () => {
       focusFirstHeaderCell();
       grid.scrollToIndex(100);
-      await nextFrame();
+      flushGrid(grid);
       expect(getFirstHeaderCell().getAttribute('part')).to.contain('focused-cell');
 
       grid.scrollToIndex(0);
-      await nextFrame();
+      flushGrid(grid);
       expect(getFirstHeaderCell().getAttribute('part')).to.contain('focused-cell');
     });
   });

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -1325,34 +1325,38 @@ describe('keyboard navigation', () => {
       });
 
       describe('rotating focus indicator prevention', () => {
-        it('should hide navigation mode when a focused row goes off screen', () => {
+        it('should hide navigation mode when a focused row goes off screen', async () => {
           focusItem(0);
           right();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
 
           grid.scrollToIndex(100);
+          await nextFrame();
 
           expect(grid.hasAttribute('navigating')).to.be.false;
         });
 
-        it('should reveal navigation mode when a focused row is back on screen', () => {
+        it('should reveal navigation mode when a focused row is back on screen', async () => {
           focusItem(0);
           right();
           grid.scrollToIndex(100);
+          await nextFrame();
 
           grid.scrollToIndex(0);
+          await nextFrame();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
         });
 
-        it('should not hide navigation mode if a header cell is focused', () => {
+        it('should not hide navigation mode if a header cell is focused', async () => {
           tabToHeader();
           right();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
 
           grid.scrollToIndex(100);
+          await nextFrame();
 
           expect(grid.hasAttribute('navigating')).to.be.true;
         });


### PR DESCRIPTION
## Description

Fixes the issue where the focus outline repeatedly appeared on random items as the user scrolled when the actual focused item was out of view. This specifically happened if the item was focused by the mouse and a custom CSS was applied to show the focus outline on clicks:

```css
vaadin-grid::part(focused-cell)::before {
  content: '';
  position: absolute;
  top: 0;
  right: 0;
  bottom: 0;
  left: 0;
  pointer-events: none;
  box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
}
```

Depends on 
- https://github.com/vaadin/web-components/pull/7977

Fixes https://github.com/vaadin/web-components/issues/7614

## Type of change

- [x] Bugfix
