### PR TITLE
feat: support partial i18n in login

### DIFF
--- a/packages/login/src/vaadin-lit-login-form.js
+++ b/packages/login/src/vaadin-lit-login-form.js
@@ -49,15 +49,15 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
         id="vaadinLoginFormWrapper"
         theme="${ifDefined(this._theme)}"
         .error="${this.error}"
-        .i18n="${this.i18n}"
+        .i18n="${this.__effectiveI18n}"
         .headingLevel="${this.headingLevel}"
       >
         <form method="POST" action="${ifDefined(this.action)}" @formdata="${this._onFormData}" slot="form">
           <input id="csrf" type="hidden" />
           <vaadin-text-field
             name="username"
-            .label="${this.i18n.form.username}"
-            .errorMessage="${this.i18n.errorMessage.username}"
+            .label="${this.__effectiveI18n.form.username}"
+            .errorMessage="${this.__effectiveI18n.errorMessage.username}"
             id="vaadinLoginUsername"
             required
             @keydown="${this._handleInputKeydown}"
@@ -72,8 +72,8 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
 
           <vaadin-password-field
             name="password"
-            .label="${this.i18n.form.password}"
-            .errorMessage="${this.i18n.errorMessage.password}"
+            .label="${this.__effectiveI18n.form.password}"
+            .errorMessage="${this.__effectiveI18n.errorMessage.password}"
             id="vaadinLoginPassword"
             required
             @keydown="${this._handleInputKeydown}"
@@ -91,7 +91,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
           @click="${this.submit}"
           .disabled="${this.disabled}"
         >
-          ${this.i18n.form.submit}
+          ${this.__effectiveI18n.form.submit}
         </vaadin-button>
 
         <vaadin-button
@@ -100,7 +100,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
           @click="${this._onForgotPasswordClick}"
           ?hidden="${this.noForgotPassword}"
         >
-          ${this.i18n.form.forgotPassword}
+          ${this.__effectiveI18n.form.forgotPassword}
         </vaadin-button>
       </vaadin-login-form-wrapper>
     `;

--- a/packages/login/src/vaadin-lit-login-overlay.js
+++ b/packages/login/src/vaadin-lit-login-overlay.js
@@ -53,7 +53,7 @@ class LoginOverlay extends LoginOverlayMixin(ElementMixin(ThemableMixin(PolylitM
           .noAutofocus="${this.noAutofocus}"
           .noForgotPassword="${this.noForgotPassword}"
           .headingLevel="${this.__computeHeadingLevel(this.headingLevel)}"
-          .i18n="${this.i18n}"
+          .i18n="${this.__effectiveI18n}"
           @login="${this._retargetEvent}"
           @forgot-password="${this._retargetEvent}"
           @disabled-changed="${this._onDisabledChanged}"

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -65,15 +65,15 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
         id="vaadinLoginFormWrapper"
         theme$="[[_theme]]"
         error="[[error]]"
-        i18n="[[i18n]]"
+        i18n="[[__effectiveI18n]]"
         heading-level="[[headingLevel]]"
       >
         <form method="POST" action$="[[action]]" on-formdata="_onFormData" slot="form">
           <input id="csrf" type="hidden" />
           <vaadin-text-field
             name="username"
-            label="[[i18n.form.username]]"
-            error-message="[[i18n.errorMessage.username]]"
+            label="[[__effectiveI18n.form.username]]"
+            error-message="[[__effectiveI18n.errorMessage.username]]"
             id="vaadinLoginUsername"
             required
             on-keydown="_handleInputKeydown"
@@ -88,8 +88,8 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
 
           <vaadin-password-field
             name="password"
-            label="[[i18n.form.password]]"
-            error-message="[[i18n.errorMessage.password]]"
+            label="[[__effectiveI18n.form.password]]"
+            error-message="[[__effectiveI18n.errorMessage.password]]"
             id="vaadinLoginPassword"
             required
             on-keydown="_handleInputKeydown"
@@ -102,7 +102,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
         </form>
 
         <vaadin-button slot="submit" theme="primary contained submit" on-click="submit" disabled$="[[disabled]]">
-          [[i18n.form.submit]]
+          [[__effectiveI18n.form.submit]]
         </vaadin-button>
 
         <vaadin-button
@@ -111,7 +111,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolymerElement
           on-click="_onForgotPasswordClick"
           hidden$="[[noForgotPassword]]"
         >
-          [[i18n.form.forgotPassword]]
+          [[__effectiveI18n.form.forgotPassword]]
         </vaadin-button>
       </vaadin-login-form-wrapper>
     `;

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -4,8 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
 
