### PR TITLE
refactor: drop threshold from reordering dashboard widgets

### DIFF
--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -79,19 +79,6 @@ describe('dashboard - widget reordering', () => {
       ]);
     });
 
-    it('should not reorder if dragged barely over another widget (start -> end)', async () => {
-      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
-      await nextFrame();
-
-      fireDragOver(getElementFromCell(dashboard, 0, 1)!, 'start');
-      await nextFrame();
-
-      // prettier-ignore
-      expectLayout(dashboard, [
-        [0, 1],
-      ]);
-    });
-
     it('should reorder the widgets while dragging (end -> start)', async () => {
       fireDragStart(getElementFromCell(dashboard, 0, 1)!);
       await nextFrame();
@@ -102,19 +89,6 @@ describe('dashboard - widget reordering', () => {
       // prettier-ignore
       expectLayout(dashboard, [
         [1, 0],
-      ]);
-    });
-
-    it('should not reorder if dragged barely over another widget (end -> start)', async () => {
-      fireDragStart(getElementFromCell(dashboard, 0, 1)!);
-      await nextFrame();
-
-      fireDragOver(getElementFromCell(dashboard, 0, 0)!, 'end');
-      await nextFrame();
-
-      // prettier-ignore
-      expectLayout(dashboard, [
-        [0, 1],
       ]);
     });
 
@@ -141,29 +115,6 @@ describe('dashboard - widget reordering', () => {
       ]);
     });
 
-    it('should not reorder if dragged barely over another widget (top -> bottom)', async () => {
-      dashboard.style.width = `${columnWidth}px`;
-      await onceResized(dashboard);
-
-      // prettier-ignore
-      expectLayout(dashboard, [
-        [0],
-        [1],
-      ]);
-
-      fireDragStart(getElementFromCell(dashboard, 0, 0)!);
-      await nextFrame();
-
-      fireDragOver(getElementFromCell(dashboard, 1, 0)!, 'top');
-      await nextFrame();
-
-      // prettier-ignore
-      expectLayout(dashboard, [
-        [0],
-        [1],
-      ]);
-    });
-
     it('should reorder the widgets while dragging (bottom -> top)', async () => {
       dashboard.style.width = `${columnWidth}px`;
       await onceResized(dashboard);
@@ -187,29 +138,6 @@ describe('dashboard - widget reordering', () => {
       ]);
     });
 
-    it('should not reorder if dragged barely over another widget (bottom -> top)', async () => {
-      dashboard.style.width = `${columnWidth}px`;
-      await onceResized(dashboard);
-
-      // prettier-ignore
-      expectLayout(dashboard, [
-        [0],
-        [1],
-      ]);
-
-      fireDragStart(getElementFromCell(dashboard, 1, 0)!);
-      await nextFrame();
-
-      fireDragOver(getElementFromCell(dashboard, 0, 0)!, 'bottom');
-      await nextFrame();
-
-      // prettier-ignore
-      expectLayout(dashboard, [
-        [0],
-        [1],
-      ]);
-    });
-
     // The sendMouse helper does not seem to work well with Firefox
     (isFirefox ? it.skip : it)('should reorder using native DnD', async () => {
       const spy = sinon.spy();
@@ -221,6 +149,17 @@ describe('dashboard - widget reordering', () => {
       await sendMouse({
         type: 'down',
       });
+      // Start moving the mouse
+      const draggedWidget = getElementFromCell(dashboard, 0, 0);
+      const draggedWidgetRect = draggedWidget!.getBoundingClientRect();
+      const startY = draggedWidgetRect.top + draggedWidgetRect.height / 2;
+      const startX = document.dir === 'rtl' ? draggedWidgetRect.right - 1 : draggedWidgetRect.left + 1;
+      // await sendMouse({ type: 'move', position: [Math.round(startX), Math.round(startY)] });
+      // Workaround an issue with sendMouse not supporting multiple subsequent moves
+      const reorderController = (dashboard as any).__widgetReorderController;
+      reorderController.__previousX = startX;
+      reorderController.__previousY = startY;
+
       // Move the mouse to the second widget
       const secondWidget = getElementFromCell(dashboard, 0, 1)!;
       const secondWidgetRect = secondWidget.getBoundingClientRect();

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -224,17 +224,6 @@ export function createDragEvent(type: string, { x, y }: { x: number; y: number }
   return event;
 }
 
-export function fireDragStart(dragStartTarget: Element): TestDragEvent {
-  const draggable = getDraggable(dragStartTarget);
-  const draggableRect = draggable.getBoundingClientRect();
-  const event = createDragEvent('dragstart', {
-    x: draggableRect.left + draggableRect.width / 2,
-    y: draggableRect.top + draggableRect.height / 2,
-  });
-  draggable.dispatchEvent(event);
-  return event;
-}
-
 function getEventCoordinates(relativeElement: Element, location: 'top' | 'bottom' | 'start' | 'end') {
   const { top, bottom, left, right } = relativeElement.getBoundingClientRect();
   const y = location === 'top' ? top : bottom;
@@ -246,6 +235,26 @@ function getEventCoordinates(relativeElement: Element, location: 'top' | 'bottom
 export function fireDragOver(dragOverTarget: Element, location: 'top' | 'bottom' | 'start' | 'end'): TestDragEvent {
   const event = createDragEvent('dragover', getEventCoordinates(dragOverTarget, location));
   dragOverTarget.dispatchEvent(event);
+  return event;
+}
+
+export function fireDragStart(dragStartTarget: Element): TestDragEvent {
+  const draggable = getDraggable(dragStartTarget);
+  const draggableRect = draggable.getBoundingClientRect();
+  const event = createDragEvent('dragstart', {
+    x: draggableRect.left + draggableRect.width / 2,
+    y: draggableRect.top + draggableRect.height / 2,
+  });
+  draggable.dispatchEvent(event);
+
+  // Dispatch initial dragover event to make sure any following dragover has some delta
+  draggable.dispatchEvent(
+    createDragEvent('dragover', {
+      x: draggableRect.left + draggableRect.width / 2,
+      y: draggableRect.top + draggableRect.height / 2,
+    }),
+  );
+
   return event;
 }
 


### PR DESCRIPTION
## Description

This PR removes the threshold over which a widget needs to overlap another one before their ordering gets swapped. After the change, the widgets reorder immediately regardless of how much they overlap. Delta x and y related to the previous dragover event are used to eliminate reorder loops.

https://github.com/user-attachments/assets/6cc547a6-8f67-46ad-982a-d760d0d03f41

Fixes https://github.com/vaadin/web-components/issues/8151

## Type of change

Refactor