### PR TITLE
test: remove IntersectionObserver-related test

### DIFF
--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '../vaadin-form-layout.js';
@@ -446,7 +446,7 @@ describe('form layout', () => {
   describe('hidden', () => {
     let container, layout;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       container = fixtureSync(`
         <div hidden>
           <vaadin-form-layout>
@@ -456,6 +456,7 @@ describe('form layout', () => {
         </div>
       `);
       layout = container.querySelector('vaadin-form-layout');
+      await nextResize(layout);
     });
 
     it('should update steps on show after hidden', (done) => {
@@ -485,63 +486,17 @@ describe('form layout', () => {
       await nextRender();
 
       container.hidden = false;
-
-      // Wait for intersection observer
-      await nextFrame();
-      await nextFrame();
+      await nextResize(layout);
 
       expect(parseFloat(getParsedWidth(layout.children[0]).percentage)).to.be.closeTo(100, 0.1);
       expect(parseFloat(getParsedWidth(layout.children[1]).percentage)).to.be.closeTo(100, 0.1);
     });
 
     it('should change layout opacity when its parent becomes visible', async () => {
-      // Wait for intersection observer
-      await nextFrame();
-      await nextFrame();
       expect(layout.$.layout.style.opacity).to.equal('0');
 
       container.hidden = false;
-
-      // Wait for intersection observer
-      await nextFrame();
-      await nextFrame();
-
-      expect(layout.$.layout.style.opacity).to.equal('');
-    });
-  });
-
-  describe('fixed size parent', () => {
-    let container, layout;
-
-    beforeEach(async () => {
-      container = fixtureSync(`
-        <div style="height: 100px; overflow: auto">
-          <div style="height: 25px">
-            <vaadin-form-layout style="height: 100%">
-              <div>1</div>
-              <div>2</div>
-              <div>3</div>
-              <div>4</div>
-              <div>5</div>
-              <div>6</div>
-              <div>7</div>
-              <div>8</div>
-              <div>9</div>
-              <div>10</div>
-            </vaadin-form-layout>
-          </div>
-        </div>
-      `);
-      layout = container.querySelector('vaadin-form-layout');
-      layout.responsiveSteps = [{ columns: 1 }];
-      await nextRender();
-    });
-
-    it('should not set opacity to 0 when host is scrolled out due to fixed height', async () => {
-      container.scrollTop = container.scrollHeight;
-      // Wait for intersection observer
-      await nextFrame();
-      await nextFrame();
+      await nextResize(layout);
       expect(layout.$.layout.style.opacity).to.equal('');
     });
   });


### PR DESCRIPTION
## Description

This test was relevant when using IntersectionObserver but is no longer needed now that we rely on ResizeObserver for detecting visibility changes.

Part of #8583 

## Type of change

- [x] Internal
