### PR TITLE
test: another attempt to stabilize grid-pro test

### DIFF
--- a/packages/grid-pro/test/keyboard-navigation.common.js
+++ b/packages/grid-pro/test/keyboard-navigation.common.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import {
   createItems,
@@ -15,7 +15,7 @@ import {
 describe('keyboard navigation', () => {
   let grid;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     grid = fixtureSync(`
       <vaadin-grid-pro>
         <vaadin-grid-pro-edit-column path="name" header="Name"></vaadin-grid-pro-edit-column>
@@ -28,6 +28,8 @@ describe('keyboard navigation', () => {
     };
 
     grid.items = createItems();
+    // Wait for vaadin-grid-appear animation to finish
+    await oneEvent(grid, 'animationend');
     flushGrid(grid);
   });
 
@@ -93,8 +95,6 @@ describe('keyboard navigation', () => {
       const secondCell = getContainerCell(grid.$.items, 2, 0);
       const spy = sinon.spy(secondCell, 'focus');
       await sendKeys({ press: 'Enter' });
-      // Wait for possible scroll to get the cell into view
-      await nextFrame();
       expect(spy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6633b30a-0564-4747-8257-e65928ccf93b)

There was sometimes a second focus call originating from:

https://github.com/vaadin/web-components/blob/e34b3ba52150e9e8224f72ecbf0df927f503f562/packages/grid/src/vaadin-grid-mixin.js#L795-L807

The PR updates the tests to wait for this animation to finish before any interactions.