### PR TITLE
test: replace flushGrid with nextFrame to fix local failure

### DIFF
--- a/packages/grid/test/keyboard-navigation-row-focus.common.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.common.js
@@ -144,7 +144,7 @@ describe('keyboard navigation - row focus', () => {
   });
 
   describe('scrolling and navigating', () => {
-    it('should scroll focused nested row into view on arrow key', () => {
+    it('should scroll focused nested row into view on arrow key', async () => {
       focusItem(0);
       // Expand first row
       right();
@@ -153,12 +153,12 @@ describe('keyboard navigation - row focus', () => {
       // Simulate real scrolling to get the virtualizer to render
       // the focused item in a different element.
       grid.$.table.scrollTop = grid.$.table.scrollHeight / 2;
-      flushGrid(grid);
+      await nextFrame();
       down();
       expect(getFocusedRowIndex(grid)).to.equal(2);
     });
 
-    it('should scroll focused nested row into view on Tab', () => {
+    it('should scroll focused nested row into view on Tab', async () => {
       focusItem(0);
       // Expand first row
       right();
@@ -169,7 +169,7 @@ describe('keyboard navigation - row focus', () => {
       // Simulate real scrolling to get the virtualizer to render
       // the focused item in a different element.
       grid.$.table.scrollTop = grid.$.table.scrollHeight / 2;
-      flushGrid(grid);
+      await nextFrame();
       // Move focus back to items
       tab();
       expect(getFocusedRowIndex(grid)).to.equal(1);


### PR DESCRIPTION
## Description

Replacing `flushGrid` with `nextFrame` helps deal with this failure when running tests locally in Firefox:

```
yarn test:firefox --group grid --glob="keyboard-navigation-row-focus*"
yarn run v1.22.19
$ web-test-runner --config web-test-runner-firefox.config.js --group grid '--glob=keyboard-navigation-row-focus*'

packages/grid/test/keyboard-navigation-row-focus-polymer.test.js:

 ❌ keyboard navigation - row focus > scrolling and navigating > should scroll focused nested row into view on Tab
      TypeError: Node.insertBefore: Argument 1 is not an object.
        at __reorderElements (packages/component-base/src/virtualizer-iron-list-adapter.js:824:32)
        at _scrollHandler/this.__scrollReorderDebouncer< (packages/component-base/src/virtualizer-iron-list-adapter.js:567:20)
        at flush (packages/component-base/src/debounce.js:124:12)
        at flush (packages/component-base/src/virtualizer-iron-list-adapter.js:162:37)
        at flush (packages/component-base/src/virtualizer.js:81:20)
        at flushGrid (packages/grid/test/helpers.js:17:22)
        at packages/grid/test/keyboard-navigation-row-focus.common.js:172:16
```

Follow-up to #8355 

## Type of change

- [x] Internal
