### PR TITLE
refactor!: update avatar group to not use Polymer splices API

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -189,12 +189,6 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
       },
 
       /** @private */
-      __maxReached: {
-        type: Boolean,
-        computed: '__computeMaxReached(items, maxItemsVisible)',
-      },
-
-      /** @private */
       __itemsInView: {
         type: Number,
         value: null,
@@ -230,8 +224,7 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
       '__i18nItemsChanged(i18n, items)',
       '__updateAvatarsTheme(_overflow, _avatars, _theme)',
       '__updateAvatars(items, __itemsInView, maxItemsVisible, _overflow, i18n)',
-      '__updateOverflowAbbr(_overflow, items, __itemsInView, maxItemsVisible)',
-      '__updateOverflowHidden(_overflow, items, __itemsInView, __maxReached)',
+      '__updateOverflowAvatar(_overflow, items, __itemsInView, maxItemsVisible)',
       '__updateOverflowTooltip(_overflowTooltip, items, __itemsInView, maxItemsVisible)',
     ];
   }
@@ -420,23 +413,12 @@ class AvatarGroup extends ResizeMixin(OverlayClassMixin(ElementMixin(ThemableMix
   }
 
   /** @private */
-  __computeMaxReached(items, maxItemsVisible) {
-    const count = Array.isArray(items) ? items.length : 0;
-    return maxItemsVisible != null && count > this.__getMax(maxItemsVisible);
-  }
-
-  /** @private */
-  __updateOverflowAbbr(overflow, items, itemsInView, maxItemsVisible) {
+  __updateOverflowAvatar(overflow, items, itemsInView, maxItemsVisible) {
     if (overflow) {
       const count = Array.isArray(items) ? items.length : 0;
+      const maxReached = maxItemsVisible != null && count > this.__getMax(maxItemsVisible);
+
       overflow.abbr = `+${count - this.__getLimit(count, itemsInView, maxItemsVisible)}`;
-    }
-  }
-
-  /** @private */
-  __updateOverflowHidden(overflow, items, itemsInView, maxReached) {
-    if (overflow) {
-      const count = Array.isArray(items) ? items.length : 0;
       overflow.toggleAttribute('hidden', !maxReached && !(itemsInView && itemsInView < count));
     }
   }

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -224,7 +224,7 @@ describe('avatar-group', () => {
     });
 
     it('should always show at least two avatars', async () => {
-      group.set('items', group.items.slice(0, 2));
+      group.items = group.items.slice(0, 2);
       group.style.width = '50px';
       await onceResized(group);
       const items = group.querySelectorAll('vaadin-avatar:not([hidden])');

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -163,7 +163,7 @@ describe('avatar-group', () => {
     it('should hide overflow avatar when items property is changed', async () => {
       group.maxItemsVisible = 2;
       await nextRender(group);
-      group.splice('items', 1, 3);
+      group.items = group.items.slice(0, 2);
       await nextRender(group);
       expect(group._overflow.hasAttribute('hidden')).to.be.true;
     });
@@ -588,7 +588,7 @@ describe('avatar-group', () => {
     });
 
     it('should announce when adding single item', () => {
-      group.splice('items', 2, 0, { name: 'DD' });
+      group.items = [...group.items, { name: 'DD' }];
 
       clock.tick(150);
 
@@ -596,7 +596,7 @@ describe('avatar-group', () => {
     });
 
     it('should announce when removing single item', () => {
-      group.splice('items', 2, 1);
+      group.items = group.items.slice(0, 2);
 
       clock.tick(150);
 
@@ -604,7 +604,7 @@ describe('avatar-group', () => {
     });
 
     it('should announce when adding multiple items', () => {
-      group.splice('items', 2, 0, { name: 'DD' }, { name: 'EE' });
+      group.items = [...group.items, { name: 'DD' }, { name: 'EE' }];
 
       clock.tick(150);
 
@@ -612,7 +612,7 @@ describe('avatar-group', () => {
     });
 
     it('should announce when removing multiple items', () => {
-      group.splice('items', 1, 2);
+      group.items = group.items.slice(0, 1);
 
       clock.tick(150);
 
@@ -620,7 +620,7 @@ describe('avatar-group', () => {
     });
 
     it('should announce when adding and removing single item', () => {
-      group.splice('items', 2, 1, { name: 'DD' });
+      group.items = [...group.items.slice(0, 2), { name: 'DD' }];
 
       clock.tick(150);
 
@@ -628,19 +628,11 @@ describe('avatar-group', () => {
     });
 
     it('should announce when adding and removing multiple items', () => {
-      group.splice('items', 1, 2, { name: 'DD' }, { name: 'EE' });
+      group.items = [...group.items.slice(0, 1), { name: 'DD' }, { name: 'EE' }];
 
       clock.tick(150);
 
       expect(region.textContent).to.equal('BB left, CC left, DD joined, EE joined');
-    });
-
-    it('should announce when the items property is reset', () => {
-      group.set('items', [group.items[0]]);
-
-      clock.tick(150);
-
-      expect(region.textContent).to.equal('BB left, CC left');
     });
   });
 });

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-avatar-group default"] = 
 `<vaadin-avatar-group aria-label="Currently 0 active users">
   <vaadin-avatar
-    abbr="+NaN"
+    abbr="+0"
     aria-expanded="false"
     aria-haspopup="menu"
     hidden=""


### PR DESCRIPTION
## Description

Removed usage of `.splice()` API from `vaadin-avatar-group` and removed `calculateSplices()` usage.

From now one, mutating `items` property is no longer supported, instead it needs to be re-assigned.
Marked as a behavior altering change because of that (but Flow counterpart shouldn't be affected).

Also updated observers syntax which is a pre-requisite for creating LitElement based version.

## Type of change

- Refactor