### PR TITLE
test: add missing test for date-picker label click

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -247,6 +247,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
 
   /** @private */
   _onVaadinOverlayClose(e) {
+    // Prevent closing the overlay on label element click
     if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
       e.preventDefault();
     }

--- a/packages/date-picker/src/vaadin-lit-date-picker.js
+++ b/packages/date-picker/src/vaadin-lit-date-picker.js
@@ -150,6 +150,7 @@ class DatePicker extends DatePickerMixin(InputControlMixin(ThemableMixin(Element
 
   /** @private */
   _onVaadinOverlayClose(e) {
+    // Prevent closing the overlay on label element click
     if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
       e.preventDefault();
     }

--- a/packages/date-picker/test/dropdown.common.js
+++ b/packages/date-picker/test/dropdown.common.js
@@ -56,6 +56,32 @@ describe('dropdown', () => {
     });
   });
 
+  describe('label click', () => {
+    let label;
+
+    beforeEach(() => {
+      label = datePicker.querySelector('label');
+    });
+
+    it('should open by clicking the label', async () => {
+      label.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      expect(datePicker.opened).to.be.true;
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should prevent overlay close on label click', async () => {
+      label.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      const spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-close', spy);
+
+      label.click();
+      expect(spy.firstCall.args[0].defaultPrevented).to.be.true;
+    });
+  });
+
   describe('scroll to date', () => {
     it('should scroll to today by default', async () => {
       datePicker.open();


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/7812#issuecomment-2511720183

While we might want to reconsider the current behavior or align it across components, let's first add missing tests to ensure this listener is actually covered (as `preventDefault()` for `vaadin-overlay-close` keeps the date-picker open).

## Type of change

- Test