### PR TITLE
fix: exclude items from drag image for large scrollers

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -115,6 +115,11 @@ export const DragAndDropMixin = (superClass) =>
       return ['_dragDropAccessChanged(rowsDraggable, dropMode, dragFilter, dropFilter, loading)'];
     }
 
+    constructor() {
+      super();
+      this.__onDocumentDragStart = this.__onDocumentDragStart.bind(this);
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -129,8 +134,6 @@ export const DragAndDropMixin = (superClass) =>
           e.stopPropagation();
         }
       });
-      this.__boundGridDragStartListener = this.__onGridDragStart.bind(this);
-      document.addEventListener('dragstart', this.__boundGridDragStartListener, { capture: true });
     }
 
     /** @protected */
@@ -140,13 +143,13 @@ export const DragAndDropMixin = (superClass) =>
       // that have children with massive heights. This workaround prevents crashes
       // and performance issues by excluding the items from the drag image.
       // https://github.com/vaadin/web-components/issues/7985
-      document.addEventListener('dragstart', this.__boundGridDragStartListener, { capture: true });
+      document.addEventListener('dragstart', this.__onDocumentDragStart, { capture: true });
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      document.removeEventListener('dragstart', this.__boundGridDragStartListener, { capture: true });
+      document.removeEventListener('dragstart', this.__onDocumentDragStart, { capture: true });
     }
 
     /** @private */
@@ -310,7 +313,7 @@ export const DragAndDropMixin = (superClass) =>
     }
 
     /** @private */
-    __onGridDragStart(e) {
+    __onDocumentDragStart(e) {
       // The dragged element can be the element itself or a parent of the element
       if (!e.target.contains(this)) {
         return;

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -322,12 +322,15 @@ export const DragAndDropMixin = (superClass) =>
       //   - avoid the crash and the performance issues
       //   - unnecessarily avoid excluding items from the drag image
       if (this.$.items.offsetHeight > 20000) {
-        const initialMaxHeight = this.$.items.style.maxHeight;
+        const initialItemsMaxHeight = this.$.items.style.maxHeight;
+        const initialTableOverflow = this.$.table.style.overflow;
         // Momentarily hides the items until the browser starts generating the
         // drag image.
         this.$.items.style.maxHeight = '0';
+        this.$.table.style.overflow = 'hidden';
         requestAnimationFrame(() => {
-          this.$.items.style.maxHeight = initialMaxHeight;
+          this.$.items.style.maxHeight = initialItemsMaxHeight;
+          this.$.table.style.overflow = initialTableOverflow;
         });
       }
     }

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -129,6 +129,24 @@ export const DragAndDropMixin = (superClass) =>
           e.stopPropagation();
         }
       });
+      this.__boundGridDragStartListener = this.__onGridDragStart.bind(this);
+      document.addEventListener('dragstart', this.__boundGridDragStartListener, { capture: true });
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      // Chromium based browsers cannot properly generate drag images for elements
+      // that have children with massive heights. This workaround prevents crashes
+      // and performance issues by excluding the items from the drag image.
+      // https://github.com/vaadin/web-components/issues/7985
+      document.addEventListener('dragstart', this.__boundGridDragStartListener, { capture: true });
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      document.removeEventListener('dragstart', this.__boundGridDragStartListener, { capture: true });
     }
 
     /** @private */
@@ -288,6 +306,26 @@ export const DragAndDropMixin = (superClass) =>
         } else {
           this._clearDragStyles();
         }
+      }
+    }
+
+    /** @private */
+    __onGridDragStart(e) {
+      // The dragged element can be the element itself or a parent of the element
+      if (!e.target.contains(this)) {
+        return;
+      }
+      // The threshold value 20000 provides a buffer to both
+      //   - avoid the crash and the performance issues
+      //   - unnecessarily avoid excluding items from the drag image
+      if (this.$.items.offsetHeight > 20000) {
+        const initialMaxHeight = this.$.items.style.maxHeight;
+        // Momentarily hides the items until the browser starts generating the
+        // drag image.
+        this.$.items.style.maxHeight = '0';
+        requestAnimationFrame(() => {
+          this.$.items.style.maxHeight = initialMaxHeight;
+        });
       }
     }
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -270,33 +270,6 @@ export const GridMixin = (superClass) =>
         reorderElements: true,
       });
 
