### PR TITLE
fix: prevent unselecting already committed value on outside click

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
@@ -344,6 +344,19 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
     /**
      * Override method inherited from the combo-box
      * to not commit an already selected item again
+     * after closing overlay on outside click.
+     * @protected
+     * @override
+     */
+    _onClosed() {
+      this._ignoreCommitValue = true;
+
+      super._onClosed();
+    }
+
+    /**
+     * Override method inherited from the combo-box
+     * to not commit an already selected item again
      * on blur, which would result in un-selecting.
      * @protected
      * @override

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
@@ -328,6 +328,12 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
      * @override
      */
     _setFocused(focused) {
+      // Disable combo-box logic that updates selectedItem
+      // based on the overlay focused index on input blur
+      if (!focused) {
+        this._ignoreCommitValue = true;
+      }
+
       super._setFocused(focused);
 
       if (!focused && this.readonly && !this._closeOnBlurIsPrevented) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
@@ -328,12 +328,6 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
      * @override
      */
     _setFocused(focused) {
-      // Disable combo-box logic that updates selectedItem
-      // based on the overlay focused index on input blur
-      if (!focused) {
-        this._ignoreCommitValue = true;
-      }
-
       super._setFocused(focused);
 
       if (!focused && this.readonly && !this._closeOnBlurIsPrevented) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
@@ -366,7 +366,7 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
         this._ignoreCommitValue = false;
 
         // Reset internal combo-box state
-        this.selectedItem = null;
+        this.clear();
         this._inputElementValue = '';
         return;
       }

--- a/packages/multi-select-combo-box/test/selecting-items.common.js
+++ b/packages/multi-select-combo-box/test/selecting-items.common.js
@@ -136,6 +136,17 @@ describe('selecting items', () => {
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 
+    it('should not unselect previously committed item on blur after outside click with allow custom value', async () => {
+      comboBox.allowCustomValue = true;
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      await sendMouse({ type: 'click', position: [200, 200] });
+      await resetMouse();
+      await sendKeys({ down: 'Tab' });
+      expect(comboBox.selectedItems).to.deep.equal(['apple']);
+    });
+
     it('should un-select item when using clear() method', () => {
       comboBox.selectedItems = ['orange'];
       comboBox.clear();

--- a/packages/multi-select-combo-box/test/selecting-items.common.js
+++ b/packages/multi-select-combo-box/test/selecting-items.common.js
@@ -147,6 +147,16 @@ describe('selecting items', () => {
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 
+    it('should not set previously committed item to input on blur with allow custom value', async () => {
+      comboBox.allowCustomValue = true;
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      await sendKeys({ down: 'Tab' });
+      expect(comboBox.filter).to.equal('');
+      expect(inputElement.value).to.equal('');
+    });
+
     it('should un-select item when using clear() method', () => {
       comboBox.selectedItems = ['orange'];
       comboBox.clear();

--- a/packages/multi-select-combo-box/test/selecting-items.common.js
+++ b/packages/multi-select-combo-box/test/selecting-items.common.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
-import { sendKeys } from '@web/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
 
@@ -124,6 +124,15 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'Enter' });
       await sendKeys({ down: 'Tab' });
+      expect(comboBox.selectedItems).to.deep.equal(['apple']);
+    });
+
+    it('should not unselect previously committed item on outside click', async () => {
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'ArrowDown' });
+      await sendKeys({ down: 'Enter' });
+      await sendMouse({ type: 'click', position: [200, 200] });
+      await resetMouse();
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 


### PR DESCRIPTION
## Description

Fixes #8300

Originally, unselecting was workarounded by #3807 which was setting a flag on `focusout` event.
However, since #7846 there is no more focusout when closing combo-box overlay on outside click.

Updated to also set this flag in `_onClosed()` method which triggers value commit in combo-box.
Also added a missing test using `sendMouse()` - note, `outsideClick()` helper isn't suitable here.

UPD: also fixed the problem with selected item text incorrectly applied to input field on blur.

## Type of change

- Bugfix

## Note

Will cherry-pick manually to `24.5` once this is merged since that branch doesn't have a mixin.