### PR TITLE
test: update message list test to use correct items format

### DIFF
--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -23,35 +23,34 @@ describe('message-list', () => {
     root.style.setProperty('--vaadin-user-color-2', 'blue');
 
     messageList = fixtureSync('<vaadin-message-list></vaadin-message-list>');
+
+    // Transparent 1px gif
+    const img = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
     messages = [
       {
         text: 'A message in the stream of messages',
         time: '9:34 AM',
         userName: 'Joan Doe',
         userAbbr: 'JD',
-        userImg: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
+        userImg: img,
         userColorIndex: 1,
         theme: 'fancy',
       },
       {
         text: 'A message in the stream of messages',
         time: '9:35 AM',
-        user: {
-          name: 'Joan Doe',
-          abbr: 'JD',
-          img: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
-          colorIndex: 1,
-        },
+        userName: 'Joan Doe',
+        userAbbr: 'JD',
+        userImg: img,
+        userColorIndex: 1,
       },
       {
         text: 'A message in the stream of messages',
         time: '9:36 AM',
-        user: {
-          name: 'Joan Doe',
-          abbr: 'JD',
-          img: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
-          colorIndex: 1,
-        },
+        userName: 'Joan Doe',
+        userAbbr: 'JD',
+        userImg: img,
+        userColorIndex: 1,
       },
       {
         text: 'Call upon the times of glory',
@@ -169,11 +168,9 @@ describe('message-list', () => {
           {
             text: 'A new message arrives!',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
         ];
         await nextRender(messageList);
@@ -187,11 +184,9 @@ describe('message-list', () => {
           {
             text: 'A new message arrives!',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
         ];
         await nextRender(messageList);
@@ -214,20 +209,16 @@ describe('message-list', () => {
           {
             text: 'This is a new list',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
           {
             text: 'With two items',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
         ];
         await nextRender(messageList);
@@ -245,11 +236,9 @@ describe('message-list', () => {
           {
             text: 'A new message arrives!',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
         ];
         await nextRender(messageList);
@@ -269,20 +258,16 @@ describe('message-list', () => {
           {
             text: 'This is a new list',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
           {
             text: 'With two items',
             time: '2:35 PM',
-            user: {
-              name: 'Steve Mops',
-              abbr: 'SM',
-              colorIndex: 2,
-            },
+            userName: 'Steve Mops',
+            userAbbr: 'SM',
+            userColorIndex: 2,
           },
         ];
 


### PR DESCRIPTION
## Description

Updated `vaadin-message-list` tests to use correct properties e.g. `userName`, `userImg` etc instead of the `user` object. The object was used in the initial version https://github.com/vaadin/vaadin-messages/pull/9, but we then changed to use individual properties in https://github.com/vaadin/vaadin-messages/pull/19 and tests were not updated accordingly.

Also changed the base64 image to the one that doesn't affect syntax highlighting in VSCode.

## Type of change

- Tests