### PR TITLE
 feat: support partial i18n in avatar group 

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.d.ts
@@ -5,7 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { AvatarI18n } from '@vaadin/avatar/src/vaadin-avatar.js';
-import type { PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
@@ -33,7 +33,11 @@ export interface AvatarGroupItem {
  */
 export declare function AvatarGroupMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<AvatarGroupMixinClass> & Constructor<OverlayClassMixinClass> & Constructor<ResizeMixinClass> & T;
+): Constructor<AvatarGroupMixinClass> &
+  Constructor<I18nMixinClass<AvatarGroupI18n>> &
+  Constructor<OverlayClassMixinClass> &
+  Constructor<ResizeMixinClass> &
+  T;
 
 export declare class AvatarGroupMixinClass {
   /**

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.d.ts
@@ -5,17 +5,20 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { AvatarI18n } from '@vaadin/avatar/src/vaadin-avatar.js';
+import type { PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
-export interface AvatarGroupI18n extends AvatarI18n {
-  activeUsers: {
-    one: string;
-    many: string;
-  };
-  joined: string;
-  left: string;
-}
+export type AvatarGroupI18n = PartialI18n<
+  {
+    activeUsers: {
+      one: string;
+      many: string;
+    };
+    joined: string;
+    left: string;
+  } & AvatarI18n
+>;
 
 export interface AvatarGroupItem {
   name?: string;

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -157,8 +157,7 @@ export const AvatarGroupMixin = (superClass) =>
      *   left: '{user} left'
      * }
      * ```
-     * @type {!AvatarGroupI18n}
-     * @default {English/US}
+     * @return {!AvatarGroupI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -464,16 +464,16 @@ export const AvatarGroupMixin = (superClass) =>
     }
 
     /** @private */
-    __i18nItemsChanged(i18n, items) {
-      if (i18n && i18n.activeUsers) {
+    __i18nItemsChanged(effectiveI18n, items) {
+      if (effectiveI18n && effectiveI18n.activeUsers) {
         const count = Array.isArray(items) ? items.length : 0;
         const field = count === 1 ? 'one' : 'many';
-        if (i18n.activeUsers[field]) {
-          this.setAttribute('aria-label', i18n.activeUsers[field].replace('{count}', count || 0));
+        if (effectiveI18n.activeUsers[field]) {
+          this.setAttribute('aria-label', effectiveI18n.activeUsers[field].replace('{count}', count || 0));
         }
 
         this._avatars.forEach((avatar) => {
-          avatar.i18n = i18n;
+          avatar.i18n = effectiveI18n;
         });
       }
     }

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -28,11 +28,12 @@ const DEFAULT_I18N = {
  * A mixin providing common avatar group functionality.
  *
  * @polymerMixin
+ * @mixes I18nMixin
  * @mixes ResizeMixin
  * @mixes OverlayClassMixin
  */
 export const AvatarGroupMixin = (superClass) =>
-  class AvatarGroupMixinClass extends I18nMixin(ResizeMixin(OverlayClassMixin(superClass)), DEFAULT_I18N) {
+  class AvatarGroupMixinClass extends I18nMixin(DEFAULT_I18N, ResizeMixin(OverlayClassMixin(superClass))) {
     static get properties() {
       return {
         /**

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -505,9 +505,9 @@ describe('avatar-group', () => {
     it('should pass i18n property to avatars', () => {
       group.i18n = customI18n;
       const items = group.querySelectorAll('vaadin-avatar');
-      expect(items[0].i18n).to.deep.equal(customI18n);
-      expect(items[1].i18n).to.deep.equal(customI18n);
-      expect(items[2].i18n).to.deep.equal(customI18n);
+      expect(items[0].i18n).to.deep.equal(group.__effectiveI18n);
+      expect(items[1].i18n).to.deep.equal(group.__effectiveI18n);
+      expect(items[2].i18n).to.deep.equal(group.__effectiveI18n);
     });
 
     it('should pass i18n property to overlay avatars', async () => {
@@ -518,8 +518,8 @@ describe('avatar-group', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       const avatars = overlay.querySelectorAll('vaadin-avatar');
-      expect(avatars[0].i18n).to.deep.equal(customI18n);
-      expect(avatars[1].i18n).to.deep.equal(customI18n);
+      expect(avatars[0].i18n).to.deep.equal(group.__effectiveI18n);
+      expect(avatars[1].i18n).to.deep.equal(group.__effectiveI18n);
     });
   });
 

--- a/packages/avatar-group/test/typings/avatar-group.types.ts
+++ b/packages/avatar-group/test/typings/avatar-group.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-avatar-group.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -25,10 +26,15 @@ assertType<string | undefined>(item.name);
 assertType<number | undefined>(item.colorIndex);
 assertType<string | undefined>(item.className);
 
+// I18n
+assertType<AvatarGroupI18n>({ joined: 'yesterday' });
+assertType<AvatarGroupI18n>({ activeUsers: { one: '1 user' } });
+
 // Mixins
 assertType<AvatarGroupMixinClass>(group);
 assertType<ControllerMixinClass>(group);
 assertType<ElementMixinClass>(group);
+assertType<I18nMixinClass<AvatarGroupI18n>>(group);
 assertType<OverlayClassMixinClass>(group);
 assertType<ResizeMixinClass>(group);
 assertType<ThemableMixinClass>(group);

--- a/packages/component-base/src/i18n-mixin.d.ts
+++ b/packages/component-base/src/i18n-mixin.d.ts
@@ -6,6 +6,17 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
+ * Recursively makes all properties of an i18n object optional.
+ *
+ * For internal use only.
+ */
+export type PartialI18n<T> = T extends object
+  ? {
+      [P in keyof T]?: PartialI18n<T[P]>;
+    }
+  : T;
+
+/**
  * A mixin that allows to set partial I18N properties.
  */
 export declare function I18nMixin<T extends Constructor<HTMLElement>, I>(

--- a/packages/component-base/src/i18n-mixin.d.ts
+++ b/packages/component-base/src/i18n-mixin.d.ts
@@ -19,9 +19,9 @@ export type PartialI18n<T> = T extends object
 /**
  * A mixin that allows to set partial I18N properties.
  */
-export declare function I18nMixin<T extends Constructor<HTMLElement>, I>(
-  superclass: T,
+export declare function I18nMixin<I, T extends Constructor<HTMLElement>>(
   defaultI18n: I,
+  superclass: T,
 ): Constructor<I18nMixinClass<I>> & T;
 
 export declare class I18nMixinClass<I> {

--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -37,7 +37,7 @@ function deepMerge(target, ...sources) {
  *
  * @polymerMixin
  */
-export const I18nMixin = (superClass, defaultI18n) =>
+export const I18nMixin = (defaultI18n, superClass) =>
   class I18nMixinClass extends superClass {
     static get properties() {
       return {

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -13,7 +13,7 @@ const DEFAULT_I18N = {
   qux: ['q', 'u', 'x'],
 };
 
-class I18nMixinPolymerElement extends I18nMixin(PolymerElement, DEFAULT_I18N) {
+class I18nMixinPolymerElement extends I18nMixin(DEFAULT_I18N, PolymerElement) {
   static get is() {
     return 'i18n-mixin-polymer-element';
   }
@@ -21,7 +21,7 @@ class I18nMixinPolymerElement extends I18nMixin(PolymerElement, DEFAULT_I18N) {
 
 customElements.define(I18nMixinPolymerElement.is, I18nMixinPolymerElement);
 
-class I18nMixinLitElement extends I18nMixin(PolylitMixin(LitElement), DEFAULT_I18N) {
+class I18nMixinLitElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElement)) {
   static get is() {
     return 'i18n-mixin-lit-element';
   }

--- a/packages/component-base/test/typings/i18n-mixin/i18n-mixin.types.ts
+++ b/packages/component-base/test/typings/i18n-mixin/i18n-mixin.types.ts
@@ -10,7 +10,7 @@ const DEFAULT_I18N = {
   },
 };
 
-class TestElement extends I18nMixin(HTMLElement, DEFAULT_I18N) {}
+class TestElement extends I18nMixin(DEFAULT_I18N, HTMLElement) {}
 
 const element = new TestElement();
 


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to avatar group. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
