### PR TITLE
refactor: make selected property in ListMixin use sync: true

### DIFF
--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -40,6 +40,7 @@ export const ListMixin = (superClass) =>
           type: Number,
           reflectToAttribute: true,
           notify: true,
+          sync: true,
         },
 
         /**

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -774,7 +774,6 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should reset previously selected item when listbox and items are disabled', async () => {
       list.selected = 3;
-      await nextUpdate(list);
       expect(items[3].selected).to.be.true;
 
       list.disabled = true;
@@ -788,7 +787,6 @@ const runTests = (defineHelper, baseMixin) => {
 
     it('should restore previously selected item when listbox becomes re-enabled', async () => {
       list.selected = 3;
-      await nextUpdate(list);
 
       list.disabled = true;
       items.forEach((item) => {

--- a/packages/select/test/select-lit.test.js
+++ b/packages/select/test/select-lit.test.js
@@ -1,3 +1,5 @@
+import '@vaadin/item/vaadin-lit-item.js';
+import '@vaadin/list-box/vaadin-lit-list-box.js';
 import './not-animated-styles.js';
 import '../src/vaadin-lit-select.js';
 import './select.common.js';

--- a/packages/select/test/select-polymer.test.js
+++ b/packages/select/test/select-polymer.test.js
@@ -1,3 +1,5 @@
+import '@vaadin/item/vaadin-item.js';
+import '@vaadin/list-box/vaadin-list-box.js';
 import './not-animated-styles.js';
 import '../src/vaadin-select.js';
 import './select.common.js';

--- a/packages/select/test/select.common.js
+++ b/packages/select/test/select.common.js
@@ -14,8 +14,6 @@ import {
   tab,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
 import { html, render } from 'lit';
 
 describe('vaadin-select', () => {


### PR DESCRIPTION
## Description

Added missing `sync: true` to ensure Lit based `vaadin-list-box` works correctly in `vaadin-select`.
Also, updated tests to import respective versions of `vaadin-item` and `vaadin-list-box`.

## Type of change

- Refactor