### PR TITLE
feat: support partial i18n in app layout

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.d.ts
@@ -4,28 +4,21 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
 
-export interface AppLayoutI18n {
+export type AppLayoutI18n = PartialI18n<{
   drawer: string;
-}
+}>;
 
 export declare function AppLayoutMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<AppLayoutMixinClass> & T;
+): Constructor<AppLayoutMixinClass> & Constructor<I18nMixinClass<AppLayoutI18n>> & T;
 
 export declare class AppLayoutMixinClass {
   /**
-   * The object used to localize this component.
-   * To change the default localization, replace the entire
-   * `i18n` object with a custom one.
-   *
-   * To update individual properties, extend the existing i18n object as follows:
-   * ```js
-   * appLayout.i18n = {
-   *   ...appLayout.i18n,
-   *   drawer: 'Drawer'
-   * }
-   * ```
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
    *
    * The object has the following structure and default values:
    * ```

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -6,52 +6,24 @@
 import { afterNextRender, beforeNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { AriaModalController } from '@vaadin/a11y-base/src/aria-modal-controller.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 
 /**
  * @typedef {import('./vaadin-app-layout.js').AppLayoutI18n} AppLayoutI18n
  */
 
+const DEFAULT_I18N = {
+  drawer: 'Drawer',
+};
+
 /**
  * @polymerMixin
+ * @mixes I18nMixin
  */
 export const AppLayoutMixin = (superclass) =>
-  class AppLayoutMixinClass extends superclass {
+  class AppLayoutMixinClass extends I18nMixin(DEFAULT_I18N, superclass) {
     static get properties() {
       return {
-        /**
-         * The object used to localize this component.
-         * To change the default localization, replace the entire
-         * `i18n` object with a custom one.
-         *
-         * To update individual properties, extend the existing i18n object as follows:
-         * ```js
-         * appLayout.i18n = {
-         *   ...appLayout.i18n,
-         *   drawer: 'Drawer'
-         * }
-         * ```
-         *
-         * The object has the following structure and default values:
-         * ```
-         * {
-         *   drawer: 'Drawer'
-         * }
-         * ```
-         *
-         * @type {AppLayoutI18n}
-         * @default {English/US}
-         */
-        i18n: {
-          type: Object,
-          observer: '__i18nChanged',
-          sync: true,
-          value: () => {
-            return {
-              drawer: 'Drawer',
-            };
-          },
-        },
-
         /**
          * Defines whether navbar or drawer will come first visually.
          * - By default (`primary-section="navbar"`), the navbar takes the full available width and moves the drawer down.
@@ -114,11 +86,36 @@ export const AppLayoutMixin = (superclass) =>
       };
     }
 
+    static get observers() {
+      return ['__i18nChanged(__effectiveI18n)'];
+    }
+
     /**
      * Helper static method that dispatches a `close-overlay-drawer` event
      */
     static dispatchCloseOverlayDrawerEvent() {
       window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
+    }
+
+    /**
+     * The object used to localize this component. To change the default
+     * localization, replace this with an object that provides all properties, or
+     * just the individual properties you want to change.
+     *
+     * The object has the following structure and default values:
+     * ```
+     * {
+     *   drawer: 'Drawer'
+     * }
+     * ```
+     * @return {!AppLayoutI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
     }
 
     constructor() {
@@ -357,7 +354,7 @@ export const AppLayoutMixin = (superclass) =>
       if (this.overlay) {
         drawer.setAttribute('role', 'dialog');
         drawer.setAttribute('aria-modal', 'true');
-        drawer.setAttribute('aria-label', this.i18n.drawer);
+        drawer.setAttribute('aria-label', this.__effectiveI18n.drawer);
       } else {
         drawer.removeAttribute('role');
         drawer.removeAttribute('aria-modal');

--- a/packages/app-layout/test/typings/app-layout.types.ts
+++ b/packages/app-layout/test/typings/app-layout.types.ts
@@ -1,6 +1,7 @@
 import '../../vaadin-app-layout.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type {
   AppLayoutDrawerOpenedChangedEvent,
@@ -15,6 +16,7 @@ const layout = document.createElement('vaadin-app-layout');
 
 // Mixins
 assertType<ElementMixinClass>(layout);
+assertType<I18nMixinClass<AppLayoutI18n>>(layout);
 assertType<ThemableMixinClass>(layout);
 assertType<ControllerMixinClass>(layout);
 
@@ -24,6 +26,10 @@ assertType<boolean>(layout.drawerOpened);
 assertType<boolean>(layout.overlay);
 assertType<string>(layout.closeDrawerOn);
 assertType<AppLayoutI18n>(layout.i18n);
+
+// I18n
+assertType<AppLayoutI18n>({});
+assertType<AppLayoutI18n>({ drawer: 'drawer' });
 
 // Events
 layout.addEventListener('drawer-opened-changed', (event) => {


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to app layout. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
