### PR TITLE
fix: do not dispatch event on stopedit when editor loading (#8232) (CP: 24.4)

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -227,7 +227,7 @@ export const InlineEditingMixin = (superClass) =>
     }
 
     /** @private */
-    _applyEdit({ path, value, index, item }) {
+    _applyEdit({ path, value, _, item }) {
       set(path, value, item);
       this.requestContentUpdate();
     }
@@ -273,6 +273,7 @@ export const InlineEditingMixin = (superClass) =>
     }
 
     /** @private */
+    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
     _isEditColumn(column) {
       return column && column.localName.toLowerCase() === 'vaadin-grid-pro-edit-column';
     }
@@ -405,7 +406,7 @@ export const InlineEditingMixin = (superClass) =>
       }
       const { cell, column, model } = this.__edited;
 
-      if (!shouldCancel) {
+      if (!shouldCancel && !this.hasAttribute('loading-editor')) {
         const editor = column._getEditorComponent(cell);
         if (editor) {
           const value = column._getEditorValue(editor);

--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import {
@@ -369,6 +369,41 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Escape' });
       expect(getContainerCellContent(grid.$.items, 0, 0).textContent).to.equal('0 foo');
+    });
+
+    it('should not fire event when tabbed through cells with slow editor', async () => {
+      const itemPropertyChangedSpy = sinon.spy();
+      grid.addEventListener('item-property-changed', itemPropertyChangedSpy);
+
+      const column = grid.querySelector('vaadin-grid-pro-edit-column');
+
+      // Custom editor with delayed operations
+      column.editModeRenderer = (root, _, __) => {
+        if (!root.firstElementChild) {
+          const input = document.createElement('input');
+          let actualValue = '';
+          Object.defineProperty(input, 'value', {
+            async get() {
+              await aTimeout(100);
+              return actualValue;
+            },
+            async set(v) {
+              await aTimeout(100);
+              actualValue = v;
+            },
+          });
+          root.appendChild(input);
+        }
+      };
+
+      const firstCell = getContainerCell(grid.$.items, 0, 0);
+      dblclick(firstCell._content);
+
+      await sendKeys({ press: 'Tab' });
+      await sendKeys({ press: 'Tab' });
+      await nextFrame();
+
+      expect(itemPropertyChangedSpy.called).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

Back-port of [8232](https://github.com/vaadin/web-components/pull/8232) for v24.4.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.