### PR TITLE
test: add missing nextResize

### DIFF
--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -427,6 +427,7 @@ describe('form layout', () => {
       const spy = sinon.spy(layout, '_selectResponsiveStep');
       await nextResize(layout);
       container.hidden = false;
+      await nextResize(layout);
       expect(spy).to.be.calledOnce;
     });
 


### PR DESCRIPTION
## Description

Fixes the following test failures that were introduced in #8633:

```
packages/form-layout/test/form-layout-lit.generated.test.js:

 ❌ form layout > hidden > should update steps on show after hidden
      AssertionError: expected _selectResponsiveStep to have been called exactly once, but it was called 0 times
        at n.<anonymous> (packages/form-layout/test/form-layout-lit.generated.test.js:444:24)


packages/form-layout/test/form-layout.test.js:

 ❌ form layout > hidden > should update steps on show after hidden
      AssertionError: expected _selectResponsiveStep to have been called exactly once, but it was called 0 times
        at n.<anonymous> (packages/form-layout/test/form-layout.test.js:444:24)
```

## Type of change

- [x] Internal
