### PR TITLE
refactor: remove unused method in list-mixin

### DIFF
--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -266,15 +266,6 @@ export const ListMixin = (superClass) =>
     }
 
     /**
-     * @param {!Element} item
-     * @return {boolean}
-     * @protected
-     */
-    _isItemHidden(item) {
-      return getComputedStyle(item).display === 'none';
-    }
-
-    /**
      * @param {number} idx
      * @protected
      */


### PR DESCRIPTION
## Description

The `_isItemHidden` of ListMixin isn't used anywhere.

## Type of change

- [x] Refactor
