### PR TITLE
refactor: update list-box observer to not use Polymer syntax

### DIFF
--- a/packages/list-box/src/vaadin-multi-select-list-mixin.js
+++ b/packages/list-box/src/vaadin-multi-select-list-mixin.js
@@ -39,7 +39,7 @@ export const MultiSelectListMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_enhanceMultipleItems(items, multiple, selected, disabled, selectedValues, selectedValues.*)'];
+      return ['_enhanceMultipleItems(items, multiple, selected, disabled, selectedValues)'];
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

Current logic covers the case with mutating `selectedValues` array property using Polymer splices API.
As we already updated most of components to not support this, let's update `vaadin-list-box` as well.

## Type of change

- Refactor