### PR TITLE
refactor: extract map logic into reusable mixin

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -35,6 +35,7 @@
     "polymer"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "24.7.0-alpha4",
     "@vaadin/component-base": "24.7.0-alpha4",

--- a/packages/map/src/vaadin-map-mixin.d.ts
+++ b/packages/map/src/vaadin-map-mixin.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type OpenLayersMap from 'ol/Map.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
+import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
+
+export declare function MapMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<MapMixinClass> & Constructor<ResizeMixinClass> & Constructor<FocusMixinClass> & T;
+
+export declare class MapMixinClass {
+  /**
+   * The internal OpenLayers map instance used to configure the map.
+   * See the OpenLayers [API](https://openlayers.org/en/latest/apidoc/) and
+   * [examples](https://openlayers.org/en/latest/examples/) for further information.
+   * @returns {*}
+   */
+  get configuration(): OpenLayersMap;
+}

--- a/packages/map/src/vaadin-map-mixin.js
+++ b/packages/map/src/vaadin-map-mixin.js
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { defaults as defaultControls } from 'ol/control';
+import { defaults as defaultInteractions } from 'ol/interaction';
+import OpenLayersMap from 'ol/Map.js';
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
+import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
+
+/**
+ * @polymerMixin
+ * @mixes ResizeMixin
+ * @mixes FocusMixin
+ */
+export const MapMixin = (superClass) =>
+  class extends FocusMixin(ResizeMixin(superClass)) {
+    constructor() {
+      super();
+      // Create map container element and initialize OL map instance
+      this._mapTarget = document.createElement('div');
+      this._mapTarget.id = 'map';
+      // Ensure accessible keyboard controls are enabled
+      this._mapTarget.setAttribute('tabindex', '0');
+      const options = {
+        // Override default controls to remove default labels, which is required to
+        // correctly display icons through pseudo-element
+        controls: defaultControls({
+          rotate: false,
+          zoomOptions: { zoomInLabel: '', zoomOutLabel: '' },
+        }),
+        // Override default interactions to allow mouse-wheel zoom + drag-pan when not focused
+        interactions: defaultInteractions({ onFocusOnly: false }),
+        target: this._mapTarget,
+      };
+      this._configuration = new OpenLayersMap(options);
+    }
+
+    /**
+     * The internal OpenLayers map instance used to configure the map.
+     * See the OpenLayers [API](https://openlayers.org/en/latest/apidoc/) and
+     * [examples](https://openlayers.org/en/latest/examples/) for further information.
+     * @returns {*}
+     */
+    get configuration() {
+      return this._configuration;
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+      // Add map container to shadow root, trigger OL resize calculation
+      this.shadowRoot.appendChild(this._mapTarget);
+      this.__addMapFocusListeners();
+    }
+
+    /**
+     * Implements resize callback from ResizeMixin to update size of OL map instance
+     * @override
+     * @protected
+     */
+    _onResize(_contentRect) {
+      this._configuration.updateSize();
+    }
+
+    /**
+     * Registers focus listeners on the map container to manually manage focus in
+     * FocusMixin. FocusMixin currently assumes that the focusable element will
+     * be in the light DOM and is available as event target.
+     * The map container however is in the shadow DOM and thus focus events will
+     * always have the host element as target.
+     * @private
+     */
+    __addMapFocusListeners() {
+      this._mapTarget.addEventListener('focusin', (e) => {
+        if (e.target === this._mapTarget) {
+          this._setFocused(true);
+        }
+      });
+      this._mapTarget.addEventListener('focusout', () => {
+        this._setFocused(false);
+      });
+    }
+
+    /**
+     * Overrides method from `FocusMixin` to disable automatic focus management.
+     * See custom logic in __addMapFocusListeners
+     *
+     * @param {FocusEvent} _event
+     * @return {boolean}
+     * @override
+     * @protected
+     */
+    _shouldSetFocus(_event) {
+      return false;
+    }
+  };

--- a/packages/map/src/vaadin-map.d.ts
+++ b/packages/map/src/vaadin-map.d.ts
@@ -8,11 +8,9 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import type OpenLayersMap from 'ol/Map.js';
-import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
+import { MapMixin } from './vaadin-map-mixin.js';
 
 /**
  * `vaadin-map` is a web component for displaying web maps.
@@ -50,18 +48,9 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin
- * @mixes FocusMixin
- * @mixes ResizeMixin
+ * @mixes MapMixin
  */
