### PR TITLE
docs: mark updated method in combo-box mixin as protected

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -453,6 +453,7 @@ export const ComboBoxMixin = (subclass) =>
     /**
      * Override LitElement lifecycle callback to handle filter property change.
      * @param {Object} props
+     * @protected
      */
     updated(props) {
       super.updated(props);


### PR DESCRIPTION
## Description

Added missing JSDoc annotation to remove `updated()` from the list of public methods in API docs.

## Type of change

- Documentation