### PR TITLE
fix: close tooltip immediately on global mousedown event

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -447,7 +447,7 @@ export const TooltipMixin = (superClass) =>
       this._isConnected = true;
 
       document.body.addEventListener('vaadin-overlay-open', this.__onOverlayOpen);
-      document.addEventListener('mousedown', this.__onMouseDown, true);
+      document.addEventListener('mousedown', this.__onMouseDown);
     }
 
     /** @protected */
@@ -460,7 +460,7 @@ export const TooltipMixin = (superClass) =>
       this._isConnected = false;
 
       document.body.removeEventListener('vaadin-overlay-open', this.__onOverlayOpen);
-      document.removeEventListener('mousedown', this.__onMouseDown, true);
+      document.removeEventListener('mousedown', this.__onMouseDown);
     }
 
     /** @protected */

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -447,6 +447,7 @@ export const TooltipMixin = (superClass) =>
       this._isConnected = true;
 
       document.body.addEventListener('vaadin-overlay-open', this.__onOverlayOpen);
+      document.addEventListener('mousedown', this.__onMouseDown, true);
     }
 
     /** @protected */
@@ -459,6 +460,7 @@ export const TooltipMixin = (superClass) =>
       this._isConnected = false;
 
       document.body.removeEventListener('vaadin-overlay-open', this.__onOverlayOpen);
+      document.removeEventListener('mousedown', this.__onMouseDown, true);
     }
 
     /** @protected */
@@ -499,7 +501,6 @@ export const TooltipMixin = (superClass) =>
       target.addEventListener('mouseleave', this.__onMouseLeave);
       target.addEventListener('focusin', this.__onFocusin);
       target.addEventListener('focusout', this.__onFocusout);
-      target.addEventListener('mousedown', this.__onMouseDown);
 
       // Wait before observing to avoid Chrome issue.
       requestAnimationFrame(() => {
@@ -517,7 +518,6 @@ export const TooltipMixin = (superClass) =>
       target.removeEventListener('mouseleave', this.__onMouseLeave);
       target.removeEventListener('focusin', this.__onFocusin);
       target.removeEventListener('focusout', this.__onFocusout);
-      target.removeEventListener('mousedown', this.__onMouseDown);
 
       this.__targetVisibilityObserver.unobserve(target);
     }
@@ -576,11 +576,13 @@ export const TooltipMixin = (superClass) =>
     }
 
     /** @private */
-    __onMouseDown() {
-      if (this.manual) {
+    __onMouseDown(event) {
+      if (this.manual || event.composedPath().includes(this._overlayElement)) {
         return;
       }
 
+      // Immediately close on any mousedown to avoid overlay from interfering
+      // with other component overlays that might open on the following click.
       this._stateController.close(true);
     }
 

--- a/packages/tooltip/test/tooltip.common.js
+++ b/packages/tooltip/test/tooltip.common.js
@@ -397,6 +397,18 @@ describe('vaadin-tooltip', () => {
       expect(overlay.opened).to.be.false;
     });
 
+    it('should close overlay on document mousedown', () => {
+      mouseenter(target);
+      mousedown(document.body);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not close overlay on overlay mousedown', () => {
+      mouseenter(target);
+      mousedown(overlay);
+      expect(overlay.opened).to.be.true;
+    });
+
     it('should re-open overlay on subsequent mouseenter', () => {
       mouseenter(target);
       mousedown(target);
@@ -494,16 +506,6 @@ describe('vaadin-tooltip', () => {
       tabKeyDown(target);
       target.focus();
       expect(overlay.opened).to.be.false;
-    });
-
-    it('should not close overlay on mousedown when target is reset', async () => {
-      mouseenter(target);
-
-      tooltip.target = null;
-      await nextUpdate(tooltip);
-
-      mousedown(target);
-      expect(overlay.opened).to.be.true;
     });
 
     it('should not close overlay on focusout when target is reset', async () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6836

Changed the logic of the tooltip to make sure it closes immediately on any `mousedown` event, not just the on target.
This ensures that tooltip with hide delay does not interfere with opening logic of `vaadin-dialog` overlay.

## Type of change

- Bugfix