### PR TITLE
refactor!: remove date focused part when input is unparsable

### DIFF
--- a/dev/date-picker.html
+++ b/dev/date-picker.html
@@ -9,20 +9,22 @@
     <script type="module">
       import '@vaadin/date-picker';
       import '@vaadin/tooltip';
-      // const isDateDisabled = (date) => {
-      //   // Exclude weekends and the 16th day of each month:
-      //   const checkDate = new Date(0, 0);
-      //   checkDate.setFullYear(date.year);
-      //   checkDate.setMonth(date.month);
-      //   checkDate.setDate(date.day);
-      //   return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
-      // }
-      // const picker = document.querySelector('vaadin-date-picker');
-      // picker.isDateDisabled = isDateDisabled;
-      // picker.min = '2023-11-01';
+      const isDateDisabled = (date) => {
+        // Exclude weekends and the 16th day of each month:
+        const checkDate = new Date(0, 0);
+        checkDate.setFullYear(date.year);
+        checkDate.setMonth(date.month);
+        checkDate.setDate(date.day);
+        return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
+      }
+      const picker = document.querySelector('vaadin-date-picker');
+      picker.isDateDisabled = isDateDisabled;
+      picker.min = '2023-11-01';
     </script>
   </head>
   <body>
-    <vaadin-date-picker label="Start date"></vaadin-date-picker>
+    <vaadin-date-picker label="Start date">
+      <vaadin-tooltip slot="tooltip" text="Counted as first day"></vaadin-tooltip>
+    </vaadin-date-picker>
   </body>
 </html>

--- a/dev/date-picker.html
+++ b/dev/date-picker.html
@@ -9,22 +9,20 @@
     <script type="module">
       import '@vaadin/date-picker';
       import '@vaadin/tooltip';
-      const isDateDisabled = (date) => {
-        // Exclude weekends and the 16th day of each month:
-        const checkDate = new Date(0, 0);
-        checkDate.setFullYear(date.year);
-        checkDate.setMonth(date.month);
-        checkDate.setDate(date.day);
-        return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
-      }
-      const picker = document.querySelector('vaadin-date-picker');
-      picker.isDateDisabled = isDateDisabled;
-      picker.min = '2023-11-01';
+      // const isDateDisabled = (date) => {
+      //   // Exclude weekends and the 16th day of each month:
+      //   const checkDate = new Date(0, 0);
+      //   checkDate.setFullYear(date.year);
+      //   checkDate.setMonth(date.month);
+      //   checkDate.setDate(date.day);
+      //   return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
+      // }
+      // const picker = document.querySelector('vaadin-date-picker');
+      // picker.isDateDisabled = isDateDisabled;
+      // picker.min = '2023-11-01';
     </script>
   </head>
   <body>
-    <vaadin-date-picker label="Start date">
-      <vaadin-tooltip slot="tooltip" text="Counted as first day"></vaadin-tooltip>
-    </vaadin-date-picker>
+    <vaadin-date-picker label="Start date"></vaadin-date-picker>
   </body>
 </html>

--- a/dev/date-picker.html
+++ b/dev/date-picker.html
@@ -7,23 +7,24 @@
     <title>Date picker</title>
     <script type="module" src="./common.js"></script>
     <script type="module">
-      import '@vaadin/date-picker/vaadin-date-picker.js';
-      // import '@vaadin/tooltip';
-      // const isDateDisabled = (date) => {
-      //   // Exclude weekends and the 16th day of each month:
-      //   const checkDate = new Date(0, 0);
-      //   checkDate.setFullYear(date.year);
-      //   checkDate.setMonth(date.month);
-      //   checkDate.setDate(date.day);
-      //   return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
-      // }
-      // const picker = document.querySelector('vaadin-date-picker');
-      // picker.isDateDisabled = isDateDisabled;
-      // picker.min = '2023-11-01';
+      import '@vaadin/date-picker';
+      import '@vaadin/tooltip';
+      const isDateDisabled = (date) => {
+        // Exclude weekends and the 16th day of each month:
+        const checkDate = new Date(0, 0);
+        checkDate.setFullYear(date.year);
+        checkDate.setMonth(date.month);
+        checkDate.setDate(date.day);
+        return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
+      }
+      const picker = document.querySelector('vaadin-date-picker');
+      picker.isDateDisabled = isDateDisabled;
+      picker.min = '2023-11-01';
     </script>
   </head>
   <body>
     <vaadin-date-picker label="Start date">
