### PR TITLE
chore: do not use vaadin prefix for icons visual test

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -162,7 +162,7 @@ const getVisualTestGroups = (packages, theme) => {
       files: `packages/vaadin-${theme}-styles/test/visual/*.test.{js,ts}`,
     })
     .concat({
-      name: `vaadin-icons`,
+      name: `icons`,
       files: `packages/icons/test/visual/*.test.{js,ts}`,
     });
 };


### PR DESCRIPTION
## Description

This is needed to make it possible to use package name for running visual tests, as with other packages:

```
yarn test:lumo --group icons
```

Currently used `vaadin-icons` group is a leftover from pre-V22 era when we had `@vaadin/vaadin-icons`.

## Type of change

- Internal change