### PR TITLE
test: increase specificity to hide caret color in visual tests

### DIFF
--- a/packages/multi-select-combo-box/test/visual/common.js
+++ b/packages/multi-select-combo-box/test/visual/common.js
@@ -4,7 +4,8 @@ registerStyles(
   'vaadin-multi-select-combo-box',
   css`
     /* Hide caret */
-    :host([focused]) ::slotted(input) {
+    :host([focused]:not([has-value])) ::slotted(input),
+    :host([focused][has-value]) ::slotted(input) {
       caret-color: transparent !important;
     }
 


### PR DESCRIPTION
## Description

Unlike other components, `vaadin-multi-select-combo-box` handles `caret-color` property on the slotted input to detect whether to show placeholder or not. This rule overrides the hack that we have in visual tests making one of them flaky:

<img width="635" alt="Screenshot 2025-01-28 at 14 16 25" src="https://github.com/user-attachments/assets/046e4388-8912-457e-bee8-4fa78aaf7001" />

Updated the hack to increase specificity so that it overrides the style defined in Lumo and Material themes. 

## Type of change

- Test