### PR TITLE
fix: allow all rows visible grid shrink horizontally

### DIFF
--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -45,7 +45,7 @@ export const gridStyles = css`
   :host([all-rows-visible]) {
     height: auto;
     align-self: flex-start;
-    flex-shrink: 0;
+    min-height: auto;
     flex-grow: 0;
     width: 100%;
   }

--- a/packages/grid/test/min-height.common.js
+++ b/packages/grid/test/min-height.common.js
@@ -115,14 +115,4 @@ describe('min-height', () => {
       expect(height).to.equal(200);
     });
   });
-
-  describe('with all rows visible', () => {
-    beforeEach(() => {
-      grid.allRowsVisible = true;
-    });
-
-    it('should have min-height of one row', () => {
-      verifyMinHeight();
-    });
-  });
 });

--- a/packages/grid/test/resizing.common.js
+++ b/packages/grid/test/resizing.common.js
@@ -168,6 +168,13 @@ describe('resizing', () => {
       expect(grid._firstVisibleIndex).to.equal(0);
       expect(grid._lastVisibleIndex).to.equal(grid.size - 1);
     });
+
+    it('should shrink horizontally inside a row flexbox with another child', () => {
+      component.style.flexDirection = 'row';
+      grid.after(fixtureSync('<div style="height: 100%; width: 100px;"></div>'));
+
+      expect(grid.getBoundingClientRect().width).to.be.below(780);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

https://github.com/vaadin/web-components/pull/8535 caused a regression by preventing a grid with all rows visible from shrinking horizontally in a flexbox.

Seems we have to use the `min-height: auto` approach to fix the original issue after all.

## Type of change

Bugfix