### PR TITLE
feat: add option to return feature flag name from static getter

### DIFF
--- a/packages/component-base/src/define.js
+++ b/packages/component-base/src/define.js
@@ -11,6 +11,8 @@ function dashToCamelCase(dash) {
   return dash.replace(/-[a-z]/gu, (m) => m[1].toUpperCase());
 }
 
+const experimentalMap = {};
+
 export function defineCustomElement(CustomElement, version = '24.6.0-alpha8') {
   Object.defineProperty(CustomElement, 'version', {
     get() {
@@ -23,19 +25,30 @@ export function defineCustomElement(CustomElement, version = '24.6.0-alpha8') {
       typeof CustomElement.experimental === 'string'
         ? CustomElement.experimental
         : `${dashToCamelCase(CustomElement.is.split('-').slice(1).join('-'))}Component`;
-    if (!window.Vaadin.featureFlags[featureFlagKey]) {
+
+    if (!window.Vaadin.featureFlags[featureFlagKey] && !experimentalMap[featureFlagKey]) {
       // Add setter to define experimental component when it's set to true
+      experimentalMap[featureFlagKey] = new Set();
+      experimentalMap[featureFlagKey].add(CustomElement);
+
       Object.defineProperty(window.Vaadin.featureFlags, featureFlagKey, {
         get() {
-          return !!customElements.get(CustomElement.is);
+          return experimentalMap[featureFlagKey].size === 0;
         },
         set(value) {
-          if (!!value && !customElements.get(CustomElement.is)) {
-            customElements.define(CustomElement.is, CustomElement);
+          if (!!value && experimentalMap[featureFlagKey].size > 0) {
+            experimentalMap[featureFlagKey].forEach((elementClass) => {
+              customElements.define(elementClass.is, elementClass);
+            });
+            experimentalMap[featureFlagKey].clear();
           }
         },
       });
 
+      return;
+    } else if (experimentalMap[featureFlagKey]) {
+      // Allow to register multiple components with single flag
+      experimentalMap[featureFlagKey].add(CustomElement);
       return;
     }
   }

--- a/packages/component-base/src/define.js
+++ b/packages/component-base/src/define.js
@@ -19,8 +19,10 @@ export function defineCustomElement(CustomElement, version = '24.6.0-alpha8') {
   });
 
   if (CustomElement.experimental) {
-    const name = CustomElement.is.split('-').slice(1).join('-');
-    const featureFlagKey = `${dashToCamelCase(name)}Component`;
+    const featureFlagKey =
+      typeof CustomElement.experimental === 'string'
+        ? CustomElement.experimental
+        : `${dashToCamelCase(CustomElement.is.split('-').slice(1).join('-'))}Component`;
     if (!window.Vaadin.featureFlags[featureFlagKey]) {
       // Add setter to define experimental component when it's set to true
       Object.defineProperty(window.Vaadin.featureFlags, featureFlagKey, {

--- a/packages/component-base/test/define.test.js
+++ b/packages/component-base/test/define.test.js
@@ -61,5 +61,21 @@ describe('define', () => {
       );
       expect(customElements.get('x-foo-bar')).to.be.ok;
     });
+
+    it('should support defining feature flag name using experimental getter', () => {
+      defineCustomElement(
+        class XBaz extends HTMLElement {
+          static get is() {
+            return 'x-baz-item';
+          }
+
+          static get experimental() {
+            return 'bazComponent';
+          }
+        },
+      );
+      window.Vaadin.featureFlags.bazComponent = true;
+      expect(customElements.get('x-baz-item')).to.be.ok;
+    });
   });
 });

--- a/packages/component-base/test/define.test.js
+++ b/packages/component-base/test/define.test.js
@@ -66,6 +66,17 @@ describe('define', () => {
       defineCustomElement(
         class XBaz extends HTMLElement {
           static get is() {
+            return 'x-baz';
+          }
+
+          static get experimental() {
+            return 'bazComponent';
+          }
+        },
+      );
+      defineCustomElement(
+        class XBaz extends HTMLElement {
+          static get is() {
             return 'x-baz-item';
           }
 
@@ -74,7 +85,11 @@ describe('define', () => {
           }
         },
       );
+      expect(customElements.get('x-baz')).to.be.not.ok;
+      expect(customElements.get('x-baz-item')).to.be.not.ok;
+
       window.Vaadin.featureFlags.bazComponent = true;
+      expect(customElements.get('x-baz')).to.be.ok;
       expect(customElements.get('x-baz-item')).to.be.ok;
     });
   });


### PR DESCRIPTION
## Description

- Added option to specify feature flag using the `static get experimental()`
- Refactored to support defining multiple custom elements with single flag

## Type of change

- Internal feature