### PR TITLE
fix: do not reset opened state when set to open initially

### DIFF
--- a/packages/select/test/lit-renderer-directives.common.js
+++ b/packages/select/test/lit-renderer-directives.common.js
@@ -24,7 +24,7 @@ describe('lit renderer directives', () => {
     describe('basic', () => {
       beforeEach(async () => {
         select = await renderOpenedSelect(container, { content: 'Content' });
-        overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
+        overlay = select.$.overlay;
       });
 
       it('should set `renderer` property when the directive is attached', () => {

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -734,6 +734,21 @@ describe('vaadin-select', () => {
     });
   });
 
+  describe('initially opened', () => {
+    beforeEach(async () => {
+      select = fixtureSync(`<vaadin-select opened></vaadin-select>`);
+      select.items = [
+        { label: 'Option 0', value: 'option-0' },
+        { label: 'Option 1', value: 'option-1' },
+      ];
+      await nextRender();
+    });
+
+    it('should open the overlay when opened attribute is set initially', () => {
+      expect(select.$.overlay.opened).to.be.true;
+    });
+  });
+
   describe('with value', () => {
     let menu, valueButton;
 


### PR DESCRIPTION
## Description

The PR fixes the issue where the select would immediately close when it was initially set to open.

Fixes https://github.com/vaadin/web-components/issues/8398

## Type of change

- [x] Bugfix
