### PR TITLE
feat: add support for Gantt task progress indication

### DIFF
--- a/packages/charts/theme/vaadin-chart-base-theme.js
+++ b/packages/charts/theme/vaadin-chart-base-theme.js
@@ -1030,6 +1030,7 @@ const chartBaseTheme = css`
     stroke-width: 1px;
   }
 
+	/* Workaround for https://github.com/highcharts/highcharts/issues/22490 */
   :where([styled-mode]) .highcharts-gantt-series .highcharts-partfill-overlay {
     fill: hsla(0, 0%, 0%, 0.3);
     stroke: hsla(0, 0%, 0%, 0.3);

--- a/packages/charts/theme/vaadin-chart-base-theme.js
+++ b/packages/charts/theme/vaadin-chart-base-theme.js
@@ -1030,6 +1030,11 @@ const chartBaseTheme = css`
     stroke-width: 1px;
   }
 
+  :where([styled-mode]) .highcharts-gantt-series .highcharts-partfill-overlay {
+    fill: hsla(0, 0%, 0%, 0.3);
+    stroke: hsla(0, 0%, 0%, 0.3);
+  }
+
   /* RTL styles */
   :host([dir='rtl']) :where([styled-mode]) .highcharts-container {
     text-align: right;

--- a/packages/charts/theme/vaadin-chart-base-theme.js
+++ b/packages/charts/theme/vaadin-chart-base-theme.js
@@ -1030,7 +1030,7 @@ const chartBaseTheme = css`
     stroke-width: 1px;
   }
 
-	/* Workaround for https://github.com/highcharts/highcharts/issues/22490 */
+  /* Workaround for https://github.com/highcharts/highcharts/issues/22490 */
   :where([styled-mode]) .highcharts-gantt-series .highcharts-partfill-overlay {
     fill: hsla(0, 0%, 0%, 0.3);
     stroke: hsla(0, 0%, 0%, 0.3);


### PR DESCRIPTION
## Description

In the Highcharts Gantt chart, you can create tasks (as data points of the series) and using the `completed` property you can define how much the given task is completed:

<img width="433" alt="image" src="https://github.com/user-attachments/assets/22910b4c-9d27-4faa-befa-e3f78beda0a0" />

 This should be visually represented in the chart (for example, see this demo: https://www.highcharts.com/demo/gantt/progress-indicator). While testing Gantt chart integration in Vaadin `<vaadin-chart>` component, I noticed that the progress is not visible in the chart at all.
The reason for it was that in the `styled mode` there is no custom style defined for the progress element overlay:

<img width="896" alt="SCR-20250102-jjfn" src="https://github.com/user-attachments/assets/b0151ee8-157c-4e2a-95be-16390cc06338" />

This change introduces a proper style, that darkens the underlying color a bit so the progress is visible (the default behavior of the Highcharts Gantt is also to darken the underlying color):

<img width="897" alt="SCR-20250102-jjbv" src="https://github.com/user-attachments/assets/9fae600a-0871-4037-b477-14dd2dcd383f" />

Part of https://github.com/vaadin/flow-components/issues/4731

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
