### PR TITLE
fix: prevent repeated selection attempts during drag selection

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -393,7 +393,10 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      */
     __toggleItem(item, selected = !this._grid._isSelected(item)) {
       if (selected === this._grid._isSelected(item)) {
-        // Do nothing if the item is already in the desired state.
+        // Skip selection if the item is already in the desired state.
+        // Note, _selectItem and _deselectItem may be overridden in custom
+        // selection column implementations, and calling them unnecessarily
+        // might affect performance (e.g. vaadin-grid-flow-selection-column).
         return;
       }
 

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -219,11 +219,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       } else if (event.detail.state === 'end') {
         // if drag start and end stays within the same item, then toggle its state
         if (this.__dragStartItem) {
-          if (this.__selectOnDrag) {
-            this._selectItem(this.__dragStartItem);
-          } else {
-            this._deselectItem(this.__dragStartItem);
-          }
+          this.__toggleItem(this.__dragStartItem, this.__selectOnDrag);
         }
         // clear drag state after timeout, which allows preventing the
         // subsequent click event if drag started and ended on the same item
@@ -289,6 +285,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       if (this.__dragStartIndex === undefined) {
         return;
       }
+
       // Get the row being hovered over
       const renderedRows = this._grid._getRenderedRows();
       const hoveredRow = renderedRows.find((row) => {
@@ -313,11 +310,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
             (hoveredIndex > this.__dragStartIndex && row.index >= this.__dragStartIndex && row.index <= hoveredIndex) ||
             (hoveredIndex < this.__dragStartIndex && row.index <= this.__dragStartIndex && row.index >= hoveredIndex)
           ) {
-            if (this.__selectOnDrag) {
-              this._selectItem(row._item);
-            } else {
-              this._deselectItem(row._item);
-            }
+            this.__toggleItem(row._item, this.__selectOnDrag);
             this.__dragStartItem = undefined;
           }
         });
@@ -399,6 +392,11 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      * @private
      */
     __toggleItem(item, selected = !this._grid._isSelected(item)) {
+      if (selected === this._grid._isSelected(item)) {
+        // Do nothing if the item is already in the desired state.
+        return;
+      }
+
       if (selected) {
         this._selectItem(item);
       } else {

--- a/packages/grid/test/selection.common.js
+++ b/packages/grid/test/selection.common.js
@@ -690,7 +690,7 @@ describe('multi selection column', () => {
     });
 
     it('should not attempt to select item on mouse drag if it is already selected', () => {
-      const selectItemSpy = sinon.spy(grid, 'selectItem');
+      const selectItemSpy = sinon.spy(selectionColumn, '_selectItem');
 
       const row0cell = getBodyCellContent(grid, 0, 0);
       const row1cell = getBodyCellContent(grid, 1, 0);
@@ -795,7 +795,7 @@ describe('multi selection column', () => {
     });
 
     it('should not attempt to deselect item on mouse drag if it is already deselected', () => {
-      const deselectItemSpy = sinon.spy(grid, 'deselectItem');
+      const deselectItemSpy = sinon.spy(selectionColumn, '_deselectItem');
 
       const row0cell = getBodyCellContent(grid, 0, 0);
       const row1cell = getBodyCellContent(grid, 1, 0);

--- a/packages/grid/test/selection.common.js
+++ b/packages/grid/test/selection.common.js
@@ -689,6 +689,25 @@ describe('multi selection column', () => {
       expect(grid.selectedItems).to.eql(grid.items.slice(1, 4));
     });
 
+    it('should not attempt to select item on mouse drag if it is already selected', () => {
+      const selectItemSpy = sinon.spy(grid, 'selectItem');
+
+      const row0cell = getBodyCellContent(grid, 0, 0);
+      const row1cell = getBodyCellContent(grid, 1, 0);
+
+      grid.selectedItems = [rows[1]._item];
+
+      fireTrackEvent(row0cell, row0cell, 'start');
+      clock.tick(10);
+      fireTrackEvent(row1cell, row0cell, 'track');
+      clock.tick(10);
+      fireTrackEvent(row1cell, row0cell, 'end');
+      clock.tick(10);
+
+      expect(selectItemSpy).to.be.calledOnce;
+      expect(selectItemSpy.args[0][0]).to.not.equal('1');
+    });
+
     it('should not select any items on mouse drag when dragSelect is disabled', () => {
       selectionColumn.dragSelect = false;
 
@@ -773,6 +792,25 @@ describe('multi selection column', () => {
       });
 
       expect(grid.selectedItems).to.empty;
+    });
+
+    it('should not attempt to deselect item on mouse drag if it is already deselected', () => {
+      const deselectItemSpy = sinon.spy(grid, 'deselectItem');
+
+      const row0cell = getBodyCellContent(grid, 0, 0);
+      const row1cell = getBodyCellContent(grid, 1, 0);
+
+      grid.selectedItems = [rows[0]._item];
+
+      fireTrackEvent(row0cell, row0cell, 'start');
+      clock.tick(10);
+      fireTrackEvent(row1cell, row0cell, 'track');
+      clock.tick(10);
+      fireTrackEvent(row1cell, row0cell, 'end');
+      clock.tick(10);
+
+      expect(deselectItemSpy).to.be.calledOnce;
+      expect(deselectItemSpy.args[0][0]).to.not.equal('1');
     });
 
     it('should prevent text selection on mouse dragging', () => {


### PR DESCRIPTION
## Description

The PR fixes a dragSelect issue that caused recurring attempts to select or deselect items after they were already in the desired state.

Fixes https://github.com/vaadin/flow-components/issues/6909

## Type of change

- [x] Bugfix
