### PR TITLE
fix: do not stop ignored dragleave events in grid

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -222,9 +222,6 @@ export const DragAndDropMixin = (superClass) =>
 
     /** @private */
     _onDragEnd(e) {
-      if (!this.__draggedItems.length) {
-        return;
-      }
       this.toggleAttribute('dragging-rows', false);
       e.stopPropagation();
       const event = new CustomEvent('grid-dragend');

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -222,6 +222,9 @@ export const DragAndDropMixin = (superClass) =>
 
     /** @private */
     _onDragEnd(e) {
+      if (!this.__draggedItems.length) {
+        return;
+      }
       this.toggleAttribute('dragging-rows', false);
       e.stopPropagation();
       const event = new CustomEvent('grid-dragend');
@@ -234,6 +237,9 @@ export const DragAndDropMixin = (superClass) =>
 
     /** @private */
     _onDragLeave(e) {
+      if (!this.dropMode) {
+        return;
+      }
       e.stopPropagation();
       this._clearDragStyles();
     }

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -414,12 +414,12 @@ describe('drag and drop', () => {
         expect(spy.called).to.be.false;
       });
 
-      it('should not stop the native event if not dragging', () => {
+      it('should not stop the native event on grid itself', () => {
         fireDragEnd();
 
         const spy = sinon.spy();
         listenOnce(grid, 'dragend', spy);
-        fireDragEnd();
+        fireDragEnd(grid);
         expect(spy.called).to.be.true;
       });
 

--- a/packages/grid/test/drag-and-drop.common.js
+++ b/packages/grid/test/drag-and-drop.common.js
@@ -403,6 +403,8 @@ describe('drag and drop', () => {
       beforeEach(() => {
         dragEndSpy = sinon.spy();
         listenOnce(grid, 'grid-dragend', dragEndSpy);
+        grid.selectedItems = grid.items;
+        fireDragStart();
       });
 
       it('should stop the native event', () => {
@@ -412,8 +414,16 @@ describe('drag and drop', () => {
         expect(spy.called).to.be.false;
       });
 
+      it('should not stop the native event if not dragging', () => {
+        fireDragEnd();
+
+        const spy = sinon.spy();
+        listenOnce(grid, 'dragend', spy);
+        fireDragEnd();
+        expect(spy.called).to.be.true;
+      });
+
       it('should remove dragging state attribute', () => {
-        fireDragStart();
         fireDragEnd();
         expect(grid.hasAttribute('dragging-rows')).to.be.false;
       });
@@ -636,10 +646,18 @@ describe('drag and drop', () => {
 
     describe('dragleave', () => {
       it('should stop the native event', () => {
+        grid.dropMode = 'on-grid';
         const spy = sinon.spy();
         listenOnce(grid, 'dragleave', spy);
         fireDragLeave();
         expect(spy.called).to.be.false;
+      });
+
+      it('should not stop the native event if grid has no drop mode', () => {
+        const spy = sinon.spy();
+        listenOnce(grid, 'dragleave', spy);
+        fireDragLeave();
+        expect(spy.called).to.be.true;
       });
 
       it('should clear the grid dragover attribute', () => {


### PR DESCRIPTION
## Description

Grid currently stops the propagation of all native "dragleave" events which causes the issue. The propagation of "dragleave" event should only be stopped if the grid has a `dropMode`, in which case corresponding "dragover" and "dragenter" events are also processed by the grid dnd logic

Fixes #8476

## Type of change

- Bugfix