### PR TITLE
test: correctly apply CSS in date-time-picker visual test

### DIFF
--- a/packages/date-time-picker/test/visual/common.js
+++ b/packages/date-time-picker/test/visual/common.js
@@ -1,7 +1,7 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
-  'vaadin-date-picker',
+  'vaadin-*-picker',
   css`
     /* Hide caret */
     :host([focused]) ::slotted(input) {


### PR DESCRIPTION
## Description

Currently, in `vaadin-date-time-picker` visual tests the CSS workaround is applied to `vaadin-date-picker`.
Changed it to use `vaadin-*-picker` so that it also applies to `vaadin-date-time-picker` and `vaadin-time-picker`.

This is needed because the slotted input styles are for individual pickers, but disabling animations on the error message part needs to be done on the `vaadin-date-time-picker` element itself (which is currently not applied).

This should fix the flakiness in the following visual tests:


```
 ❌ date-time-picker > default > error message
      Error: Visual diff failed. New screenshot is 0.42% different.
      See diff for details: /home/runner/work/web-components/web-components/packages/date-time-picker/test/visual/material/screenshots/date-time-picker/failed/error-message-diff.png
        at async n.<anonymous> (packages/date-time-picker/test/visual/material/date-time-picker.test.js:64:7)

 ❌ date-time-picker > RTL > RTL error message
      Error: Visual diff failed. New screenshot is 0.42% different.
      See diff for details: /home/runner/work/web-components/web-components/packages/date-time-picker/test/visual/material/screenshots/date-time-picker/failed/rtl-error-message-diff.png
        at async n.<anonymous> (packages/date-time-picker/test/visual/material/date-time-picker.test.js:91:7)
```
## Type of change

- Test