### PR TITLE
refactor: clean up grid column auto width mixin

### DIFF
--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -55,7 +55,7 @@ export const ColumnAutoWidthMixin = (superClass) =>
     /** @private */
     __columnTreeChangedAutoWidth(_columnTree) {
       // Column tree changed, recalculate column widths
-      this.recalculateColumnWidths();
+      queueMicrotask(() => this.recalculateColumnWidths());
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -67,21 +67,21 @@ import { StylingMixin } from './vaadin-grid-styling-mixin.js';
  * @mixes DragAndDropMixin
  */
 export const GridMixin = (superClass) =>
-  class extends ArrayDataProviderMixin(
-    DataProviderMixin(
-      DynamicColumnsMixin(
-        ActiveItemMixin(
-          ScrollMixin(
-            SelectionMixin(
-              SortMixin(
-                RowDetailsMixin(
-                  KeyboardNavigationMixin(
-                    A11yMixin(
-                      FilterMixin(
-                        ColumnReorderingMixin(
-                          ColumnResizingMixin(
-                            EventContextMixin(
-                              DragAndDropMixin(ColumnAutoWidthMixin(StylingMixin(TabindexMixin(superClass)))),
+  class extends ColumnAutoWidthMixin(
+    ArrayDataProviderMixin(
+      DataProviderMixin(
+        DynamicColumnsMixin(
+          ActiveItemMixin(
+            ScrollMixin(
+              SelectionMixin(
+                SortMixin(
+                  RowDetailsMixin(
+                    KeyboardNavigationMixin(
+                      A11yMixin(
+                        FilterMixin(
+                          ColumnReorderingMixin(
+                            ColumnResizingMixin(
+                              EventContextMixin(DragAndDropMixin(StylingMixin(TabindexMixin(superClass)))),
                             ),
                           ),
                         ),
@@ -197,7 +197,6 @@ export const GridMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       this.isAttached = true;
-      this.recalculateColumnWidths();
     }
 
     /** @protected */
@@ -269,7 +268,6 @@ export const GridMixin = (superClass) =>
       new ResizeObserver(() =>
         setTimeout(() => {
           this.__updateColumnsBodyContentHidden();
-          this.__tryToRecalculateColumnWidthsIfPending();
         }),
       ).observe(this.$.table);
 
@@ -348,15 +346,6 @@ export const GridMixin = (superClass) =>
       }
     }
 
-    /**
-     * @protected
-     * @override
-     */
-    _onDataProviderPageLoaded() {
-      super._onDataProviderPageLoaded();
-      this.__tryToRecalculateColumnWidthsIfPending();
-    }
-
     /** @private */
     _createScrollerRows(count) {
       const rows = [];
@@ -384,7 +373,6 @@ export const GridMixin = (superClass) =>
         animationFrame,
         () => {
           this._afterScroll();
-          this.__tryToRecalculateColumnWidthsIfPending();
         },
       );
       return rows;
@@ -670,7 +658,6 @@ export const GridMixin = (superClass) =>
     /** @private */
     _columnTreeChanged(columnTree) {
       this._renderColumnTree(columnTree);
-      this.recalculateColumnWidths();
       this.__updateColumnsBodyContentHidden();
     }
 
@@ -809,7 +796,6 @@ export const GridMixin = (superClass) =>
       // ShadyCSS applies scoping suffixes to animation names
       if (e.animationName.indexOf('vaadin-grid-appear') === 0) {
         e.stopPropagation();
-        this.__tryToRecalculateColumnWidthsIfPending();
 
         // Ensure header and footer have tabbable elements
         this._resetKeyboardNavigation();

--- a/packages/grid/test/column-auto-width.common.js
+++ b/packages/grid/test/column-auto-width.common.js
@@ -295,6 +295,21 @@ describe('column auto-width', () => {
     expectColumnWidthsToBeOk(columns);
   });
 
+  it('should have correct column widths for lazily added columns', async () => {
+    const grid = fixtureSync(`<vaadin-grid style="width: 600px; height: 200px;">
+      <vaadin-grid-column header="Foo"></vaadin-grid-column>
+    </vaadin-grid>`);
+    await nextFrame();
+
+    fixtureSync(
+      `<vaadin-grid-column id="new" flex-grow="0" header="foo bar baz" auto-width></vaadin-grid-column>`,
+      grid,
+    );
+    const newColumn = grid.querySelector('vaadin-grid-column#new');
+    await nextFrame();
+    expect(parseFloat(newColumn.width)).to.be.closeTo(107, 5);
+  });
+
   describe('focusButtonMode column', () => {
     beforeEach(async () => {
       const column = document.createElement('vaadin-grid-column');

--- a/packages/grid/test/filtering.common.js
+++ b/packages/grid/test/filtering.common.js
@@ -357,7 +357,7 @@ describe('array data provider', () => {
     expect(spy).to.be.calledOnce;
   });
 
-  it('should not filter items before grid is re-attached', () => {
+  it('should not filter items before grid is re-attached', async () => {
     filterFirst.value = 'bar';
     flushFilters(grid);
 
@@ -369,6 +369,7 @@ describe('array data provider', () => {
     expect(Object.keys(grid._dataProviderController.rootCache.items).length).to.equal(1);
 
     parentNode.appendChild(grid);
+    await nextFrame();
 
     expect(Object.keys(grid._dataProviderController.rootCache.items).length).to.equal(3);
   });

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -14,6 +14,12 @@ export const flushGrid = (grid) => {
     grid.__debounceUpdateFrozenColumn,
   ].forEach((debouncer) => debouncer?.flush());
 
+  [...grid.$.header.children, ...grid.$.footer.children].forEach((row) => {
+    if (row.__debounceUpdateHeaderFooterRowVisibility) {
+      row.__debounceUpdateHeaderFooterRowVisibility.flush();
+    }
+  });
+
   grid.__virtualizer.flush();
   grid.__preventScrollerRotatingCellFocusDebouncer?.flush();
   grid.performUpdate?.();


### PR DESCRIPTION
## Description

Follow-up for https://github.com/vaadin/web-components/pull/8507

This PR cleans up the newly added `ColumnAutoWidthMixin`
- All checks for whether grid is ready for column width recalculation are now performed in a single function (`__isReadyForColumnWidthCalculation`) instead of having them scattered around like before
  - `recalculateColumnWidths` is now short and clean
- All external calls to the mixin's functions (`__tryToRecalculateColumnWidthsIfPending`, `recalculateColumnWidths`) are removed. The mixin itself uses property observers and event listeners to determine when they should be called.

Related to https://github.com/vaadin/flow-components/issues/6976

## Type of change

Refactor