### PR TITLE
refactor: cleanup no longer needed date-time-picker logic

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -459,14 +459,7 @@ export const DateTimePickerMixin = (superClass) =>
 
       this.__addInputListeners(newDatePicker);
 
-      if (this.__isDefaultPicker(newDatePicker, 'date')) {
-        // Synchronize properties to default date picker
-        newDatePicker.placeholder = this.datePlaceholder;
-        newDatePicker.invalid = this.invalid;
-        newDatePicker.initialPosition = this.initialPosition;
-        newDatePicker.showWeekNumbers = this.showWeekNumbers;
-        this.__syncI18n(newDatePicker, this, datePickerI18nProps);
-      } else {
+      if (!this.__isDefaultPicker(newDatePicker, 'date')) {
         // Synchronize properties from slotted date picker
         this.datePlaceholder = newDatePicker.placeholder;
         this.initialPosition = newDatePicker.initialPosition;
@@ -481,7 +474,6 @@ export const DateTimePickerMixin = (superClass) =>
 
       // Disable default internal validation for the component
       newDatePicker.validate = () => {};
-      newDatePicker._validateInput = () => {};
     }
 
     /** @private */
@@ -497,13 +489,7 @@ export const DateTimePickerMixin = (superClass) =>
 
       this.__addInputListeners(newTimePicker);
 
-      if (this.__isDefaultPicker(newTimePicker, 'time')) {
-        // Synchronize properties to default time picker
-        newTimePicker.placeholder = this.timePlaceholder;
-        newTimePicker.step = this.step;
-        newTimePicker.invalid = this.invalid;
-        this.__syncI18n(newTimePicker, this, timePickerI18nProps);
-      } else {
+      if (!this.__isDefaultPicker(newTimePicker, 'time')) {
         // Synchronize properties from slotted time picker
         this.timePlaceholder = newTimePicker.placeholder;
         this.step = newTimePicker.step;
@@ -523,7 +509,6 @@ export const DateTimePickerMixin = (superClass) =>
       if (this.__timePicker && this.__datePicker) {
         const selectedDate = this.__parseDate(this.__datePicker.value);
         const isMinMaxSameDay = dateEquals(this.__minDateTime, this.__maxDateTime, normalizeUTCDate);
-        const oldTimeValue = this.__timePicker.value;
 
         if ((this.__minDateTime && dateEquals(selectedDate, this.__minDateTime, normalizeUTCDate)) || isMinMaxSameDay) {
           this.__timePicker.min = this.__dateToIsoTimeString(this.__minDateTime);
@@ -536,23 +521,17 @@ export const DateTimePickerMixin = (superClass) =>
         } else {
           this.__timePicker.max = this.__defaultTimeMaxValue;
         }
-
-        // If time picker automatically adjusts the time value due to the new min or max
-        // revert the time value
-        if (this.__timePicker.value !== oldTimeValue) {
-          this.__timePicker.value = oldTimeValue;
-        }
       }
     }
 
     /** @private */
-    __i18nChanged(i18n, datePicker, timePicker) {
+    __i18nChanged(_i18n, datePicker, timePicker) {
       if (datePicker) {
-        datePicker.i18n = { ...datePicker.i18n, ...i18n };
+        this.__syncI18n(datePicker, this, datePickerI18nProps);
       }
 
       if (timePicker) {
-        timePicker.i18n = { ...timePicker.i18n, ...i18n };
+        this.__syncI18n(timePicker, this, timePickerI18nProps);
       }
     }
 


### PR DESCRIPTION
## Description

Removed logic for propagating properties to default pickers since that is covered by individual observers since https://github.com/vaadin/web-components/pull/4971. Some of these properties were removed in https://github.com/vaadin/web-components/pull/4987 but not all of them, removed remaining ones and tests still pass.

Also removed logic for time-picker `value` update on `min` change since we no longer adjust value based on `min` or `max` since V24 as of https://github.com/vaadin/web-components/pull/4987 (the original logic was there since V14 version and is no longer needed).

Also, updated logic for setting `i18n` on individual pickers to only set relevant properties using `__syncI18n()` method.

## Type of change

- Refactor