### PR TITLE
fix: slot dashboard widgets instead of dom reordering

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -173,6 +173,11 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
         type: String,
         value: '',
       },
+
+      __widgetCount: {
+        type: Number,
+        value: 0,
+      },
     };
   }
 
@@ -192,6 +197,7 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
       </div>
 
       <slot></slot>
+      ${[...Array(this.__widgetCount)].map((_item, index) => html`<slot name="slot-${index}"></slot>`)}
     `;
   }
 

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -174,7 +174,7 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
         value: '',
       },
 
-      /* @private */
+      /** @private */
       __childCount: {
         type: Number,
         value: 0,

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -174,7 +174,8 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
         value: '',
       },
 
-      __widgetCount: {
+      /* @private */
+      __childCount: {
         type: Number,
         value: 0,
       },
@@ -197,7 +198,7 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
       </div>
 
       <slot></slot>
-      ${[...Array(this.__widgetCount)].map((_item, index) => html`<slot name="slot-${index}"></slot>`)}
+      ${[...Array(this.__childCount)].map((_, index) => html`<slot name="slot-${index}"></slot>`)}
     `;
   }
 

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -197,7 +197,9 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
         </header>
       </div>
 
+      <!-- Default slot is used by <vaadin-dashboard-layout> -->
       <slot></slot>
