### PR TITLE
feat: add form layout CSS properties, deprecate form item ones

### DIFF
--- a/packages/form-layout/src/vaadin-form-item-mixin.js
+++ b/packages/form-layout/src/vaadin-form-item-mixin.js
@@ -6,6 +6,10 @@
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
+let spacingDeprecationNotified = false;
+let labelWidthDeprecationNotified = false;
+let labelSpacingDeprecationNotified = false;
+
 /**
  * @polymerMixin
  */
@@ -46,32 +50,30 @@ export const FormItemMixin = (superClass) =>
     ready() {
       super.ready();
 
-      if (!this.constructor.__isDeprecationWarningShown) {
-        const computedStyle = getComputedStyle(this);
+      const computedStyle = getComputedStyle(this);
+      const spacing = computedStyle.getPropertyValue('--vaadin-form-item-row-spacing');
+      const labelWidth = computedStyle.getPropertyValue('--vaadin-form-item-label-width');
+      const labelSpacing = computedStyle.getPropertyValue('--vaadin-form-item-label-spacing');
 
-        const spacing = computedStyle.getPropertyValue('--vaadin-form-item-row-spacing');
-        if (spacing !== '' && parseInt(spacing) !== 0) {
-          console.warn(
-            '`--vaadin-form-item-row-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-row-spacing` on <vaadin-form-layout> instead.',
-          );
-          this.constructor.__isDeprecationWarningShown = true;
-        }
+      if (!spacingDeprecationNotified && spacing !== '' && parseInt(spacing) !== 0) {
+        console.warn(
+          '`--vaadin-form-item-row-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-row-spacing` on <vaadin-form-layout> instead.',
+        );
+        spacingDeprecationNotified = true;
+      }
 
-        const labelWidth = computedStyle.getPropertyValue('--vaadin-form-item-label-width');
-        if (labelWidth !== '' && parseInt(labelWidth) !== 0) {
-          console.warn(
-            '`--vaadin-form-item-label-width` is deprecated since 24.7. Use `--vaadin-form-layout-label-width` on <vaadin-form-layout> instead.',
-          );
-          this.constructor.__isDeprecationWarningShown = true;
-        }
+      if (!labelWidthDeprecationNotified && labelWidth !== '' && parseInt(labelWidth) !== 0) {
+        console.warn(
+          '`--vaadin-form-item-label-width` is deprecated since 24.7. Use `--vaadin-form-layout-label-width` on <vaadin-form-layout> instead.',
+        );
+        labelWidthDeprecationNotified = true;
+      }
 
-        const labelSpacing = computedStyle.getPropertyValue('--vaadin-form-item-label-spacing');
-        if (labelSpacing !== '' && parseInt(labelSpacing) !== 0) {
-          console.warn(
-            '`--vaadin-form-item-label-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-label-spacing` on <vaadin-form-layout> instead.',
-          );
-          this.constructor.__isDeprecationWarningShown = true;
-        }
+      if (!labelSpacingDeprecationNotified && labelSpacing !== '' && parseInt(labelSpacing) !== 0) {
+        console.warn(
+          '`--vaadin-form-item-label-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-label-spacing` on <vaadin-form-layout> instead.',
+        );
+        labelSpacingDeprecationNotified = true;
       }
     }
 

--- a/packages/form-layout/src/vaadin-form-item-mixin.js
+++ b/packages/form-layout/src/vaadin-form-item-mixin.js
@@ -46,27 +46,32 @@ export const FormItemMixin = (superClass) =>
     ready() {
       super.ready();
 
-      const computedStyle = getComputedStyle(this);
+      if (!this.constructor.__isDeprecationWarningShown) {
+        const computedStyle = getComputedStyle(this);
 
-      const spacing = computedStyle.getPropertyValue('--vaadin-form-item-row-spacing');
-      if (spacing !== '' && parseInt(spacing) !== 0) {
-        console.warn(
-          '`--vaadin-form-item-row-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-row-spacing` on <vaadin-form-layout> instead.',
-        );
-      }
+        const spacing = computedStyle.getPropertyValue('--vaadin-form-item-row-spacing');
+        if (spacing !== '' && parseInt(spacing) !== 0) {
+          console.warn(
+            '`--vaadin-form-item-row-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-row-spacing` on <vaadin-form-layout> instead.',
+          );
+          this.constructor.__isDeprecationWarningShown = true;
+        }
 
-      const labelWidth = computedStyle.getPropertyValue('--vaadin-form-item-label-width');
-      if (labelWidth !== '' && parseInt(labelWidth) !== 0) {
-        console.warn(
-          '`--vaadin-form-item-label-width` is deprecated since 24.7. Use `--vaadin-form-layout-label-width` on <vaadin-form-layout> instead.',
-        );
-      }
+        const labelWidth = computedStyle.getPropertyValue('--vaadin-form-item-label-width');
+        if (labelWidth !== '' && parseInt(labelWidth) !== 0) {
+          console.warn(
+            '`--vaadin-form-item-label-width` is deprecated since 24.7. Use `--vaadin-form-layout-label-width` on <vaadin-form-layout> instead.',
+          );
+          this.constructor.__isDeprecationWarningShown = true;
+        }
 
-      const labelSpacing = computedStyle.getPropertyValue('--vaadin-form-item-label-spacing');
-      if (labelSpacing !== '' && parseInt(labelSpacing) !== 0) {
-        console.warn(
-          '`--vaadin-form-item-label-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-label-spacing` on <vaadin-form-layout> instead.',
-        );
+        const labelSpacing = computedStyle.getPropertyValue('--vaadin-form-item-label-spacing');
+        if (labelSpacing !== '' && parseInt(labelSpacing) !== 0) {
+          console.warn(
+            '`--vaadin-form-item-label-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-label-spacing` on <vaadin-form-layout> instead.',
+          );
+          this.constructor.__isDeprecationWarningShown = true;
+        }
       }
     }
 

--- a/packages/form-layout/src/vaadin-form-item-mixin.js
+++ b/packages/form-layout/src/vaadin-form-item-mixin.js
@@ -6,8 +6,6 @@
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
-let itemRowSpacingDeprecationNotified = false;
-
 /**
  * @polymerMixin
  */
@@ -44,16 +42,30 @@ export const FormItemMixin = (superClass) =>
       this.__fieldNode = null;
     }
 
-    connectedCallback() {
-      super.connectedCallback();
-      if (!itemRowSpacingDeprecationNotified) {
-        const spacing = getComputedStyle(this).getPropertyValue('--vaadin-form-item-row-spacing');
-        if (spacing !== '' && parseInt(spacing) !== 0) {
-          console.warn(
-            '`--vaadin-form-item-row-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-row-spacing` on <vaadin-form-layout> instead.',
-          );
-          itemRowSpacingDeprecationNotified = true;
-        }
+    ready() {
+      super.ready();
+
+      const computedStyle = getComputedStyle(this);
+
+      const spacing = computedStyle.getPropertyValue('--vaadin-form-item-row-spacing');
+      if (spacing !== '' && parseInt(spacing) !== 0) {
+        console.warn(
+          '`--vaadin-form-item-row-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-row-spacing` on <vaadin-form-layout> instead.',
+        );
+      }
+
+      const labelWidth = computedStyle.getPropertyValue('--vaadin-form-item-label-width');
+      if (labelWidth !== '' && parseInt(labelWidth) !== 0) {
+        console.warn(
+          '`--vaadin-form-item-label-width` is deprecated since 24.7. Use `--vaadin-form-layout-label-width` on <vaadin-form-layout> instead.',
+        );
+      }
+
+      const labelSpacing = computedStyle.getPropertyValue('--vaadin-form-item-label-spacing');
+      if (labelSpacing !== '' && parseInt(labelSpacing) !== 0) {
+        console.warn(
+          '`--vaadin-form-item-label-spacing` is deprecated since 24.7. Use `--vaadin-form-layout-label-spacing` on <vaadin-form-layout> instead.',
+        );
       }
     }
 

--- a/packages/form-layout/src/vaadin-form-item-mixin.js
+++ b/packages/form-layout/src/vaadin-form-item-mixin.js
@@ -42,6 +42,7 @@ export const FormItemMixin = (superClass) =>
       this.__fieldNode = null;
     }
 
+    /** @protected */
     ready() {
       super.ready();
 

--- a/packages/form-layout/src/vaadin-form-item.d.ts
+++ b/packages/form-layout/src/vaadin-form-item.d.ts
@@ -87,8 +87,8 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  *
  * Custom CSS property | Description | Default
  * ---|---|---
- * `--vaadin-form-item-label-width` | Width of the label column when the labels are aside | `8em`
- * `--vaadin-form-item-label-spacing` | Spacing between the label column and the input column when the labels are aside | `1em`
+ * `--vaadin-form-item-label-width` | (DEPRECATED: Use `--vaadin-form-layout-label-width` on `<vaadin-form-layout>` instead) Width of the label column when the labels are aside | `8em`
+ * `--vaadin-form-item-label-spacing` | (DEPRECATED: Use `--vaadin-form-layout-label-spacing` on `<vaadin-form-layout>` instead) Spacing between the label column and the input column when the labels are aside | `1em`
  * `--vaadin-form-item-row-spacing` | (DEPRECATED: Use `--vaadin-form-layout-row-spacing` on `<vaadin-form-layout>` instead) Height of the spacing between the form item elements | `1em`
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -92,8 +92,8 @@ registerStyles('vaadin-form-item', formItemStyles, { moduleId: 'vaadin-form-item
  *
  * Custom CSS property | Description | Default
  * ---|---|---
- * `--vaadin-form-item-label-width` | Width of the label column when the labels are aside | `8em`
- * `--vaadin-form-item-label-spacing` | Spacing between the label column and the input column when the labels are aside | `1em`
+ * `--vaadin-form-item-label-width` | (DEPRECATED: Use `--vaadin-form-layout-label-width` on `<vaadin-form-layout>` instead) Width of the label column when the labels are aside | `8em`
+ * `--vaadin-form-item-label-spacing` | (DEPRECATED: Use `--vaadin-form-layout-label-spacing` on `<vaadin-form-layout>` instead) Spacing between the label column and the input column when the labels are aside | `1em`
  * `--vaadin-form-item-row-spacing` | (DEPRECATED: Use `--vaadin-form-layout-row-spacing` on `<vaadin-form-layout>` instead) Height of the spacing between the form item elements | `1em`
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/form-layout/src/vaadin-form-layout-styles.js
+++ b/packages/form-layout/src/vaadin-form-layout-styles.js
@@ -7,13 +7,14 @@ import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const formLayoutStyles = css`
   :host {
+    /* Default values */
+    --vaadin-form-layout-row-spacing: 1em;
+    --vaadin-form-layout-column-spacing: 2em;
+    --vaadin-form-layout-label-width: 8em;
+    --vaadin-form-layout-label-spacing: 1em;
+
     display: block;
     max-width: 100%;
-    /* CSS API for host */
-    --vaadin-form-item-label-width: 8em;
-    --vaadin-form-item-label-spacing: 1em;
-    --vaadin-form-layout-row-spacing: 1em;
-    --vaadin-form-layout-column-spacing: 2em; /* (default) */
     align-self: stretch;
   }
 
@@ -62,7 +63,7 @@ export const formItemStyles = css`
   }
 
   #label {
-    width: var(--vaadin-form-item-label-width, 8em);
+    width: var(--vaadin-form-item-label-width, var(--vaadin-form-layout-label-width, 8em));
     flex: 0 0 auto;
   }
 
@@ -71,7 +72,7 @@ export const formItemStyles = css`
   }
 
   #spacing {
-    width: var(--vaadin-form-item-label-spacing, 1em);
+    width: var(--vaadin-form-item-label-spacing, var(--vaadin-form-layout-label-spacing, 1em));
     flex: 0 0 auto;
   }
 

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -101,7 +101,9 @@ registerStyles('vaadin-form-layout', formLayoutStyles, { moduleId: 'vaadin-form-
  * Custom CSS property | Description | Default
  * ---|---|---
  * `--vaadin-form-layout-column-spacing` | Length of the spacing between columns | `2em`
- * `--vaadin-form-layout-row-spacing` | Length of the spacing between rows | 1em`
+ * `--vaadin-form-layout-row-spacing` | Length of the spacing between rows | `1em`
+ * `--vaadin-form-layout-label-width` | Width of the label when labels are displayed aside | `8em`
+ * `--vaadin-form-layout-label-spacing` | Length of the spacing between the label and the input when labels are displayed aside | `1em`
  *
  * @customElement
  * @extends HTMLElement

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '../src/vaadin-form-layout.js';
 import '../src/vaadin-form-item.js';
-import { FormItem } from '../src/vaadin-form-item.js';
 
 function estimateEffectiveColumnCount(layout) {
   const offsets = [...layout.children]
@@ -139,7 +138,6 @@ describe('form layout', () => {
     });
 
     afterEach(() => {
-      FormItem.__isDeprecationWarningShown = false;
       console.warn.restore();
     });
 

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '@vaadin/text-field/vaadin-text-field.js';
 import '../src/vaadin-form-layout.js';
 import '../src/vaadin-form-item.js';
-import '@polymer/polymer/lib/elements/dom-repeat.js';
+import { FormItem } from '../src/vaadin-form-item.js';
 
 function estimateEffectiveColumnCount(layout) {
   const offsets = [...layout.children]
@@ -139,6 +139,7 @@ describe('form layout', () => {
     });
 
     afterEach(() => {
+      FormItem.__isDeprecationWarningShown = false;
       console.warn.restore();
     });
 
@@ -154,27 +155,36 @@ describe('form layout', () => {
       expect(getComputedStyle(item).getPropertyValue('--vaadin-form-item-row-spacing')).to.be.empty;
     });
 
-    it('should warn when adding form-item with deprecated --vaadin-form-item-label-width', () => {
-      const item = document.createElement('vaadin-form-item');
-      item.style.setProperty('--vaadin-form-item-label-width', '100px');
-      layout.appendChild(item);
-      expect(console.warn.calledOnce).to.be.true;
+    it('should warn once when adding form items with deprecated --vaadin-form-item-label-width', () => {
+      for (let i = 0; i < 2; i++) {
+        const item = document.createElement('vaadin-form-item');
+        item.style.setProperty('--vaadin-form-item-label-width', '100px');
+        layout.appendChild(item);
+      }
+
+      expect(console.warn).to.be.calledOnce;
       expect(console.warn.args[0][0]).to.contain('`--vaadin-form-item-label-width` is deprecated');
     });
 
-    it('should warn when adding form-item with deprecated --vaadin-form-item-label-spacing', () => {
-      const item = document.createElement('vaadin-form-item');
-      item.style.setProperty('--vaadin-form-item-label-spacing', '8px');
-      layout.appendChild(item);
-      expect(console.warn.calledOnce).to.be.true;
+    it('should warn once when adding form items with deprecated --vaadin-form-item-label-spacing', () => {
+      for (let i = 0; i < 2; i++) {
+        const item = document.createElement('vaadin-form-item');
+        item.style.setProperty('--vaadin-form-item-label-spacing', '8px');
+        layout.appendChild(item);
+      }
+
+      expect(console.warn).to.be.calledOnce;
       expect(console.warn.args[0][0]).to.contain('`--vaadin-form-item-label-spacing` is deprecated');
     });
 
-    it('should warn when adding form-item with deprecated --vaadin-form-item-row-spacing', () => {
-      const item = document.createElement('vaadin-form-item');
-      item.style.setProperty('--vaadin-form-item-row-spacing', '8px');
-      layout.appendChild(item);
-      expect(console.warn.calledOnce).to.be.true;
+    it('should warn when adding form items with deprecated --vaadin-form-item-row-spacing', () => {
+      for (let i = 0; i < 2; i++) {
+        const item = document.createElement('vaadin-form-item');
+        item.style.setProperty('--vaadin-form-item-row-spacing', '8px');
+        layout.appendChild(item);
+      }
+
+      expect(console.warn).to.be.calledOnce;
       expect(console.warn.args[0][0]).to.contain('`--vaadin-form-item-row-spacing` is deprecated');
     });
 


### PR DESCRIPTION
## Description

This PR introduces the CSS properties `--vaadin-form-layout-label-width` and `--vaadin-form-layout-label-spacing`, and deprecates the old form item properties `--vaadin-form-item-label-width` and `--vaadin-form-item-label-spacing`.

Fixes https://github.com/vaadin/web-components/issues/8683

## Type of change

- [x] Feature
