### PR TITLE
feat: add API do define Dialog size programmatically

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
@@ -58,4 +58,16 @@ export declare class DialogBaseMixinClass {
    * overlay from stretching all the way to the left of the viewport).
    */
   left: string;
+
+  /**
+   * Set the width of the overlay.
+   * If a unitless number is provided, pixels are assumed.
+   */
+  width: string;
+
+  /**
+   * Set the height of the overlay.
+   * If a unitless number is provided, pixels are assumed.
+   */
+  height: string;
 }

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -183,12 +183,12 @@ export const DialogBaseMixin = (superClass) =>
 
     /** @private */
     __positionChanged(top, left) {
-      this.$.overlay.setBounds({ top, left });
+      requestAnimationFrame(() => this.$.overlay.setBounds({ top, left }));
     }
 
     /** @private */
     __sizeChanged(width, height) {
-      this.$.overlay.setBounds({ width, height });
+      requestAnimationFrame(() => this.$.overlay.setBounds({ width, height }));
     }
 
     /**

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -75,6 +75,22 @@ export const DialogBaseMixin = (superClass) =>
         },
 
         /**
+         * Set the width of the overlay.
+         * If a unitless number is provided, pixels are assumed.
+         */
+        width: {
+          type: String,
+        },
+
+        /**
+         * Set the height of the overlay.
+         * If a unitless number is provided, pixels are assumed.
+         */
+        height: {
+          type: String,
+        },
+
+        /**
          * The `role` attribute value to be set on the overlay. Defaults to "dialog".
          *
          * @attr {string} overlay-role
@@ -87,7 +103,7 @@ export const DialogBaseMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__positionChanged(top, left)'];
+      return ['__positionChanged(top, left)', '__sizeChanged(width, height)'];
     }
 
     /** @protected */
