### PR TITLE
fix: resize only on direction of drag move

### DIFF
--- a/packages/dashboard/src/widget-resize-controller.js
+++ b/packages/dashboard/src/widget-resize-controller.js
@@ -89,10 +89,10 @@ export class WidgetResizeController {
 
     const currentElementHeight = itemWrapper.firstElementChild.offsetHeight;
     const rowMinHeight = Math.min(...gridStyle.gridTemplateRows.split(' ').map((height) => parseFloat(height)));
-    if (this.__resizeHeight > currentElementHeight + gapSize + rowMinHeight / 2) {
+    if (e.detail.ddy > 0 && this.__resizeHeight > currentElementHeight + gapSize + rowMinHeight / 2) {
       // Resized vertically above the half of the next row, increase rowspan
       this.__updateResizedItem(0, 1);
-    } else if (this.__resizeHeight < currentElementHeight - rowMinHeight / 2) {
+    } else if (e.detail.ddy < 0 && this.__resizeHeight < currentElementHeight - rowMinHeight / 2) {
       // Resized vertically below the half of the current row, decrease rowspan
       this.__updateResizedItem(0, -1);
     }

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -349,10 +349,16 @@ describe('dashboard - widget resizing', () => {
       ]);
     });
 
-    it('should resize only when dragged in the same direction (top -> bottom)', async () => {
+    (isSafari ? it.skip : it)('should resize only when dragged in the same direction (top -> bottom)', async () => {
       setMinimumRowHeight(dashboard, 50);
       dashboard.items = [{ id: 0, rowspan: 2 }, { id: 1 }, { id: 2 }];
       await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [0, 2],
+      ]);
 
       const widget = getElementFromCell(dashboard, 0, 1)!;
       const initialHeight = widget.offsetHeight;

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -229,7 +229,10 @@ export function createDragEvent(type: string, { x, y }: { x: number; y: number }
   return event;
 }
 
-function getEventCoordinates(relativeElement: Element, location: 'top' | 'bottom' | 'start' | 'end') {
+export function getEventCoordinates(
+  relativeElement: Element,
+  location: 'top' | 'bottom' | 'start' | 'end',
+): { x: number; y: number } {
   const { top, bottom, left, right } = relativeElement.getBoundingClientRect();
   const y = location === 'top' ? top : bottom;
   const dir = document.dir;


### PR DESCRIPTION
## Description

This PR fixes the flicker on drag resize by only allowing resize if the drag direction is the same with the resize direction.

Fixes #7950 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.