### PR TITLE
fix: prevent notification from affecting overlay interactions

### DIFF
--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -14,12 +14,19 @@ const getAttachedInstances = () =>
     .sort((a, b) => a.__zIndex - b.__zIndex || 0);
 
 /**
+ * Returns all attached overlay instances excluding notification container,
+ * which only needs to be in the stack for zIndex but not pointer-events.
+ * @private
+ */
+const getOverlayInstances = () => getAttachedInstances().filter((el) => el.$.overlay);
+
+/**
  * Returns true if the overlay is the last one in the opened overlays stack.
  * @param {HTMLElement} overlay
  * @return {boolean}
  * @protected
  */
-export const isLastOverlay = (overlay) => overlay === getAttachedInstances().pop();
+export const isLastOverlay = (overlay) => overlay === getOverlayInstances().pop();
 
 /**
  * @polymerMixin
@@ -68,8 +75,8 @@ export const OverlayStackMixin = (superClass) =>
       }
 
       // Disable pointer events in other attached overlays
-      getAttachedInstances().forEach((el) => {
-        if (el !== this && el.$.overlay) {
+      getOverlayInstances().forEach((el) => {
+        if (el !== this) {
           el.$.overlay.style.pointerEvents = 'none';
         }
       });
@@ -84,7 +91,7 @@ export const OverlayStackMixin = (superClass) =>
       }
 
       // Restore pointer events in the previous overlay(s)
-      const instances = getAttachedInstances();
+      const instances = getOverlayInstances();
 
       let el;
       // Use instances.pop() to ensure the reverse order
@@ -93,9 +100,7 @@ export const OverlayStackMixin = (superClass) =>
           // Skip the current instance
           continue;
         }
-        if (el.$.overlay) {
-          el.$.overlay.style.removeProperty('pointer-events');
-        }
+        el.$.overlay.style.removeProperty('pointer-events');
         if (!el.modeless) {
           // Stop after the last modal
           break;

--- a/test/integration/not-animated-styles.js
+++ b/test/integration/not-animated-styles.js
@@ -2,7 +2,7 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 
 // Disable animations for all overlays
 registerStyles(
-  'vaadin-*-overlay',
+  'vaadin-*-overlay vaadin-notification-card',
   css`
     :host([opening]),
     :host([closing]),


### PR DESCRIPTION
## Description

Fixes #8281

The change in #8198 introduced two regressions related to "notification" + "dialog" combination:

1. First, the `vaadin-notification-container` is now considered a "last" overlay so the keydown listener is not firing thus making it impossible to close `vaadin-dialog` on <kbd>Esc</kbd> if there is a notification on top of it,
2. Also, the `vaadin-notification-container` is treated as modal overlay (as it doesn't have `modeless`) - as a result, `pointer-events: none` is not removed from parent dialog if notification is open before closing nested dialog.

This PR changes the logic to only include notification container in the "visual" stack (z-index) and adds separate helper that filters it out from `getAttachedInstances()` so that overlay "modality" stack is not affected.

## Type of change

- Bugfix