### PR TITLE
fix: support sub-properties in polylit mixin complex observers

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -275,7 +275,7 @@ const PolylitMixinImplementation = (superclass) => {
     /** @private */
     __runComplexObservers(props, observers) {
       observers.forEach((observerProps, method) => {
-        if (observerProps.some((prop) => props.has(prop.split('.')[0]))) {
+        if (observerProps.some((prop) => !prop.endsWith('.*') && props.has(prop.split('.')[0]))) {
           if (!this[method]) {
             console.warn(`observer method ${method} not defined`);
           } else {

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -275,11 +275,11 @@ const PolylitMixinImplementation = (superclass) => {
     /** @private */
     __runComplexObservers(props, observers) {
       observers.forEach((observerProps, method) => {
-        if (observerProps.some((prop) => props.has(prop))) {
+        if (observerProps.some((prop) => props.has(prop.split('.')[0]))) {
           if (!this[method]) {
             console.warn(`observer method ${method} not defined`);
           } else {
-            this[method](...observerProps.map((prop) => this[prop]));
+            this[method](...observerProps.map((prop) => get(prop, this)));
           }
         }
       });

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -504,7 +504,7 @@ describe('PolylitMixin', () => {
 
   describe('complex observer', () => {
     let element;
-    let valueOrLoadingChangedSpy, countOrLoadingChangedSpy;
+    let valueOrLoadingChangedSpy, countOrLoadingChangedSpy, i18nSpy;
 
     const readySpy = sinon.spy();
     const helperChangedSpy = sinon.spy();
@@ -534,6 +534,10 @@ describe('PolylitMixin', () => {
               type: String,
               value: 'Default Helper',
             },
+
+            i18n: {
+              type: Object,
+            },
           };
         }
 
@@ -543,6 +547,7 @@ describe('PolylitMixin', () => {
             '_countOrLoadingChanged(count, loading)',
             '_idChanged(id)',
             '_helperChanged(helper)',
+            '_i18nChanged(i18n.name)',
           ];
         }
 
@@ -563,6 +568,8 @@ describe('PolylitMixin', () => {
 
         _countOrLoadingChanged(_count, _loading) {}
 
+        _i18nChanged(_name) {}
+
         _helperChanged(value) {
           helperChangedSpy(value);
 
@@ -575,6 +582,7 @@ describe('PolylitMixin', () => {
       element = fixtureSync(`<${tag}></${tag}>`);
       valueOrLoadingChangedSpy = sinon.spy(element, '_valueOrLoadingChanged');
       countOrLoadingChangedSpy = sinon.spy(element, '_countOrLoadingChanged');
+      i18nSpy = sinon.spy(element, '_i18nChanged');
       await element.updateComplete;
     });
 
@@ -614,6 +622,13 @@ describe('PolylitMixin', () => {
 
     it('should run a complex observer whose dependency has a default value', () => {
       expect(countOrLoadingChangedSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass sub-properties of observed object to the complex observer', async () => {
+      element.i18n = { name: 'foo' };
+      await element.updateComplete;
+      expect(i18nSpy.calledOnce).to.be.true;
+      expect(i18nSpy.getCall(0).args).to.eql(['foo']);
     });
 
     describe('missing', () => {

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -504,7 +504,7 @@ describe('PolylitMixin', () => {
 
   describe('complex observer', () => {
     let element;
-    let valueOrLoadingChangedSpy, countOrLoadingChangedSpy, i18nSpy;
+    let valueOrLoadingChangedSpy, countOrLoadingChangedSpy, i18nSpy, wildcardSpy;
 
     const readySpy = sinon.spy();
     const helperChangedSpy = sinon.spy();
@@ -538,6 +538,10 @@ describe('PolylitMixin', () => {
             i18n: {
               type: Object,
             },
+
+            wildcard: {
+              type: Object,
+            },
           };
         }
 
@@ -548,6 +552,7 @@ describe('PolylitMixin', () => {
             '_idChanged(id)',
             '_helperChanged(helper)',
             '_i18nChanged(i18n.name)',
+            '_wildcardChanged(wildcard.*)',
           ];
         }
 
@@ -570,6 +575,8 @@ describe('PolylitMixin', () => {
 
         _i18nChanged(_name) {}
 
+        _wildcardChanged(_wildcard) {}
+
         _helperChanged(value) {
           helperChangedSpy(value);
 
@@ -583,6 +590,7 @@ describe('PolylitMixin', () => {
       valueOrLoadingChangedSpy = sinon.spy(element, '_valueOrLoadingChanged');
       countOrLoadingChangedSpy = sinon.spy(element, '_countOrLoadingChanged');
       i18nSpy = sinon.spy(element, '_i18nChanged');
+      wildcardSpy = sinon.spy(element, '_wildcardChanged');
       await element.updateComplete;
     });
 
@@ -629,6 +637,12 @@ describe('PolylitMixin', () => {
       await element.updateComplete;
       expect(i18nSpy.calledOnce).to.be.true;
       expect(i18nSpy.getCall(0).args).to.eql(['foo']);
+    });
+
+    it('should not invoke complex observer for wildcard syntax', async () => {
+      element.wildcard = { name: 'foo' };
+      await element.updateComplete;
+      expect(wildcardSpy.called).to.be.false;
     });
 
     describe('missing', () => {


### PR DESCRIPTION
## Description

Some components [list sub-properties](https://github.com/vaadin/web-components/blob/de17f9000054a81aee40aa6ca84768057707088a/packages/crud/src/vaadin-crud-mixin.js#L332) in complex observers.

This change makes `PolylitMixin` correctly pass the sub-properties to observer functions

## Type of change

Bugfix/internal feature