### PR TITLE
fix: add @vaadin/test-runner-commands to each package (CP: 24.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/mocha": "^10.0.7",
     "@types/sinon": "^17.0.3",
     "@vaadin/testing-helpers": "^1.1.0",
-    "@vaadin/test-runner-commands": "24.6.2",
     "@web/dev-server": "^0.4.3",
     "@web/dev-server-esbuild": "^1.0.2",
     "@web/rollup-plugin-html": "^2.0.0",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/icon": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-field": "~24.5.8",
     "lit": "^3.0.0",

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~24.5.8",
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0"
   },
   "cvdlName": "vaadin-cookie-consent",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/combo-box": "~24.5.8",
     "@vaadin/date-picker": "~24.5.8",
     "@vaadin/email-field": "~24.5.8",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~24.5.8",
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-area": "~24.5.8",
     "sinon": "^18.0.0"

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/checkbox": "~24.5.8",
     "@vaadin/checkbox-group": "~24.5.8",
     "@vaadin/combo-box": "~24.5.8",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/custom-field": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "@vaadin/text-field": "~24.5.8",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/icon": "~24.5.8",
     "@vaadin/icons": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/checkbox": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/icon": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "lit": "^3.0.0",
     "sinon": "^18.0.0"

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@vaadin/button": "~24.5.8",
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/polymer-legacy-adapter/package.json
+++ b/packages/polymer-legacy-adapter/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/checkbox": "~24.5.8",
     "@vaadin/grid": "~24.5.8",
     "@vaadin/grid-pro": "~24.5.8",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~24.5.8",
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "lit": "^3.0.0",
     "sinon": "^18.0.0"

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0"
   },
   "web-types": [

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/testing-helpers": "^1.1.0",
     "sinon": "^18.0.0"
   },

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -10,6 +10,7 @@
     "@vaadin/accordion": "~24.5.8",
     "@vaadin/button": "~24.5.8",
     "@vaadin/chai-plugins": "~24.5.8",
+    "@vaadin/test-runner-commands": "~24.5.8",
     "@vaadin/checkbox": "~24.5.8",
     "@vaadin/checkbox-group": "~24.5.8",
     "@vaadin/combo-box": "~24.5.8",


### PR DESCRIPTION
## Description

Adds `@vaadin/test-runner-commands` to each package individually to fix release errors:

```
09:55:37 + yarn --frozen-lockfile --no-progress --non-interactive --ignore-engines
09:55:37   yarn install v1.22.19
09:55:37   [1/4] Resolving packages...
09:55:38   error An unexpected error occurred: "https://registry.npmjs.org/@vaadin%2ftest-runner-commands: Not found".
09:55:38   info If you think this is a bug, please open a bug report with the information provided in "/opt/agent/work/510b88227363ba06/24.5.8/yarn-error.log".
09:55:38   info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

## Type of change

- [x] Bugfix
