### PR TITLE
fix: ignore target set while popover is detached until re-attached

### DIFF
--- a/packages/popover/src/vaadin-popover-target-mixin.js
+++ b/packages/popover/src/vaadin-popover-target-mixin.js
@@ -37,7 +37,7 @@ export const PopoverTargetMixin = (superClass) =>
         },
 
         /** @private */
-        _isConnected: {
+        __isConnected: {
           type: Boolean,
           sync: true,
         },
@@ -45,21 +45,21 @@ export const PopoverTargetMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__targetOrConnectedChanged(target, _isConnected)'];
+      return ['__targetOrConnectedChanged(target, __isConnected)'];
     }
 
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
 
-      this._isConnected = true;
+      this.__isConnected = true;
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
 
-      this._isConnected = false;
+      this.__isConnected = false;
     }
 
     /** @private */

--- a/packages/popover/src/vaadin-popover-target-mixin.js
+++ b/packages/popover/src/vaadin-popover-target-mixin.js
@@ -34,27 +34,32 @@ export const PopoverTargetMixin = (superClass) =>
          */
         target: {
           type: Object,
-          observer: '__targetChanged',
+        },
+
+        /** @private */
+        _isConnected: {
+          type: Boolean,
+          sync: true,
         },
       };
+    }
+
+    static get observers() {
+      return ['__targetOrConnectedChanged(target, _isConnected)'];
     }
 
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
 
-      if (this.target) {
-        this._addTargetListeners(this.target);
-      }
+      this._isConnected = true;
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
 
-      if (this.target) {
-        this._removeTargetListeners(this.target);
-      }
+      this._isConnected = false;
     }
 
     /** @private */
@@ -82,14 +87,16 @@ export const PopoverTargetMixin = (superClass) =>
     }
 
     /** @private */
-    __targetChanged(target, oldTarget) {
-      if (oldTarget) {
-        this._removeTargetListeners(oldTarget);
+    __targetOrConnectedChanged(target, isConnected) {
+      if (this.__previousTarget && (this.__previousTarget !== target || !isConnected)) {
+        this._removeTargetListeners(this.__previousTarget);
       }
 
-      if (target) {
+      if (target && isConnected) {
         this._addTargetListeners(target);
       }
+
+      this.__previousTarget = target;
     }
 
     /**

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -429,6 +429,18 @@ describe('popover', () => {
 
       expect(popover.opened).to.be.true;
     });
+
+    it('should not open on target click when target is cleared', async () => {
+      popover.target = target;
+      await nextUpdate(popover);
+
+      popover.target = null;
+      await nextUpdate(popover);
+
+      target.click();
+
+      expect(popover.opened).to.be.false;
+    });
   });
 
   describe('dimensions', () => {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -374,6 +374,63 @@ describe('popover', () => {
     });
   });
 
+  describe('detach and re-attach', () => {
+    let target;
+
+    beforeEach(() => {
+      target = fixtureSync('<button>Target</button>');
+    });
+
+    it('should not open on target click when detached', async () => {
+      popover.target = target;
+      await nextUpdate(popover);
+
+      popover.remove();
+      target.click();
+
+      expect(popover.opened).to.be.false;
+    });
+
+    it('should open on target click when re-attached', async () => {
+      popover.target = target;
+      await nextUpdate(popover);
+
+      popover.remove();
+
+      target.parentNode.appendChild(popover);
+      await nextUpdate(popover);
+
+      target.click();
+
+      expect(popover.opened).to.be.true;
+    });
+
+    it('should not open on target click when target set while detached', async () => {
+      popover.remove();
+
+      popover.target = target;
+      await nextUpdate(popover);
+
+      target.click();
+
+      expect(popover.opened).to.be.false;
+    });
+
+    it('should open when target set while detached after re-attached', async () => {
+      popover.remove();
+
+      popover.target = target;
+      await nextUpdate(popover);
+
+      target.parentNode.appendChild(popover);
+      await nextUpdate(popover);
+
+      target.click();
+
+      expect(popover.opened).to.be.true;
+    });
+  });
+
   describe('dimensions', () => {
     function getStyleValue(element) {
       return element


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/6953

Currently, target listeners are removed when popover is detached. However, we don't handle case when `target` property is set while detached - in this case, the target listeners will be still added. This PR fixes that by changing the observer logic to use `_isConnected` property and take it into account when checking whether listeners should be added.

## Type of change

- Bugfix