### PR TITLE
test: cleanup outdated date-picker wrapping unit test

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -369,27 +369,6 @@ describe('clear button', () => {
   });
 });
 
-describe('wrapped', () => {
-  let container, datePicker;
-
-  beforeEach(() => {
-    container = fixtureSync(`
-      <div style="height: 100px; overflow: scroll;">
-        <div style="height: 1000px;">
-          <vaadin-date-picker></vaadin-date-picker>
-        </div>
-      </div>
-    `);
-    datePicker = container.querySelector('vaadin-date-picker');
-  });
-
-  it('should match the parent width', () => {
-    container.querySelector('div').style.width = '120px';
-    datePicker.style.width = '100%';
-    expect(datePicker.clientWidth).to.equal(120);
-  });
-});
-
 describe('initial value attribute', () => {
   let datePicker, input;
 


### PR DESCRIPTION
## Description
 
This test was added in https://github.com/vaadin/vaadin-date-picker/pull/420 - back then, the component was using nested `vaadin-text-field`. While the style is still there in [shared styles](https://github.com/vaadin/web-components/blob/870230ea45058d62ba8ade14a077aa3773524269/packages/field-base/src/styles/input-field-container-styles.js#L13), removing it doesn't affect the test so it can be removed as outdated.

## Type of change

- Test