### PR TITLE
chore: fix ESLint override glob, remove console.log from test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,7 +85,7 @@
       }
     },
     {
-      "files": ["scripts/**/*.js", "*.js"],
+      "files": ["scripts/**/*.js", "*.config.js", "wtr-utils.js"],
       "rules": {
         "@typescript-eslint/no-require-imports": "off",
         "no-console": "off"

--- a/test/integration/notification-overlay.test.js
+++ b/test/integration/notification-overlay.test.js
@@ -85,7 +85,6 @@ describe('notification and overlays', () => {
               const close = document.createElement('button');
               close.textContent = 'Close and show notification';
               close.addEventListener('click', () => {
-                console.log('close and show');
                 notification.opened = true;
                 dialog2.opened = false;
               });


### PR DESCRIPTION
## Description

Fixed incorrect override glob that was using `*.js` and removed one `console.log` which was unnoticed because of that.

## Type of change

- Internal change