### PR TITLE
fix: do not throw on requestContentUpdate if card is not set

### DIFF
--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -264,7 +264,7 @@ export const NotificationMixin = (superClass) =>
      * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
      */
     requestContentUpdate() {
-      if (!this.renderer) {
+      if (!this.renderer || !this._card) {
         return;
       }
 

--- a/packages/notification/test/renderer.common.js
+++ b/packages/notification/test/renderer.common.js
@@ -114,13 +114,32 @@ describe('renderer', () => {
     });
 
     afterEach(() => {
-      document.body.removeChild(notification);
+      notification.remove();
     });
 
     it('should not throw when the renderer is set before adding to DOM', () => {
       expect(() => {
         notification.renderer = () => {};
         document.body.appendChild(notification);
+      }).to.not.throw(Error);
+    });
+
+    it('should not throw when requesting content update after adding', () => {
+      notification.renderer = (root) => {
+        root.textContent = 'Text';
+      };
+      document.body.appendChild(notification);
+      expect(() => {
+        notification.requestContentUpdate();
+      }).to.not.throw(Error);
+    });
+
+    it('should not throw when requesting content without adding to DOM', () => {
+      notification.renderer = (root) => {
+        root.textContent = 'Text';
+      };
+      expect(() => {
+        notification.requestContentUpdate();
       }).to.not.throw(Error);
     });
   });

--- a/packages/notification/test/renderer.common.js
+++ b/packages/notification/test/renderer.common.js
@@ -134,7 +134,7 @@ describe('renderer', () => {
       }).to.not.throw(Error);
     });
 
-    it('should not throw when requesting content without adding to DOM', () => {
+    it('should not throw when requesting content update without adding to DOM', () => {
       notification.renderer = (root) => {
         root.textContent = 'Text';
       };


### PR DESCRIPTION
## Description

Fixes #8109

This fixes an issue in Lit based version (related test is Lit specific) but the error thrown can be also reproduced in Polymer when calling `requestContentUpdate()` without adding to the DOM.

## Type of change

- Bugfix