### PR TITLE
refactor: simplify isValidCSSLength by using CSS.supports

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -116,26 +116,6 @@ export const FormLayoutMixin = (superClass) =>
     }
 
     /** @protected */
-    ready() {
-      // Here we attach a style element that we use for validating
-      // CSS values in `responsiveSteps`. We can't add this to the `<template>`,
-      // because Polymer will throw it away. We need to create this before
-      // `super.ready()`, because `super.ready()` invokes property observers,
-      // and the observer for `responsiveSteps` does CSS value validation.
-      this.appendChild(this._styleElement);
-
-      super.ready();
-    }
-
-    constructor() {
-      super();
-
-      this._styleElement = document.createElement('style');
-      // Ensure there is a child text node in the style element
-      this._styleElement.textContent = ' ';
-    }
-
-    /** @protected */
     connectedCallback() {
       super.connectedCallback();
 

--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -7,20 +7,10 @@ import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 
 function isValidCSSLength(value) {
-  // Let us choose a CSS property for validating CSS <length> values:
-  // - `border-spacing` accepts `<length> | inherit`, it's the best! But
-  //   it does not disallow invalid values at all in MSIE :-(
-  // - `letter-spacing` and `word-spacing` accept
-  //   `<length> | normal | inherit`, and disallows everything else, like
-  //   `<percentage>`, `auto` and such, good enough.
-  // - `word-spacing` is used since its shorter.
-
-  // Disallow known keywords allowed as the `word-spacing` value
-  if (['inherit', 'normal'].includes(value)) {
-    return false;
-  }
-
-  return CSS.supports('word-spacing', value);
+  // Check if the value is a valid CSS length and not `inherit` or `normal`,
+  // which are also valid values for `word-spacing`, see:
+  // https://drafts.csswg.org/css-text-3/#word-spacing-property
+  return CSS.supports('word-spacing', value) && !['inherit', 'normal'].includes(value);
 }
 
 /**


### PR DESCRIPTION
## Description

The PR refactors the `isValidCSSLength` method in FormLayout to use `CSS.supports` which is supported by all modern browsers. As a result, it also removes the need for the `style` element that was previously added as a child of FormLayout.

Part of #8583 

## Type of change

- [x] Refactor
