### PR TITLE
 fix: use non timezone-aware date APIs in date time picker #8021 (CP: 24.4)

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -17,6 +17,7 @@ import {
   dateAllowed,
   dateEquals,
   extractDateParts,
+  formatISODate,
   getAdjustedYear,
   getClosestDate,
   parseDate,
@@ -751,28 +752,7 @@ export const DatePickerMixin = (subclass) =>
 
     /** @private */
     _formatISO(date) {
-      if (!(date instanceof Date)) {
-        return '';
-      }
-
-      const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
-
-      let yearSign = '';
-      let yearFmt = '0000';
-      let yearAbs = date.getFullYear();
-      if (yearAbs < 0) {
-        yearAbs = -yearAbs;
-        yearSign = '-';
-        yearFmt = '000000';
-      } else if (date.getFullYear() >= 10000) {
-        yearSign = '+';
-        yearFmt = '000000';
-      }
-
-      const year = yearSign + pad(yearAbs, yearFmt);
-      const month = pad(date.getMonth() + 1);
-      const day = pad(date.getDate());
-      return [year, month, day].join('-');
+      return formatISODate(date);
     }
 
     /** @protected */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -11,7 +11,12 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
-import { dateEquals, parseDate } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
+import {
+  dateEquals,
+  formatUTCISODate,
+  normalizeUTCDate,
+  parseUTCDate,
+} from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
@@ -615,16 +620,16 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   __updateTimePickerMinMax() {
     if (this.__timePicker && this.__datePicker) {
       const selectedDate = this.__parseDate(this.__datePicker.value);
-      const isMinMaxSameDay = dateEquals(this.__minDateTime, this.__maxDateTime);
+      const isMinMaxSameDay = dateEquals(this.__minDateTime, this.__maxDateTime, normalizeUTCDate);
       const oldTimeValue = this.__timePicker.value;
 
-      if ((this.__minDateTime && dateEquals(selectedDate, this.__minDateTime)) || isMinMaxSameDay) {
+      if ((this.__minDateTime && dateEquals(selectedDate, this.__minDateTime, normalizeUTCDate)) || isMinMaxSameDay) {
         this.__timePicker.min = this.__dateToIsoTimeString(this.__minDateTime);
       } else {
         this.__timePicker.min = this.__defaultTimeMinValue;
       }
 
-      if ((this.__maxDateTime && dateEquals(selectedDate, this.__maxDateTime)) || isMinMaxSameDay) {
+      if ((this.__maxDateTime && dateEquals(selectedDate, this.__maxDateTime, normalizeUTCDate)) || isMinMaxSameDay) {
         this.__timePicker.max = this.__dateToIsoTimeString(this.__maxDateTime);
       } else {
         this.__timePicker.max = this.__defaultTimeMaxValue;
@@ -750,7 +755,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
    * @private
    */
   __parseDate(str) {
-    return parseDate(str);
+    return parseUTCDate(str);
   }
 
   /**
@@ -764,7 +769,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     if (!date) {
       return defaultValue;
     }
-    return DatePicker.prototype._formatISO(date);
+    return formatUTCISODate(date);
   }
 
   /**
@@ -811,10 +816,10 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       return;
     }
 
-    date.setHours(parseInt(time.hours));
-    date.setMinutes(parseInt(time.minutes || 0));
-    date.setSeconds(parseInt(time.seconds || 0));
-    date.setMilliseconds(parseInt(time.milliseconds || 0));
+    date.setUTCHours(parseInt(time.hours));
+    date.setUTCMinutes(parseInt(time.minutes || 0));
+    date.setUTCSeconds(parseInt(time.seconds || 0));
+    date.setUTCMilliseconds(parseInt(time.milliseconds || 0));
 
     return date;
   }
@@ -844,10 +849,10 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   __dateToIsoTimeString(date) {
     return this.__formatTimeISO(
       this.__validateTime({
-        hours: date.getHours(),
-        minutes: date.getMinutes(),
-        seconds: date.getSeconds(),
-        milliseconds: date.getMilliseconds(),
+        hours: date.getUTCHours(),
+        minutes: date.getUTCMinutes(),
+        seconds: date.getUTCSeconds(),
+        milliseconds: date.getUTCMilliseconds(),
       }),
     );
   }
@@ -908,14 +913,14 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
    * @private
    */
   __dateTimeEquals(date1, date2) {
-    if (!dateEquals(date1, date2)) {
+    if (!dateEquals(date1, date2, normalizeUTCDate)) {
       return false;
     }
     return (
-      date1.getHours() === date2.getHours() &&
-      date1.getMinutes() === date2.getMinutes() &&
-      date1.getSeconds() === date2.getSeconds() &&
-      date1.getMilliseconds() === date2.getMilliseconds()
+      date1.getUTCHours() === date2.getUTCHours() &&
+      date1.getUTCMinutes() === date2.getUTCMinutes() &&
+      date1.getUTCSeconds() === date2.getUTCSeconds() &&
+      date1.getUTCMilliseconds() === date2.getUTCMilliseconds()
     );
   }
 

--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -189,17 +189,17 @@ describe('Basic features', () => {
 
   describe('value property formats', () => {
     it('should accept ISO format', () => {
-      const date = new Date(0, 1, 3, 8, 30, 0);
+      const date = new Date(Date.UTC(0, 1, 3, 8, 30, 0));
 
-      date.setFullYear(0);
+      date.setUTCFullYear(0);
       dateTimePicker.value = '0000-02-03T08:30:00';
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
 
-      date.setFullYear(10000);
+      date.setUTCFullYear(10000);
       dateTimePicker.value = '+010000-02-03T08:30:00';
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
 
-      date.setFullYear(-10000);
+      date.setUTCFullYear(-10000);
       dateTimePicker.value = '-010000-02-03T08:30:00';
       expect(dateTimePicker.__selectedDateTime).to.eql(date);
     });
@@ -221,9 +221,9 @@ describe('Basic features', () => {
     });
 
     it('should output ISO format', () => {
-      const date = new Date(0, 1, 3, 8, 30, 0);
+      const date = new Date(Date.UTC(0, 1, 3, 8, 30, 0));
 
-      date.setFullYear(0);
+      date.setUTCFullYear(0);
       dateTimePicker.__selectedDateTime = date;
       expect(dateTimePicker.value).to.equal('0000-02-03T08:30');
 
@@ -241,7 +241,7 @@ describe('Basic features', () => {
       dateTimePicker.__selectedDateTime = date;
       expect(dateTimePicker.value).to.equal('0000-02-03T08:30:00.000');
 
-      date.setFullYear(10000);
+      date.setUTCFullYear(10000);
       dateTimePicker.step = undefined;
       dateTimePicker.__selectedDateTime = new Date(date.getTime());
       expect(dateTimePicker.value).to.equal('+010000-02-03T08:30');
@@ -250,7 +250,7 @@ describe('Basic features', () => {
       dateTimePicker.step = 0.001;
       expect(dateTimePicker.value).to.equal('+010000-02-03T08:30:00.000');
 
-      date.setFullYear(-10000);
+      date.setUTCFullYear(-10000);
       dateTimePicker.step = undefined;
       dateTimePicker.__selectedDateTime = new Date(date.getTime());
       expect(dateTimePicker.value).to.equal('-010000-02-03T08:30');

--- a/packages/date-time-picker/test/timezone.test.js
+++ b/packages/date-time-picker/test/timezone.test.js
@@ -1,0 +1,37 @@
+import { expect } from '@esm-bundle/chai';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../src/vaadin-date-time-picker.js';
+
+describe('timezone independent', () => {
+  let dateTimePicker;
+  let datePicker;
+  let timePicker;
+
+  beforeEach(() => {
+    dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
+    datePicker = dateTimePicker.querySelector('[slot="date-picker"]');
+    timePicker = dateTimePicker.querySelector('[slot="time-picker"]');
+  });
+
+  it('should not skip missing hour from DST switch', () => {
+    // There's no good way to mock the system timezone, so use multiple test
+    // cases to cover different timezones, in one of which this test hopefully
+    // runs. The setup should verify that the component does not use the system
+    // timezone to manipulate date instances, which would lead to skipping an
+    // hour when entering the date and time of DST start, as this is an hour
+    // that does not exist in timezones that use DST.
+    const testCases = [
+      '2024-03-10T02:00', // US Eastern DST start
+      '2024-03-31T02:00', // Central european DST start
+      '2024-03-31T03:00', // Eastern european DST start
+    ];
+
+    testCases.forEach((value) => {
+      const [date, time] = value.split('T');
+      datePicker.value = date;
+      timePicker.value = time;
+
+      expect(dateTimePicker.value).to.equal(value);
+    });
+  });
+});


### PR DESCRIPTION
Cherry-pick of #8021 

Merge conflict came from `vaadin-date-picker-helper.js`, which didn't yet use the `normalizeDate` function as part of `dateEquals`. Should be fine to update it as such.