### PR TITLE
refactor: use minRows property for message input textarea

### DIFF
--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -116,11 +116,7 @@ export const MessageInputMixin = (superClass) =>
             }
           });
 
-          const input = textarea.inputElement;
-
-          // Set initial height to one row
-          input.setAttribute('rows', 1);
-          input.style.minHeight = '0';
+          textarea.minRows = 1;
 
           this._textArea = textarea;
         },

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -33,7 +33,6 @@ snapshots["vaadin-message-input default"] =
       placeholder="Message"
       rows="1"
       slot="textarea"
-      style="min-height: 0px;"
     >
     </textarea>
   </vaadin-text-area>
@@ -78,7 +77,6 @@ snapshots["vaadin-message-input disabled"] =
       placeholder="Message"
       rows="1"
       slot="textarea"
-      style="min-height: 0px;"
       tabindex="-1"
     >
     </textarea>


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/web-components/pull/8168

Now when we can set `minRows` to `1`, let's use this API instead of modifying native `<textarea>`.

## Type of change

- Refactor