### PR TITLE
refactor!: remove unnecessary subscription to animationend

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -108,8 +108,6 @@ export const FormLayoutMixin = (superClass) =>
       this.appendChild(this._styleElement);
 
       super.ready();
-
-      this.addEventListener('animationend', this.__onAnimationEnd);
     }
 
     constructor() {
@@ -268,13 +266,6 @@ export const FormLayoutMixin = (superClass) =>
       }
 
       this._selectResponsiveStep();
-    }
-
-    /** @private */
-    __onAnimationEnd(e) {
-      if (e.animationName.indexOf('vaadin-form-layout-appear') === 0) {
-        this._selectResponsiveStep();
-      }
     }
 
     /** @private */

--- a/packages/form-layout/src/vaadin-form-layout-styles.js
+++ b/packages/form-layout/src/vaadin-form-layout-styles.js
@@ -9,19 +9,12 @@ export const formLayoutStyles = css`
   :host {
     display: block;
     max-width: 100%;
-    animation: 1ms vaadin-form-layout-appear;
     /* CSS API for host */
     --vaadin-form-item-label-width: 8em;
     --vaadin-form-item-label-spacing: 1em;
     --vaadin-form-item-row-spacing: 1em;
     --vaadin-form-layout-column-spacing: 2em; /* (default) */
     align-self: stretch;
-  }
-
-  @keyframes vaadin-form-layout-appear {
-    to {
-      opacity: 1 !important; /* stylelint-disable-line keyframe-declaration-no-important */
-    }
   }
 
   :host([hidden]) {

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -458,26 +458,11 @@ describe('form layout', () => {
       layout = container.querySelector('vaadin-form-layout');
     });
 
-    it('should update steps on show after hidden', (done) => {
+    it('should update steps on show after hidden', async () => {
       const spy = sinon.spy(layout, '_selectResponsiveStep');
-      layout.addEventListener('animationend', () => {
-        expect(spy.called).to.be.true;
-        done();
-      });
-
+      await nextResize(layout);
       container.hidden = false;
-    });
-
-    it('should not update steps on custom animation name', (done) => {
-      const spy = sinon.spy(layout, '_selectResponsiveStep');
-      layout.addEventListener('animationend', () => {
-        expect(spy.called).to.be.false;
-        done();
-      });
-
-      const ev = new Event('animationend');
-      ev.animationName = 'foo';
-      layout.dispatchEvent(ev);
+      expect(spy).to.be.calledOnce;
     });
 
     it('should update layout when its parent becomes visible', async () => {


### PR DESCRIPTION
## Description

Listening to `animationend` to trigger a layout update is no longer necessary since this is now handled by ResizeObserver. The change is marked wuth `!` because it removes the CSS animation.

Part of #8583 

## Type of change

- [x] Refactor
