### PR TITLE
fix: add missing aria-label attribute to Lit confirm-dialog

### DIFF
--- a/packages/confirm-dialog/src/vaadin-lit-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-lit-confirm-dialog-overlay.js
@@ -111,6 +111,7 @@ class ConfirmDialogDialog extends ConfirmDialogBaseMixin(
         .modeless="${this.modeless}"
         .withBackdrop="${!this.modeless}"
         ?resizable="${this.resizable}"
+        aria-label="${this.ariaLabel}"
         restore-focus-on-close
         focus-trap
       ></vaadin-confirm-dialog-overlay>


### PR DESCRIPTION
## Description

The Lit version is lacking `aria-label` attribute propagation (can be checked by snapshot test). This PR fixes that.

## Type of change

- Bugfix