### PR TITLE
feat: improve virtual-list a11y

### DIFF
--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.d.ts
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.d.ts
@@ -54,6 +54,11 @@ export declare class VirtualListMixinClass<TItem = VirtualListDefaultItem> {
   items: TItem[] | undefined;
 
   /**
+   * A function that generates accessible names for virtual list items.
+   */
+  itemAccessibleNameGenerator?: (item: TItem) => string;
+
+  /**
    * Scroll to a specific index in the virtual list.
    */
   scrollToIndex(index: number): void;

--- a/packages/virtual-list/test/typings/virtual-list.types.ts
+++ b/packages/virtual-list/test/typings/virtual-list.types.ts
@@ -40,3 +40,5 @@ assertType<(index: number) => void>(virtualList.scrollToIndex);
 
 assertType<number>(virtualList.firstVisibleIndex);
 assertType<number>(virtualList.lastVisibleIndex);
+
+assertType<((item: TestVirtualListItem) => string) | undefined>(virtualList.itemAccessibleNameGenerator);


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/8318
Part of https://github.com/vaadin/platform/issues/6838

Address the following a11y-related topics from the AC:
- When selection is disabled, VirtualList has ARIA role="list" and item wrappers have role="listitem"
- VirtualList needs an aria-label(ledby) API in order to provide an accessible name
  - Added as `itemAccessibleNameGenerator`

This PR also adds `aria-setsize` and `aria-posinset` attributes to the elements.

## Type of change

Feature