### PR TITLE
refactor: extract vertical layout styles into CSS literal

### DIFF
--- a/packages/vertical-layout/src/vaadin-lit-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-lit-vertical-layout.js
@@ -3,11 +3,12 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { verticalLayoutStyles } from './vaadin-vertical-layout-styles.js';
 
 /**
  * LitElement based version of `<vaadin-vertical-layout>` web component.
@@ -19,38 +20,15 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * Feel free to try this code in your apps as per Apache 2.0 license.
  */
 class VerticalLayout extends ThemableMixin(ElementMixin(PolylitMixin(LitElement))) {
-  static get styles() {
-    return css`
-      :host {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        box-sizing: border-box;
-      }
-
-      :host([hidden]) {
-        display: none !important;
-      }
-
-      /* Theme variations */
-      :host([theme~='margin']) {
-        margin: 1em;
-      }
-
-      :host([theme~='padding']) {
-        padding: 1em;
-      }
-
-      :host([theme~='spacing']) {
-        gap: 1em;
-      }
-    `;
-  }
-
   static get is() {
     return 'vaadin-vertical-layout';
   }
 
+  static get styles() {
+    return verticalLayoutStyles;
+  }
+
+  /** @protected */
   render() {
     return html`<slot></slot>`;
   }

--- a/packages/vertical-layout/src/vaadin-vertical-layout-styles.d.ts
+++ b/packages/vertical-layout/src/vaadin-vertical-layout-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const verticalLayoutStyles: CSSResult;

--- a/packages/vertical-layout/src/vaadin-vertical-layout-styles.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout-styles.js
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+export const verticalLayoutStyles = css`
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    box-sizing: border-box;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  /* Theme variations */
+  :host([theme~='margin']) {
+    margin: 1em;
+  }
+
+  :host([theme~='padding']) {
+    padding: 1em;
+  }
+
+  :host([theme~='spacing']) {
+    gap: 1em;
+  }
+`;

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -6,7 +6,10 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { verticalLayoutStyles } from './vaadin-vertical-layout-styles.js';
+
+registerStyles('vaadin-vertical-layout', verticalLayoutStyles, { moduleId: 'vaadin-vertical-layout-styles' });
 
 /**
  * `<vaadin-vertical-layout>` provides a simple way to vertically align your HTML elements.
@@ -36,35 +39,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 class VerticalLayout extends ElementMixin(ThemableMixin(PolymerElement)) {
   static get template() {
-    return html`
-      <style>
-        :host {
-          display: flex;
-          flex-direction: column;
-          align-items: flex-start;
-          box-sizing: border-box;
-        }
-
-        :host([hidden]) {
-          display: none !important;
-        }
-
-        /* Theme variations */
-        :host([theme~='margin']) {
-          margin: 1em;
-        }
-
-        :host([theme~='padding']) {
-          padding: 1em;
-        }
-
-        :host([theme~='spacing']) {
-          gap: 1em;
-        }
-      </style>
-
-      <slot></slot>
-    `;
+    return html`<slot></slot>`;
   }
 
   static get is() {


### PR DESCRIPTION
Similar to https://github.com/vaadin/web-components/pull/8510, extracts vertical layout styles to avoid further duplication when adding the planned layout fixes.