### PR TITLE
fix: ensure grid root cache has a valid size

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -384,7 +384,7 @@ export const DataProviderMixin = (superClass) =>
      */
     clearCache() {
       this._dataProviderController.clearCache();
-      this._dataProviderController.rootCache.size = this.size;
+      this._dataProviderController.rootCache.size = this.size || 0;
       this._dataProviderController.recalculateFlatSize();
       this._hasData = false;
       this.__updateVisibleRows();

--- a/packages/grid/test/data-provider.common.js
+++ b/packages/grid/test/data-provider.common.js
@@ -533,6 +533,13 @@ describe('data provider', () => {
           }
         });
 
+        it('should not jam on clear cache', () => {
+          grid.dataProvider = (params, callback) => {
+            setTimeout(() => finiteDataProvider(params, callback), 0);
+          };
+          grid.clearCache();
+        });
+
         it('should not render synchronously until all data requests have finished', (done) => {
           generateItemIds = true;
           grid.itemIdPath = 'id';


### PR DESCRIPTION
## Description

Ensure grid root cache has a valid size

Fixes #8524 

## Type of change

Bugfix