### PR TITLE
refactor: add elements to $ map immediately after their connection to DOM

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -195,6 +195,22 @@ const PolylitMixinImplementation = (superclass) => {
       return result;
     }
 
+    constructor() {
+      super();
+      this.__hasPolylitMixin = true;
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      const parentHost = this.getRootNode().host;
+      if (parentHost && parentHost.__hasPolylitMixin && this.id) {
+        parentHost.$ ||= {};
+        parentHost.$[this.id] = this;
+      }
+    }
+
     /** @protected */
     firstUpdated() {
       super.firstUpdated();
@@ -203,8 +219,10 @@ const PolylitMixinImplementation = (superclass) => {
         this.$ = {};
       }
 
-      this.renderRoot.querySelectorAll('[id]').forEach((node) => {
-        this.$[node.id] = node;
+      [...Object.values(this.$), this.renderRoot].forEach((node) => {
+        node.querySelectorAll('[id]').forEach((node) => {
+          this.$[node.id] = node;
+        });
       });
     }
 

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -204,11 +204,11 @@ const PolylitMixinImplementation = (superclass) => {
     connectedCallback() {
       super.connectedCallback();
 
-      // Components like `vaadin-overlay` teleport themselves to the body element when opened.
+      // Components like `vaadin-overlay` are teleported to the body element when opened.
       // If their opened state is set as an attribute, the teleportation happens immediately
-      // after they are connected to the DOM. This means they won't be found by querySelector
-      // in the parent component's `firstUpdated()`. To ensure their reference is still registered
-      // in the parent host component, we propagate the reference here.
+      // after they are connected to the DOM. This means they will be outside the scope of
+      // querySelectorAll in the parent component's `firstUpdated()`. To ensure their reference
+      // is still registered in the $ map, we propagate the reference here.
       const parentHost = this.getRootNode().host;
       if (parentHost && parentHost.__hasPolylitMixin && this.id) {
         parentHost.$ ||= {};
@@ -224,13 +224,8 @@ const PolylitMixinImplementation = (superclass) => {
         this.$ = {};
       }
 
-      // Register all elements with an id in the $ map, including those
-      // that might have been already teleported to a different element
-      // (e.g. opened overlays are teleported to the body element).
-      [...Object.values(this.$), this.renderRoot].forEach((node) => {
-        node.querySelectorAll('[id]').forEach((node) => {
-          this.$[node.id] = node;
-        });
+      this.renderRoot.querySelectorAll('[id]').forEach((node) => {
+        this.$[node.id] = node;
       });
     }
 

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -204,6 +204,11 @@ const PolylitMixinImplementation = (superclass) => {
     connectedCallback() {
       super.connectedCallback();
 
+      // Components like `vaadin-overlay` teleport themselves to the body element when opened.
+      // If their opened state is set as an attribute, the teleportation happens immediately
+      // after they are connected to the DOM. This means they won't be found by querySelector
+      // in the parent component's `firstUpdated()`. To ensure their reference is still registered
+      // in the parent host component, we propagate the reference here.
       const parentHost = this.getRootNode().host;
       if (parentHost && parentHost.__hasPolylitMixin && this.id) {
         parentHost.$ ||= {};
@@ -219,6 +224,9 @@ const PolylitMixinImplementation = (superclass) => {
         this.$ = {};
       }
 
+      // Register all elements with an id in the $ map, including those
+      // that might have been already teleported to a different element
+      // (e.g. opened overlays are teleported to the body element).
       [...Object.values(this.$), this.renderRoot].forEach((node) => {
         node.querySelectorAll('[id]').forEach((node) => {
           this.$[node.id] = node;

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -1189,12 +1189,10 @@ describe('PolylitMixin', () => {
         class extends PolylitMixin(LitElement) {
           connectedCallback() {
             super.connectedCallback();
-            document.body.appendChild(this);
-          }
 
-          disconnectedCallback() {
-            super.disconnectedCallback();
-            document.body.removeChild(this);
+            if (this.parentNode !== document.body) {
+              document.body.appendChild(this);
+            }
           }
 
           render() {
@@ -1217,6 +1215,10 @@ describe('PolylitMixin', () => {
       beforeEach(async () => {
         element = fixtureSync(`<${tag}></${tag}>`);
         await element.updateComplete;
+      });
+
+      afterEach(() => {
+        document.querySelector('#teleported').remove();
       });
 
       it('should register elements with id', () => {

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { defineCE, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, LitElement } from 'lit';
+import { LitElement } from 'lit';
+import { html, unsafeStatic } from 'lit/static-html.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 
 describe('PolylitMixin', () => {
@@ -37,7 +38,7 @@ describe('PolylitMixin', () => {
     const tag = defineCE(
       class extends PolylitMixin(LitElement) {
         render() {
-          return html`<div id="foo">Component</div>`;
+          return html`<div>Component</div>`;
         }
 
         get(path, object) {
@@ -55,10 +56,6 @@ describe('PolylitMixin', () => {
       await element.updateComplete;
     });
 
-    it('should reference elements with id', () => {
-      expect(element.$.foo).to.be.instanceOf(HTMLDivElement);
-    });
-
     it('should get the nested value', () => {
       expect(element.get('foo.bar', { foo: { bar: 'baz' } })).to.equal('baz');
     });
@@ -71,31 +68,6 @@ describe('PolylitMixin', () => {
       const object = { foo: {} };
       element.set('foo.bar', 'baz', object);
       expect(object.foo.bar).to.equal('baz');
-    });
-  });
-
-  describe('createRenderRoot', () => {
-    let element;
-
-    const tag = defineCE(
-      class extends PolylitMixin(LitElement) {
-        render() {
-          return html`<div id="foo">Component</div>`;
-        }
-
-        createRenderRoot() {
-          return this;
-        }
-      },
-    );
-
-    beforeEach(async () => {
-      element = fixtureSync(`<${tag}></${tag}>`);
-      await element.updateComplete;
-    });
-
-    it('should reference elements with id when rendering to light DOM', () => {
-      expect(element.$.foo).to.be.instanceOf(HTMLDivElement);
     });
   });
 
@@ -1206,6 +1178,79 @@ describe('PolylitMixin', () => {
       expect(() => {
         document.createElement(tag).setProperties({ disabled: true });
       }).to.not.throw(Error);
+    });
+  });
+
+  describe('element id map', () => {
+    let element;
+
+    describe('basic', () => {
+      const teleportedTag = defineCE(
+        class extends PolylitMixin(LitElement) {
+          connectedCallback() {
+            super.connectedCallback();
+            document.body.appendChild(this);
+          }
+
+          disconnectedCallback() {
+            super.disconnectedCallback();
+            document.body.removeChild(this);
+          }
+
+          render() {
+            return html`Teleported`;
+          }
+        },
+      );
+
+      const tag = defineCE(
+        class extends PolylitMixin(LitElement) {
+          render() {
+            return html`
+              <div id="title">Title</div>
+              <${unsafeStatic(teleportedTag)} id="teleported" />
+            `;
+          }
+        },
+      );
+
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        await element.updateComplete;
+      });
+
+      it('should register elements with id', () => {
+        expect(element.$.title).to.be.instanceOf(HTMLDivElement);
+        expect(element.$.title.id).to.equal('title');
+      });
+
+      it('should register teleported elements with id', () => {
+        expect(element.$.teleported).to.be.instanceOf(HTMLElement);
+        expect(element.$.teleported.id).to.equal('teleported');
+      });
+    });
+
+    describe('createRenderRoot', () => {
+      const tag = defineCE(
+        class extends PolylitMixin(LitElement) {
+          render() {
+            return html`<div id="foo">Component</div>`;
+          }
+
+          createRenderRoot() {
+            return this;
+          }
+        },
+      );
+
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        await element.updateComplete;
+      });
+
+      it('should register elements with id when rendering to light DOM', () => {
+        expect(element.$.foo).to.be.instanceOf(HTMLDivElement);
+      });
     });
   });
 });

--- a/packages/select/src/vaadin-lit-select-overlay.js
+++ b/packages/select/src/vaadin-lit-select-overlay.js
@@ -65,16 +65,6 @@ class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolylitMixin(LitEle
       this.requestContentUpdate();
     }
   }
-
-  requestContentUpdate() {
-    super.requestContentUpdate();
-
-    if (this.owner) {
-      // Ensure menuElement reference is correct.
-      const menuElement = this._getMenuElement();
-      this.owner._assignMenuElement(menuElement);
-    }
-  }
 }
 
 defineCustomElement(SelectOverlay);

--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -84,6 +84,7 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
       </div>
 
       <vaadin-select-overlay
+        id="overlay"
         .owner="${this}"
         .positionTarget="${this._inputContainer}"
         .opened="${this.opened}"
@@ -101,15 +102,6 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
         <slot name="sr-label"></slot>
       </div>
     `;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    const overlay = this.shadowRoot.querySelector('vaadin-select-overlay');
-    overlay.owner = this;
-    this._overlayElement = overlay;
   }
 
   /** @private */

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -182,6 +182,8 @@ export const SelectBaseMixin = (superClass) =>
     ready() {
       super.ready();
 
+      this._overlayElement = this.$.overlay;
+
       this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
 
       this._valueButtonController = new ButtonController(this);

--- a/packages/select/src/vaadin-select-overlay-mixin.js
+++ b/packages/select/src/vaadin-select-overlay-mixin.js
@@ -44,4 +44,14 @@ export const SelectOverlayMixin = (superClass) =>
         }
       }
     }
+
+    requestContentUpdate() {
+      super.requestContentUpdate();
+
+      if (this.owner) {
+        // Ensure menuElement reference is correct.
+        const menuElement = this._getMenuElement();
+        this.owner._assignMenuElement(menuElement);
+      }
+    }
   };

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -54,27 +54,6 @@ export class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolymerEleme
       </div>
     `;
   }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    // When setting `opened` as an attribute, the overlay is already teleported to body
-    // by the time when `ready()` callback of the `vaadin-select` is executed by Polymer,
-    // so querySelector() would return null. So we use this workaround to set properties.
-    this.owner = this.__dataHost;
-    this.owner._overlayElement = this;
-  }
-
-  requestContentUpdate() {
-    super.requestContentUpdate();
-
-    if (this.owner) {
-      // Ensure menuElement reference is correct.
-      const menuElement = this._getMenuElement();
-      this.owner._assignMenuElement(menuElement);
-    }
-  }
 }
 
 defineCustomElement(SelectOverlay);

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -200,6 +200,7 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolymerElement))
 
   static get properties() {
     return {
+      /** @private */
       __overlayOwner: {
         value() {
           return this;

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -180,6 +180,8 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolymerElement))
       </div>
 
       <vaadin-select-overlay
+        id="overlay"
+        owner="[[__overlayOwner]]"
         position-target="[[_inputContainer]]"
         opened="{{opened}}"
         with-backdrop="[[_phone]]"
@@ -194,6 +196,16 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolymerElement))
         <slot name="sr-label"></slot>
       </div>
     `;
+  }
+
+  static get properties() {
+    return {
+      __overlayOwner: {
+        value() {
+          return this;
+        },
+      },
+    };
   }
 
   static get observers() {

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -307,6 +307,7 @@ snapshots["vaadin-select host opened default"] =
 
 snapshots["vaadin-select host opened overlay"] = 
 `<vaadin-select-overlay
+  id="overlay"
   opened=""
   start-aligned=""
   top-aligned=""
@@ -339,6 +340,7 @@ snapshots["vaadin-select host opened overlay"] =
 snapshots["vaadin-select host opened overlay class"] = 
 `<vaadin-select-overlay
   class="custom select-overlay"
+  id="overlay"
   opened=""
   start-aligned=""
   top-aligned=""
@@ -403,7 +405,7 @@ snapshots["vaadin-select shadow default"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
+<vaadin-select-overlay id="overlay">
   <vaadin-select-list-box
     aria-orientation="vertical"
     role="listbox"
@@ -471,7 +473,7 @@ snapshots["vaadin-select shadow disabled"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
+<vaadin-select-overlay id="overlay">
   <vaadin-select-list-box
     aria-orientation="vertical"
     role="listbox"
@@ -539,7 +541,7 @@ snapshots["vaadin-select shadow readonly"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
+<vaadin-select-overlay id="overlay">
   <vaadin-select-list-box
     aria-orientation="vertical"
     role="listbox"
@@ -607,7 +609,7 @@ snapshots["vaadin-select shadow invalid"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay>
+<vaadin-select-overlay id="overlay">
   <vaadin-select-list-box
     aria-orientation="vertical"
     role="listbox"
@@ -675,7 +677,10 @@ snapshots["vaadin-select shadow theme"] =
     </slot>
   </div>
 </div>
-<vaadin-select-overlay theme="align-right">
+<vaadin-select-overlay
+  id="overlay"
+  theme="align-right"
+>
   <vaadin-select-list-box
     aria-orientation="vertical"
     role="listbox"

--- a/packages/tooltip/src/vaadin-lit-tooltip.js
+++ b/packages/tooltip/src/vaadin-lit-tooltip.js
@@ -45,6 +45,7 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(
 
     return html`
       <vaadin-tooltip-overlay
+        id="overlay"
         .renderer="${this._renderer}"
         .owner="${this}"
         theme="${ifDefined(this._theme)}"
@@ -62,13 +63,6 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(
 
       <slot name="sr-label"></slot>
     `;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-
-    this._overlayElement = this.shadowRoot.querySelector('vaadin-tooltip-overlay');
   }
 }
 

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -465,6 +465,8 @@ export const TooltipMixin = (superClass) =>
     ready() {
       super.ready();
 
+      this._overlayElement = this.$.overlay;
+
       this._srLabelController = new SlotController(this, 'sr-label', 'div', {
         initializer: (element) => {
           element.id = this._uniqueId;

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -48,17 +48,6 @@ class TooltipOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolymerE
     return 'vaadin-tooltip';
   }
 
-  /** @protected */
-  ready() {
-    super.ready();
-
-    // When setting `manual` and `opened` attributes, the overlay is already moved to body
-    // by the time when `ready()` callback of the `vaadin-tooltip` is executed by Polymer,
-    // so querySelector() would return null. So we use this workaround to set properties.
-    this.owner = this.__dataHost;
-    this.owner._overlayElement = this;
-  }
-
   requestContentUpdate() {
     super.requestContentUpdate();
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -69,6 +69,8 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(ControllerMix
         }
       </style>
       <vaadin-tooltip-overlay
+        id="overlay"
+        owner="[[__overlayOwner]]"
         renderer="[[_renderer]]"
         theme$="[[_theme]]"
         opened="[[__computeOpened(manual, opened, _autoOpened, _isConnected)]]"
@@ -85,6 +87,17 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(ControllerMix
 
       <slot name="sr-label"></slot>
     `;
+  }
+
+  static get properties() {
+    return {
+      /** @private */
+      __overlayOwner: {
+        value() {
+          return this;
+        },
+      },
+    };
   }
 }
 

--- a/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
+++ b/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
@@ -16,6 +16,7 @@ snapshots["vaadin-tooltip host"] =
 snapshots["vaadin-tooltip default"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="bottom"
@@ -29,6 +30,7 @@ snapshots["vaadin-tooltip default"] =
 snapshots["vaadin-tooltip top-start"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="top-start"
@@ -42,6 +44,7 @@ snapshots["vaadin-tooltip top-start"] =
 snapshots["vaadin-tooltip top"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="top"
@@ -55,6 +58,7 @@ snapshots["vaadin-tooltip top"] =
 snapshots["vaadin-tooltip top-end"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="top-end"
@@ -68,6 +72,7 @@ snapshots["vaadin-tooltip top-end"] =
 snapshots["vaadin-tooltip bottom-start"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="bottom-start"
@@ -81,6 +86,7 @@ snapshots["vaadin-tooltip bottom-start"] =
 snapshots["vaadin-tooltip bottom"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="bottom"
@@ -94,6 +100,7 @@ snapshots["vaadin-tooltip bottom"] =
 snapshots["vaadin-tooltip bottom-end"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   position="bottom-end"
@@ -107,6 +114,7 @@ snapshots["vaadin-tooltip bottom-end"] =
 snapshots["vaadin-tooltip start-top"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-horizontal-overlap=""
   position="start-top"
@@ -120,6 +128,7 @@ snapshots["vaadin-tooltip start-top"] =
 snapshots["vaadin-tooltip start"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-horizontal-overlap=""
   position="start"
@@ -133,6 +142,7 @@ snapshots["vaadin-tooltip start"] =
 snapshots["vaadin-tooltip start-bottom"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-horizontal-overlap=""
   position="start-bottom"
@@ -146,6 +156,7 @@ snapshots["vaadin-tooltip start-bottom"] =
 snapshots["vaadin-tooltip end-top"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-horizontal-overlap=""
   position="end-top"
@@ -159,6 +170,7 @@ snapshots["vaadin-tooltip end-top"] =
 snapshots["vaadin-tooltip end"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-horizontal-overlap=""
   position="end"
@@ -172,6 +184,7 @@ snapshots["vaadin-tooltip end"] =
 snapshots["vaadin-tooltip end-bottom"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-horizontal-overlap=""
   position="end-bottom"
@@ -185,6 +198,7 @@ snapshots["vaadin-tooltip end-bottom"] =
 snapshots["vaadin-tooltip opened overlay"] = 
 `<vaadin-tooltip-overlay
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   opened=""
@@ -198,6 +212,7 @@ snapshots["vaadin-tooltip opened overlay class"] =
 `<vaadin-tooltip-overlay
   class="custom tooltip-overlay"
   hidden=""
+  id="overlay"
   modeless=""
   no-vertical-overlap=""
   opened=""


### PR DESCRIPTION
## Description

The PR improves PolylitMixin to make it add custom elements with id to the `$` map immediately after they are connected to the DOM. This guarantees that the reference will be saved even if the element, such as an overlay, is teleported elsewhere during the first render.

## Type of change

- [x] Bugfix
