### PR TITLE
chore: add support for specifying test files glob

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 require('dotenv').config();
 const fs = require('fs');
+const argv = require('minimist')(process.argv.slice(2));
 const path = require('path');
 const glob = require('glob');
 const { execSync } = require('child_process');
@@ -137,10 +138,8 @@ const getSnapshotTestGroups = (packages) => {
  */
 const getUnitTestGroups = (packages) => {
   return packages.map((pkg) => {
-    return {
-      name: pkg,
-      files: `packages/${pkg}/test/*.test.{js,ts}`,
-    };
+    const filesGlob = argv.glob || '*';
+    return { name: pkg, files: `packages/${pkg}/test/${filesGlob}.test.{js,ts}` };
   });
 };
 


### PR DESCRIPTION
## Description

Added support for running individual unit test files using `--glob` argument. Can be used e.g. like this:

- Only run Lit tests: `yarn test --group combo-box --glob="*-lit"`
- Only run Polymer tests: `yarn test --group combo-box --glob="*-polymer"`
- Only run validation tests: `yarn test --group combo-box --glob="validation-*"`

## Type of change

- Internal change