### PR TITLE
fix: preserve large items when new items are added

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -728,6 +728,53 @@ export class IronListAdapter {
   }
 
   /**
+   * An optimal physical size such that we will have enough physical items
+   * to fill up the viewport and recycle when the user scrolls.
+   *
+   * This default value assumes that we will at least have the equivalent
+   * to a viewport of physical items above and below the user's viewport.
+   * @override
+   */
+  get _optPhysicalSize() {
+    const optPhysicalSize = super._optPhysicalSize;
+    // No need to adjust
+    if (optPhysicalSize <= 0 || this.__hasPlaceholders()) {
+      return optPhysicalSize;
+    }
+    // Item height buffer accounts for the cases where some items are much larger than the average.
+    // This can lead to some items not being rendered and leaving empty space in the viewport.
+    // https://github.com/vaadin/flow-components/issues/6651
+    return optPhysicalSize + this.__getItemHeightBuffer();
+  }
+
+  /**
+   * Extra item height buffer used when calculating optimal physical size.
+   *
+   * The iron list core uses the optimal physical size when determining whether to increase the item pool.
+   * For the cases where some items are much larger than the average, the iron list core might not increase item pool.
+   * This can lead to the large item not being rendered.
+   *
+   * @returns {Number} - Extra item height buffer
+   * @private
+   */
+  __getItemHeightBuffer() {
+    // No need for a buffer with no items
+    if (this._physicalCount > 0) {
+      return 0;
+    }
+    // The regular buffer zone height for either top or bottom
+    const bufferZoneHeight = Math.ceil((this._viewportHeight * (this._maxPages - 1)) / 2);
+    // The maximum height of the currently rendered items
+    const maxItemHeight = Math.max(...this._physicalSizes);
+    // Only add buffer if the item is larger that the other items
+    if (maxItemHeight > Math.min(...this._physicalSizes)) {
+      // Add a buffer height since the large item can still be in the viewport and out of the original buffer
+      return Math.max(0, maxItemHeight - bufferZoneHeight);
+    }
+    return 0;
+  }
+
+  /**
    * @returns {Number|undefined} - The browser's default font-size in pixels
    * @private
    */

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -759,7 +759,7 @@ export class IronListAdapter {
    */
   __getItemHeightBuffer() {
     // No need for a buffer with no items
-    if (this._physicalCount > 0) {
+    if (this._physicalCount === 0) {
       return 0;
     }
     // The regular buffer zone height for either top or bottom

--- a/packages/component-base/test/virtualizer-variable-row-height.test.js
+++ b/packages/component-base/test/virtualizer-variable-row-height.test.js
@@ -95,6 +95,19 @@ describe('virtualizer - variable row height - large variance', () => {
     }
   }
 
+  /**
+   * Sets a large size, and expands the first and the last items.
+   */
+  function initWithLargeSize() {
+    // This is kept separate because some tests need physical items
+    // to be initialized during the test.
+    virtualizer.size = 200000;
+    // Expand the first and the last item
+    expandedItems = [0, virtualizer.size - 1];
+    virtualizer.update();
+    virtualizer.scrollToIndex(0);
+  }
+
   beforeEach(() => {
     scrollTarget = fixtureSync(`
       <div style="height: 300px; width: 200px;">
@@ -128,16 +141,10 @@ describe('virtualizer - variable row height - large variance', () => {
     });
 
     sinon.spy(virtualizer.__adapter, '__fixInvalidItemPositioning');
-
-    virtualizer.size = 200000;
-
-    // Expand the first and the last item
-    expandedItems = [0, virtualizer.size - 1];
-    virtualizer.update();
-    virtualizer.scrollToIndex(0);
   });
 
   it('should reveal new items when scrolling downwards', async () => {
+    initWithLargeSize();
     const rect = scrollTarget.getBoundingClientRect();
 
     await scrollDownwardsFromStart();
@@ -155,6 +162,7 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should reveal new items when scrolling upwards', async () => {
+    initWithLargeSize();
     const rect = scrollTarget.getBoundingClientRect();
 
     await scrollToEnd();
@@ -173,6 +181,7 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should not update the item at last index', async () => {
+    initWithLargeSize();
     updateElement.resetHistory();
     await scrollDownwardsFromStart();
     await fixItemPositioningTimeout();
@@ -185,6 +194,7 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should not update the item at first index', async () => {
+    initWithLargeSize();
     await scrollToEnd();
     updateElement.resetHistory();
     await scrollUpwardsFromEnd();
@@ -197,6 +207,7 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should allow scrolling to end of a padded scroll target', async () => {
+    initWithLargeSize();
     scrollTarget.style.padding = '60px 0 ';
     scrollTarget.style.boxSizing = 'border-box';
 
@@ -208,6 +219,7 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should allow scrolling to start', async () => {
+    initWithLargeSize();
     // Expand every 10th item
     expandedItems = Array.from(Array(virtualizer.size).keys()).filter((index) => index % 10 === 0);
 
@@ -221,12 +233,14 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should not jam when when size is changed after fix', async () => {
+    initWithLargeSize();
     await scrollDownwardsFromStart();
     await fixItemPositioningTimeout();
     virtualizer.size = 1;
   });
 
   it('should not invoke when size is changed after scrolling', async () => {
+    initWithLargeSize();
     await scrollDownwardsFromStart();
     virtualizer.size = 0;
     await fixItemPositioningTimeout();
@@ -234,20 +248,6 @@ describe('virtualizer - variable row height - large variance', () => {
   });
 
   it('should preserve large item in viewport when new item is added', async () => {
-    // Not using the virtualizer defined above because setting size 1 after initializing with 20000 keeps multiple hidden physical items. This leads to a change in scrolling behaviour. If a new item is added and then scrolled to, it does not appear at the end but the start of the container.
-    const scrollContainer = scrollTarget.firstElementChild;
-    virtualizer = new Virtualizer({
-      createElements: (count) =>
-        Array.from(Array(count)).map(() => {
-          const el = document.createElement('div');
-          el.classList.add('item');
-          return el;
-        }),
-      updateElement,
-      scrollTarget,
-      scrollContainer,
-    });
-
     // Initially only have a large item
     virtualizer.size = 1;
     expandedItems = [0];

--- a/packages/component-base/test/virtualizer-variable-row-height.test.js
+++ b/packages/component-base/test/virtualizer-variable-row-height.test.js
@@ -232,6 +232,40 @@ describe('virtualizer - variable row height - large variance', () => {
     await fixItemPositioningTimeout();
     expect(virtualizer.__adapter.__fixInvalidItemPositioning.callCount).to.equal(0);
   });
+
+  it('should preserve large item in viewport when new item is added', async () => {
+    // Not using the virtualizer defined above because setting size 1 after initializing with 20000 keeps multiple hidden physical items. This leads to a change in scrolling behaviour. If a new item is added and then scrolled to, it does not appear at the end but the start of the container.
+    const scrollContainer = scrollTarget.firstElementChild;
+    virtualizer = new Virtualizer({
+      createElements: (count) =>
+        Array.from(Array(count)).map(() => {
+          const el = document.createElement('div');
+          el.classList.add('item');
+          return el;
+        }),
+      updateElement,
+      scrollTarget,
+      scrollContainer,
+    });
+
+    // Initially only have a large item
+    virtualizer.size = 1;
+    expandedItems = [0];
+    virtualizer.update();
+    await nextFrame();
+
+    // Calculated using the virtualizer height of 300px and regular item height of 30px
+    const requiredRegularItemCountToFillViewport = 10;
+
+    // Add items until the large item disappears
+    for (let i = 0; i < requiredRegularItemCountToFillViewport - 1; i++) {
+      // Add a new item and scroll to the end
+      virtualizer.size += 1;
+      virtualizer.scrollToIndex(Infinity);
+      await nextFrame();
+      expect(virtualizer.firstVisibleIndex).to.equal(0);
+    }
+  });
 });
 
 describe('virtualizer - variable row height - size changes', () => {


### PR DESCRIPTION
## Description

The iron list core uses the optimal physical size (`_optPhysicalSize`) when determining whether to increase the item pool. For the cases where some items are much larger than the average, the iron list core might not increase item pool. This can lead to the large item not being rendered.

This PR overrides the getter for `_optPhysicalSize` from iron list core and adds an item height buffer whenever necessary.

The calculation for the extra item buffer is based on the calculation of the regular buffer, which is `_viewportHeight * (_maxPages - 1)`. `_maxPages` is 1.3 in our case. So there is a buffer with a height of  `_viewportHeight * 0.15` each for top and bottom. If the item heights are varied, then the extra buffer of `maxItemHeight - _viewportHeight * 0.15` is added to the optimal physical size. This makes sure that there is always enough space so that the iron list creates more items in the pool.

`_optPhysicalSize` is private and only used when the virtualizer needs determine whether to add more items to the pool. Therefore this should not cause any changes in other calculations.

Note:
Playing with the value of `_maxPages` can hide the issue for certain combinations of `_viewportHeight` and `maxItemHeight`, however it will not completely fix it.

Fixes #7986 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.