### PR TITLE
test: remove incorrect usage of PatternMixin from typing tests

### DIFF
--- a/packages/text-area/test/typings/text-area.types.ts
+++ b/packages/text-area/test/typings/text-area.types.ts
@@ -3,7 +3,6 @@ import type { ControllerMixinClass } from '@vaadin/component-base/src/controller
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
 import type { ClearButtonMixinClass } from '@vaadin/field-base/src/clear-button-mixin.js';
 import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
-import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type {
   TextArea,
@@ -22,7 +21,6 @@ assertType<ClearButtonMixinClass>(area);
 assertType<ControllerMixinClass>(area);
 assertType<ElementMixinClass>(area);
 assertType<InputFieldMixinClass>(area);
-assertType<PatternMixinClass>(area);
 assertType<ThemableMixinClass>(area);
 
 // Events

--- a/packages/text-field/test/typings/text-field.types.ts
+++ b/packages/text-field/test/typings/text-field.types.ts
@@ -14,7 +14,6 @@ import type { InputControlMixinClass } from '@vaadin/field-base/src/input-contro
 import type { InputFieldMixinClass } from '@vaadin/field-base/src/input-field-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
-import type { PatternMixinClass } from '@vaadin/field-base/src/pattern-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type {
@@ -44,7 +43,6 @@ assertType<InputFieldMixinClass>(field);
 assertType<InputMixinClass>(field);
 assertType<KeyboardMixinClass>(field);
 assertType<LabelMixinClass>(field);
-assertType<PatternMixinClass>(field);
 assertType<SlotStylesMixinClass>(field);
 assertType<ValidateMixinClass>(field);
 assertType<ThemableMixinClass>(field);


### PR DESCRIPTION
## Description

The usage of `PatternMixin` was removed in the following PRs but typings tests were not updated:

- #5520
- #5521

Typings tests still pass since corresponding property is just moved to other mixin class.

## Type of change

- Test