### PR TITLE
refactor!: remove unnecessary subscription to animationend

### DIFF
--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -113,8 +113,6 @@ export const TextAreaMixin = (superClass) =>
       this.addController(this.__textAreaController);
       this.addController(new LabelledInputController(this.inputElement, this._labelController));
 
-      this.addEventListener('animationend', this._onAnimationEnd);
-
       this._inputField = this.shadowRoot.querySelector('[part=input-field]');
 
       // Wheel scrolling results in async scroll events. Preventing the wheel
@@ -138,13 +136,6 @@ export const TextAreaMixin = (superClass) =>
     __scrollPositionUpdated() {
       this._inputField.style.setProperty('--_text-area-vertical-scroll-position', '0px');
       this._inputField.style.setProperty('--_text-area-vertical-scroll-position', `${this._inputField.scrollTop}px`);
-    }
-
-    /** @private */
-    _onAnimationEnd(e) {
-      if (e.animationName.indexOf('vaadin-text-area-appear') === 0) {
-        this._updateHeight();
-      }
     }
 
     /**

--- a/packages/text-area/src/vaadin-text-area-styles.js
+++ b/packages/text-area/src/vaadin-text-area-styles.js
@@ -6,10 +6,6 @@
 import { css } from 'lit';
 
 export const textAreaStyles = css`
-  :host {
-    animation: 1ms vaadin-text-area-appear;
-  }
-
   .vaadin-text-area-container {
     flex: auto;
   }
@@ -64,11 +60,5 @@ export const textAreaStyles = css`
   /* Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1739079 */
   :host([disabled]) ::slotted(textarea) {
     user-select: none;
-  }
-
-  @keyframes vaadin-text-area-appear {
-    to {
-      opacity: 1;
-    }
   }
 `;

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fire, fixtureSync, nextFrame, nextRender, nextResize, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextFrame, nextRender, nextResize, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-text-area.js';
 
@@ -125,26 +125,6 @@ describe('text-area', () => {
         await nextUpdate(textArea);
         expect(textArea.hasAttribute('has-value')).to.be.true;
       });
-    });
-  });
-
-  describe('vaadin-text-area-appear', () => {
-    it('should update height on show after hidden', async () => {
-      const savedHeight = textArea.clientHeight;
-      textArea.style.display = 'none';
-      // Three new lines will expand initial height
-      setInputValue(textArea, '\n\n\n');
-      textArea.style.display = 'block';
-      await oneEvent(textArea, 'animationend');
-      expect(textArea.clientHeight).to.be.above(savedHeight);
-    });
-
-    it('should not update height on custom animation name', () => {
-      const spy = sinon.spy(textArea, '_updateHeight');
-      const ev = new Event('animationend');
-      ev.animationName = 'foo';
-      textArea.dispatchEvent(ev);
-      expect(spy.called).to.be.false;
     });
   });
 
@@ -287,6 +267,21 @@ describe('text-area', () => {
       await nextResize(textArea);
 
       // Expect the height to have increased
+      expect(textArea.offsetHeight).to.be.above(height);
+    });
+
+    it('should update height on show after hidden', async () => {
+      const height = textArea.offsetHeight;
+      textArea.setAttribute('hidden', '');
+      await nextResize(textArea);
+
+      // Three new lines will expand initial height
+      setInputValue(textArea, '\n\n\n');
+      await nextUpdate(textArea);
+
+      textArea.removeAttribute('hidden');
+      await nextResize(textArea);
+
       expect(textArea.offsetHeight).to.be.above(height);
     });
 


### PR DESCRIPTION
## Description

Similar to #8633 but for `vaadin-text-area`.

We originally added the animation in https://github.com/vaadin/vaadin-text-field/pull/278 in V14 days. Later on the `ResizeMixin` was added in #3359 and then `_updateHeight()` call was added in #6840 - so the animation is no longer needed.

I preserved the test and modified it to use `nextResize` helper accordingly so it verifies the original case.

## Type of change

- Refactor