### PR TITLE
fix: delegate accordion panel theme attribute in Lit version

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-panel-mixin.js
@@ -36,12 +36,8 @@ export const AccordionPanelMixin = (superClass) =>
       return ['__updateAriaAttributes(focusElement, _contentElements)'];
     }
 
-    static get delegateAttrs() {
-      return ['theme'];
-    }
-
     static get delegateProps() {
-      return ['disabled', 'opened'];
+      return ['disabled', 'opened', '_theme'];
     }
 
     constructor() {
@@ -67,6 +63,25 @@ export const AccordionPanelMixin = (superClass) =>
 
       this.addController(this._summaryController);
       this.addController(this._tooltipController);
+    }
+
+    /**
+     * Override method from `DelegateStateMixin` to set delegate `theme`
+     * using attribute instead of property (needed for the Lit version).
+     * @protected
+     * @override
+     */
+    _delegateProperty(name, value) {
+      if (!this.stateTarget) {
+        return;
+      }
+
+      if (name === '_theme') {
+        this._delegateAttribute('theme', value);
+        return;
+      }
+
+      super._delegateProperty(name, value);
     }
 
     /**

--- a/packages/accordion/test/accordion-panel.common.js
+++ b/packages/accordion/test/accordion-panel.common.js
@@ -148,6 +148,16 @@ describe('vaadin-accordion-panel', () => {
         await nextUpdate(panel);
         expect(heading.hasAttribute('disabled')).to.be.false;
       });
+
+      it(`should propagate theme attribute to ${type} heading`, async () => {
+        panel.setAttribute('theme', 'filled');
+        await nextUpdate(panel);
+        expect(heading.getAttribute('theme')).to.equal('filled');
+
+        panel.removeAttribute('theme');
+        await nextUpdate(panel);
+        expect(heading.hasAttribute('theme')).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Fixed the issue with `vaadin-accordion-panel` not delegating `theme` attribute to its heading in Lit version.

The reason is that `DelegateStateMixin` supposes that attribute should have matching property, which is not the case for `theme` and `_theme` - however, Polymer somehow still creates also `theme` property so there it works.

Updated to use the same workaround as implemented in #7945 for `vaadin-tabsheet`.

## Type of change

- Bugfix