### PR TITLE
test: remove date-time-picker tests covered by snapshots

### DIFF
--- a/packages/date-time-picker/test/basic.test.js
+++ b/packages/date-time-picker/test/basic.test.js
@@ -409,19 +409,6 @@ describe('Initial value', () => {
   });
 });
 
-describe('helperText', () => {
-  let dateTimePicker;
-
-  beforeEach(() => {
-    dateTimePicker = fixtureSync('<vaadin-date-time-picker></vaadin-date-time-picker>');
-  });
-
-  it('should display the helper text when provided', () => {
-    dateTimePicker.helperText = 'Foo';
-    expect(dateTimePicker.querySelector('[slot="helper"]').textContent).to.equal('Foo');
-  });
-});
-
 describe('Theme attribute', () => {
   let dateTimePicker;
   let datePicker;

--- a/packages/date-time-picker/test/properties.test.js
+++ b/packages/date-time-picker/test/properties.test.js
@@ -205,12 +205,6 @@ function getTimePicker(dateTimePicker) {
       expect(datePicker.showWeekNumbers).to.be.true;
     });
 
-    it('should handle label', () => {
-      dateTimePicker.label = 'Birth date and time';
-      const label = dateTimePicker.querySelector(':scope > label');
-      expect(label.textContent).to.equal('Birth date and time');
-    });
-
     it('should propagate invalid to date and time pickers', () => {
       dateTimePicker.invalid = true;
       expect(datePicker.invalid).to.be.true;
@@ -221,13 +215,6 @@ function getTimePicker(dateTimePicker) {
       dateTimePicker.required = true;
       expect(datePicker.required).to.be.true;
       expect(timePicker.required).to.be.true;
-    });
-
-    it('should handle error-message', () => {
-      dateTimePicker.errorMessage = 'error-message';
-      dateTimePicker.invalid = true;
-      const errorMessage = dateTimePicker.querySelector(':scope > [slot=error-message]');
-      expect(errorMessage.textContent).to.equal('error-message');
     });
 
     it('should propagate disabled to date and time pickers', () => {


### PR DESCRIPTION
## Description

We don't need to have tests for label, helper and error message `textContent` as these are covered by snapshots.

## Type of change

- Tests