### PR TITLE
fix: restore scroll position when virtualizer host is connected

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -55,8 +55,10 @@ export class IronListAdapter {
     const attachObserver = new ResizeObserver(([{ contentRect }]) => {
       const isHidden = contentRect.width === 0 && contentRect.height === 0;
       if (!isHidden && this.__scrollTargetHidden && this.scrollTarget.scrollTop !== this._scrollPosition) {
-        // Adjust scroll position after moving the element within DOM
-        // while also making it visible (e.g. inside of the dialog).
+        // When removing element from DOM, its scroll position is lost and
+        // virtualizer doesn't re-render when adding it to the DOM again.
+        // Restore scroll position when the scroll target becomes visible,
+        // which is the case e.g. when virtualizer is used inside a dialog.
         this.scrollTarget.scrollTop = this._scrollPosition;
       }
 

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -52,6 +52,18 @@ export class IronListAdapter {
     this.__resizeObserver.observe(this.scrollTarget);
     this.scrollTarget.addEventListener('scroll', () => this._scrollHandler());
 
+    const attachObserver = new ResizeObserver(([{ contentRect }]) => {
+      const isHidden = contentRect.width === 0 && contentRect.height === 0;
+      if (!isHidden && this.__scrollTargetHidden && this.scrollTarget.scrollTop !== this._scrollPosition) {
+        // Adjust scroll position after moving the element within DOM
+        // while also making it visible (e.g. inside of the dialog).
+        this.scrollTarget.scrollTop = this._scrollPosition;
+      }
+
+      this.__scrollTargetHidden = isHidden;
+    });
+    attachObserver.observe(this.scrollTarget);
+
     this._scrollLineHeight = this._getScrollLineHeight();
     this.scrollTarget.addEventListener('wheel', (e) => this.__onWheel(e));
 

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';
 
@@ -348,6 +348,22 @@ describe('virtualizer', () => {
     const itemHeight = elementsContainer.querySelector('#item-0').offsetHeight;
     const expectedCount = Math.ceil((viewportHeight / itemHeight) * 1.3) + 1;
     expect(initialCount).not.to.be.above(expectedCount);
+  });
+
+  it('should preserve scroll position when moving within DOM and changing visibility', async () => {
+    scrollTarget.scrollTop = 100;
+    await oneEvent(scrollTarget, 'scroll');
+
+    scrollTarget.hidden = true;
+    await nextResize(scrollTarget);
+
+    const wrapper = fixtureSync('<div></div>');
+    wrapper.appendChild(scrollTarget);
+
+    scrollTarget.hidden = false;
+    await nextResize(scrollTarget);
+
+    expect(scrollTarget.scrollTop).to.equal(100);
   });
 
   describe('lazy rendering', () => {


### PR DESCRIPTION
## Description

Fixes #8630

Related to https://github.com/vaadin/web-components/issues/6431#issuecomment-2620032575

When an element using virtualizer (e.g. virtual-list or grid) is used in dialog or other overlay, it is moved within DOM while also changing visibility. Added `ResizeObserver` to handle this case and restore `scrollTop`, which gets reset whenever the element gets disconnected from the DOM. This fixes the problem of empty items after dialog reopening.

## Type of change

- Bugfix