### PR TITLE
test: cleanup outdated checkbox-group focus test

### DIFF
--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -302,15 +302,6 @@ describe('vaadin-checkbox-group', () => {
       expect(checkboxes[0].hasAttribute('focused')).to.be.false;
       expect(group.hasAttribute('focused')).to.be.false;
     });
-
-    it('should not steal focus from currently focused element', () => {
-      const focusInput = document.createElement('input');
-      document.body.appendChild(focusInput);
-      focusInput.focus();
-      group.value = '1';
-      expect(document.activeElement).to.be.equal(focusInput);
-      document.body.removeChild(focusInput);
-    });
   });
 
   describe('has-value attribute', () => {


### PR DESCRIPTION
## Description

This test was added in the original MVP at https://github.com/vaadin/vaadin-checkbox/pull/103 and its purpose is unclear.
There is no logic related to moving focus in the component nowadays, so it can be removed.

## Type of change

- Test