### PR TITLE
refactor: make disabled property update synchronously with Lit

### DIFF
--- a/packages/a11y-base/src/disabled-mixin.js
+++ b/packages/a11y-base/src/disabled-mixin.js
@@ -23,6 +23,7 @@ export const DisabledMixin = dedupingMixin(
             value: false,
             observer: '_disabledChanged',
             reflectToAttribute: true,
+            sync: true,
           },
         };
       }

--- a/packages/a11y-base/test/disabled-mixin.test.js
+++ b/packages/a11y-base/test/disabled-mixin.test.js
@@ -1,23 +1,22 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DisabledMixin } from '../src/disabled-mixin.js';
 
-customElements.define(
-  'disabled-mixin-element',
-  class extends DisabledMixin(PolymerElement) {
-    static get template() {
-      return html`<slot></slot>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'disabled-mixin',
+    '<slot></slot>',
+    (Base) => class extends DisabledMixin(baseMixin(Base)) {},
+  );
 
-describe('disabled-mixin', () => {
   let element;
 
-  beforeEach(() => {
-    element = fixtureSync(`<disabled-mixin-element></disabled-mixin-element>`);
+  beforeEach(async () => {
+    element = fixtureSync(`<${tag}></${tag}>`);
+    await nextRender();
   });
 
   it('should set disabled property to false by default', () => {
@@ -47,4 +46,12 @@ describe('disabled-mixin', () => {
     element.click();
     expect(spy.called).to.be.false;
   });
+};
+
+describe('DisabledMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('DisabledMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/radio-group/test/radio-group.common.js
+++ b/packages/radio-group/test/radio-group.common.js
@@ -61,13 +61,12 @@ describe('radio-group', () => {
       buttons = [...group.querySelectorAll('vaadin-radio-button')];
     });
 
-    it('should propagate disabled property to radio buttons', async () => {
+    it('should propagate disabled property to radio buttons', () => {
       buttons.forEach((button) => {
         expect(button.disabled).to.be.true;
       });
 
       group.disabled = false;
-      await nextUpdate(group);
       buttons.forEach((button) => {
         expect(button.disabled).to.be.false;
       });
@@ -75,6 +74,15 @@ describe('radio-group', () => {
 
     it('should set disabled property to dynamically added radio buttons', async () => {
       const radio = document.createElement('vaadin-radio-button');
+      group.appendChild(radio);
+      await nextFrame();
+      expect(radio.disabled).to.be.true;
+    });
+
+    it('should not override disabled property on dynamically added radio buttons', async () => {
+      group.disabled = false;
+      const radio = document.createElement('vaadin-radio-button');
+      radio.disabled = true;
       group.appendChild(radio);
       await nextFrame();
       expect(radio.disabled).to.be.true;


### PR DESCRIPTION
## Description

Fixes #8111 

Updated `disabled` property to use `sync: true` for the Lit version and added missing Lit tests for the `DisabledMixin`.
Added also a new test to `radio-group` package to make sure https://github.com/vaadin/flow-components/pull/2563 also works with Lit.

## Type of change

- Refactor