### PR TITLE
test: fix flaky RTE test by moving Tab tests to a separate suite

### DIFF
--- a/packages/rich-text-editor/test/a11y.common.js
+++ b/packages/rich-text-editor/test/a11y.common.js
@@ -100,7 +100,6 @@ describe('accessibility', () => {
       editor = rte._editor;
       buttons = Array.from(rte.shadowRoot.querySelectorAll(`[part=toolbar] button`));
       content = rte.shadowRoot.querySelector('[contenteditable]');
-      announcer = rte.shadowRoot.querySelector('[aria-live=polite]');
     });
 
     it('should have only one tabbable button in toolbar', () => {


### PR DESCRIPTION
## Description

Moves Tab RTE tests to a separate suite to ensure there is only one RTE on the page, which seems to fix the flakiness in Webkit.

Follow-up #8355 

## Type of change

- [x] Internal
