### PR TITLE
test: import files that register styles before custom elements

### DIFF
--- a/packages/combo-box/test/visual/lumo/combo-box.test.js
+++ b/packages/combo-box/test/visual/lumo/combo-box.test.js
@@ -2,8 +2,8 @@ import { sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
-import '../../../theme/lumo/vaadin-combo-box.js';
 import '../../not-animated-styles.js';
+import '../../../theme/lumo/vaadin-combo-box.js';
 
 describe('combo-box', () => {
   let div, element;

--- a/packages/combo-box/test/visual/material/combo-box.test.js
+++ b/packages/combo-box/test/visual/material/combo-box.test.js
@@ -2,8 +2,8 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
-import '../../../theme/material/vaadin-combo-box.js';
 import '../../not-animated-styles.js';
+import '../../../theme/material/vaadin-combo-box.js';
 
 describe('combo-box', () => {
   let div, element;

--- a/packages/date-picker/test/visual/lumo/date-picker.test.js
+++ b/packages/date-picker/test/visual/lumo/date-picker.test.js
@@ -1,9 +1,9 @@
 import { sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/lumo/vaadin-date-picker.js';
 import '../../not-animated-styles.js';
 import '../common.js';
+import '../../../theme/lumo/vaadin-date-picker.js';
 
 describe('date-picker', () => {
   let div, element;

--- a/packages/date-picker/test/visual/material/date-picker.test.js
+++ b/packages/date-picker/test/visual/material/date-picker.test.js
@@ -1,9 +1,9 @@
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/material/vaadin-date-picker.js';
 import '../../not-animated-styles.js';
 import '../common.js';
+import '../../../theme/material/vaadin-date-picker.js';
 
 describe('date-picker', () => {
   let div, element;

--- a/packages/date-time-picker/test/visual/lumo/date-time-picker.test.js
+++ b/packages/date-time-picker/test/visual/lumo/date-time-picker.test.js
@@ -1,7 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/lumo/vaadin-date-time-picker.js';
 import '../common.js';
+import '../../../theme/lumo/vaadin-date-time-picker.js';
 
 describe('date-time-picker', () => {
   let div, element;

--- a/packages/date-time-picker/test/visual/material/date-time-picker.test.js
+++ b/packages/date-time-picker/test/visual/material/date-time-picker.test.js
@@ -1,7 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/material/vaadin-date-time-picker.js';
 import '../common.js';
+import '../../../theme/material/vaadin-date-time-picker.js';
 
 describe('date-time-picker', () => {
   let div, element;

--- a/packages/field-highlighter/test/visual/lumo/field-highlighter.test.js
+++ b/packages/field-highlighter/test/visual/lumo/field-highlighter.test.js
@@ -9,8 +9,8 @@ import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
 import '@vaadin/radio-group/theme/lumo/vaadin-radio-group.js';
 import '@vaadin/text-area/theme/lumo/vaadin-text-area.js';
 import '@vaadin/text-field/theme/lumo/vaadin-text-field.js';
-import '../../../theme/lumo/vaadin-field-highlighter.js';
 import '../common.js';
+import '../../../theme/lumo/vaadin-field-highlighter.js';
 import { setUsers } from '../helpers.js';
 
 describe('field-highlighter', () => {

--- a/packages/field-highlighter/test/visual/material/field-highlighter.test.js
+++ b/packages/field-highlighter/test/visual/material/field-highlighter.test.js
@@ -9,8 +9,8 @@ import '@vaadin/list-box/theme/material/vaadin-list-box.js';
 import '@vaadin/radio-group/theme/material/vaadin-radio-group.js';
 import '@vaadin/text-area/theme/material/vaadin-text-area.js';
 import '@vaadin/text-field/theme/material/vaadin-text-field.js';
-import '../../../theme/material/vaadin-field-highlighter.js';
 import '../common.js';
+import '../../../theme/material/vaadin-field-highlighter.js';
 import { setUsers } from '../helpers.js';
 
 describe('field-highlighter', () => {

--- a/packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/visual/lumo/multi-select-combo-box.test.js
@@ -2,8 +2,8 @@ import { sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
-import '../../../theme/lumo/vaadin-multi-select-combo-box.js';
 import '../../not-animated-styles.js';
+import '../../../theme/lumo/vaadin-multi-select-combo-box.js';
 
 describe('multi-select-combo-box', () => {
   let div, element;

--- a/packages/multi-select-combo-box/test/visual/material/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/visual/material/multi-select-combo-box.test.js
@@ -2,8 +2,8 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../common.js';
-import '../../../theme/material/vaadin-multi-select-combo-box.js';
 import '../../not-animated-styles.js';
+import '../../../theme/material/vaadin-multi-select-combo-box.js';
 
 describe('multi-select-combo-box', () => {
   let div, element;


### PR DESCRIPTION
## Description

This fixes the following warnings in visual tests after converting `field-highlighter` package to Lit:

```
      The custom element definition for "vaadin-user-tags-overlay" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting "window.Vaadin.suppressPostFinalizeStylesWarning = true".
      The custom element definition for "vaadin-user-tag" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting "window.Vaadin.suppressPostFinalizeStylesWarning = true".
```

Updated other visual tests to make sure `common.js` and `not-animated-styles.js` get imported before the component.

## Type of change

- Test