-export interface LoginI18n {
+export type LoginI18n = PartialI18n<{
   form: {
     title: string;
     username: string;
@@ -24,7 +25,7 @@ export interface LoginI18n {
     description?: string;
   };
   additionalInformation?: string;
-}
+}>;
 
 export declare function LoginMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<LoginMixinClass> & T;
 
@@ -61,9 +62,9 @@ export declare class LoginMixinClass {
   noAutofocus: boolean;
 
   /**
-   * The object used to localize this component.
-   * For changing the default localization, change the entire
-   * _i18n_ object or just the property you want to modify.
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
    *
    * The object has the following JSON structure (by default it doesn't include `additionalInformation`
    * and `header` sections, `header` can be added to override `title` and `description` properties

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -3,12 +3,30 @@
  * Copyright (c) 2018 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
+
+const DEFAULT_I18N = {
+  form: {
+    title: 'Log in',
+    username: 'Username',
+    password: 'Password',
+    submit: 'Log in',
+    forgotPassword: 'Forgot password',
+  },
+  errorMessage: {
+    title: 'Incorrect username or password',
+    message: 'Check that you have entered the correct username and password and try again.',
+    username: 'Username is required',
+    password: 'Password is required',
+  },
+};
 
 /**
+ * @mixes LoginMixin
  * @polymerMixin
  */
 export const LoginMixin = (superClass) =>
-  class LoginMixin extends superClass {
+  class LoginMixin extends I18nMixin(DEFAULT_I18N, superClass) {
     /**
      * Fired when user clicks on the "Forgot password" button.
      *
@@ -79,62 +97,6 @@ export const LoginMixin = (superClass) =>
         },
 
         /**
-         * The object used to localize this component.
-         * For changing the default localization, change the entire
-         * _i18n_ object or just the property you want to modify.
-         *
-         * The object has the following JSON structure (by default it doesn't include `additionalInformation`
-         * and `header` sections, `header` can be added to override `title` and `description` properties
-         * in `vaadin-login-overlay`):
-         *
-         * ```
-         * {
-         *   header: {
-         *     title: 'App name',
-         *     description: 'Inspiring application description'
-         *   },
-         *   form: {
-         *     title: 'Log in',
-         *     username: 'Username',
-         *     password: 'Password',
-         *     submit: 'Log in',
-         *     forgotPassword: 'Forgot password'
-         *   },
-         *   errorMessage: {
-         *     title: 'Incorrect username or password',
-         *     message: 'Check that you have entered the correct username and password and try again.',
-         *     username: 'Username is required',
-         *     password: 'Password is required'
-         *   },
-         *   additionalInformation: 'In case you need to provide some additional info for the user.'
-         * }
-         * ```
-         *
-         * @type {!LoginI18n}
-         * @default {English/US}
-         */
-        i18n: {
-          type: Object,
-          value() {
-            return {
-              form: {
-                title: 'Log in',
-                username: 'Username',
-                password: 'Password',
-                submit: 'Log in',
-                forgotPassword: 'Forgot password',
-              },
-              errorMessage: {
-                title: 'Incorrect username or password',
-                message: 'Check that you have entered the correct username and password and try again.',
-                username: 'Username is required',
-                password: 'Password is required',
-              },
-            };
-          },
-        },
-
-        /**
          * Sets the root heading level (`aria-level`) for the heading hierarchy. Default value: 1.
          * Child headings automatically increment from this base level i.e. standalone login form
          * renders its title as `<h1>`, whereas the form in the overlay uses `<h2>`, as the `<h1>`
@@ -156,5 +118,46 @@ export const LoginMixin = (superClass) =>
           value: false,
         },
       };
+    }
+
+    /**
+     * The object used to localize this component. To change the default
+     * localization, replace this with an object that provides all properties, or
+     * just the individual properties you want to change.
+     *
+     * The object has the following JSON structure (by default it doesn't include `additionalInformation`
+     * and `header` sections, `header` can be added to override `title` and `description` properties
+     * in `vaadin-login-overlay`):
+     *
+     * ```
+     * {
+     *   header: {
+     *     title: 'App name',
+     *     description: 'Inspiring application description'
+     *   },
+     *   form: {
+     *     title: 'Log in',
+     *     username: 'Username',
+     *     password: 'Password',
+     *     submit: 'Log in',
+     *     forgotPassword: 'Forgot password'
+     *   },
+     *   errorMessage: {
+     *     title: 'Incorrect username or password',
+     *     message: 'Check that you have entered the correct username and password and try again.',
+     *     username: 'Username is required',
+     *     password: 'Password is required'
+     *   },
+     *   additionalInformation: 'In case you need to provide some additional info for the user.'
+     * }
+     * ```
+     * @return {!LoginI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
     }
   };

--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -47,7 +47,7 @@ export const LoginOverlayMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__i18nChanged(i18n)'];
+      return ['__i18nChanged(__effectiveI18n)'];
     }
 
     /** @protected */
@@ -77,8 +77,8 @@ export const LoginOverlayMixin = (superClass) =>
     }
 
     /** @private */
-    __i18nChanged(i18n) {
-      const header = i18n && i18n.header;
+    __i18nChanged(effectiveI18n) {
+      const header = effectiveI18n && effectiveI18n.header;
       if (!header) {
         return;
       }

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -75,7 +75,7 @@ class LoginOverlay extends LoginOverlayMixin(ElementMixin(ThemableMixin(PolymerE
           heading-level="[[__computeHeadingLevel(headingLevel)]]"
           no-autofocus="[[noAutofocus]]"
           no-forgot-password="[[noForgotPassword]]"
-          i18n="{{i18n}}"
+          i18n="{{__effectiveI18n}}"
           on-login="_retargetEvent"
           on-forgot-password="_retargetEvent"
         ></vaadin-login-form>

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -341,6 +341,117 @@ snapshots["vaadin-login-form host i18n"] =
 `;
 /* end snapshot vaadin-login-form host i18n */
 
+snapshots["vaadin-login-form host i18n-partial"] = 
+`<vaadin-login-form>
+  <vaadin-login-form-wrapper id="vaadinLoginFormWrapper">
+    <form
+      method="POST"
+      slot="form"
+    >
+      <input
+        id="csrf"
+        type="hidden"
+      >
+      <vaadin-text-field
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        focused=""
+        has-label=""
+        id="vaadinLoginUsername"
+        manual-validation=""
+        name="username"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
+          autocomplete="username"
+          autocorrect="off"
+          id="input-vaadin-text-field-6"
+          name="username"
+          required=""
+          slot="input"
+          type="text"
+        >
+        <label
+          for="input-vaadin-text-field-6"
+          id="label-vaadin-text-field-0"
+          slot="label"
+        >
+          Username
+        </label>
+        <div
+          hidden=""
+          id="error-message-vaadin-text-field-2"
+          slot="error-message"
+        >
+        </div>
+      </vaadin-text-field>
+      <vaadin-password-field
+        autocomplete="current-password"
+        has-label=""
+        id="vaadinLoginPassword"
+        manual-validation=""
+        name="password"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-labelledby="label-vaadin-password-field-3"
+          autocapitalize="off"
+          autocomplete="current-password"
+          id="input-vaadin-password-field-7"
+          name="password"
+          required=""
+          slot="input"
+          type="password"
+        >
+        <label
+          for="input-vaadin-password-field-7"
+          id="label-vaadin-password-field-3"
+          slot="label"
+        >
+          Password
+        </label>
+        <div
+          hidden=""
+          id="error-message-vaadin-password-field-5"
+          slot="error-message"
+        >
+        </div>
+        <vaadin-password-field-button
+          aria-label="Show password"
+          aria-pressed="false"
+          role="button"
+          slot="reveal"
+          tabindex="0"
+        >
+        </vaadin-password-field-button>
+      </vaadin-password-field>
+    </form>
+    <vaadin-button
+      role="button"
+      slot="submit"
+      tabindex="0"
+      theme="primary contained submit"
+    >
+      Log in
+    </vaadin-button>
+    <vaadin-button
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Custom forgot password
+    </vaadin-button>
+  </vaadin-login-form-wrapper>
+</vaadin-login-form>
+`;
+/* end snapshot vaadin-login-form host i18n-partial */
+
 snapshots["vaadin-login-form host i18n-required"] = 
 `<vaadin-login-form>
   <vaadin-login-form-wrapper id="vaadinLoginFormWrapper">
@@ -682,115 +793,4 @@ snapshots["vaadin-login-form shadow i18n"] =
 </section>
 `;
 /* end snapshot vaadin-login-form shadow i18n */
-
-snapshots["vaadin-login-form host i18n-partial"] = 
-`<vaadin-login-form>
-  <vaadin-login-form-wrapper id="vaadinLoginFormWrapper">
-    <form
-      method="POST"
-      slot="form"
-    >
-      <input
-        id="csrf"
-        type="hidden"
-      >
-      <vaadin-text-field
-        autocapitalize="none"
-        autocomplete="username"
-        autocorrect="off"
-        focused=""
-        has-label=""
-        id="vaadinLoginUsername"
-        manual-validation=""
-        name="username"
-        required=""
-        spellcheck="false"
-      >
-        <input
-          aria-labelledby="label-vaadin-text-field-0"
-          autocapitalize="none"
-          autocomplete="username"
-          autocorrect="off"
-          id="input-vaadin-text-field-6"
-          name="username"
-          required=""
-          slot="input"
-          type="text"
-        >
-        <label
-          for="input-vaadin-text-field-6"
-          id="label-vaadin-text-field-0"
-          slot="label"
-        >
-          Username
-        </label>
-        <div
-          hidden=""
-          id="error-message-vaadin-text-field-2"
-          slot="error-message"
-        >
-        </div>
-      </vaadin-text-field>
-      <vaadin-password-field
-        autocomplete="current-password"
-        has-label=""
-        id="vaadinLoginPassword"
-        manual-validation=""
-        name="password"
-        required=""
-        spellcheck="false"
-      >
-        <input
-          aria-labelledby="label-vaadin-password-field-3"
-          autocapitalize="off"
-          autocomplete="current-password"
-          id="input-vaadin-password-field-7"
-          name="password"
-          required=""
-          slot="input"
-          type="password"
-        >
-        <label
-          for="input-vaadin-password-field-7"
-          id="label-vaadin-password-field-3"
-          slot="label"
-        >
-          Password
-        </label>
-        <div
-          hidden=""
-          id="error-message-vaadin-password-field-5"
-          slot="error-message"
-        >
-        </div>
-        <vaadin-password-field-button
-          aria-label="Show password"
-          aria-pressed="false"
-          role="button"
-          slot="reveal"
-          tabindex="0"
-        >
-        </vaadin-password-field-button>
-      </vaadin-password-field>
-    </form>
-    <vaadin-button
-      role="button"
-      slot="submit"
-      tabindex="0"
-      theme="primary contained submit"
-    >
-      Log in
-    </vaadin-button>
-    <vaadin-button
-      role="button"
-      slot="forgot-password"
-      tabindex="0"
-      theme="tertiary small"
-    >
-      Custom forgot password
-    </vaadin-button>
-  </vaadin-login-form-wrapper>
-</vaadin-login-form>
-`;
-/* end snapshot vaadin-login-form host i18n-partial */
 

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -683,3 +683,114 @@ snapshots["vaadin-login-form shadow i18n"] =
 `;
 /* end snapshot vaadin-login-form shadow i18n */
 
+snapshots["vaadin-login-form host i18n-partial"] = 
+`<vaadin-login-form>
+  <vaadin-login-form-wrapper id="vaadinLoginFormWrapper">
+    <form
+      method="POST"
+      slot="form"
+    >
+      <input
+        id="csrf"
+        type="hidden"
+      >
+      <vaadin-text-field
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        focused=""
+        has-label=""
+        id="vaadinLoginUsername"
+        manual-validation=""
+        name="username"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-labelledby="label-vaadin-text-field-0"
+          autocapitalize="none"
+          autocomplete="username"
+          autocorrect="off"
+          id="input-vaadin-text-field-6"
+          name="username"
+          required=""
+          slot="input"
+          type="text"
+        >
+        <label
+          for="input-vaadin-text-field-6"
+          id="label-vaadin-text-field-0"
+          slot="label"
+        >
+          Username
+        </label>
+        <div
+          hidden=""
+          id="error-message-vaadin-text-field-2"
+          slot="error-message"
+        >
+        </div>
+      </vaadin-text-field>
+      <vaadin-password-field
+        autocomplete="current-password"
+        has-label=""
+        id="vaadinLoginPassword"
+        manual-validation=""
+        name="password"
+        required=""
+        spellcheck="false"
+      >
+        <input
+          aria-labelledby="label-vaadin-password-field-3"
+          autocapitalize="off"
+          autocomplete="current-password"
+          id="input-vaadin-password-field-7"
+          name="password"
+          required=""
+          slot="input"
+          type="password"
+        >
+        <label
+          for="input-vaadin-password-field-7"
+          id="label-vaadin-password-field-3"
+          slot="label"
+        >
+          Password
+        </label>
+        <div
+          hidden=""
+          id="error-message-vaadin-password-field-5"
+          slot="error-message"
+        >
+        </div>
+        <vaadin-password-field-button
+          aria-label="Show password"
+          aria-pressed="false"
+          role="button"
+          slot="reveal"
+          tabindex="0"
+        >
+        </vaadin-password-field-button>
+      </vaadin-password-field>
+    </form>
+    <vaadin-button
+      role="button"
+      slot="submit"
+      tabindex="0"
+      theme="primary contained submit"
+    >
+      Log in
+    </vaadin-button>
+    <vaadin-button
+      role="button"
+      slot="forgot-password"
+      tabindex="0"
+      theme="tertiary small"
+    >
+      Custom forgot password
+    </vaadin-button>
+  </vaadin-login-form-wrapper>
+</vaadin-login-form>
+`;
+/* end snapshot vaadin-login-form host i18n-partial */
+

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -460,3 +460,129 @@ snapshots["vaadin-login-overlay shadow i18n"] =
 `;
 /* end snapshot vaadin-login-overlay shadow i18n */
 
+snapshots["vaadin-login-overlay host i18n-partial"] = 
+`<vaadin-login-overlay-wrapper
+  aria-label="App name"
+  focus-trap=""
+  id="vaadinLoginOverlayWrapper"
+  opened=""
+  role="dialog"
+  with-backdrop=""
+>
+  <vaadin-login-form
+    id="vaadinLoginForm"
+    theme="with-overlay"
+  >
+    <vaadin-login-form-wrapper
+      id="vaadinLoginFormWrapper"
+      theme="with-overlay"
+    >
+      <form
+        method="POST"
+        slot="form"
+      >
+        <input
+          id="csrf"
+          type="hidden"
+        >
+        <vaadin-text-field
+          autocapitalize="none"
+          autocomplete="username"
+          autocorrect="off"
+          focused=""
+          has-label=""
+          id="vaadinLoginUsername"
+          manual-validation=""
+          name="username"
+          required=""
+          spellcheck="false"
+        >
+          <input
+            aria-labelledby="label-vaadin-text-field-0"
+            autocapitalize="none"
+            autocomplete="username"
+            autocorrect="off"
+            id="input-vaadin-text-field-6"
+            name="username"
+            required=""
+            slot="input"
+            type="text"
+          >
+          <label
+            for="input-vaadin-text-field-6"
+            id="label-vaadin-text-field-0"
+            slot="label"
+          >
+            Username
+          </label>
+          <div
+            hidden=""
+            id="error-message-vaadin-text-field-2"
+            slot="error-message"
+          >
+          </div>
+        </vaadin-text-field>
+        <vaadin-password-field
+          autocomplete="current-password"
+          has-label=""
+          id="vaadinLoginPassword"
+          manual-validation=""
+          name="password"
+          required=""
+          spellcheck="false"
+        >
+          <input
+            aria-labelledby="label-vaadin-password-field-3"
+            autocapitalize="off"
+            autocomplete="current-password"
+            id="input-vaadin-password-field-7"
+            name="password"
+            required=""
+            slot="input"
+            type="password"
+          >
+          <label
+            for="input-vaadin-password-field-7"
+            id="label-vaadin-password-field-3"
+            slot="label"
+          >
+            Password
+          </label>
+          <div
+            hidden=""
+            id="error-message-vaadin-password-field-5"
+            slot="error-message"
+          >
+          </div>
+          <vaadin-password-field-button
+            aria-label="Show password"
+            aria-pressed="false"
+            role="button"
+            slot="reveal"
+            tabindex="0"
+          >
+          </vaadin-password-field-button>
+        </vaadin-password-field>
+      </form>
+      <vaadin-button
+        role="button"
+        slot="submit"
+        tabindex="0"
+        theme="primary contained submit"
+      >
+        Log in
+      </vaadin-button>
+      <vaadin-button
+        role="button"
+        slot="forgot-password"
+        tabindex="0"
+        theme="tertiary small"
+      >
+        Custom forgot password
+      </vaadin-button>
+    </vaadin-login-form-wrapper>
+  </vaadin-login-form>
+</vaadin-login-overlay-wrapper>
+`;
+/* end snapshot vaadin-login-overlay host i18n-partial */
+

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -253,6 +253,132 @@ snapshots["vaadin-login-overlay host i18n"] =
 `;
 /* end snapshot vaadin-login-overlay host i18n */
 
+snapshots["vaadin-login-overlay host i18n-partial"] = 
+`<vaadin-login-overlay-wrapper
+  aria-label="App name"
+  focus-trap=""
+  id="vaadinLoginOverlayWrapper"
+  opened=""
+  role="dialog"
+  with-backdrop=""
+>
+  <vaadin-login-form
+    id="vaadinLoginForm"
+    theme="with-overlay"
+  >
+    <vaadin-login-form-wrapper
+      id="vaadinLoginFormWrapper"
+      theme="with-overlay"
+    >
+      <form
+        method="POST"
+        slot="form"
+      >
+        <input
+          id="csrf"
+          type="hidden"
+        >
+        <vaadin-text-field
+          autocapitalize="none"
+          autocomplete="username"
+          autocorrect="off"
+          focused=""
+          has-label=""
+          id="vaadinLoginUsername"
+          manual-validation=""
+          name="username"
+          required=""
+          spellcheck="false"
+        >
+          <input
+            aria-labelledby="label-vaadin-text-field-0"
+            autocapitalize="none"
+            autocomplete="username"
+            autocorrect="off"
+            id="input-vaadin-text-field-6"
+            name="username"
+            required=""
+            slot="input"
+            type="text"
+          >
+          <label
+            for="input-vaadin-text-field-6"
+            id="label-vaadin-text-field-0"
+            slot="label"
+          >
+            Username
+          </label>
+          <div
+            hidden=""
+            id="error-message-vaadin-text-field-2"
+            slot="error-message"
+          >
+          </div>
+        </vaadin-text-field>
+        <vaadin-password-field
+          autocomplete="current-password"
+          has-label=""
+          id="vaadinLoginPassword"
+          manual-validation=""
+          name="password"
+          required=""
+          spellcheck="false"
+        >
+          <input
+            aria-labelledby="label-vaadin-password-field-3"
+            autocapitalize="off"
+            autocomplete="current-password"
+            id="input-vaadin-password-field-7"
+            name="password"
+            required=""
+            slot="input"
+            type="password"
+          >
+          <label
+            for="input-vaadin-password-field-7"
+            id="label-vaadin-password-field-3"
+            slot="label"
+          >
+            Password
+          </label>
+          <div
+            hidden=""
+            id="error-message-vaadin-password-field-5"
+            slot="error-message"
+          >
+          </div>
+          <vaadin-password-field-button
+            aria-label="Show password"
+            aria-pressed="false"
+            role="button"
+            slot="reveal"
+            tabindex="0"
+          >
+          </vaadin-password-field-button>
+        </vaadin-password-field>
+      </form>
+      <vaadin-button
+        role="button"
+        slot="submit"
+        tabindex="0"
+        theme="primary contained submit"
+      >
+        Log in
+      </vaadin-button>
+      <vaadin-button
+        role="button"
+        slot="forgot-password"
+        tabindex="0"
+        theme="tertiary small"
+      >
+        Custom forgot password
+      </vaadin-button>
+    </vaadin-login-form-wrapper>
+  </vaadin-login-form>
+</vaadin-login-overlay-wrapper>
+`;
+/* end snapshot vaadin-login-overlay host i18n-partial */
+
 snapshots["vaadin-login-overlay host overlay class"] = 
 `<vaadin-login-overlay-wrapper
   aria-label="App name"
@@ -459,130 +585,4 @@ snapshots["vaadin-login-overlay shadow i18n"] =
 </div>
 `;
 /* end snapshot vaadin-login-overlay shadow i18n */
-
-snapshots["vaadin-login-overlay host i18n-partial"] = 
-`<vaadin-login-overlay-wrapper
-  aria-label="App name"
-  focus-trap=""
-  id="vaadinLoginOverlayWrapper"
-  opened=""
-  role="dialog"
-  with-backdrop=""
->
-  <vaadin-login-form
-    id="vaadinLoginForm"
-    theme="with-overlay"
-  >
-    <vaadin-login-form-wrapper
-      id="vaadinLoginFormWrapper"
-      theme="with-overlay"
-    >
-      <form
-        method="POST"
-        slot="form"
-      >
-        <input
-          id="csrf"
-          type="hidden"
-        >
-        <vaadin-text-field
-          autocapitalize="none"
-          autocomplete="username"
-          autocorrect="off"
-          focused=""
-          has-label=""
-          id="vaadinLoginUsername"
-          manual-validation=""
-          name="username"
-          required=""
-          spellcheck="false"
-        >
-          <input
-            aria-labelledby="label-vaadin-text-field-0"
-            autocapitalize="none"
-            autocomplete="username"
-            autocorrect="off"
-            id="input-vaadin-text-field-6"
-            name="username"
-            required=""
-            slot="input"
-            type="text"
-          >
-          <label
-            for="input-vaadin-text-field-6"
-            id="label-vaadin-text-field-0"
-            slot="label"
-          >
-            Username
-          </label>
-          <div
-            hidden=""
-            id="error-message-vaadin-text-field-2"
-            slot="error-message"
-          >
-          </div>
-        </vaadin-text-field>
-        <vaadin-password-field
-          autocomplete="current-password"
-          has-label=""
-          id="vaadinLoginPassword"
-          manual-validation=""
-          name="password"
-          required=""
-          spellcheck="false"
-        >
-          <input
-            aria-labelledby="label-vaadin-password-field-3"
-            autocapitalize="off"
-            autocomplete="current-password"
-            id="input-vaadin-password-field-7"
-            name="password"
-            required=""
-            slot="input"
-            type="password"
-          >
-          <label
-            for="input-vaadin-password-field-7"
-            id="label-vaadin-password-field-3"
-            slot="label"
-          >
-            Password
-          </label>
-          <div
-            hidden=""
-            id="error-message-vaadin-password-field-5"
-            slot="error-message"
-          >
-          </div>
-          <vaadin-password-field-button
-            aria-label="Show password"
-            aria-pressed="false"
-            role="button"
-            slot="reveal"
-            tabindex="0"
-          >
-          </vaadin-password-field-button>
-        </vaadin-password-field>
-      </form>
-      <vaadin-button
-        role="button"
-        slot="submit"
-        tabindex="0"
-        theme="primary contained submit"
-      >
-        Log in
-      </vaadin-button>
-      <vaadin-button
-        role="button"
-        slot="forgot-password"
-        tabindex="0"
-        theme="tertiary small"
-      >
-        Custom forgot password
-      </vaadin-button>
-    </vaadin-login-form-wrapper>
-  </vaadin-login-form>
-</vaadin-login-overlay-wrapper>
-`;
-/* end snapshot vaadin-login-overlay host i18n-partial */
 

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -46,6 +46,11 @@ describe('vaadin-login-form', () => {
       await expect(form).dom.to.equalSnapshot();
     });
 
+    it('i18n-partial', async () => {
+      form.i18n = { form: { forgotPassword: 'Custom forgot password' } };
+      await expect(form).dom.to.equalSnapshot();
+    });
+
     it('i18n-required', async () => {
       form.i18n = I18N_FINNISH;
       form.querySelectorAll('[required]').forEach((el) => {

--- a/packages/login/test/dom/login-overlay.test.js
+++ b/packages/login/test/dom/login-overlay.test.js
@@ -42,6 +42,11 @@ describe('vaadin-login-overlay', () => {
       await expect(wrapper).dom.to.equalSnapshot();
     });
 
+    it('i18n-partial', async () => {
+      overlay.i18n = { form: { forgotPassword: 'Custom forgot password' } };
+      await expect(wrapper).dom.to.equalSnapshot();
+    });
+
     it('overlay class', async () => {
       overlay.overlayClass = 'custom login-overlay';
       await expect(wrapper).dom.to.equalSnapshot();

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -174,7 +174,7 @@ describe('title and description', () => {
   });
 
   it('should update title and description when i18n.header updated', async () => {
-    const i18n = { ...overlay.i18n, header: { title: 'The newest title', description: 'The newest description' } };
+    const i18n = { header: { title: 'The newest title', description: 'The newest description' } };
     overlay.i18n = i18n;
     await nextUpdate(overlay);
     await nextUpdate(overlay.$.vaadinLoginOverlayWrapper);

--- a/packages/login/test/typings/login.types.ts
+++ b/packages/login/test/typings/login.types.ts
@@ -5,6 +5,7 @@ import type {
   LoginFormDisabledChangedEvent,
   LoginFormErrorChangedEvent,
   LoginFormLoginEvent,
+  LoginI18n,
 } from '../../vaadin-login-form.js';
 import type {
   LoginOverlayDescriptionChangedEvent,
@@ -21,6 +22,7 @@ assertType<ElementMixinClass>(overlay);
 assertType<OverlayClassMixinClass>(overlay);
 
 assertType<number>(overlay.headingLevel);
+assertType<LoginI18n>(overlay.i18n);
 
 overlay.addEventListener('login', (event) => {
   assertType<LoginOverlayLoginEvent>(event);
@@ -47,6 +49,7 @@ overlay.addEventListener('description-changed', (event) => {
 const form = document.createElement('vaadin-login-form');
 
 assertType<number>(form.headingLevel);
+assertType<LoginI18n>(form.i18n);
 
 form.addEventListener('login', (event) => {
   assertType<LoginFormLoginEvent>(event);
@@ -63,3 +66,8 @@ form.addEventListener('disabled-changed', (event) => {
   assertType<LoginFormDisabledChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
+
+// I18n
+assertType<LoginI18n>({});
+assertType<LoginI18n>({ additionalInformation: 'additionalInformation' });
+assertType<LoginI18n>({ form: { title: 'formTitle' } });


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to login. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
