### PR TITLE
test: remove console.log from grid-pro keyboard test (24.5)

### DIFF
--- a/packages/grid-pro/test/keyboard-navigation.test.js
+++ b/packages/grid-pro/test/keyboard-navigation.test.js
@@ -330,7 +330,6 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Tab' });
       const secondCellContent = getContainerCellContent(grid.$.items, 0, 1);
-      console.log(secondCellContent);
       expect(secondCellContent.contains(document.activeElement)).to.be.true;
     });
 


### PR DESCRIPTION
## Description

The `console.log` was left when backporting loading editor state in #8164

## Type of change

- Test