### PR TITLE
fix: clear value when removing the last input

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -56,7 +56,6 @@ export const CustomFieldMixin = (superClass) =>
           type: String,
           observer: '__valueChanged',
           notify: true,
-          sync: true,
         },
 
         /**
@@ -67,7 +66,6 @@ export const CustomFieldMixin = (superClass) =>
           type: Array,
           readOnly: true,
           observer: '__inputsChanged',
-          sync: true,
         },
 
         /**
@@ -250,11 +248,8 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __setValue() {
       this.__settingValue = true;
-      const initialValue = this.value;
       const formatFn = this.formatValue || defaultFormatValue;
-      const valueToSet = formatFn.apply(this, [this.inputs.map((input) => input.value)]);
-      this.value = valueToSet;
-      this.__valueUpdatedByInputs = initialValue !== valueToSet;
+      this.value = formatFn.apply(this, [this.inputs.map((input) => input.value)]);
       this.__settingValue = false;
     }
 
@@ -277,11 +272,12 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __inputsChanged(inputs, oldInputs) {
       if (inputs.length === 0) {
-        if (this.__valueUpdatedByInputs) {
+        if (oldInputs && oldInputs.length > 0) {
           this.__setValue();
         }
         return;
       }
+
       // When inputs are first initialized, apply value set with property.
       if (this.value && this.value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
         this.__applyInputsValue(this.value);
@@ -298,8 +294,6 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __valueChanged(value, oldValue) {
       this.__toggleHasValue(value);
-
-      this.__valueUpdatedByInputs = this.__settingValue;
 
       if (this.__settingValue || !this.inputs) {
         return;

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -56,6 +56,7 @@ export const CustomFieldMixin = (superClass) =>
           type: String,
           observer: '__valueChanged',
           notify: true,
+          sync: true,
         },
 
         /**
@@ -66,6 +67,7 @@ export const CustomFieldMixin = (superClass) =>
           type: Array,
           readOnly: true,
           observer: '__inputsChanged',
+          sync: true,
         },
 
         /**
@@ -248,8 +250,11 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __setValue() {
       this.__settingValue = true;
+      const initialValue = this.value;
       const formatFn = this.formatValue || defaultFormatValue;
-      this.value = formatFn.apply(this, [this.inputs.map((input) => input.value)]);
+      const valueToSet = formatFn.apply(this, [this.inputs.map((input) => input.value)]);
+      this.value = valueToSet;
+      this.__valueUpdatedByInputs = initialValue !== valueToSet;
       this.__settingValue = false;
     }
 
@@ -272,9 +277,11 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __inputsChanged(inputs, oldInputs) {
       if (inputs.length === 0) {
+        if (this.__valueUpdatedByInputs) {
+          this.__setValue();
+        }
         return;
       }
-
       // When inputs are first initialized, apply value set with property.
       if (this.value && this.value !== '\t' && (!oldInputs || oldInputs.length === 0)) {
         this.__applyInputsValue(this.value);
@@ -291,6 +298,8 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __valueChanged(value, oldValue) {
       this.__toggleHasValue(value);
+
+      this.__valueUpdatedByInputs = this.__settingValue;
 
       if (this.__settingValue || !this.inputs) {
         return;

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -88,6 +88,17 @@ describe('custom field', () => {
         expect(el.value).to.equal('');
       });
     });
+
+    it('should clear value when removing all inputs', async () => {
+      customField.value = '1\t1';
+      await nextUpdate(customField);
+
+      customField.removeChild(customField.inputs[0]);
+      customField.removeChild(customField.inputs[1]);
+      await nextUpdate(customField);
+
+      expect(customField.value).to.equal('');
+    });
   });
 
   describe('value set with attribute', () => {
@@ -108,49 +119,6 @@ describe('custom field', () => {
     it('should apply value set using attribute to inputs', () => {
       expect(customField.inputs[0].value).to.equal('01');
       expect(customField.inputs[1].value).to.equal('25');
-    });
-  });
-
-  describe('value on input node changes', () => {
-    beforeEach(async () => {
-      customField = fixtureSync(`
-        <vaadin-custom-field value="01">
-          <input type="number" />
-        </vaadin-custom-field>
-      `);
-      await nextRender();
-    });
-
-    it('should remove value when an input node is removed after updating value via input', async () => {
-      customField.inputs[0].value = '02';
-      fire(customField.inputs[0], 'change');
-      await nextUpdate(customField);
-      expect(customField.value).to.equal('02');
-
-      customField.removeChild(customField.inputs[0]);
-      await nextUpdate(customField);
-      expect(customField.value).to.equal('');
-    });
-
-    it('should not remove value when an input node is removed after updating value using attribute', async () => {
-      customField.inputs[0].value = '02';
-      fire(customField.inputs[0], 'change');
-      await nextUpdate(customField);
-      expect(customField.value).to.equal('02');
-
-      customField.value = '01';
-      await nextUpdate(customField);
-      expect(customField.value).to.equal('01');
-
-      customField.removeChild(customField.inputs[0]);
-      await nextUpdate(customField);
-      expect(customField.value).to.equal('01');
-    });
-
-    it('should not remove value set using attribute when an input node is removed', async () => {
-      customField.removeChild(customField.inputs[0]);
-      await nextUpdate(customField);
-      expect(customField.value).to.equal('01');
     });
   });
 

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -111,6 +111,49 @@ describe('custom field', () => {
     });
   });
 
+  describe('value on input node changes', () => {
+    beforeEach(async () => {
+      customField = fixtureSync(`
+        <vaadin-custom-field value="01">
+          <input type="number" />
+        </vaadin-custom-field>
+      `);
+      await nextRender();
+    });
+
+    it('should remove value when an input node is removed after updating value via input', async () => {
+      customField.inputs[0].value = '02';
+      fire(customField.inputs[0], 'change');
+      await nextUpdate(customField);
+      expect(customField.value).to.equal('02');
+
+      customField.removeChild(customField.inputs[0]);
+      await nextUpdate(customField);
+      expect(customField.value).to.equal('');
+    });
+
+    it('should not remove value when an input node is removed after updating value using attribute', async () => {
+      customField.inputs[0].value = '02';
+      fire(customField.inputs[0], 'change');
+      await nextUpdate(customField);
+      expect(customField.value).to.equal('02');
+
+      customField.value = '01';
+      await nextUpdate(customField);
+      expect(customField.value).to.equal('01');
+
+      customField.removeChild(customField.inputs[0]);
+      await nextUpdate(customField);
+      expect(customField.value).to.equal('01');
+    });
+
+    it('should not remove value set using attribute when an input node is removed', async () => {
+      customField.removeChild(customField.inputs[0]);
+      await nextUpdate(customField);
+      expect(customField.value).to.equal('01');
+    });
+  });
+
   describe('aria-required', () => {
     it('should toggle aria-required attribute on required property change', async () => {
       customField.required = true;

--- a/packages/custom-field/test/custom-field.common.js
+++ b/packages/custom-field/test/custom-field.common.js
@@ -89,14 +89,16 @@ describe('custom field', () => {
       });
     });
 
-    it('should clear value when removing all inputs', async () => {
+    it('should update value when removing inputs', async () => {
       customField.value = '1\t1';
       await nextUpdate(customField);
 
       customField.removeChild(customField.inputs[0]);
-      customField.removeChild(customField.inputs[1]);
       await nextUpdate(customField);
+      expect(customField.value).to.equal('1');
 
+      customField.removeChild(customField.inputs[0]);
+      await nextUpdate(customField);
       expect(customField.value).to.equal('');
     });
   });


### PR DESCRIPTION
## Description

When all the inputs are removed, the value modified via the inputs is incorrectly preserved. This PR fixes this by setting a flag on whether the value change was made on the input, and resetting the value also when all the inputs are removed. Because of the Polymer&Lit timing differences, both `input` and `value` properties are now marked as `sync`.

Fixes #8252 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.