### PR TITLE
chore: add check-releases script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ web-types.lit.json
 
 # Generated auto-complete CSS file for Lumo theme
 packages/vaadin-lumo-styles/auto-complete.css
+
+# Generated release check
+scripts/check-releases.html

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "husky",
     "serve:dist": "web-dev-server --app-index dist/index.html --open",
     "start": "web-dev-server --node-resolve --open /dev",
+    "check-releases": "node ./scripts/check-releases.js && web-dev-server --node-resolve --open /scripts/check-releases.html",
     "test": "node scripts/generateLitTests.js && web-test-runner",
     "test:firefox": "yarn test --config web-test-runner-firefox.config.js",
     "test:it": "yarn test --config web-test-runner-it.config.js",

--- a/scripts/check-releases.js
+++ b/scripts/check-releases.js
@@ -1,0 +1,108 @@
+require('dotenv').config();
+const fs = require('fs');
+
+const REPO_OWNER = 'vaadin';
+const REPO_NAME = 'web-components';
+const BRANCHES = ['main', '24.6', '24.5', '23.5'];
+const GITHUB_TOKEN = process.env.GITHUB_API_TOKEN; // Set this in your .env file
+
+if (!GITHUB_TOKEN) {
+  console.error('Error: GITHUB_API_TOKEN is required. Set it in a .env file.');
+  process.exit(1);
+}
+
+const headers = {
+  Authorization: `token ${GITHUB_TOKEN}`,
+  Accept: 'application/vnd.github.v3+json',
+};
+
+async function getCommits(branch, page = 1) {
+  const response = await fetch(
+    `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits?sha=${branch}&per_page=100&page=${page}`,
+    { headers },
+  );
+  if (!response.ok) {
+    throw new Error(`Error: Failed to fetch commits from GitHub: status=${response.status}`);
+  }
+  return await response.json();
+}
+
+function extractVersion(commitMessage) {
+  const match = commitMessage.match(/chore\(release\):\s*(\d+\.\d+\.\d+(?:-(alpha|beta|rc)\d+)?)$/u);
+  return match ? match[1] : null;
+}
+
+function parseVersion(version) {
+  const match = version.match(/(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)(\d+))?/u);
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+    preRelease: match[4] || null,
+    preReleaseNumber: match[5] ? parseInt(match[5], 10) : null,
+  };
+}
+
+function determineNextPatchVersion(versionString) {
+  const version = parseVersion(versionString);
+
+  if (version.preRelease) {
+    version.preReleaseNumber += 1;
+    return `${version.major}.${version.minor}.${version.patch}-${version.preRelease}${version.preReleaseNumber}`;
+  }
+
+  version.patch += 1;
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+async function getBranchInfo(branch) {
+  const branchInfo = {
+    branch,
+    commits: [],
+  };
+  // Loading 5 pages should be enough to find the last release commit
+  for (let page = 1; page < 5; page += 1) {
+    const commits = await getCommits(branch, page);
+    if (commits.length === 0) {
+      break;
+    }
+
+    for (const commit of commits) {
+      if (commit.commit.message.startsWith('chore(release)')) {
+        const version = extractVersion(commit.commit.message);
+        if (!version) {
+          // Effectively the same as not being able to find a release commit
+          break;
+        }
+        branchInfo.releaseCommit = commit;
+        branchInfo.currentVersion = version;
+        branchInfo.nextPatchVersion = determineNextPatchVersion(commit.commit.message);
+        return branchInfo;
+      }
+      branchInfo.commits.push(commit);
+    }
+  }
+
+  console.error('Error: Could not find release commit for branch:', branch);
+  return null;
+}
+
+async function run() {
+  const branchInfos = [];
+  for (const branch of BRANCHES) {
+    const branchInfo = await getBranchInfo(branch);
+    if (branchInfo) {
+      branchInfos.push(branchInfo);
+    }
+  }
+
+  const template = fs.readFileSync('./scripts/check-releases.template.html', 'utf8');
+  const filledTemplate = template.replace(
+    '/*{inject-branch-info}*/',
+    `window.branches = ${JSON.stringify(branchInfos, null, 2)};`,
+  );
+
+  fs.writeFileSync('./scripts/check-releases.html', filledTemplate, 'utf8');
+}
+
+run();

--- a/scripts/check-releases.js
+++ b/scripts/check-releases.js
@@ -76,7 +76,7 @@ async function getBranchInfo(branch) {
         }
         branchInfo.releaseCommit = commit;
         branchInfo.currentVersion = version;
-        branchInfo.nextPatchVersion = determineNextPatchVersion(commit.commit.message);
+        branchInfo.nextPatchVersion = determineNextPatchVersion(version);
         return branchInfo;
       }
       branchInfo.commits.push(commit);

