### PR TITLE
refactor: set opened to false by default on accordion heading

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -73,6 +73,7 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolymerElement
       opened: {
         type: Boolean,
         reflectToAttribute: true,
+        value: false,
       },
     };
   }

--- a/packages/accordion/src/vaadin-lit-accordion-heading.js
+++ b/packages/accordion/src/vaadin-lit-accordion-heading.js
@@ -41,6 +41,7 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolylitMixin(L
       opened: {
         type: Boolean,
         reflectToAttribute: true,
+        value: false,
       },
     };
   }

--- a/packages/accordion/test/dom/__snapshots__/accordion-heading.test.snap.js
+++ b/packages/accordion/test/dom/__snapshots__/accordion-heading.test.snap.js
@@ -31,6 +31,7 @@ snapshots["vaadin-accordion-heading host disabled"] =
 
 snapshots["vaadin-accordion-heading shadow default"] = 
 `<button
+  aria-expanded="false"
   id="button"
   part="content"
 >
@@ -47,6 +48,7 @@ snapshots["vaadin-accordion-heading shadow default"] =
 
 snapshots["vaadin-accordion-heading shadow disabled"] = 
 `<button
+  aria-expanded="false"
   disabled=""
   id="button"
   part="content"


### PR DESCRIPTION
## Description

This is a finding from snapshot test: Lit version sets `aria-expanded="false"` by default, but with Polymer it's not set until `opened` has a value (that's how computed property bindings generally work in Polymer). 

Updated the property to add default `false` value (also this make it aligned with `vaadin-accordion-panel`.

## Type of change

- Refactor