### PR TITLE
fix: add missing .js extension to the controller import

### DIFF
--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { TooltipController } from '@vaadin/component-base/src/tooltip-controller';
+import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';


### PR DESCRIPTION
## Description

Fixes #8362

The `.js` extension was removed by accident when moving the `TooltipController` code to the mixin.

## Type of change

- Bugfix