### PR TITLE
refactor: use _onResize instead of IntersectionObserver

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -91,11 +91,6 @@ export const FormLayoutMixin = (superClass) =>
           type: Boolean,
           sync: true,
         },
-
-        /** @private */
-        __isVisible: {
-          type: Boolean,
-        },
       };
     }
 
@@ -123,23 +118,6 @@ export const FormLayoutMixin = (superClass) =>
       this._styleElement = document.createElement('style');
       // Ensure there is a child text node in the style element
       this._styleElement.textContent = ' ';
-
-      this.__intersectionObserver = new IntersectionObserver((entries) => {
-        // If the browser is busy (e.g. due to slow rendering), multiple entries can
-        // be queued and then passed to the callback invocation at once. Make sure we
-        // use the most recent entry to detect whether the layout is visible or not.
-        // See https://github.com/vaadin/web-components/issues/8564
-        const entry = [...entries].pop();
-        if (!entry.isIntersecting) {
-          // Prevent possible jump when layout becomes visible
-          this.$.layout.style.opacity = 0;
-        }
-        if (!this.__isVisible && entry.isIntersecting) {
-          this._updateLayout();
-          this.$.layout.style.opacity = '';
-        }
-        this.__isVisible = entry.isIntersecting;
-      });
     }
 
     /** @protected */
@@ -150,7 +128,6 @@ export const FormLayoutMixin = (superClass) =>
       requestAnimationFrame(() => this._updateLayout());
 
       this._observeChildrenColspanChange();
-      this.__intersectionObserver.observe(this.$.layout);
     }
 
     /** @protected */
@@ -159,7 +136,6 @@ export const FormLayoutMixin = (superClass) =>
 
       this.__mutationObserver.disconnect();
       this.__childObserver.disconnect();
-      this.__intersectionObserver.disconnect();
     }
 
     /** @private */
@@ -432,7 +408,15 @@ export const FormLayoutMixin = (superClass) =>
      * @protected
      * @override
      */
-    _onResize() {
+    _onResize(contentRect) {
+      if (contentRect.width === 0 && contentRect.height === 0) {
+        this.$.layout.style.opacity = '0';
+        return;
+      }
+
       this._selectResponsiveStep();
+      this._updateLayout();
+
+      this.$.layout.style.opacity = '';
     }
   };


### PR DESCRIPTION
## Description

Removes `IntersectionObserver` from FormLayout in favor of ResizeMixin's `_onResize` which is also triggered when the element's visibility changes as a result of `display: none` or any other method that completely removes the element from the render tree.

Part of #8583 

## Type of change

- [x] Refactor
