### PR TITLE
fix: limit popovers opened by the same trigger to one

### DIFF
--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -417,6 +417,60 @@ describe('trigger', () => {
       await nextUpdate(popover);
       expect(overlay.opened).to.be.true;
     });
+
+    describe('single open popover per trigger', () => {
+      let target1, target2, overlay1, overlay2;
+
+      beforeEach(async () => {
+        const popover1 = fixtureSync('<vaadin-popover></vaadin-popover>');
+        target1 = fixtureSync('<button>Target 1</button>');
+        popover1.target = target1;
+        popover1.trigger = ['hover', 'focus'];
+        popover1.renderer = (root) => {
+          if (!root.firstChild) {
+            root.textContent = 'First popover';
+          }
+        };
+
+        const popover2 = fixtureSync('<vaadin-popover></vaadin-popover>');
+        target2 = fixtureSync('<button>Target 2</button>');
+        popover2.target = target2;
+        popover2.trigger = ['hover', 'focus'];
+        popover2.renderer = (root) => {
+          if (!root.firstChild) {
+            root.textContent = 'Second popover';
+          }
+        };
+
+        await nextRender();
+
+        overlay1 = popover1.shadowRoot.querySelector('vaadin-popover-overlay');
+        overlay2 = popover2.shadowRoot.querySelector('vaadin-popover-overlay');
+      });
+
+      it('should close first hovered popover when second popover is hovered', async () => {
+        mouseenter(target1);
+        await nextRender();
+        expect(overlay1.opened).to.be.true;
+
+        mouseenter(target2);
+        await nextRender();
+
+        expect(overlay2.opened).to.be.true;
+        expect(overlay1.opened).to.be.false;
+      });
+
+      it('should close first focused popover when second popover is focused', async () => {
+        focusin(target1);
+        await nextRender();
+        expect(overlay1.opened).to.be.true;
+
+        focusin(target2);
+        await nextRender();
+        expect(overlay2.opened).to.be.true;
+        expect(overlay1.opened).to.be.false;
+      });
+    });
   });
 
   describe('focus and click', () => {


### PR DESCRIPTION
## Description

This PR limits the number of popovers opened by the same trigger to 1. This applies only to hover and focus. The approach was inspired by the [comment](https://github.com/vaadin/flow-components/issues/7085#issuecomment-2631310844) under the issue.

Fixes [#7085](https://github.com/vaadin/flow-components/issues/7085)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.