### PR TITLE
fix: remove null from dashboard section item title type

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -46,7 +46,7 @@ export interface DashboardSectionItem<TItem extends DashboardItem> {
   /**
    * The title of the section
    */
-  title?: string | null;
+  title?: string;
 
   /**
    * The items of the section

--- a/packages/dashboard/test/typings/dashboard.types.ts
+++ b/packages/dashboard/test/typings/dashboard.types.ts
@@ -27,7 +27,7 @@ const genericDashboard = document.createElement('vaadin-dashboard');
 assertType<Dashboard>(genericDashboard);
 
 assertType<{ colspan?: number; rowspan?: number }>(genericDashboard.items[0] as DashboardItem);
-assertType<{ items: DashboardItem[]; title?: string | null }>(
+assertType<{ items: DashboardItem[]; title?: string }>(
   genericDashboard.items[0] as DashboardSectionItem<DashboardItem>,
 );
 


### PR DESCRIPTION
## Description

To make the dashboard section item typing better compatible with Hilla, remove `null` from the title type

## Type of change

Bugfix