### PR TITLE
fix: check if options object is defined when creating property

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -52,7 +52,7 @@ const PolylitMixinImplementation = (superclass) => {
         };
       }
 
-      if (options.reflectToAttribute) {
+      if (options && options.reflectToAttribute) {
         options.reflect = true;
       }
 

--- a/packages/component-base/test/polylit-mixin.test.js
+++ b/packages/component-base/test/polylit-mixin.test.js
@@ -1359,4 +1359,13 @@ describe('PolylitMixin', () => {
       expect(valueChangedSpy).to.be.calledOnce;
     });
   });
+
+  describe('createProperty', () => {
+    it('should not throw when calling createProperty() without options', () => {
+      expect(() => {
+        const PolyLitClass = class extends PolylitMixin(LitElement) {};
+        PolyLitClass.createProperty('prop');
+      }).to.not.throw(Error);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #8419

This should fix the problem with `@property()` decorator where the `options` object can be undefined.

## Type of change

- Bugfix