### PR TITLE
fix: generate aria-label attribute on the avatar

### DIFF
--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -7,6 +7,7 @@ snapshots["vaadin-avatar-group default"] =
     abbr="+0"
     aria-expanded="false"
     aria-haspopup="menu"
+    aria-label="+0"
     hidden=""
     role="button"
     slot="overflow"
@@ -23,6 +24,7 @@ snapshots["vaadin-avatar-group items"] =
 `<vaadin-avatar-group aria-label="Currently 2 active users">
   <vaadin-avatar
     abbr="YY"
+    aria-label="YY"
     role="img"
     tabindex="0"
     with-tooltip=""
@@ -32,6 +34,7 @@ snapshots["vaadin-avatar-group items"] =
   </vaadin-avatar>
   <vaadin-avatar
     abbr="TV"
+    aria-label="TV"
     name="Tomi Virkki"
     role="img"
     tabindex="0"
@@ -44,6 +47,7 @@ snapshots["vaadin-avatar-group items"] =
     abbr="+2"
     aria-expanded="false"
     aria-haspopup="menu"
+    aria-label="+2"
     hidden=""
     role="button"
     slot="overflow"
@@ -63,6 +67,7 @@ snapshots["vaadin-avatar-group theme"] =
 >
   <vaadin-avatar
     abbr="YY"
+    aria-label="YY"
     role="img"
     tabindex="0"
     theme="small"
@@ -73,6 +78,7 @@ snapshots["vaadin-avatar-group theme"] =
   </vaadin-avatar>
   <vaadin-avatar
     abbr="TV"
+    aria-label="TV"
     name="Tomi Virkki"
     role="img"
     tabindex="0"
@@ -86,6 +92,7 @@ snapshots["vaadin-avatar-group theme"] =
     abbr="+2"
     aria-expanded="false"
     aria-haspopup="menu"
+    aria-label="+2"
     hidden=""
     role="button"
     slot="overflow"
@@ -103,6 +110,7 @@ snapshots["vaadin-avatar-group opened default"] =
 `<vaadin-avatar-group aria-label="Currently 4 active users">
   <vaadin-avatar
     abbr="AD"
+    aria-label="AD"
     name="Abc Def"
     role="img"
     tabindex="0"
@@ -113,6 +121,7 @@ snapshots["vaadin-avatar-group opened default"] =
   </vaadin-avatar>
   <vaadin-avatar
     abbr="GJ"
+    aria-label="GJ"
     name="Ghi Jkl"
     role="img"
     tabindex="0"
@@ -125,6 +134,7 @@ snapshots["vaadin-avatar-group opened default"] =
     abbr="+2"
     aria-expanded="false"
     aria-haspopup="menu"
+    aria-label="+2"
     focused=""
     role="button"
     slot="overflow"
@@ -156,6 +166,7 @@ snapshots["vaadin-avatar-group opened overlay"] =
       <vaadin-avatar
         abbr="MP"
         aria-hidden="true"
+        aria-label="Mno Pqr (MP)"
         name="Mno Pqr"
         role="img"
         tabindex="-1"
@@ -171,6 +182,7 @@ snapshots["vaadin-avatar-group opened overlay"] =
       <vaadin-avatar
         abbr="SV"
         aria-hidden="true"
+        aria-label="Stu Vwx (SV)"
         name="Stu Vwx"
         role="img"
         tabindex="-1"
@@ -203,6 +215,7 @@ snapshots["vaadin-avatar-group opened overlay class"] =
       <vaadin-avatar
         abbr="MP"
         aria-hidden="true"
+        aria-label="Mno Pqr (MP)"
         name="Mno Pqr"
         role="img"
         tabindex="-1"
@@ -218,6 +231,7 @@ snapshots["vaadin-avatar-group opened overlay class"] =
       <vaadin-avatar
         abbr="SV"
         aria-hidden="true"
