### PR TITLE
test: increase clock tick time to fix local failure

### DIFF
--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -164,7 +164,7 @@ const runTests = (defineHelper, baseMixin) => {
         element.invalid = true;
         element.setAttribute('error-message', 'This field is required');
         await nextUpdate(element);
-        clock.tick(150);
+        clock.tick(200);
         expect(announceRegion.textContent).to.equal('This field is required');
         expect(announceRegion.getAttribute('aria-live')).to.equal('assertive');
       });
@@ -173,7 +173,7 @@ const runTests = (defineHelper, baseMixin) => {
         element.invalid = true;
         element.errorMessage = 'This field is required';
         await nextUpdate(element);
-        clock.tick(150);
+        clock.tick(200);
         expect(announceRegion.textContent).to.equal('This field is required');
         expect(announceRegion.getAttribute('aria-live')).to.equal('assertive');
       });
@@ -181,7 +181,7 @@ const runTests = (defineHelper, baseMixin) => {
       it('should not announce error message when field is valid', async () => {
         element.errorMessage = 'This field is required';
         await nextUpdate(element);
-        clock.tick(150);
+        clock.tick(200);
         expect(announceRegion.textContent).to.equal('');
       });
     });


### PR DESCRIPTION
## Description

Increased the fake clock tick time from 150ms to 200ms to fix the test failure, which apparently happens only locally:

```
➜  web-components git:(main) ✗ yarn test --group field-base
yarn run v1.22.19
$ web-test-runner --group field-base

packages/field-base/test/field-mixin.test.js:

 ❌ FieldMixin + Polymer > error message > announcements > should not announce error message when field is valid
      AssertionError: expected 'This field is required' to equal ''
      + expected - actual

      -This field is required

      at n.<anonymous> (packages/field-base/test/field-mixin.test.js:185:47)

Chromium: |██████████████████████████████| 14/14 test files | 672 passed, 1 failed, 4 skipped

Finished running tests in 6s with 1 failed tests.
```

## Type of change

- [x] Internal
