### PR TITLE
fix: import src version of vaadin-tabs in tabsheet

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2022 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/tabs/src/vaadin-tabs.js';
 import './vaadin-tabsheet-scroller.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';


### PR DESCRIPTION
## Description

Current implementation of `vaadin-tabsheet` imports `vaadin-tabs` in Lumo and Material, but not in `src`.
As a result, the error will be thrown when using the unstyled version as seen in https://github.com/vaadin/web-components/pull/7945#discussion_r1789579308.

## Type of change

- Bugfix