### PR TITLE
fix: update form-layout when its parent becomes visible

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -275,11 +275,11 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
     this.__intersectionObserver = new IntersectionObserver(([entry]) => {
       if (!entry.isIntersecting) {
         // Prevent possible jump when layout becomes visible
-        this.style.opacity = 0;
+        this.$.layout.style.opacity = 0;
       }
       if (!this.__isVisible && entry.isIntersecting) {
         this._updateLayout();
-        this.style.opacity = '';
+        this.$.layout.style.opacity = '';
       }
       this.__isVisible = entry.isIntersecting;
     });

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -240,6 +240,11 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
       _labelsOnTop: {
         type: Boolean,
       },
+
+      /** @private */
+      __isVisible: {
+        type: Boolean,
+      },
     };
   }
 
@@ -264,6 +269,22 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
     this.addEventListener('animationend', this.__onAnimationEnd);
   }
 
+  constructor() {
+    super();
+
+    this.__intersectionObserver = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) {
+        // Prevent possible jump when layout becomes visible
+        this.style.opacity = 0;
+      }
+      if (!this.__isVisible && entry.isIntersecting) {
+        this._updateLayout();
+        this.style.opacity = '';
+      }
+      this.__isVisible = entry.isIntersecting;
+    });
+  }
+
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
@@ -272,6 +293,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
     requestAnimationFrame(() => this._updateLayout());
 
     this._observeChildrenColspanChange();
+    this.__intersectionObserver.observe(this);
   }
 
   /** @protected */
@@ -280,6 +302,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
 
     this.__mutationObserver.disconnect();
     this.__childObserver.disconnect();
+    this.__intersectionObserver.disconnect();
   }
 
   /** @private */

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -568,7 +568,7 @@ describe('form layout', () => {
       // Wait for intersection observer
       await nextFrame();
       await nextFrame();
-      expect(getComputedStyle(layout).opacity).to.equal('0');
+      expect(getComputedStyle(layout.$.layout).opacity).to.equal('0');
 
       container.hidden = false;
 
@@ -576,7 +576,7 @@ describe('form layout', () => {
       await nextFrame();
       await nextFrame();
 
-      expect(getComputedStyle(layout).opacity).to.equal('1');
+      expect(getComputedStyle(layout.$.layout).opacity).to.equal('1');
     });
   });
 

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '@vaadin/text-field/vaadin-text-field.js';
@@ -519,7 +519,10 @@ describe('form layout', () => {
     beforeEach(() => {
       container = fixtureSync(`
         <div hidden>
-          <vaadin-form-layout></vaadin-form-layout>
+          <vaadin-form-layout>
+            <div>Foo</div>
+            <div>Bar</div>
+          </vaadin-form-layout>
         </div>
       `);
       layout = container.querySelector('vaadin-form-layout');
@@ -545,6 +548,35 @@ describe('form layout', () => {
       const ev = new Event('animationend');
       ev.animationName = 'foo';
       layout.dispatchEvent(ev);
+    });
+
+    it('should update layout when its parent becomes visible', async () => {
+      layout.responsiveSteps = [{ columns: 1 }];
+      await nextRender();
+
+      container.hidden = false;
+
+      // Wait for intersection observer
+      await nextFrame();
+      await nextFrame();
+
+      expect(parseFloat(getParsedWidth(layout.children[0]).percentage)).to.be.closeTo(100, 0.1);
+      expect(parseFloat(getParsedWidth(layout.children[1]).percentage)).to.be.closeTo(100, 0.1);
+    });
+
+    it('should change layout opacity when its parent becomes visible', async () => {
+      // Wait for intersection observer
+      await nextFrame();
+      await nextFrame();
+      expect(getComputedStyle(layout).opacity).to.equal('0');
+
+      container.hidden = false;
+
+      // Wait for intersection observer
+      await nextFrame();
+      await nextFrame();
+
+      expect(getComputedStyle(layout).opacity).to.equal('1');
     });
   });
 

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -568,7 +568,7 @@ describe('form layout', () => {
       // Wait for intersection observer
       await nextFrame();
       await nextFrame();
-      expect(getComputedStyle(layout.$.layout).opacity).to.equal('0');
+      expect(layout.$.layout.style.opacity).to.equal('0');
 
       container.hidden = false;
 
@@ -576,7 +576,7 @@ describe('form layout', () => {
       await nextFrame();
       await nextFrame();
 
-      expect(getComputedStyle(layout.$.layout).opacity).to.equal('1');
+      expect(layout.$.layout.style.opacity).to.equal('');
     });
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6728

This is a fix for regression from #7792: as we no longer update layout when it's hidden, let's add `IntersectionObserver` to check the case when it becomes visible (e.g. by `hidden` attribute removed from the parent element).

## Type of change

- Bugfix

## Note

Can be tested with the following example:

```html
<div hidden>
  <vaadin-form-layout>
    <div>Foo</div>
    <div>Bar</div>
  </vaadin-form-layout>
</div>

<script type="module">
  import '@vaadin/form-layout';

  document.querySelector('vaadin-form-layout').responsiveSteps = [{ columns: 1 }];

  requestAnimationFrame(() => {
    document.querySelector('div').removeAttribute('hidden');
  });
</script>
```