### PR TITLE
fix: fix Material combo box overlay sizing

### DIFF
--- a/packages/combo-box/theme/material/vaadin-combo-box-overlay-styles.js
+++ b/packages/combo-box/theme/material/vaadin-combo-box-overlay-styles.js
@@ -6,9 +6,14 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 const comboBoxOverlay = css`
   [part='overlay'] {
     position: relative;
-    overflow: visible;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+  }
+
+  /* Overflow needs to be auto by default to make overlay sizing logic work */
+  /* When loading, overflow needs to be visible to make loading indicator visible */
+  :host([loading]) [part='overlay'] {
+    overflow: visible;
   }
 
   [part='content'] {


### PR DESCRIPTION
## Description

The Material theme for combo box uses `overflow: visible` on the overlay part to allow showing the loading indicator, which is positioned upwards to cover the field's bottom border (added in https://github.com/vaadin/vaadin-combo-box/pull/743). However this causes the overlay sizing logic to break, which apparently needs `overflow: auto`.

This fixes the styles to only apply `overflow: visible` when the combo box is actually loading. That should be fine as the combo box is empty in that state and the overlay sizing logic is not (as) relevant.

**Before:**

https://github.com/user-attachments/assets/fe430979-7aad-4b70-bf8c-5c7de704dae8

**After:**

https://github.com/user-attachments/assets/332b5222-e261-439b-887e-fe77152e0f0f


Fixes https://github.com/vaadin/flow-components/issues/7063

## Type of change

- Bugfix
