### PR TITLE
chore: pin ubuntu version in GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   tests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   chrome:
     name: Chrome
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,7 +27,7 @@ jobs:
         run: yarn test
   firefox:
     name: Firefox
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,7 +49,7 @@ jobs:
         run: yarn test:firefox
   webkit:
     name: WebKit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +31,7 @@ jobs:
         run: yarn lint:types
   snapshots:
     name: Snapshot tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
         run: yarn test:snapshots
   integration:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   lumo:
     name: Lumo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'vaadin'
 
     steps:
@@ -45,7 +45,7 @@ jobs:
             packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png
   material:
     name: Material
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'vaadin'
 
     steps:


### PR DESCRIPTION
`ubuntu-latest` now refers to `ubuntu-24.04`, which results in the following issues:
- Ubuntu now includes an App Armor profile for Chrome that prevents running builds downloaded from the internet, such as the ones downloaded by Puppeteer and Playwright
- Playwright browser install fails with `Package libicu70 is not available, but is referred to by another package`

For the App Armor issue we could do what the Puppeteer team did, and disable App Armor for CI runs (https://github.com/puppeteer/puppeteer/pull/13196). However that doesn't solve the Playwright installation issue. For now it seems easiest to pin the Ubuntu version to the one we used before and wait for things to settle.