### PR TITLE
fix: use Math.round to get correct scroller first index

### DIFF
--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -391,7 +391,8 @@ export class InfiniteScroller extends HTMLElement {
 
   /** @private */
   _updateClones(viewPortOnly) {
-    this._firstIndex = ~~((this._buffers[0].translateY - this._initialScroll) / this.itemHeight) + this._initialIndex;
+    this._firstIndex =
+      Math.round((this._buffers[0].translateY - this._initialScroll) / this.itemHeight) + this._initialIndex;
 
     const scrollerRect = viewPortOnly ? this.$.scroller.getBoundingClientRect() : undefined;
     this._buffers.forEach((buffer, bufferIndex) => {

--- a/packages/date-picker/test/scroller.test.js
+++ b/packages/date-picker/test/scroller.test.js
@@ -125,3 +125,18 @@ describe('vaadin-infinite-scroller', () => {
     });
   });
 });
+
+describe('fractional item size', () => {
+  let scroller;
+
+  beforeEach(async () => {
+    scroller = fixtureSync('<vaadin-infinite-scroller></vaadin-infinite-scroller>');
+    scroller.bufferSize = 80;
+    scroller.style.setProperty('--vaadin-infinite-scroller-item-height', '30.0001px');
+    await activateScroller(scroller);
+  });
+
+  it('should be at the position 0', () => {
+    expect(scroller.position).to.be.closeTo(0, 0.001);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1665

See https://github.com/vaadin/web-components/issues/1665#issuecomment-2519771918 for clarification.

Added a test that sets item height to `30.0001px` - with the test setup, the first item should be `0` but with previous logic the item count is calculated incorrectly and the item text content becomes `1`. 

## Type of change

- Bugfix