### PR TITLE
fix: update select all checkbox visibility when adding column to DOM

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -54,6 +54,7 @@ export const GridSelectionColumnMixin = (superClass) =>
         this._grid.addEventListener('is-item-selectable-changed', this.__boundUpdateSelectAllVisibility);
         this._grid.addEventListener('filter-changed', this.__boundOnSelectedItemsChanged);
         this._grid.addEventListener('selected-items-changed', this.__boundOnSelectedItemsChanged);
+        this.__updateSelectAllVisibility();
       }
     }
 

--- a/packages/grid/test/selectable-provider.common.js
+++ b/packages/grid/test/selectable-provider.common.js
@@ -204,6 +204,22 @@ describe('selectable-provider', () => {
       expect(selectAllCheckbox.hasAttribute('hidden')).to.be.true;
     });
 
+    it('should hide select all checkbox when adding a selection column to an existing grid with an isItemSelectable provider', async () => {
+      // remove existing selection column
+      selectionColumn.remove();
+      // column mixin only removes cells after an animation frame
+      await nextFrame();
+
+      // add new selection column
+      selectionColumn = document.createElement('vaadin-grid-selection-column');
+      grid.prepend(selectionColumn);
+      // column mixin only adds cells after an animation frame
+      await nextFrame();
+      selectAllCheckbox = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-checkbox');
+
+      expect(selectAllCheckbox.hasAttribute('hidden')).to.be.true;
+    });
+
     it('should show select all checkbox when removing isItemSelectable provider', async () => {
       grid.isItemSelectable = null;
       await nextFrame();


### PR DESCRIPTION
Currently the select all checkbox is only hidden if the column is already part of the grid when a respective event fires. This change also hides it if a selection column is added to an existing grid.