### PR TITLE
test: cleanup outdated text-field unit tests

### DIFF
--- a/packages/text-field/test/text-field.test.js
+++ b/packages/text-field/test/text-field.test.js
@@ -214,33 +214,6 @@ describe('text-field', () => {
     });
   });
 
-  describe('value property', () => {
-    it('should not consider updating the value as user input if the value is not changed', async () => {
-      const event = new Event('input', {
-        bubbles: true,
-        cancelable: true,
-      });
-      input.dispatchEvent(event);
-
-      textField.value = 'foo';
-      await nextUpdate(textField);
-      expect(input.value).to.equal('foo');
-    });
-  });
-
-  describe('events', () => {
-    it('should not stop native input events', () => {
-      const inputSpy = sinon.spy();
-      textField.addEventListener('input', inputSpy);
-
-      const inputEvent = new Event('input', { bubbles: true, composed: true });
-      input.dispatchEvent(inputEvent);
-
-      expect(inputSpy.calledOnce).to.be.true;
-      expect(inputSpy.calledWith(inputEvent)).to.be.true;
-    });
-  });
-
   describe(`methods`, () => {
     it('should clear the value when clear() is called', async () => {
       textField.value = 'Foo';


### PR DESCRIPTION
## Description

Removed tests that were only relevant with V14 version:

- value property test was added in https://github.com/vaadin/vaadin-text-field/pull/480 - back then, we used to have different logic for `__userInput`. The test is now pointless since we check for `event.isTrusted` anyways and the fake input event dispatched in the test would not set the flag. Also, the original issue is not reproducible anymore.
- input event test was added in https://github.com/vaadin/vaadin-text-field/pull/353 - back then, we used to have some logic for input event prevention and `__preventInput` flag. This logic was removed when restructuring text-field related mixins for V22.

## Type of change

- Test