### PR TITLE
fix: improve context menu positioning when opening menu with keyboard

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { isKeyboardActive } from '@vaadin/a11y-base';
-import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
+import { isFirefox, isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { prevent, register } from '@vaadin/component-base/src/gestures.js';
 
 register({
@@ -94,11 +94,13 @@ register({
   contextmenu(e) {
     if (!e.shiftKey) {
       this._setSourceEvent(e);
-      // When context menu is triggered by keyboard, position the context menu
-      // in the center of the target
-      if (isKeyboardActive()) {
-        // Need to use composed path here as the target for synthetic
-        // contextmenu events seems to be the host element
+      if (isFirefox && isKeyboardActive()) {
+        // When using the context menu key on the keyboard in Windows, Firefox
+        // does not always return the correct coordinates for the focused
+        // element. Instead, calculate the coordinates manually based on the
+        // context menu target. Need to use composed path here as the target for
+        // synthetic contextmenu events seems to be the host element.
+        // See https://github.com/vaadin/flow-components/issues/7153
         const keyboardTarget = e.composedPath()[0];
         const targetRect = keyboardTarget.getBoundingClientRect();
         this.fire(keyboardTarget, targetRect.left, targetRect.bottom);

--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isKeyboardActive } from '@vaadin/a11y-base';
+import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { isFirefox, isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { prevent, register } from '@vaadin/component-base/src/gestures.js';
 

--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { isKeyboardActive } from '@vaadin/a11y-base';
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { prevent, register } from '@vaadin/component-base/src/gestures.js';
 
@@ -93,7 +94,18 @@ register({
   contextmenu(e) {
     if (!e.shiftKey) {
       this._setSourceEvent(e);
-      this.fire(e.target, e.clientX, e.clientY);
+      // When context menu is triggered by keyboard, position the context menu
+      // in the center of the target
+      if (isKeyboardActive()) {
+        // Need to use composed path here as the target for synthetic
+        // contextmenu events seems to be the host element
+        const keyboardTarget = e.composedPath()[0];
+        const targetRect = keyboardTarget.getBoundingClientRect();
+        this.fire(keyboardTarget, targetRect.left, targetRect.bottom);
+      } else {
+        // Otherwise use mouse coordinates reported in pointer event
+        this.fire(e.target, e.clientX, e.clientY);
+      }
       prevent('tap');
     }
   },

--- a/test/integration/context-menu-grid.test.js
+++ b/test/integration/context-menu-grid.test.js
@@ -90,4 +90,31 @@ describe('grid in context-menu', () => {
       expect(focusSpy.called).to.be.false;
     });
   });
+
+  describe('using keyboard', () => {
+    it('should position the context menu to the bottom left of the cell where the context menu was triggered', async () => {
+      // Ensure isKeyboardActive() returns true
+      fire(window, 'keydown', { key: 'Enter', keyCode: 13 });
+
+      // Fire contextmenu event on a cell, with intentionally wrong coordinates
+      // Reproduces an issue in Firefox, which reports wrong coordinates when
+      // contextmenu is triggered through keyboard when a cell is focused
+      const cell = getCell(grid, 1, 1);
+      fire(cell, 'contextmenu', undefined, {
+        composed: true,
+        bubbles: true,
+        clientX: 0,
+        clientY: 0,
+      });
+      await overlayOpened(contextMenu);
+
+      // Actual position should be close to the center of the cell
+      const cellRect = cell.getBoundingClientRect();
+      const overlay = contextMenu._overlayElement;
+      const overlayRect = overlay.getBoundingClientRect();
+
+      expect(overlayRect.left).to.closeTo(cellRect.left, 5);
+      expect(overlayRect.top).to.closeTo(cellRect.bottom, 5);
+    });
+  });
 });

--- a/test/integration/context-menu-grid.test.js
+++ b/test/integration/context-menu-grid.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { esc, fire, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { esc, fire, fixtureSync, isFirefox, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/grid';
 import '@vaadin/context-menu';
@@ -91,7 +91,7 @@ describe('grid in context-menu', () => {
     });
   });
 
-  describe('using keyboard', () => {
+  (isFirefox ? describe : describe.skip)('trigger context menu using the keyboard', () => {
     it('should position the context menu to the bottom left of the cell where the context menu was triggered', async () => {
       // Ensure isKeyboardActive() returns true
       fire(window, 'keydown', { key: 'Enter', keyCode: 13 });


### PR DESCRIPTION
## Description

When triggering the context menu for a focused grid cell, Firefox seems to provide coordinates for the top left corner of the table body. So the menu opens further up the more you scroll down. Chrome does not have this issue and always opens the context menu in the center of the element.

This change adds custom logic for positioning the context menu when it is triggered by keyboard for Firefox specifically, so that it uses the bottom left coordinate of the closest element relating to the context menu event.



https://github.com/user-attachments/assets/6b16b5d2-ccf2-4aee-bc45-7cc10f498ad0



Fixes https://github.com/vaadin/flow-components/issues/7153

## Type of change

- Bugfix