### PR TITLE
test: wait for possible scroll into view

### DIFF
--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -93,6 +93,8 @@ describe('keyboard navigation', () => {
       const secondCell = getContainerCell(grid.$.items, 2, 0);
       const spy = sinon.spy(secondCell, 'focus');
       await sendKeys({ press: 'Enter' });
+      // Wait for possible scroll to get the cell into view
+      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Description

Adds `await nextFrame()` to wait for possible scroll into view, which may occur if the next cell isn't fully within the viewport. This should hopefully stabilize the test in Webkit.

## Type of change

- [x] Internal