+      <vaadin-tooltip slot="tooltip" text="Counted as first day"></vaadin-tooltip>
     </vaadin-date-picker>
   </body>
 </html>

--- a/dev/date-picker.html
+++ b/dev/date-picker.html
@@ -7,24 +7,23 @@
     <title>Date picker</title>
     <script type="module" src="./common.js"></script>
     <script type="module">
-      import '@vaadin/date-picker';
-      import '@vaadin/tooltip';
-      const isDateDisabled = (date) => {
-        // Exclude weekends and the 16th day of each month:
-        const checkDate = new Date(0, 0);
-        checkDate.setFullYear(date.year);
-        checkDate.setMonth(date.month);
-        checkDate.setDate(date.day);
-        return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
-      }
-      const picker = document.querySelector('vaadin-date-picker');
-      picker.isDateDisabled = isDateDisabled;
-      picker.min = '2023-11-01';
+      import '@vaadin/date-picker/vaadin-date-picker.js';
+      // import '@vaadin/tooltip';
+      // const isDateDisabled = (date) => {
+      //   // Exclude weekends and the 16th day of each month:
+      //   const checkDate = new Date(0, 0);
+      //   checkDate.setFullYear(date.year);
+      //   checkDate.setMonth(date.month);
+      //   checkDate.setDate(date.day);
+      //   return checkDate.getDay() === 0 || checkDate.getDay() === 6 || checkDate.getDate() === 16;
+      // }
+      // const picker = document.querySelector('vaadin-date-picker');
+      // picker.isDateDisabled = isDateDisabled;
+      // picker.min = '2023-11-01';
     </script>
   </head>
   <body>
     <vaadin-date-picker label="Start date">
