### PR TITLE
 feat: support partial i18n in crud

### DIFF
--- a/packages/crud/src/vaadin-crud-mixin.d.ts
+++ b/packages/crud/src/vaadin-crud-mixin.d.ts
@@ -9,6 +9,7 @@
  * license.
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
 
 export type CrudDataProviderCallback<T> = (items: T[], size?: number) => void;
@@ -24,7 +25,7 @@ export type CrudDataProvider<T> = (params: CrudDataProviderParams, callback: Cru
 
 export type CrudEditorPosition = '' | 'aside' | 'bottom';
 
-export interface CrudI18n {
+export type CrudI18n = PartialI18n<{
   newItem: string;
   editItem: string;
   saveItem: string;
@@ -49,7 +50,7 @@ export interface CrudI18n {
       };
     };
   };
-}
+}>;
 
 /**
  * Fired when the `editorOpened` property changes.
@@ -123,7 +124,7 @@ export type CrudEventMap<T> = CrudCustomEventMap<T> & HTMLElementEventMap;
  */
 export declare function CrudMixin<Item, T extends Constructor<HTMLElement> = Constructor<HTMLElement>>(
   base: T,
-): Constructor<CrudMixinClass<Item>> & T;
+): Constructor<CrudMixinClass<Item>> & Constructor<I18nMixinClass<CrudI18n>> & T;
 
 export declare class CrudMixinClass<Item> {
   /**
@@ -225,9 +226,9 @@ export declare class CrudMixinClass<Item> {
   noToolbar: boolean;
 
   /**
-   * The object used to localize this component.
-   * For changing the default localization, change the entire
-   * _i18n_ object or just the property you want to modify.
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
    *
    * The object has the following JSON structure and default values:
    *

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -10,18 +10,47 @@
  */
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { FocusRestorationController } from '@vaadin/a11y-base/src/focus-restoration-controller.js';
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { ButtonSlotController, FormSlotController, GridSlotController } from './vaadin-crud-controllers.js';
 import { getProperty, isValidEditorPosition, setProperty } from './vaadin-crud-helpers.js';
 
+const DEFAULT_I18N = {
+  newItem: 'New item',
+  editItem: 'Edit item',
+  saveItem: 'Save',
+  cancel: 'Cancel',
+  deleteItem: 'Delete...',
+  editLabel: 'Edit',
+  confirm: {
+    delete: {
+      title: 'Delete item',
+      content: 'Are you sure you want to delete this item? This action cannot be undone.',
+      button: {
+        confirm: 'Delete',
+        dismiss: 'Cancel',
+      },
+    },
+    cancel: {
+      title: 'Discard changes',
+      content: 'There are unsaved changes to this item.',
+      button: {
+        confirm: 'Discard',
+        dismiss: 'Cancel',
+      },
+    },
+  },
+};
+
 /**
  * A mixin providing common crud functionality.
  *
  * @polymerMixin
+ * @mixes I18nMixin
  */
 export const CrudMixin = (superClass) =>
-  class extends superClass {
+  class extends I18nMixin(DEFAULT_I18N, superClass) {
     static get properties() {
       return {
         /**
@@ -225,78 +254,6 @@ export const CrudMixin = (superClass) =>
           sync: true,
         },
 
-        /**
-         * The object used to localize this component.
-         * For changing the default localization, change the entire
-         * _i18n_ object or just the property you want to modify.
-         *
-         * The object has the following JSON structure and default values:
-         *
-         * ```
-         * {
-         *   newItem: 'New item',
-         *   editItem: 'Edit item',
-         *   saveItem: 'Save',
-         *   cancel: 'Cancel',
-         *   deleteItem: 'Delete...',
-         *   editLabel: 'Edit',
-         *   confirm: {
-         *     delete: {
-         *       title: 'Confirm delete',
-         *       content: 'Are you sure you want to delete the selected item? This action cannot be undone.',
-         *       button: {
-         *         confirm: 'Delete',
-         *         dismiss: 'Cancel'
-         *       }
-         *     },
-         *     cancel: {
-         *       title: 'Unsaved changes',
-         *       content: 'There are unsaved modifications to the item.',
-         *       button: {
-         *         confirm: 'Discard',
-         *         dismiss: 'Continue editing'
-         *       }
-         *     }
-         *   }
-         * }
-         * ```
-         *
-         * @type {!CrudI18n}
-         * @default {English/US}
-         */
-        i18n: {
-          type: Object,
-          sync: true,
-          value() {
-            return {
-              newItem: 'New item',
-              editItem: 'Edit item',
-              saveItem: 'Save',
-              cancel: 'Cancel',
-              deleteItem: 'Delete...',
-              editLabel: 'Edit',
-              confirm: {
-                delete: {
-                  title: 'Delete item',
-                  content: 'Are you sure you want to delete this item? This action cannot be undone.',
-                  button: {
-                    confirm: 'Delete',
-                    dismiss: 'Cancel',
-                  },
-                },
-                cancel: {
-                  title: 'Discard changes',
-                  content: 'There are unsaved changes to this item.',
-                  button: {
-                    confirm: 'Discard',
-                    dismiss: 'Cancel',
-                  },
-                },
-              },
-            };
-          },
-        },
-
         /** @private */
         __dialogAriaLabel: String,
 
@@ -331,16 +288,61 @@ export const CrudMixin = (superClass) =>
 
     static get observers() {
       return [
-        '__headerPropsChanged(_defaultHeader, __isNew, i18n)',
+        '__headerPropsChanged(_defaultHeader, __isNew, __effectiveI18n)',
         '__formPropsChanged(_form, _theme, include, exclude)',
         '__gridPropsChanged(_grid, _theme, include, exclude, noFilter, noHead, noSort, items)',
-        '__i18nChanged(i18n, _grid)',
+        '__i18nChanged(__effectiveI18n, _grid)',
         '__editOnClickChanged(editOnClick, _grid)',
-        '__saveButtonPropsChanged(_saveButton, i18n, __isDirty)',
-        '__cancelButtonPropsChanged(_cancelButton, i18n)',
-        '__deleteButtonPropsChanged(_deleteButton, i18n, __isNew)',
-        '__newButtonPropsChanged(_newButton, i18n)',
+        '__saveButtonPropsChanged(_saveButton, __effectiveI18n, __isDirty)',
+        '__cancelButtonPropsChanged(_cancelButton, __effectiveI18n)',
+        '__deleteButtonPropsChanged(_deleteButton, __effectiveI18n, __isNew)',
+        '__newButtonPropsChanged(_newButton, __effectiveI18n)',
       ];
+    }
+
+    /**
+     * The object used to localize this component. To change the default
+     * localization, replace this with an object that provides all properties, or
+     * just the individual properties you want to change.
+     *
+     * The object has the following JSON structure and default values:
+     *
+     * ```
+     * {
+     *   newItem: 'New item',
+     *   editItem: 'Edit item',
+     *   saveItem: 'Save',
+     *   cancel: 'Cancel',
+     *   deleteItem: 'Delete...',
+     *   editLabel: 'Edit',
+     *   confirm: {
+     *     delete: {
+     *       title: 'Confirm delete',
+     *       content: 'Are you sure you want to delete the selected item? This action cannot be undone.',
+     *       button: {
+     *         confirm: 'Delete',
+     *         dismiss: 'Cancel'
+     *       }
+     *     },
+     *     cancel: {
+     *       title: 'Unsaved changes',
+     *       content: 'There are unsaved modifications to the item.',
+     *       button: {
+     *         confirm: 'Discard',
+     *         dismiss: 'Continue editing'
+     *       }
+     *     }
+     *   }
+     * }
+     * ```
+     * @return {!CrudI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
     }
 
     constructor() {
@@ -429,29 +431,28 @@ export const CrudMixin = (superClass) =>
     /**
      * @param {HTMLElement | undefined} headerNode
      * @param {boolean} isNew
-     * @param {string} i18nNewItem
-     * @param {string} i18nEditItem
+     * @param {CrudI18n} effectiveI18n
      * @private
      */
-    __headerPropsChanged(headerNode, isNew, i18n) {
+    __headerPropsChanged(headerNode, isNew, effectiveI18n) {
       if (headerNode) {
-        headerNode.textContent = isNew ? i18n.newItem : i18n.editItem;
+        headerNode.textContent = isNew ? effectiveI18n.newItem : effectiveI18n.editItem;
       }
     }
 
     /**
-     * @param {CrudI18n} i18n
+     * @param {CrudI18n} effectiveI18n
      * @param {CrudGrid | Grid} grid
      * @private
      */
-    __i18nChanged(i18n, grid) {
+    __i18nChanged(effectiveI18n, grid) {
       if (!grid) {
         return;
       }
 
       afterNextRender(grid, () => {
         Array.from(grid.querySelectorAll('vaadin-crud-edit-column')).forEach((column) => {
-          column.ariaLabel = i18n.editLabel;
+          column.ariaLabel = effectiveI18n.editLabel;
         });
       });
     }
@@ -684,55 +685,55 @@ export const CrudMixin = (superClass) =>
 
     /**
      * @param {HTMLElement | undefined} saveButton
-     * @param {string} i18nLabel
+     * @param {CrudI18n} effectiveI18n
      * @param {boolean} isDirty
      * @private
      */
-    __saveButtonPropsChanged(saveButton, i18n, isDirty) {
+    __saveButtonPropsChanged(saveButton, effectiveI18n, isDirty) {
       if (saveButton) {
         saveButton.toggleAttribute('disabled', this.__isSaveBtnDisabled(isDirty));
 
         if (saveButton === this._saveButtonController.defaultNode) {
-          saveButton.textContent = i18n.saveItem;
+          saveButton.textContent = effectiveI18n.saveItem;
         }
       }
     }
 
     /**
      * @param {HTMLElement | undefined} deleteButton
-     * @param {string} i18nLabel
+     * @param {CrudI18n} effectiveI18n
      * @param {boolean} isNew
      * @private
      */
-    __deleteButtonPropsChanged(deleteButton, i18n, isNew) {
+    __deleteButtonPropsChanged(deleteButton, effectiveI18n, isNew) {
       if (deleteButton) {
         deleteButton.toggleAttribute('hidden', isNew);
 
         if (deleteButton === this._deleteButtonController.defaultNode) {
-          deleteButton.textContent = i18n.deleteItem;
+          deleteButton.textContent = effectiveI18n.deleteItem;
         }
       }
     }
 
     /**
      * @param {HTMLElement | undefined} cancelButton
-     * @param {string} i18nLabel
+     * @param {CrudI18n} effectiveI18n
      * @private
      */
-    __cancelButtonPropsChanged(cancelButton, i18n) {
+    __cancelButtonPropsChanged(cancelButton, effectiveI18n) {
       if (cancelButton && cancelButton === this._cancelButtonController.defaultNode) {
-        cancelButton.textContent = i18n.cancel;
+        cancelButton.textContent = effectiveI18n.cancel;
       }
     }
 
     /**
      * @param {HTMLElement | undefined} newButton
-     * @param {string} i18nNewItem
+     * @param {CrudI18n} effectiveI18n
      * @private
      */
-    __newButtonPropsChanged(newButton, i18n) {
+    __newButtonPropsChanged(newButton, effectiveI18n) {
       if (newButton && newButton === this._newButtonController.defaultNode) {
-        newButton.textContent = i18n.newItem;
+        newButton.textContent = effectiveI18n.newItem;
       }
     }
 

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -223,10 +223,10 @@ class Crud extends CrudMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
         id="confirmCancel"
         on-confirm="__confirmCancel"
         cancel-button-visible
-        confirm-text="[[i18n.confirm.cancel.button.confirm]]"
-        cancel-text="[[i18n.confirm.cancel.button.dismiss]]"
-        header="[[i18n.confirm.cancel.title]]"
-        message="[[i18n.confirm.cancel.content]]"
+        confirm-text="[[__effectiveI18n.confirm.cancel.button.confirm]]"
+        cancel-text="[[__effectiveI18n.confirm.cancel.button.dismiss]]"
+        header="[[__effectiveI18n.confirm.cancel.title]]"
+        message="[[__effectiveI18n.confirm.cancel.content]]"
         confirm-theme="primary"
       ></vaadin-confirm-dialog>
 
@@ -235,10 +235,10 @@ class Crud extends CrudMixin(ControllerMixin(ElementMixin(ThemableMixin(PolymerE
         id="confirmDelete"
         on-confirm="__confirmDelete"
         cancel-button-visible
-        confirm-text="[[i18n.confirm.delete.button.confirm]]"
-        cancel-text="[[i18n.confirm.delete.button.dismiss]]"
-        header="[[i18n.confirm.delete.title]]"
-        message="[[i18n.confirm.delete.content]]"
+        confirm-text="[[__effectiveI18n.confirm.delete.button.confirm]]"
+        cancel-text="[[__effectiveI18n.confirm.delete.button.dismiss]]"
+        header="[[__effectiveI18n.confirm.delete.title]]"
+        message="[[__effectiveI18n.confirm.delete.content]]"
         confirm-theme="primary error"
       ></vaadin-confirm-dialog>
     `;

--- a/packages/crud/src/vaadin-lit-crud.js
+++ b/packages/crud/src/vaadin-lit-crud.js
@@ -87,10 +87,10 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(CrudMixin(PolylitM
         id="confirmCancel"
         @confirm="${this.__confirmCancel}"
         cancel-button-visible
-        .confirmText="${this.i18n.confirm.cancel.button.confirm}"
-        .cancelText="${this.i18n.confirm.cancel.button.dismiss}"
-        .header="${this.i18n.confirm.cancel.title}"
-        .message="${this.i18n.confirm.cancel.content}"
+        .confirmText="${this.__effectiveI18n.confirm.cancel.button.confirm}"
+        .cancelText="${this.__effectiveI18n.confirm.cancel.button.dismiss}"
+        .header="${this.__effectiveI18n.confirm.cancel.title}"
+        .message="${this.__effectiveI18n.confirm.cancel.content}"
         confirm-theme="primary"
       ></vaadin-confirm-dialog>
 
@@ -99,10 +99,10 @@ class Crud extends ControllerMixin(ElementMixin(ThemableMixin(CrudMixin(PolylitM
         id="confirmDelete"
         @confirm="${this.__confirmDelete}"
         cancel-button-visible
-        .confirmText="${this.i18n.confirm.delete.button.confirm}"
-        .cancelText="${this.i18n.confirm.delete.button.dismiss}"
-        .header="${this.i18n.confirm.delete.title}"
-        .message="${this.i18n.confirm.delete.content}"
+        .confirmText="${this.__effectiveI18n.confirm.delete.button.confirm}"
+        .cancelText="${this.__effectiveI18n.confirm.delete.button.dismiss}"
+        .header="${this.__effectiveI18n.confirm.delete.title}"
+        .message="${this.__effectiveI18n.confirm.delete.content}"
         confirm-theme="primary error"
       ></vaadin-confirm-dialog>
     `;

--- a/packages/crud/test/crud-buttons.test.js
+++ b/packages/crud/test/crud-buttons.test.js
@@ -46,7 +46,7 @@ describe('crud buttons', () => {
           });
 
           it('should update the label of the delete button on i18n property change', () => {
-            crud.i18n = { ...crud.i18n, deleteItem: 'Custom' };
+            crud.i18n = { deleteItem: 'Custom' };
             expect(deleteButton.textContent).to.equal('Custom');
           });
 
@@ -55,7 +55,7 @@ describe('crud buttons', () => {
           });
 
           it('should update the label of the save button on i18n property change', () => {
-            crud.i18n = { ...crud.i18n, saveItem: 'Custom' };
+            crud.i18n = { saveItem: 'Custom' };
             expect(saveButton.textContent).to.equal('Custom');
           });
 
@@ -64,7 +64,7 @@ describe('crud buttons', () => {
           });
 
           it('should update the label of the cancel button on i18n property change', () => {
-            crud.i18n = { ...crud.i18n, cancel: 'Custom' };
+            crud.i18n = { cancel: 'Custom' };
             expect(cancelButton.textContent).to.equal('Custom');
           });
         });
@@ -734,7 +734,7 @@ describe('crud buttons', () => {
         crud.appendChild(button);
         await nextRender();
 
-        crud.i18n = { ...crud.i18n, newItem: 'Add user' };
+        crud.i18n = { newItem: 'Add user' };
         await nextRender();
 
         expect(button.textContent).to.equal('Add user');
@@ -789,7 +789,7 @@ describe('crud buttons', () => {
         crud.appendChild(button);
         await nextRender();
 
-        crud.i18n = { ...crud.i18n, deleteItem: 'Drop user' };
+        crud.i18n = { deleteItem: 'Drop user' };
         await nextRender();
 
         expect(button.textContent).to.equal('Drop user');
@@ -844,7 +844,7 @@ describe('crud buttons', () => {
         crud.appendChild(button);
         await nextRender();
 
-        crud.i18n = { ...crud.i18n, saveItem: 'Save user' };
+        crud.i18n = { saveItem: 'Save user' };
         await nextRender();
 
         expect(button.textContent).to.equal('Save user');

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -64,7 +64,7 @@ describe('crud', () => {
 
     it('should be able to internationalize via `i18n` property', async () => {
       expect(crud._newButton.textContent).to.be.equal('New item');
-      crud.i18n = { ...crud.i18n, newItem: 'Nueva entidad', editLabel: 'Editar entidad' };
+      crud.i18n = { newItem: 'Nueva entidad', editLabel: 'Editar entidad' };
       await nextRender(crud._grid);
       expect(crud._newButton.textContent).to.be.equal('Nueva entidad');
       expect(crud._grid.querySelector('vaadin-crud-edit-column').ariaLabel).to.be.equal('Editar entidad');

--- a/packages/crud/test/typings/crud.types.ts
+++ b/packages/crud/test/typings/crud.types.ts
@@ -6,6 +6,7 @@ import type {
   CrudEditedItemChangedEvent,
   CrudEditEvent,
   CrudEditorOpenedChangedEvent,
+  CrudI18n,
   CrudItemsChangedEvent,
   CrudNewEvent,
   CrudSaveEvent,
@@ -80,3 +81,8 @@ assertType<boolean>(edit.disabled);
 
 const column: CrudEditColumn = document.createElement('vaadin-crud-edit-column');
 assertType<string>(column.ariaLabel);
+
+// I18n
+assertType<CrudI18n>({});
+assertType<CrudI18n>({ cancel: 'cancel' });
+assertType<CrudI18n>({ confirm: { cancel: { title: 'title' } } });


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to crud. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
