### PR TITLE
feat: add option to mark defined custom element as experimental

### DIFF
--- a/packages/component-base/src/define.js
+++ b/packages/component-base/src/define.js
@@ -4,12 +4,38 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
+window.Vaadin ||= {};
+window.Vaadin.featureFlags ||= {};
+
+function dashToCamelCase(dash) {
+  return dash.replace(/-[a-z]/gu, (m) => m[1].toUpperCase());
+}
+
 export function defineCustomElement(CustomElement, version = '24.6.0-alpha8') {
   Object.defineProperty(CustomElement, 'version', {
     get() {
       return version;
     },
   });
+
+  if (CustomElement.experimental) {
+    const featureFlagKey = `${dashToCamelCase(CustomElement.is)}Component`;
+    if (!window.Vaadin.featureFlags[featureFlagKey]) {
+      // Add setter to define experimental component when it's set to true
+      Object.defineProperty(window.Vaadin.featureFlags, featureFlagKey, {
+        get() {
+          return !!customElements.get(CustomElement.is);
+        },
+        set(value) {
+          if (!!value && !customElements.get(CustomElement.is)) {
+            customElements.define(CustomElement.is, CustomElement);
+          }
+        },
+      });
+
+      return;
+    }
+  }
 
   const defined = customElements.get(CustomElement.is);
   if (!defined) {

--- a/packages/component-base/src/define.js
+++ b/packages/component-base/src/define.js
@@ -19,7 +19,8 @@ export function defineCustomElement(CustomElement, version = '24.6.0-alpha8') {
   });
 
   if (CustomElement.experimental) {
-    const featureFlagKey = `${dashToCamelCase(CustomElement.is)}Component`;
+    const name = CustomElement.is.split('-').slice(1).join('-');
+    const featureFlagKey = `${dashToCamelCase(name)}Component`;
     if (!window.Vaadin.featureFlags[featureFlagKey]) {
       // Add setter to define experimental component when it's set to true
       Object.defineProperty(window.Vaadin.featureFlags, featureFlagKey, {

--- a/packages/component-base/test/define.test.js
+++ b/packages/component-base/test/define.test.js
@@ -2,21 +2,64 @@ import { expect } from '@vaadin/chai-plugins';
 import { defineCustomElement } from '../src/define.js';
 
 describe('define', () => {
-  before(() => {
-    defineCustomElement(
-      class XElement extends HTMLElement {
-        static get is() {
-          return 'x-element';
-        }
-      },
-    );
+  describe('default', () => {
+    before(() => {
+      defineCustomElement(
+        class XElement extends HTMLElement {
+          static get is() {
+            return 'x-element';
+          }
+        },
+      );
+    });
+
+    it('should define a custom element', () => {
+      expect(customElements.get('x-element')).to.be.ok;
+    });
+
+    it('should have a valid version number', () => {
+      expect(customElements.get('x-element').version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/u);
+    });
   });
 
-  it('should define a custom element', () => {
-    expect(customElements.get('x-element')).to.be.ok;
-  });
+  describe('experimental', () => {
+    before(() => {
+      defineCustomElement(
+        class XFoo extends HTMLElement {
+          static get is() {
+            return 'x-foo';
+          }
 
-  it('should have a valid version number', () => {
-    expect(customElements.get('x-element').version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta|rc)\d+)?$/u);
+          static get experimental() {
+            return true;
+          }
+        },
+      );
+    });
+
+    it('should not define an experimental custom element by default', () => {
+      expect(customElements.get('x-foo')).to.be.not.ok;
+    });
+
+    it('should define an experimental custom element when flag is set after define', () => {
+      window.Vaadin.featureFlags.xFooComponent = true;
+      expect(customElements.get('x-foo')).to.be.ok;
+    });
+
+    it('should define an experimental custom element when flag is set before define', () => {
+      window.Vaadin.featureFlags.xBarComponent = true;
+      defineCustomElement(
+        class XBar extends HTMLElement {
+          static get is() {
+            return 'x-bar';
+          }
+
+          static get experimental() {
+            return true;
+          }
+        },
+      );
+      expect(customElements.get('x-bar')).to.be.ok;
+    });
   });
 });

--- a/packages/component-base/test/define.test.js
+++ b/packages/component-base/test/define.test.js
@@ -42,16 +42,16 @@ describe('define', () => {
     });
 
     it('should define an experimental custom element when flag is set after define', () => {
-      window.Vaadin.featureFlags.xFooComponent = true;
+      window.Vaadin.featureFlags.fooComponent = true;
       expect(customElements.get('x-foo')).to.be.ok;
     });
 
     it('should define an experimental custom element when flag is set before define', () => {
-      window.Vaadin.featureFlags.xBarComponent = true;
+      window.Vaadin.featureFlags.fooBarComponent = true;
       defineCustomElement(
-        class XBar extends HTMLElement {
+        class XFooBar extends HTMLElement {
           static get is() {
-            return 'x-bar';
+            return 'x-foo-bar';
           }
 
           static get experimental() {
@@ -59,7 +59,7 @@ describe('define', () => {
           }
         },
       );
-      expect(customElements.get('x-bar')).to.be.ok;
+      expect(customElements.get('x-foo-bar')).to.be.ok;
     });
   });
 });


### PR DESCRIPTION
## Description

Added an option to mark the custom element as experimental with the following syntax:

```js
static get experimental() {
  return true;
}
```

This is needed to enable using Vaadin feature flags in web components without separate `enable.js` file.
The reason behind this approach is that separate `enable.js` would still have to be added to dev bundle.

## Type of change

- Internal feature