### PR TITLE
fix: always strip input value to match step interval

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -593,6 +593,11 @@ export const TimePickerMixin = (superClass) =>
     __updateValue(obj) {
       const timeString = formatISOTime(validateTime(obj, this.step)) || '';
       this.value = timeString;
+
+      // Always strip the input value to match the step interval, even
+      // if the component value hasn't changed. For example, if the step
+      // is 3600 "10:00:50" should become "10:00".
+      this.__updateInputValue(obj);
     }
 
     /** @private */

--- a/packages/time-picker/test/value-commit.common.js
+++ b/packages/time-picker/test/value-commit.common.js
@@ -462,6 +462,22 @@ describe('value commit', () => {
       expectValueCommit('23:59:59');
     });
 
+    it('should strip milliseconds and commit on Enter', async () => {
+      await sendKeys({ type: '10:00:00.000' });
+      await sendKeys({ press: 'Enter' });
+      expectValueCommit('10:00:00');
+      expect(timePicker.inputElement.value).to.equal('10:00:00');
+    });
+
+    it('should strip milliseconds without commit on Enter if value was unchanged', async () => {
+      timePicker.value = '10:00:00';
+      valueChangedSpy.resetHistory();
+      await sendKeys({ type: '.000' });
+      await sendKeys({ press: 'Enter' });
+      expectNoValueCommit();
+      expect(timePicker.inputElement.value).to.equal('10:00:00');
+    });
+
     describe('with arrow key committed', () => {
       beforeEach(async () => {
         await sendKeys({ press: 'ArrowDown' });


### PR DESCRIPTION
## Description

Fixes the issue where time-picker would not strip milliseconds on commit attempt when the value remained unchanged.

Fixes https://github.com/vaadin/web-components/issues/711

## Type of change

- [x] Bugfix
