### PR TITLE
fix: observe internal layout to avoid problems with fixed height

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -293,7 +293,7 @@ class FormLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolymerElement))
     requestAnimationFrame(() => this._updateLayout());
 
     this._observeChildrenColspanChange();
-    this.__intersectionObserver.observe(this);
+    this.__intersectionObserver.observe(this.$.layout);
   }
 
   /** @protected */

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -580,6 +580,42 @@ describe('form layout', () => {
     });
   });
 
+  describe('fixed size parent', () => {
+    let container, layout;
+
+    beforeEach(async () => {
+      container = fixtureSync(`
+        <div style="height: 100px; overflow: auto">
+          <div style="height: 25px">
+            <vaadin-form-layout style="height: 100%">
+              <div>1</div>
+              <div>2</div>
+              <div>3</div>
+              <div>4</div>
+              <div>5</div>
+              <div>6</div>
+              <div>7</div>
+              <div>8</div>
+              <div>9</div>
+              <div>10</div>
+            </vaadin-form-layout>
+          </div>
+        </div>
+      `);
+      layout = container.querySelector('vaadin-form-layout');
+      layout.responsiveSteps = [{ columns: 1 }];
+      await nextRender();
+    });
+
+    it('should not set opacity to 0 when host is scrolled out due to fixed height', async () => {
+      container.scrollTop = container.scrollHeight;
+      // Wait for intersection observer
+      await nextFrame();
+      await nextFrame();
+      expect(layout.$.layout.style.opacity).to.equal('');
+    });
+  });
+
   describe('mutations', () => {
     let container, layout;
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow/issues/20598 (which is a regression from https://github.com/vaadin/web-components/pull/7988)

This is a fix for the case when `vaadin-form-layout` height is inherited from a fixed-size parent element (which is what happens in Flow due to the fact that it sets `height: 100vh` on the `<body>` and outlet element).

Currently, when scrolling long enough, the layout is becoming "not intersecting" and `opacity` is wrongly set to 0. This change ensures that `IntersectionObserver` instead uses the internal element since its height is defined by content.

## Type of change

- Bugfix