### PR TITLE
fix: make multi-select-combo-box overlay opened property sync

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-lit-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-lit-multi-select-combo-box-overlay.js
@@ -49,6 +49,22 @@ class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(
     return [overlayStyles, multiSelectComboBoxOverlayStyles];
   }
 
+  static get properties() {
+    return {
+      /**
+       * When true, the overlay is visible and attached to body.
+       * This property config is overridden to set `sync: true`.
+       */
+      opened: {
+        type: Boolean,
+        notify: true,
+        observer: '_openedChanged',
+        reflectToAttribute: true,
+        sync: true,
+      },
+    };
+  }
+
   /** @protected */
   render() {
     return html`


### PR DESCRIPTION
## Description

Without this logic, some tests are failing in #8223

Note, we should eventually update `OverlayMixin` to use `sync: true` and remove overrides. I'll do that in a separate PR.

## Type of change

- Bugfix