### PR TITLE
fix: do not open popover after focusout during focus delay

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -759,7 +759,7 @@ class Popover extends PopoverPositionMixin(
     // Do not close the popover on overlay focusout if it's not the last one.
     // This covers the case when focus moves to the nested popover opened
     // without focusing parent popover overlay (e.g. using hover trigger).
-    if (!isLastOverlay(this._overlayElement)) {
+    if (this._overlayElement.opened && !isLastOverlay(this._overlayElement)) {
       return;
     }
 

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -187,6 +187,13 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.false;
     });
 
+    it('should not open on target focusout after focusin', async () => {
+      focusin(target);
+      focusout(target);
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
     it('should not close on target focusout to the overlay', async () => {
       focusin(target);
       await nextRender();


### PR DESCRIPTION
## Description

Fixes #8740

There was a similar issue previously fixed for `mouseleave` event in #8093.
The problem was introduced in #7661 where `isLastOverlay()` was added.

## Type of change

- Bugfix