### PR TITLE
refactor: extract field highlighter styles into reusable css literals

### DIFF
--- a/packages/field-highlighter/src/vaadin-field-highlighter-styles.d.ts
+++ b/packages/field-highlighter/src/vaadin-field-highlighter-styles.d.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const fieldOutlineStyles: CSSResult;
+
+export const userTagStyles: CSSResult;
+
+export const userTagsOverlayStyles: CSSResult;

--- a/packages/field-highlighter/src/vaadin-field-highlighter-styles.js
+++ b/packages/field-highlighter/src/vaadin-field-highlighter-styles.js
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const fieldOutlineStyles = css`
+  :host {
+    display: block;
+    box-sizing: border-box;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    user-select: none;
+    opacity: 0;
+    --_active-user-color: transparent;
+  }
+
+  :host([has-active-user]) {
+    opacity: 1;
+  }
+`;
+
+export const userTagStyles = css`
+  :host {
+    display: block;
+    box-sizing: border-box;
+    margin: 0 0 var(--vaadin-user-tag-offset);
+    opacity: 0;
+    height: 1.3rem;
+    transition: opacity 0.2s ease-in-out;
+    background-color: var(--vaadin-user-tag-color);
+    color: #fff;
+    cursor: default;
+    -webkit-user-select: none;
+    user-select: none;
+    --vaadin-user-tag-offset: 4px;
+  }
+
+  :host(.show) {
+    opacity: 1;
+  }
+
+  :host(:last-of-type) {
+    margin-bottom: 0;
+  }
+
+  [part='name'] {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+    padding: 2px 4px;
+    height: 1.3rem;
+    font-size: 13px;
+  }
+`;
+
+export const userTagsOverlayStyles = css`
+  :host {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  [part='overlay'] {
+    box-shadow: none;
+    background: transparent;
+    position: relative;
+    left: -4px;
+    padding: 4px;
+    outline: none;
+    overflow: visible;
+  }
+
+  ::slotted([part='tags']) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  :host([dir='rtl']) [part='overlay'] {
+    left: auto;
+    right: -4px;
+  }
+
+  [part='content'] {
+    padding: 0;
+  }
+
+  :host([opening]),
+  :host([closing]) {
+    animation: 0.14s user-tags-overlay-dummy-animation;
+  }
+
+  @keyframes user-tags-overlay-dummy-animation {
+    0% {
+      opacity: 1;
+    }
+
+    100% {
+      opacity: 1;
+    }
+  }
+`;

--- a/packages/field-highlighter/src/vaadin-field-outline.js
+++ b/packages/field-highlighter/src/vaadin-field-outline.js
@@ -6,7 +6,10 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { fieldOutlineStyles } from './vaadin-field-highlighter-styles.js';
+
+registerStyles('vaadin-field-outline', fieldOutlineStyles, { moduleId: 'vaadin-field-outline-styles' });
 
 /**
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
@@ -22,26 +25,7 @@ export class FieldOutline extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: block;
-          box-sizing: border-box;
-          position: absolute;
-          inset: 0;
-          width: 100%;
-          height: 100%;
-          pointer-events: none;
-          user-select: none;
-          opacity: 0;
-          --_active-user-color: transparent;
-        }
-
-        :host([has-active-user]) {
-          opacity: 1;
-        }
-      </style>
-    `;
+    return html``;
   }
 
   static get properties() {

--- a/packages/field-highlighter/src/vaadin-user-tag.js
+++ b/packages/field-highlighter/src/vaadin-user-tag.js
@@ -6,7 +6,10 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { userTagStyles } from './vaadin-field-highlighter-styles.js';
+
+registerStyles('vaadin-user-tag', userTagStyles, { moduleId: 'vaadin-user-tag-styles' });
 
 /**
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
@@ -23,43 +26,7 @@ export class UserTag extends ThemableMixin(DirMixin(PolymerElement)) {
   }
 
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: block;
-          box-sizing: border-box;
-          margin: 0 0 var(--vaadin-user-tag-offset);
-          opacity: 0;
-          height: 1.3rem;
-          transition: opacity 0.2s ease-in-out;
-          background-color: var(--vaadin-user-tag-color);
-          color: #fff;
-          cursor: default;
-          -webkit-user-select: none;
-          user-select: none;
-          --vaadin-user-tag-offset: 4px;
-        }
-
-        :host(.show) {
-          opacity: 1;
-        }
-
-        :host(:last-of-type) {
-          margin-bottom: 0;
-        }
-
-        [part='name'] {
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-          box-sizing: border-box;
-          padding: 2px 4px;
-          height: 1.3rem;
-          font-size: 13px;
-        }
-      </style>
-      <div part="name">[[name]]</div>
-    `;
+    return html`<div part="name">[[name]]</div>`;
   }
 
   static get properties() {

--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -9,54 +9,8 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
-import { css, registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-
-const userTagsOverlayStyles = css`
-  :host {
-    background: transparent;
-    box-shadow: none;
-  }
-
-  [part='overlay'] {
-    box-shadow: none;
-    background: transparent;
-    position: relative;
-    left: -4px;
-    padding: 4px;
-    outline: none;
-    overflow: visible;
-  }
-
-  ::slotted([part='tags']) {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  :host([dir='rtl']) [part='overlay'] {
-    left: auto;
-    right: -4px;
-  }
-
-  [part='content'] {
-    padding: 0;
-  }
-
-  :host([opening]),
-  :host([closing]) {
-    animation: 0.14s user-tags-overlay-dummy-animation;
-  }
-
-  @keyframes user-tags-overlay-dummy-animation {
-    0% {
-      opacity: 1;
-    }
-
-    100% {
-      opacity: 1;
-    }
-  }
-`;
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { userTagsOverlayStyles } from './vaadin-field-highlighter-styles.js';
 
 registerStyles('vaadin-user-tags-overlay', [overlayStyles, userTagsOverlayStyles]);
 


### PR DESCRIPTION
## Description

Extracted `vaadin-field-highlighter` styles into CSS tagged literals for reusing by LitElement based version.

## Type of change

- Refactor