### PR TITLE
test: cleanup outdated dialog test using text-area

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -52,7 +52,6 @@
     "@vaadin/chai-plugins": "24.7.0-alpha9",
     "@vaadin/test-runner-commands": "24.7.0-alpha9",
     "@vaadin/testing-helpers": "^1.1.0",
-    "@vaadin/text-area": "24.7.0-alpha9",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -3,7 +3,6 @@ import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-dialog.js';
-import '@vaadin/text-area/vaadin-text-area.js';
 
 customElements.define(
   'internally-draggable',
@@ -857,16 +856,6 @@ describe('overflowing content', () => {
     // Emulate removing "pointer-events: none"
     overlayPart.setAttribute('style', '');
     expect(overlayPart.offsetHeight).to.equal(container.offsetHeight);
-  });
-
-  it('should not overflow when using vaadin-textarea in the content', async () => {
-    const textarea = document.createElement('vaadin-text-area');
-    textarea.value = Array(20).join('Lorem ipsum dolor sit amet');
-    overlay.appendChild(textarea);
-    overlay.$.content.style.padding = '20px';
-    resize(overlayPart.querySelector('.s'), 0, -50);
-    await nextFrame();
-    expect(getComputedStyle(overlayPart).height).to.equal(getComputedStyle(container).height);
   });
 
   it('should not reset scroll position on resize', async () => {


### PR DESCRIPTION
## Description

This test was added as part of https://github.com/vaadin/vaadin-dialog/pull/182 which was a workaround for an older Safari 13 where "force reflow" was needed - see also https://github.com/vaadin/vaadin-dialog-flow/issues/207#issuecomment-662386853. 

The workaround itself was removed in #5310 but the test was not. Let's remove it now in order to avoid `dialog` depending on `text-area` unnecessarily.

## Type of change

- Test