### PR TITLE
feat: add "dragged" event in Dialog

### DIFF
--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -124,4 +124,10 @@ export const DialogDraggableMixin = (superClass) =>
       window.removeEventListener('mousemove', this._drag);
       window.removeEventListener('touchmove', this._drag);
     }
+
+    /**
+     * Fired when the dialog drag is finished.
+     *
+     * @event dragged
+     */
   };

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -116,6 +116,9 @@ export const DialogDraggableMixin = (superClass) =>
 
     /** @private */
     _stopDrag() {
+      this.dispatchEvent(
+        new CustomEvent('dragged', { bubbles: true, composed: true, detail: { top: this.top, left: this.left } }),
+      );
       window.removeEventListener('mouseup', this._stopDrag);
       window.removeEventListener('touchend', this._stopDrag);
       window.removeEventListener('mousemove', this._drag);

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -120,6 +120,7 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
+ * @fires {CustomEvent} dragged - Fired when the dialog drag is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the dialog is closed.
  */

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -24,6 +24,11 @@ export type DialogResizeDimensions = {
   contentHeight: string;
 };
 
+export type DialogPosition = {
+  top: string;
+  left: string;
+};
+
 /**
  * Fired when the `opened` property changes.
  */
@@ -33,6 +38,11 @@ export type DialogOpenedChangedEvent = CustomEvent<{ value: boolean }>;
  * Fired when the dialog resize is finished.
  */
 export type DialogResizeEvent = CustomEvent<DialogResizeDimensions>;
+
+/**
+ * Fired when the dialog drag is finished.
+ */
+export type DialogDraggedEvent = CustomEvent<DialogPosition>;
 
 /**
  * Fired when the dialog is closed.
@@ -45,6 +55,8 @@ export interface DialogCustomEventMap {
   closed: DialogClosedEvent;
 
   resize: DialogResizeEvent;
+
+  dragged: DialogDraggedEvent;
 }
 
 export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -76,6 +76,7 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.
+ * @fires {CustomEvent} dragged - Fired when the dialog drag is finished.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the dialog is closed.
  *

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -597,6 +597,17 @@ describe('draggable', () => {
     expect(dialog.top).to.be.equal(bounds.top);
     expect(dialog.left).to.be.equal(bounds.left);
   });
+
+  it('should fire "dragged" event on drag', async () => {
+    const onDragged = sinon.spy();
+    dialog.addEventListener('dragged', onDragged);
+    drag(container);
+    await nextRender();
+    expect(onDragged.calledOnce).to.be.true;
+    const { detail } = onDragged.args[0][0];
+    expect(detail.top).to.be.equal(dialog.top);
+    expect(detail.left).to.be.equal(dialog.left);
+  });
 });
 
 describe('touch', () => {

--- a/packages/dialog/test/typings/dialog.types.ts
+++ b/packages/dialog/test/typings/dialog.types.ts
@@ -7,7 +7,9 @@ import type { DialogResizableMixinClass } from '../../src/vaadin-dialog-resizabl
 import type {
   Dialog,
   DialogClosedEvent,
+  DialogDraggedEvent,
   DialogOpenedChangedEvent,
+  DialogPosition,
   DialogRenderer,
   DialogResizeDimensions,
   DialogResizeEvent,
@@ -33,6 +35,11 @@ dialog.addEventListener('opened-changed', (event) => {
 dialog.addEventListener('resize', (event) => {
   assertType<DialogResizeEvent>(event);
   assertType<DialogResizeDimensions>(event.detail);
+});
+
+dialog.addEventListener('dragged', (event) => {
+  assertType<DialogDraggedEvent>(event);
+  assertType<DialogPosition>(event.detail);
 });
 
 dialog.addEventListener('closed', (event) => {


### PR DESCRIPTION
## Description

Adds a `dragged` event at the end of the drag of Dialog overlay. The event is particularly useful for keep the `top` and `left` properties in sync with the Flow counterpart.

Part of #1060 

## Type of change

- Feature
