### PR TITLE
fix: ensure grid has tabbable elements after it becomes visible

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -1017,6 +1017,9 @@ export const GridMixin = (superClass) =>
         e.stopPropagation();
         this.__tryToRecalculateColumnWidthsIfPending();
 
+        // Ensure header and footer have tabbable elements
+        this._resetKeyboardNavigation();
+
         requestAnimationFrame(() => {
           this.__scrollToPendingIndexes();
         });

--- a/packages/grid/test/hidden-grid.common.js
+++ b/packages/grid/test/hidden-grid.common.js
@@ -1,18 +1,20 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { fire, flushGrid, getBodyCellContent, infiniteDataProvider } from './helpers.js';
+import { fire, flushGrid, getBodyCellContent, getHeaderCell, infiniteDataProvider } from './helpers.js';
 
 describe('hidden grid', () => {
   let grid;
 
   describe('initially hidden', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       grid = fixtureSync(`
       <vaadin-grid style="height: 200px; width: 200px;" hidden size="1">
         <vaadin-grid-column header="foo"></vaadin-grid-column>
       </vaadin-grid>
     `);
+      await nextRender();
       grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
         root.textContent = model.index;
       };
@@ -30,6 +32,15 @@ describe('hidden grid', () => {
       await oneEvent(grid, 'animationend');
       await nextFrame();
       expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('0');
+    });
+
+    it('should make it possible to Tab to header', async () => {
+      grid.removeAttribute('hidden');
+      await oneEvent(grid, 'animationend');
+      await nextFrame();
+
+      await sendKeys({ press: 'Tab' });
+      expect(grid.shadowRoot.activeElement).to.equal(getHeaderCell(grid, 0, 0));
     });
   });
 


### PR DESCRIPTION
## Description

Fixes #8098

When the grid is initially hidden, `_headerFocusable` is set to `undefined` since there is no first visible row.
Added the call to `_resetKeyboardNavigation()` on appear and a test to ensure focus gets moved properly.

This makes the grid <kbd>Tab</kbd> navigation work in `Popover` and manually attached `Dialog`.

## Type of change

- Bugfix