### PR TITLE
docs: deprecate form-item label-position attribute

### DIFF
--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -44,8 +44,8 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  * `<vaadin-form-layout>`, depending on its width and responsive behavior.
  *
  * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * V24.7 and will be removed in V25, when a new method for setting the label position
- * will be introduced.
+ * 24.7 and will be removed in Vaddin 25, when a new approach for setting the label
+ * position will be introduced.
  *
  * ### Input Width
  *
@@ -71,8 +71,8 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  * ```
  *
  * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * V24.7 and will be removed in V25, when a new method for styling the form-item based
- * on the label position will be introduced.
+ * 24.7 and will be removed in Vaadin 25, when a new approach to styling the form-item
+ * based on the label position will be introduced.
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -43,6 +43,10 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  * because the `label-position` attribute is triggered automatically by the parent
  * `<vaadin-form-layout>`, depending on its width and responsive behavior.
  *
+ * **Deprecation note:** The `label-position` attribute is getting deprecated since
+ * V24.7 and will be removed in V25, when a new method for setting the label position
+ * will be introduced.
+ *
  * ### Input Width
  *
  * By default, `<vaadin-form-item>` does not manipulate the width of the slotted
@@ -65,6 +69,10 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  *   padding-top: 0.5rem;
  * }
  * ```
+ *
+ * **Deprecation note:** The `label-position` attribute is getting deprecated since
+ * V24.7 and will be removed in V25, when a new method for styling the form-item based
+ * on the label position will be introduced.
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -43,9 +43,9 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  * because the `label-position` attribute is triggered automatically by the parent
  * `<vaadin-form-layout>`, depending on its width and responsive behavior.
  *
- * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * 24.7 and will be removed in Vaddin 25, when a new approach for setting the label
- * position will be introduced.
+ * **Deprecation note:** The `label-position` attribute is deprecated since 24.7 and
+ * will be removed in Vaadin 25, when a new approach for setting the label position
+ * will be introduced.
  *
  * ### Input Width
  *
@@ -70,8 +70,8 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  * }
  * ```
  *
- * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * 24.7 and will be removed in Vaadin 25, when a new approach to styling the form-item
+ * **Deprecation note:** The `label-position` attribute is deprecated since 24.7 and
+ * will be removed in Vaadin 25, when a new approach to styling the form-item
  * based on the label position will be introduced.
  *
  * The following shadow DOM parts are available for styling:

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -49,8 +49,8 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  * `<vaadin-form-layout>`, depending on its width and responsive behavior.
  *
  * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * V24.7 and will be removed in V25, when a new method for setting the label position
- * will be introduced.
+ * 24.7 and will be removed in Vaddin 25, when a new approach for setting the label
+ * position will be introduced.
  *
  * ### Input Width
  *
@@ -76,8 +76,8 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  * ```
  *
  * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * V24.7 and will be removed in V25, when a new method for styling the form-item based
- * on the label position will be introduced.
+ * 24.7 and will be removed in Vaadin 25, when a new approach to styling the form-item
+ * based on the label position will be introduced.
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -48,6 +48,10 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  * because the `label-position` attribute is triggered automatically by the parent
  * `<vaadin-form-layout>`, depending on its width and responsive behavior.
  *
+ * **Deprecation note:** The `label-position` attribute is getting deprecated since
+ * V24.7 and will be removed in V25, when a new method for setting the label position
+ * will be introduced.
+ *
  * ### Input Width
  *
  * By default, `<vaadin-form-item>` does not manipulate the width of the slotted
@@ -70,6 +74,10 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  *   padding-top: 0.5rem;
  * }
  * ```
+ *
+ * **Deprecation note:** The `label-position` attribute is getting deprecated since
+ * V24.7 and will be removed in V25, when a new method for styling the form-item based
+ * on the label position will be introduced.
  *
  * The following shadow DOM parts are available for styling:
  *

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -48,9 +48,9 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  * because the `label-position` attribute is triggered automatically by the parent
  * `<vaadin-form-layout>`, depending on its width and responsive behavior.
  *
- * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * 24.7 and will be removed in Vaddin 25, when a new approach for setting the label
- * position will be introduced.
+ * **Deprecation note:** The `label-position` attribute is deprecated since 24.7 and
+ * will be removed in Vaadin 25, when a new approach for setting the label position
+ * will be introduced.
  *
  * ### Input Width
  *
@@ -75,8 +75,8 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  * }
  * ```
  *
- * **Deprecation note:** The `label-position` attribute is getting deprecated since
- * 24.7 and will be removed in Vaadin 25, when a new approach to styling the form-item
+ * **Deprecation note:** The `label-position` attribute is deprecated since 24.7 and
+ * will be removed in Vaadin 25, when a new approach to styling the form-item
  * based on the label position will be introduced.
  *
  * The following shadow DOM parts are available for styling:


### PR DESCRIPTION
## Description

Adds a deprecation note on the documentation that mentions the `label-position` attribute for `FormItem`

Part of #8583 