### PR TITLE
test: prevent date-picker aria-hidden warning in ITs

### DIFF
--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -117,13 +117,14 @@ import { mouseenter, mouseleave } from '@vaadin/tooltip/test/helpers.js';
       expect(tooltipOverlay.position).to.equal(position || 'bottom');
     });
 
-    it('should or should not show tooltip', () => {
+    it('should or should not show tooltip', async () => {
       mouseenter(tooltip.target);
       expect(tooltipOverlay.opened).to.be.true;
       mouseleave(tooltip.target);
 
       if (applyShouldNotShowCondition) {
         applyShouldNotShowCondition(element);
+        await nextRender();
 
         mouseenter(tooltip.target);
         expect(tooltipOverlay.opened).to.be.false;

--- a/test/integration/confirm-dialog-fields.test.js
+++ b/test/integration/confirm-dialog-fields.test.js
@@ -30,6 +30,9 @@ describe('confirm-dialog with fields', () => {
         dialog = document.createElement('vaadin-confirm-dialog');
         field = document.createElement(`vaadin-${component}`);
         field.label = 'Label';
+        if (component === 'date-picker') {
+          field.autoOpenDisabled = true;
+        }
         dialog.appendChild(field);
         document.body.appendChild(dialog);
         dialog.opened = true;


### PR DESCRIPTION
## Description

Updated IT tests to avoid following warnings:

```
test/integration/component-tooltip.test.js:

 🚧 Browser logs:
      Error: [object HTMLInputElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
      Error: [object HTMLInputElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.

test/integration/confirm-dialog-fields.test.js:

 🚧 Browser logs:
      Error: [object HTMLInputElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
      Error: [object HTMLElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
```

- In the component tooltip test, added `await nextRender()` after opening date-picker overlay,
- in the confirm-dialog test, added `autoOpenDisabled` as we don't need to open overlay there.

## Type of change

- Test