### PR TITLE
refactor!: return a marker string to help Flow detect bad input

### DIFF
--- a/packages/field-base/src/input-mixin.d.ts
+++ b/packages/field-base/src/input-mixin.d.ts
@@ -68,6 +68,4 @@ export declare class InputMixinClass {
   protected _toggleHasValue(hasValue: boolean): void;
 
   protected _valueChanged(value?: string, oldValue?: string): void;
-
-  protected _setHasInputValue(event: InputEvent): void;
 }

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -206,7 +206,7 @@ export const InputMixin = dedupingMixin(
        * @private
        */
       __onInput(event) {
-        this._setHasInputValue(event);
+        this._hasInputValue = !!this._inputElementValue;
         this._onInput(event);
       }
 
@@ -266,20 +266,6 @@ export const InputMixin = dedupingMixin(
 
         // Setting a value programmatically, sync it to input element.
         this._forwardInputValue(newVal);
-      }
-
-      /**
-       * Sets the `_hasInputValue` property based on the `input` event.
-       *
-       * @param {InputEvent} event
-       * @protected
-       */
-      _setHasInputValue(event) {
-        // In the case a custom web component is passed as `inputElement`,
-        // the actual native input element, on which the event occurred,
-        // can be inside shadow trees.
-        const target = event.composedPath()[0];
-        this._hasInputValue = target.value.length > 0;
       }
     },
 );

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -9,10 +9,13 @@ import { InputController } from '@vaadin/field-base/src/input-controller.js';
 import { InputFieldMixin } from '@vaadin/field-base/src/input-field-mixin.js';
 import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
 
-// [type=number] inputs return an empty string for invalid numbers,
-// which makes them indistinguishable from empty values. This string
-// is used in _inputElementValue as a marker to help Flow detect and
-// clear unparsable values (if needed).
+// [type=number] value returns an empty string for invalid numbers,
+// while valueAsNumber returns NaN for empty strings, which makes
+// invalid and empty values indistinguishable. It's only possible
+// to detect unparsable input by checking the validity.badInput
+// boolean property. We use this string in _inputElementValue as
+// a marker to help Flow detect and clear unparsable values
+// (if needed).
 const BAD_INPUT_STRING = 'NaN';
 
 /**

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -413,22 +413,6 @@ export const NumberFieldMixin = (superClass) =>
     }
 
     /**
-     * Native [type=number] inputs don't update their value
-     * when you are entering input that the browser is unable to parse
-     * e.g. "--5", hence we have to override this method from `InputMixin`
-     * so that, when value is empty, it would additionally check
-     * for bad input based on the native `validity.badInput` property.
-     *
-     * @param {InputEvent} event
-     * @protected
-     * @override
-     */
-    _setHasInputValue(event) {
-      const target = event.composedPath()[0];
-      this._hasInputValue = target.value.length > 0 || !!this.__unparsableValue;
-    }
-
-    /**
      * Override this method from `InputMixin` to prevent
      * the value change caused by user input from being treated
      * as initiated programmatically by the developer and therefore

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -13,9 +13,9 @@ import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-c
 // while valueAsNumber returns NaN for empty strings, which makes
 // invalid and empty values indistinguishable. It's only possible
 // to detect unparsable input by checking the validity.badInput
-// boolean property. We use this string in _inputElementValue as
-// a marker to help Flow detect and clear unparsable values
-// (if needed).
+// boolean property. This string is used in _inputElementValue
+// as a marker to help Flow detect and clear unparsable values
+// through that property.
 const BAD_INPUT_STRING = 'NaN';
 
 /**

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -112,13 +112,12 @@ export const NumberFieldMixin = (superClass) =>
     }
 
     /**
-     * The input element's value when it cannot be parsed as a number, and an empty string otherwise.
+     * Whether the input element's value is unparsable.
      *
-     * @return {string}
      * @private
      */
-    get __unparsableValue() {
-      return this._inputElementValue === BAD_INPUT_STRING ? this._inputElementValue : '';
+    get __hasUnparsableValue() {
+      return this._inputElementValue === BAD_INPUT_STRING;
     }
 
     /** @protected */
@@ -389,7 +388,7 @@ export const NumberFieldMixin = (superClass) =>
 
       if (!this.__keepCommittedValue) {
         this.__committedValue = this.value;
-        this.__committedUnparsableValue = '';
+        this.__committedUnparsableValueStatus = false;
       }
     }
 
@@ -510,19 +509,22 @@ export const NumberFieldMixin = (superClass) =>
       if (this.__committedValue !== this.value) {
         this._requestValidation();
         this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
-      } else if (this.__committedUnparsableValue !== this.__unparsableValue) {
+      } else if (this.__committedUnparsableValueStatus !== this.__hasUnparsableValue) {
         this._requestValidation();
         this.dispatchEvent(new CustomEvent('unparsable-change'));
       }
 
       this.__committedValue = this.value;
-      this.__committedUnparsableValue = this.__unparsableValue;
+      this.__committedUnparsableValueStatus = this.__hasUnparsableValue;
     }
 
     /** @override */
     get _inputElementValue() {
-      const { validity } = this.inputElement;
-      return validity.badInput ? BAD_INPUT_STRING : super._inputElementValue;
+      if (this.inputElement && this.inputElement.validity.badInput) {
+        return BAD_INPUT_STRING;
+      }
+
+      return super._inputElementValue;
     }
 
     /** @override */

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -112,7 +112,7 @@ export const NumberFieldMixin = (superClass) =>
     }
 
     /**
-     * The input element's value when it cannot be parsed as a date, and an empty string otherwise.
+     * The input element's value when it cannot be parsed as a number, and an empty string otherwise.
      *
      * @return {string}
      * @private


### PR DESCRIPTION
## Description

This PR changes number fields to make the `_inputElementValue` getter return a `NaN` marker string when input can't be parsed. This change will allow us to [replace](https://github.com/vaadin/flow-components/pull/6991) `_hasInputValue` with `_inputElementValue` in Flow NumberField and then deprecate it in the web components. Previously, detecting bad input via `_inputElementValue` wasn't possible since `input[type=number]` elements give an empty string for unparsable values.

Since `_inputElementValue` is a protected method, I marked this as a possible breaking change

## Type of change

- [x] Bugfix
