### PR TITLE
fix: prevent possible errors when inputs property is not set

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -172,7 +172,7 @@ export const CustomFieldMixin = (superClass) =>
      */
     _shouldRemoveFocus(event) {
       const { relatedTarget } = event;
-      return !this.inputs.some((el) => relatedTarget === (el.focusElement || el));
+      return this.inputs && !this.inputs.some((el) => relatedTarget === (el.focusElement || el));
     }
 
     /**
@@ -181,9 +181,10 @@ export const CustomFieldMixin = (superClass) =>
      * @return {boolean}
      */
     checkValidity() {
-      const invalidFields = this.inputs.filter((input) => !(input.validate || input.checkValidity).call(input));
+      const hasInvalidFields =
+        this.inputs && this.inputs.some((input) => !(input.validate || input.checkValidity).call(input));
 
-      if (invalidFields.length || (this.required && !(this.value && this.value.trim()))) {
+      if (hasInvalidFields || (this.required && !(this.value && this.value.trim()))) {
         // Either 1. one of the input fields is invalid or
         // 2. the custom field itself is required but doesn't have a value
         return false;
@@ -213,9 +214,10 @@ export const CustomFieldMixin = (superClass) =>
      */
     _onKeyDown(e) {
       if (e.key === 'Tab') {
+        const inputs = this.inputs || [];
         if (
-          (this.inputs.indexOf(e.target) < this.inputs.length - 1 && !e.shiftKey) ||
-          (this.inputs.indexOf(e.target) > 0 && e.shiftKey)
+          (inputs.indexOf(e.target) < inputs.length - 1 && !e.shiftKey) ||
+          (inputs.indexOf(e.target) > 0 && e.shiftKey)
         ) {
           this.dispatchEvent(new CustomEvent('internal-tab'));
         } else {

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -172,7 +172,7 @@ export const CustomFieldMixin = (superClass) =>
      */
     _shouldRemoveFocus(event) {
       const { relatedTarget } = event;
-      return this.inputs && !this.inputs.some((el) => relatedTarget === (el.focusElement || el));
+      return !this.inputs || !this.inputs.some((el) => relatedTarget === (el.focusElement || el));
     }
 
     /**

--- a/packages/custom-field/test/validation.common.js
+++ b/packages/custom-field/test/validation.common.js
@@ -62,6 +62,12 @@ describe('validation', () => {
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
     });
+
+    it('should not throw when checkValidity() called without inputs', () => {
+      expect(() => {
+        document.createElement('vaadin-custom-field').checkValidity();
+      }).to.not.throw(Error);
+    });
   });
 
   describe('required', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6739

Updated `checkValidity()` method to check that `this.inputs` and `this.value` are defined before accessing them.

## Type of change

- Bugfix