### PR TITLE
test: use nextUpdate to stabilize dashboard tests on Webkit

### DIFF
--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-dashboard.js';
 import type { CustomElementType } from '@vaadin/component-base/src/define.js';
@@ -51,8 +51,7 @@ describe('dashboard', () => {
     await updateComplete(dashboard);
   });
 
-  it('should render a widget for each item', async () => {
-    await updateComplete(dashboard);
+  it('should render a widget for each item', () => {
     const widgets = [getElementFromCell(dashboard, 0, 0), getElementFromCell(dashboard, 0, 1)];
     widgets.forEach((widget, index) => {
       expect(widget).to.be.ok;
@@ -622,7 +621,6 @@ describe('dashboard', () => {
       // Add enough items to make the dashboard scrollable
       dashboard.items = Array.from({ length: 10 }, (_, i) => ({ id: i.toString() }));
       await updateComplete(dashboard);
-      await nextFrame();
 
       // Scroll the dashboard to make the focused item partially visible
       const scrollingContainer = getScrollingContainer(dashboard);
@@ -632,7 +630,6 @@ describe('dashboard', () => {
       // Change the items to trigger a render
       dashboard.items = dashboard.items.slice(0, -1);
       await updateComplete(dashboard);
-      await nextFrame();
 
       // Expect no scrolling to have occurred
       expect(scrollingContainer.scrollTop).to.equal(scrollTop);

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -24,8 +24,12 @@ import {
 
 type TestDashboardItem = DashboardItem & { id: string; component?: Element | string };
 
-async function updateComplete(Dashboard: Dashboard<TestDashboardItem>) {
-  await nextUpdate(Dashboard);
+async function updateComplete(dashboard: Dashboard<TestDashboardItem>) {
+  await nextUpdate(dashboard);
+  const widgets = dashboard.querySelectorAll('vaadin-dashboard-widget');
+  for (const widget of widgets) {
+    await nextUpdate(widget);
+  }
   await nextFrame();
 }
 
@@ -626,6 +630,7 @@ describe('dashboard', () => {
       // Add enough items to make the dashboard scrollable
       dashboard.items = Array.from({ length: 10 }, (_, i) => ({ id: i.toString() }));
       await updateComplete(dashboard);
+      await nextFrame();
 
       // Scroll the dashboard to make the focused item partially visible
       const scrollingContainer = getScrollingContainer(dashboard);
@@ -635,6 +640,7 @@ describe('dashboard', () => {
       // Change the items to trigger a render
       dashboard.items = dashboard.items.slice(0, -1);
       await updateComplete(dashboard);
+      await nextFrame();
 
       // Expect no scrolling to have occurred
       expect(scrollingContainer.scrollTop).to.equal(scrollTop);

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../vaadin-dashboard.js';
 import type { CustomElementType } from '@vaadin/component-base/src/define.js';
@@ -20,18 +20,10 @@ import {
   setMinimumColumnWidth,
   setMinimumRowHeight,
   setSpacing,
+  updateComplete,
 } from './helpers.js';
 
 type TestDashboardItem = DashboardItem & { id: string; component?: Element | string };
-
-async function updateComplete(dashboard: Dashboard<TestDashboardItem>) {
-  await nextUpdate(dashboard);
-  const widgets = dashboard.querySelectorAll('vaadin-dashboard-widget');
-  for (const widget of widgets) {
-    await nextUpdate(widget);
-  }
-  await nextFrame();
-}
 
 describe('dashboard', () => {
   let dashboard: Dashboard<TestDashboardItem>;

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { nextFrame, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
@@ -373,4 +374,13 @@ function onceInvoked(object, functionName): Promise<void> {
 
 export async function onceResized(dashboard: HTMLElement): Promise<void> {
   await onceInvoked(dashboard, '_onResize');
+}
+
+export async function updateComplete(dashboard: HTMLElement): Promise<void> {
+  await nextUpdate(dashboard);
+  const widgets = dashboard.querySelectorAll('vaadin-dashboard-widget');
+  for (const widget of widgets) {
+    await nextUpdate(widget);
+  }
+  await nextFrame();
 }

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -378,9 +378,11 @@ export async function onceResized(dashboard: HTMLElement): Promise<void> {
 
 export async function updateComplete(dashboard: HTMLElement): Promise<void> {
   await nextUpdate(dashboard);
-  const widgets = dashboard.querySelectorAll('vaadin-dashboard-widget');
-  for (const widget of widgets) {
-    await nextUpdate(widget);
+
+  const widgetsAndSections = dashboard.querySelectorAll('vaadin-dashboard-widget, vaadin-dashboard-section');
+  for (const child of widgetsAndSections) {
+    await nextUpdate(child as HTMLElement);
   }
+
   await nextFrame();
 }

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { nextFrame, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
@@ -384,5 +384,8 @@ export async function updateComplete(dashboard: HTMLElement): Promise<void> {
     await nextUpdate(child as HTMLElement);
   }
 
+  // Next frame is also needed to wait for a possible ResizeObserver invocation
+  // The observer uses a timeout internally so an additional timeout is also needed
   await nextFrame();
+  await aTimeout(0);
 }


### PR DESCRIPTION
## Description

Try to stabilize flaky Dashboard tests by using a helper with `nextUpdate`

## Type of change

Tests