+      <!-- Named slots are used by <vaadin-dashboard> -->
       ${[...Array(this.__childCount)].map((_, index) => html`<slot name="slot-${index}"></slot>`)}
     `;
   }

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -196,7 +196,7 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
         },
       },
 
-      /* @private */
+      /** @private */
       __childCount: {
         type: Number,
         value: 0,

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -366,6 +366,11 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
       return wrapper;
     }
 
+    // Sibling wrappers sorted by their slot name
+    const siblingWrappers = [...wrapper.parentElement.children].sort((a, b) => {
+      return a.slot < b.slot ? -1 : 1;
+    });
+
     // Starting from the given wrapper element, iterates through the siblings in the given direction
     // to find the closest wrapper that represents an item in the dashboard's items array
     const findSiblingWrapper = (wrapper, dir) => {
@@ -373,7 +378,8 @@ class Dashboard extends DashboardLayoutMixin(ElementMixin(ThemableMixin(PolylitM
         if (this.__isActiveWrapper(wrapper)) {
           return wrapper;
         }
-        wrapper = dir === 1 ? wrapper.nextElementSibling : wrapper.previousElementSibling;
+        const currentIndex = siblingWrappers.indexOf(wrapper);
+        wrapper = dir === 1 ? siblingWrappers[currentIndex + 1] : siblingWrappers[currentIndex - 1];
       }
     };
 

--- a/packages/dashboard/test/dashboard-keyboard.test.ts
+++ b/packages/dashboard/test/dashboard-keyboard.test.ts
@@ -23,6 +23,7 @@ import {
   setMinimumColumnWidth,
   setMinimumRowHeight,
   setSpacing,
+  updateComplete,
 } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: number };
@@ -209,7 +210,7 @@ describe('dashboard - keyboard interaction', () => {
 
     it('should move the widget backwards on arrow up', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await nextFrame();
+      await updateComplete(dashboard);
       await sendKeys({ press: 'ArrowUp' });
       expect(dashboard.items).to.eql([{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }]);
     });
@@ -246,7 +247,7 @@ describe('dashboard - keyboard interaction', () => {
       setMinimumRowHeight(dashboard, 100);
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'ArrowDown' });
-      await nextFrame();
+      await updateComplete(dashboard);
       await sendKeys({ press: 'ArrowUp' });
       await sendKeys({ up: 'Shift' });
       expect((dashboard.items[0] as DashboardItem).rowspan).to.equal(1);
@@ -365,7 +366,7 @@ describe('dashboard - keyboard interaction', () => {
 
       it('should move the widget backwards on arrow backwards', async () => {
         await sendKeys({ press: arrowForwards });
-        await nextFrame();
+        await updateComplete(dashboard);
         await sendKeys({ press: arrowBackwards });
         expect(dashboard.items).to.eql([{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }]);
       });
@@ -380,7 +381,7 @@ describe('dashboard - keyboard interaction', () => {
       it('should decrease the widget column span on shift + arrow backwards', async () => {
         await sendKeys({ down: 'Shift' });
         await sendKeys({ press: arrowForwards });
-        await nextFrame();
+        await updateComplete(dashboard);
         await sendKeys({ press: arrowBackwards });
         await sendKeys({ up: 'Shift' });
         expect((dashboard.items[0] as DashboardItem).colspan).to.equal(1);

--- a/packages/dashboard/test/dashboard-keyboard.test.ts
+++ b/packages/dashboard/test/dashboard-keyboard.test.ts
@@ -209,6 +209,7 @@ describe('dashboard - keyboard interaction', () => {
 
     it('should move the widget backwards on arrow up', async () => {
       await sendKeys({ press: 'ArrowDown' });
+      await nextFrame();
       await sendKeys({ press: 'ArrowUp' });
       expect(dashboard.items).to.eql([{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }]);
     });
@@ -245,6 +246,7 @@ describe('dashboard - keyboard interaction', () => {
       setMinimumRowHeight(dashboard, 100);
       await sendKeys({ down: 'Shift' });
       await sendKeys({ press: 'ArrowDown' });
+      await nextFrame();
       await sendKeys({ press: 'ArrowUp' });
       await sendKeys({ up: 'Shift' });
       expect((dashboard.items[0] as DashboardItem).rowspan).to.equal(1);
@@ -363,6 +365,7 @@ describe('dashboard - keyboard interaction', () => {
 
       it('should move the widget backwards on arrow backwards', async () => {
         await sendKeys({ press: arrowForwards });
+        await nextFrame();
         await sendKeys({ press: arrowBackwards });
         expect(dashboard.items).to.eql([{ id: 0 }, { id: 1 }, { items: [{ id: 2 }, { id: 3 }] }]);
       });
@@ -377,6 +380,7 @@ describe('dashboard - keyboard interaction', () => {
       it('should decrease the widget column span on shift + arrow backwards', async () => {
         await sendKeys({ down: 'Shift' });
         await sendKeys({ press: arrowForwards });
+        await nextFrame();
         await sendKeys({ press: arrowBackwards });
         await sendKeys({ up: 'Shift' });
         expect((dashboard.items[0] as DashboardItem).colspan).to.equal(1);

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -681,6 +681,22 @@ describe('dashboard', () => {
         expect(document.activeElement).to.equal(getElementFromCell(dashboard, 0, 0)!);
       });
 
+      it('should focus next widget on focused widget removal after reordering', async () => {
+        getElementFromCell(dashboard, 0, 0)!.focus();
+        // Reorder items (the focused widget is moved to the end)
+        dashboard.items = [dashboard.items[1], dashboard.items[2], dashboard.items[0]];
+        await updateComplete(dashboard);
+
+        // Remove the focused widget
+        dashboard.items = [dashboard.items[0], dashboard.items[1]];
+        await updateComplete(dashboard);
+
+        // Expect the section to be focused
+        const sectionWidget = getElementFromCell(dashboard, 1, 0)!;
+        const section = getParentSection(sectionWidget)!;
+        expect(document.activeElement).to.equal(section);
+      });
+
       it('should focus the previous widget on focused widget removal', async () => {
         const sectionWidget = getElementFromCell(dashboard, 1, 1)!;
         getParentSection(sectionWidget)!.focus();


### PR DESCRIPTION
## Description

Refactor `<vaadin-dashboard>` to reorder the widgets by assigning them updated `slot` names instead of reordering the elements in the DOM. This will fix issues such as a `<vaadin-grid>` losing its scroll position on reorder when used as a widget child element.

NOTE: This change will require picking up [this commit](https://github.com/vaadin/flow-components/commit/d6409f0ee6f19b79c24bddc3b42d13e475b05651) to the web component version bump PR in `flow-components`

## Type of change

Bugfix/refactor