### PR TITLE
fix: do not close select overlay when opened before attached

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -64,7 +64,6 @@ export const SelectBaseMixin = (superClass) =>
           value: false,
           notify: true,
           reflectToAttribute: true,
-          observer: '_openedChanged',
         },
 
         /**
@@ -160,7 +159,11 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_updateAriaExpanded(opened, focusElement)', '_updateSelectedItem(value, _items, placeholder)'];
+      return [
+        '_updateAriaExpanded(opened, focusElement)',
+        '_updateSelectedItem(value, _items, placeholder)',
+        '_openedChanged(opened, _overlayElement)',
+      ];
     }
 
     constructor() {
@@ -183,9 +186,8 @@ export const SelectBaseMixin = (superClass) =>
     ready() {
       super.ready();
 
-      this._overlayElement = this.$.overlay;
-
       this._inputContainer = this.shadowRoot.querySelector('[part~="input-field"]');
+      this._overlayElement = this.$.overlay;
 
       this._valueButtonController = new ButtonController(this);
       this.addController(this._valueButtonController);
@@ -361,20 +363,22 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _openedChanged(opened, wasOpened) {
+    _openedChanged(opened, overlayElement) {
       if (opened) {
-        // Avoid multiple announcements when a value gets selected from the dropdown
-        this._updateAriaLive(false);
+        if (!overlayElement) {
+          return;
+        }
 
-        if (!this._overlayElement || !this._menuElement || !this.focusElement || this.disabled || this.readonly) {
+        if (this.disabled || this.readonly) {
+          // Disallow programmatic opening when disabled or readonly
           this.opened = false;
           return;
         }
 
-        this._overlayElement.style.setProperty(
-          '--vaadin-select-text-field-width',
-          `${this._inputContainer.offsetWidth}px`,
-        );
+        // Avoid multiple announcements when a value gets selected from the dropdown
+        this._updateAriaLive(false);
+
+        overlayElement.style.setProperty('--vaadin-select-text-field-width', `${this._inputContainer.offsetWidth}px`);
 
         // Preserve focus-ring to restore it later
         const hasFocusRing = this.hasAttribute('focus-ring');
@@ -384,7 +388,7 @@ export const SelectBaseMixin = (superClass) =>
         if (hasFocusRing) {
           this.removeAttribute('focus-ring');
         }
-      } else if (wasOpened) {
+      } else if (this.__oldOpened) {
         if (this._openedWithFocusRing) {
           this.setAttribute('focus-ring', '');
         }
@@ -396,6 +400,8 @@ export const SelectBaseMixin = (superClass) =>
           this._requestValidation();
         }
       }
+
+      this.__oldOpened = opened;
     }
 
     /** @private */

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -364,11 +364,11 @@ export const SelectBaseMixin = (superClass) =>
 
     /** @private */
     _openedChanged(opened, overlayElement) {
-      if (opened) {
-        if (!overlayElement) {
-          return;
-        }
+      if (!overlayElement) {
+        return;
+      }
 
+      if (opened) {
         if (this.disabled || this.readonly) {
           // Disallow programmatic opening when disabled or readonly
           this.opened = false;

--- a/packages/select/test/lit-renderer-directives.common.js
+++ b/packages/select/test/lit-renderer-directives.common.js
@@ -24,7 +24,7 @@ describe('lit renderer directives', () => {
     describe('basic', () => {
       beforeEach(async () => {
         select = await renderOpenedSelect(container, { content: 'Content' });
-        overlay = select.shadowRoot.querySelector('vaadin-select-overlay');
+        overlay = select._overlayElement;
       });
 
       it('should set `renderer` property when the directive is attached', () => {

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -521,6 +521,14 @@ describe('vaadin-select', () => {
         expect(select.opened).to.be.false;
         expect(select._overlayElement.opened).to.be.false;
       });
+
+      it('should disallow programmatic opening when disabled', async () => {
+        select.readonly = true;
+        await nextUpdate(select);
+        select.opened = true;
+        await nextUpdate(select);
+        expect(select._overlayElement.opened).to.be.false;
+      });
     });
 
     describe('readonly', () => {
@@ -531,6 +539,14 @@ describe('vaadin-select', () => {
         expect(select._overlayElement.opened).to.be.false;
 
         click(valueButton);
+        expect(select._overlayElement.opened).to.be.false;
+      });
+
+      it('should disallow programmatic opening when readonly', async () => {
+        select.readonly = true;
+        await nextUpdate(select);
+        select.opened = true;
+        await nextUpdate(select);
         expect(select._overlayElement.opened).to.be.false;
       });
     });
@@ -778,6 +794,24 @@ describe('vaadin-select', () => {
       const select = container.querySelector('vaadin-select');
       expect(window.getComputedStyle(container).width).to.eql('500px');
       expect(parseFloat(window.getComputedStyle(select).width)).to.eql(500);
+    });
+  });
+
+  describe('pre-opened', () => {
+    beforeEach(() => {
+      select = document.createElement('vaadin-select');
+      select.items = [{ label: 'Option 1', value: 'value-1' }];
+    });
+
+    afterEach(() => {
+      select.remove();
+    });
+
+    it('should not close overlay when opened set before adding to DOM', async () => {
+      select.opened = true;
+      document.body.appendChild(select);
+      await nextUpdate(select);
+      expect(select._overlayElement.opened).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #8398

Changed the observer to depend on `_overlayElement` (also, updated the order of setting references in `ready()` as the observer also uses `_inputContainer` internally - didn't include both to avoid triggering it multiple times unnecessarily).

## Type of change

- Bugfix

## Note

I didn't remove resetting `opened` to `false` as that could be considered a behavior altering change, and I added some missing tests that cover the relevant part of the observer for `readonly` and `disabled` test suites.