### PR TITLE
fix: use correct binding for boolean attributes in Lit grid

### DIFF
--- a/packages/grid/src/vaadin-lit-grid.js
+++ b/packages/grid/src/vaadin-lit-grid.js
@@ -37,10 +37,10 @@ class Grid extends GridMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)
     return html`
       <div
         id="scroller"
-        safari="${isSafari}"
-        ios="${isIOS}"
+        ?safari="${isSafari}"
+        ?ios="${isIOS}"
         ?loading="${this.loading}"
-        column-reordering-allowed="${this.columnReorderingAllowed}"
+        ?column-reordering-allowed="${this.columnReorderingAllowed}"
         ?empty-state="${this.__emptyState}"
       >
         <table


### PR DESCRIPTION
## Description

There's a problem in Lit grid which can be checked by snapshot tests with e.g. `safari="false"`. This PR fixes that.

```
 ❌ vaadin-grid > shadow > default
      AssertionError: Snapshot vaadin-grid shadow default does not match the saved snapshot on disk
      + expected - actual

       <div
      -  column-reordering-allowed="false"
         id="scroller"
      -  ios="false"
      -  safari="false"
         style="touch-action: none;"
       >
```

## Type of change

- Bugfix