### PR TITLE
fix: scroll to correct focused row on keyboard navigation

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -508,7 +508,7 @@ export const InlineEditingMixin = (superClass) =>
       if (!this.singleCellEdit && nextCell !== cell) {
         this._startEdit(nextCell, nextColumn);
       } else {
-        this._ensureScrolledToIndex(nextIndex);
+        this.__ensureFlatIndexInViewport(nextIndex);
         nextCell.focus();
       }
     }

--- a/packages/grid/test/keyboard-navigation-row-focus.common.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.common.js
@@ -101,7 +101,7 @@ function getTabbableRows(root) {
 
 function hierarchicalDataProvider({ parentItem }, callback) {
   // Let's use a count lower than pageSize so we can ignore page + pageSize for now
-  const itemsOnEachLevel = 5;
+  const itemsOnEachLevel = 100;
 
   const items = [...Array(itemsOnEachLevel)].map((_, i) => {
     return {
@@ -143,6 +143,39 @@ describe('keyboard navigation - row focus', () => {
     left();
 
     await nextRender(grid);
+  });
+
+  describe('scrolling and navigating', () => {
+    it('should scroll focused nested row into view on arrow key', () => {
+      focusItem(0);
+      // Expand first row
+      right();
+      // Focus first nested row
+      down();
+      // Simulate real scrolling to get the virtualizer to render
+      // the focused item in a different element.
+      grid.$.table.scrollTop = grid.$.table.scrollHeight / 2;
+      flushGrid(grid);
+      down();
+      expect(getFocusedRowIndex(grid)).to.equal(2);
+    });
+
+    it('should scroll focused nested row into view on Tab', () => {
+      focusItem(0);
+      // Expand first row
+      right();
+      // Focus first nested row
+      down();
+      // Move focus to header
+      shiftTab();
+      // Simulate real scrolling to get the virtualizer to render
+      // the focused item in a different element.
+      grid.$.table.scrollTop = grid.$.table.scrollHeight / 2;
+      flushGrid(grid);
+      // Move focus back to items
+      tab();
+      expect(getFocusedRowIndex(grid)).to.equal(1);
+    });
   });
 
   describe('navigating with tab', () => {
@@ -339,7 +372,7 @@ describe('keyboard navigation - row focus', () => {
 
         end();
 
-        expect(getFocusedRowIndex(grid)).to.equal(4);
+        expect(getFocusedRowIndex(grid)).to.equal(99);
       });
     });
   });

--- a/packages/grid/test/keyboard-navigation.common.js
+++ b/packages/grid/test/keyboard-navigation.common.js
@@ -1305,43 +1305,73 @@ describe('keyboard navigation', () => {
         up();
         expect(grid.$.table.scrollTop).to.equal(scrollTop);
       });
+    });
 
-      describe('rotating focus indicator prevention', () => {
-        it('should hide navigation mode when a focused row goes off screen', () => {
-          focusItem(0);
-          right();
+    describe('scrolling and navigating', () => {
+      beforeEach(() => {
+        grid.items = undefined;
+        grid.size = 200;
+        grid.dataProvider = infiniteDataProvider;
+        flushGrid(grid);
+      });
 
-          expect(grid.hasAttribute('navigating')).to.be.true;
+      it('should hide navigation mode when a focused row goes off screen', () => {
+        focusItem(0);
+        right();
 
-          grid.scrollToIndex(100);
-          flushGrid(grid);
+        expect(grid.hasAttribute('navigating')).to.be.true;
 
-          expect(grid.hasAttribute('navigating')).to.be.false;
-        });
+        grid.scrollToIndex(100);
+        flushGrid(grid);
 
-        it('should reveal navigation mode when a focused row is back on screen', () => {
-          focusItem(0);
-          right();
-          grid.scrollToIndex(100);
-          flushGrid(grid);
+        expect(grid.hasAttribute('navigating')).to.be.false;
+      });
 
-          grid.scrollToIndex(0);
-          flushGrid(grid);
+      it('should reveal navigation mode when a focused row is back on screen', () => {
+        focusItem(0);
+        right();
+        grid.scrollToIndex(100);
+        flushGrid(grid);
 
-          expect(grid.hasAttribute('navigating')).to.be.true;
-        });
+        grid.scrollToIndex(0);
+        flushGrid(grid);
 
-        it('should not hide navigation mode if a header cell is focused', () => {
-          tabToHeader();
-          right();
+        expect(grid.hasAttribute('navigating')).to.be.true;
+      });
 
-          expect(grid.hasAttribute('navigating')).to.be.true;
+      it('should not hide navigation mode if a header cell is focused', () => {
+        tabToHeader();
+        right();
 
-          grid.scrollToIndex(100);
-          flushGrid(grid);
+        expect(grid.hasAttribute('navigating')).to.be.true;
 
-          expect(grid.hasAttribute('navigating')).to.be.true;
-        });
+        grid.scrollToIndex(100);
+        flushGrid(grid);
+
+        expect(grid.hasAttribute('navigating')).to.be.true;
+      });
+
+      it('should scroll focused row into view on arrow key', () => {
+        focusItem(0);
+        // Simulate real scrolling to get the virtualizer to render
+        // the focused item in a different element.
+        grid.$.table.scrollTop = grid.$.table.scrollHeight / 2;
+        flushGrid(grid);
+        down();
+        expect(getFocusedRowIndex(grid)).to.equal(1);
+        expect(getFocusedCellIndex(grid)).to.equal(0);
+      });
+
+      it('should scroll focused row into view on Tab', () => {
+        focusItem(0);
+        tabToHeader();
+        // Simulate real scrolling to get the virtualizer to render
+        // the focused item in a different element.
+        grid.$.table.scrollTop = grid.$.table.scrollHeight / 2;
+        flushGrid(grid);
+        tab();
+        expect(getFocusedRowIndex(grid)).to.equal(0);
+        expect(getFocusedCellIndex(grid)).to.equal(0);
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes the regression where the grid could scroll to and focus the wrong item on keyboard navigation when some items were expanded.

Fixes #7991

## Type of change

- [x] Bugfix
