### PR TITLE
fix: add missing .js extension to mixin imports in typings

### DIFF
--- a/packages/notification/src/vaadin-notification-mixin.d.ts
+++ b/packages/notification/src/vaadin-notification-mixin.d.ts
@@ -1,6 +1,6 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin';
-import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin';
+import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { Notification } from './vaadin-notification.js';
 
 export type NotificationPosition =


### PR DESCRIPTION
## Description

For some reason React components build fails without `.js` extension 😕 

## Type of change

- Bugfix