### PR TITLE
fix: add missing hidden attribute styles to board and board row

### DIFF
--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -64,6 +64,10 @@ class BoardRow extends BoardRowMixin(ElementMixin(PolymerElement)) {
           --medium-size: var(--vaadin-board-width-medium, 960px);
         }
 
+        :host([hidden]) {
+          display: none !important;
+        }
+
         :host ::slotted(*) {
           box-sizing: border-box;
           flex-grow: 1;

--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -44,6 +44,10 @@ class Board extends ElementMixin(PolymerElement) {
         :host {
           display: block;
         }
+
+        :host([hidden]) {
+          display: none !important;
+        }
       </style>
       <slot></slot>
     `;


### PR DESCRIPTION
## Description

Both `vaadin-board` and `vaadin-board-row` are missing styles for `hidden` attribute. This PR fixes that.

## Type of change

- Bugfix