### PR TITLE
test: regenerate snapshots to match order in respective tests

### DIFF
--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -176,7 +176,7 @@ snapshots["vaadin-crud host default"] =
 `;
 /* end snapshot vaadin-crud host default */
 
-snapshots["vaadin-crud shadow default"] =
+snapshots["vaadin-crud shadow default"] = 
 `<div id="container">
   <div id="main">
     <slot name="grid">

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -56,6 +56,35 @@ snapshots["vaadin-email-field host helper"] =
 `;
 /* end snapshot vaadin-email-field host helper */
 
+snapshots["vaadin-email-field host error"] = 
+`<vaadin-email-field
+  has-error-message=""
+  invalid=""
+>
+  <label
+    for="input-vaadin-email-field-3"
+    id="label-vaadin-email-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    id="error-message-vaadin-email-field-2"
+    slot="error-message"
+  >
+    Error
+  </div>
+  <input
+    aria-describedby="error-message-vaadin-email-field-2"
+    aria-invalid="true"
+    id="input-vaadin-email-field-3"
+    invalid=""
+    slot="input"
+    type="email"
+  >
+</vaadin-email-field>
+`;
+/* end snapshot vaadin-email-field host error */
+
 snapshots["vaadin-email-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -297,33 +326,4 @@ snapshots["vaadin-email-field shadow theme"] =
 </slot>
 `;
 /* end snapshot vaadin-email-field shadow theme */
-
-snapshots["vaadin-email-field host error"] = 
-`<vaadin-email-field
-  has-error-message=""
-  invalid=""
->
-  <label
-    for="input-vaadin-email-field-3"
-    id="label-vaadin-email-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    id="error-message-vaadin-email-field-2"
-    slot="error-message"
-  >
-    Error
-  </div>
-  <input
-    aria-describedby="error-message-vaadin-email-field-2"
-    aria-invalid="true"
-    id="input-vaadin-email-field-3"
-    invalid=""
-    slot="input"
-    type="email"
-  >
-</vaadin-email-field>
-`;
-/* end snapshot vaadin-email-field host error */
 

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -92,6 +92,84 @@ snapshots["vaadin-number-field host error"] =
 `;
 /* end snapshot vaadin-number-field host error */
 
+snapshots["vaadin-number-field host min"] = 
+`<vaadin-number-field>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-number-field-3"
+    max="undefined"
+    min="2"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host min */
+
+snapshots["vaadin-number-field host max"] = 
+`<vaadin-number-field>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-number-field-3"
+    max="2"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host max */
+
+snapshots["vaadin-number-field host step"] = 
+`<vaadin-number-field>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-number-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="2"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host step */
+
 snapshots["vaadin-number-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -461,82 +539,4 @@ snapshots["vaadin-number-field shadow theme"] =
 </slot>
 `;
 /* end snapshot vaadin-number-field shadow theme */
-
-snapshots["vaadin-number-field host min"] = 
-`<vaadin-number-field>
-  <label
-    for="input-vaadin-number-field-3"
-    id="label-vaadin-number-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-number-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    id="input-vaadin-number-field-3"
-    max="undefined"
-    min="2"
-    slot="input"
-    step="any"
-    type="number"
-  >
-</vaadin-number-field>
-`;
-/* end snapshot vaadin-number-field host min */
-
-snapshots["vaadin-number-field host max"] = 
-`<vaadin-number-field>
-  <label
-    for="input-vaadin-number-field-3"
-    id="label-vaadin-number-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-number-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    id="input-vaadin-number-field-3"
-    max="2"
-    min="undefined"
-    slot="input"
-    step="any"
-    type="number"
-  >
-</vaadin-number-field>
-`;
-/* end snapshot vaadin-number-field host max */
-
-snapshots["vaadin-number-field host step"] = 
-`<vaadin-number-field>
-  <label
-    for="input-vaadin-number-field-3"
-    id="label-vaadin-number-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-number-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    id="input-vaadin-number-field-3"
-    max="undefined"
-    min="undefined"
-    slot="input"
-    step="2"
-    type="number"
-  >
-</vaadin-number-field>
-`;
-/* end snapshot vaadin-number-field host step */
 

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -24,6 +24,31 @@ snapshots["vaadin-text-field host default"] =
 `;
 /* end snapshot vaadin-text-field host default */
 
+snapshots["vaadin-text-field host label"] = 
+`<vaadin-text-field has-label="">
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+    Label
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-labelledby="label-vaadin-text-field-0"
+    id="input-vaadin-text-field-3"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host label */
+
 snapshots["vaadin-text-field host helper"] = 
 `<vaadin-text-field has-helper="">
   <label
@@ -324,29 +349,4 @@ snapshots["vaadin-text-field shadow theme"] =
 </slot>
 `;
 /* end snapshot vaadin-text-field shadow theme */
-
-snapshots["vaadin-text-field host label"] = 
-`<vaadin-text-field has-label="">
-  <label
-    for="input-vaadin-text-field-3"
-    id="label-vaadin-text-field-0"
-    slot="label"
-  >
-    Label
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-text-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-labelledby="label-vaadin-text-field-0"
-    id="input-vaadin-text-field-3"
-    slot="input"
-    type="text"
-  >
-</vaadin-text-field>
-`;
-/* end snapshot vaadin-text-field host label */
 

--- a/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
+++ b/packages/upload/test/dom/__snapshots__/vaadin-upload.test.snap.js
@@ -127,35 +127,6 @@ snapshots["vaadin-upload host max files"] =
 `;
 /* end snapshot vaadin-upload host max files */
 
-snapshots["vaadin-upload shadow default"] = 
-`<div part="primary-buttons">
-  <slot name="add-button">
-  </slot>
-  <div
-    aria-hidden="true"
-    id="dropLabelContainer"
-    part="drop-label"
-  >
-    <slot name="drop-label-icon">
-    </slot>
-    <slot name="drop-label">
-    </slot>
-  </div>
-</div>
-<slot name="file-list">
-</slot>
-<slot>
-</slot>
-<input
-  accept=""
-  hidden=""
-  id="fileInput"
-  multiple=""
-  type="file"
->
-`;
-/* end snapshot vaadin-upload shadow default */
-
 snapshots["vaadin-upload host disabled"] = 
 `<vaadin-upload disabled="">
   <vaadin-button
@@ -222,4 +193,33 @@ snapshots["vaadin-upload host disabled"] =
 </vaadin-upload>
 `;
 /* end snapshot vaadin-upload host disabled */
+
+snapshots["vaadin-upload shadow default"] = 
+`<div part="primary-buttons">
+  <slot name="add-button">
+  </slot>
+  <div
+    aria-hidden="true"
+    id="dropLabelContainer"
+    part="drop-label"
+  >
+    <slot name="drop-label-icon">
+    </slot>
+    <slot name="drop-label">
+    </slot>
+  </div>
+</div>
+<slot name="file-list">
+</slot>
+<slot>
+</slot>
+<input
+  accept=""
+  hidden=""
+  id="fileInput"
+  multiple=""
+  type="file"
+>
+`;
+/* end snapshot vaadin-upload shadow default */
 


### PR DESCRIPTION
## Description

When adding a new snapshot test, the snapshot is appended to the corresponding file.
I have regenerated these files using the following command to rearrange snapshots:

```sh
rm -rf ./packages/**/test/dom/__snapshots__/*.test.snap.js && yarn update:snapshots
```

We probably could consider updating CI build to run this and check there are no files changed.

## Type of change

- Test