### PR TITLE
feat: add manual property to popover, allow closing unless manual

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -182,6 +182,12 @@ declare class Popover extends PopoverPositionMixin(
   renderer: PopoverRenderer | null | undefined;
 
   /**
+   * When true, the popover is controlled programmatically
+   * instead of reacting to click, focus, or hover triggers.
+   */
+  manual: boolean;
+
+  /**
    * When true, the popover prevents interacting with background elements
    * by setting `pointer-events` style on the document body to `none`.
    * This also enables trapping focus inside the overlay.

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -324,6 +324,15 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
+       * When true, the popover is controlled programmatically
+       * instead of reacting to click, focus, or hover triggers.
+       */
+      manual: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
        * When true, the popover prevents interacting with background elements
        * by setting `pointer-events` style on the document body to `none`.
        * This also enables trapping focus inside the overlay.
@@ -611,7 +620,7 @@ class Popover extends PopoverPositionMixin(
   __onGlobalClick(event) {
     if (
       this.opened &&
-      !this.__isManual &&
+      !this.manual &&
       !this.modal &&
       !event.composedPath().some((el) => el === this._overlayElement || el === this.target) &&
       !this.noCloseOnOutsideClick &&
@@ -623,6 +632,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetClick() {
+    if (this.manual) {
+      return;
+    }
+
     if (this.__hasTrigger('click')) {
       if (!this.opened) {
         this.__shouldRestoreFocus = true;
@@ -650,7 +663,7 @@ class Popover extends PopoverPositionMixin(
       event.key === 'Escape' &&
       !this.noCloseOnEsc &&
       this.opened &&
-      !this.__isManual &&
+      !this.manual &&
       isLastOverlay(this._overlayElement)
     ) {
       // Prevent closing parent overlay (e.g. dialog)
@@ -743,6 +756,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetFocusIn() {
+    if (this.manual) {
+      return;
+    }
+
     this.__focusInside = true;
 
     if (this.__hasTrigger('focus')) {
@@ -763,6 +780,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetFocusOut(event) {
+    if (this.manual) {
+      return;
+    }
+
     // Do not close the popover on overlay focusout if it's not the last one.
     // This covers the case when focus moves to the nested popover opened
     // without focusing parent popover overlay (e.g. using hover trigger).
@@ -779,6 +800,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetMouseEnter() {
+    if (this.manual) {
+      return;
+    }
+
     this.__hoverInside = true;
 
     if (this.__hasTrigger('hover') && !this.opened) {
@@ -792,6 +817,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onTargetMouseLeave(event) {
+    if (this.manual) {
+      return;
+    }
+
     // Do not close the popover on target focusout if the overlay is not the last one.
     // This happens e.g. when opening the nested popover that uses non-modal overlay.
     if (this._overlayElement.opened && !isLastOverlay(this._overlayElement)) {
@@ -818,6 +847,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onOverlayFocusOut(event) {
+    if (this.manual) {
+      return;
+    }
+
     // Do not close the popover on overlay focusout if it's not the last one.
     // This covers the following cases of nested overlay based components:
     // 1. Moving focus to the nested overlay (e.g. vaadin-select, vaadin-menu-bar)
@@ -854,6 +887,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onOverlayMouseEnter() {
+    if (this.manual) {
+      return;
+    }
+
     this.__hoverInside = true;
 
     // Prevent closing if cursor moves to the overlay during hide delay.
@@ -864,6 +901,10 @@ class Popover extends PopoverPositionMixin(
 
   /** @private */
   __onOverlayMouseLeave(event) {
+    if (this.manual) {
+      return;
+    }
+
     // Do not close the popover on overlay focusout if it's not the last one.
     // This happens when opening the nested component that uses "modal" overlay
     // setting `pointer-events: none` on the body (combo-box, date-picker etc).
@@ -939,7 +980,7 @@ class Popover extends PopoverPositionMixin(
    * @private
    */
   __onEscapePress(e) {
-    if (this.noCloseOnEsc || this.__isManual) {
+    if (this.noCloseOnEsc || this.manual) {
       e.preventDefault();
     }
   }
@@ -949,7 +990,7 @@ class Popover extends PopoverPositionMixin(
    * @private
    */
   __onOutsideClick(e) {
-    if (this.noCloseOnOutsideClick || this.__isManual) {
+    if (this.noCloseOnOutsideClick || this.manual) {
       e.preventDefault();
     }
   }
@@ -957,11 +998,6 @@ class Popover extends PopoverPositionMixin(
   /** @private */
   __hasTrigger(trigger) {
     return Array.isArray(this.trigger) && this.trigger.includes(trigger);
-  }
-
-  /** @private */
-  get __isManual() {
-    return this.trigger == null || (Array.isArray(this.trigger) && this.trigger.length === 0);
   }
 
   /** @private */

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -497,51 +497,51 @@ describe('trigger', () => {
           expect(overlay.opened).to.be.true;
         });
 
-        it(`should not close on global Escape press with trigger set to ${trigger}`, async () => {
+        it(`should close on global Escape press with trigger set to ${trigger}`, async () => {
           popover.opened = true;
           await nextRender();
 
           esc(document.body);
           await nextUpdate(popover);
-          expect(overlay.opened).to.be.true;
+          expect(overlay.opened).to.be.false;
         });
 
-        it(`should not close on target Escape press with trigger set to ${trigger}`, async () => {
+        it(`should close on target Escape press with trigger set to ${trigger}`, async () => {
           popover.opened = true;
           await nextRender();
 
           esc(target);
           await nextUpdate(popover);
-          expect(overlay.opened).to.be.true;
+          expect(overlay.opened).to.be.false;
         });
 
-        it(`should not close on global Escape press when modal with trigger set to ${trigger}`, async () => {
+        it(`should close on global Escape press when modal with trigger set to ${trigger}`, async () => {
           popover.modal = true;
           popover.opened = true;
           await nextRender();
 
           esc(document.body);
           await nextUpdate(popover);
-          expect(overlay.opened).to.be.true;
+          expect(overlay.opened).to.be.false;
         });
 
-        it(`should not close on outside click when not modal with trigger set to ${trigger}`, async () => {
+        it(`should close on outside click when not modal with trigger set to ${trigger}`, async () => {
           popover.opened = true;
           await nextRender();
 
           outsideClick();
           await nextUpdate(popover);
-          expect(overlay.opened).to.be.true;
+          expect(overlay.opened).to.be.false;
         });
 
-        it(`should not close on outside click when modal with trigger set to ${trigger}`, async () => {
+        it(`should close on outside click when modal with trigger set to ${trigger}`, async () => {
           popover.modal = true;
           popover.opened = true;
           await nextRender();
 
           outsideClick();
           await nextUpdate(popover);
-          expect(overlay.opened).to.be.true;
+          expect(overlay.opened).to.be.false;
         });
 
         it(`should close when setting opened to false with trigger set to ${trigger}`, async () => {
@@ -551,6 +551,144 @@ describe('trigger', () => {
           popover.opened = false;
           await nextUpdate(popover);
           expect(overlay.opened).to.be.false;
+        });
+      });
+
+      describe('manual property', () => {
+        beforeEach(async () => {
+          popover.manual = true;
+          await nextUpdate(popover);
+        });
+
+        describe('opening', () => {
+          it('should not open on target click with click trigger in manual mode', async () => {
+            popover.trigger = ['click'];
+            target.click();
+            await nextRender();
+            expect(overlay.opened).to.be.false;
+          });
+
+          it('should not open on target mouseenter with hover trigger in manual mode', async () => {
+            popover.trigger = ['hover'];
+            mouseenter(target);
+            await nextRender();
+            expect(overlay.opened).to.be.false;
+          });
+
+          it('should not open on target focusin with focus trigger in manual mode', async () => {
+            popover.trigger = ['focus'];
+            focusin(target);
+            await nextRender();
+            expect(overlay.opened).to.be.false;
+          });
+        });
+
+        describe('closing', () => {
+          it('should not close on target click with click trigger in manual mode', async () => {
+            popover.trigger = ['click'];
+
+            popover.opened = true;
+            await nextRender();
+
+            target.click();
+            await nextRender();
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on target mouseleave with hover trigger in manual mode', async () => {
+            popover.trigger = ['hover'];
+
+            popover.opened = true;
+            await nextRender();
+
+            mouseenter(target);
+            mouseleave(target);
+            await nextRender();
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on overlay mouseleave with hover trigger in manual mode', async () => {
+            popover.trigger = ['hover'];
+
+            popover.opened = true;
+            await nextRender();
+
+            mouseenter(overlay);
+            mouseleave(overlay);
+            await nextRender();
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on target focusout with focus trigger in manual mode', async () => {
+            popover.trigger = ['focus'];
+
+            popover.opened = true;
+            await nextRender();
+
+            focusin(target);
+            focusout(target);
+            await nextRender();
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on overlay focusout with focus trigger in manual mode', async () => {
+            popover.trigger = ['focus'];
+
+            popover.opened = true;
+            await nextRender();
+
+            focusin(overlay);
+            focusout(overlay);
+            await nextRender();
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on global Escape press in manual mode', async () => {
+            popover.opened = true;
+            await nextRender();
+
+            esc(document.body);
+            await nextUpdate(popover);
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on target Escape press in manual mode', async () => {
+            popover.opened = true;
+            await nextRender();
+
+            esc(target);
+            await nextUpdate(popover);
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should close on global Escape press when modal in manual mode', async () => {
+            popover.modal = true;
+            popover.opened = true;
+            await nextRender();
+
+            esc(document.body);
+            await nextUpdate(popover);
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on outside click when not modal in manual mode', async () => {
+            popover.opened = true;
+            await nextRender();
+
+            outsideClick();
+            await nextUpdate(popover);
+            expect(overlay.opened).to.be.true;
+          });
+
+          it('should not close on outside click when modal in manual mode', async () => {
+            popover.modal = true;
+            popover.opened = true;
+            await nextRender();
+
+            outsideClick();
+            await nextUpdate(popover);
+            expect(overlay.opened).to.be.true;
+          });
         });
       });
     });

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -36,6 +36,7 @@ assertType<string>(popover.overlayClass);
 assertType<string>(popover.overlayRole);
 assertType<boolean>(popover.autofocus);
 assertType<boolean>(popover.opened);
+assertType<boolean>(popover.manual);
 assertType<boolean>(popover.modal);
 assertType<boolean>(popover.withBackdrop);
 assertType<boolean>(popover.noCloseOnEsc);


### PR DESCRIPTION
## Description

Fixes #8306

Previously, closing the popover on outside click / <kbd>Esc</kbd> key wasn't working unless some opening trigger is specified. However, in certain cases with Flow counterpart it's desirable to open popover manually while still allowing it to close on outside click / <kbd>Esc</kbd> key (see the code snippet in the issue above).

Added explicit `manual` property to align with `vaadin-tooltip` and changed the logic to use it in event listeners.
This can be considered a behavior altering change for those who relied on previous "implicit" manual behavior.

## Type of change

- Feature