-      <vaadin-tooltip slot="tooltip" text="Counted as first day"></vaadin-tooltip>
     </vaadin-date-picker>
   </body>
 </html>

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -396,7 +396,7 @@ export const DatePickerMixin = (subclass) =>
     /** @override */
     set _inputElementValue(value) {
       super._inputElementValue = value;
-      this.__enteredDate = this.__parseDate(value);
+      this.__setEnteredDate(value);
     }
 
     /**
@@ -1185,17 +1185,27 @@ export const DatePickerMixin = (subclass) =>
         this.open();
       }
 
-      const parsedDate = this.__parseDate(this._inputElementValue || '');
-      if (parsedDate) {
-        this._ignoreFocusedDateChange = true;
-        if (!dateEquals(parsedDate, this._focusedDate)) {
-          this._focusedDate = parsedDate;
+      if (this._inputElementValue) {
+        const parsedDate = this.__parseDate(this._inputElementValue);
+        if (parsedDate) {
+          this._ignoreFocusedDateChange = true;
+          if (!dateEquals(parsedDate, this._focusedDate)) {
+            this._focusedDate = parsedDate;
+          }
+          this._ignoreFocusedDateChange = false;
         }
-        this._ignoreFocusedDateChange = false;
       }
 
-      if (!dateEquals(parsedDate, this.__enteredDate)) {
+      this.__setEnteredDate(this._inputElementValue);
+    }
+
+    /** @private */
+    __setEnteredDate(value) {
+      const parsedDate = this.__parseDate(value);
+      if (value && !dateEquals(parsedDate, this.__enteredDate)) {
         this.__enteredDate = parsedDate;
+      } else if (this.__enteredDate != null) {
+        this.__enteredDate = null;
       }
     }
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1209,7 +1209,9 @@ export const DatePickerMixin = (subclass) =>
           this.__enteredDate = date;
         }
       } else if (this.__enteredDate != null) {
-        // Preserve the undefined value
+        // Do not override initial undefined value with null
+        // to avoid triggering a Lit update that can cause
+        // other scheduled properties to flush too early.
         this.__enteredDate = null;
       }
     }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -361,6 +361,7 @@ export const DatePickerMixin = (subclass) =>
         /** @private */
         __enteredDate: {
           type: Date,
+          sync: true,
         },
       };
     }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -396,7 +396,9 @@ export const DatePickerMixin = (subclass) =>
     /** @override */
     set _inputElementValue(value) {
       super._inputElementValue = value;
-      this.__setEnteredDate(value);
+
+      const parsedDate = this.__parseDate(value);
+      this.__setEnteredDate(parsedDate);
     }
 
     /**
@@ -1185,26 +1187,29 @@ export const DatePickerMixin = (subclass) =>
         this.open();
       }
 
-      if (this._inputElementValue) {
-        const parsedDate = this.__parseDate(this._inputElementValue);
-        if (parsedDate) {
-          this._ignoreFocusedDateChange = true;
-          if (!dateEquals(parsedDate, this._focusedDate)) {
-            this._focusedDate = parsedDate;
-          }
-          this._ignoreFocusedDateChange = false;
+      const parsedDate = this.__parseDate(this._inputElementValue || '');
+      if (parsedDate) {
+        this._ignoreFocusedDateChange = true;
+        if (!dateEquals(parsedDate, this._focusedDate)) {
+          this._focusedDate = parsedDate;
         }
+        this._ignoreFocusedDateChange = false;
       }
 
-      this.__setEnteredDate(this._inputElementValue);
+      this.__setEnteredDate(parsedDate);
     }
 
-    /** @private */
-    __setEnteredDate(value) {
-      const parsedDate = this.__parseDate(value);
-      if (value && !dateEquals(parsedDate, this.__enteredDate)) {
-        this.__enteredDate = parsedDate;
+    /**
+     * @param {Date} date
+     * @private
+     */
+    __setEnteredDate(date) {
+      if (date) {
+        if (!dateEquals(this.__enteredDate, date)) {
+          this.__enteredDate = date;
+        }
       } else if (this.__enteredDate != null) {
+        // Preserve the undefined value
         this.__enteredDate = null;
       }
     }

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -357,6 +357,11 @@ export const DatePickerMixin = (subclass) =>
           type: Object,
           sync: true,
         },
+
+        /** @private */
+        __enteredDate: {
+          type: Date,
+        },
       };
     }
 
@@ -364,7 +369,7 @@ export const DatePickerMixin = (subclass) =>
       return [
         '_selectedDateChanged(_selectedDate, i18n)',
         '_focusedDateChanged(_focusedDate, i18n)',
-        '__updateOverlayContent(_overlayContent, i18n, label, _minDate, _maxDate, _focusedDate, _selectedDate, showWeekNumbers, isDateDisabled)',
+        '__updateOverlayContent(_overlayContent, i18n, label, _minDate, _maxDate, _focusedDate, _selectedDate, showWeekNumbers, isDateDisabled, __enteredDate)',
         '__updateOverlayContentTheme(_overlayContent, _theme)',
         '__updateOverlayContentFullScreen(_overlayContent, _fullscreen)',
       ];
@@ -380,6 +385,17 @@ export const DatePickerMixin = (subclass) =>
       this._boundOnClick = this._onClick.bind(this);
       this._boundOnScroll = this._onScroll.bind(this);
       this._boundOverlayRenderer = this._overlayRenderer.bind(this);
