### PR TITLE
chore: add protected JSDoc annotation to render method

### DIFF
--- a/packages/icon/src/vaadin-lit-icon.js
+++ b/packages/icon/src/vaadin-lit-icon.js
@@ -26,6 +26,7 @@ import { iconStyles } from './vaadin-icon-styles.js';
 class Icon extends IconMixin(ControllerMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
   static styles = iconStyles;
 
+  /** @protected */
   render() {
     return html`
       <svg

--- a/packages/notification/src/vaadin-lit-notification.js
+++ b/packages/notification/src/vaadin-lit-notification.js
@@ -27,6 +27,7 @@ class NotificationContainer extends NotificationContainerMixin(ElementMixin(Them
     return notificationContainerStyles;
   }
 
+  /** @protected */
   render() {
     return html`
       <div region="top-stretch"><slot name="top-stretch"></slot></div>
@@ -64,6 +65,7 @@ class NotificationCard extends ElementMixin(ThemableMixin(PolylitMixin(LitElemen
     return notificationCardStyles;
   }
 
+  /** @protected */
   render() {
     return html`
       <div part="overlay">
@@ -103,6 +105,7 @@ class Notification extends NotificationMixin(ElementMixin(ThemableMixin(PolylitM
     `;
   }
 
+  /** @protected */
   render() {
     return html`
       <vaadin-notification-card

--- a/packages/virtual-list/src/vaadin-lit-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-lit-virtual-list.js
@@ -29,6 +29,7 @@ class VirtualList extends VirtualListMixin(ThemableMixin(ElementMixin(PolylitMix
     return [virtualListStyles];
   }
 
+  /** @protected */
   render() {
     return html`
       <div id="items">


### PR DESCRIPTION
## Description

Some components were missing this annotation so I added it for consistency. This will be needed in the future when we switch implementations to use Lit by default so that `render()` doesn't get shown as public method in the API docs.

## Type of change

- Internal change