### PR TITLE
refactor: move autoSelect logic to SelectionColumnBaseMixin

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -101,6 +101,27 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       ];
     }
 
+    constructor() {
+      super();
+      this.__onActiveItemChanged = this.__onActiveItemChanged.bind(this);
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      if (this._grid) {
+        this._grid.addEventListener('active-item-changed', this.__onActiveItemChanged);
+      }
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      if (this._grid) {
+        this._grid.removeEventListener('active-item-changed', this.__onActiveItemChanged);
+      }
+    }
+
     /**
      * Renders the Select All checkbox to the header cell.
      *
@@ -182,11 +203,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         return;
       }
 
-      if (e.target.checked) {
-        this._selectItem(e.target.__item);
-      } else {
-        this._deselectItem(e.target.__item);
-      }
+      this.__toggleItem(e.target.__item, e.target.checked);
     }
 
     /** @private */
@@ -262,6 +279,18 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         const checkbox = target._content.firstElementChild;
         this.__toggleItem(checkbox.__item);
       }
+    }
+
+    /** @private */
+    __onActiveItemChanged(e) {
+      const activeItem = e.detail.value;
+      if (this.autoSelect) {
+        const item = activeItem || this.__previousActiveItem;
+        if (item) {
+          this.__toggleItem(item);
+        }
+      }
+      this.__previousActiveItem = activeItem;
     }
 
     /** @private */
@@ -376,11 +405,11 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      * @param item the item to toggle
      * @private
      */
-    __toggleItem(item) {
-      if (this._grid._isSelected(item)) {
-        this._deselectItem(item);
-      } else {
+    __toggleItem(item, selected = !this._grid._isSelected(item)) {
+      if (selected) {
         this._selectItem(item);
+      } else {
+        this._deselectItem(item);
       }
     }
 

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -402,7 +402,9 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
     /**
      * Toggles the selected state of the given item.
+     *
      * @param item the item to toggle
+     * @param {boolean} [selected] whether to select or deselect the item
      * @private
      */
     __toggleItem(item, selected = !this._grid._isSelected(item)) {

--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -29,14 +29,12 @@ export const GridSelectionColumnMixin = (superClass) =>
     constructor() {
       super();
 
-      this.__boundOnActiveItemChanged = this.__onActiveItemChanged.bind(this);
       this.__boundUpdateSelectAllVisibility = this.__updateSelectAllVisibility.bind(this);
       this.__boundOnSelectedItemsChanged = this.__onSelectedItemsChanged.bind(this);
     }
 
     /** @protected */
     disconnectedCallback() {
-      this._grid.removeEventListener('active-item-changed', this.__boundOnActiveItemChanged);
       this._grid.removeEventListener('data-provider-changed', this.__boundUpdateSelectAllVisibility);
       this._grid.removeEventListener('is-item-selectable-changed', this.__boundUpdateSelectAllVisibility);
       this._grid.removeEventListener('filter-changed', this.__boundOnSelectedItemsChanged);
@@ -49,7 +47,6 @@ export const GridSelectionColumnMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       if (this._grid) {
-        this._grid.addEventListener('active-item-changed', this.__boundOnActiveItemChanged);
         this._grid.addEventListener('data-provider-changed', this.__boundUpdateSelectAllVisibility);
         this._grid.addEventListener('is-item-selectable-changed', this.__boundUpdateSelectAllVisibility);
         this._grid.addEventListener('filter-changed', this.__boundOnSelectedItemsChanged);
@@ -131,18 +128,6 @@ export const GridSelectionColumnMixin = (superClass) =>
       if (this._grid.__isItemSelectable(item)) {
         this._grid.deselectItem(item);
       }
-    }
-
-    /** @private */
-    __onActiveItemChanged(e) {
-      const activeItem = e.detail.value;
-      if (this.autoSelect) {
-        const item = activeItem || this.__previousActiveItem;
-        if (item) {
-          this.__toggleItem(item);
-        }
-      }
-      this.__previousActiveItem = activeItem;
     }
 
     /** @private */


### PR DESCRIPTION
## Description

The `autoSelect` property is defined in `SelectionColumnBaseMixin`, so it makes sense to have the autoSelect logic there as well.

Part of #8142 

## Type of change

- [x] Refactor
