### PR TITLE
fix: ensure error message is announced by VoiceOver

### DIFF
--- a/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
+++ b/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
@@ -545,7 +545,6 @@ snapshots["vaadin-checkbox-group host error"] =
   </label>
   <div
     id="error-message-vaadin-checkbox-group-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
+++ b/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
@@ -219,7 +219,6 @@ snapshots["vaadin-checkbox host error"] =
   </label>
   <div
     id="error-message-vaadin-checkbox-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -264,7 +264,6 @@ snapshots["vaadin-combo-box host error"] =
   </label>
   <div
     id="error-message-vaadin-combo-box-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -102,7 +102,6 @@ snapshots["vaadin-custom-field host error"] =
   </label>
   <div
     id="error-message-vaadin-custom-field-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -213,7 +213,6 @@ snapshots["vaadin-date-picker host error"] =
   </label>
   <div
     id="error-message-vaadin-date-picker-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -455,7 +455,6 @@ snapshots["vaadin-date-time-picker host error"] =
   </label>
   <div
     id="error-message-vaadin-date-time-picker-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -311,7 +311,6 @@ snapshots["vaadin-email-field host error"] =
   </label>
   <div
     id="error-message-vaadin-email-field-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2024 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { announce } from '@vaadin/a11y-base/src/announce.js';
 import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
 
 /**
@@ -108,12 +109,8 @@ export class ErrorController extends SlotChildObserveController {
       errorNode.textContent = hasError ? errorMessage : '';
       errorNode.hidden = !hasError;
 
-      // Role alert will make the error message announce immediately
-      // as the field becomes invalid
       if (hasError) {
-        errorNode.setAttribute('role', 'alert');
-      } else {
-        errorNode.removeAttribute('role');
+        announce(errorMessage, { mode: 'assertive' });
       }
     }
 

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -110,6 +110,8 @@ export class ErrorController extends SlotChildObserveController {
       errorNode.hidden = !hasError;
 
       if (hasError) {
+        // Assertive mode ensures VoiceOver reads
+        // the error message on commit with Enter.
         announce(errorMessage, { mode: 'assertive' });
       }
     }

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -73,7 +73,6 @@ snapshots["vaadin-integer-field host error"] =
   </label>
   <div
     id="error-message-vaadin-integer-field-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -159,7 +159,6 @@ snapshots["vaadin-login-form host required"] =
         </label>
         <div
           id="error-message-vaadin-text-field-2"
-          role="alert"
           slot="error-message"
         >
           Username is required
@@ -196,7 +195,6 @@ snapshots["vaadin-login-form host required"] =
         </label>
         <div
           id="error-message-vaadin-password-field-5"
-          role="alert"
           slot="error-message"
         >
           Password is required
@@ -390,7 +388,6 @@ snapshots["vaadin-login-form host i18n-required"] =
         </label>
         <div
           id="error-message-vaadin-text-field-2"
-          role="alert"
           slot="error-message"
         >
           Käyttäjätunnus vaaditaan
@@ -427,7 +424,6 @@ snapshots["vaadin-login-form host i18n-required"] =
         </label>
         <div
           id="error-message-vaadin-password-field-5"
-          role="alert"
           slot="error-message"
         >
           Salasana vaaditaan

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -131,7 +131,6 @@ snapshots["vaadin-multi-select-combo-box host error"] =
   </label>
   <div
     id="error-message-vaadin-multi-select-combo-box-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -73,7 +73,6 @@ snapshots["vaadin-number-field host error"] =
   </label>
   <div
     id="error-message-vaadin-number-field-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -85,7 +85,6 @@ snapshots["vaadin-password-field host error"] =
   </label>
   <div
     id="error-message-vaadin-password-field-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -394,7 +394,6 @@ snapshots["vaadin-radio-group host error"] =
   </label>
   <div
     id="error-message-vaadin-radio-group-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -250,7 +250,6 @@ snapshots["vaadin-select host error"] =
   </label>
   <div
     id="error-message-vaadin-select-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -69,7 +69,6 @@ snapshots["vaadin-text-area host error"] =
   </label>
   <div
     id="error-message-vaadin-text-area-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -67,7 +67,6 @@ snapshots["vaadin-text-field host error"] =
   </label>
   <div
     id="error-message-vaadin-text-field-2"
-    role="alert"
     slot="error-message"
   >
     Error

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -110,7 +110,6 @@ snapshots["vaadin-time-picker host error"] =
   </label>
   <div
     id="error-message-vaadin-time-picker-2"
-    role="alert"
     slot="error-message"
   >
     Error


### PR DESCRIPTION
## Description

The PR fixes the issue where VoiceOver didn't announce the error message when returning focus to the field from another element in Safari. The issue is fixed by removing the `alert` role from the error message element and instead using a separate element with `aria-live="assertive"` for the announcement. The assertive mode ensures the error message is correctly announced on value commit with <kbd>Enter</kbd> to match the previous behavior.

| Screen reader | Tested |
|:--------------|:-------|
| VoiceOver | ✅  |
| NVDA         | ✅ |
| JAWS         | ✅ |

Fixes #8349 

## Type of change

- [x] Bugfix
