### PR TITLE
refactor: remove duplicate property declarations from text-field

### DIFF
--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -121,24 +121,6 @@ export class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(Polymer
     `;
   }
 
-  static get properties() {
-    return {
-      /**
-       * Maximum number of characters (in Unicode code points) that the user can enter.
-       */
-      maxlength: {
-        type: Number,
-      },
-
-      /**
-       * Minimum number of characters (in Unicode code points) that the user can enter.
-       */
-      minlength: {
-        type: Number,
-      },
-    };
-  }
-
   /** @protected */
   ready() {
     super.ready();


### PR DESCRIPTION
## Description

These properties were extracted to `TextFieldMixin` in #5520 but I missed to remove them from the component.

## Type of change

- Refactor