### PR TITLE
fix: use item id provider when comparing selected items

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -151,7 +151,7 @@ export const GridSelectionColumnMixin = (superClass) =>
           if (!this._grid.selectedItems.length) {
             this.selectAll = false;
             this._indeterminate = false;
-          } else if (this._grid._areAllSelected(items)) {
+          } else if (items.every((item) => this._grid._isSelected(item))) {
             this.selectAll = true;
             this._indeterminate = false;
           } else {

--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -81,19 +81,6 @@ export const GridSelectionColumnMixin = (superClass) =>
     }
 
     /**
-     * Return true if array `left` contains all the items in `right`,
-     * using the `getItemId` method to compare items.
-     * We need this when sorting or to preserve selection after filtering.
-     * @private
-     */
-    __arrayContains(left, right) {
-      left ||= [];
-      right ||= [];
-      const leftIds = left.map((item) => this._grid.getItemId(item));
-      return (right || []).every((item) => leftIds.includes(this._grid.getItemId(item)));
-    }
-
-    /**
      * Override a method from `GridSelectionColumnBaseMixin` to handle the user
      * selecting all items.
      *
@@ -164,7 +151,7 @@ export const GridSelectionColumnMixin = (superClass) =>
           if (!this._grid.selectedItems.length) {
             this.selectAll = false;
             this._indeterminate = false;
-          } else if (this.__arrayContains(this._grid.selectedItems, items)) {
+          } else if (this._grid._areAllSelected(items)) {
             this.selectAll = true;
             this._indeterminate = false;
           } else {

--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -81,12 +81,16 @@ export const GridSelectionColumnMixin = (superClass) =>
     }
 
     /**
-     * Return true if array `a` contains all the items in `b`
+     * Return true if array `left` contains all the items in `right`,
+     * using the `getItemId` method to compare items.
      * We need this when sorting or to preserve selection after filtering.
      * @private
      */
-    __arrayContains(a, b) {
-      return Array.isArray(a) && Array.isArray(b) && b.every((i) => a.includes(i));
+    __arrayContains(left, right) {
+      left ||= [];
+      right ||= [];
+      const leftIds = left.map((item) => this._grid.getItemId(item));
+      return (right || []).every((item) => leftIds.includes(this._grid.getItemId(item)));
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -47,15 +47,6 @@ export const SelectionMixin = (superClass) =>
     }
 
     /**
-     * @param {!Array<!GridItem>} items
-     * @return {boolean}
-     * @protected
-     */
-    _areAllSelected(items) {
-      return items.every((item) => this.__selectedKeys.has(this.getItemId(item)));
-    }
-
-    /**
      * Selects the given item.
      *
      * @method selectItem

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -47,6 +47,15 @@ export const SelectionMixin = (superClass) =>
     }
 
     /**
+     * @param {!Array<!GridItem>} items
+     * @return {boolean}
+     * @protected
+     */
+    _areAllSelected(items) {
+      return items.every((item) => this.__selectedKeys.has(this.getItemId(item)));
+    }
+
+    /**
      * Selects the given item.
      *
      * @method selectItem

--- a/packages/grid/test/selection.common.js
+++ b/packages/grid/test/selection.common.js
@@ -388,6 +388,20 @@ describe('multi selection column', () => {
     expect(grid.items).not.to.eql(grid.selectedItems);
   });
 
+  it('should set selectAll to true when selecting all items', () => {
+    grid.selectedItems = ['foo', 'bar', 'baz'];
+
+    expect(selectionColumn.selectAll).to.be.true;
+  });
+
+  it('should set selectAll to true when selecting copies of all items', () => {
+    grid.items = [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }];
+    grid.itemIdPath = 'value';
+    grid.selectedItems = [{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }];
+
+    expect(selectionColumn.selectAll).to.be.true;
+  });
+
   it('should not set selection when data provider is used', () => {
     grid.items = undefined;
     grid.dataProvider = infiniteDataProvider;


### PR DESCRIPTION
Use `getItemId` when comparing items from `selectedItems` with items from the data provider, instead of comparing by reference.