### PR TITLE
test: remove not needed await in date-picker dropdown test

### DIFF
--- a/packages/date-picker/test/dropdown.common.js
+++ b/packages/date-picker/test/dropdown.common.js
@@ -1,14 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import {
-  aTimeout,
-  fire,
-  fixtureSync,
-  mousedown,
-  nextRender,
-  nextUpdate,
-  oneEvent,
-  touchstart,
-} from '@vaadin/testing-helpers';
+import { aTimeout, fire, fixtureSync, mousedown, nextRender, oneEvent, touchstart } from '@vaadin/testing-helpers';
 import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { getFocusableCell, monthsEqual, open, waitForOverlayRender } from './helpers.js';
@@ -32,7 +23,6 @@ describe('dropdown', () => {
   it('should detach overlay on datePicker detach', async () => {
     await open(datePicker);
     datePicker.parentElement.removeChild(datePicker);
-    await nextUpdate(datePicker);
     expect(overlay.parentElement).to.not.be.ok;
   });
 
@@ -55,7 +45,6 @@ describe('dropdown', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       toggleButton.click();
-      await nextUpdate(datePicker);
 
       expect(datePicker.opened).to.be.false;
       expect(overlay.opened).to.be.false;
@@ -70,7 +59,6 @@ describe('dropdown', () => {
   describe('scroll to date', () => {
     it('should scroll to today by default', async () => {
       datePicker.open();
-      await nextUpdate(datePicker);
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -84,7 +72,6 @@ describe('dropdown', () => {
       datePicker.initialPosition = '2016-01-01';
 
       datePicker.open();
-      await nextUpdate(datePicker);
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -98,7 +85,6 @@ describe('dropdown', () => {
       datePicker.value = '2000-02-01';
 
       datePicker.open();
-      await nextUpdate(datePicker);
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -122,7 +108,6 @@ describe('dropdown', () => {
 
     it('should scroll to date on reopen', async () => {
       datePicker.open();
-      await nextUpdate(datePicker);
 
       // We must scroll to initial position on reopen because
       // scrollTop can be reset while the dropdown is closed.
@@ -143,7 +128,6 @@ describe('dropdown', () => {
       datePicker.min = '2100-01-01';
 
       datePicker.open();
-      await nextUpdate(datePicker);
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -157,7 +141,6 @@ describe('dropdown', () => {
       datePicker.max = '2000-01-01';
 
       datePicker.open();
-      await nextUpdate(datePicker);
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -174,7 +157,6 @@ describe('dropdown', () => {
       datePicker.initialPosition = '2015-01-01';
 
       datePicker.open();
-      await nextUpdate(datePicker);
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -202,7 +184,6 @@ describe('dropdown', () => {
       expect(document.activeElement).to.equal(document.body);
       await open(datePicker);
       await sendMouse({ type: 'click', position: [200, 10] });
-      await nextUpdate(datePicker);
       await aTimeout(0);
       expect(document.activeElement).to.equal(input);
     });
@@ -212,7 +193,6 @@ describe('dropdown', () => {
       await sendKeys({ press: 'Tab' });
       await open(datePicker);
       await sendMouse({ type: 'click', position: [200, 10] });
-      await nextUpdate(datePicker);
       await aTimeout(0);
       expect(datePicker.hasAttribute('focus-ring')).to.be.true;
     });
@@ -290,7 +270,6 @@ describe('dropdown', () => {
     it('should disable virtual keyboard on close', async () => {
       await open(datePicker);
       datePicker.close();
-      await nextUpdate(datePicker);
       expect(input.inputMode).to.equal('none');
     });
 


### PR DESCRIPTION
## Description

Reverted some changes added in https://github.com/vaadin/web-components/pull/6270 - looks like these are no longer necessary since `opened` property now uses `sync: true` in both `DatePickerMixin` and Lit version of `vaadin-date-picker-overlay`.

## Type of change

- Test