### PR TITLE
fix: do not close popover when it is just moved in DOM

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -534,7 +534,7 @@ class Popover extends PopoverPositionMixin(
 
     // Automatically close popover when it is removed from DOM
     // Avoid closing if the popover is just moved in the DOM
-    setTimeout(() => {
+    queueMicrotask(() => {
       if (!this.isConnected) {
         this._openedStateController.close(true);
       }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -532,7 +532,13 @@ class Popover extends PopoverPositionMixin(
 
     document.documentElement.removeEventListener('click', this.__onGlobalClick, true);
 
-    this._openedStateController.close(true);
+    // Automatically close popover when it is removed from DOM
+    // Avoid closing if the popover is just moved in the DOM
+    setTimeout(() => {
+      if (!this.isConnected) {
+        this._openedStateController.close(true);
+      }
+    });
   }
 
   /**

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -232,6 +232,17 @@ describe('popover', () => {
       expect(overlay.opened).to.be.false;
     });
 
+    it('should not close overlay when popover is moved in DOM', async () => {
+      target.click();
+      await nextRender();
+
+      const parent = popover.parentElement;
+      popover.remove();
+      parent.appendChild(popover);
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
     it('should remove document click listener when popover is detached', async () => {
       const spy = sinon.spy(document.documentElement, 'removeEventListener');
       popover.remove();


### PR DESCRIPTION
Currently a popover is immediately closed when it is disconnected from the DOM. That can be an issue in a Flow dialog when the popover is opened right away after adding it to the dialog. Here the element is first added as a child of the dialog, then opened, and afterwards moved to the dialog overlay by the renderer function. The last step causes the popover to close again.

This fixes the issue by delaying closing and checking if the element has been added to the DOM again. This is similar to what we are doing in other components such as dialog or notification.

Fixes https://github.com/vaadin/flow-components/issues/6840