### PR TITLE
refactor: update dashboard default spacing

### DIFF
--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -26,7 +26,7 @@ const [defaultSpacing, defaultMinimumColumnWidth] = (() => {
   document.body.appendChild(div);
   div.style.width = '1rem';
   const minColWidth = div.offsetWidth * 25;
-  div.style.width = 'var(--lumo-space-xl)';
+  div.style.width = 'var(--lumo-space-l)';
   const spacing = div.offsetWidth;
   div.remove();
   return [spacing, minColWidth];

--- a/packages/dashboard/theme/lumo/vaadin-dashboard-layout-styles.js
+++ b/packages/dashboard/theme/lumo/vaadin-dashboard-layout-styles.js
@@ -2,7 +2,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 
 export const dashboardLayoutStyles = css`
   #grid {
-    --_vaadin-dashboard-default-spacing: var(--lumo-space-xl);
+    --_vaadin-dashboard-default-spacing: var(--lumo-space-l);
   }
 `;
 


### PR DESCRIPTION
## Description

Update Dashboard default spacing to `--lumo-space-l`.

This will cause a temporary issue where the resize mode buttons may overlap other widgets, but it will get fixed by https://github.com/vaadin/web-components/issues/8153

Fixes https://github.com/vaadin/web-components/issues/8150

## Type of change

Refactor