--- a/scripts/check-releases.template.html
+++ b/scripts/check-releases.template.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Release check</title>
+    <style>
+      body {
+        padding: var(--lumo-space-l);
+      }
+
+      section {
+        margin-bottom: var(--lumo-space-l);
+      }
+
+      h1,
+      h2,
+      h3 {
+        margin-bottom: var(--lumo-space-m);
+      }
+
+      table {
+        border-collapse: collapse;
+        margin: var(--lumo-space-s) 0;
+      }
+
+      td {
+        border: 1px solid var(--lumo-contrast-10pct);
+        padding: var(--lumo-space-xs) var(--lumo-space-s);
+      }
+
+      ul {
+        margin: 0;
+      }
+
+      code {
+        padding: 0 4px;
+      }
+
+      vaadin-button[theme='tertiary icon'] {
+        margin: 0;
+      }
+
+      .guibutton {
+        font-size: 0.8em;
+        line-height: 1.25;
+        font-weight: 600;
+        border-radius: var(--lumo-border-radius-s);
+        padding: 0.3em 0.6em;
+        background: linear-gradient(white, var(--lumo-contrast-5pct));
+        box-shadow: inset 0 0 0 1px var(--lumo-contrast-10pct);
+        cursor: default;
+        position: relative;
+        top: -0.1em;
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Release check</h1>
+    <script type="module">
+      /*{inject-branch-info}*/
+    </script>
+    <script type="module">
+      import '@vaadin/vaadin-lumo-styles/test/autoload.js';
+      import '@vaadin/button';
+      import '@vaadin/details';
+      import '@vaadin/dialog';
+      import { dialogRenderer } from '@vaadin/dialog/lit.js';
+      import { Notification } from '@vaadin/notification';
+      import { html, LitElement } from 'lit';
+
+      class BranchSection extends LitElement {
+        createRenderRoot() {
+          return this;
+        }
+
+        firstUpdated() {
+          this.dialog = this.querySelector('vaadin-dialog');
+        }
+
+        render() {
+          return html`
+            <section>
+              <h2>${this.branch.branch}</h2>
+
+              <table>
+                <tr>
+                  <td>Current version</td>
+                  <td>${this.branch.currentVersion}</td>
+                </tr>
+                <tr>
+                  <td>Next patch version</td>
+                  <td>${this.branch.nextPatchVersion}</td>
+                </tr>
+                <tr>
+                  <td>Unreleased commits</td>
+                  <td>${this.branch.commits.length}</td>
+                </tr>
+              </table>
+
+              ${this.branch.commits.length > 0
+                ? html`
+                    <vaadin-details summary="View unreleased commits">
+                      <ul>
+                        ${this.branch.commits.map(
+                          (commit) => html`
+                            <li>
+                              <a href="${commit.html_url}" target="_blank">${commit.commit.message.split('\n')[0]}</a>
+                            </li>
+                          `,
+                        )}
+                      </ul>
+                    </vaadin-details>
+                  `
+                : html`<p data-no-commits>No unreleased commits</p>`}
+
+              <vaadin-button @click="${() => (this.dialog.opened = true)}">Release instructions</vaadin-button>
+
+              <vaadin-dialog ${dialogRenderer(this.renderInstructions, [])}></vaadin-dialog>
+            </section>
+          `;
+        }
+
+        renderInstructions() {
+          return html`
+            <section>
+              <h3>Step 1: Release web components</h3>
+              <ul>
+                <li>
+                  <a
+                    href="https://bender.vaadin.com/viewType.html?buildTypeId=VaadinWebComponents_ReleaseVaadinWebComponents"
+                    target="_blank"
+                    >Open CI build on Bender</a
+                  >
+                </li>
+                <li
+                  >Press <span class="guibutton">...</span> to the right of the
+                  <span class="guibutton">Run</span> button
+                </li>
+                <li>
+                  <span>Open the <span class="guibutton">Parameters</span> tab and fill in the values:</span>
+                  <table>
+                    <tr>
+                      <td>Branch</td>
+                      <td>${this.branch.branch}</td>
+                      <td> ${this.renderCopyButton(this.branch.branch)} </td>
+                    </tr>
+                    <tr>
+                      <td>Version</td>
+                      <td>${this.branch.nextPatchVersion}</td>
+                      <td> ${this.renderCopyButton(this.branch.nextPatchVersion)} </td>
+                    </tr>
+                  </table>
+                </li>
+                <li>Click <span class="guibutton">Run build</span></li>
+                <li>Confirm if a dialog asks about using an auto-generated branch name</li>
+                <li
+                  >Wait for the build to finish, then check that new versions have appeared on NPM (e.g.
+                  <a href="https://www.npmjs.com/package/@vaadin/grid">https://www.npmjs.com/package/@vaadin/grid</a>)
+                </li>
+              </ul>
+            </section>
+
+            <section>
+              <h3>Step 2: Release API docs</h3>
+              <ul>
+                <li>
+                  <a
+                    href="https://bender.vaadin.com/buildConfiguration/VaadinWebComponents_PublishWebComponentsApiDocs?mode=branches"
+                    target="_blank"
+                    >Open CI build on Bender</a
+                  >
+                </li>
+                <li
+                  >Press <span class="guibutton">...</span> to the right of the
+                  <span class="guibutton">Run</span> button
+                </li>
+                <li>
+                  <span>Open the <span class="guibutton">Parameters</span> tab and in the values:</span>
+                  <table>
+                    <tr>
+                      <td>Branch</td>
+                      <td>${this.branch.branch}</td>
+                      <td> ${this.renderCopyButton(this.branch.branch)} </td>
+                    </tr>
+                    <tr>
+                      <td>Tag</td>
+                      <td>v${this.branch.nextPatchVersion}</td>
+                      <td> ${this.renderCopyButton(`v${this.branch.nextPatchVersion}`)} </td>
+                    </tr>
+                    <tr>
+                      <td>Version</td>
+                      <td>${this.branch.nextPatchVersion}</td>
+                      <td> ${this.renderCopyButton(this.branch.nextPatchVersion)} </td>
+                    </tr>
+                  </table>
+                </li>
+                <li>Click <span class="guibutton">Run build</span></li>
+                <li>Confirm if a dialog asks about using an auto-generated branch name</li>
+                <li>Wait for the build to finish</li>
+              </ul>
+            </section>
+
+            <section>
+              <h3>Step 3: Publish GitHub Release</h3>
+              <ul>
+                <li>
+                  <a
+                    href="https://github.com/vaadin/web-components/releases/edit/v${this.branch.nextPatchVersion}"
+                    target="_blank"
+                    >Edit the GitHub release created in Step 1</a
+                  >
+                </li>
+                <li>Check that the documentation link works</li>
+                <li>Check that the contents are correct</li>
+                <li>If the release is for the latest version, check <i>Set as the latest release</i></li>
+                <li>Then publish the release</li>
+              </ul>
+            </section>
+          `;
+        }
+
+        renderCopyButton(value) {
+          return html`
+            <vaadin-button theme="tertiary icon" @click="${() => this.copy(value)}">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="icon icon-tabler icons-tabler-outline icon-tabler-copy"
+              >
+                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                <path
+                  d="M7 7m0 2.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667z"
+                />
+                <path
+                  d="M4.012 16.737a2.005 2.005 0 0 1 -1.012 -1.737v-10c0 -1.1 .9 -2 2 -2h10c.75 0 1.158 .385 1.5 1"
+                />
+              </svg>
+            </vaadin-button>
+          `;
+        }
+
+        copy(value) {
+          navigator.clipboard.writeText(value);
+          Notification.show('Copied to clipboard', { theme: 'success', duration: 2000 });
+        }
+      }
+
+      customElements.define('branch-section', BranchSection);
+
+      branches.forEach((branch) => {
+        const section = document.createElement('branch-section');
+        section.branch = branch;
+        document.body.append(section);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Description

Adds a script for checking whether new versions need to be released. The script does:
- Look up the last release commit and all commits added since then
- Determines the next patch version
- Generates an HTML file with that information for each maintained branch (branches are currently hard-coded)
- Opens the HTML file using Web Dev Server
- The HTML also contains branch-specific release instructions with specific steps, links and data that needs to be filled in

To use it:
- Define `GITHUB_API_TOKEN` in an env variable, for example with the `.env` file
- Run `npm run check-releases`

## Type of change

- Internal