### PR TITLE
fix: make text area auto-sizing stable

### DIFF
--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -200,7 +200,6 @@ export const TextAreaMixin = (superClass) =>
       // Restore
       input.style.removeProperty('max-width');
       input.style.removeProperty('align-self');
-      inputField.style.removeProperty('display');
       inputField.style.removeProperty('height');
       inputField.scrollTop = scrollTop;
 

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -181,13 +181,13 @@ export const TextAreaMixin = (superClass) =>
         // position while resetting the textareas height. If the textarea had a large height, then removing its height
         // will reset its height to the default of two rows. That might reduce the height of the page, and the
         // browser might adjust the scroll position before we can restore the measured height of the textarea.
-        inputField.style.display = 'block';
         inputField.style.height = inputFieldHeight;
 
         // Fix the input element width so its scroll height isn't affected by host's disappearing scrollbars
         input.style.maxWidth = inputWidth;
 
         // Clear the height of the textarea to allow measuring a reduced scroll height
+        input.style.alignSelf = 'flex-start';
         input.style.height = 'auto';
       }
       this._oldValueLength = valueLength;
@@ -199,6 +199,7 @@ export const TextAreaMixin = (superClass) =>
 
       // Restore
       input.style.removeProperty('max-width');
+      input.style.removeProperty('align-self');
       inputField.style.removeProperty('display');
       inputField.style.removeProperty('height');
       inputField.scrollTop = scrollTop;


### PR DESCRIPTION
The auto-sizing mechanism of `<vaadin-text-area>` is currently not stable when the component switches from three rows to two rows. In that case subsequent `_updateHeight` calls can determine alternating content heights for the same value. In combination with the resize observer that the component uses that can end in an infinite resize loop, but the issue is also noticable without the resize observer when removing characters one by one.

This change makes the mechanism stable so that multiple `_updateHeight` calls in succession will determine the same height.

Fixes https://github.com/vaadin/web-components/issues/7828