### PR TITLE
chore: do not document is-item-selectable-changed event

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -42,7 +42,7 @@ export const SelectionMixin = (superClass) =>
          */
         isItemSelectable: {
           type: Function,
-          notify: true,
+          notify: (() => true)(), // prevent Polymer analyzer from documenting a changed event
         },
 
         /**


### PR DESCRIPTION
Removes the `is-item-selectable-changed` event from the API docs, which then hopefully fixes this issue when generating React components:
```
  [dts] src/generated/Grid.ts(21,60): error TS2339: Property 'is-item-selectable-changed' does not exist on type 'GridEventMap<T1>'.
```