### PR TITLE
fix: save userOptions charts disconnect

### DIFF
--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -1078,6 +1078,10 @@ class Chart extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))) {
   disconnectedCallback() {
     super.disconnectedCallback();
 
+    if (this.configuration) {
+      this._jsonConfigurationBuffer = this.configuration.userOptions;
+    }
+
     queueMicrotask(() => {
       if (this.isConnected) {
         return;

--- a/packages/charts/test/reattach.test.js
+++ b/packages/charts/test/reattach.test.js
@@ -186,6 +186,20 @@ describe('reattach', () => {
     expect(chart.configuration.options.plotOptions.series.stacking).to.be.equal('percent');
   });
 
+  it('should restore configuration done through `updateConfigaration` after reattach', async () => {
+    const wrapper = fixtureSync(`<div><vaadin-chart></vaadin-chart></div>`);
+    const chart = wrapper.firstElementChild;
+    chart.updateConfiguration({ title: { text: 'New title' }, series: [{ name: 'series', data: [1, 2, 3] }] });
+    await nextFrame();
+    wrapper.removeChild(chart);
+    await nextFrame();
+    wrapper.appendChild(chart);
+    await nextFrame();
+    expect(chart.configuration.options.title.text).to.be.equal('New title');
+    expect(chart.configuration.options.series.length).to.be.equal(1);
+    expect(chart.configuration.options.series[0].name).to.be.equal('series');
+  });
+
   it('should apply categories updated while detached after reattach', async () => {
     chart.categories = ['Jan', 'Feb', 'Mar'];
     await oneEvent(chart, 'chart-load');


### PR DESCRIPTION
## Description

Fix an issue where a chart defined using the `updateConfiguration` method loses its configuration after detaching and re-attaching. This fix stores the `userOptions` object when the component is disconnected to use it again when the component is connected back later.

The `userOptions`, according to the [Highcharts documentation](https://api.highcharts.com/class-reference/Highcharts.Chart#userOptions) is:

>The original options given to the constructor or a chart factory like [Highcharts.chart](https://api.highcharts.com/class-reference/Highcharts.html#.chart) and [Highcharts.stockChart](https://api.highcharts.com/class-reference/Highcharts.html#.stockChart). The original options are shallow copied to avoid mutation. The copy, chart.userOptions, may later be mutated to reflect updated options throughout the lifetime of the chart.

While this is true in the latest version of the library, I could verify that adding and removing series dynamically through `Chart#addSeries()` and `Series#remove()` (these are methods in the HighCharts API) are not reflected on the `userOptions` object in the version we are current using. That might be problematic for cases where series are added through the `Configuration#addSeries()` API in the Flow component. I believe that this fix proposal will cover most of the cases, hence I am creating it for discussion.

Fixes https://github.com/vaadin/flow-components/issues/6802

## Type of change

- [X] Bugfix
- [ ] Feature
