### PR TITLE
refactor: add missing check import logic to Lit based list-box

### DIFF
--- a/packages/list-box/src/vaadin-lit-list-box.js
+++ b/packages/list-box/src/vaadin-lit-list-box.js
@@ -81,8 +81,18 @@ class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(PolylitMix
 
     this.setAttribute('role', 'listbox');
 
+    setTimeout(this._checkImport.bind(this), 2000);
+
     this._tooltipController = new TooltipController(this);
     this.addController(this._tooltipController);
+  }
+
+  /** @private */
+  _checkImport() {
+    const item = this.querySelector('vaadin-item');
+    if (item && !(item instanceof LitElement)) {
+      console.warn(`Make sure you have imported the vaadin-item element.`);
+    }
   }
 }
 


### PR DESCRIPTION
## Description

With the new approach of auto-generated Lit test files, the `list-box` test suite fails (the logic was previously not implemented in the Lit based version). Let's add it for now to make the tests pass in #8300

## Type of change

- Refactor