### PR TITLE
refactor: use checkVisibility when supported by browser

### DIFF
--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -145,6 +145,13 @@ function sortElementsByTabIndex(elements) {
  * @return {boolean}
  */
 export function isElementHidden(element) {
+  if (element.checkVisibility) {
+    return !element.checkVisibility({ visibilityProperty: true });
+  }
+
+  // TODO: checkVisibility is supported only from Safari 17.4, so we still need to
+  // keep the custom implementation as a fallback for older versions until Vaadin 25:
+
   // `offsetParent` is `null` when the element itself
   // or one of its ancestors is hidden with `display: none`.
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent


### PR DESCRIPTION
## Description

Updates the isElementHidden implementation to use the native `checkVisibility` method when supported by the browser. Since this method is only available from Safari 17.4, the custom implementation remains in place as a fallback until Vaadin 25.

## Type of change

- [x] Refactor
