### PR TITLE
fix: do not open popover after mouseleave during hover delay

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -89,6 +89,8 @@ class PopoverOpenedStateController {
       this.__abortClose();
       this.__setOpened(false);
     }
+
+    this.__abortOpen();
   }
 
   /** @private */
@@ -786,7 +788,7 @@ class Popover extends PopoverPositionMixin(
   __onTargetMouseLeave(event) {
     // Do not close the popover on target focusout if the overlay is not the last one.
     // This happens e.g. when opening the nested popover that uses non-modal overlay.
-    if (!isLastOverlay(this._overlayElement)) {
+    if (this._overlayElement.opened && !isLastOverlay(this._overlayElement)) {
       return;
     }
 

--- a/packages/popover/test/timers.test.js
+++ b/packages/popover/test/timers.test.js
@@ -100,6 +100,17 @@ describe('timers', () => {
       await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });
+
+    it('should not open the overlay after mouseleave during hover delay', async () => {
+      mouseenter(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+
+      mouseleave(target);
+
+      await aTimeout(5);
+      expect(overlay.opened).to.be.false;
+    });
   });
 
   describe('focusDelay', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6750

The issue was caused by missing logic to abort opening when close is triggered (as I missed to add this logic which is present in `TooltipStateController` in the `__abortWarmup()` method).

Also, the check for `isLastOverlay()` returns false when overlay is not yet opened, so I had to modify that as well.

## Type of change

- Bugfix