### PR TITLE
fix: exclude items from drag image for large scrollers (#8028) (CP: 23.5)

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -96,6 +96,11 @@ export const DragAndDropMixin = (superClass) =>
       return ['_dragDropAccessChanged(rowsDraggable, dropMode, dragFilter, dropFilter, loading)'];
     }
 
+    constructor() {
+      super();
+      this.__onDocumentDragStart = this.__onDocumentDragStart.bind(this);
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -110,6 +115,22 @@ export const DragAndDropMixin = (superClass) =>
           e.stopPropagation();
         }
       });
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      // Chromium based browsers cannot properly generate drag images for elements
+      // that have children with massive heights. This workaround prevents crashes
+      // and performance issues by excluding the items from the drag image.
+      // https://github.com/vaadin/web-components/issues/7985
+      document.addEventListener('dragstart', this.__onDocumentDragStart, { capture: true });
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      document.removeEventListener('dragstart', this.__onDocumentDragStart, { capture: true });
     }
 
     /** @private */
@@ -262,6 +283,29 @@ export const DragAndDropMixin = (superClass) =>
         } else {
           this._clearDragStyles();
         }
+      }
+    }
+
+    /** @private */
+    __onDocumentDragStart(e) {
+      // The dragged element can be the element itself or a parent of the element
+      if (!e.target.contains(this)) {
+        return;
+      }
+      // The threshold value 20000 provides a buffer to both
+      //   - avoid the crash and the performance issues
+      //   - unnecessarily avoid excluding items from the drag image
+      if (this.$.items.offsetHeight > 20000) {
+        const initialItemsMaxHeight = this.$.items.style.maxHeight;
+        const initialTableOverflow = this.$.table.style.overflow;
+        // Momentarily hides the items until the browser starts generating the
+        // drag image.
+        this.$.items.style.maxHeight = '0';
+        this.$.table.style.overflow = 'hidden';
+        requestAnimationFrame(() => {
+          this.$.items.style.maxHeight = initialItemsMaxHeight;
+          this.$.table.style.overflow = initialTableOverflow;
+        });
       }
     }
 

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -110,6 +110,11 @@ class VirtualList extends ElementMixin(ControllerMixin(ThemableMixin(PolymerElem
     return ['__itemsOrRendererChanged(items, renderer, __virtualizer)'];
   }
 
+  constructor() {
+    super();
+    this.__onDragStart = this.__onDragStart.bind(this);
+  }
+
   /** @protected */
   ready() {
     super.ready();
@@ -126,6 +131,22 @@ class VirtualList extends ElementMixin(ControllerMixin(ThemableMixin(PolymerElem
     this.addController(this.__overflowController);
 
     processTemplates(this);
+  }
+
+  /** @protected */
+  connectedCallback() {
+    super.connectedCallback();
+    // Chromium based browsers cannot properly generate drag images for elements
+    // that have children with massive heights. This workaround prevents crashes
+    // and performance issues by excluding the items from the drag image.
+    // https://github.com/vaadin/web-components/issues/7985
+    document.addEventListener('dragstart', this.__onDragStart, { capture: true });
+  }
+
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('dragstart', this.__onDragStart, { capture: true });
   }
 
   /**
@@ -176,6 +197,29 @@ class VirtualList extends ElementMixin(ControllerMixin(ThemableMixin(PolymerElem
     if ((renderer || hasRenderedItems) && virtualizer) {
       virtualizer.size = (items || []).length;
       virtualizer.update();
+    }
+  }
+
+  /** @private */
+  __onDragStart(e) {
+    // The dragged element can be the element itself or a parent of the element
+    if (!e.target.contains(this)) {
+      return;
+    }
+    // The threshold value 20000 provides a buffer to both
+    //   - avoid the crash and the performance issues
+    //   - unnecessarily avoid excluding items from the drag image
+    if (this.$.items.offsetHeight > 20000) {
+      const initialItemsMaxHeight = this.$.items.style.maxHeight;
+      const initialVirtualListOverflow = this.style.overflow;
+      // Momentarily hides the items until the browser starts generating the
+      // drag image.
+      this.$.items.style.maxHeight = '0';
+      this.style.overflow = 'hidden';
+      requestAnimationFrame(() => {
+        this.$.items.style.maxHeight = initialItemsMaxHeight;
+        this.style.overflow = initialVirtualListOverflow;
+      });
     }
   }
 

--- a/packages/virtual-list/test/virtual-list.test.js
+++ b/packages/virtual-list/test/virtual-list.test.js
@@ -145,4 +145,90 @@ describe('virtual-list', () => {
       });
     });
   });
