### PR TITLE
refactor: remove no longer needed await from dialog ready

### DIFF
--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -45,7 +45,7 @@ export const DialogDraggableMixin = (superClass) =>
     }
 
     /** @protected */
-    async ready() {
+    ready() {
       super.ready();
       this._originalBounds = {};
       this._originalMouseCoords = {};
@@ -53,8 +53,6 @@ export const DialogDraggableMixin = (superClass) =>
       this._drag = this._drag.bind(this);
       this._stopDrag = this._stopDrag.bind(this);
 
-      // Wait for overlay render
-      await new Promise(requestAnimationFrame);
       this.$.overlay.$.overlay.addEventListener('mousedown', this._startDrag);
       this.$.overlay.$.overlay.addEventListener('touchstart', this._startDrag);
     }

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -24,14 +24,11 @@ export const DialogResizableMixin = (superClass) =>
     }
 
     /** @protected */
-    async ready() {
+    ready() {
       super.ready();
       this._originalBounds = {};
       this._originalMouseCoords = {};
       this._resizeListeners = { start: {}, resize: {}, stop: {} };
-
-      // Wait for overlay render
-      await new Promise(requestAnimationFrame);
       this._addResizeListeners();
     }
 


### PR DESCRIPTION
## Description

Reverted changes added in #6187 since the initial render in Lit is now synchronous and `await` is no longer needed.

## Type of change

- Refactor