-      // Chromium based browsers cannot properly generate drag images for elements
-      // that have children with massive heights. This workaround prevents crashes
-      // and performance issues by excluding the items from the drag image.
-      // https://github.com/vaadin/web-components/issues/7985
-      document.addEventListener(
-        'dragstart',
-        (e) => {
-          // The dragged element can be the element itself or a parent of the element
-          if (e.target !== this && !e.target.contains(this)) {
-            return;
-          }
-          // The threshold value 20000 provides a buffer to both
-          //   - avoid the crash and the performance issues
-          //   - unnecessarily avoid excluding items from the drag image
-          if (this.$.items.offsetHeight > 20000) {
-            const initialMaxHeight = this.$.items.style.maxHeight;
-            // Momentarily hides the items until the browser starts generating the
-            // drag image.
-            this.$.items.style.maxHeight = '0';
-            requestAnimationFrame(() => {
-              this.$.items.style.maxHeight = initialMaxHeight;
-            });
-          }
-        },
-        { capture: true },
-      );
-
       new ResizeObserver(() =>
         setTimeout(() => {
           this.__updateColumnsBodyContentHidden();

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -274,30 +274,28 @@ export const GridMixin = (superClass) =>
       // that have children with massive heights. This workaround prevents crashes
       // and performance issues by excluding the items from the drag image.
       // https://github.com/vaadin/web-components/issues/7985
-      if (isSafari || isChrome) {
-        document.addEventListener(
-          'dragstart',
-          (e) => {
-            // The dragged element can be the element itself or a parent of the element
-            if (e.target !== this && !e.target.contains(this)) {
-              return;
-            }
-            // The threshold value 20000 provides a buffer to both
-            //   - avoid the crash and the performance issues
-            //   - unnecessarily avoid excluding items from the drag image
-            if (this.$.items.offsetHeight > 20000) {
-              const initialMaxHeight = this.$.items.style.maxHeight;
-              // Momentarily hides the items until the browser starts generating the
-              // drag image.
-              this.$.items.style.maxHeight = '0';
-              requestAnimationFrame(() => {
-                this.$.items.style.maxHeight = initialMaxHeight;
-              });
-            }
-          },
-          { capture: true },
-        );
-      }
+      document.addEventListener(
+        'dragstart',
+        (e) => {
+          // The dragged element can be the element itself or a parent of the element
+          if (e.target !== this && !e.target.contains(this)) {
+            return;
+          }
+          // The threshold value 20000 provides a buffer to both
+          //   - avoid the crash and the performance issues
+          //   - unnecessarily avoid excluding items from the drag image
+          if (this.$.items.offsetHeight > 20000) {
+            const initialMaxHeight = this.$.items.style.maxHeight;
+            // Momentarily hides the items until the browser starts generating the
+            // drag image.
+            this.$.items.style.maxHeight = '0';
+            requestAnimationFrame(() => {
+              this.$.items.style.maxHeight = initialMaxHeight;
+            });
+          }
+        },
+        { capture: true },
+      );
 
       new ResizeObserver(() =>
         setTimeout(() => {

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -270,6 +270,35 @@ export const GridMixin = (superClass) =>
         reorderElements: true,
       });
 
+      // Chromium based browsers cannot properly generate drag images for elements
+      // that have children with massive heights. This workaround prevents crashes
+      // and performance issues by excluding the items from the drag image.
+      // https://github.com/vaadin/web-components/issues/7985
+      if (isSafari || isChrome) {
+        document.addEventListener(
+          'dragstart',
+          (e) => {
+            // The dragged element can be the element itself or a parent of the element
+            if (e.target !== this && !e.target.contains(this)) {
+              return;
+            }
+            // The threshold value 20000 provides a buffer to both
+            //   - avoid the crash and the performance issues
+            //   - unnecessarily avoid excluding items from the drag image
+            if (this.$.items.offsetHeight > 20000) {
+              const initialMaxHeight = this.$.items.style.maxHeight;
+              // Momentarily hides the items until the browser starts generating the
+              // drag image.
+              this.$.items.style.maxHeight = '0';
+              requestAnimationFrame(() => {
+                this.$.items.style.maxHeight = initialMaxHeight;
+              });
+            }
+          },
+          { capture: true },
+        );
+      }
+
       new ResizeObserver(() =>
         setTimeout(() => {
           this.__updateColumnsBodyContentHidden();

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -1089,6 +1089,7 @@ describe('drag and drop', () => {
   describe('draggable grid', () => {
     let container;
     let items;
+    let table;
 
     beforeEach(async () => {
       container = fixtureSync(`
@@ -1103,6 +1104,7 @@ describe('drag and drop', () => {
       flushGrid(grid);
       await nextFrame();
       items = grid.shadowRoot.querySelector('#items');
+      table = grid.shadowRoot.querySelector('#table');
     });
 
     async function setGridItems(count) {
@@ -1118,21 +1120,26 @@ describe('drag and drop', () => {
       await sendMouse({ type: 'up' });
     }
 
+    async function assertDragSucceeds(draggedElement) {
+      // maxHeight and overflow are temporarily updated in the related fix
+      const initialItemsMaxHeight = items.style.maxHeight;
+      const initialTableOverflow = table.style.overflow;
+      await dragElement(draggedElement);
+      expect(items.style.maxHeight).to.equal(initialItemsMaxHeight);
+      expect(table.style.overflow).to.equal(initialTableOverflow);
+    }
+
     ['5000', '50000'].forEach((count) => {
       it(`should not crash when dragging a grid with ${count} items`, async () => {
         await setGridItems(count);
-        const initialMaxHeight = items.style.maxHeight;
-        await dragElement(grid);
-        expect(items.style.maxHeight).to.equal(initialMaxHeight);
+        await assertDragSucceeds(grid);
       });
 
       it(`should not crash when dragging a container that has a grid with ${count} items`, async () => {
         grid.removeAttribute('draggable');
         container.setAttribute('draggable', true);
         await setGridItems(count);
-        const initialMaxHeight = items.style.maxHeight;
-        await dragElement(container);
-        expect(items.style.maxHeight).to.equal(initialMaxHeight);
+        await assertDragSucceeds(container);
       });
     });
   });

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -1,6 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { resetMouse, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
+import { hover } from '@vaadin/button/test/visual/helpers.js';
 import { flushGrid, getBodyCellContent, getFirstCell, getRowBodyCells, getRows } from './helpers.js';
 
 describe('drag and drop', () => {
@@ -1090,12 +1092,12 @@ describe('drag and drop', () => {
 
     beforeEach(async () => {
       container = fixtureSync(`
-      <div style="width: 400px; height: 400px;">
-        <vaadin-grid draggable="true" style="width: 300px; height: 300px;">
-          <vaadin-grid-column path="value"></vaadin-grid-column>
-        </vaadin-grid>
-      </div>
-    `);
+        <div style="width: 400px; height: 400px;">
+          <vaadin-grid draggable="true" style="width: 300px; height: 300px;">
+            <vaadin-grid-column path="value"></vaadin-grid-column>
+          </vaadin-grid>
+        </div>
+      `);
       grid = container.querySelector('vaadin-grid');
       document.body.appendChild(container);
       flushGrid(grid);
@@ -1108,45 +1110,28 @@ describe('drag and drop', () => {
       await nextFrame();
     }
 
-    async function getMaxHeightDuringDragStart(element, items) {
-      let maxHeightDuringDragStart;
-      element.addEventListener(
-        'dragstart',
-        () => {
-          maxHeightDuringDragStart = items.style.maxHeight;
-        },
-        { once: true },
-      );
-      element.dispatchEvent(new DragEvent('dragstart'));
-      await new Promise((resolve) => {
-        requestAnimationFrame(resolve);
-      });
-      return maxHeightDuringDragStart;
+    async function dragElement(element) {
+      await resetMouse();
+      await hover(element);
+      await sendMouse({ type: 'down' });
+      await sendMouse({ type: 'move', position: [100, 100] });
+      await sendMouse({ type: 'up' });
     }
 
-    it('should not modify maxHeight on dragstart for small grids', async () => {
-      await setGridItems(10);
-      const initialMaxHeight = items.style.maxHeight;
-      const maxHeightDuringDragStart = await getMaxHeightDuringDragStart(grid, items);
-      expect(maxHeightDuringDragStart).to.equal(initialMaxHeight);
-    });
-
     ['5000', '50000'].forEach((count) => {
-      it('should temporarily set maxHeight to 0 on dragstart for large grids', async () => {
+      it(`should not crash when dragging a grid with ${count} items`, async () => {
         await setGridItems(count);
         const initialMaxHeight = items.style.maxHeight;
-        const maxHeightDuringDragStart = await getMaxHeightDuringDragStart(grid, items);
-        expect(maxHeightDuringDragStart).to.equal('0px');
+        await dragElement(grid);
         expect(items.style.maxHeight).to.equal(initialMaxHeight);
       });
 
-      it('should temporarily set maxHeight to 0 on dragstart for large grids in draggable containers', async () => {
+      it(`should not crash when dragging a container that has a grid with ${count} items`, async () => {
         grid.removeAttribute('draggable');
         container.setAttribute('draggable', true);
         await setGridItems(count);
         const initialMaxHeight = items.style.maxHeight;
-        const maxHeightDuringDragStart = await getMaxHeightDuringDragStart(container, items);
-        expect(maxHeightDuringDragStart).to.equal('0px');
+        await dragElement(container);
         expect(items.style.maxHeight).to.equal(initialMaxHeight);
       });
     });

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -75,38 +75,29 @@ export const VirtualListMixin = (superClass) =>
         scrollContainer: this.shadowRoot.querySelector('#items'),
         reorderElements: true,
       });
-
-      // Chromium based browsers cannot properly generate drag images for elements
-      // that have children with massive heights. This workaround prevents crashes
-      // and performance issues by excluding the items from the drag image.
-      // https://github.com/vaadin/web-components/issues/7985
-      document.addEventListener(
-        'dragstart',
-        (e) => {
-          // The dragged element can be the element itself or a parent of the element
-          if (e.target !== this && !e.target.contains(this)) {
-            return;
-          }
-          // The threshold value 20000 provides a buffer to both
-          //   - avoid the crash and the performance issues
-          //   - unnecessarily avoid excluding items from the drag image
-          if (this.$.items.offsetHeight > 20000) {
-            const initialMaxHeight = this.$.items.style.maxHeight;
-            // Momentarily hides the items until the browser starts generating the
-            // drag image.
-            this.$.items.style.maxHeight = '0';
-            requestAnimationFrame(() => {
-              this.$.items.style.maxHeight = initialMaxHeight;
-            });
-          }
-        },
-        { capture: true },
-      );
-
       this.__overflowController = new OverflowController(this);
       this.addController(this.__overflowController);
 
       processTemplates(this);
+
+      this.__boundDragStartListener = this.__onDragStart.bind(this);
+      document.addEventListener('dragstart', this.__boundDragStartListener, { capture: true });
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      // Chromium based browsers cannot properly generate drag images for elements
+      // that have children with massive heights. This workaround prevents crashes
+      // and performance issues by excluding the items from the drag image.
+      // https://github.com/vaadin/web-components/issues/7985
+      document.addEventListener('dragstart', this.__boundDragStartListener, { capture: true });
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      document.removeEventListener('dragstart', this.__boundDragStartListener, { capture: true });
     }
 
     /**
@@ -157,6 +148,26 @@ export const VirtualListMixin = (superClass) =>
       if ((renderer || hasRenderedItems) && virtualizer) {
         virtualizer.size = (items || []).length;
         virtualizer.update();
+      }
+    }
+
+    /** @private */
+    __onDragStart(e) {
+      // The dragged element can be the element itself or a parent of the element
+      if (!e.target.contains(this)) {
+        return;
+      }
+      // The threshold value 20000 provides a buffer to both
+      //   - avoid the crash and the performance issues
+      //   - unnecessarily avoid excluding items from the drag image
+      if (this.$.items.offsetHeight > 20000) {
+        const initialMaxHeight = this.$.items.style.maxHeight;
+        // Momentarily hides the items until the browser starts generating the
+        // drag image.
+        this.$.items.style.maxHeight = '0';
+        requestAnimationFrame(() => {
+          this.$.items.style.maxHeight = initialMaxHeight;
+        });
       }
     }
 

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isChrome, isSafari } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
@@ -81,30 +80,28 @@ export const VirtualListMixin = (superClass) =>
       // that have children with massive heights. This workaround prevents crashes
       // and performance issues by excluding the items from the drag image.
       // https://github.com/vaadin/web-components/issues/7985
-      if (isSafari || isChrome) {
-        document.addEventListener(
-          'dragstart',
-          (e) => {
-            // The dragged element can be the element itself or a parent of the element
-            if (e.target !== this && !e.target.contains(this)) {
-              return;
-            }
-            // The threshold value 20000 provides a buffer to both
-            //   - avoid the crash and the performance issues
-            //   - unnecessarily avoid excluding items from the drag image
-            if (this.$.items.offsetHeight > 20000) {
-              const initialMaxHeight = this.$.items.style.maxHeight;
-              // Momentarily hides the items until the browser starts generating the
-              // drag image.
-              this.$.items.style.maxHeight = '0';
-              requestAnimationFrame(() => {
-                this.$.items.style.maxHeight = initialMaxHeight;
-              });
-            }
-          },
-          { capture: true },
-        );
-      }
+      document.addEventListener(
+        'dragstart',
+        (e) => {
+          // The dragged element can be the element itself or a parent of the element
+          if (e.target !== this && !e.target.contains(this)) {
+            return;
+          }
+          // The threshold value 20000 provides a buffer to both
+          //   - avoid the crash and the performance issues
+          //   - unnecessarily avoid excluding items from the drag image
+          if (this.$.items.offsetHeight > 20000) {
+            const initialMaxHeight = this.$.items.style.maxHeight;
+            // Momentarily hides the items until the browser starts generating the
+            // drag image.
+            this.$.items.style.maxHeight = '0';
+            requestAnimationFrame(() => {
+              this.$.items.style.maxHeight = initialMaxHeight;
+            });
+          }
+        },
+        { capture: true },
+      );
 
       this.__overflowController = new OverflowController(this);
       this.addController(this.__overflowController);

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -63,6 +63,11 @@ export const VirtualListMixin = (superClass) =>
       return this.__virtualizer.lastVisibleIndex;
     }
 
+    constructor() {
+      super();
+      this.__onDragStart = this.__onDragStart.bind(this);
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -79,9 +84,6 @@ export const VirtualListMixin = (superClass) =>
       this.addController(this.__overflowController);
 
       processTemplates(this);
-
-      this.__boundDragStartListener = this.__onDragStart.bind(this);
-      document.addEventListener('dragstart', this.__boundDragStartListener, { capture: true });
     }
 
     /** @protected */
@@ -91,13 +93,13 @@ export const VirtualListMixin = (superClass) =>
       // that have children with massive heights. This workaround prevents crashes
       // and performance issues by excluding the items from the drag image.
       // https://github.com/vaadin/web-components/issues/7985
-      document.addEventListener('dragstart', this.__boundDragStartListener, { capture: true });
+      document.addEventListener('dragstart', this.__onDragStart, { capture: true });
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      document.removeEventListener('dragstart', this.__boundDragStartListener, { capture: true });
+      document.removeEventListener('dragstart', this.__onDragStart, { capture: true });
     }
 
     /**

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -163,12 +163,15 @@ export const VirtualListMixin = (superClass) =>
       //   - avoid the crash and the performance issues
       //   - unnecessarily avoid excluding items from the drag image
       if (this.$.items.offsetHeight > 20000) {
-        const initialMaxHeight = this.$.items.style.maxHeight;
+        const initialItemsMaxHeight = this.$.items.style.maxHeight;
+        const initialVirtualListOverflow = this.style.overflow;
         // Momentarily hides the items until the browser starts generating the
         // drag image.
         this.$.items.style.maxHeight = '0';
+        this.style.overflow = 'hidden';
         requestAnimationFrame(() => {
-          this.$.items.style.maxHeight = initialMaxHeight;
+          this.$.items.style.maxHeight = initialItemsMaxHeight;
+          this.style.overflow = initialVirtualListOverflow;
         });
       }
     }

--- a/packages/virtual-list/test/drag-and-drop-lit.test.js
+++ b/packages/virtual-list/test/drag-and-drop-lit.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-lit-virtual-list.js';
+import './drag-and-drop.common.js';

--- a/packages/virtual-list/test/drag-and-drop-polymer.test.js
+++ b/packages/virtual-list/test/drag-and-drop-polymer.test.js
@@ -1,0 +1,2 @@
+import '../vaadin-virtual-list.js';
+import './drag-and-drop.common.js';

--- a/packages/virtual-list/test/drag-and-drop.common.js
+++ b/packages/virtual-list/test/drag-and-drop.common.js
@@ -1,0 +1,73 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+
+describe('drag and drop', () => {
+  let virtualList;
+  let container;
+  let items;
+
+  beforeEach(async () => {
+    container = fixtureSync(`
+      <div style="width: 300px; height: 300px;">
+        <vaadin-virtual-list draggable="true"></vaadin-virtual-list>
+      </div>
+    `);
+    virtualList = container.querySelector('vaadin-virtual-list');
+    virtualList.renderer = (root, _, { item }) => {
+      root.innerHTML = `<div>${item.label}</div>`;
+    };
+    document.body.appendChild(container);
+    await nextFrame();
+    items = virtualList.shadowRoot.querySelector('#items');
+  });
+
+  async function setVirtualListItems(count) {
+    virtualList.items = Array.from({ length: count }).map((_, i) => {
+      return { label: `Item ${i}` };
+    });
+    await nextFrame();
+  }
+
+  async function getMaxHeightDuringDragStart(element, items) {
+    let maxHeightDuringDragStart;
+    element.addEventListener(
+      'dragstart',
+      () => {
+        maxHeightDuringDragStart = items.style.maxHeight;
+      },
+      { once: true },
+    );
+    element.dispatchEvent(new DragEvent('dragstart'));
+    await new Promise((resolve) => {
+      requestAnimationFrame(resolve);
+    });
+    return maxHeightDuringDragStart;
+  }
+
+  it('should not modify maxHeight on dragstart for small virtual lists', async () => {
+    await setVirtualListItems(50);
+    const initialMaxHeight = items.style.maxHeight;
+    const maxHeightDuringDragStart = await getMaxHeightDuringDragStart(virtualList, items);
+    expect(maxHeightDuringDragStart).to.equal(initialMaxHeight);
+  });
+
+  ['5000', '50000'].forEach((count) => {
+    it('should temporarily set maxHeight to 0 on dragstart for large virtual lists', async () => {
+      await setVirtualListItems(count);
+      const initialMaxHeight = items.style.maxHeight;
+      const maxHeightDuringDragStart = await getMaxHeightDuringDragStart(virtualList, items);
+      expect(maxHeightDuringDragStart).to.equal('0px');
+      expect(items.style.maxHeight).to.equal(initialMaxHeight);
+    });
+
+    it('should temporarily set maxHeight to 0 on dragstart for large virtual lists in draggable containers', async () => {
+      virtualList.removeAttribute('draggable');
+      container.setAttribute('draggable', true);
+      await setVirtualListItems(count);
+      const initialMaxHeight = items.style.maxHeight;
+      const maxHeightDuringDragStart = await getMaxHeightDuringDragStart(container, items);
+      expect(maxHeightDuringDragStart).to.equal('0px');
+      expect(items.style.maxHeight).to.equal(initialMaxHeight);
+    });
+  });
+});

--- a/packages/virtual-list/test/drag-and-drop.common.js
+++ b/packages/virtual-list/test/drag-and-drop.common.js
@@ -38,21 +38,26 @@ describe('drag and drop', () => {
     await sendMouse({ type: 'up' });
   }
 
+  async function assertDragSucceeds(draggedElement) {
+    // maxHeight and overflow are temporarily updated in the related fix
+    const initialItemsMaxHeight = items.style.maxHeight;
+    const initialVirtualListOverflow = virtualList.style.overflow;
+    await dragElement(draggedElement);
+    expect(items.style.maxHeight).to.equal(initialItemsMaxHeight);
+    expect(virtualList.style.overflow).to.equal(initialVirtualListOverflow);
+  }
+
   ['5000', '50000'].forEach((count) => {
     it(`should not crash when dragging a virtual list with ${count} items`, async () => {
       await setVirtualListItems(count);
-      const initialMaxHeight = items.style.maxHeight;
-      await dragElement(virtualList);
-      expect(items.style.maxHeight).to.equal(initialMaxHeight);
+      await assertDragSucceeds(virtualList);
     });
 
     it(`should not crash when dragging a container that has a virtual list with ${count} items`, async () => {
       virtualList.removeAttribute('draggable');
       container.setAttribute('draggable', true);
       await setVirtualListItems(count);
-      const initialMaxHeight = items.style.maxHeight;
-      await dragElement(container);
-      expect(items.style.maxHeight).to.equal(initialMaxHeight);
+      await assertDragSucceeds(container);
     });
   });
 });


### PR DESCRIPTION
## Description

Chromium based browsers cannot properly generate drag images for elements that have children with massive heights. Chrome is prone to crashing while Safari slows down when a grid or virtual list with 1000+ items is dragged.

This PR temporarily sets the max height for items scroll containers to 0 when the "dragstart" event is fired. This prevents the crashes and slowdowns. This workaround also handles the case when a parent is dragged instead of the element itself.

The cutoff for applying the workaround is 20000px, and is based on experimentation with the parameters that cause the issues.

Fixes #7985 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.