### PR TITLE
fix: apply widget content blur on slotted content

### DIFF
--- a/packages/dashboard/theme/lumo/vaadin-dashboard-widget-styles.js
+++ b/packages/dashboard/theme/lumo/vaadin-dashboard-widget-styles.js
@@ -157,8 +157,8 @@ const dashboardWidget = css`
     opacity: 1;
   }
 
-  :host([resize-mode]) [part~='content'],
-  :host([move-mode]) [part~='content'] {
+  :host([resize-mode]) [part~='content'] ::slotted(*),
+  :host([move-mode]) [part~='content'] ::slotted(*) {
     opacity: 0.3;
     filter: blur(10px);
   }


### PR DESCRIPTION
## Description

Apply widget content blur on slotted content to avoid it bleeding outside the widget

Depends on https://github.com/vaadin/web-components/pull/8191

Fixes https://github.com/vaadin/web-components/issues/8137

## Type of change

Bugfix