### PR TITLE
fix: close popover with hover trigger on target mousedown

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -453,6 +453,7 @@ class Popover extends PopoverPositionMixin(
     this.__onTargetClick = this.__onTargetClick.bind(this);
     this.__onTargetFocusIn = this.__onTargetFocusIn.bind(this);
     this.__onTargetFocusOut = this.__onTargetFocusOut.bind(this);
+    this.__onTargetMouseDown = this.__onTargetMouseDown.bind(this);
     this.__onTargetMouseEnter = this.__onTargetMouseEnter.bind(this);
     this.__onTargetMouseLeave = this.__onTargetMouseLeave.bind(this);
 
@@ -550,6 +551,7 @@ class Popover extends PopoverPositionMixin(
     target.addEventListener('click', this.__onTargetClick);
     target.addEventListener('mouseenter', this.__onTargetMouseEnter);
     target.addEventListener('mouseleave', this.__onTargetMouseLeave);
+    target.addEventListener('mousedown', this.__onTargetMouseDown);
     target.addEventListener('focusin', this.__onTargetFocusIn);
     target.addEventListener('focusout', this.__onTargetFocusOut);
   }
@@ -563,6 +565,7 @@ class Popover extends PopoverPositionMixin(
     target.removeEventListener('click', this.__onTargetClick);
     target.removeEventListener('mouseenter', this.__onTargetMouseEnter);
     target.removeEventListener('mouseleave', this.__onTargetMouseLeave);
+    target.removeEventListener('mousedown', this.__onTargetMouseDown);
     target.removeEventListener('focusin', this.__onTargetFocusIn);
     target.removeEventListener('focusout', this.__onTargetFocusOut);
   }
@@ -803,6 +806,17 @@ class Popover extends PopoverPositionMixin(
     }
 
     this.__handleMouseLeave();
+  }
+
+  /** @private */
+  __onTargetMouseDown() {
+    if (this._overlayElement.opened && !isLastOverlay(this._overlayElement)) {
+      return;
+    }
+
+    if (this.__hasTrigger('hover') && !this.__hasTrigger('click')) {
+      this._openedStateController.close(true);
+    }
   }
 
   /** @private */

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -149,6 +149,15 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.true;
     });
 
+    it('should close on target mousedown', async () => {
+      mouseenter(target);
+      await nextRender();
+
+      mousedown(target);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.false;
+    });
+
     it('should not open on target mouseenter when detached', async () => {
       popover.remove();
       mouseenter(target);
@@ -412,6 +421,21 @@ describe('trigger', () => {
       focusin(overlay);
       mouseenter(overlay);
       mouseleave(overlay);
+      await nextUpdate(popover);
+      expect(overlay.opened).to.be.true;
+    });
+  });
+
+  describe('hover and click', () => {
+    beforeEach(async () => {
+      popover.trigger = ['hover', 'click'];
+      await nextUpdate(popover);
+    });
+
+    it('should not close on target mousedown', async () => {
+      mouseenter(target);
+      await nextRender();
+      mousedown(target);
       await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });


### PR DESCRIPTION
## Description

Fixes #8197

Added logic to close the popover on `mousedown` to align with the tooltip behavior.

Note: when using `hover` and `click` triggers this isn't used since in this case the click event would immediately reopen the popover previously closed on `mousedown`. However, I think this combination shouldn't be widely used.

## Type of change

- Bugfix