### PR TITLE
fix: place confirm-dialog footer correctly when height is set

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay-styles.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay-styles.js
@@ -16,6 +16,10 @@ export const confirmDialogOverlay = css`
     height: var(--_vaadin-confirm-dialog-content-height);
   }
 
+  #resizerContainer {
+    height: 100%;
+  }
+
   ::slotted([slot='header']) {
     pointer-events: auto;
   }

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -654,6 +654,14 @@ describe('vaadin-confirm-dialog', () => {
         await nextFrame();
         expect(overlay.getAttribute('style')).to.be.not.ok;
       });
+
+      it('should place footer part at the bottom of the overlay', async () => {
+        confirm._contentHeight = '500px';
+        await nextFrame();
+        const footer = overlay.$.overlay.querySelector('[part="footer"]');
+        const overlayRect = overlay.$.overlay.getBoundingClientRect();
+        expect(footer.getBoundingClientRect().bottom).to.be.closeTo(overlayRect.bottom, 0.1);
+      });
     });
 
     describe('before attach', () => {


### PR DESCRIPTION
## Description

Fixes #8650

The `_contentHeight` property sets height of the `overlay` part but the inner `<section id="resizerContainer">` does not respect it and that makes footer look incorrect. Added `height: 100%` to make sure the footer is placed at the bottom.

## Type of change

- Bugfix