### PR TITLE
chore: enforce Webdriver classic protocol in visual tests

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -333,6 +333,7 @@ const createVisualTestsConfig = (theme, browserVersion) => {
         browserName: 'chrome',
         platformName: 'Windows 10',
         browserVersion,
+        'wdio:enforceWebDriverClassic': true,
       }),
     ],
     plugins: [


### PR DESCRIPTION
## Description

Let's use this to get rid of webdriver BiDi protocol errors and also hopefully fix the following error:

```
 Error: Error while executing command set-window-height with payload {"height":610}: WebDriverError: unknown error: failed to change window state to 'normal', current state is 'maximized'
```

## Type of change

- Internal change