### PR TITLE
refactor: add updating-cell part styles

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -17,7 +17,8 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-grid-pro',
   css`
-    :host([loading-editor]) [part~='focused-cell'] ::slotted(vaadin-grid-cell-content) {
+    :host([loading-editor]) [part~='focused-cell'] ::slotted(vaadin-grid-cell-content),
+    [part~='updating-cell'] ::slotted(vaadin-grid-cell-content) {
       opacity: 0;
       pointer-events: none;
     }

--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -388,4 +388,13 @@ describe('keyboard navigation', () => {
       expect(itemPropertyChangedSpy.called).to.be.false;
     });
   });
+
+  describe('updating cell', () => {
+    it('should hide cell content while cell is updating', async () => {
+      grid.cellPartNameGenerator = () => 'updating-cell';
+      await nextFrame();
+      const container = getContainerCellContent(grid.$.items, 0, 0);
+      expect(getComputedStyle(container).opacity).to.equal('0');
+    });
+  });
 });

--- a/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
+++ b/packages/grid-pro/theme/lumo/vaadin-grid-pro-styles.js
@@ -63,6 +63,25 @@ registerStyles(
         opacity: 1;
       }
     }
+
+    [part~='updating-cell']::after {
+      content: '';
+      position: absolute;
+      inset: var(--_cell-padding);
+      margin: var(--_focus-ring-width);
+      border-radius: 4px;
+      background-size: max(4em, 50%);
+      background-repeat: no-repeat;
+      background-position: min(-200%, -4em) 0;
+      background-image: linear-gradient(90deg, transparent, var(--lumo-contrast-10pct), transparent);
+      animation: vaadin-grid-pro-updating-cell 1.3s ease-out infinite;
+    }
+
+    @keyframes vaadin-grid-pro-updating-cell {
+      100% {
+        background-position: max(300%, 8em) 0;
+      }
+    }
   `,
   { moduleId: 'lumo-grid-pro' },
 );


### PR DESCRIPTION
Adds cell styles for hiding cell content and showing a loading animation while a cell is being updated. Intended to be used by the Flow component to hide cell content while updating cell values, which requires a server roundtrip for custom editors.

Part of https://github.com/vaadin/web-components/issues/8234
Corresponding Flow PR: https://github.com/vaadin/flow-components/pull/6973