### PR TITLE
fix: add missing mixin class to MenuBar type

### DIFF
--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -6,6 +6,7 @@ import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 import type { ItemMixinClass } from '@vaadin/item/src/vaadin-item-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { MenuBarItem } from '../../src/vaadin-menu-bar-item.js';
 import type { MenuBarListBox } from '../../src/vaadin-menu-bar-list-box.js';
 import type { MenuBarMixinClass } from '../../src/vaadin-menu-bar-mixin.js';
@@ -24,6 +25,8 @@ assertType<ResizeMixinClass>(menu);
 assertType<ControllerMixinClass>(menu);
 assertType<FocusMixinClass>(menu);
 assertType<MenuBarMixinClass>(menu);
+assertType<ThemableMixinClass>(menu);
+assertType<ThemePropertyMixinClass>(menu);
 
 menu.addEventListener('item-selected', (event) => {
   assertType<MenuBarItemSelectedEvent>(event);

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.d.ts
@@ -20,6 +20,9 @@ export declare class ThemableMixinClass {
   protected static finalizeStyles(styles?: CSSResultGroup): CSSResult[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export declare interface ThemableMixinClass extends ThemePropertyMixinClass {}
+
 /**
  * Registers CSS styles for a component type. Make sure to register the styles before
  * the first instance of a component of the type is attached to DOM.


### PR DESCRIPTION
## Description

Add `ThemePropertyMixinClass` to the `ThemableMixinClass` type, as it would otherwise be missing from components that extend from `ThemableMixinClass` instead of using the `ThemableMixin` function.

This fixes a regression in `MenuBar` introduced by https://github.com/vaadin/web-components/pull/8698, where the type needed to be changed to extend from mixin class types instead of using mixin functions.

## Type of change

- Bugfix