@@ -168,6 +184,11 @@ export const DialogBaseMixin = (superClass) =>
     /** @private */
     __positionChanged(top, left) {
       this.$.overlay.setBounds({ top, left });
+    }
+
+    /** @private */
+    __sizeChanged(width, height) {
+      this.$.overlay.setBounds({ width, height });
     }
 
     /**

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -75,7 +75,7 @@ export const DialogResizableMixin = (superClass) =>
         window.addEventListener('touchmove', this._resizeListeners.resize[direction]);
         window.addEventListener('mouseup', this._resizeListeners.stop[direction]);
         window.addEventListener('touchend', this._resizeListeners.stop[direction]);
-        if (this.$.overlay.$.overlay.style.position !== 'absolute') {
+        if (this.$.overlay.$.overlay.style.position !== 'absolute' || this.width || this.height) {
           this.$.overlay.setBounds(this._originalBounds);
         }
       }

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -96,21 +96,22 @@ export const DialogResizableMixin = (superClass) =>
               const height = this._originalBounds.height - (event.pageY - this._originalMouseCoords.top);
               const top = this._originalBounds.top + (event.pageY - this._originalMouseCoords.top);
               if (height > minimumSize) {
-                this.$.overlay.setBounds({ top, height });
+                this.top = top;
+                this.height = height;
               }
               break;
             }
             case 'e': {
               const width = this._originalBounds.width + (event.pageX - this._originalMouseCoords.left);
               if (width > minimumSize) {
-                this.$.overlay.setBounds({ width });
+                this.width = width;
               }
               break;
             }
             case 's': {
               const height = this._originalBounds.height + (event.pageY - this._originalMouseCoords.top);
               if (height > minimumSize) {
-                this.$.overlay.setBounds({ height });
+                this.height = height;
               }
               break;
             }
@@ -118,7 +119,8 @@ export const DialogResizableMixin = (superClass) =>
               const width = this._originalBounds.width - (event.pageX - this._originalMouseCoords.left);
               const left = this._originalBounds.left + (event.pageX - this._originalMouseCoords.left);
               if (width > minimumSize) {
-                this.$.overlay.setBounds({ left, width });
+                this.left = left;
+                this.width = width;
               }
               break;
             }

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -263,7 +263,7 @@ describe('vaadin-dialog', () => {
     });
   });
 
-  describe('position', () => {
+  describe('position/sizing', () => {
     let dialog, overlay;
 
     beforeEach(async () => {
@@ -282,32 +282,44 @@ describe('vaadin-dialog', () => {
       await nextRender();
       dialog.left = 100;
       dialog.top = 200;
+      dialog.width = 300;
+      dialog.height = 400;
       await nextRender();
       expect(overlay.$.overlay.style.position).to.equal('absolute');
       expect(overlay.$.overlay.style.top).to.equal('200px');
       expect(overlay.$.overlay.style.left).to.equal('100px');
+      expect(overlay.$.overlay.style.width).to.equal('300px');
+      expect(overlay.$.overlay.style.height).to.equal('400px');
     });
 
-    it('should allow setting position with units', async () => {
+    it('should allow setting position/size with units', async () => {
       dialog.opened = true;
       await nextRender();
       dialog.left = '100px';
       dialog.top = '10em';
+      dialog.width = '200px';
+      dialog.height = '20em';
       await nextRender();
       expect(overlay.$.overlay.style.position).to.equal('absolute');
       expect(overlay.$.overlay.style.top).to.equal('10em');
       expect(overlay.$.overlay.style.left).to.equal('100px');
+      expect(overlay.$.overlay.style.width).to.equal('200px');
+      expect(overlay.$.overlay.style.height).to.equal('20em');
     });
 
-    it('should allow setting position through attribute', async () => {
+    it('should allow setting position/size through attribute', async () => {
       dialog.opened = true;
       await nextRender();
       dialog.setAttribute('left', 100);
       dialog.setAttribute('top', 200);
+      dialog.setAttribute('width', 300);
+      dialog.setAttribute('height', 400);
       await nextRender();
       expect(overlay.$.overlay.style.position).to.equal('absolute');
-      expect(overlay.$.overlay.style.top).to.equal('200px');
       expect(overlay.$.overlay.style.left).to.equal('100px');
+      expect(overlay.$.overlay.style.top).to.equal('200px');
+      expect(overlay.$.overlay.style.width).to.equal('300px');
+      expect(overlay.$.overlay.style.height).to.equal('400px');
     });
   });
 });

--- a/packages/dialog/test/dialog.common.js
+++ b/packages/dialog/test/dialog.common.js
@@ -321,5 +321,15 @@ describe('vaadin-dialog', () => {
       expect(overlay.$.overlay.style.width).to.equal('300px');
       expect(overlay.$.overlay.style.height).to.equal('400px');
     });
+
+    it('should allow declaring position/size as attributes', async () => {
+      dialog = fixtureSync('<vaadin-dialog top="100px" left="200px" width="100px" height="200px"></vaadin-dialog>');
+      await nextRender();
+      const overlay = dialog.$.overlay.$.overlay;
+      expect(overlay.style.top).to.be.equal('100px');
+      expect(overlay.style.left).to.be.equal('200px');
+      expect(overlay.style.width).to.be.equal('100px');
+      expect(overlay.style.height).to.be.equal('200px');
+    });
   });
 });

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -129,8 +129,9 @@ describe('resizable', () => {
     dx = 30;
   });
 
-  it('should resize dialog from top right corner', () => {
+  it('should resize dialog from top right corner', async () => {
     resize(overlayPart.querySelector('.ne'), dx, -dx);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top - dx));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left));
@@ -138,8 +139,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height + dx));
   });
 
-  it('should resize dialog from bottom right corner', () => {
+  it('should resize dialog from bottom right corner', async () => {
     resize(overlayPart.querySelector('.se'), dx, dx);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left));
@@ -147,8 +149,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height + dx));
   });
 
-  it('should resize dialog from bottom left corner', () => {
+  it('should resize dialog from bottom left corner', async () => {
     resize(overlayPart.querySelector('.sw'), -dx, dx);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left - dx));
@@ -156,8 +159,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height + dx));
   });
 
-  it('should resize dialog from top left corner', () => {
+  it('should resize dialog from top left corner', async () => {
     resize(overlayPart.querySelector('.nw'), -dx, -dx);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top - dx));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left - dx));
@@ -165,8 +169,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height + dx));
   });
 
-  it('should resize dialog from top edge', () => {
+  it('should resize dialog from top edge', async () => {
     resize(overlayPart.querySelector('.n'), 0, -dx);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top - dx));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left));
@@ -174,8 +179,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height + dx));
   });
 
-  it('should resize dialog from right edge', () => {
+  it('should resize dialog from right edge', async () => {
     resize(overlayPart.querySelector('.e'), dx, 0);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left));
@@ -183,8 +189,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height));
   });
 
-  it('should resize dialog from bottom edge', () => {
+  it('should resize dialog from bottom edge', async () => {
     resize(overlayPart.querySelector('.s'), 0, dx);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left));
@@ -192,8 +199,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height + dx));
   });
 
-  it('should resize dialog from left edge', () => {
+  it('should resize dialog from left edge', async () => {
     resize(overlayPart.querySelector('.w'), -dx, 0);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left - dx));
@@ -201,8 +209,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height));
   });
 
-  it('should resize content part when the overlay is resized', () => {
+  it('should resize content part when the overlay is resized', async () => {
     resize(overlayPart.querySelector('.w'), -dx, 0);
+    await nextRender();
 
     const resizedBounds = overlayPart.getBoundingClientRect();
     const contentPartBounds = dialog.$.overlay.$.content.getBoundingClientRect();
@@ -212,8 +221,9 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(contentPartBounds.height));
   });
 
-  it('should resize content part when the overlay is expanded vertically', () => {
+  it('should resize content part when the overlay is expanded vertically', async () => {
     resize(overlayPart.querySelector('.s'), 0, 10);
+    await nextRender();
 
     const resizedBounds = overlayPart.getBoundingClientRect();
     const contentPartBounds = dialog.$.overlay.$.content.getBoundingClientRect();
@@ -284,12 +294,13 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.height)).to.be.eql(Math.floor(bounds.height));
   });
 
-  it('should be able to resize dialog to be wider than window', () => {
+  it('should be able to resize dialog to be wider than window', async () => {
     dialog.$.overlay.$.content.style.padding = '20px';
     dx = 20;
     dialog.$.overlay.setBounds({ left: -dx });
     dx = Math.floor(window.innerWidth - bounds.width + 5);
     resize(overlayPart.querySelector('.e'), dx, 0);
+    await nextRender();
     const resizedBounds = overlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.width)).to.be.eql(Math.floor(bounds.width + dx));
   });
@@ -468,6 +479,7 @@ describe('draggable', () => {
 
   it('should drag and move dialog after resizing', async () => {
     resize(container.querySelector('.s'), 0, dx);
+    await nextRender();
     const bounds = container.getBoundingClientRect();
     const coords = { y: bounds.top + bounds.height / 2, x: bounds.left + bounds.width / 2 };
     const target = dialog.$.overlay.shadowRoot.elementFromPoint(coords.x, coords.y);
@@ -709,10 +721,11 @@ describe('touch', () => {
     expect(draggedBounds.top).to.eql(bounds.top);
   });
 
-  it('should resize dialog from top right corner', () => {
+  it('should resize dialog from top right corner', async () => {
     const d = 100;
     const bounds = resizableOverlayPart.getBoundingClientRect();
     touchResize(resizableOverlayPart.querySelector('.ne'), d, -d);
+    await nextRender();
     const resizedBounds = resizableOverlayPart.getBoundingClientRect();
     expect(Math.floor(resizedBounds.top)).to.be.eql(Math.floor(bounds.top - d));
     expect(Math.floor(resizedBounds.left)).to.be.eql(Math.floor(bounds.left));

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -338,6 +338,33 @@ describe('resizable', () => {
     expect(parseInt(detail.contentWidth)).to.be.eql(parseInt(contentStyles.width));
     expect(parseInt(detail.contentHeight)).to.be.eql(parseInt(contentStyles.height) - verticalPadding);
   });
+
+  it('should update "width" and "height" properties on resize', async () => {
+    resize(overlayPart.querySelector('.sw'), -dx, dx);
+    await nextRender();
+    const overlay = dialog.$.overlay.$.overlay;
+    const bounds = overlay.getBoundingClientRect();
+    expect(dialog.width).to.be.equal(bounds.width);
+    expect(dialog.height).to.be.equal(bounds.height);
+  });
+
+  it('should set height on resize if "width" has been defined', async () => {
+    dialog.width = '200px';
+    const overlay = dialog.$.overlay.$.overlay;
+    const bounds = overlay.getBoundingClientRect();
+    resize(overlayPart.querySelector('.w'), dx, 0);
+    await nextRender();
+    expect(parseInt(overlay.style.height)).to.be.equal(bounds.height);
+  });
+
+  it('should set width on resize if "height" has been defined', async () => {
+    dialog.height = '100px';
+    const overlay = dialog.$.overlay.$.overlay;
+    const bounds = overlay.getBoundingClientRect();
+    resize(overlayPart.querySelector('.s'), 0, dx);
+    await nextRender();
+    expect(parseInt(overlay.style.width)).to.be.equal(bounds.width);
+  });
 });
 
 describe('draggable', () => {


### PR DESCRIPTION
## Description

Add `width` and `height` API to `<vaadin-dialog>` to allow defining the overlay size programmatically.

Part of https://github.com/vaadin/web-components/issues/1060

## Type of change

- Feature
