### PR TITLE
fix: check if node is an element when removing slot attribute

### DIFF
--- a/packages/split-layout/src/vaadin-split-layout-mixin.js
+++ b/packages/split-layout/src/vaadin-split-layout-mixin.js
@@ -55,7 +55,7 @@ export const SplitLayoutMixin = (superClass) =>
     /** @private */
     _cleanupNodes(nodes) {
       nodes.forEach((node) => {
-        if (!(node.parentElement instanceof this.constructor)) {
+        if (node.nodeType === Node.ELEMENT_NODE && !(node.parentElement instanceof this.constructor)) {
           const slot = node.getAttribute('slot');
           if (slot) {
             this[`_${slot}Child`] = null;

--- a/packages/split-layout/test/split-layout.common.js
+++ b/packages/split-layout/test/split-layout.common.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextRender, track } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
+import { html, render } from 'lit';
 
 const initialSizes = { width: 128, height: 128 };
 
@@ -461,5 +462,25 @@ describe('moving nodes between layouts', () => {
     await nextFrame();
     expect(second.getAttribute('slot')).to.equal('primary');
     expect(first.getAttribute('slot')).to.equal('secondary');
+  });
+
+  describe('nested Lit template', () => {
+    let root;
+
+    beforeEach(() => {
+      root = fixtureSync('<div></div>');
+    });
+
+    it('should not throw when re-rendering child element conditionally', async () => {
+      const fooTpl = html`<div>Foo</div>`;
+      const nestedTpl = (foo) => (foo ? html`${fooTpl}` : html`<div>Bar</div>`);
+      const parentTpl = (foo) => html`<vaadin-split-layout>${nestedTpl(foo)}</vaadin-split-layout>`;
+
+      render(parentTpl(true), root);
+      await nextFrame();
+
+      render(parentTpl(false), root);
+      await nextFrame();
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #8531

Added missing check for `nodeType` in `MutationObserver` to ignore disconnected comment nodes inserted by Lit.

## Type of change

- Bugfix