### PR TITLE
refactor!: align hasInputValue behavior across components

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -357,20 +357,6 @@ export const DatePickerMixin = (subclass) =>
           type: Object,
           sync: true,
         },
-
-        /**
-         * In date-picker, unlike other components extending `InputMixin`,
-         * the property indicates true only if the input has been entered by the user.
-         * In the case of programmatic changes, the property is reset to false.
-         * Read more about why this workaround is needed:
-         * https://github.com/vaadin/web-components/issues/5639
-         *
-         * @protected
-         * @override
-         */
-        _hasInputValue: {
-          type: Boolean,
-        },
       };
     }
 
@@ -394,30 +380,6 @@ export const DatePickerMixin = (subclass) =>
       this._boundOnClick = this._onClick.bind(this);
       this._boundOnScroll = this._onScroll.bind(this);
       this._boundOverlayRenderer = this._overlayRenderer.bind(this);
-    }
-
-    /**
-     * @override
-     * @protected
-     */
-    get _inputElementValue() {
-      return super._inputElementValue;
-    }
-
-    /**
-     * The setter is overridden to reset the `_hasInputValue` property
-     * to false when the input element's value is updated programmatically.
-     * In date-picker, `_hasInputValue` is supposed to indicate true only
-     * if the input has been entered by the user.
-     * Read more about why this workaround is needed:
-     * https://github.com/vaadin/web-components/issues/5639
-     *
-     * @override
-     * @protected
-     */
-    set _inputElementValue(value) {
-      super._inputElementValue = value;
-      this._hasInputValue = false;
     }
 
     /**

--- a/packages/date-picker/test/events.common.js
+++ b/packages/date-picker/test/events.common.js
@@ -61,25 +61,6 @@ describe('events', () => {
           expect(datePicker.inputElement.value).to.be.empty;
           expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         });
-
-        it('should be fired when comitting the user input with Enter', async () => {
-          await sendKeys({ press: 'Enter' });
-          expect(valueChangedSpy.calledOnce).to.be.true;
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-          expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-        });
-
-        // FIXME: flaky test often failing in CI
-        it.skip('should be fired when selecting a date with Space', async () => {
-          // Move focus inside the dropdown to the typed date.
-          await sendKeys({ press: 'ArrowDown' });
-          await waitForScrollToFinish(datePicker._overlayContent);
-          // Select that date.
-          await sendKeys({ press: 'Space' });
-          expect(valueChangedSpy.calledOnce).to.be.true;
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-          expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-        });
       });
     });
 
@@ -105,12 +86,6 @@ describe('events', () => {
           expect(valueChangedSpy.calledOnce).to.be.true;
           expect(hasInputValueChangedSpy.calledOnce).to.be.true;
           expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-        });
-
-        it('should be fired when reverting the user input to the value with Esc', async () => {
-          await sendKeys({ press: 'Escape' });
-          expect(datePicker.inputElement.value).to.equal('1/1/2022');
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
         });
       });
     });

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -115,6 +115,8 @@ export const InputMixin = dedupingMixin(
         if (this.inputElement) {
           this.inputElement[this._inputElementValueProperty] = value;
         }
+
+        this._hasInputValue = value && value.length > 0;
       }
 
       /**

--- a/packages/time-picker/src/vaadin-lit-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-lit-time-picker-combo-box.js
@@ -61,27 +61,6 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolylitMixin(LitEle
     return this.querySelector('[part="clear-button"]');
   }
 
-  /**
-   * @override
-   * @protected
-   */
-  get _inputElementValue() {
-    return super._inputElementValue;
-  }
-
-  /**
-   * The setter is overridden to ensure the `_hasInputValue` property
-   * doesn't wrongly indicate true after the input element's value
-   * is reverted or cleared programmatically.
-   *
-   * @override
-   * @protected
-   */
-  set _inputElementValue(value) {
-    super._inputElementValue = value;
-    this._hasInputValue = value && value.length > 0;
-  }
-
   /** @protected */
   render() {
     return html`

--- a/packages/time-picker/src/vaadin-time-picker-combo-box.js
+++ b/packages/time-picker/src/vaadin-time-picker-combo-box.js
@@ -73,27 +73,6 @@ class TimePickerComboBox extends ComboBoxMixin(ThemableMixin(PolymerElement)) {
     return this.querySelector('[part="clear-button"]');
   }
 
-  /**
-   * @override
-   * @protected
-   */
-  get _inputElementValue() {
-    return super._inputElementValue;
-  }
-
-  /**
-   * The setter is overridden to ensure the `_hasInputValue` property
-   * doesn't wrongly indicate true after the input element's value
-   * is reverted or cleared programmatically.
-   *
-   * @override
-   * @protected
-   */
-  set _inputElementValue(value) {
-    super._inputElementValue = value;
-    this._hasInputValue = value.length > 0;
-  }
-
   /** @protected */
   ready() {
     super.ready();


### PR DESCRIPTION
## Description

DatePicker and TimePicker counterparts [have been recently updated](https://github.com/vaadin/flow-components/pull/6846) to no longer rely on the `hasInputValue` property for detecting bad input. This removes the need for workarounds that caused the `hasInputValue` behavior to be inconsistent with other components

Fixes https://github.com/vaadin/web-components/issues/5639

## Type of change

- [x] Refactor
