### PR TITLE
fix: import progress-bar from correct file in Lit version of upload

### DIFF
--- a/packages/upload/src/vaadin-lit-upload-file.js
+++ b/packages/upload/src/vaadin-lit-upload-file.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
+import '@vaadin/progress-bar/src/vaadin-lit-progress-bar.js';
 import './vaadin-upload-icons.js';
 import { html, LitElement, nothing } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';


### PR DESCRIPTION
## Description

Follow-up to #8551

The `vaadin-progress-bar` was also incorrectly imported from the Polymer version in Lit upload. This PR fixes that.

## Type of change

- Bugfix