### PR TITLE
refactor: move resize mode buttons inside dashboard widget

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -111,16 +111,15 @@ export const dashboardWidgetAndSectionStyles = css`
     top: 50%;
   }
 
-  :host(:not([dir='rtl']))
-    [part~='resize-shrink-width-button']:not(:has(~ [part~='resize-grow-width-button'][hidden])) {
+  :host(:not([dir='rtl'])) [part~='resize-shrink-width-button'] {
     transform: translateY(-50%) translateX(-100%);
   }
 
-  :host([dir='rtl']) [part~='resize-shrink-width-button']:not(:has(~ [part~='resize-grow-width-button'][hidden])) {
+  :host([dir='rtl']) [part~='resize-shrink-width-button'] {
     transform: translateY(-50%) translateX(100%);
   }
 
-  [part~='resize-shrink-width-button']:has(~ [part~='resize-grow-width-button'][hidden]) {
+  .mode-controls:has([part~='resize-grow-width-button'][hidden]) [part~='resize-shrink-width-button'] {
     transform: translateY(-50%);
   }
 

--- a/packages/dashboard/src/vaadin-dashboard-styles.js
+++ b/packages/dashboard/src/vaadin-dashboard-styles.js
@@ -19,11 +19,6 @@ export const hasWidgetWrappers = css`
 export const dashboardWidgetAndSectionStyles = css`
   :host {
     box-sizing: border-box;
-    /* Calculates the offset by which mode buttons that by default overflow the widget edges
-    should be shifted inwards based on a custom --vaadin-dashboard-spacing value */
-    --_mode-button-spacing-offset: calc(
-      max(0px, var(--_vaadin-dashboard-default-spacing) - var(--_vaadin-dashboard-spacing))
-    );
   }
 
   :host([dragging]) * {
@@ -111,28 +106,47 @@ export const dashboardWidgetAndSectionStyles = css`
     position: absolute;
   }
 
-  #resize-shrink-width {
-    inset-inline-end: calc(0px + var(--_mode-button-spacing-offset));
+  [part~='resize-shrink-width-button'] {
+    inset-inline-end: 0;
     top: 50%;
+  }
+
+  :host(:not([dir='rtl']))
+    [part~='resize-shrink-width-button']:not(:has(~ [part~='resize-grow-width-button'][hidden])) {
+    transform: translateY(-50%) translateX(-100%);
+  }
+
+  :host([dir='rtl']) [part~='resize-shrink-width-button']:not(:has(~ [part~='resize-grow-width-button'][hidden])) {
+    transform: translateY(-50%) translateX(100%);
+  }
+
+  [part~='resize-shrink-width-button']:has(~ [part~='resize-grow-width-button'][hidden]) {
     transform: translateY(-50%);
   }
 
-  #resize-grow-width {
-    inset-inline-start: calc(100% - var(--_mode-button-spacing-offset));
+  [part~='resize-grow-width-button'] {
+    inset-inline-start: 100%;
     top: 50%;
-    transform: translateY(-50%);
+  }
+
+  :host(:not([dir='rtl'])) [part~='resize-grow-width-button'] {
+    transform: translateY(-50%) translateX(-100%);
+  }
+
+  :host([dir='rtl']) [part~='resize-grow-width-button'] {
+    transform: translateY(-50%) translateX(100%);
   }
 
   #resize-shrink-height {
-    bottom: calc(0px + var(--_mode-button-spacing-offset));
+    bottom: 0;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-50%) translateY(-100%);
   }
 
   #resize-grow-height {
-    top: calc(100% - var(--_mode-button-spacing-offset));
+    top: 100%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-50%) translateY(-100%);
   }
 
   #resize-apply {

--- a/packages/dashboard/test/dashboard-keyboard.test.ts
+++ b/packages/dashboard/test/dashboard-keyboard.test.ts
@@ -93,7 +93,7 @@ describe('dashboard - keyboard interaction', () => {
     expect(spy.firstCall.args[0].detail).to.eql({ item: { id: 0 }, value: true });
   });
 
-  it('should not remove the widget on backspace', async () => {
+  (isChrome || isFirefox ? it : it.skip)('should not remove the widget on backspace', async () => {
     await sendKeys({ press: 'Tab' });
     await sendKeys({ press: 'Backspace' });
     expect(dashboard.items).to.eql([{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }]);

--- a/packages/dashboard/theme/lumo/vaadin-dashboard-widget-styles.js
+++ b/packages/dashboard/theme/lumo/vaadin-dashboard-widget-styles.js
@@ -204,29 +204,51 @@ const dashboardWidget = css`
     margin: 0;
   }
 
-  :host(:not([dir='rtl'])) #resize-shrink-width,
-  :host([dir='rtl']) #resize-grow-width {
+  :host(:not([dir='rtl'])) [part~='resize-grow-width-button'],
+  :host(:not([dir='rtl'])) [part~='resize-shrink-width-button'] {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+  }
+
+  :host([dir='rtl']) [part~='resize-grow-width-button'],
+  :host([dir='rtl']) [part~='resize-shrink-width-button'] {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  :host(:not([dir='rtl'])) [part~='resize-shrink-width-button']:not([hidden]) + [part~='resize-grow-width-button'] {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  :host([dir='rtl']) [part~='resize-shrink-width-button']:not([hidden]) + [part~='resize-grow-width-button'] {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  :host(:not([dir='rtl'])) #resize-shrink-width,
+  :host([dir='rtl']) #resize-grow-width {
     --icon: var(--lumo-icons-angle-left);
   }
 
   :host(:not([dir='rtl'])) #resize-grow-width,
   :host([dir='rtl']) #resize-shrink-width {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
     --icon: var(--lumo-icons-angle-right);
   }
 
-  #resize-grow-height {
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+  [part~='resize-grow-height-button'],
+  [part~='resize-shrink-height-button'] {
     --icon: var(--lumo-icons-angle-down);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  [part~='resize-shrink-height-button']:not([hidden]) + [part~='resize-grow-height-button'] {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }
 
   #resize-shrink-height {
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
     --icon: var(--lumo-icons-angle-up);
   }
 `;


### PR DESCRIPTION
## Description

Move resize mode buttons inside dashboard widget

https://github.com/user-attachments/assets/27919695-1b95-420d-b4dd-43f673aa0f95

Fixes https://github.com/vaadin/web-components/issues/8153

## Type of change

Refactor