### PR TITLE
refactor: remove use of calculateSplices in user tags

### DIFF
--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -264,11 +264,13 @@ export class UserTags extends PolymerElement {
     const hasOldUsers = Array.isArray(this.users);
 
     if (hasOldUsers) {
-      removedUsers = this.users.filter((item) => hasNewUsers && !users.includes(item));
+      const newUserIds = (users || []).map((user) => user.id);
+      removedUsers = this.users.filter((item) => !newUserIds.includes(item.id));
     }
 
     if (hasNewUsers) {
-      addedUsers = [...users].reverse().filter((item) => hasOldUsers && !this.users.includes(item));
+      const oldUserIds = (this.users || []).map((user) => user.id);
+      addedUsers = users.filter((item) => !oldUserIds.includes(item.id)).reverse();
     }
 
     if (addedUsers.length === 0 && removedUsers.length === 0) {

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -108,6 +108,14 @@ describe('user-tags', () => {
       expect(getComputedStyle(tags[1]).backgroundColor).to.equal('rgb(255, 0, 0)');
     });
 
+    it('should not clear tags with a new instance of same user', () => {
+      setUsers([user1]);
+      setUsers([{ ...user1 }]);
+
+      const tags = getTags();
+      expect(tags).to.have.lengthOf(1);
+    });
+
     it('should not set custom property if index is null', () => {
       addUser({ name: 'xyz', colorIndex: null });
       const tags = getTags();


### PR DESCRIPTION
## Description

Remove the use of `calculateSplices` in `<vaadin-user-tags>` as suggested in https://github.com/vaadin/web-components/pull/8494#pullrequestreview-2542593734

## Type of change

Refactor