### PR TITLE
chore: add failed screenshots for themes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-error.log
 .env
 
 # Failures from visual tests
+packages/*/test/visual/screenshots/failed
 packages/*/test/visual/*/screenshots/*/failed
 packages/icons/test/visual/screenshots/failed
 


### PR DESCRIPTION
## Description

In Lumo and Material themes, the path to visual test screenshots folder is different from other packages, so failed screenshots aren't currently ignored as expected. This PR fixes that.

## Type of change

- Internal change