### PR TITLE
fix: also apply focus-ring width custom property to invalid state

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -106,7 +106,7 @@ const inputField = css`
   }
 
   :host([invalid][focus-ring]) [part='input-field'] {
-    box-shadow: 0 0 0 2px var(--lumo-error-color-50pct);
+    box-shadow: 0 0 0 var(--_focus-ring-width) var(--lumo-error-color-50pct);
   }
 
   :host([input-prevented]) [part='input-field'] {


### PR DESCRIPTION
## Description

Currently, the focus-ring width is hardcoded to `2px` in case of `invalid` state.
I checked https://github.com/vaadin/web-components/pull/6634 and there was no mention of it, most probably it's an oversight.

## Type of change

- Bugfix