### PR TITLE
fix: focus text-area on required indicator click

### DIFF
--- a/packages/text-area/src/vaadin-lit-text-area.js
+++ b/packages/text-area/src/vaadin-lit-text-area.js
@@ -39,7 +39,7 @@ export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMi
       <div class="vaadin-text-area-container">
         <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" @click="${this.focus}"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -71,7 +71,7 @@ export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolymerEl
       <div class="vaadin-text-area-container">
         <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" on-click="focus"></span>
         </div>
 
         <vaadin-input-container

--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -44,6 +44,18 @@ describe('text-area', () => {
         expect(textArea.focusElement).to.equal(textArea.inputElement);
       });
     });
+
+    describe('required', () => {
+      beforeEach(async () => {
+        textArea.required = true;
+        await nextUpdate(textArea);
+      });
+
+      it('should focus on required indicator click', () => {
+        textArea.shadowRoot.querySelector('[part="required-indicator"]').click();
+        expect(textArea.hasAttribute('focused')).to.be.true;
+      });
+    });
   });
 
   describe('multi-line', () => {


### PR DESCRIPTION
## Description

Originally in V14 and up until V21, the textarea was focused on label click:

https://github.com/vaadin/web-components/blob/a865d00fa145a86f989cf19ce33042c2b6ad437a/packages/vaadin-text-field/src/vaadin-text-area.js#L138

However, I missed to add this click listener in the V22 version added in #2276 (compared to text-field in #2274).
Later we changed to focus on required indicator click in #2824 and the text-area wasn't covered.

Added listener and corresponding test to align with `vaadin-text-field` and other field components.

## Type of change

- Bugfix