### PR TITLE
test: cleanup outdated grid-pro edit select test

### DIFF
--- a/packages/grid-pro/test/edit-column-type.test.js
+++ b/packages/grid-pro/test/edit-column-type.test.js
@@ -273,12 +273,6 @@ describe('edit column editor type', () => {
         expect(editor.opened).to.equal(false);
       });
 
-      it('should not throw when moving focus out of the select', () => {
-        focusout(editor);
-        grid._debouncerStopEdit?.flush();
-        expect(column._getEditorComponent(cell)).to.not.be.ok;
-      });
-
       it('should warn about missing options on enter key', () => {
         enter(editor.focusElement);
         expect(console.warn.called).to.be.true;


### PR DESCRIPTION
## Description

This test was in https://github.com/vaadin/vaadin-grid-pro/pull/53 added alongside with check to avoid following error:

```
vaadin-grid-pro-edit-select.html.js:56 Uncaught TypeError: Cannot read properties of undefined (reading 'contains')
    at GridProEditSelectWrapperElement._onSelectFocusout (vaadin-grid-pro-edit-select.html.js:56:25)
```

The `_onSelectFocusout` method was later on removed in https://github.com/vaadin/vaadin-grid-pro/pull/96 when switching to different workaround. So this test is essentially no longer relevant and can be removed as outdated.

## Type of change

- Test