### PR TITLE
fix: close tooltip immediately on target click from keyboard

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -422,6 +422,7 @@ export const TooltipMixin = (superClass) =>
       this._uniqueId = `vaadin-tooltip-${generateUniqueId()}`;
       this._renderer = this.__tooltipRenderer.bind(this);
 
+      this.__onClick = this.__onClick.bind(this);
       this.__onFocusin = this.__onFocusin.bind(this);
       this.__onFocusout = this.__onFocusout.bind(this);
       this.__onMouseDown = this.__onMouseDown.bind(this);
@@ -495,6 +496,7 @@ export const TooltipMixin = (superClass) =>
      * @override
      */
     _addTargetListeners(target) {
+      target.addEventListener('click', this.__onClick);
       target.addEventListener('mouseenter', this.__onMouseEnter);
       target.addEventListener('mouseleave', this.__onMouseLeave);
       target.addEventListener('focusin', this.__onFocusin);
@@ -513,6 +515,7 @@ export const TooltipMixin = (superClass) =>
      * @override
      */
     _removeTargetListeners(target) {
+      target.removeEventListener('click', this.__onClick);
       target.removeEventListener('mouseenter', this.__onMouseEnter);
       target.removeEventListener('mouseleave', this.__onMouseLeave);
       target.removeEventListener('focusin', this.__onFocusin);
@@ -520,6 +523,22 @@ export const TooltipMixin = (superClass) =>
       target.removeEventListener('mousedown', this.__onMouseDown);
 
       this.__targetVisibilityObserver.unobserve(target);
+    }
+
+    /** @private */
+    __onClick() {
+      if (this.manual) {
+        return;
+      }
+
+      // Only close on keyboard click.
+      if (!isKeyboardActive()) {
+        return;
+      }
+
+      // Close immediately when click event is triggered
+      // by pressing Enter or Space e.g. on the button.
+      this._stateController.close(true);
     }
 
     /** @private */

--- a/packages/tooltip/test/tooltip-timers.common.js
+++ b/packages/tooltip/test/tooltip-timers.common.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
   aTimeout,
+  enterKeyDown,
   escKeyDown,
   fixtureSync,
   focusin,
@@ -177,6 +178,15 @@ describe('timers', () => {
       target.focus();
 
       escKeyDown(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close the overlay immediately on click from keyboard', () => {
+      tabKeyDown(document.body);
+      target.focus();
+
+      enterKeyDown(target);
+      target.click();
       expect(overlay.opened).to.be.false;
     });
 

--- a/packages/tooltip/test/tooltip.common.js
+++ b/packages/tooltip/test/tooltip.common.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
+  enterKeyDown,
   escKeyDown,
   fixtureSync,
   focusin,
@@ -394,6 +395,15 @@ describe('vaadin-tooltip', () => {
     it('should close overlay on target mousedown', () => {
       mouseenter(target);
       mousedown(target);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should close overlay on target keyboard click', () => {
+      tabKeyDown(target);
+      target.focus();
+
+      enterKeyDown(target);
+      target.click();
       expect(overlay.opened).to.be.false;
     });
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow-components/issues/6836

Fixes a finding from https://github.com/vaadin/web-components/pull/8193#discussion_r1851401827

## Type of change

- Bugfix