### PR TITLE
refactor: make radio-group properties use sync updates in Lit

### DIFF
--- a/packages/radio-group/src/vaadin-radio-group-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-group-mixin.js
@@ -30,6 +30,7 @@ export const RadioGroupMixin = (superclass) =>
         name: {
           type: String,
           observer: '__nameChanged',
+          sync: true,
         },
 
         /**
@@ -41,6 +42,7 @@ export const RadioGroupMixin = (superclass) =>
           type: String,
           notify: true,
           value: '',
+          sync: true,
           observer: '__valueChanged',
         },
 
@@ -56,6 +58,7 @@ export const RadioGroupMixin = (superclass) =>
           type: Boolean,
           value: false,
           reflectToAttribute: true,
+          sync: true,
           observer: '__readonlyChanged',
         },
 

--- a/packages/radio-group/test/radio-group.common.js
+++ b/packages/radio-group/test/radio-group.common.js
@@ -112,9 +112,8 @@ describe('radio-group', () => {
       expect(radio.name).to.equal(groupName);
     });
 
-    it('should propagate the group name to the existing radio buttons', async () => {
+    it('should propagate the group name to the existing radio buttons', () => {
       group.name = 'name';
-      await nextFrame();
       buttons.forEach((radio) => {
         expect(radio.name).to.equal(group.name);
       });
@@ -122,7 +121,6 @@ describe('radio-group', () => {
 
     it('should propagate the group name to the dynamically added radio buttons', async () => {
       group.name = 'name';
-      await nextFrame();
 
       const radio = document.createElement('vaadin-radio-button');
       group.appendChild(radio);
@@ -131,12 +129,10 @@ describe('radio-group', () => {
       expect(radio.name).to.equal(group.name);
     });
 
-    it('should restore the default name on the radio buttons when group name removed', async () => {
+    it('should restore the default name on the radio buttons when group name removed', () => {
       group.name = 'name';
-      await nextFrame();
 
       group.name = null;
-      await nextFrame();
       buttons.forEach((radio) => {
         expect(radio.name).to.equal(groupName);
       });
@@ -161,35 +157,28 @@ describe('radio-group', () => {
       });
     });
 
-    it('should enable button when value is set while readonly', async () => {
+    it('should enable button when value is set while readonly', () => {
       group.value = '2';
-      await nextUpdate(group);
       expect(buttons[0].disabled).to.be.true;
       expect(buttons[1].disabled).to.be.false;
     });
 
-    it('should enable all buttons when readonly is set back to false', async () => {
+    it('should enable all buttons when readonly is set back to false', () => {
       group.readonly = false;
-      await nextUpdate(group);
       buttons.forEach((button) => {
         expect(button.disabled).to.be.false;
       });
     });
 
-    it('should reflect to lowercase readonly attribute', async () => {
+    it('should reflect to lowercase readonly attribute', () => {
       group.readonly = false;
-      await nextUpdate(group);
       expect(group.hasAttribute('readonly')).to.be.false;
 
       group.readonly = true;
-      await nextUpdate(group);
       expect(group.hasAttribute('readonly')).to.be.true;
     });
 
     it('should disable a new button when added to a readonly group', async () => {
-      group.readonly = true;
-      await nextUpdate(group);
-
       const newRadioButton = document.createElement('vaadin-radio-button');
       newRadioButton.label = 'Button 3';
       newRadioButton.value = '3';
@@ -200,9 +189,6 @@ describe('radio-group', () => {
     });
 
     it('should not disable a checked button when added to a readonly group', async () => {
-      group.readonly = true;
-      await nextUpdate(group);
-
       const newRadioButton = document.createElement('vaadin-radio-button');
       newRadioButton.label = 'Button 3';
       newRadioButton.value = '3';
@@ -291,78 +277,65 @@ describe('radio-group', () => {
       expect(group.value).to.equal('');
     });
 
-    it('should set value when radio button is checked', async () => {
+    it('should set value when radio button is checked', () => {
       buttons[0].checked = true;
-      await nextUpdate(group);
       expect(group.value).to.eq('on');
 
       buttons[1].checked = true;
-      await nextUpdate(group);
       expect(group.value).to.eq('2');
     });
 
-    it('should check proper button when value is set', async () => {
+    it('should check proper button when value is set', () => {
       group.value = '2';
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.true;
 
       group.value = 'on';
-      await nextUpdate(group);
       expect(buttons[0].checked).to.be.true;
     });
 
-    it('should un-check proper button when value is set to null', async () => {
+    it('should un-check proper button when value is set to null', () => {
       group.value = '2';
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.true;
 
       group.value = null;
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.false;
     });
 
-    it('should un-check proper button when value is set to undefined', async () => {
+    it('should un-check proper button when value is set to undefined', () => {
       group.value = '2';
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.true;
 
       group.value = undefined;
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.false;
     });
 
-    it('should un-check proper button when value is set to empty string', async () => {
+    it('should un-check proper button when value is set to empty string', () => {
       group.value = '2';
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.true;
 
       group.value = '';
-      await nextUpdate(group);
       expect(buttons[1].checked).to.be.false;
     });
 
-    it('should dispatch value-changed event when value changes', async () => {
+    it('should dispatch value-changed event when value changes', () => {
       const spy = sinon.spy();
       group.addEventListener('value-changed', spy);
       buttons[0].checked = true;
-      await nextUpdate(group);
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('should not focus radio group when value is set programmatically', async () => {
+    it('should not focus radio group when value is set programmatically', () => {
       const input = document.createElement('input');
       document.body.appendChild(input);
       input.focus();
       group.value = '2';
-      await nextUpdate(group);
       expect(document.activeElement).to.equal(input);
       document.body.removeChild(input);
     });
 
-    it('should warn when no radio button matches value set programmatically', async () => {
+    it('should warn when no radio button matches value set programmatically', () => {
       const stub = sinon.stub(console, 'warn');
       group.value = 'foo';
-      await nextUpdate(group);
       expect(stub.callCount).to.equal(1);
       stub.restore();
     });
@@ -380,23 +353,19 @@ describe('radio-group', () => {
       buttons = [...group.querySelectorAll('vaadin-radio-button')];
     });
 
-    it('should add and keep the attribute on radio button click', async () => {
+    it('should add and keep the attribute on radio button click', () => {
       buttons[0].click();
-      await nextUpdate(group);
       expect(group.hasAttribute('has-value')).to.be.true;
 
       buttons[1].click();
-      await nextUpdate(group);
       expect(group.hasAttribute('has-value')).to.be.true;
     });
 
-    it('should toggle the attribute on value change', async () => {
+    it('should toggle the attribute on value change', () => {
       group.value = '2';
-      await nextUpdate(group);
       expect(group.hasAttribute('has-value')).to.be.true;
 
       group.value = '';
-      await nextUpdate(group);
       expect(group.hasAttribute('has-value')).to.be.false;
     });
   });
@@ -538,7 +507,7 @@ describe('radio-group', () => {
     });
 
     it('should keep value when set immediately after removing and adding new children', async () => {
-      group.__radioButtons.forEach((button) => group.removeChild(button));
+      buttons.forEach((button) => group.removeChild(button));
 
       ['value1', 'value2', 'value3'].forEach((value) => {
         const radio = document.createElement('vaadin-radio-button');


### PR DESCRIPTION
## Description

Currently the Lit version breaks with [read-only group](https://github.com/vaadin/flow-components/blob/9e18d5c747ac161a88c85ad8d6e57086fdab3a7c/vaadin-radio-button-flow-parent/vaadin-radio-button-flow-integration-tests/src/main/java/com/vaadin/flow/component/radiobutton/tests/RadioButtonGroupDemoPage.java#L196) where there is an infinite loop (as far as I understand it's related to calling `rebuild()`). Changing `value` property to use `sync: true` fixes that.

Note: I though that it makes sense to also update `name` and `readonly` so that the component works consistently in terms of updating radio buttons (as e.g. `disabled` property is already using `sync` as well as `value`).

## Type of change

- Refactor