### PR TITLE
fix: get the correct reference to the Notification class

### DIFF
--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -228,6 +228,7 @@ export const NotificationMixin = (superClass) =>
 
     /** @private */
     get _container() {
+      const Notification = customElements.get('vaadin-notification');
       if (!Notification._container) {
         Notification._container = document.createElement('vaadin-notification-container');
         document.body.appendChild(Notification._container);


### PR DESCRIPTION
## Description

This fixes a  problem reported at [forum](https://vaadin.com/forum/t/notification-component-not-working-in-ff/168004) with `Notification is not defined` - the regression is introduced in #8083.
The component just happens to work since there's a global `Notification` object, but it's not 100% available. 

## Type of change

- Bugfix