### PR TITLE
fix: do not render hidden combo box items

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.js
@@ -97,7 +97,7 @@ export const ComboBoxItemMixin = (superClass) =>
      * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
      */
     requestContentUpdate() {
-      if (!this.renderer) {
+      if (!this.renderer || this.hidden) {
         return;
       }
 


### PR DESCRIPTION
Since adding the data provider controller to combo box in https://github.com/vaadin/web-components/pull/7044, the component now calls `ComboBoxMixin.requestContentUpdate` when filtering using a data provider. That method iterates over every item in the overlay, regardless whether visible or hidden, and runs its renderer function:
https://github.com/vaadin/web-components/blob/d8772844d1d469094ef26762db90f295ec510ea7/packages/combo-box/src/vaadin-combo-box-mixin.js#L412-L414

That can lead to an issue in the Flow component when using component renderers:
- Entering a filter can move an item's content element to a different item (for example the first one if there is only one match)
- The item that originally contained the content element is then hidden and not updated - it still references the same data, and thus the same content element
- Then we run the renderer function for the hidden item, and move the content element back to it
- The result is that the visible item ends up being empty

This change fixes the issue by not running the renderer function for hidden items.

Fixes https://github.com/vaadin/flow-components/issues/6810