### PR TITLE
refactor: update OverlayMixin properties to use sync: true

### DIFF
--- a/packages/avatar-group/src/vaadin-lit-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-lit-avatar-group-overlay.js
@@ -32,22 +32,6 @@ class AvatarGroupOverlay extends PositionMixin(OverlayMixin(DirMixin(ThemableMix
     return overlayStyles;
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   /** @protected */
   render() {
     return html`

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -45,22 +45,6 @@ export class ComboBoxOverlay extends ComboBoxOverlayMixin(
     return [overlayStyles, comboBoxOverlayStyles, comboBoxOverlayStyles];
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   /** @protected */
   render() {
     return html`

--- a/packages/context-menu/src/vaadin-lit-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-lit-context-menu-overlay.js
@@ -31,22 +31,6 @@ export class ContextMenuOverlay extends MenuOverlayMixin(
     return 'vaadin-context-menu-overlay';
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   static get styles() {
     return [overlayStyles, styles];
   }

--- a/packages/date-picker/src/vaadin-lit-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker-overlay.js
@@ -30,22 +30,6 @@ class DatePickerOverlay extends DatePickerOverlayMixin(DirMixin(ThemableMixin(Po
     return [overlayStyles, datePickerOverlayStyles];
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   /** @protected */
   render() {
     return html`

--- a/packages/menu-bar/src/vaadin-lit-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-lit-menu-bar-overlay.js
@@ -29,22 +29,6 @@ export class MenuBarOverlay extends MenuOverlayMixin(OverlayMixin(DirMixin(Thema
     return 'vaadin-menu-bar-overlay';
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   static get styles() {
     return [overlayStyles, styles];
   }

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -25,6 +25,7 @@ export const OverlayMixin = (superClass) =>
           notify: true,
           observer: '_openedChanged',
           reflectToAttribute: true,
+          sync: true,
         },
 
         /**
@@ -33,6 +34,7 @@ export const OverlayMixin = (superClass) =>
          */
         owner: {
           type: Object,
+          sync: true,
         },
 
         /**
@@ -40,6 +42,7 @@ export const OverlayMixin = (superClass) =>
          */
         model: {
           type: Object,
+          sync: true,
         },
 
         /**
@@ -53,6 +56,7 @@ export const OverlayMixin = (superClass) =>
          */
         renderer: {
           type: Object,
+          sync: true,
         },
 
         /**
@@ -65,6 +69,7 @@ export const OverlayMixin = (superClass) =>
           value: false,
           reflectToAttribute: true,
           observer: '_modelessChanged',
+          sync: true,
         },
 
         /**
@@ -76,6 +81,7 @@ export const OverlayMixin = (superClass) =>
           type: Boolean,
           reflectToAttribute: true,
           observer: '_hiddenChanged',
+          sync: true,
         },
 
         /**
@@ -86,6 +92,7 @@ export const OverlayMixin = (superClass) =>
           type: Boolean,
           value: false,
           reflectToAttribute: true,
+          sync: true,
         },
       };
     }

--- a/packages/overlay/test/animations.common.js
+++ b/packages/overlay/test/animations.common.js
@@ -121,81 +121,64 @@ function afterOverlayClosingFinished(overlay, callback) {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
-    it('should flush closing overlay when re-opened while closing animation is in progress', async () => {
+    it('should flush closing overlay when re-opened while closing animation is in progress', () => {
       overlay.opened = true;
-      await nextRender();
       overlay._flushAnimation('opening');
 
       overlay.opened = false;
-      await nextRender();
 
       overlay.opened = true;
-      await nextRender();
 
       expect(overlay.hasAttribute('closing')).to.be.false;
     });
 
-    it('should flush opening overlay when closed while opening animation is in progress', async () => {
+    it('should flush opening overlay when closed while opening animation is in progress', () => {
       overlay.opened = true;
-      await nextRender();
 
       overlay.opened = false;
-      await nextRender();
 
       expect(overlay.hasAttribute('opening')).to.be.false;
     });
 
-    it('should detach the overlay even if it is scheduled for reopening', async () => {
+    it('should detach the overlay even if it is scheduled for reopening', () => {
       overlay.opened = true;
-      await nextRender();
 
       overlay.opened = false;
-      await nextRender();
 
       overlay.opened = true;
-      await nextRender();
 
       overlay.opened = false;
-      await nextRender();
       overlay._flushAnimation('closing');
 
       expect(overlay.parentNode).not.to.equal(document.body);
     });
 
-    it('should not animate closing if the overlay is explicitly hidden', async () => {
+    it('should not animate closing if the overlay is explicitly hidden', () => {
       overlay.opened = true;
-      await nextRender();
 
       overlay.hidden = true;
-      await nextRender();
 
       overlay.opened = false;
-      await nextRender();
 
       expect(overlay.parentNode).not.to.equal(document.body);
     });
 
-    it('should close the overlay if hidden is set while closing', async () => {
+    it('should close the overlay if hidden is set while closing', () => {
       overlay.opened = true;
-      await nextRender();
 
       overlay.opened = false;
-      await nextRender();
 
       overlay.hidden = true;
-      await nextRender();
 
       expect(overlay.parentNode).not.to.equal(document.body);
     });
 
-    it('should close the overlay when ESC pressed while opening', async () => {
+    it('should close the overlay when ESC pressed while opening', () => {
       overlay.opened = true;
-      await nextRender();
       escKeyDown(document.body);
       expect(overlay.opened).to.equal(false);
     });
@@ -214,11 +197,10 @@ function afterOverlayClosingFinished(overlay, callback) {
       overlays[0].opened = true;
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlays.forEach((overlay) => {
         overlay.opened = false;
       });
-      await nextRender();
     });
 
     it('should remove pointer events on previously opened overlay', (done) => {
@@ -242,11 +224,10 @@ function afterOverlayClosingFinished(overlay, callback) {
       }
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlays.forEach((overlay) => {
         overlay.opened = false;
       });
-      await nextRender();
     });
 
     it('should not remove pointer events on last opened overlay', (done) => {
@@ -275,11 +256,10 @@ function afterOverlayClosingFinished(overlay, callback) {
       }
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlays.forEach((overlay) => {
         overlay.opened = false;
       });
-      await nextRender();
     });
 
     it('should restore pointer events on the remaining overlay', (done) => {
@@ -330,11 +310,10 @@ function afterOverlayClosingFinished(overlay, callback) {
       }
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlays.forEach((overlay) => {
         overlay.opened = false;
       });
-      await nextRender();
     });
 
     it('should not remove pointer events on last opened overlay', (done) => {

--- a/packages/overlay/test/basic.common.js
+++ b/packages/overlay/test/basic.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, isIOS, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { createOverlay } from './helpers.js';
 
@@ -13,23 +13,20 @@ describe('vaadin-overlay', () => {
       overlay.renderer = (root) => {
         root.textContent = 'overlay content';
       };
-      await nextRender();
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     it('should move under document body when open', () => {
       expect(overlay.parentElement).to.eql(document.body);
     });
 
-    it('should move back to original place after closing', async () => {
+    it('should move back to original place after closing', () => {
       overlay.opened = false;
-      await nextRender();
       expect(overlay.parentElement).to.eql(parent);
     });
   });
@@ -39,19 +36,16 @@ describe('vaadin-overlay', () => {
 
     beforeEach(async () => {
       overlay = createOverlay('overlay content');
-      await nextRender();
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
-    it('should not prevent clicking elements outside overlay when modeless (non-modal)', async () => {
+    it('should not prevent clicking elements outside overlay when modeless (non-modal)', () => {
       overlay.modeless = true;
-      await nextRender();
       expect(document.body.style.pointerEvents).to.eql('');
     });
 
@@ -59,9 +53,8 @@ describe('vaadin-overlay', () => {
       expect(document.body.style.pointerEvents).to.eql('none');
     });
 
-    it('should not prevent clicking document elements after modal is closed', async () => {
+    it('should not prevent clicking document elements after modal is closed', () => {
       overlay.opened = false;
-      await nextRender();
       expect(document.body.style.pointerEvents).to.eql('');
     });
 
@@ -76,15 +69,13 @@ describe('vaadin-overlay', () => {
 
     beforeEach(async () => {
       overlay = createOverlay('overlay content');
-      await nextRender();
-      backdrop = overlay.$.backdrop;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
+      backdrop = overlay.$.backdrop;
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     it('should set withBackdrop to false by default', () => {
@@ -95,15 +86,13 @@ describe('vaadin-overlay', () => {
       expect(backdrop.hidden).to.be.true;
     });
 
-    it('should show backdrop when withBackdrop is true', async () => {
+    it('should show backdrop when withBackdrop is true', () => {
       overlay.withBackdrop = true;
-      await nextRender();
       expect(backdrop.hidden).to.be.false;
     });
 
-    it('should reflect withBackdrop property to attribute', async () => {
+    it('should reflect withBackdrop property to attribute', () => {
       overlay.withBackdrop = true;
-      await nextRender();
       expect(overlay.hasAttribute('with-backdrop')).to.be.true;
     });
   });
@@ -113,15 +102,13 @@ describe('vaadin-overlay', () => {
 
     beforeEach(async () => {
       overlay = createOverlay('overlay content');
-      await nextRender();
-      overlayPart = overlay.$.overlay;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
+      overlayPart = overlay.$.overlay;
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     it('should fit in the viewport by default', () => {
@@ -187,9 +174,8 @@ describe('vaadin-overlay', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     it('should set value to bottom when landscape and clientHeight > innerHeight', () => {

--- a/packages/overlay/test/focus-trap.common.js
+++ b/packages/overlay/test/focus-trap.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('focus-trap', () => {
@@ -25,17 +25,14 @@ describe('focus-trap', () => {
           `;
         }
       };
-      await nextRender();
-      overlayPart = overlay.$.overlay;
-      overlay.requestContentUpdate();
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
+      overlayPart = overlay.$.overlay;
       focusableElements = getFocusableElements(overlayPart);
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     it('should properly detect focusable elements inside the content', () => {
@@ -107,7 +104,6 @@ describe('focus-trap', () => {
 
     beforeEach(async () => {
       overlay = fixtureSync('<vaadin-overlay focus-trap></vaadin-overlay>');
-      await nextRender();
       overlay.renderer = (root) => {
         if (!root.firstChild) {
           const button = document.createElement('button');
@@ -124,7 +120,6 @@ describe('focus-trap', () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
       focusableElements = getFocusableElements(overlay.$.overlay);
-      await nextRender();
       nested = overlay.querySelector('vaadin-overlay');
     });
 
@@ -134,7 +129,8 @@ describe('focus-trap', () => {
 
     it('should not release focus when closing nested overlay without focus-trap', async () => {
       nested.opened = true;
-      await nextRender();
+      await oneEvent(nested, 'vaadin-overlay-open');
+
       nested.opened = false;
 
       const button = overlay.querySelector('button');
@@ -148,7 +144,7 @@ describe('focus-trap', () => {
   describe('aria-hidden', () => {
     let outer, inner, overlay;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       // Create outer element and pass it explicitly.
       outer = document.createElement('main');
 
@@ -165,7 +161,6 @@ describe('focus-trap', () => {
       );
 
       overlay = inner.querySelector('vaadin-overlay');
-      await nextRender();
       overlay.renderer = (root) => {
         root.innerHTML = '<input placeholder="Input">';
       };
@@ -187,8 +182,6 @@ describe('focus-trap', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       overlay.opened = false;
-      await aTimeout(0);
-
       expect(outer.hasAttribute('aria-hidden')).to.be.false;
     });
 

--- a/packages/overlay/test/interactions.common.js
+++ b/packages/overlay/test/interactions.common.js
@@ -24,9 +24,8 @@ describe('interactions', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     it('should close on Esc', () => {
@@ -75,16 +74,14 @@ describe('interactions', () => {
           root.appendChild(div);
         }
       };
-      await nextRender();
-      overlayPart = overlay.$.overlay;
-      backdrop = overlay.$.backdrop;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
+      overlayPart = overlay.$.overlay;
+      backdrop = overlay.$.backdrop;
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay.opened = false;
-      await nextRender();
     });
 
     describe('close on click', () => {

--- a/packages/overlay/test/multiple.common.js
+++ b/packages/overlay/test/multiple.common.js
@@ -16,40 +16,33 @@ describe('multiple overlays', () => {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay1.opened = false;
       overlay2.opened = false;
       overlay3.opened = false;
-      await nextRender();
     });
 
     describe('last flag', () => {
-      it('should be the last when only one overlay is opened', async () => {
+      it('should be the last when only one overlay is opened', () => {
         overlay1.opened = true;
-        await nextRender();
         expect(overlay1._last).to.be.true;
       });
 
-      it('should not be the last when another overlay is opened after this', async () => {
+      it('should not be the last when another overlay is opened after this', () => {
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
 
         expect(overlay1._last).not.to.be.true;
         expect(overlay2._last).to.be.true;
       });
 
-      it('should become last when the last overlay is closed', async () => {
+      it('should become last when the last overlay is closed', () => {
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
 
         overlay2.opened = false;
-        await nextRender();
 
         expect(overlay1._last).to.be.true;
       });
@@ -63,19 +56,16 @@ describe('multiple overlays', () => {
         overlay1.addEventListener('vaadin-overlay-escape-press', spy);
       });
 
-      it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', async () => {
+      it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', () => {
         overlay1.opened = true;
-        await nextRender();
         escKeyDown(document.body);
         expect(spy.called).to.be.true;
       });
 
-      it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', async () => {
+      it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', () => {
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
 
         escKeyDown(document.body);
         expect(spy.called).to.be.false;
@@ -90,98 +80,80 @@ describe('multiple overlays', () => {
         overlay1.addEventListener('vaadin-overlay-outside-click', spy);
       });
 
-      it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', async () => {
+      it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', () => {
         overlay1.opened = true;
-        await nextRender();
         click(parent);
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', async () => {
+      it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', () => {
         overlay1.opened = true;
-        await nextRender();
+
         overlay2.opened = true;
-        await nextRender();
+
         click(parent);
         expect(spy.called).to.be.false;
       });
     });
 
     describe('pointer-events', () => {
-      it('should restore pointer-events correctly when overlays are not closed in order', async () => {
+      it('should restore pointer-events correctly when overlays are not closed in order', () => {
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
         expect(document.body.style.pointerEvents).to.eql('none');
 
         overlay1.opened = false;
-        await nextRender();
 
         overlay2.opened = false;
-        await nextRender();
         expect(document.body.style.pointerEvents).to.eql('');
       });
 
-      it('should disable pointer-events in first overlay when second opens', async () => {
+      it('should disable pointer-events in first overlay when second opens', () => {
         const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
 
         expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
       });
 
-      it('should restore pointer-events in first overlay when second closes', async () => {
+      it('should restore pointer-events in first overlay when second closes', () => {
         const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
 
         overlay2.opened = false;
-        await nextRender();
         expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
       });
 
-      it('should restore pointer-events in second overlay when third closes', async () => {
+      it('should restore pointer-events in second overlay when third closes', () => {
         const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
         const overlay2Part = overlay2.shadowRoot.querySelector('[part="overlay"]');
         overlay1.opened = true;
-        await nextRender();
 
         overlay2.opened = true;
-        await nextRender();
 
         overlay3.opened = true;
-        await nextRender();
 
         overlay3.opened = false;
-        await nextRender();
 
         expect(getComputedStyle(overlay2Part).pointerEvents).to.equal('auto');
         expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
       });
 
-      it('should clear pointer events after closing overlays', async () => {
+      it('should clear pointer events after closing overlays', () => {
         const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
         // Step 1: Opening overlay 1 so it's physically moved under the body
         overlay1.opened = true;
-        await nextRender();
         // Step 2: As overlay2 is modal, it will set overlay 1's pointer events to none
         overlay2.opened = true;
-        await nextRender();
         // Step 3: Closing overlay 1 so it's physically moved back from under the body
         overlay1.opened = false;
-        await nextRender();
         // Step 4: Closing overlay 2 restores pointer-events of an overlay it
         // finds under the body node, but overlay 1 is no longer there.
         overlay2.opened = false;
-        await nextRender();
         // The fix: Clear pointer-events whenever an overlay is closed
         // (in this case overlay 1 at step 3)
         expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
@@ -226,17 +198,14 @@ describe('multiple overlays', () => {
       await nextRender();
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       modeless1.opened = false;
       modeless2.opened = false;
-      await nextRender();
     });
 
-    it('should bring the overlay to front with bringToFront', async () => {
+    it('should bring the overlay to front with bringToFront', () => {
       modeless1.opened = true;
-      await nextRender();
       modeless2.opened = true;
-      await nextRender();
       modeless1.bringToFront();
 
       expect(modeless1._last).to.be.true;
@@ -245,9 +214,8 @@ describe('multiple overlays', () => {
       expect(frontmost).to.equal(modeless1);
     });
 
-    it('should not lose scroll position when brought to front', async () => {
+    it('should not lose scroll position when brought to front', () => {
       modeless1.opened = true;
-      await nextRender();
       modeless1.$.content.style.height = '200px';
 
       const overlay = modeless1.$.overlay;
@@ -255,16 +223,13 @@ describe('multiple overlays', () => {
       overlay.scrollTop = 100;
 
       modeless2.opened = true;
-      await nextRender();
       modeless1.bringToFront();
       expect(overlay.scrollTop).to.equal(100);
     });
 
-    it('should grow the z-index by 1', async () => {
+    it('should grow the z-index by 1', () => {
       modeless1.opened = true;
-      await nextRender();
       modeless2.opened = true;
-      await nextRender();
       modeless1.bringToFront();
 
       const zIndex1 = parseFloat(getComputedStyle(modeless1).zIndex);
@@ -272,58 +237,47 @@ describe('multiple overlays', () => {
       expect(zIndex1).to.equal(zIndex2 + 1);
     });
 
-    it('should bring the newly opened overlay to front', async () => {
+    it('should bring the newly opened overlay to front', () => {
       modeless1.opened = true;
-      await nextRender();
       modeless2.opened = true;
-      await nextRender();
       modeless1.bringToFront();
 
       modeless2.opened = false;
-      await nextRender();
       modeless2.opened = true;
-      await nextRender();
 
       const frontmost = getFrontmostOverlayFromScreenCenter();
       expect(frontmost).to.equal(modeless2);
     });
 
-    it('should reset z-indexes', async () => {
+    it('should reset z-indexes', () => {
       modeless1.opened = true;
-      await nextRender();
       modeless2.opened = true;
-      await nextRender();
 
       const zIndex1 = parseFloat(getComputedStyle(modeless1).zIndex);
       expect(parseFloat(modeless2.style.zIndex)).to.equal(zIndex1 + 1);
 
       modeless1.opened = false;
-      await nextRender();
       modeless2.opened = false;
-      await nextRender();
 
       modeless2.opened = true;
-      await nextRender();
       expect(modeless2.style.zIndex).to.be.empty;
     });
 
-    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', async () => {
+    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
-      await nextRender();
 
       escKeyDown(document.body);
       expect(spy.called).to.be.false;
     });
 
-    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', async () => {
+    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
-      await nextRender();
 
       const input = modeless1.querySelector('input');
       input.focus();
@@ -332,15 +286,13 @@ describe('multiple overlays', () => {
       expect(spy.called).to.be.true;
     });
 
-    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', async () => {
+    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
-      await nextRender();
 
       modeless2.opened = true;
-      await nextRender();
       modeless1.bringToFront();
 
       const input = modeless1.querySelector('input');
@@ -350,14 +302,12 @@ describe('multiple overlays', () => {
       expect(spy.called).to.be.true;
     });
 
-    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', async () => {
+    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
 
       modeless1.opened = true;
-      await nextRender();
       modeless2.opened = true;
-      await nextRender();
 
       const input = modeless2.querySelector('input');
       input.focus();

--- a/packages/overlay/test/position-mixin.common.js
+++ b/packages/overlay/test/position-mixin.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import { setViewport } from '@web/test-runner-commands';
 
 describe('position mixin', () => {
@@ -67,13 +67,11 @@ describe('position mixin', () => {
     expectEdgesAligned(LEFT, LEFT);
   });
 
-  it('should update position on open', async () => {
+  it('should update position on open', () => {
     overlay.opened = false;
-    await nextUpdate(overlay);
     target.style.top = '5px';
     target.style.left = '10px';
     overlay.opened = true;
-    await nextUpdate(overlay);
     expectEdgesAligned(TOP, TOP);
     expectEdgesAligned(LEFT, LEFT);
   });

--- a/packages/overlay/test/renderer.common.js
+++ b/packages/overlay/test/renderer.common.js
@@ -12,19 +12,17 @@ describe('renderer', () => {
     content.textContent = 'renderer-content';
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     overlay.opened = false;
-    await nextRender();
   });
 
-  it('should use renderer when it is defined', async () => {
+  it('should use renderer when it is defined', () => {
     overlay.renderer = (root) => root.appendChild(content);
     overlay.opened = true;
-    await nextRender();
     expect(overlay.textContent.trim()).to.equal('renderer-content');
   });
 
-  it('should receive empty root, model and owner when they are defined', async () => {
+  it('should receive empty root, model and owner when they are defined', () => {
     const overlayOwner = {};
     const overlayModel = {};
 
@@ -35,7 +33,6 @@ describe('renderer', () => {
 
     overlay.renderer = renderer;
     overlay.opened = true;
-    await nextRender();
 
     const [root, owner, model] = renderer.firstCall.args;
     expect(root.firstChild).to.be.null;
@@ -43,24 +40,21 @@ describe('renderer', () => {
     expect(model).to.eql(overlayModel);
   });
 
-  it('should clean the root on renderer change', async () => {
+  it('should clean the root on renderer change', () => {
     overlay.renderer = (root) => root.appendChild(content);
     overlay.opened = true;
-    await nextRender();
     expect(overlay.textContent.trim()).to.equal('renderer-content');
 
     const renderer = sinon.spy();
     overlay.renderer = renderer;
-    await nextRender();
 
     const root = renderer.firstCall.args[0];
     expect(root.firstChild).to.be.null;
   });
 
-  it('should not clean the root on model or owner change', async () => {
+  it('should not clean the root on model or owner change', () => {
     overlay.renderer = (root) => root.appendChild(content);
     overlay.opened = true;
-    await nextRender();
     expect(overlay.textContent.trim()).to.equal('renderer-content');
 
     const overlayOwner = {};
@@ -68,12 +62,11 @@ describe('renderer', () => {
 
     overlay.owner = overlayOwner;
     overlay.model = overlayModel;
-    await nextRender();
 
     expect(overlay.textContent.trim()).to.equal('renderer-content');
   });
 
-  it('should pass owner as this to the renderer', async () => {
+  it('should pass owner as this to the renderer', () => {
     const owner = {};
     overlay.owner = owner;
 
@@ -81,35 +74,30 @@ describe('renderer', () => {
     overlay.renderer = renderer;
 
     overlay.opened = true;
-    await nextRender();
 
     expect(renderer.firstCall.thisValue).to.equal(owner);
   });
 
-  it('should call renderer on model change', async () => {
+  it('should call renderer on model change', () => {
     const renderer = sinon.spy();
 
     overlay.opened = true;
     overlay.renderer = renderer;
-    await nextRender();
 
     renderer.resetHistory();
     overlay.model = {};
-    await nextRender();
 
     expect(renderer.calledOnce).to.be.true;
   });
 
-  it('should call renderer on owner change', async () => {
+  it('should call renderer on owner change', () => {
     const renderer = sinon.spy();
 
     overlay.opened = true;
     overlay.renderer = renderer;
-    await nextRender();
 
     renderer.resetHistory();
     overlay.owner = {};
-    await nextRender();
 
     expect(renderer.calledOnce).to.be.true;
   });
@@ -121,27 +109,24 @@ describe('renderer', () => {
     expect(overlay.renderer.calledOnce).to.be.true;
   });
 
-  it('should not call renderer if overlay is not open', async () => {
+  it('should not call renderer if overlay is not open', () => {
     overlay.renderer = sinon.spy();
-    await nextRender();
     expect(overlay.renderer.called).to.be.false;
   });
 
-  it('should clear the content when removing the renderer', async () => {
+  it('should clear the content when removing the renderer', () => {
     overlay.renderer = (root) => {
       root.innerHTML = 'foo';
     };
 
     overlay.opened = true;
-    await nextRender();
     expect(overlay.textContent.trim()).to.equal('foo');
 
     overlay.renderer = null;
-    await nextRender();
     expect(overlay.textContent.trim()).to.equal('');
   });
 
-  it('should not clear the root on open when setting renderer', async () => {
+  it('should not clear the root on open when setting renderer', () => {
     const spy = sinon.spy(overlay, 'innerHTML', ['set']);
     overlay.renderer = (root) => {
       if (!root.innerHTML) {
@@ -149,11 +134,10 @@ describe('renderer', () => {
       }
     };
     overlay.opened = true;
-    await nextRender();
     expect(spy.set).to.not.be.called;
   });
 
-  it('should not re-render when opened after requesting content update', async () => {
+  it('should not re-render when opened after requesting content update', () => {
     const spy = sinon.spy(overlay, 'appendChild');
     overlay.renderer = (root) => {
       if (!root.innerHTML) {
@@ -162,7 +146,6 @@ describe('renderer', () => {
     };
     overlay.requestContentUpdate();
     overlay.opened = true;
-    await nextRender();
     expect(spy).to.be.calledOnce;
   });
 });

--- a/packages/overlay/test/restore-focus.common.js
+++ b/packages/overlay/test/restore-focus.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { escKeyDown, fixtureSync, mousedown, nextRender } from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, mousedown, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -65,9 +65,8 @@ describe('restore focus', () => {
     it('should not restore focus on close by default', async () => {
       focusInput.focus();
       overlay.opened = true;
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       overlay.opened = false;
-      await nextRender();
       expect(getDeepActiveElement()).to.not.equal(focusInput);
     });
 
@@ -79,9 +78,8 @@ describe('restore focus', () => {
       it('should not restore focus on close by default', async () => {
         focusInput.focus();
         overlay.opened = true;
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
         overlay.opened = false;
-        await nextRender();
         expect(getDeepActiveElement()).to.not.equal(focusInput);
       });
     });
@@ -104,28 +102,25 @@ describe('restore focus', () => {
       it('should restore focus on close', async () => {
         focusInput.focus();
         overlay.opened = true;
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
         overlay.opened = false;
-        await nextRender();
         expect(getDeepActiveElement()).to.equal(focusInput);
       });
 
       it('should restore focus on close in Shadow DOM', async () => {
         focusable.focus();
         overlay.opened = true;
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
         overlay.opened = false;
-        await nextRender();
         expect(getDeepActiveElement()).to.equal(focusable);
       });
 
       it('should not restore focus on close if focus was moved outside overlay', async () => {
         focusInput.focus();
         overlay.opened = true;
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
         focusable.focus();
         overlay.opened = false;
-        await nextRender();
         expect(getDeepActiveElement()).to.equal(focusable);
       });
 
@@ -137,9 +132,8 @@ describe('restore focus', () => {
         it('should restore focus to the restoreFocusNode', async () => {
           focusable.focus();
           overlay.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
           overlay.opened = false;
-          await nextRender();
           expect(getDeepActiveElement()).to.equal(focusInput);
         });
       });
@@ -148,11 +142,10 @@ describe('restore focus', () => {
         it('should prevent scroll when restoring focus on close after mousedown', async () => {
           focusable.focus();
           overlay.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
           const spy = sinon.spy(focusable, 'focus');
           mousedown(document.body);
           overlay.opened = false;
-          await nextRender();
           expect(spy).to.be.calledOnce;
           expect(spy.firstCall.args[0]).to.eql({ preventScroll: true });
         });
@@ -160,11 +153,10 @@ describe('restore focus', () => {
         it('should not prevent scroll when restoring focus on close after keydown', async () => {
           focusable.focus();
           overlay.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
           const spy = sinon.spy(focusable, 'focus');
           escKeyDown(document.body);
           overlay.opened = false;
-          await nextRender();
           expect(spy).to.be.calledOnce;
           expect(spy.firstCall.args[0]).to.eql({ preventScroll: false });
         });

--- a/packages/time-picker/src/vaadin-lit-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-lit-time-picker-overlay.js
@@ -45,22 +45,6 @@ export class TimePickerOverlay extends ComboBoxOverlayMixin(
     return [overlayStyles, timePickerOverlayStyles];
   }
 
-  static get properties() {
-    return {
-      /**
-       * When true, the overlay is visible and attached to body.
-       * This property config is overridden to set `sync: true`.
-       */
-      opened: {
-        type: Boolean,
-        notify: true,
-        observer: '_openedChanged',
-        reflectToAttribute: true,
-        sync: true,
-      },
-    };
-  }
-
   /** @protected */
   render() {
     return html`


### PR DESCRIPTION
## Description

Updated properties in `OverlayMixin` to use `sync: true` and removed corresponding overrides from Lit components.

Also removed a bunch of `await` statements added back in the day as part of the following PRs:

- https://github.com/vaadin/web-components/pull/6047
- https://github.com/vaadin/web-components/pull/6113
- https://github.com/vaadin/web-components/pull/6115

## Type of change

- Refactor