### PR TITLE
Revert "fix: add min-width to MenuBar"

### DIFF
--- a/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
+++ b/packages/menu-bar/theme/lumo/vaadin-menu-bar-styles.js
@@ -4,10 +4,6 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-menu-bar',
   css`
-    :host {
-      min-width: var(--lumo-size-m);
-    }
-
     :host([has-single-button]) ::slotted(vaadin-menu-bar-button) {
       border-radius: var(--lumo-border-radius-m);
     }


### PR DESCRIPTION
Reverts vaadin/web-components#7498 because it causes MenuBar to shrink unexpectedly when used in Vaadin layouts, as reported in https://github.com/vaadin/web-components/issues/8004
