### PR TITLE
feat: add _createPropertyObserver() to PolylitMixin

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -217,12 +217,16 @@ const PolylitMixinImplementation = (superclass) => {
         this.__runObservers(props, this.constructor.__observers);
       }
 
+      if (this.__dynamicPropertyObservers) {
+        this.__runDynamicObservers(props, this.__dynamicPropertyObservers);
+      }
+
       if (this.constructor.__complexObservers) {
         this.__runComplexObservers(props, this.constructor.__complexObservers);
       }
 
-      if (this.__dynamicObservers) {
-        this.__runComplexObservers(props, this.__dynamicObservers);
+      if (this.__dynamicMethodObservers) {
+        this.__runComplexObservers(props, this.__dynamicMethodObservers);
       }
 
       if (this.constructor.__notifyProps) {
@@ -257,9 +261,15 @@ const PolylitMixinImplementation = (superclass) => {
 
     /** @protected */
     _createMethodObserver(observer) {
-      const dynamicObservers = getOrCreateMap(this, '__dynamicObservers');
+      const dynamicObservers = getOrCreateMap(this, '__dynamicMethodObservers');
       const { method, observerProps } = parseObserver(observer);
       dynamicObservers.set(method, observerProps);
+    }
+
+    /** @protected */
+    _createPropertyObserver(property, method) {
+      const dynamicObservers = getOrCreateMap(this, '__dynamicPropertyObservers');
+      dynamicObservers.set(method, property);
     }
 
     /** @private */
@@ -271,6 +281,15 @@ const PolylitMixinImplementation = (superclass) => {
           } else {
             this[method](...observerProps.map((prop) => this[prop]));
           }
+        }
+      });
+    }
+
+    /** @private */
+    __runDynamicObservers(props, observers) {
+      observers.forEach((prop, method) => {
+        if (props.has(prop) && this[method]) {
+          this[method](this[prop], props.get(prop));
         }
       });
     }


### PR DESCRIPTION
## Description

Fixes #8136

This is needed to make Grid and Virtual List connectors work. Note, I also added support for multiple dynamic observers per property as Grid connector does that for `activeItem` property to handle [selection](https://github.com/vaadin/flow-components/blob/ac0436312aae4bd55a80958420ed50d68290b28a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts#L190) and [details visibility](https://github.com/vaadin/flow-components/blob/ac0436312aae4bd55a80958420ed50d68290b28a/vaadin-grid-flow-parent/vaadin-grid-flow/src/main/resources/META-INF/resources/frontend/gridConnector.ts#L207) separately.

## Type of change

- Internal feature