### PR TITLE
refactor: remove obsolete vendor-prefixed CSS properties

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -10,7 +10,6 @@ export const accordionHeading = css`
     display: block;
     outline: none;
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
   }
 

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -12,7 +12,6 @@ export const buttonStyles = css`
     outline: none;
     white-space: nowrap;
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
   }
 

--- a/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/lumo/vaadin-checkbox-styles.js
@@ -18,7 +18,6 @@ registerStyles(
       -moz-osx-font-smoothing: grayscale;
       -webkit-tap-highlight-color: transparent;
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
       cursor: default;
       outline: none;

--- a/packages/checkbox/theme/material/vaadin-checkbox-styles.js
+++ b/packages/checkbox/theme/material/vaadin-checkbox-styles.js
@@ -7,8 +7,6 @@ registerStyles(
     :host {
       display: inline-block;
       -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
       user-select: none;
       outline: none;
       -webkit-tap-highlight-color: transparent;

--- a/packages/context-menu/theme/lumo/vaadin-context-menu-item-styles.js
+++ b/packages/context-menu/theme/lumo/vaadin-context-menu-item-styles.js
@@ -9,7 +9,6 @@ const contextMenuItem = css`
   /* :hover needed to workaround https://github.com/vaadin/web-components/issues/3133 */
   :host(:hover) {
     user-select: none;
-    -ms-user-select: none;
     -webkit-user-select: none;
   }
 

--- a/packages/date-picker/src/vaadin-date-picker-year-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-scroller.js
@@ -19,7 +19,6 @@ stylesTemplate.innerHTML = `
       transform: translateX(100%);
       -webkit-tap-highlight-color: transparent;
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
       /* Center the year scroller position. */
       --vaadin-infinite-scroller-buffer-offset: 50%;

--- a/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-month-calendar-styles.js
@@ -9,7 +9,6 @@ registerStyles(
   'vaadin-month-calendar',
   css`
     :host {
-      -moz-user-select: none;
       -webkit-user-select: none;
       -webkit-tap-highlight-color: transparent;
       user-select: none;

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -52,7 +52,6 @@ class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolymerElement))
           outline: none;
           white-space: nowrap;
           -webkit-user-select: none;
-          -moz-user-select: none;
           user-select: none;
         }
 

--- a/packages/details/src/vaadin-lit-details-summary.js
+++ b/packages/details/src/vaadin-lit-details-summary.js
@@ -31,7 +31,6 @@ class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(Lit
         outline: none;
         white-space: nowrap;
         -webkit-user-select: none;
-        -moz-user-select: none;
         user-select: none;
       }
 

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-edit-select-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-edit-select-styles.js
@@ -14,7 +14,6 @@ const gridProEditSelect = css`
     font-size: var(--lumo-font-size-m);
     /* prevent selection on editor focus */
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
   }
 `;

--- a/packages/grid-pro/theme/material/vaadin-grid-pro-edit-select-styles.js
+++ b/packages/grid-pro/theme/material/vaadin-grid-pro-edit-select-styles.js
@@ -7,7 +7,6 @@ const gridProEditSelect = css`
     font-size: inherit;
     /* prevent selection on editor focus */
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
   }
 `;

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -239,7 +239,6 @@ export const gridStyles = css`
   }
 
   :host([reordering]) {
-    -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;
   }
@@ -294,8 +293,6 @@ export const gridStyles = css`
   }
 
   #scroller[column-resizing] {
-    -ms-user-select: none;
-    -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;
   }

--- a/packages/grid/test/column-reordering.common.js
+++ b/packages/grid/test/column-reordering.common.js
@@ -121,7 +121,7 @@ describe('reordering simple grid', () => {
   it('should prevent text selection while reordering', () => {
     dragStart(headerContent[0]);
     const style = window.getComputedStyle(grid);
-    const userSelect = style['user-select'] || style['-moz-user-select'] || style['-webkit-user-select'];
+    const userSelect = style['user-select'] || style['-webkit-user-select'];
     expect(userSelect).to.equal('none');
   });
 

--- a/packages/grid/theme/lumo/vaadin-grid-sorter-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-sorter-styles.js
@@ -10,7 +10,6 @@ registerStyles(
       justify-content: flex-start;
       align-items: baseline;
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
       cursor: var(--lumo-clickable-cursor);
     }

--- a/packages/grid/theme/material/vaadin-grid-sorter-styles.js
+++ b/packages/grid/theme/material/vaadin-grid-sorter-styles.js
@@ -10,7 +10,6 @@ registerStyles(
       height: 100%;
       align-items: center;
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
     }
 

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -114,8 +114,6 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         .ol-unselectable {
           -webkit-touch-callout: none;
           -webkit-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
           user-select: none;
           -webkit-tap-highlight-color: transparent;
         }
@@ -127,8 +125,6 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
         .ol-selectable {
           -webkit-touch-callout: default;
           -webkit-user-select: text;
-          -moz-user-select: text;
-          -ms-user-select: text;
           user-select: text;
         }
 

--- a/packages/number-field/src/vaadin-number-field-styles.js
+++ b/packages/number-field/src/vaadin-number-field-styles.js
@@ -21,7 +21,6 @@ export const numberFieldStyles = css`
   [part='decrease-button'],
   [part='increase-button'] {
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
   }
 

--- a/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/lumo/vaadin-radio-button-styles.js
@@ -17,7 +17,6 @@ registerStyles(
       -moz-osx-font-smoothing: grayscale;
       -webkit-tap-highlight-color: transparent;
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
       cursor: default;
       outline: none;

--- a/packages/radio-group/theme/material/vaadin-radio-button-styles.js
+++ b/packages/radio-group/theme/material/vaadin-radio-button-styles.js
@@ -7,7 +7,6 @@ registerStyles(
     :host {
       display: inline-block;
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
       outline: none;
       -webkit-tap-highlight-color: transparent;

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-styles.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-styles.js
@@ -50,7 +50,6 @@ export const statesStyles = css`
     pointer-events: none;
     opacity: 0.5;
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
   }
 

--- a/packages/select/src/vaadin-select-value-button-styles.js
+++ b/packages/select/src/vaadin-select-value-button-styles.js
@@ -12,7 +12,6 @@ export const valueButton = css`
     outline: none;
     white-space: nowrap;
     -webkit-user-select: none;
-    -moz-user-select: none;
     user-select: none;
     min-width: 0;
     width: 0;

--- a/packages/tabs/theme/lumo/vaadin-tab-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tab-styles.js
@@ -31,7 +31,6 @@ registerStyles(
       overflow: hidden;
       min-width: var(--lumo-size-m);
       -webkit-user-select: none;
-      -moz-user-select: none;
       user-select: none;
       --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
       --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);


### PR DESCRIPTION
## Description

The PR removes `-ms-user-select` and `-moz-user-select`, as they are no longer necessary according to [caniuse](https://caniuse.com/mdn-css_properties_user-select):

![image](https://github.com/user-attachments/assets/8c5b56fc-5972-4c44-b4a4-88472faa70d6)

## Type of change

- [x] Refactor
