### PR TITLE
fix: set input value font weight property on input container

### DIFF
--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -10,7 +10,7 @@ registerStyles(
     :host {
       background: var(--_background);
       padding: 0 calc(0.375em + var(--_input-container-radius) / 4 - 1px);
-      font-weight: 500;
+      font-weight: var(--vaadin-input-field-value-font-weight, 500);
       line-height: 1;
       position: relative;
       cursor: text;

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -19,7 +19,6 @@ const inputField = css`
     --lumo-text-field-size: var(--lumo-size-m);
     color: var(--vaadin-input-field-value-color, var(--lumo-body-text-color));
     font-size: var(--vaadin-input-field-value-font-size, var(--lumo-font-size-m));
-    font-weight: var(--vaadin-input-field-value-font-weight, 400);
     font-family: var(--lumo-font-family);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -110,7 +110,7 @@ const globals = css`
     --vaadin-input-field-readonly-border: 1px dashed var(--lumo-contrast-30pct);
     --vaadin-input-field-value-color: var(--lumo-body-text-color);
     --vaadin-input-field-value-font-size: var(--lumo-font-size-m);
-    --vaadin-input-field-value-font-weight: 400;
+    --vaadin-input-field-value-font-weight: 500;
   }
 `;
 


### PR DESCRIPTION
## Description

Fixes #7957

Moved the font-weight custom CSS property to the correct file. Also changed it to `500` for backwards compatibility in order to not break screenshots (currently used `400` has never been working properly). 

Marked as a behavior altering fix, though I think we can still backport it at least to 24.5 to make the property work.

## Type of change

- Behavior altering fix