+    }
+
+    /** @override */
+    get _inputElementValue() {
+      return super._inputElementValue;
+    }
+
+    /** @override */
+    set _inputElementValue(value) {
+      super._inputElementValue = value;
+      this.__enteredDate = this.__parseDate(value);
     }
 
     /**
@@ -833,6 +849,7 @@ export const DatePickerMixin = (subclass) =>
       selectedDate,
       showWeekNumbers,
       isDateDisabled,
+      enteredDate,
     ) {
       if (overlayContent) {
         overlayContent.i18n = i18n;
@@ -843,6 +860,7 @@ export const DatePickerMixin = (subclass) =>
         overlayContent.selectedDate = selectedDate;
         overlayContent.showWeekNumbers = showWeekNumbers;
         overlayContent.isDateDisabled = isDateDisabled;
+        overlayContent.enteredDate = enteredDate;
       }
     }
 
@@ -1166,15 +1184,17 @@ export const DatePickerMixin = (subclass) =>
         this.open();
       }
 
-      if (this._inputElementValue) {
-        const parsedDate = this.__parseDate(this._inputElementValue);
-        if (parsedDate) {
-          this._ignoreFocusedDateChange = true;
-          if (!dateEquals(parsedDate, this._focusedDate)) {
-            this._focusedDate = parsedDate;
-          }
-          this._ignoreFocusedDateChange = false;
+      const parsedDate = this.__parseDate(this._inputElementValue || '');
+      if (parsedDate) {
+        this._ignoreFocusedDateChange = true;
+        if (!dateEquals(parsedDate, this._focusedDate)) {
+          this._focusedDate = parsedDate;
         }
+        this._ignoreFocusedDateChange = false;
+      }
+
+      if (!dateEquals(parsedDate, this.__enteredDate)) {
+        this.__enteredDate = parsedDate;
       }
     }
 

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -57,7 +57,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
         initialPosition: {
           type: Object,
           observer: '_initialPositionChanged',
-          sync: true,
         },
 
         _originDate: {
@@ -127,6 +126,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
         enteredDate: {
           type: Date,
+          sync: true,
         },
 
         /**

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -125,6 +125,10 @@ export const DatePickerOverlayContentMixin = (superClass) =>
           type: Function,
         },
 
+        enteredDate: {
+          type: Date,
+        },
+
         /**
          * Input label
          */
