### PR TITLE
feat: allow adding custom data to context menu item types

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.d.ts
@@ -5,11 +5,12 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { ContextMenuRenderer } from './vaadin-context-menu.js';
-import type { ItemsMixinClass } from './vaadin-contextmenu-items-mixin.js';
+import type { ContextMenuItem, ItemsMixinClass } from './vaadin-contextmenu-items-mixin.js';
 
-export declare function ContextMenuMixin<T extends Constructor<HTMLElement>>(
-  base: T,
-): Constructor<ContextMenuMixinClass> & Constructor<ItemsMixinClass> & T;
+export declare function ContextMenuMixin<
+  T extends Constructor<HTMLElement>,
+  TItem extends ContextMenuItem = ContextMenuItem,
+>(base: T): Constructor<ContextMenuMixinClass> & Constructor<ItemsMixinClass<TItem>> & T;
 
 export declare class ContextMenuMixinClass {
   /**
@@ -79,3 +80,7 @@ export declare class ContextMenuMixinClass {
    */
   open(e: Event | undefined): void;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export declare interface ContextMenuMixinClass<TItem extends ContextMenuItem = ContextMenuItem>
+  extends ItemsMixinClass<TItem> {}

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -3,11 +3,11 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
-import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
-import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
-import { ContextMenuItem } from './vaadin-contextmenu-items-mixin.js';
+import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import type { ContextMenuMixinClass } from './vaadin-context-menu-mixin.js';
+import type { ContextMenuItem } from './vaadin-contextmenu-items-mixin.js';
 
 export { ContextMenuItem };
 
@@ -30,19 +30,23 @@ export type ContextMenuOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 /**
  * Fired when an item is selected when the context menu is populated using the `items` API.
  */
-export type ContextMenuItemSelectedEvent = CustomEvent<{ value: ContextMenuItem }>;
+export type ContextMenuItemSelectedEvent<TItem extends ContextMenuItem = ContextMenuItem> = CustomEvent<{
+  value: TItem;
+}>;
 
-export interface ContextMenuCustomEventMap {
+export interface ContextMenuCustomEventMap<TItem extends ContextMenuItem = ContextMenuItem> {
   'opened-changed': ContextMenuOpenedChangedEvent;
 
-  'item-selected': ContextMenuItemSelectedEvent;
+  'item-selected': ContextMenuItemSelectedEvent<TItem>;
 
   'close-all-menus': Event;
 
   'items-outside-click': Event;
 }
 
-export interface ContextMenuEventMap extends HTMLElementEventMap, ContextMenuCustomEventMap {}
+export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenuItem>
+  extends HTMLElementEventMap,
+    ContextMenuCustomEventMap<TItem> {}
 
 /**
  * `<vaadin-context-menu>` is a Web Component for creating context menus.
@@ -233,19 +237,25 @@ export interface ContextMenuEventMap extends HTMLElementEventMap, ContextMenuCus
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
  */
-declare class ContextMenu extends ContextMenuMixin(OverlayClassMixin(ElementMixin(ThemePropertyMixin(HTMLElement)))) {
+declare class ContextMenu<TItem extends ContextMenuItem = ContextMenuItem> extends HTMLElement {
   addEventListener<K extends keyof ContextMenuEventMap>(
     type: K,
-    listener: (this: ContextMenu, ev: ContextMenuEventMap[K]) => void,
+    listener: (this: ContextMenu<TItem>, ev: ContextMenuEventMap<TItem>[K]) => void,
     options?: AddEventListenerOptions | boolean,
   ): void;
 
   removeEventListener<K extends keyof ContextMenuEventMap>(
     type: K,
-    listener: (this: ContextMenu, ev: ContextMenuEventMap[K]) => void,
+    listener: (this: ContextMenu<TItem>, ev: ContextMenuEventMap<TItem>[K]) => void,
     options?: EventListenerOptions | boolean,
   ): void;
 }
+
+interface ContextMenu<TItem extends ContextMenuItem = ContextMenuItem>
+  extends ContextMenuMixinClass<TItem>,
+    OverlayClassMixinClass,
+    ElementMixinClass,
+    ThemePropertyMixinClass {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.d.ts
@@ -7,7 +7,7 @@ import './vaadin-context-menu-item.js';
 import './vaadin-context-menu-list-box.js';
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
-export interface ContextMenuItem {
+export type ContextMenuItem<TItemData extends object = object> = {
   text?: string;
   component?: HTMLElement | string;
   disabled?: boolean;
@@ -15,12 +15,12 @@ export interface ContextMenuItem {
   keepOpen?: boolean;
   theme?: string[] | string;
   className?: string;
-  children?: ContextMenuItem[];
-}
+  children?: Array<ContextMenuItem<TItemData>>;
+} & TItemData;
 
 export declare function ItemsMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ItemsMixinClass> & T;
 
-export declare class ItemsMixinClass {
+export declare class ItemsMixinClass<TItem extends ContextMenuItem = ContextMenuItem> {
   /**
    * Defines a (hierarchical) menu structure for the component.
    * If a menu item has a non-empty `children` set, a sub-menu with the child items is opened
@@ -49,7 +49,7 @@ export declare class ItemsMixinClass {
    * ];
    * ```
    */
-  items: ContextMenuItem[] | undefined;
+  items: TItem[] | undefined;
 
   /**
    * Tag name prefix used by overlay, list-box and items.

--- a/packages/context-menu/test/typings/context-menu.types.ts
+++ b/packages/context-menu/test/typings/context-menu.types.ts
@@ -45,6 +45,22 @@ const renderer: ContextMenuRenderer = (root, contextMenu, context) => {
 
 menu.renderer = renderer;
 
+// Custom item data
+interface ItemData {
+  type: 'copy' | 'cut' | 'paste';
+  value: string;
+}
+
+const narrowedMenu = menu as ContextMenu<MenuItem<ItemData>>;
+
+assertType<ItemData>(narrowedMenu.items![0]);
+assertType<ItemData>(narrowedMenu.items![0].children![0]);
+assertType<ItemData>(narrowedMenu.items![0].children![0].children![0]);
+
+narrowedMenu.addEventListener('item-selected', (event) => {
+  assertType<ItemData>(event.detail.value);
+});
+
 // Item
 const item = document.createElement('vaadin-context-menu-item');
 


### PR DESCRIPTION
Make `ContextMenu` and `ContextMenuItem` types generic so that:
- `ContextMenuItem` accepts a type for custom item data, so that you can easily create custom item types
- `ContextMenu` accepts a custom item type, which restricts the items that can be set, and provides that type in the `item-selected` event

Part of https://github.com/vaadin/web-components/issues/8700