### PR TITLE
refactor: extract time-picker formatTime and parseTime helpers

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -20,6 +20,7 @@ import {
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
+import { formatISOTime, parseISOTime } from '@vaadin/time-picker/src/vaadin-time-picker-helper.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-date-time-picker', inputFieldShared, { moduleId: 'vaadin-date-time-picker' });
@@ -779,26 +780,6 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
   }
 
   /**
-   * Custom time object to string (ISO time)
-   * @param {!TimePickerTime} time Time components as properties { hours, minutes, seconds, milliseconds }
-   * @return {string} e.g. 'hh:mm', 'hh:mm:ss', 'hh:mm:ss.fff'
-   * @private
-   */
-  __formatTimeISO(time) {
-    return timePickerI18nDefaults.formatTime(time);
-  }
-
-  /**
-   * String (ISO time) to custom time object
-   * @param {string} str e.g. 'hh:mm', 'hh:mm:ss', 'hh:mm:ss.fff'
-   * @return {!TimePickerTime | undefined} Time components as properties { hours, minutes, seconds, milliseconds }
-   * @private
-   */
-  __parseTimeISO(str) {
-    return timePickerI18nDefaults.parseTime(str);
-  }
-
-  /**
    * String (ISO date time) to Date object
    * @param {string} str e.g. 'yyyy-mm-ddThh:mm', 'yyyy-mm-ddThh:mm:ss', 'yyyy-mm-ddThh:mm:ss.fff'
    * @return {Date | undefined}
@@ -817,7 +798,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
       return;
     }
 
-    const time = this.__parseTimeISO(timeValue);
+    const time = parseISOTime(timeValue);
     if (!time) {
       return;
     }
@@ -853,7 +834,7 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
    * @private
    */
   __dateToIsoTimeString(date) {
-    return this.__formatTimeISO(
+    return formatISOTime(
       this.__validateTime({
         hours: date.getUTCHours(),
         minutes: date.getUTCMinutes(),

--- a/packages/time-picker/src/vaadin-time-picker-helper.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker-helper.d.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+export interface TimePickerTime {
+  hours: number | string;
+  minutes: number | string;
+  seconds?: number | string;
+  milliseconds?: number | string;
+}
+
+/**
+ * A function to format given `Object` as time string.
+ * Object is in the format `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`
+ */
+export function formatISOTime(time: TimePickerTime | undefined): string;
+
+/**
+ * A function to parse the given string to an `Object` in the format
+ * `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`.
+ */
+export function parseISOTime(timeString: string): TimePickerTime | undefined;

--- a/packages/time-picker/src/vaadin-time-picker-helper.js
+++ b/packages/time-picker/src/vaadin-time-picker-helper.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright (c) 2018 - 2024 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A function to format given `Object` as time string.
+ * Object is in the format `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`
+ * @param {object} time
+ * @return {string}
+ */
+export function formatISOTime(time) {
+  if (!time) {
+    return '';
+  }
+
+  const pad = (num = 0, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
+  // Always display hour and minute
+  let timeString = `${pad(time.hours)}:${pad(time.minutes)}`;
+  // Adding second and millisecond depends on resolution
+  if (time.seconds !== undefined) {
+    timeString += `:${pad(time.seconds)}`;
+  }
+  if (time.milliseconds !== undefined) {
+    timeString += `.${pad(time.milliseconds, '000')}`;
+  }
+  return timeString;
+}
+
+const MATCH_HOURS = '(\\d|[0-1]\\d|2[0-3])';
+const MATCH_MINUTES = '(\\d|[0-5]\\d)';
+const MATCH_SECONDS = MATCH_MINUTES;
+const MATCH_MILLISECONDS = '(\\d{1,3})';
+const re = new RegExp(`^${MATCH_HOURS}(?::${MATCH_MINUTES}(?::${MATCH_SECONDS}(?:\\.${MATCH_MILLISECONDS})?)?)?$`, 'u');
+
+/**
+ * A function to parse the given string to an `Object` in the format
+ * `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`.
+ *
+ * @param {string} timeString
+ * @return {object | undefined}
+ */
+export function parseISOTime(timeString) {
+  // Parsing with RegExp to ensure correct format
+  const parts = re.exec(timeString);
+  if (parts) {
+    // Allows setting the milliseconds with hundreds and tens precision
+    if (parts[4]) {
+      while (parts[4].length < 3) {
+        parts[4] += '0';
+      }
+    }
+    return { hours: parts[1], minutes: parts[2], seconds: parts[3], milliseconds: parts[4] };
+  }
+}

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -7,13 +7,9 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { TimePickerTime } from './vaadin-time-picker-helper.js';
 
-export interface TimePickerTime {
-  hours: number | string;
-  minutes: number | string;
-  seconds?: number | string;
-  milliseconds?: number | string;
-}
+export type { TimePickerTime };
 
 export interface TimePickerI18n {
   parseTime(time: string): TimePickerTime | undefined;


### PR DESCRIPTION
## Description

Extracted default implementations of `formatTime` and `parseTime` to get rid of the following Polymer API usage:

https://github.com/vaadin/web-components/blob/72f4b092db55e71542c53bd6c9fd7040817e6afb/packages/time-picker/src/vaadin-time-picker.js#L807-L817

This is a pre-requisite for extracting `vaadin-time-picker` logic into a mixin for using in LitElement version.

## Type of change

- Refactor