### PR TITLE
fix: prevent grid with all rows visible from shrinking

### DIFF
--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -45,6 +45,7 @@ export const gridStyles = css`
   :host([all-rows-visible]) {
     height: auto;
     align-self: flex-start;
+    flex-shrink: 0;
     flex-grow: 0;
     width: 100%;
   }

--- a/packages/grid/test/min-height.common.js
+++ b/packages/grid/test/min-height.common.js
@@ -39,7 +39,7 @@ describe('min-height', () => {
   });
 
   describe('without header or footer', () => {
-    it('should should have min-height of one row', () => {
+    it('should have min-height of one row', () => {
       verifyMinHeight();
     });
   });
@@ -51,7 +51,7 @@ describe('min-height', () => {
       await nextResize(grid);
     });
 
-    it('should should have min-height of header and one row', () => {
+    it('should have min-height of header and one row', () => {
       verifyMinHeight(true, false);
     });
   });
@@ -65,7 +65,7 @@ describe('min-height', () => {
       await nextResize(grid);
     });
 
-    it('should should have min-height of footer and one row', () => {
+    it('should have min-height of footer and one row', () => {
       verifyMinHeight(false, true);
     });
   });
@@ -80,7 +80,7 @@ describe('min-height', () => {
       await nextResize(grid);
     });
 
-    it('should should have min-height of header, footer and one row', () => {
+    it('should have min-height of header, footer and one row', () => {
       verifyMinHeight(true, true);
     });
   });
@@ -94,7 +94,7 @@ describe('min-height', () => {
       await nextResize(grid);
     });
 
-    it('should should have min-height of one row', () => {
+    it('should have min-height of one row', () => {
       verifyMinHeight();
     });
   });
@@ -113,6 +113,16 @@ describe('min-height', () => {
     it('should allow overriding min-height through stylesheet', () => {
       const height = grid.getBoundingClientRect().height;
       expect(height).to.equal(200);
+    });
+  });
+
+  describe('with all rows visible', () => {
+    beforeEach(() => {
+      grid.allRowsVisible = true;
+    });
+
+    it('should have min-height of one row', () => {
+      verifyMinHeight();
     });
   });
 });

--- a/packages/grid/test/resizing.common.js
+++ b/packages/grid/test/resizing.common.js
@@ -158,6 +158,16 @@ describe('resizing', () => {
       component.style.flexDirection = 'row';
       expect(grid.getBoundingClientRect().width).to.be.above(780);
     });
+
+    it('should not shrink vertically inside a column flexbox with another child', () => {
+      grid.size = 5;
+
+      component.style.height = '500px';
+      grid.after(fixtureSync('<div style="height: 100%"></div>'));
+
+      expect(grid._firstVisibleIndex).to.equal(0);
+      expect(grid._lastVisibleIndex).to.equal(grid.size - 1);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Prevent grid with all rows visible from shrinking.

Fixes #8509 

## Type of change

Bugfix