### PR TITLE
fix(FormLayout): observe DOM changes in form rows

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -225,7 +225,11 @@ export const FormLayoutMixin = (superClass) =>
       super.connectedCallback();
 
       this.__childrenObserver = new MutationObserver((mutations) => {
-        const shouldUpdateLayout = mutations.some(({ target }) => target === this || target.parentElement === this);
+        const shouldUpdateLayout = mutations.some(({ target }) => {
+          return (
+            target === this || target.parentElement === this || target.parentElement.localName === 'vaadin-form-row'
+          );
+        });
         if (shouldUpdateLayout) {
           this._updateLayout();
         }

--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -224,18 +224,15 @@ export const FormLayoutMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
 
-      // Set up an observer to update layout when new children are added or removed.
-      this.__childrenObserver = new MutationObserver(() => this._updateLayout());
-      this.__childrenObserver.observe(this, { childList: true });
-
-      // Set up an observer to update layout when children's attributes change.
-      this.__childrenAttributesObserver = new MutationObserver((mutations) => {
-        if (mutations.some((mutation) => mutation.target.parentElement === this)) {
+      this.__childrenObserver = new MutationObserver((mutations) => {
+        const shouldUpdateLayout = mutations.some(({ target }) => target === this || target.parentElement === this);
+        if (shouldUpdateLayout) {
           this._updateLayout();
         }
       });
-      this.__childrenAttributesObserver.observe(this, {
+      this.__childrenObserver.observe(this, {
         subtree: true,
+        childList: true,
         attributes: true,
         attributeFilter: ['colspan', 'data-colspan', 'hidden'],
       });
@@ -247,9 +244,7 @@ export const FormLayoutMixin = (superClass) =>
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-
       this.__childrenObserver.disconnect();
-      this.__childrenAttributesObserver.disconnect();
     }
 
     /**

--- a/packages/form-layout/test/form-layout-auto-responsive.test.js
+++ b/packages/form-layout/test/form-layout-auto-responsive.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import '../src/vaadin-form-layout.js';
 import '../src/vaadin-form-item.js';
 import '../src/vaadin-form-row.js';
@@ -238,6 +238,50 @@ describe('form-layout auto responsive', () => {
       layout.children[2].setAttribute('data-colspan', '3');
       await nextFrame();
       expect(getComputedStyle(layout.children[2]).gridColumnEnd).to.equal('span 3');
+    });
+  });
+
+  describe('explicit rows', () => {
+    let rows;
+
+    beforeEach(async () => {
+      layout = fixtureSync(`
+        <vaadin-form-layout auto-responsive style="width: 800px">
+          <vaadin-form-row>
+            <input placeholder="First name" />
+            <input placeholder="Last name" />
+          </vaadin-form-row>
+          <vaadin-form-row>
+            <input placeholder="Email" />
+            <input placeholder="Phone" />
+          </vaadin-form-row>
+        </vaadin-form-layout>
+      `);
+      await nextFrame();
+
+      rows = [...layout.children];
+    });
+
+    it('should update layout after adding a field to a row', async () => {
+      const newField = document.createElement('input');
+      rows[1].appendChild(newField);
+      await nextRender(layout);
+      assertFormLayoutGrid(layout, { columns: 3, rows: 2 });
+    });
+
+    it('should update layout after removing a field from a row', async () => {
+      const newField = document.createElement('input');
+      rows[1].appendChild(newField);
+      await nextRender(layout);
+      rows[1].removeChild(newField);
+      await nextRender(layout);
+      assertFormLayoutGrid(layout, { columns: 2, rows: 2 });
+    });
+
+    it('should update layout after adding colspan on a field', async () => {
+      rows[0].children[1].setAttribute('colspan', '2');
+      await nextRender(layout);
+      expect(getComputedStyle(rows[0].children[1]).gridColumnEnd).to.equal('span 2');
     });
   });
 });

--- a/packages/form-layout/test/form-layout-auto-responsive.test.js
+++ b/packages/form-layout/test/form-layout-auto-responsive.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import '../src/vaadin-form-layout.js';
 import '../src/vaadin-form-item.js';
 import '../src/vaadin-form-row.js';
@@ -246,42 +246,41 @@ describe('form-layout auto responsive', () => {
 
     beforeEach(async () => {
       layout = fixtureSync(`
-        <vaadin-form-layout auto-responsive style="width: 800px">
+        <vaadin-form-layout auto-responsive style="width: 1024px; height: 768px;">
           <vaadin-form-row>
             <input placeholder="First name" />
             <input placeholder="Last name" />
           </vaadin-form-row>
           <vaadin-form-row>
-            <input placeholder="Email" />
-            <input placeholder="Phone" />
+            <input placeholder="Address" />
           </vaadin-form-row>
         </vaadin-form-layout>
       `);
+      await nextResize(layout);
       await nextFrame();
-
       rows = [...layout.children];
     });
 
     it('should update layout after adding a field to a row', async () => {
       const newField = document.createElement('input');
-      rows[1].appendChild(newField);
-      await nextRender(layout);
+      rows[0].appendChild(newField);
+      await nextFrame();
       assertFormLayoutGrid(layout, { columns: 3, rows: 2 });
     });
 
     it('should update layout after removing a field from a row', async () => {
       const newField = document.createElement('input');
-      rows[1].appendChild(newField);
-      await nextRender(layout);
-      rows[1].removeChild(newField);
-      await nextRender(layout);
+      rows[0].appendChild(newField);
+      await nextFrame();
+      rows[0].removeChild(newField);
+      await nextFrame();
       assertFormLayoutGrid(layout, { columns: 2, rows: 2 });
     });
 
     it('should update layout after adding colspan on a field', async () => {
-      rows[0].children[1].setAttribute('colspan', '2');
-      await nextRender(layout);
-      expect(getComputedStyle(rows[0].children[1]).gridColumnEnd).to.equal('span 2');
+      rows[1].children[0].setAttribute('colspan', '2');
+      await nextFrame();
+      expect(getComputedStyle(rows[1].children[0]).gridColumnEnd).to.equal('span 2');
     });
   });
 });


### PR DESCRIPTION
## Description

The PR fixes the issue where adding / removing fields dynamically to form rows didn't trigger a layout update.

Part of https://github.com/vaadin/platform/issues/7172

## Type of change

- [x] Bugfix