-declare class Map extends ResizeMixin(FocusMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
-  /**
-   * The internal OpenLayers map instance used to configure the map.
-   * See the OpenLayers [API](https://openlayers.org/en/latest/apidoc/) and
-   * [examples](https://openlayers.org/en/latest/examples/) for further information.
-   * @returns {*}
-   */
-  get configuration(): OpenLayersMap;
-}
+declare class Map extends MapMixin(ThemableMixin(ElementMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -9,14 +9,10 @@
  * license.
  */
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { defaults as defaultControls } from 'ol/control';
-import { defaults as defaultInteractions } from 'ol/interaction';
-import OpenLayersMap from 'ol/Map.js';
-import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { MapMixin } from './vaadin-map-mixin.js';
 import { mapStyles } from './vaadin-map-styles.js';
 
 registerStyles('vaadin-map', mapStyles, { moduleId: 'vaadin-map-styles' });
@@ -57,16 +53,11 @@ registerStyles('vaadin-map', mapStyles, { moduleId: 'vaadin-map-styles' });
  *
  * @customElement
  * @extends HTMLElement
+ * @mixes MapMixin
  * @mixes ThemableMixin
  * @mixes ElementMixin
- * @mixes FocusMixin
- * @mixes ResizeMixin
  */
-class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerElement)))) {
-  static get template() {
-    return html``;
-  }
-
+class Map extends MapMixin(ThemableMixin(ElementMixin(PolymerElement))) {
   static get is() {
     return 'vaadin-map';
   }
@@ -75,84 +66,8 @@ class Map extends ResizeMixin(FocusMixin(ElementMixin(ThemableMixin(PolymerEleme
     return 'vaadin-map';
   }
 
-  constructor() {
-    super();
-    // Create map container element and initialize OL map instance
-    this._mapTarget = document.createElement('div');
-    this._mapTarget.id = 'map';
-    // Ensure accessible keyboard controls are enabled
-    this._mapTarget.setAttribute('tabindex', '0');
-    const options = {
-      // Override default controls to remove default labels, which is required to
-      // correctly display icons through pseudo-element
-      controls: defaultControls({
-        rotate: false,
-        zoomOptions: { zoomInLabel: '', zoomOutLabel: '' },
-      }),
-      // Override default interactions to allow mouse-wheel zoom + drag-pan when not focused
-      interactions: defaultInteractions({ onFocusOnly: false }),
-      target: this._mapTarget,
-    };
-    this._configuration = new OpenLayersMap(options);
-  }
-
-  /**
-   * The internal OpenLayers map instance used to configure the map.
-   * See the OpenLayers [API](https://openlayers.org/en/latest/apidoc/) and
-   * [examples](https://openlayers.org/en/latest/examples/) for further information.
-   * @returns {*}
-   */
-  get configuration() {
-    return this._configuration;
-  }
-
-  /** @protected */
-  ready() {
-    super.ready();
-    // Add map container to shadow root, trigger OL resize calculation
-    this.shadowRoot.appendChild(this._mapTarget);
-    this.__addMapFocusListeners();
-  }
-
-  /**
-   * Implements resize callback from ResizeMixin to update size of OL map instance
-   * @override
-   * @protected
-   */
-  _onResize(_contentRect) {
-    this._configuration.updateSize();
-  }
-
-  /**
-   * Registers focus listeners on the map container to manually manage focus in
-   * FocusMixin. FocusMixin currently assumes that the focusable element will
-   * be in the light DOM and is available as event target.
-   * The map container however is in the shadow DOM and thus focus events will
-   * always have the host element as target.
-   * @private
-   */
-  __addMapFocusListeners() {
-    this._mapTarget.addEventListener('focusin', (e) => {
-      if (e.target === this._mapTarget) {
-        this._setFocused(true);
-      }
-    });
-    this._mapTarget.addEventListener('focusout', () => {
-      this._setFocused(false);
-    });
-  }
-
-  /**
-   * Overrides method from `FocusMixin` to disable automatic focus management.
-   * See custom logic in __addMapFocusListeners
-   *
-   * @param {FocusEvent} _event
-   * @return {boolean}
-   * @override
-   * @protected
-   */
-  _shouldSetFocus(_event) {
-    return false;
+  static get template() {
+    return html``;
   }
 }
 


### PR DESCRIPTION
## Description

Extracted `vaadin-map` logic into mixin to be reused by the Lit version.

## Type of change

- Refactor