### PR TITLE
test: disable error-message animation in Material visual tests

### DIFF
--- a/packages/checkbox-group/test/visual/common.js
+++ b/packages/checkbox-group/test/visual/common.js
@@ -5,6 +5,7 @@ registerStyles(
   css`
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -11,6 +11,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/custom-field/test/visual/common.js
+++ b/packages/custom-field/test/visual/common.js
@@ -5,6 +5,7 @@ registerStyles(
   css`
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -11,6 +11,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/date-time-picker/test/visual/common.js
+++ b/packages/date-time-picker/test/visual/common.js
@@ -10,6 +10,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/multi-select-combo-box/test/visual/common.js
+++ b/packages/multi-select-combo-box/test/visual/common.js
@@ -12,6 +12,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/number-field/test/visual/common.js
+++ b/packages/number-field/test/visual/common.js
@@ -10,6 +10,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/radio-group/test/visual/common.js
+++ b/packages/radio-group/test/visual/common.js
@@ -5,6 +5,7 @@ registerStyles(
   css`
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/select/test/visual/common.js
+++ b/packages/select/test/visual/common.js
@@ -5,6 +5,7 @@ registerStyles(
   css`
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/text-area/test/visual/common.js
+++ b/packages/text-area/test/visual/common.js
@@ -10,6 +10,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/text-field/test/visual/common.js
+++ b/packages/text-field/test/visual/common.js
@@ -10,6 +10,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,

--- a/packages/time-picker/test/visual/common.js
+++ b/packages/time-picker/test/visual/common.js
@@ -11,6 +11,7 @@ registerStyles(
 
     /* Show error message immediately */
     [part='error-message'] {
+      animation: none !important;
       transition: none !important;
     }
   `,


### PR DESCRIPTION
## Description

Current styles for disabling error message transition only work for Lumo since Material theme uses `animation`:

https://github.com/vaadin/web-components/blob/0a54c0e87ec312c9dc60a308ba2181d3150aca9a/packages/vaadin-material-styles/mixins/required-field.js#L53-L61

Updated "common" styles for all field components to also cover Material. This should help to fix errors in #8383

```

## Type of change

- Test