### PR TITLE
feat: type event target for upload events

### DIFF
--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -10,47 +10,49 @@ import { type UploadFile, UploadMixin } from './vaadin-upload-mixin.js';
 
 export { UploadFile, UploadI18n, UploadMethod } from './vaadin-upload-mixin.js';
 
+type UploadEvent<T> = CustomEvent<T> & { target: Upload };
+
 /**
  * Fired when a file cannot be added to the queue due to a constrain:
  * file-size, file-type or maxFiles
  */
-export type UploadFileRejectEvent = CustomEvent<{ file: UploadFile; error: string }>;
+export type UploadFileRejectEvent = UploadEvent<{ file: UploadFile; error: string }>;
 
 /**
  * Fired when the `files` property changes.
  */
-export type UploadFilesChangedEvent = CustomEvent<{ value: UploadFile[] }>;
+export type UploadFilesChangedEvent = UploadEvent<{ value: UploadFile[] }>;
 
 /**
  * Fired when the `max-files-reached` property changes.
  */
-export type UploadMaxFilesReachedChangedEvent = CustomEvent<{ value: boolean }>;
+export type UploadMaxFilesReachedChangedEvent = UploadEvent<{ value: boolean }>;
 
 /**
  * Fired before the XHR is opened. Could be used for changing the request
  * URL. If the default is prevented, then XHR would not be opened.
  */
-export type UploadBeforeEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadBeforeEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when the XHR is sent.
  */
-export type UploadStartEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadStartEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired as many times as the progress is updated.
  */
-export type UploadProgressEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadProgressEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired in case the upload process succeeded.
  */
-export type UploadSuccessEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadSuccessEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired in case the upload process failed.
  */
-export type UploadErrorEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadErrorEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when we have the actual server response, and before the component
@@ -62,19 +64,19 @@ export type UploadErrorEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFi
  * with the normal workflow checking the `xhr.status` and `file.error`
  * which also might be modified by the user to force a customized response,
  */
-export type UploadResponseEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadResponseEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when retry upload is requested. If the default is prevented, then
  * retry would not be performed.
  */
-export type UploadRetryEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadRetryEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when upload abort is requested. If the default is prevented, then the
  * file upload would not be aborted.
  */
-export type UploadAbortEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
+export type UploadAbortEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile }>;
 
 /**
  * Fired when the XHR has been opened but not sent yet. Useful for appending
@@ -82,7 +84,7 @@ export type UploadAbortEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFi
  * headers, etc. If the event is defaultPrevented, `vaadin-upload` will not
  * send the request allowing the user to do something on his own.
  */
-export type UploadRequestEvent = CustomEvent<{ xhr: XMLHttpRequest; file: UploadFile; formData: FormData }>;
+export type UploadRequestEvent = UploadEvent<{ xhr: XMLHttpRequest; file: UploadFile; formData: FormData }>;
 
 export interface UploadCustomEventMap {
   'file-reject': UploadFileRejectEvent;

--- a/packages/upload/test/typings/upload.types.ts
+++ b/packages/upload/test/typings/upload.types.ts
@@ -1,5 +1,6 @@
 import '../../vaadin-upload.js';
 import type {
+  Upload,
   UploadAbortEvent,
   UploadBeforeEvent,
   UploadErrorEvent,
@@ -42,70 +43,82 @@ assertType<UploadI18n>(upload.i18n);
 // Events
 upload.addEventListener('max-files-reached-changed', (event) => {
   assertType<UploadMaxFilesReachedChangedEvent>(event);
+  assertType<Upload>(event.target);
   assertType<boolean>(event.detail.value);
 });
 
 upload.addEventListener('file-reject', (event) => {
   assertType<UploadFileRejectEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<string>(event.detail.error);
 });
 
 upload.addEventListener('files-changed', (event) => {
   assertType<UploadFilesChangedEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile[]>(event.detail.value);
 });
 
 upload.addEventListener('upload-before', (event) => {
   assertType<UploadBeforeEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-start', (event) => {
   assertType<UploadStartEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-progress', (event) => {
   assertType<UploadProgressEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-response', (event) => {
   assertType<UploadResponseEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-success', (event) => {
   assertType<UploadSuccessEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-error', (event) => {
   assertType<UploadErrorEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-retry', (event) => {
   assertType<UploadRetryEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-abort', (event) => {
   assertType<UploadAbortEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<XMLHttpRequest>(event.detail.xhr);
 });
 
 upload.addEventListener('upload-request', (event) => {
   assertType<UploadRequestEvent>(event);
+  assertType<Upload>(event.target);
   assertType<UploadFile>(event.detail.file);
   assertType<FormData>(event.detail.formData);
 });


### PR DESCRIPTION
## Description

Types `event.target` for upload events, so that casting the target is unnecessary when trying to use the upload element in event handlers. This could be used for example to clear the files when an upload has finished using `event.target.files = []`.

Part of https://github.com/vaadin/web-components/issues/7868

## Type of change

- Feature
