### PR TITLE
refactor: extract horizontal layout styles into CSS literal

### DIFF
--- a/packages/horizontal-layout/src/vaadin-horizontal-layout-styles.d.ts
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const horizontalLayoutStyles: CSSResult;

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout-styles.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout-styles.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const horizontalLayoutStyles = css`
+  :host {
+    display: flex;
+    box-sizing: border-box;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  /* Theme variations */
+  :host([theme~='margin']) {
+    margin: 1em;
+  }
+
+  :host([theme~='padding']) {
+    padding: 1em;
+  }
+
+  :host([theme~='spacing']) {
+    gap: 1em;
+  }
+`;

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -6,7 +6,10 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { horizontalLayoutStyles } from './vaadin-horizontal-layout-styles.js';
+
+registerStyles('vaadin-horizontal-layout', horizontalLayoutStyles, { moduleId: 'vaadin-horizontal-layout-styles' });
 
 /**
  * `<vaadin-horizontal-layout>` provides a simple way to horizontally align your HTML elements.
@@ -36,33 +39,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 class HorizontalLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: flex;
-          box-sizing: border-box;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        /* Theme variations */
-        :host([theme~='margin']) {
-          margin: 1em;
-        }
-
-        :host([theme~='padding']) {
-          padding: 1em;
-        }
-
-        :host([theme~='spacing']) {
-          gap: 1em;
-        }
-      </style>
-
-      <slot></slot>
-    `;
+    return html`<slot></slot>`;
   }
 
   static get is() {

--- a/packages/horizontal-layout/src/vaadin-lit-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-lit-horizontal-layout.js
@@ -3,11 +3,12 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { horizontalLayoutStyles } from './vaadin-horizontal-layout-styles.js';
 
 /**
  * LitElement based version of `<vaadin-horizontal-layout>` web component.
@@ -19,36 +20,15 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class HorizontalLayout extends ThemableMixin(ElementMixin(PolylitMixin(LitElement))) {
-  static get styles() {
-    return css`
-      :host {
-        display: flex;
-        box-sizing: border-box;
-      }
-
-      :host([hidden]) {
-        display: none !important;
-      }
-
-      /* Theme variations */
-      :host([theme~='margin']) {
-        margin: 1em;
-      }
-
-      :host([theme~='padding']) {
-        padding: 1em;
-      }
-
-      :host([theme~='spacing']) {
-        gap: 1em;
-      }
-    `;
-  }
-
   static get is() {
     return 'vaadin-horizontal-layout';
   }
 
+  static get styles() {
+    return horizontalLayoutStyles;
+  }
+
+  /** @protected */
   render() {
     return html`<slot></slot>`;
   }


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/platform/issues/5038

Let's extract styles into single file to avoid further code duplication when adding styles for `middle` and `end` slots.

## Type of change

- Refactor