@@ -152,7 +156,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     static get observers() {
       return [
-        '__updateCalendars(calendars, i18n, minDate, maxDate, selectedDate, focusedDate, showWeekNumbers, _ignoreTaps, _theme, isDateDisabled)',
+        '__updateCalendars(calendars, i18n, minDate, maxDate, selectedDate, focusedDate, showWeekNumbers, _ignoreTaps, _theme, isDateDisabled, enteredDate)',
         '__updateCancelButton(_cancelButton, i18n)',
         '__updateTodayButton(_todayButton, i18n, minDate, maxDate, isDateDisabled)',
         '__updateYears(years, selectedDate, _theme)',
@@ -340,6 +344,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
       ignoreTaps,
       theme,
       isDateDisabled,
+      enteredDate,
     ) {
       if (calendars && calendars.length) {
         calendars.forEach((calendar) => {
@@ -351,6 +356,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
           calendar.selectedDate = selectedDate;
           calendar.showWeekNumbers = showWeekNumbers;
           calendar.ignoreTaps = ignoreTaps;
+          calendar.enteredDate = enteredDate;
 
           if (theme) {
             calendar.setAttribute('theme', theme);

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -57,6 +57,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
         initialPosition: {
           type: Object,
           observer: '_initialPositionChanged',
+          sync: true,
         },
 
         _originDate: {

--- a/packages/date-picker/src/vaadin-lit-month-calendar.js
+++ b/packages/date-picker/src/vaadin-lit-month-calendar.js
@@ -61,6 +61,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LitEle
                 ${week.map((date) => {
                   const isFocused =
                     dateEquals(date, this.focusedDate) && (this.__hasFocus || dateEquals(date, this.enteredDate));
+                  const tabIndex = dateEquals(date, this.focusedDate) ? '0' : '-1';
                   const isSelected = dateEquals(date, this.selectedDate);
                   const isDisabled = !dateAllowed(date, this.minDate, this.maxDate, this.isDateDisabled);
                   const greaterThanToday = date > normalizeDate(new Date());
@@ -82,7 +83,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LitEle
                       part="${parts.join(' ')}"
                       .date="${date}"
                       ?disabled="${isDisabled}"
-                      tabindex="${isFocused ? '0' : '-1'}"
+                      tabindex="${tabIndex}"
                       aria-selected="${isSelected ? 'true' : 'false'}"
                       aria-disabled="${isDisabled ? 'true' : 'false'}"
                       aria-label="${this.__getDayAriaLabel(date)}"

--- a/packages/date-picker/src/vaadin-lit-month-calendar.js
+++ b/packages/date-picker/src/vaadin-lit-month-calendar.js
@@ -59,7 +59,8 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LitEle
                   ${this.__getWeekNumber(week)}
                 </td>
                 ${week.map((date) => {
-                  const isFocused = dateEquals(date, this.focusedDate);
+                  const isFocused =
+                    dateEquals(date, this.focusedDate) && (this.__hasFocus || dateEquals(date, this.enteredDate));
                   const isSelected = dateEquals(date, this.selectedDate);
                   const isDisabled = !dateAllowed(date, this.minDate, this.maxDate, this.isDateDisabled);
                   const greaterThanToday = date > normalizeDate(new Date());

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -114,6 +114,11 @@ export const MonthCalendarMixin = (superClass) =>
         _notTapping: {
           type: Boolean,
         },
+
+        /** @private */
+        __hasFocus: {
+          type: Boolean,
+        },
       };
     }
 
@@ -131,6 +136,12 @@ export const MonthCalendarMixin = (superClass) =>
     ready() {
       super.ready();
       addListener(this.$.monthGrid, 'tap', this._handleTap.bind(this));
+    }
+
+    /** @override */
+    _setFocused(focused) {
+      super._setFocused(focused);
+      this.__hasFocus = focused;
     }
 
     /**

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -91,6 +91,10 @@ export const MonthCalendarMixin = (superClass) =>
           value: () => false,
         },
 
+        enteredDate: {
+          type: Date,
+        },
+
         disabled: {
           type: Boolean,
           reflectToAttribute: true,

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -50,7 +50,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
               <template is="dom-repeat" items="[[week]]">
                 <td
                   role="gridcell"
-                  part$="[[__getDatePart(item, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled)]]"
+                  part$="[[__getDatePart(item, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled, __hasFocus)]]"
                   date="[[item]]"
                   tabindex$="[[__getDayTabindex(item, focusedDate)]]"
                   disabled$="[[__isDayDisabled(item, minDate, maxDate, isDateDisabled)]]"
@@ -108,7 +108,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   // eslint-disable-next-line @typescript-eslint/max-params
-  __getDatePart(date, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled) {
+  __getDatePart(date, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled, hasFocus) {
     const result = ['date'];
     const greaterThanToday = date > normalizeDate(new Date());
     const lessThanToday = date < normalizeDate(new Date());
@@ -117,7 +117,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
       result.push('disabled');
     }
 
-    if (this.__isDayFocused(date, focusedDate, enteredDate)) {
+    if (this.__isDayFocused(date, focusedDate, enteredDate, hasFocus)) {
       result.push('focused');
     }
 
@@ -141,8 +141,8 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @private */
-  __isDayFocused(date, focusedDate, enteredDate) {
-    return dateEquals(date, focusedDate) && dateEquals(date, enteredDate);
+  __isDayFocused(date, focusedDate, enteredDate, hasFocus) {
+    return dateEquals(date, focusedDate) && (hasFocus || dateEquals(date, enteredDate));
   }
 
   /** @private */

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -50,7 +50,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
               <template is="dom-repeat" items="[[week]]">
                 <td
                   role="gridcell"
-                  part$="[[__getDatePart(item, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled, __hasFocus)]]"
+                  part$="[[__getDatePart(item, focusedDate, selectedDate, minDate, maxDate, isDateDisabled, enteredDate, __hasFocus)]]"
                   date="[[item]]"
                   tabindex$="[[__getDayTabindex(item, focusedDate)]]"
                   disabled$="[[__isDayDisabled(item, minDate, maxDate, isDateDisabled)]]"
@@ -108,7 +108,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   // eslint-disable-next-line @typescript-eslint/max-params
-  __getDatePart(date, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled, hasFocus) {
+  __getDatePart(date, focusedDate, selectedDate, minDate, maxDate, isDateDisabled, enteredDate, hasFocus) {
     const result = ['date'];
     const greaterThanToday = date > normalizeDate(new Date());
     const lessThanToday = date < normalizeDate(new Date());
@@ -117,7 +117,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
       result.push('disabled');
     }
 
-    if (this.__isDayFocused(date, focusedDate, enteredDate, hasFocus)) {
+    if (dateEquals(date, focusedDate) && (hasFocus || dateEquals(date, enteredDate))) {
       result.push('focused');
     }
 
@@ -138,11 +138,6 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
     }
 
     return result.join(' ');
-  }
-
-  /** @private */
-  __isDayFocused(date, focusedDate, enteredDate, hasFocus) {
-    return dateEquals(date, focusedDate) && (hasFocus || dateEquals(date, enteredDate));
   }
 
   /** @private */
@@ -175,11 +170,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   __getDayTabindex(date, focusedDate) {
-    if (this.__isDayFocused(date, focusedDate)) {
-      return '0';
-    }
-
-    return '-1';
+    return dateEquals(date, focusedDate) ? '0' : '-1';
   }
 }
 

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -50,7 +50,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
               <template is="dom-repeat" items="[[week]]">
                 <td
                   role="gridcell"
-                  part$="[[__getDatePart(item, focusedDate, selectedDate, minDate, maxDate, isDateDisabled)]]"
+                  part$="[[__getDatePart(item, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled)]]"
                   date="[[item]]"
                   tabindex$="[[__getDayTabindex(item, focusedDate)]]"
                   disabled$="[[__isDayDisabled(item, minDate, maxDate, isDateDisabled)]]"
@@ -108,7 +108,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
 
   /** @private */
   // eslint-disable-next-line @typescript-eslint/max-params
-  __getDatePart(date, focusedDate, selectedDate, minDate, maxDate, isDateDisabled) {
+  __getDatePart(date, focusedDate, selectedDate, enteredDate, minDate, maxDate, isDateDisabled) {
     const result = ['date'];
     const greaterThanToday = date > normalizeDate(new Date());
     const lessThanToday = date < normalizeDate(new Date());
@@ -117,7 +117,7 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
       result.push('disabled');
     }
 
-    if (this.__isDayFocused(date, focusedDate)) {
+    if (this.__isDayFocused(date, focusedDate, enteredDate)) {
       result.push('focused');
     }
 
@@ -141,8 +141,8 @@ class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolymerElement)) {
   }
 
   /** @private */
-  __isDayFocused(date, focusedDate) {
-    return dateEquals(date, focusedDate);
+  __isDayFocused(date, focusedDate, enteredDate) {
+    return dateEquals(date, focusedDate) && dateEquals(date, enteredDate);
   }
 
   /** @private */

--- a/packages/date-picker/test/keyboard-input.common.js
+++ b/packages/date-picker/test/keyboard-input.common.js
@@ -21,17 +21,6 @@ describe('keyboard', () => {
     return datePicker._overlayContent.focusedDate;
   }
 
-  function assertFocusedPart(date) {
-    const focusableCell = getFocusableCell(datePicker);
-    expect(formatISODate(focusableCell.date)).to.equal(date);
-    expect(focusableCell.getAttribute('part')).to.contain('focused');
-  }
-
-  function assertNoFocusedPart() {
-    const focusableCell = getFocusableCell(datePicker);
-    expect(focusableCell.getAttribute('part')).to.not.contain('focused');
-  }
-
   beforeEach(async () => {
     datePicker = fixtureSync('<vaadin-date-picker></vaadin-date-picker>');
     await nextRender();
@@ -39,7 +28,41 @@ describe('keyboard', () => {
     input.focus();
   });
 
+  describe('focused date', () => {
+    it('should select focused date on Enter', async () => {
+      await sendKeys({ type: '1/1/2001' });
+      await waitForOverlayRender();
+      await waitForScrollToFinish(datePicker);
+      await sendKeys({ press: 'Enter' });
+      expect(datePicker.value).to.equal('2001-01-01');
+    });
+
+    it('should reflect focused date to input', async () => {
+      datePicker.value = '2000-01-01';
+      await open(datePicker);
+
+      // Move focus to the calendar
+      await sendKeys({ press: 'Tab' });
+
+      await nextRender(datePicker);
+
+      await sendKeys({ press: 'ArrowDown' });
+      expect(input.value).to.equal('1/8/2000');
+    });
+  });
+
   describe('focused part', () => {
+    function assertFocusedPart(date) {
+      const focusableCell = getFocusableCell(datePicker);
+      expect(formatISODate(focusableCell.date)).to.equal(date);
+      expect(focusableCell.getAttribute('part')).to.contain('focused');
+    }
+
+    function assertNoFocusedPart() {
+      const focusableCell = getFocusableCell(datePicker);
+      expect(focusableCell.getAttribute('part')).to.not.contain('focused');
+    }
+
     it('should add the part when entering parsable dates', async () => {
       await sendKeys({ type: '1/1/2000' });
       await waitForOverlayRender();
@@ -85,28 +108,6 @@ describe('keyboard', () => {
       await waitForScrollToFinish(datePicker);
 
       assertNoFocusedPart();
-    });
-  });
-
-  describe('focused date', () => {
-    it('should select focused date on Enter', async () => {
-      await sendKeys({ type: '1/1/2001' });
-      await waitForOverlayRender();
-      await waitForScrollToFinish(datePicker);
-      await sendKeys({ press: 'Enter' });
-      expect(datePicker.value).to.equal('2001-01-01');
-    });
-
-    it('should reflect focused date to input', async () => {
-      datePicker.value = '2000-01-01';
-      await open(datePicker);
-
-      // Move focus to the calendar
-      await sendKeys({ press: 'Tab' });
-
-      await sendKeys({ press: 'ArrowDown' });
-      await waitForScrollToFinish(datePicker);
-      expect(input.value).to.equal('1/8/2000');
     });
   });
 

--- a/packages/date-picker/test/keyboard-input.common.js
+++ b/packages/date-picker/test/keyboard-input.common.js
@@ -88,6 +88,19 @@ describe('keyboard', () => {
       assertFocusedPart(formatISODate(new Date()));
     });
 
+    it('should add the part after selecting a date with click', async () => {
+      datePicker.click();
+      await waitForOverlayRender();
+
+      const cell = getFocusableCell(datePicker);
+      tap(cell);
+
+      datePicker.click();
+      await waitForOverlayRender();
+
+      assertFocusedPart(formatISODate(new Date()));
+    });
+
     it('should update the part on value change', async () => {
       await sendKeys({ press: 'ArrowDown' });
       await waitForOverlayRender();

--- a/packages/date-picker/test/wai-aria.common.js
+++ b/packages/date-picker/test/wai-aria.common.js
@@ -19,13 +19,13 @@ describe('WAI-ARIA', () => {
       expect(input.getAttribute('aria-expanded')).to.equal('false');
     });
 
-    it('should set aria-hidden on all calendars except focused one', async () => {
+    it('should set aria-hidden on all calendars except focusable one', async () => {
       await open(datePicker);
       await nextRender(datePicker);
       const calendars = datePicker._overlayContent.querySelectorAll('vaadin-month-calendar');
       calendars.forEach((calendar) => {
-        const focused = calendar.shadowRoot.querySelector('[part~="focused"]');
-        expect(calendar.getAttribute('aria-hidden')).to.equal(focused ? null : 'true');
+        const focusable = calendar.shadowRoot.querySelector('[tabindex="0"]');
+        expect(calendar.getAttribute('aria-hidden')).to.equal(focusable ? null : 'true');
       });
     });
   });


### PR DESCRIPTION
## Description

The PR hides the flashing calendar date outline when the user enters unparsable input to avoid misleading since pressing <kbd>Enter</kbd> doesn't apply the flashing date in such cases. The outline is hidden by removing the `focused` part, except when the date element directly receives browser focus. 

Depends on 
- https://github.com/vaadin/web-components/pull/8220

Related to
- https://github.com/vaadin/flow-components/pull/6743#discussion_r1839963822
- https://github.com/vaadin/flow-components/issues/2466

## Type of change

- [x] Refactor
