### PR TITLE
refactor: fix crud grid hide edit column usage

### DIFF
--- a/packages/crud/src/vaadin-crud-grid-mixin.d.ts
+++ b/packages/crud/src/vaadin-crud-grid-mixin.d.ts
@@ -36,4 +36,10 @@ export declare class CrudGridMixinClass {
    * @attr {boolean} no-head
    */
   noHead: boolean | null | undefined;
+
+  /**
+   * Determines whether the edit column should be hidden.
+   * @attr {boolean} hide-edit-column
+   */
+  hideEditColumn: boolean | null | undefined;
 }

--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -39,13 +39,17 @@ export const CrudGridMixin = (superClass) =>
          */
         noHead: Boolean,
 
-        /** @private */
-        __hideEditColumn: Boolean,
+        /**
+         * Determines whether the edit column should be hidden.
+         */
+        hideEditColumn: {
+          type: Boolean,
+        },
       };
     }
 
     static get observers() {
-      return ['__onItemsChange(items)', '__onHideEditColumnChange(__hideEditColumn)'];
+      return ['__onItemsChange(items)', '__onHideEditColumnChange(hideEditColumn)'];
     }
 
     /** @private */
@@ -65,7 +69,7 @@ export const CrudGridMixin = (superClass) =>
     /** @private */
     __toggleEditColumn() {
       let editColumn = this.querySelector('vaadin-crud-edit-column');
-      if (this.__hideEditColumn) {
+      if (this.hideEditColumn) {
         if (editColumn) {
           this.removeChild(editColumn);
         }

--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -45,7 +45,7 @@ export const CrudGridMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__onItemsChange(items)', '__onHideEditColumnChange(hideEditColumn)'];
+      return ['__onItemsChange(items)', '__onHideEditColumnChange(__hideEditColumn)'];
     }
 
     /** @private */
@@ -65,7 +65,7 @@ export const CrudGridMixin = (superClass) =>
     /** @private */
     __toggleEditColumn() {
       let editColumn = this.querySelector('vaadin-crud-edit-column');
-      if (this.hideEditColumn) {
+      if (this.__hideEditColumn) {
         if (editColumn) {
           this.removeChild(editColumn);
         }

--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -41,6 +41,7 @@ export const CrudGridMixin = (superClass) =>
 
         /**
          * Determines whether the edit column should be hidden.
+         * @attr {boolean} hide-edit-column
          */
         hideEditColumn: {
           type: Boolean,

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -738,7 +738,7 @@ export const CrudMixin = (superClass) =>
         return;
       }
 
-      grid.hideEditColumn = editOnClick;
+      grid.__hideEditColumn = editOnClick;
 
       if (editOnClick) {
         grid.addEventListener('active-item-changed', this.__onGridActiveItemChanged);

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -738,7 +738,7 @@ export const CrudMixin = (superClass) =>
         return;
       }
 
-      grid.__hideEditColumn = editOnClick;
+      grid.hideEditColumn = editOnClick;
 
       if (editOnClick) {
         grid.addEventListener('active-item-changed', this.__onGridActiveItemChanged);


### PR DESCRIPTION
## Description

The (internal) crud grid component currently [declares](https://github.com/vaadin/web-components/blob/849dc36562b677ca7faad7e0845eacc87bbe841d/packages/crud/src/vaadin-crud-grid-mixin.js#L43) a private `__hideEditColumn` property, which isn't used. An undeclared `hideEditColumn` is used instead by the `__onHideEditColumnChange` observer.

Update the component to declare the `hideEditColumn` property

## Type of change

Refactor