### PR TITLE
refactor: remove z-index override from tooltip overlay

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-overlay-styles.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay-styles.js
@@ -6,10 +6,6 @@
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const tooltipOverlayStyles = css`
-  :host {
-    z-index: 1100;
-  }
-
   [part='overlay'] {
     max-width: 40ch;
   }


### PR DESCRIPTION
## Description

Follow-up to #8198

Now when notification container is included to the overlay stack, we no longer need this workaround added in #6074

## Type of change

- Refactor