+  describe('drag and drop', () => {
+    let container;
+    let items;
+
+    beforeEach(async () => {
+      container = fixtureSync(`
+      <div style="width: 300px; height: 300px;">
+        <vaadin-virtual-list draggable="true"></vaadin-virtual-list>
+      </div>
+    `);
+      list = container.querySelector('vaadin-virtual-list');
+      list.renderer = (root, _, { item }) => {
+        root.innerHTML = `<div>${item.label}</div>`;
+      };
+      document.body.appendChild(container);
+      await nextFrame();
+      items = list.shadowRoot.querySelector('#items');
+    });
+
+    async function setVirtualListItems(count) {
+      list.items = Array.from({ length: count }).map((_, i) => {
+        return { label: `Item ${i}` };
+      });
+      await nextFrame();
+    }
+
+    function getState() {
+      return { itemsMaxHeight: items.style.maxHeight, listOverflow: list.style.overflow };
+    }
+
+    function getExpectedDragStartState() {
+      return { itemsMaxHeight: '0px', listOverflow: 'hidden' };
+    }
+
+    function assertStatesEqual(state1, state2) {
+      expect(state1.itemsMaxHeight).to.equal(state2.itemsMaxHeight);
+      expect(state1.listOverflow).to.equal(state2.listOverflow);
+    }
+
+    async function getStateDuringDragStart(element) {
+      let stateDuringDragStart;
+      element.addEventListener(
+        'dragstart',
+        () => {
+          stateDuringDragStart = getState();
+        },
+        { once: true },
+      );
+      element.dispatchEvent(new DragEvent('dragstart'));
+      await new Promise((resolve) => {
+        requestAnimationFrame(resolve);
+      });
+      return stateDuringDragStart;
+    }
+
+    it('should not change state on dragstart for small virtual lists', async () => {
+      await setVirtualListItems(10);
+      const initialState = getState();
+      const stateDuringDragStart = await getStateDuringDragStart(list);
+      assertStatesEqual(stateDuringDragStart, initialState);
+      const finalState = getState();
+      assertStatesEqual(finalState, initialState);
+    });
+
+    ['5000', '50000'].forEach((count) => {
+      it('should temporarily change state on dragstart for large virtual lists', async () => {
+        await setVirtualListItems(count);
+        const initialState = getState();
+        const stateDuringDragStart = await getStateDuringDragStart(list);
+        assertStatesEqual(stateDuringDragStart, getExpectedDragStartState());
+        const finalState = getState();
+        assertStatesEqual(finalState, initialState);
+      });
+
+      it('should temporarily change state on dragstart for large virtual lists in draggable containers', async () => {
+        list.removeAttribute('draggable');
+        container.setAttribute('draggable', true);
+        await setVirtualListItems(count);
+        const initialState = getState();
+        const stateDuringDragStart = await getStateDuringDragStart(container);
+        assertStatesEqual(stateDuringDragStart, getExpectedDragStartState());
+        const finalState = getState();
+        assertStatesEqual(finalState, initialState);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description

Back-port of #8028 for v23.5. 

Note: Tests are an older version of the tests in the original PR. The reason is that simulating the mouse events or manually dispatching drag events do not reproduce the issue and crash the browser. It still can be manually reproduced.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.