### PR TITLE
refactor: prefix CSS properties set on #layout with _grid

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -429,10 +429,10 @@ export const FormLayoutMixin = (superClass) =>
           }
 
           if (resetColumn && !isElementHidden(child) && parentElement.localName !== 'vaadin-form-row') {
-            child.style.setProperty('--_column-start', 1);
+            child.style.setProperty('--_grid-colstart', 1);
             resetColumn = false;
           } else {
-            child.style.removeProperty('--_column-start');
+            child.style.removeProperty('--_grid-colstart');
           }
         });
     }

--- a/packages/form-layout/src/vaadin-form-layout-styles.js
+++ b/packages/form-layout/src/vaadin-form-layout-styles.js
@@ -98,7 +98,7 @@ export const formLayoutStyles = css`
   }
 
   :host([auto-responsive][auto-rows]) #layout ::slotted(*) {
-    grid-column-start: var(--_column-start, auto);
+    grid-column-start: var(--_grid-colstart, auto);
   }
 
   :host([auto-responsive][labels-aside]) #layout {

--- a/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
+++ b/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
@@ -96,7 +96,7 @@ snapshots["vaadin-form-layout auto-responsive autoRows default"] =
   >
   <input
     placeholder="Email"
-    style="--_column-start: 1;"
+    style="--_grid-colstart: 1;"
   >
   <input placeholder="Phone">
 </vaadin-form-layout>


### PR DESCRIPTION
Adds the `_grid` prefix to CSS properties that are set on the `#layout` element for consistency.