### PR TITLE
test: move app-layout styles import to avoid warning with Lit

### DIFF
--- a/packages/app-layout/test/app-layout-lit.test.js
+++ b/packages/app-layout/test/app-layout-lit.test.js
@@ -1,3 +1,4 @@
+import './not-animated-styles.js';
 import '../src/vaadin-lit-app-layout.js';
 import '../src/vaadin-lit-drawer-toggle.js';
 import './app-layout.common.js';

--- a/packages/app-layout/test/app-layout-polymer.test.js
+++ b/packages/app-layout/test/app-layout-polymer.test.js
@@ -1,3 +1,4 @@
+import './not-animated-styles.js';
 import '../vaadin-app-layout.js';
 import '../vaadin-drawer-toggle.js';
 import './app-layout.common.js';

--- a/packages/app-layout/test/app-layout.common.js
+++ b/packages/app-layout/test/app-layout.common.js
@@ -10,7 +10,6 @@ import {
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
 
 describe('vaadin-app-layout', () => {
   let layout;


### PR DESCRIPTION
## Description

This fixes the following warning introduced in #8387:

```
packages/app-layout/test/app-layout-lit.test.js:

 🚧 Browser logs:
      The custom element definition for "vaadin-app-layout" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting "window.Vaadin.suppressPostFinalizeStylesWarning = true".
```

## Type of change

- Test