### PR TITLE
refactor: focus editor synchronously also in Lit version

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -285,11 +285,7 @@ export const GridProEditColumnMixin = (superClass) =>
       this._setEditorValue(editor, get(this.path, model.item));
       editor._grid = this._grid;
 
-      if (editor.updateComplete) {
-        editor.updateComplete.then(() => this._focusEditor(editor));
-      } else {
-        this._focusEditor(editor);
-      }
+      this._focusEditor(editor);
     }
 
     /**

--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -93,8 +93,6 @@ describe('keyboard navigation', () => {
       const secondCell = getContainerCell(grid.$.items, 2, 0);
       const spy = sinon.spy(secondCell, 'focus');
       await sendKeys({ press: 'Enter' });
-      // Wait for possible scroll to get the cell into view
-      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Description

This essentially reverts #7235 and removes a delayed `focus()` call on the editor in favor of focusing it immediately, like it's done in Polymer version. This should work now since we render synchronously in `PolylitMixin` by default.

Also reverted #8574 which appears to be incorrect fix for the flaky test that this change tries to address:

```
packages/grid-pro/test/keyboard-navigation-lit.test.js:

 ❌ keyboard navigation > when `singleCellEdit` is true > should focus editable cell on the next row in non-edit mode on Enter, if `enterNextRow` is true
      AssertionError: expected false to be true
      + expected - actual
      
      -false
      +true
```

## Type of change

- Refactor