### PR TITLE
fix: add missing uniqueIdPrefix to Lit date-picker version

### DIFF
--- a/packages/date-picker/src/vaadin-lit-date-picker.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker.js
@@ -113,12 +113,21 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
     super.ready();
 
     this.addController(
-      new InputController(this, (input) => {
-        this._setInputElement(input);
-        this._setFocusElement(input);
-        this.stateTarget = input;
-        this.ariaTarget = input;
-      }),
+      new InputController(
+        this,
+        (input) => {
+          this._setInputElement(input);
+          this._setFocusElement(input);
+          this.stateTarget = input;
+          this.ariaTarget = input;
+        },
+        {
+          // The "search" word is a trick to prevent Safari from enabling AutoFill,
+          // which is causing click issues:
+          // https://github.com/vaadin/web-components/issues/6817#issuecomment-2268229567
+          uniqueIdPrefix: 'search-input',
+        },
+      ),
     );
     this.addController(new LabelledInputController(this.inputElement, this._labelController));
 


### PR DESCRIPTION
## Description

Noticed this while reviewing #8254. The logic is apparently only covered by snapshot tests and they only run for Polymer.

## Type of change

- Bugfix for Lit version