### PR TITLE
chore: upgrade @vaadin/testing-helpers to 1.1.0 (#8388) (CP: 24.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@types/mocha": "^10.0.7",
     "@types/sinon": "^17.0.3",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@web/dev-server": "^0.4.3",
     "@web/dev-server-esbuild": "^1.0.2",
     "@web/rollup-plugin-html": "^2.0.0",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-board",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
     "@vaadin/icon": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-chart",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-field": "~24.6.0",
     "sinon": "^18.0.0"
   },

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~24.6.0",
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "cvdlName": "vaadin-cookie-consent",
   "web-types": [

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-crud",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -53,7 +53,7 @@
     "@vaadin/number-field": "~24.6.0",
     "@vaadin/password-field": "~24.6.0",
     "@vaadin/select": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-area": "~24.6.0",
     "@vaadin/text-field": "~24.6.0",
     "@vaadin/time-picker": "~24.6.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "cvdlName": "vaadin-dashboard",
   "web-types": [

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~24.6.0",
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-area": "~24.6.0",
     "sinon": "^18.0.0"
   },

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -53,7 +53,7 @@
     "@vaadin/list-box": "~24.6.0",
     "@vaadin/radio-group": "~24.6.0",
     "@vaadin/select": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-area": "~24.6.0",
     "@vaadin/text-field": "~24.6.0",
     "@vaadin/time-picker": "~24.6.0",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
     "@vaadin/custom-field": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-field": "~24.6.0",
     "sinon": "^18.0.0"
   },

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-grid-pro",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -42,7 +42,7 @@
     "@vaadin/chai-plugins": "~24.6.0",
     "@vaadin/icon": "~24.6.0",
     "@vaadin/icons": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
     "@vaadin/checkbox": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-map",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
     "@vaadin/icon": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/button": "~24.6.0",
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -40,7 +40,7 @@
     "@vaadin/checkbox": "~24.6.0",
     "@vaadin/grid": "~24.6.0",
     "@vaadin/grid-pro": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~24.6.0",
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
     "gulp-iconfont": "^11.0.0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "lit": "^3.0.0",
     "sinon": "^18.0.0"
   },

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -38,7 +38,7 @@
     "@vaadin/radio-group": "~24.6.0",
     "@vaadin/select": "~24.6.0",
     "@vaadin/tabs": "~24.6.0",
-    "@vaadin/testing-helpers": "^1.0.0",
+    "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-area": "~24.6.0",
     "@vaadin/text-field": "~24.6.0",
     "@vaadin/time-picker": "~24.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vaadin/testing-helpers@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-1.0.0.tgz#e63ca3d6c8e201177ae9a9a0b50dbbf71851ad29"
-  integrity sha512-khYSX4uBBpI2eX883jNiGWyQDAx+X29vKud0T1VyLgiXT4lwFwaqO8pOIDG2k2feOFRKAwbNPbbxl8HTGTU2Kw==
+"@vaadin/testing-helpers@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-1.1.0.tgz#8eeac00443cf7d4c130fc136fc7d2c9abee1dbfc"
+  integrity sha512-fbBIsla857GlzQDDd/NPNQxTcV76F0SzFm4U2WaDhH+RouCVta2z1IhAeIIOXz+dc2Ni0VLwlF77QEr9hSzLIQ==
   dependencies:
     "@polymer/polymer" "^3.5.1"
     lit "^3.0.0"
@@ -12018,7 +12018,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12035,15 +12035,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -12129,7 +12120,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12142,13 +12133,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -13392,7 +13376,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13413,15 +13397,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Cherry-picks https://github.com/vaadin/web-components/pull/8388 to branch 24.6