### PR TITLE
fix: set max-height on popover overlay to not overflow viewport

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -48,10 +48,13 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
         [part='overlay'] {
           position: relative;
           overflow: visible;
+          max-height: 100%;
         }
 
         [part='content'] {
           overflow: auto;
+          box-sizing: border-box;
+          max-height: 100%;
           width: var(--_vaadin-popover-content-width);
           height: var(--_vaadin-popover-content-height);
         }

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -413,6 +413,24 @@ describe('popover', () => {
     });
   });
 
+  describe('content overflow', () => {
+    beforeEach(async () => {
+      popover.renderer = (root) => {
+        root.textContent = new Array(1000).fill('foo').join(' ');
+      };
+      popover.opened = true;
+      await nextRender();
+    });
+
+    it('should limit overlay height if content overflows the viewport', () => {
+      expect(overlay.$.overlay.getBoundingClientRect().height).to.equal(overlay.getBoundingClientRect().height);
+    });
+
+    it('should limit content height if content overflows the viewport', () => {
+      expect(overlay.$.content.getBoundingClientRect().height).to.equal(overlay.getBoundingClientRect().height);
+    });
+  });
+
   describe('closed event', () => {
     beforeEach(async () => {
       popover.opened = true;


### PR DESCRIPTION
## Description

Fixes #8016

Unlike `vaadin-dialog`, the `vaadin-popover` was missing `max-height: 100%` on the overlay part.
Also, I had to set it on the content part as well in order to make sure scrolling works properly.

Note: original styles for dialog were added in https://github.com/vaadin/vaadin-dialog/pull/168 but in case of popover we need a slightly different approach since we don't have a "resizer container" element.

Here's how the resulting behavior looks like:

https://github.com/user-attachments/assets/adafaf9d-f894-4e14-84a8-030cddba83bb


## Type of change

- Bugfix