### PR TITLE
fix: bring popover overlay to front when used in modeless dialog

### DIFF
--- a/packages/popover/test/nested.test.js
+++ b/packages/popover/test/nested.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import { Popover } from '../vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';
@@ -165,6 +166,24 @@ describe('nested popover', () => {
       await nextUpdate(popover);
 
       expect(popover.opened).to.be.true;
+    });
+  });
+
+  describe('bring to front', () => {
+    beforeEach(async () => {
+      // Open the first popover
+      target.click();
+      await nextRender();
+
+      // Open the second popover
+      secondTarget.click();
+      await nextRender();
+    });
+
+    it('should bring to front nested overlay on parent overlay bringToFront()', () => {
+      const spy = sinon.spy(secondPopover._overlayElement, 'bringToFront');
+      popover._overlayElement.bringToFront();
+      expect(spy).to.be.calledOnce;
     });
   });
 });

--- a/test/integration/dialog-popover.test.js
+++ b/test/integration/dialog-popover.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextFrame, nextRender, nextUpdate, touchstart } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/dialog';
 import '@vaadin/popover';
@@ -82,6 +82,33 @@ describe('popover in dialog', () => {
 
         expect(overlay.opened).to.be.false;
         expect(dialog.opened).to.be.true;
+      });
+    });
+
+    describe('modeless dialog', () => {
+      beforeEach(async () => {
+        dialog.modeless = true;
+
+        button.click();
+        await nextRender();
+      });
+
+      it('should bring popover overlay to front on dialog overlay mousedown', () => {
+        mousedown(dialog.$.overlay);
+
+        const dialogZIndex = parseInt(getComputedStyle(dialog.$.overlay).zIndex);
+        const popoverZIndex = parseInt(getComputedStyle(overlay).zIndex);
+
+        expect(popoverZIndex).to.equal(dialogZIndex + 1);
+      });
+
+      it('should bring popover overlay to front on dialog overlay touchstart', () => {
+        touchstart(dialog.$.overlay);
+
+        const dialogZIndex = parseInt(getComputedStyle(dialog.$.overlay).zIndex);
+        const popoverZIndex = parseInt(getComputedStyle(overlay).zIndex);
+
+        expect(popoverZIndex).to.equal(dialogZIndex + 1);
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes #8521

Depends on #8690

## Type of change

- Bugfix

## Note

For now the `vaadin-popover` is the only web component where the original issue can be reproduced. Other components e.g. `vaadin-combo-box` have their overlays as modal by default. The `vaadin-tooltip` is modeless but should close on mousedown regardless. So for now I thought the fix can be limited to the popover package.

If we decide to add public API for making overlays non-modal (see #451) then we should reconsider this fix as the issue would then likely affect other components using overlays as well.