### PR TITLE
feat: allow dropping folders

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -577,7 +577,7 @@ export const UploadMixin = (superClass) =>
      * @returns {Promise<File[]>} - The files from the drop event
      * @private
      */
-    async __getFilesFromDropEvent(dropEvent) {
+    __getFilesFromDropEvent(dropEvent) {
       async function getFilesFromEntry(entry) {
         if (entry.isFile) {
           return new Promise((resolve) => {
@@ -600,7 +600,7 @@ export const UploadMixin = (superClass) =>
         .filter((entry) => !!entry)
         .map(getFilesFromEntry);
 
-      return await Promise.all(filePromises).then((files) => files.flat());
+      return Promise.all(filePromises).then((files) => files.flat());
     }
 
     /** @private */

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -574,7 +574,7 @@ export const UploadMixin = (superClass) =>
      * it will be recursively traversed to get all files.
      *
      * @param {!DragEvent} dropEvent - The drop event
-     * @returns {!Array<!File>} - The files from the drop event
+     * @returns {Promise<File[]>} - The files from the drop event
      * @private
      */
     async __getFilesFromDropEvent(dropEvent) {

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -581,12 +581,14 @@ export const UploadMixin = (superClass) =>
       async function getFilesFromEntry(entry) {
         if (entry.isFile) {
           return new Promise((resolve) => {
-            entry.file(resolve);
+            // In case of an error, resolve without any files
+            entry.file(resolve, () => resolve([]));
           });
         } else if (entry.isDirectory) {
           const reader = entry.createReader();
           const entries = await new Promise((resolve) => {
-            reader.readEntries(resolve);
+            // In case of an error, resolve without any files
+            reader.readEntries(resolve, () => resolve([]));
           });
           const files = await Promise.all(entries.map(getFilesFromEntry));
           return files.flat();

--- a/packages/upload/test/adding-files.common.js
+++ b/packages/upload/test/adding-files.common.js
@@ -6,6 +6,8 @@ import {
   createFiles,
   createFileSystemDirectoryEntry,
   createFileSystemFileEntry,
+  createUnreadableFileSystemDirectoryEntry,
+  createUnreadableFileSystemFileEntry,
   touchDevice,
   xhrCreator,
 } from './helpers.js';
@@ -144,6 +146,19 @@ describe('adding files', () => {
     it('should handle non-file entries on drop', async () => {
       const fileEntry = createFileSystemFileEntry(100, 'text/plain');
       const dropEvent = createDndEvent('drop', [fileEntry, null]);
+      upload.dispatchEvent(dropEvent);
+      await nextUpdate(upload);
+      await nextFrame();
+
+      expect(upload.files.length).to.equal(1);
+      expect(upload.files).to.include(fileEntry._file);
+    });
+
+    it('should handle errors when reading from files or directories on drop', async () => {
+      const fileEntry = createFileSystemFileEntry(100, 'text/plain');
+      const unreadableFileEntry = createUnreadableFileSystemFileEntry();
+      const unreadableDirectoryEntry = createUnreadableFileSystemDirectoryEntry();
+      const dropEvent = createDndEvent('drop', [fileEntry, unreadableFileEntry, unreadableDirectoryEntry]);
       upload.dispatchEvent(dropEvent);
       await nextUpdate(upload);
       await nextFrame();

--- a/packages/upload/test/helpers.js
+++ b/packages/upload/test/helpers.js
@@ -84,7 +84,7 @@ export function createFileSystemDirectoryEntry(fileEntries) {
 }
 
 /**
- *
+ * Creates a FileSystemDirectoryEntry object that returns an error when trying to read the directory.
  */
 export function createUnreadableFileSystemDirectoryEntry() {
   return {

--- a/packages/upload/test/helpers.js
+++ b/packages/upload/test/helpers.js
@@ -9,11 +9,11 @@ export const touchDevice = (function () {
   }
 })();
 
+let fileCounter = 0;
+
 /**
  * Creates a File suitable to add to FormData.
  */
-let fileCounter = 0;
-
 export function createFile(fileSize, contentType) {
   const array = [];
   for (let i = 0; i < (fileSize || 512); i++) {
@@ -34,6 +34,38 @@ export function createFiles(arraySize, fileSize, contentType) {
     files.push(createFile(fileSize, contentType));
   }
   return files;
+}
+
+/**
+ * Creates a FileSystemFileEntry object suitable to be used in a DataTransferItem.
+ */
+export function createFileSystemFileEntry(fileSize, contentType) {
+  const file = createFile(fileSize, contentType);
+  return {
+    isFile: true,
+    isDirectory: false,
+    file(callback) {
+      callback(file);
+    },
+    _file: file, // expose the file for assertions
+  };
+}
+
+/**
+ * Creates a FileSystemDirectoryEntry object suitable to be used in a DataTransferItem.
+ */
+export function createFileSystemDirectoryEntry(fileEntries) {
+  return {
+    isFile: false,
+    isDirectory: true,
+    createReader() {
+      return {
+        readEntries(callback) {
+          callback(fileEntries);
+        },
+      };
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
Allows to drop folders into the upload component. Folders will be scanned recursively for files and any file found will be added to the file list for uploading. It's also possible to drop a combination of files and folders. Files are still filtered by the accept filter and any non-matching file will be discarded.

Just noting that this doesn't introduce any new concepts such as having folders as a separate entry in the upload component. This is just a shortcut for adding all files from a folder to the upload.

Part of #857 