### PR TITLE
chore: update links generated by check releases script

### DIFF
--- a/scripts/check-releases.template.html
+++ b/scripts/check-releases.template.html
@@ -156,7 +156,7 @@
                 <li>Confirm if a dialog asks about using an auto-generated branch name</li>
                 <li
                   >Wait for the build to finish, then check that new versions have appeared on NPM (e.g.
-                  <a href="https://www.npmjs.com/package/@vaadin/grid/v/${this.branch.nextPatchVersion}"
+                  <a href="https://www.npmjs.com/package/@vaadin/grid/v/${this.branch.nextPatchVersion}" target="_blank"
                     ><code>@vaadin/grid@${this.branch.nextPatchVersion}</code></a
                   >)
                 </li>

--- a/scripts/check-releases.template.html
+++ b/scripts/check-releases.template.html
@@ -156,7 +156,9 @@
                 <li>Confirm if a dialog asks about using an auto-generated branch name</li>
                 <li
                   >Wait for the build to finish, then check that new versions have appeared on NPM (e.g.
-                  <a href="https://www.npmjs.com/package/@vaadin/grid">https://www.npmjs.com/package/@vaadin/grid</a>)
+                  <a href="https://www.npmjs.com/package/@vaadin/grid/v/${this.branch.nextPatchVersion}"
+                    ><code>@vaadin/grid@${this.branch.nextPatchVersion}</code></a
+                  >)
                 </li>
               </ul>
             </section>

--- a/scripts/check-releases.template.html
+++ b/scripts/check-releases.template.html
@@ -207,11 +207,9 @@
               <h3>Step 3: Publish GitHub Release</h3>
               <ul>
                 <li>
-                  <a
-                    href="https://github.com/vaadin/web-components/releases/edit/v${this.branch.nextPatchVersion}"
-                    target="_blank"
-                    >Edit the GitHub release created in Step 1</a
-                  >
+                  <a href="https://github.com/vaadin/web-components/releases" target="_blank"
+                    >Open the GitHub releases and edit the <code>v${this.branch.nextPatchVersion}</code> draft release
+                  </a>
                 </li>
                 <li>Check that the documentation link works</li>
                 <li>Check that the contents are correct</li>


### PR DESCRIPTION
- Make the NPM link point directly to the released version, so you don't have to click through to the versions to find it
- Make link for editing the release point to the releases overview, as the URL can not be determined beforehand (actual URL is something like `https://github.com/vaadin/web-components/releases/tag/untagged-77285af86d5ae5871db4`)