### PR TITLE
refactor: simplify focus logic in Tab keydown handler

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -712,7 +712,7 @@ export const KeyboardNavigationMixin = (superClass) =>
 
     /** @private */
     _onTabKeyDown(e) {
-      const focusTarget = this._predictFocusStepTarget(e.composedPath()[0], e.shiftKey ? -1 : 1);
+      let focusTarget = this._predictFocusStepTarget(e.composedPath()[0], e.shiftKey ? -1 : 1);
 
       // Can be undefined if grid has tabindex
       if (!focusTarget) {
@@ -722,24 +722,24 @@ export const KeyboardNavigationMixin = (superClass) =>
       // Prevent focus-trap logic from intercepting the event.
       e.stopPropagation();
 
-      if (focusTarget === this.$.table) {
-        // The focus is about to exit the grid to the top.
-        this.$.table.focus();
-      } else if (focusTarget === this.$.focusexit) {
-        // The focus is about to exit the grid to the bottom.
-        this.$.focusexit.focus();
-      } else if (focusTarget === this._itemsFocusable) {
+      if (focusTarget === this._itemsFocusable) {
         this.__ensureFlatIndexInViewport(this._focusedItemIndex);
 
         // Ensure the correct element is set as focusable after scrolling.
         // The virtualizer may use a different element to render the item.
         this.__updateItemsFocusable();
 
+        focusTarget = this._itemsFocusable;
+      }
+
+      focusTarget.focus();
+
+      // If the next element is the table or focusexit, it indicates the user
+      // intends to leave the grid. In this case, we move focus to these elements
+      // without preventing the default Tab behavior. The default behavior then
+      // starts from these elements and moves focus outside the grid.
+      if (focusTarget !== this.$.table && focusTarget !== this.$.focusexit) {
         e.preventDefault();
-        this._itemsFocusable.focus();
-      } else {
-        e.preventDefault();
-        focusTarget.focus();
       }
 
       this.toggleAttribute('navigating', true);

--- a/packages/grid/test/keyboard-navigation-row-focus.common.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.common.js
@@ -8,7 +8,7 @@ import {
   nextRender,
   up as mouseUp,
 } from '@vaadin/testing-helpers';
-import { flushGrid, getCellContent, getFocusedCellIndex, getFocusedRowIndex, infiniteDataProvider } from './helpers.js';
+import { flushGrid, getCellContent, getFocusedCellIndex, getFocusedRowIndex } from './helpers.js';
 
 let grid, header, footer, body;
 
@@ -85,10 +85,6 @@ function focusFirstHeaderCell() {
 
 function tabToBody() {
   grid._itemsFocusable.focus();
-}
-
-function tabToHeader() {
-  grid._headerFocusable.focus();
 }
 
 function shiftTabToFooter() {
@@ -413,32 +409,6 @@ describe('keyboard navigation - row focus', () => {
       shiftTabToFooter();
 
       expect(grid.shadowRoot.activeElement).to.equal(footer.children[0]);
-    });
-  });
-
-  describe('scrolling and navigating', () => {
-    beforeEach(() => {
-      grid.items = undefined;
-      grid.size = 200;
-      grid.dataProvider = infiniteDataProvider;
-      flushGrid(grid);
-    });
-
-    it('should scroll focused row into view on arrow key', () => {
-      tabToBody();
-      grid.scrollToIndex(100);
-      flushGrid(grid);
-      down();
-      expect(getFocusedRowIndex()).to.equal(1);
-    });
-
-    it('should scroll focused row into view on Tab', () => {
-      tabToBody();
-      tabToHeader();
-      grid.scrollToIndex(100);
-      flushGrid(grid);
-      tab();
-      expect(getFocusedRowIndex()).to.equal(0);
     });
   });
 });

--- a/packages/grid/test/keyboard-navigation-row-focus.common.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.common.js
@@ -8,7 +8,7 @@ import {
   nextRender,
   up as mouseUp,
 } from '@vaadin/testing-helpers';
-import { flushGrid, getCellContent, getFocusedCellIndex, getFocusedRowIndex } from './helpers.js';
+import { flushGrid, getCellContent, getFocusedCellIndex, getFocusedRowIndex, infiniteDataProvider } from './helpers.js';
 
 let grid, header, footer, body;
 
@@ -85,6 +85,10 @@ function focusFirstHeaderCell() {
 
 function tabToBody() {
   grid._itemsFocusable.focus();
+}
+
+function tabToHeader() {
+  grid._headerFocusable.focus();
 }
 
 function shiftTabToFooter() {
@@ -409,6 +413,32 @@ describe('keyboard navigation - row focus', () => {
       shiftTabToFooter();
 
       expect(grid.shadowRoot.activeElement).to.equal(footer.children[0]);
+    });
+  });
+
+  describe('scrolling and navigating', () => {
+    beforeEach(() => {
+      grid.items = undefined;
+      grid.size = 200;
+      grid.dataProvider = infiniteDataProvider;
+      flushGrid(grid);
+    });
+
+    it('should scroll focused row into view on arrow key', () => {
+      tabToBody();
+      grid.scrollToIndex(100);
+      flushGrid(grid);
+      down();
+      expect(getFocusedRowIndex()).to.equal(1);
+    });
+
+    it('should scroll focused row into view on Tab', () => {
+      tabToBody();
+      tabToHeader();
+      grid.scrollToIndex(100);
+      flushGrid(grid);
+      tab();
+      expect(getFocusedRowIndex()).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Description

Refactor of the `_onTabKeyDown` handler in `KeyboardNavigationMixin`. 

Summary:

- Removed unnecessary conditional branches
- Explained why `preventDefault` isn't called when the next element is `this.$.table` or `this.$.focusexit`

## Type of change

- [x] Refactor
