### PR TITLE
fix: run dynamic property observer after complex observer

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -220,12 +220,12 @@ const PolylitMixinImplementation = (superclass) => {
         this.__runObservers(props, this.constructor.__observers);
       }
 
-      if (this.__dynamicPropertyObservers) {
-        this.__runDynamicObservers(props, this.__dynamicPropertyObservers);
-      }
-
       if (this.constructor.__complexObservers) {
         this.__runComplexObservers(props, this.constructor.__complexObservers);
+      }
+
+      if (this.__dynamicPropertyObservers) {
+        this.__runDynamicObservers(props, this.__dynamicPropertyObservers);
       }
 
       if (this.__dynamicMethodObservers) {

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -637,6 +637,7 @@ describe('PolylitMixin', () => {
   describe('dynamic property observer', () => {
     let element;
     let valueChangedSpy;
+    let complexSpy;
 
     const tag = defineCE(
       class extends PolylitMixin(LitElement) {
@@ -648,6 +649,10 @@ describe('PolylitMixin', () => {
           };
         }
 
+        static get observers() {
+          return ['_valueChangedComplex(value)'];
+        }
+
         render() {
           return html`${this.value}`;
         }
@@ -655,12 +660,15 @@ describe('PolylitMixin', () => {
         _valueChanged(_value, _oldValue) {}
 
         _valueChangedOther(_value, _oldValue) {}
+
+        _valueChangedComplex(_value) {}
       },
     );
 
     beforeEach(async () => {
       element = fixtureSync(`<${tag}></${tag}>`);
       valueChangedSpy = sinon.spy(element, '_valueChanged');
+      complexSpy = sinon.spy(element, '_valueChangedComplex');
       await element.updateComplete;
     });
 
@@ -696,6 +704,13 @@ describe('PolylitMixin', () => {
       await element.updateComplete;
       expect(valueChangedSpy.calledOnce).to.be.true;
       expect(otherObserverSpy.calledOnce).to.be.true;
+    });
+
+    it('should run dynamic property observer after complex observer', async () => {
+      element._createPropertyObserver('value', '_valueChanged');
+      element.value = 'bar';
+      await element.updateComplete;
+      expect(complexSpy.calledBefore(valueChangedSpy)).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Description

Fix the run order of property observers created with `_createPropertyObserver`.

The following example currently logs:

using `PolylitMixin(LitElement)`:
```
Property observer foo
Complex observer foo
```

using `PolymerElement`:
```
Complex observer foo
Property observer foo
```

```js
class TestElement extends PolylitMixin(LitElement) {
  static get is() {
    return 'test-element';
  }

  static get properties() {
    return {
      value: {
        type: String,
      },
    };
  }

  static get observers() {
    return ['__runComplexObserver(value)'];
  }

  render() {
    return html``;
  }

  ready() {
    super.ready();
    this._createPropertyObserver('value', '__runPropertyObserver');
  }

  __runComplexObserver(value) {
    console.log('Complex observer', value);
  }

  __runPropertyObserver(value) {
    console.log('Property observer', value);
  }
}

customElements.define(TestElement.is, TestElement);

requestAnimationFrame(() => {
  document.querySelector('test-element').value = 'foo';
});
```


## Type of change

Bugfix