### PR TITLE
feat: add `top` and `left` to Dialog resize event detail

### DIFF
--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -149,7 +149,7 @@ export const DialogResizableMixin = (superClass) =>
      */
     _getResizeDimensions() {
       const scrollPosition = this.$.overlay.$.resizerContainer.scrollTop;
-      const { width, height } = getComputedStyle(this.$.overlay.$.overlay);
+      const { width, height, top, left } = getComputedStyle(this.$.overlay.$.overlay);
       const content = this.$.overlay.$.content;
       content.setAttribute(
         'style',
@@ -158,7 +158,7 @@ export const DialogResizableMixin = (superClass) =>
       const { width: contentWidth, height: contentHeight } = getComputedStyle(content);
       content.removeAttribute('style');
       this.$.overlay.$.resizerContainer.scrollTop = scrollPosition;
-      return { width, height, contentWidth, contentHeight };
+      return { width, height, contentWidth, contentHeight, top, left };
     }
 
     /**

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -22,6 +22,8 @@ export type DialogResizeDimensions = {
   height: string;
   contentWidth: string;
   contentHeight: string;
+  top: string;
+  left: string;
 };
 
 export type DialogPosition = {

--- a/packages/dialog/test/draggable-resizable.common.js
+++ b/packages/dialog/test/draggable-resizable.common.js
@@ -335,6 +335,8 @@ describe('resizable', () => {
     expect(onResize.calledOnce).to.be.true;
     expect(Math.floor(resizedBounds.width)).to.be.eql(parseInt(detail.width));
     expect(Math.floor(resizedBounds.height)).to.be.eql(parseInt(detail.height));
+    expect(Math.floor(resizedBounds.left)).to.be.eql(parseInt(detail.left));
+    expect(Math.floor(resizedBounds.top)).to.be.eql(parseInt(detail.top));
     expect(parseInt(detail.contentWidth)).to.be.eql(parseInt(contentStyles.width));
     expect(parseInt(detail.contentHeight)).to.be.eql(parseInt(contentStyles.height) - verticalPadding);
   });


### PR DESCRIPTION
## Description

Add `top` and `left` to the `resize` event to make it possible to sync these values on the server on the event listener.

Part of #1060

## Type of change

- Feature
