### PR TITLE
test: improve test coverage by using native input

### DIFF
--- a/test/integration/dialog-form-layout.test.js
+++ b/test/integration/dialog-form-layout.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
-import '@vaadin/text-field';
 import '@vaadin/form-layout';
 import '@vaadin/form-layout/vaadin-form-item.js';
 import '@vaadin/dialog';
@@ -18,25 +17,25 @@ describe('form-layout in dialog', () => {
     dialog = fixtureSync(`<vaadin-dialog></vaadin-dialog>`);
     dialog.renderer = (root) => {
       root.innerHTML = `
-      <vaadin-form-layout>
-        <vaadin-form-item>
-          <label slot="label">First name</label>
-          <vaadin-text-field></vaadin-text-field>
-        </vaadin-form-item>
-        <vaadin-form-item>
-          <label slot="label">Last name</label>
-          <vaadin-text-field></vaadin-text-field>
-        </vaadin-form-item>
-        <vaadin-form-item>
-          <label slot="label">Email</label>
-          <vaadin-text-field></vaadin-text-field>
-        </vaadin-form-item>
-        <vaadin-form-item>
-          <label slot="label">Phone</label>
-          <vaadin-text-field></vaadin-text-field>
-        </vaadin-form-item>
-      </vaadin-form-layout>
-    `;
+        <vaadin-form-layout>
+          <vaadin-form-item>
+            <label slot="label">First name</label>
+            <input />
+          </vaadin-form-item>
+          <vaadin-form-item>
+            <label slot="label">Last name</label>
+            <input />
+          </vaadin-form-item>
+          <vaadin-form-item>
+            <label slot="label">Email</label>
+            <input />
+          </vaadin-form-item>
+          <vaadin-form-item>
+            <label slot="label">Phone</label>
+            <input />
+          </vaadin-form-item>
+        </vaadin-form-layout>
+      `;
     };
     dialog.opened = true;
     await nextRender();


### PR DESCRIPTION
## Description

Using `<vaadin-text-field>` appears to increase the minimum width of each FormLayout column, causing the total minimum width of FormLayout to exceed FormLayout's largest breakpoint. This in turn prevents the test from alerting us to a visual regression that emerge when [switching to CSS grid](https://github.com/vaadin/web-components/pull/8590), which was the underlying purpose of this test.

## Type of change

- [x] Internal
