### PR TITLE
refactor: export i18n defaults for using in date-time-pickers

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -23,6 +23,62 @@ import {
   parseDate,
 } from './vaadin-date-picker-helper.js';
 
+export const datePickerI18nDefaults = Object.freeze({
+  monthNames: [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ],
+  weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  firstDayOfWeek: 0,
+  today: 'Today',
+  cancel: 'Cancel',
+  referenceDate: '',
+  formatDate(d) {
+    const yearStr = String(d.year).replace(/\d+/u, (y) => '0000'.substr(y.length) + y);
+    return [d.month + 1, d.day, yearStr].join('/');
+  },
+  parseDate(text) {
+    const parts = text.split('/');
+    const today = new Date();
+    let date,
+      month = today.getMonth(),
+      year = today.getFullYear();
+
+    if (parts.length === 3) {
+      month = parseInt(parts[0]) - 1;
+      date = parseInt(parts[1]);
+      year = parseInt(parts[2]);
+      if (parts[2].length < 3 && year >= 0) {
+        const usedReferenceDate = this.referenceDate ? parseDate(this.referenceDate) : new Date();
+        year = getAdjustedYear(usedReferenceDate, year, month, date);
+      }
+    } else if (parts.length === 2) {
+      month = parseInt(parts[0]) - 1;
+      date = parseInt(parts[1]);
+    } else if (parts.length === 1) {
+      date = parseInt(parts[0]);
+    }
+
+    if (date !== undefined) {
+      return { day: date, month, year };
+    }
+  },
+  formatTitle: (monthName, fullYear) => {
+    return `${monthName} ${fullYear}`;
+  },
+});
+
 /**
  * @polymerMixin
  * @mixes ControllerMixin
@@ -217,63 +273,7 @@ export const DatePickerMixin = (subclass) =>
         i18n: {
           type: Object,
           sync: true,
-          value: () => {
-            return {
-              monthNames: [
-                'January',
-                'February',
-                'March',
-                'April',
-                'May',
-                'June',
-                'July',
-                'August',
-                'September',
-                'October',
-                'November',
-                'December',
-              ],
-              weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-              weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-              firstDayOfWeek: 0,
-              today: 'Today',
-              cancel: 'Cancel',
-              referenceDate: '',
-              formatDate(d) {
-                const yearStr = String(d.year).replace(/\d+/u, (y) => '0000'.substr(y.length) + y);
-                return [d.month + 1, d.day, yearStr].join('/');
-              },
-              parseDate(text) {
-                const parts = text.split('/');
-                const today = new Date();
-                let date,
-                  month = today.getMonth(),
-                  year = today.getFullYear();
-
-                if (parts.length === 3) {
-                  month = parseInt(parts[0]) - 1;
-                  date = parseInt(parts[1]);
-                  year = parseInt(parts[2]);
-                  if (parts[2].length < 3 && year >= 0) {
-                    const usedReferenceDate = this.referenceDate ? parseDate(this.referenceDate) : new Date();
-                    year = getAdjustedYear(usedReferenceDate, year, month, date);
-                  }
-                } else if (parts.length === 2) {
-                  month = parseInt(parts[0]) - 1;
-                  date = parseInt(parts[1]);
-                } else if (parts.length === 1) {
-                  date = parseInt(parts[0]);
-                }
-
-                if (date !== undefined) {
-                  return { day: date, month, year };
-                }
-              },
-              formatTitle: (monthName, fullYear) => {
-                return `${monthName} ${fullYear}`;
-              },
-            };
-          },
+          value: () => ({ ...datePickerI18nDefaults }),
         },
 
         /**

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -3,6 +3,8 @@
  * Copyright (c) 2019 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/date-picker/src/vaadin-date-picker.js';
+import '@vaadin/time-picker/src/vaadin-time-picker.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
@@ -10,17 +12,17 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { DatePicker } from '@vaadin/date-picker/src/vaadin-date-picker.js';
 import {
   dateEquals,
   formatUTCISODate,
   normalizeUTCDate,
   parseUTCDate,
 } from '@vaadin/date-picker/src/vaadin-date-picker-helper.js';
+import { datePickerI18nDefaults } from '@vaadin/date-picker/src/vaadin-date-picker-mixin.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
-import { TimePicker } from '@vaadin/time-picker/src/vaadin-time-picker.js';
 import { formatISOTime, parseISOTime, validateTime } from '@vaadin/time-picker/src/vaadin-time-picker-helper.js';
+import { timePickerI18nDefaults } from '@vaadin/time-picker/src/vaadin-time-picker-mixin.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles('vaadin-date-time-picker', inputFieldShared, { moduleId: 'vaadin-date-time-picker' });
@@ -33,18 +35,6 @@ registerStyles('vaadin-date-time-picker', inputFieldShared, { moduleId: 'vaadin-
  * @property {string | number} [milliseconds]
  */
 
-// Find a property definition from the prototype chain of a Polymer element class
-function getPropertyFromPrototype(clazz, prop) {
-  while (clazz) {
-    if (clazz.properties && clazz.properties[prop]) {
-      return clazz.properties[prop];
-    }
-    clazz = Object.getPrototypeOf(clazz);
-  }
-}
-
-const datePickerI18nDefaults = getPropertyFromPrototype(DatePicker, 'i18n').value();
-const timePickerI18nDefaults = getPropertyFromPrototype(TimePicker, 'i18n').value();
 const datePickerI18nProps = Object.keys(datePickerI18nDefaults);
 const timePickerI18nProps = Object.keys(timePickerI18nDefaults);
 
@@ -506,12 +496,14 @@ class DateTimePicker extends FieldMixin(DisabledMixin(FocusMixin(ThemableMixin(E
 
   /** @private */
   __syncI18n(target, source, props = Object.keys(source.i18n)) {
+    const i18n = { ...target.i18n };
     props.forEach((prop) => {
       // eslint-disable-next-line no-prototype-builtins
       if (source.i18n && source.i18n.hasOwnProperty(prop)) {
-        target.set(`i18n.${prop}`, source.i18n[prop]);
+        i18n[prop] = source.i18n[prop];
       }
     });
+    target.i18n = i18n;
   }
 
   /** @private */

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -7,6 +7,11 @@ import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js
 import { PatternMixin } from '@vaadin/field-base/src/pattern-mixin.js';
 import { formatISOTime, parseISOTime, validateTime } from './vaadin-time-picker-helper.js';
 
+export const timePickerI18nDefaults = Object.freeze({
+  formatTime: formatISOTime,
+  parseTime: parseISOTime,
+});
+
 const MIN_ALLOWED_TIME = '00:00:00.000';
 const MAX_ALLOWED_TIME = '23:59:59.999';
 
@@ -151,12 +156,7 @@ export const TimePickerMixin = (superClass) =>
         i18n: {
           type: Object,
           sync: true,
-          value: () => {
-            return {
-              formatTime: formatISOTime,
-              parseTime: parseISOTime,
-            };
-          },
+          value: () => ({ ...timePickerI18nDefaults }),
         },
 
         /** @private */


### PR DESCRIPTION
## Description

Exposed defaults to avoid getting `i18n` values from `DatePicker` and `TimePicker` prototypes.
Also changed to not use `target.set()` (Polymer API) and set the whole `i18n` object instead.

This is a pre-requisite for extracting `vaadin-date-time-picker` logic into a mixin for Lit version.

## Type of change

- Refactor