### PR TITLE
fix: only set avtar img src attribute if property is defined

### DIFF
--- a/packages/avatar/src/vaadin-lit-avatar.js
+++ b/packages/avatar/src/vaadin-lit-avatar.js
@@ -5,6 +5,7 @@
  */
 import './vaadin-avatar-icons.js';
 import { html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -44,7 +45,7 @@ class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElem
     return html`
       <img
         ?hidden="${!this.__imgVisible}"
-        src="${this.img}"
+        src="${ifDefined(this.img)}"
         aria-hidden="true"
         @error="${this.__onImageLoadError}"
         draggable="false"


### PR DESCRIPTION
## Description

Currently, in Lit version the empty `src` attribute is set by default (can be checked by snapshot test). This PR fixes that:

```
 ❌ vaadin-avatar > default
      AssertionError: Snapshot vaadin-avatar default does not match the saved snapshot on disk
      + expected - actual

       <img
         aria-hidden="true"
         draggable="false"
         hidden=""
      -  src=""
       >
       <slot name="tooltip">
       </slot>
```

## Type of change

- Bugfix