+        aria-label="Stu Vwx (SV)"
         name="Stu Vwx"
         role="img"
         tabindex="-1"

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -185,6 +185,14 @@ export const AvatarMixin = (superClass) =>
           this.__setTooltip(name);
         }
       }
+
+      if (abbr) {
+        // By default, generate aria-label attribute containing the abbr value.
+        // When no tooltip is set, prefix the aria-label with the name value.
+        this.setAttribute('aria-label', !tooltipNode && name ? `${name} (${abbr})` : abbr);
+      } else {
+        this.removeAttribute('aria-label');
+      }
     }
 
     /** @private */

--- a/packages/avatar/test/avatar.common.js
+++ b/packages/avatar/test/avatar.common.js
@@ -389,5 +389,33 @@ describe('vaadin-avatar', () => {
       const custom = fixtureSync('<vaadin-avatar role="button"></vaadin-avatar>');
       expect(custom.getAttribute('role')).to.equal('button');
     });
+
+    it('should set aria-label attribute to abbr value by default', async () => {
+      avatar.abbr = 'JD';
+      await nextUpdate(avatar);
+      expect(avatar.getAttribute('aria-label')).to.equal('JD');
+    });
+
+    it('should add name to aria-label attribute when tooltip is not set', async () => {
+      avatar.name = 'John Doe';
+      await nextUpdate(avatar);
+      expect(avatar.getAttribute('aria-label')).to.equal('John Doe (JD)');
+    });
+
+    it('should not add name to aria-label attribute when tooltip is set', async () => {
+      avatar.name = 'John Doe';
+      avatar.withTooltip = true;
+      await nextUpdate(avatar);
+      expect(avatar.getAttribute('aria-label')).to.equal('JD');
+    });
+
+    it('should remove aria-label attribute when abbr property is removed', async () => {
+      avatar.abbr = 'JD';
+      await nextUpdate(avatar);
+
+      avatar.abbr = null;
+      await nextUpdate(avatar);
+      expect(avatar.hasAttribute('aria-label')).to.be.false;
+    });
   });
 });

--- a/packages/message-list/test/dom/__snapshots__/message-list.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message-list.test.snap.js
@@ -23,6 +23,7 @@ snapshots["vaadin-message-list items"] =
     <vaadin-avatar
       abbr="JD"
       aria-hidden="true"
+      aria-label="Jane Doe (JD)"
       name="Jane Doe"
       role="img"
       slot="avatar"
@@ -38,6 +39,7 @@ snapshots["vaadin-message-list items"] =
     <vaadin-avatar
       abbr="LR"
       aria-hidden="true"
+      aria-label="Lina Roy (LR)"
       name="Lina Roy"
       role="img"
       slot="avatar"
@@ -63,6 +65,7 @@ snapshots["vaadin-message-list theme"] =
     <vaadin-avatar
       abbr="A"
       aria-hidden="true"
+      aria-label="Admin (A)"
       name="Admin"
       role="img"
       slot="avatar"
@@ -88,6 +91,7 @@ snapshots["vaadin-message-list className"] =
     <vaadin-avatar
       abbr="A"
       aria-hidden="true"
+      aria-label="Admin (A)"
       name="Admin"
       role="img"
       slot="avatar"

--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -62,6 +62,7 @@ snapshots["vaadin-message avatar username"] =
   <vaadin-avatar
     abbr="JD"
     aria-hidden="true"
+    aria-label="Joan Doe (JD)"
     name="Joan Doe"
     role="img"
     slot="avatar"
@@ -77,6 +78,7 @@ snapshots["vaadin-message avatar abbr"] =
   <vaadin-avatar
     abbr="JD"
     aria-hidden="true"
+    aria-label="JD"
     role="img"
     slot="avatar"
     tabindex="-1"


### PR DESCRIPTION
## Description

Fixes #142

Implemented `aria-label` attribute generation as suggested in https://github.com/vaadin/web-components/issues/142#issuecomment-2567392258

## Type of change

- Bugfix