### PR TITLE
chore: upgrade @vaadin/testing-helpers to 1.1.0

### DIFF
--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.7.0-alpha2",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "cvdlName": "vaadin-cookie-consent",
   "web-types": [

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.7.0-alpha2",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "cvdlName": "vaadin-dashboard",
   "web-types": [

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.7.0-alpha2",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.7.0-alpha2",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.7.0-alpha2",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "24.7.0-alpha2",
-    "@vaadin/testing-helpers": "^1.0.0"
+    "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [
     "web-types.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,14 +2301,6 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vaadin/testing-helpers@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-1.0.0.tgz#e63ca3d6c8e201177ae9a9a0b50dbbf71851ad29"
-  integrity sha512-khYSX4uBBpI2eX883jNiGWyQDAx+X29vKud0T1VyLgiXT4lwFwaqO8pOIDG2k2feOFRKAwbNPbbxl8HTGTU2Kw==
-  dependencies:
-    "@polymer/polymer" "^3.5.1"
-    lit "^3.0.0"
-
 "@vaadin/testing-helpers@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-1.1.0.tgz#8eeac00443cf7d4c130fc136fc7d2c9abee1dbfc"


### PR DESCRIPTION
I used an incorrect search pattern, which caused some files to be missed in #8388
