### PR TITLE
fix: use non timezone-aware date APIs in date time picker

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -39,8 +39,8 @@ export function getISOWeekNumber(date) {
 /**
  * Creates a new object with the same date, but sets the hours, minutes, seconds and milliseconds to 0.
  *
- * @param {Date} date
- * @return {Date} The same date time elements set to 0.
+ * @param {Date} date in system timezone
+ * @return {Date} The same date with time elements set to 0, in UTC timezone.
  */
 export function normalizeDate(date) {
   const normalizedDate = new Date(date);
@@ -49,16 +49,28 @@ export function normalizeDate(date) {
 }
 
 /**
+ * Creates a new object with the same date, but sets the hours, minutes, seconds and milliseconds to 0.
+ *
+ * Uses UTC date components to allow handling date instances independently of
+ * the system time-zone.
+ *
+ * @param {Date} date in UTC timezone
+ * @return {Date} The same date with time elements set to 0, in UTC timezone.
+ */
+export function normalizeUTCDate(date) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, 0));
+}
+
+/**
  * Check if two dates are equal.
  *
  * @param {Date} date1
  * @param {Date} date2
+ * @param {function(Date): Date} normalizer
  * @return {boolean} True if the given date objects refer to the same date
  */
-export function dateEquals(date1, date2) {
-  return (
-    date1 instanceof Date && date2 instanceof Date && normalizeDate(date1).getTime() === normalizeDate(date2).getTime()
-  );
+export function dateEquals(date1, date2, normalizer = normalizeDate) {
+  return date1 instanceof Date && date2 instanceof Date && normalizer(date1).getTime() === normalizer(date2).getTime();
 }
 
 /**
@@ -164,7 +176,7 @@ export function getAdjustedYear(referenceDate, year, month = 0, day = 1) {
  * - ISO 8601 `"YYYY-MM-DD"`
  * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
  * @param {!string} str Date string to parse
- * @return {Date} Parsed date
+ * @return {Date} Parsed date in system timezone
  */
 export function parseDate(str) {
   // Parsing with RegExp to ensure correct format
@@ -178,4 +190,100 @@ export function parseDate(str) {
   date.setMonth(parseInt(parts[2], 10) - 1);
   date.setDate(parseInt(parts[3], 10));
   return date;
+}
+
+/**
+ * Parse date string of one of the following date formats:
+ * - ISO 8601 `"YYYY-MM-DD"`
+ * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
+ *
+ * Uses UTC date components to allow handling date instances independently of
+ * the system time-zone.
+ *
+ * @param {!string} str Date string to parse
+ * @return {Date} Parsed date in UTC timezone
+ */
+export function parseUTCDate(str) {
+  // Parsing with RegExp to ensure correct format
+  const parts = /^([-+]\d{1}|\d{2,4}|[-+]\d{6})-(\d{1,2})-(\d{1,2})$/u.exec(str);
+  if (!parts) {
+    return undefined;
+  }
+
+  const date = new Date();
+  date.setUTCFullYear(parseInt(parts[1], 10));
+  date.setUTCMonth(parseInt(parts[2], 10) - 1);
+  date.setUTCDate(parseInt(parts[3], 10));
+  date.setUTCHours(0);
+  date.setUTCMinutes(0);
+  date.setUTCSeconds(0);
+  date.setUTCMilliseconds(0);
+
+  return date;
+}
+
+/**
+ * Format a date instance in ISO 8601 (`"YYYY-MM-DD"`) or 6-digit extended ISO
+ * 8601 (`"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`) format.
+ * @param {Date} date in system timezone
+ * @returns {string}
+ */
+export function formatISODate(date) {
+  if (!(date instanceof Date)) {
+    return '';
+  }
+
+  const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
+
+  let yearSign = '';
+  let yearFmt = '0000';
+  let yearAbs = date.getFullYear();
+  if (yearAbs < 0) {
+    yearAbs = -yearAbs;
+    yearSign = '-';
+    yearFmt = '000000';
+  } else if (date.getFullYear() >= 10000) {
+    yearSign = '+';
+    yearFmt = '000000';
+  }
+
+  const year = yearSign + pad(yearAbs, yearFmt);
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  return [year, month, day].join('-');
+}
+
+/**
+ * Format a date instance in ISO 8601 (`"YYYY-MM-DD"`) or 6-digit extended ISO
+ * 8601 (`"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`) format.
+ *
+ * Uses UTC date components to allow handling date instances independently of
+ * the system time-zone.
+ *
+ * @param {Date} date in UTC timezone
+ * @returns {string}
+ */
+export function formatUTCISODate(date) {
+  if (!(date instanceof Date)) {
+    return '';
+  }
+
+  const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
+
+  let yearSign = '';
+  let yearFmt = '0000';
+  let yearAbs = date.getUTCFullYear();
+  if (yearAbs < 0) {
+    yearAbs = -yearAbs;
+    yearSign = '-';
+    yearFmt = '000000';
+  } else if (date.getUTCFullYear() >= 10000) {
+    yearSign = '+';
+    yearFmt = '000000';
+  }
+
+  const year = yearSign + pad(yearAbs, yearFmt);
+  const month = pad(date.getUTCMonth() + 1);
+  const day = pad(date.getUTCDate());
+  return [year, month, day].join('-');
 }

--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -210,16 +210,33 @@ export function parseUTCDate(str) {
     return undefined;
   }
 
-  const date = new Date();
+  const date = new Date(Date.UTC(0, 0)); // Wrong date (1900-01-01), but with midnight in UTC
   date.setUTCFullYear(parseInt(parts[1], 10));
   date.setUTCMonth(parseInt(parts[2], 10) - 1);
   date.setUTCDate(parseInt(parts[3], 10));
-  date.setUTCHours(0);
-  date.setUTCMinutes(0);
-  date.setUTCSeconds(0);
-  date.setUTCMilliseconds(0);
 
   return date;
+}
+
+function formatISODateBase(dateParts) {
+  const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
+
+  let yearSign = '';
+  let yearFmt = '0000';
+  let yearAbs = dateParts.year;
+  if (yearAbs < 0) {
+    yearAbs = -yearAbs;
+    yearSign = '-';
+    yearFmt = '000000';
+  } else if (dateParts.year >= 10000) {
+    yearSign = '+';
+    yearFmt = '000000';
+  }
+
+  const year = yearSign + pad(yearAbs, yearFmt);
+  const month = pad(dateParts.month + 1);
+  const day = pad(dateParts.day);
+  return [year, month, day].join('-');
 }
 
 /**
@@ -233,24 +250,11 @@ export function formatISODate(date) {
     return '';
   }
 
-  const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
-
-  let yearSign = '';
-  let yearFmt = '0000';
-  let yearAbs = date.getFullYear();
-  if (yearAbs < 0) {
-    yearAbs = -yearAbs;
-    yearSign = '-';
-    yearFmt = '000000';
-  } else if (date.getFullYear() >= 10000) {
-    yearSign = '+';
-    yearFmt = '000000';
-  }
-
-  const year = yearSign + pad(yearAbs, yearFmt);
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
-  return [year, month, day].join('-');
+  return formatISODateBase({
+    year: date.getFullYear(),
+    month: date.getMonth(),
+    day: date.getDate(),
+  });
 }
 
 /**
@@ -268,22 +272,9 @@ export function formatUTCISODate(date) {
     return '';
   }
 
-  const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
-
-  let yearSign = '';
-  let yearFmt = '0000';
-  let yearAbs = date.getUTCFullYear();
-  if (yearAbs < 0) {
-    yearAbs = -yearAbs;
-    yearSign = '-';
-    yearFmt = '000000';
-  } else if (date.getUTCFullYear() >= 10000) {
-    yearSign = '+';
-    yearFmt = '000000';
-  }
-
-  const year = yearSign + pad(yearAbs, yearFmt);
-  const month = pad(date.getUTCMonth() + 1);
-  const day = pad(date.getUTCDate());
-  return [year, month, day].join('-');
+  return formatISODateBase({
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth(),
+    day: date.getUTCDate(),
+  });
 }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -17,6 +17,7 @@ import {
   dateAllowed,
   dateEquals,
   extractDateParts,
+  formatISODate,
   getAdjustedYear,
   getClosestDate,
   parseDate,
@@ -772,28 +773,7 @@ export const DatePickerMixin = (subclass) =>
 
     /** @private */
     _formatISO(date) {
-      if (!(date instanceof Date)) {
-        return '';
-      }
-
-      const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
-
-      let yearSign = '';
-      let yearFmt = '0000';
-      let yearAbs = date.getFullYear();
-      if (yearAbs < 0) {
-        yearAbs = -yearAbs;
-        yearSign = '-';
-        yearFmt = '000000';
-      } else if (date.getFullYear() >= 10000) {
-        yearSign = '+';
-        yearFmt = '000000';
-      }
-
-      const year = yearSign + pad(yearAbs, yearFmt);
-      const month = pad(date.getMonth() + 1);
-      const day = pad(date.getDate());
-      return [year, month, day].join('-');
+      return formatISODate(date);
     }
 
     /** @protected */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -11,7 +11,12 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
-import { dateEquals, parseDate } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
+import {
+  dateEquals,
+  formatUTCISODate,
+  normalizeUTCDate,
+  parseUTCDate,
+} from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
@@ -621,16 +626,16 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   __updateTimePickerMinMax() {
     if (this.__timePicker && this.__datePicker) {
       const selectedDate = this.__parseDate(this.__datePicker.value);
-      const isMinMaxSameDay = dateEquals(this.__minDateTime, this.__maxDateTime);
+      const isMinMaxSameDay = dateEquals(this.__minDateTime, this.__maxDateTime, normalizeUTCDate);
       const oldTimeValue = this.__timePicker.value;
 
-      if ((this.__minDateTime && dateEquals(selectedDate, this.__minDateTime)) || isMinMaxSameDay) {
+      if ((this.__minDateTime && dateEquals(selectedDate, this.__minDateTime, normalizeUTCDate)) || isMinMaxSameDay) {
         this.__timePicker.min = this.__dateToIsoTimeString(this.__minDateTime);
       } else {
         this.__timePicker.min = this.__defaultTimeMinValue;
       }
 
-      if ((this.__maxDateTime && dateEquals(selectedDate, this.__maxDateTime)) || isMinMaxSameDay) {
+      if ((this.__maxDateTime && dateEquals(selectedDate, this.__maxDateTime, normalizeUTCDate)) || isMinMaxSameDay) {
         this.__timePicker.max = this.__dateToIsoTimeString(this.__maxDateTime);
       } else {
         this.__timePicker.max = this.__defaultTimeMaxValue;
@@ -756,7 +761,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
    * @private
    */
   __parseDate(str) {
-    return parseDate(str);
+    return parseUTCDate(str);
   }
 
   /**
@@ -770,7 +775,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     if (!date) {
       return defaultValue;
     }
-    return DatePicker.prototype._formatISO(date);
+    return formatUTCISODate(date);
   }
 
   /**
@@ -817,10 +822,10 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       return;
     }
 
-    date.setHours(parseInt(time.hours));
-    date.setMinutes(parseInt(time.minutes || 0));
-    date.setSeconds(parseInt(time.seconds || 0));
-    date.setMilliseconds(parseInt(time.milliseconds || 0));
+    date.setUTCHours(parseInt(time.hours));
+    date.setUTCMinutes(parseInt(time.minutes || 0));
+    date.setUTCSeconds(parseInt(time.seconds || 0));
+    date.setUTCMilliseconds(parseInt(time.milliseconds || 0));
 
     return date;
   }
@@ -850,10 +855,10 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   __dateToIsoTimeString(date) {
     return this.__formatTimeISO(
       this.__validateTime({
-        hours: date.getHours(),
-        minutes: date.getMinutes(),
-        seconds: date.getSeconds(),
-        milliseconds: date.getMilliseconds(),
+        hours: date.getUTCHours(),
+        minutes: date.getUTCMinutes(),
+        seconds: date.getUTCSeconds(),
+        milliseconds: date.getUTCMilliseconds(),
       }),
     );
   }
@@ -910,14 +915,14 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
    * @private
    */
   __dateTimeEquals(date1, date2) {
-    if (!dateEquals(date1, date2)) {
+    if (!dateEquals(date1, date2, normalizeUTCDate)) {
       return false;
     }
     return (
-      date1.getHours() === date2.getHours() &&
-      date1.getMinutes() === date2.getMinutes() &&
-      date1.getSeconds() === date2.getSeconds() &&
-      date1.getMilliseconds() === date2.getMilliseconds()
+      date1.getUTCHours() === date2.getUTCHours() &&
+      date1.getUTCMinutes() === date2.getUTCMinutes() &&
+      date1.getUTCSeconds() === date2.getUTCSeconds() &&
+      date1.getUTCMilliseconds() === date2.getUTCMilliseconds()
     );
   }
 

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -302,17 +302,17 @@ describe('Basic features', () => {
 
   describe('value property formats', () => {
     it('should accept ISO format', () => {
-      const date = new Date(0, 1, 3, 8, 30, 0);
+      const date = new Date(Date.UTC(0, 1, 3, 8, 30, 0));
 
-      date.setFullYear(0);
+      date.setUTCFullYear(0);
       dateTimePicker.value = '0000-02-03T08:30:00';
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
 
-      date.setFullYear(10000);
+      date.setUTCFullYear(10000);
       dateTimePicker.value = '+010000-02-03T08:30:00';
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
 
-      date.setFullYear(-10000);
+      date.setUTCFullYear(-10000);
       dateTimePicker.value = '-010000-02-03T08:30:00';
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
     });
@@ -334,9 +334,9 @@ describe('Basic features', () => {
     });
 
     it('should output ISO format', () => {
-      const date = new Date(0, 1, 3, 8, 30, 0);
+      const date = new Date(Date.UTC(0, 1, 3, 8, 30, 0));
 
-      date.setFullYear(0);
+      date.setUTCFullYear(0);
       dateTimePicker.__selectedDateTime = date;
       expect(dateTimePicker.value).to.equal('0000-02-03T08:30');
 
@@ -354,7 +354,7 @@ describe('Basic features', () => {
       dateTimePicker.__selectedDateTime = date;
       expect(dateTimePicker.value).to.equal('0000-02-03T08:30:00.000');
 
-      date.setFullYear(10000);
+      date.setUTCFullYear(10000);
       dateTimePicker.step = undefined;
       dateTimePicker.__selectedDateTime = new Date(date.getTime());
       expect(dateTimePicker.value).to.equal('+010000-02-03T08:30');
@@ -363,7 +363,7 @@ describe('Basic features', () => {
       dateTimePicker.step = 0.001;
       expect(dateTimePicker.value).to.equal('+010000-02-03T08:30:00.000');
 
-      date.setFullYear(-10000);
+      date.setUTCFullYear(-10000);
       dateTimePicker.step = undefined;
       dateTimePicker.__selectedDateTime = new Date(date.getTime());
       expect(dateTimePicker.value).to.equal('-010000-02-03T08:30');

--- a/packages/date-time-picker/test/timezone.test.js
+++ b/packages/date-time-picker/test/timezone.test.js
@@ -1,0 +1,37 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../src/vaadin-date-time-picker.js';
+
+describe('timezone independent', () => {
+  let dateTimePicker;
+  let datePicker;
+  let timePicker;
+
+  beforeEach(() => {
+    dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
+    datePicker = dateTimePicker.querySelector('[slot="date-picker"]');
+    timePicker = dateTimePicker.querySelector('[slot="time-picker"]');
+  });
+
+  it('should not skip missing hour from DST switch', () => {
+    // There's no good way to mock the system timezone, so use multiple test
+    // cases to cover different timezones, in one of which this test hopefully
+    // runs. The setup should verify that the component does not use the system
+    // timezone to manipulate date instances, which would lead to skipping an
+    // hour when entering the date and time of DST start, as this is an hour
+    // that does not exist in timezones that use DST.
+    const testCases = [
+      '2024-03-10T02:00', // US Eastern DST start
+      '2024-03-31T02:00', // Central european DST start
+      '2024-03-31T03:00', // Eastern european DST start
+    ];
+
+    testCases.forEach((value) => {
+      const [date, time] = value.split('T');
+      datePicker.value = date;
+      timePicker.value = time;
+
+      expect(dateTimePicker.value).to.equal(value);
+    });
+  });
+});


### PR DESCRIPTION
Currently date time picker uses Date APIs such as `setHours` / `getHours` to parse and format date and time. These APIs are timezone-aware, using the current system timezone. When that timezone uses daylight savings time (DST), entering the start date + time of DST in the component results in the component value skipping an hour, as the hour does not exist in that timezone. For example, when using CET timezone:
```js
// Parse DST start in CET timezone
const date = new Date('2024-03-31T02:00');
// 02:00 actually doesn't exist in CET on that date, so it skips to 03:00
console.log(date); // Sun Mar 31 2024 03:00:00 GMT+0200 (Mitteleuropäische Sommerzeit)
console.log(date.getHours()); // 3
```

Our components should work independent of the system timezone, and should just allow entering a date and time, regardless of whether that time is valid in a specific timezone (similar to how Java's `LocalDateTime` class works). 

To fix this I updated date time picker to handle all date instances in UTC, and only interact with the UTC date components via APIs such as `setUTCHours` / `getUTCHours`. That requires duplicating some helper functions from date picker, as the existing ones use timezone specific APIs, and you do not get correct results if you use UTC APIs on Date instances that were created in the system timezone.

Long term we should probably use Date instances in UTC throughout all components, however updating date picker doesn't seem to be trivial as there are literally hundreds of timezone-specific API calls. There is also no urgency to do so, as date picker doesn't seem to exhibit any timezone related issues. The main benefit would be in cleaning up the code base, having a consistent approach, and avoiding confusion on how to handle Date instances in which component.

Fixes https://github.com/vaadin/flow-components/issues/6727