### PR TITLE
fix: ensure aria-selected attribute is removed from the item clone

### DIFF
--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -38,6 +38,7 @@ export const ItemMixin = (superClass) =>
           value: false,
           reflectToAttribute: true,
           observer: '_selectedChanged',
+          sync: true,
         },
 
         /** @private */

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -38,7 +38,6 @@ export const ItemMixin = (superClass) =>
           value: false,
           reflectToAttribute: true,
           observer: '_selectedChanged',
-          sync: true,
         },
 
         /** @private */

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -461,6 +461,11 @@ export const SelectBaseMixin = (superClass) =>
      */
     __appendValueItemElement(itemElement, parent) {
       parent.appendChild(itemElement);
+      // Trigger observer that sets aria-selected attribute
+      // so that we can then synchronously remove it below.
+      if (itemElement.performUpdate) {
+        itemElement.performUpdate();
+      }
       itemElement.removeAttribute('tabindex');
       itemElement.removeAttribute('aria-selected');
       itemElement.removeAttribute('role');

--- a/packages/select/test/keyboard.common.js
+++ b/packages/select/test/keyboard.common.js
@@ -151,7 +151,7 @@ describe('keyboard', () => {
       expect(clone.textContent).to.be.equal(item.textContent);
     });
 
-    ['active', 'focused', 'focus-ring', 'role', 'tabindex'].forEach((attr) => {
+    ['active', 'focused', 'focus-ring', 'role', 'tabindex', 'aria-selected'].forEach((attr) => {
       it(`should remove ${attr} attribute from the item clone`, async () => {
         await sendKeys({ press: 'Tab' });
 

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -231,16 +231,18 @@ describe('vaadin-select', () => {
       });
 
       describe('default', () => {
-        it('should select items when alphanumeric keys are pressed', () => {
+        it('should select items when alphanumeric keys are pressed', async () => {
           expect(menu.selected).to.be.equal(2);
           keyDownChar(valueButton, 'o');
           keyDownChar(valueButton, 'p');
           keyDownChar(valueButton, 't');
+          await nextUpdate(menu);
           expect(menu.selected).to.be.equal(0);
           keyDownChar(valueButton, 'i');
           keyDownChar(valueButton, 'o');
           keyDownChar(valueButton, 'n');
           keyDownChar(valueButton, '2');
+          await nextUpdate(menu);
           expect(menu.selected).to.be.equal(1);
         });
       });


### PR DESCRIPTION
## Description

- Updated `selected` property in `ItemMixin` to use `sync: true` so it triggers observer synchronously
- Added call to `performUpdate()` on the item clone in `vaadin-select` to remove `aria-selected`
- Added missing unit test to ensure `aria-selected` attribute is removed (in Lit version it was not)

Note: there was an error in the "keyboard selection" test apparently caused by the fact that  "append value item" was called too late. Added `await nextUpdate()` to this test helped to remove the error so I think it was a test issue.

```
        at SelectItem.update (node_modules/lit-element/src/lit-element.ts:163:23)
        at SelectItem.performUpdate (node_modules/@lit/reactive-element/src/reactive-element.ts:1440:13)
        at Select.__appendValueItemElement (packages/select/src/vaadin-select-base-mixin.js:467:21)
        at Select.__attachSelectedItem (packages/select/src/vaadin-select-base-mixin.js:430:12)
```

## Type of change

- Bugfix