### PR TITLE
refactor: animate opacity instead of box-shadow

### DIFF
--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -53,13 +53,14 @@ registerStyles(
       position: absolute;
       inset: 0;
       pointer-events: none;
-      box-shadow: inset 0 0 0 var(--_focus-ring-width) transparent;
+      box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
       animation: vaadin-grid-pro-loading-editor 1.4s infinite;
+      opacity: 0;
     }
 
     @keyframes vaadin-grid-pro-loading-editor {
       50% {
-        box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
+        opacity: 1;
       }
     }
   `,


### PR DESCRIPTION
Opacity animations can be done by the GPU compositor, and don't require a paint cycle by the browser as animating box-shadow does.