### PR TITLE
test: add dialog form layout integration test

### DIFF
--- a/test/integration/dialog-form-layout.test.js
+++ b/test/integration/dialog-form-layout.test.js
@@ -1,0 +1,63 @@
+import { expect } from '@vaadin/chai-plugins';
+import { setViewport } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '@vaadin/text-field';
+import '@vaadin/form-layout';
+import '@vaadin/form-layout/vaadin-form-item.js';
+import '@vaadin/dialog';
+
+describe('form-layout in dialog', () => {
+  let dialog, formLayout;
+
+  before(async () => {
+    await setViewport({ width: 1024, height: 768 });
+  });
+
+  beforeEach(async () => {
+    dialog = fixtureSync(`<vaadin-dialog></vaadin-dialog>`);
+    dialog.renderer = (root) => {
+      root.innerHTML = `
+      <vaadin-form-layout>
+        <vaadin-form-item>
+          <label slot="label">First name</label>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-form-item>
+        <vaadin-form-item>
+          <label slot="label">Last name</label>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-form-item>
+        <vaadin-form-item>
+          <label slot="label">Email</label>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-form-item>
+        <vaadin-form-item>
+          <label slot="label">Phone</label>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-form-item>
+      </vaadin-form-layout>
+    `;
+    };
+    dialog.opened = true;
+    await nextRender();
+    formLayout = dialog.$.overlay.querySelector('vaadin-form-layout');
+  });
+
+  afterEach(async () => {
+    dialog.opened = false;
+    await nextFrame();
+  });
+
+  it('should arrange form items in two columns', () => {
+    const formItems = [...formLayout.querySelectorAll('vaadin-form-item')];
+
+    // Assert that 1st and 2nd form items are on the same row
+    expect(formItems[0].offsetTop).to.equal(formItems[1].offsetTop);
+
+    // Assert that 3rd and 4th form items are on the same row
+    expect(formItems[2].offsetTop).to.equal(formItems[3].offsetTop);
+
+    // Assert that 3rd form item is on a row below 1st form item
+    expect(formItems[2].offsetTop).to.be.greaterThan(formItems[0].offsetTop);
+  });
+});

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -22,6 +22,7 @@
     "@vaadin/details": "24.7.0-alpha7",
     "@vaadin/dialog": "24.7.0-alpha7",
     "@vaadin/email-field": "24.7.0-alpha7",
+    "@vaadin/form-layout": "24.7.0-alpha7",
     "@vaadin/grid": "24.7.0-alpha7",
     "@vaadin/grid-pro": "24.7.0-alpha7",
     "@vaadin/icon": "24.7.0-alpha7",


### PR DESCRIPTION
## Description

The PR improves test coverage by adding an integration test that verifies that FormLayout arranges form items into two columns when placed inside a Dialog. In other words, this ensures that FormLayout selects the largest responsive step when there is enough space in the Dialog.

Part of #8583 

## Type of change

- [x] Internal
