### PR TITLE
refactor: ensure Lit month calendars are rendered synchronously

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -57,6 +57,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
         initialPosition: {
           type: Object,
           observer: '_initialPositionChanged',
+          sync: true,
         },
 
         _originDate: {

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -201,6 +201,21 @@ export class InfiniteScroller extends HTMLElement {
     }
   }
 
+  /** @protected */
+  disconnectedCallback() {
+    if (this._debouncerScrollFinish) {
+      this._debouncerScrollFinish.cancel();
+    }
+
+    if (this._debouncerUpdateClones) {
+      this._debouncerUpdateClones.cancel();
+    }
+
+    if (this.__pendingFinishInit) {
+      cancelAnimationFrame(this.__pendingFinishInit);
+    }
+  }
+
   /**
    * Force the scroller to update clones after a reset, without
    * waiting for the debouncer to resolve.
@@ -348,8 +363,9 @@ export class InfiniteScroller extends HTMLElement {
       }
     });
 
-    requestAnimationFrame(() => {
+    this.__pendingFinishInit = requestAnimationFrame(() => {
       this._finishInit();
+      this.__pendingFinishInit = null;
     });
   }
 
@@ -363,6 +379,10 @@ export class InfiniteScroller extends HTMLElement {
 
     itemWrapper.instance = this._createElement();
     itemWrapper.appendChild(itemWrapper.instance);
+
+    if (itemWrapper.instance.performUpdate) {
+      itemWrapper.instance.performUpdate();
+    }
 
     Object.keys(tmpInstance).forEach((prop) => {
       itemWrapper.instance[prop] = tmpInstance[prop];


### PR DESCRIPTION
## Description

The PR refactors `date-picker` to ensure that the initial rendering of Lit month calendars happens synchronously. This eliminates rendering differences between the Lit and Polymer versions, which were causing test failures in  https://github.com/vaadin/web-components/pull/8187.

## Type of change

- [x] Refactor
