### PR TITLE
refactor: extract time-picker validateTime helper to avoid duplication

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -20,7 +20,7 @@ import {
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
-import { formatISOTime, parseISOTime } from '@vaadin/time-picker/src/vaadin-time-picker-helper.js';
+import { formatISOTime, parseISOTime, validateTime } from '@vaadin/time-picker/src/vaadin-time-picker-helper.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-date-time-picker', inputFieldShared, { moduleId: 'vaadin-date-time-picker' });
@@ -835,27 +835,16 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
    */
   __dateToIsoTimeString(date) {
     return formatISOTime(
-      this.__validateTime({
-        hours: date.getUTCHours(),
-        minutes: date.getUTCMinutes(),
-        seconds: date.getUTCSeconds(),
-        milliseconds: date.getUTCMilliseconds(),
-      }),
+      validateTime(
+        {
+          hours: date.getUTCHours(),
+          minutes: date.getUTCMinutes(),
+          seconds: date.getUTCSeconds(),
+          milliseconds: date.getUTCMilliseconds(),
+        },
+        this.step,
+      ),
     );
-  }
-
-  /**
-   * @param {!TimePickerTime} timeObject
-   * @return {!TimePickerTime}
-   * @private
-   */
-  __validateTime(timeObject) {
-    if (timeObject) {
-      const stepSegment = this.__getStepSegment();
-      timeObject.seconds = stepSegment < 3 ? undefined : timeObject.seconds;
-      timeObject.milliseconds = stepSegment < 4 ? undefined : timeObject.milliseconds;
-    }
-    return timeObject;
   }
 
   /**
@@ -868,25 +857,6 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
     const hasInvalidPickers = this.__pickers.some((picker) => !picker.checkValidity());
     const hasEmptyRequiredPickers = this.required && this.__pickers.some((picker) => !picker.value);
     return !hasInvalidPickers && !hasEmptyRequiredPickers;
-  }
-
-  // Copied from vaadin-time-picker
-  /** @private */
-  __getStepSegment() {
-    const step = this.step == null ? 60 : parseFloat(this.step);
-    if (step % 3600 === 0) {
-      // Accept hours
-      return 1;
-    } else if (step % 60 === 0 || !step) {
-      // Accept minutes
-      return 2;
-    } else if (step % 1 === 0) {
-      // Accept seconds
-      return 3;
-    } else if (step < 1) {
-      // Accept milliseconds
-      return 4;
-    }
   }
 
   /**

--- a/packages/time-picker/src/vaadin-time-picker-helper.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker-helper.d.ts
@@ -22,3 +22,11 @@ export function formatISOTime(time: TimePickerTime | undefined): string;
  * `{ hours: ..., minutes: ..., seconds: ..., milliseconds: ... }`.
  */
 export function parseISOTime(timeString: string): TimePickerTime | undefined;
+
+/**
+ * A function to validate the time object based on the given step.
+ */
+export function validateTime(
+  timeObject: TimePickerTime | undefined,
+  step: number | null | undefined,
+): TimePickerTime | undefined;

--- a/packages/time-picker/src/vaadin-time-picker-helper.js
+++ b/packages/time-picker/src/vaadin-time-picker-helper.js
@@ -54,3 +54,38 @@ export function parseISOTime(timeString) {
     return { hours: parts[1], minutes: parts[2], seconds: parts[3], milliseconds: parts[4] };
   }
 }
+
+function getStepSegment(stepValue) {
+  const step = stepValue == null ? 60 : parseFloat(stepValue);
+  if (step % 3600 === 0) {
+    // Accept hours
+    return 1;
+  } else if (step % 60 === 0 || !step) {
+    // Accept minutes
+    return 2;
+  } else if (step % 1 === 0) {
+    // Accept seconds
+    return 3;
+  } else if (step < 1) {
+    // Accept milliseconds
+    return 4;
+  }
+}
+
+/**
+ * A function to validate the time object based on the given step.
+ *
+ * @param {object} timeObject
+ * @param {number} step
+ * @return {object | undefined}
+ */
+export function validateTime(timeObject, step) {
+  if (timeObject) {
+    const stepSegment = getStepSegment(step);
+    timeObject.hours = parseInt(timeObject.hours);
+    timeObject.minutes = parseInt(timeObject.minutes || 0);
+    timeObject.seconds = stepSegment < 3 ? undefined : parseInt(timeObject.seconds || 0);
+    timeObject.milliseconds = stepSegment < 4 ? undefined : parseInt(timeObject.milliseconds || 0);
+  }
+  return timeObject;
+}


### PR DESCRIPTION
## Description

Follow-up to #8073

Extracted `validateTime` helper to avoid copy-pasting corresponding code in `vaadin-date-time-picker`.

## Type of change

- Refactor