### PR TITLE
chore: update change detection branch to 24.6

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -41,7 +41,7 @@ const hasAllParam = process.argv.includes('--all');
  * Check if lockfile has changed.
  */
 const isLockfileChanged = () => {
-  const log = execSync('git diff --name-only origin/main HEAD').toString(); // NOSONAR
+  const log = execSync('git diff --name-only origin/24.6 HEAD').toString(); // NOSONAR
   return log.split('\n').some((line) => line.includes('yarn.lock'));
 };
 
@@ -50,7 +50,7 @@ const isLockfileChanged = () => {
  */
 const getChangedPackages = () => {
   const pathToLerna = path.normalize('./node_modules/.bin/lerna');
-  const output = execSync(`${pathToLerna} la --since origin/main --json --loglevel silent`); // NOSONAR
+  const output = execSync(`${pathToLerna} la --since origin/24.6 --json --loglevel silent`); // NOSONAR
   return JSON.parse(output.toString()).map((project) => project.name.replace('@vaadin/', ''));
 };
 


### PR DESCRIPTION
Update the web-test-runner change detection script to use 24.6 as a base branch for Vaadin 24.6

