### PR TITLE
fix: use correct type syntax in date picker helper

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-helper.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-helper.d.ts
@@ -1,4 +1,4 @@
-import type { DatePickerDate } from './vaadin-date-picker-mixin';
+import type { DatePickerDate } from './vaadin-date-picker-mixin.js';
 
 /**
  * Get ISO 8601 week number for the given date.

--- a/packages/date-picker/src/vaadin-date-picker-helper.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-helper.d.ts
@@ -1,3 +1,5 @@
+import type { DatePickerDate } from './vaadin-date-picker-mixin';
+
 /**
  * Get ISO 8601 week number for the given date.
  *
@@ -21,7 +23,7 @@ declare function dateAllowed(
   date: Date,
   min: Date | null,
   max: Date | null,
-  isDateDisabled: (DatePickerDate) => boolean | null,
+  isDateDisabled: (date: DatePickerDate) => boolean | null,
 ): boolean;
 
 /**


### PR DESCRIPTION
Adds missing type annotation to a helper function.