### PR TITLE
fix: add missing inputs-wrapper part to Lit based custom-field

### DIFF
--- a/packages/custom-field/src/vaadin-lit-custom-field.js
+++ b/packages/custom-field/src/vaadin-lit-custom-field.js
@@ -38,7 +38,7 @@ class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolylitMix
           <span part="required-indicator" aria-hidden="true"></span>
         </div>
 
-        <div class="inputs-wrapper" @change="${this._onInputChange}">
+        <div class="inputs-wrapper" part="input-fields" @change="${this._onInputChange}">
           <slot id="slot"></slot>
         </div>
 


### PR DESCRIPTION
## Description

The part name was added in #6703 but the Lit version was not updated accordingly. This PR fixes that.

## Type of change

- Bugfix