### PR TITLE
feat(FormLayout): add support for defaultAutoResponsiveFormLayout feature flag

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout-mixin.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.d.ts
@@ -62,11 +62,10 @@ export declare class FormLayoutMixinClass {
   responsiveSteps: FormLayoutResponsiveStep[];
 
   /**
-   * Enables the auto responsive mode in which the component automatically creates and adjusts
-   * columns based on the container's width. Columns have a fixed width defined by `columnWidth`
-   * and their number increases up to the limit set by `maxColumns`. The component dynamically
-   * adjusts the number of columns as the container size changes. When this mode is enabled,
-   * the `responsiveSteps` are ignored.
+   * When set to `true`, the component automatically creates and adjusts columns based on
+   * the container's width. Columns have a fixed width defined by `columnWidth` and their
+   * number increases up to the limit set by `maxColumns`. The component dynamically adjusts
+   * the number of columns as the container size changes.
    *
    * By default, each field is placed on a new row. To organize fields into rows, there are
    * two options:
@@ -76,13 +75,23 @@ export declare class FormLayoutMixinClass {
    * 2. Enable the `autoRows` property to automatically arrange fields in available columns,
    *    wrapping to a new row when necessary. `<br>` elements can be used to force a new row.
    *
+   * The auto-responsive mode is disabled by default. To enable it for an individual instance,
+   * use this property. Alternatively, if you want it to be enabled for all instances by default,
+   * activate the `defaultAutoResponsiveFormLayout` feature flag before `<vaadin-form-layout>`
+   * elements are added to the DOM:
+   *
+   * ```js
+   * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;
+   * ```
+   *
    * @attr {boolean} auto-responsive
    */
   autoResponsive: boolean;
 
   /**
    * When `autoResponsive` is enabled, defines the width of each column.
-   * The value must be defined in CSS length units, e.g., `100px` or `13em`.
+   * The value must be defined in CSS length units, e.g. `100px`.
+   *
    * The default value is `13em`.
    *
    * @attr {string} column-width
@@ -92,7 +101,9 @@ export declare class FormLayoutMixinClass {
   /**
    * When `autoResponsive` is enabled, defines the maximum number of columns
    * that the layout can create. The layout will create columns up to this
-   * limit based on the available container width. The default value is `10`.
+   * limit based on the available container width.
+   *
+   * The default value is `10`.
    *
    * @attr {number} max-columns
    */
@@ -104,6 +115,8 @@ export declare class FormLayoutMixinClass {
    * the next row when the current row is full. `<br>` elements can be
    * used to force a new row.
    *
+   * The default value is `false`.
+   *
    * @attr {boolean} auto-rows
    */
   autoRows: boolean;
@@ -111,7 +124,10 @@ export declare class FormLayoutMixinClass {
   /**
    * When enabled with `autoResponsive`, `<vaadin-form-item>` prefers positioning
    * labels beside the fields. If the layout is too narrow to fit a single column
-   * with side labels, they revert to their default position above the fields.
+   * with a side label, the component will automatically switch labels to their
+   * default position above the fields.
+   *
+   * The default value is `false`.
    *
    * To customize the label width and the gap between the label and the field,
    * use the following CSS properties:
@@ -125,9 +141,9 @@ export declare class FormLayoutMixinClass {
 
   /**
    * When `autoResponsive` is enabled, specifies whether the columns should expand
-   * in width to evenly fill any remaining space after the layout has created as
-   * many fixed-width (`columnWidth`) columns as possible within the `maxColumns`
-   * limit. The default value is `false`.
+   * in width to evenly fill any remaining space after all columns have been created.
+   *
+   * The default value is `false`.
    *
    * @attr {boolean} expand-columns
    */
@@ -136,7 +152,9 @@ export declare class FormLayoutMixinClass {
   /**
    * When `autoResponsive` is enabled, specifies whether fields should stretch
    * to take up all available space within columns. This setting also applies
-   * to fields inside `<vaadin-form-item>` elements. The default value is `false`.
+   * to fields inside `<vaadin-form-item>` elements.
+   *
+   * The default value is `false`.
    *
    * @attr {boolean} expand-fields
    */

--- a/packages/form-layout/src/vaadin-form-layout-mixin.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.d.ts
@@ -30,6 +30,14 @@ export declare class FormLayoutMixinClass {
    * with `minWidth` CSS length, `columns` number, and optional
    * `labelsPosition` string of `"aside"` or `"top"`. At least one item is required.
    *
+   * NOTE: Responsive steps are ignored in auto-responsive mode, which may be
+   * enabled explicitly via the `autoResponsive` property or implicitly
+   * if the following feature flag is set:
+   *
+   * ```
+   * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true
+   * ```
+   *
    * #### Examples
    *
    * ```javascript
@@ -65,7 +73,8 @@ export declare class FormLayoutMixinClass {
    * When set to `true`, the component automatically creates and adjusts columns based on
    * the container's width. Columns have a fixed width defined by `columnWidth` and their
    * number increases up to the limit set by `maxColumns`. The component dynamically adjusts
-   * the number of columns as the container size changes.
+   * the number of columns as the container size changes. When this mode is enabled,
+   * `responsiveSteps` are ignored.
    *
    * By default, each field is placed on a new row. To organize fields into rows, there are
    * two options:
@@ -77,7 +86,7 @@ export declare class FormLayoutMixinClass {
    *
    * The auto-responsive mode is disabled by default. To enable it for an individual instance,
    * use this property. Alternatively, if you want it to be enabled for all instances by default,
-   * activate the `defaultAutoResponsiveFormLayout` feature flag before `<vaadin-form-layout>`
+   * enable the `defaultAutoResponsiveFormLayout` feature flag before `<vaadin-form-layout>`
    * elements are added to the DOM:
    *
    * ```js

--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -77,11 +77,10 @@ export const FormLayoutMixin = (superClass) =>
         },
 
         /**
-         * Enables the auto responsive mode in which the component automatically creates and adjusts
-         * columns based on the container's width. Columns have a fixed width defined by `columnWidth`
-         * and their number increases up to the limit set by `maxColumns`. The component dynamically
-         * adjusts the number of columns as the container size changes. When this mode is enabled,
-         * the `responsiveSteps` are ignored.
+         * When set to `true`, the component automatically creates and adjusts columns based on
+         * the container's width. Columns have a fixed width defined by `columnWidth` and their
+         * number increases up to the limit set by `maxColumns`. The component dynamically adjusts
+         * the number of columns as the container size changes.
          *
          * By default, each field is placed on a new row. To organize fields into rows, there are
          * two options:
@@ -90,6 +89,15 @@ export const FormLayoutMixin = (superClass) =>
          *
          * 2. Enable the `autoRows` property to automatically arrange fields in available columns,
          *    wrapping to a new row when necessary. `<br>` elements can be used to force a new row.
+         *
+         * The auto-responsive mode is disabled by default. To enable it for an individual instance,
+         * use this property. Alternatively, if you want it to be enabled for all instances by default,
+         * activate the `defaultAutoResponsiveFormLayout` feature flag before `<vaadin-form-layout>`
+         * elements are added to the DOM:
+         *
+         * ```js
+         * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;
+         * ```
          *
          * @attr {boolean} auto-responsive
          */
@@ -102,7 +110,8 @@ export const FormLayoutMixin = (superClass) =>
 
         /**
          * When `autoResponsive` is enabled, defines the width of each column.
-         * The value must be defined in CSS length units, e.g., `100px` or `13em`.
+         * The value must be defined in CSS length units, e.g. `100px`.
+         *
          * The default value is `13em`.
          *
          * @attr {string} column-width
@@ -116,7 +125,9 @@ export const FormLayoutMixin = (superClass) =>
         /**
          * When `autoResponsive` is enabled, defines the maximum number of columns
          * that the layout can create. The layout will create columns up to this
-         * limit based on the available container width. The default value is `10`.
+         * limit based on the available container width.
+         *
+         * The default value is `10`.
          *
          * @attr {number} max-columns
          */
@@ -132,6 +143,8 @@ export const FormLayoutMixin = (superClass) =>
          * the next row when the current row is full. `<br>` elements can be
          * used to force a new row.
          *
+         * The default value is `false`.
+         *
          * @attr {boolean} auto-rows
          */
         autoRows: {
@@ -144,7 +157,10 @@ export const FormLayoutMixin = (superClass) =>
         /**
          * When enabled with `autoResponsive`, `<vaadin-form-item>` prefers positioning
          * labels beside the fields. If the layout is too narrow to fit a single column
-         * with side labels, they revert to their default position above the fields.
+         * with a side label, the component will automatically switch labels to their
+         * default position above the fields.
+         *
+         * The default value is `false`.
          *
          * To customize the label width and the gap between the label and the field,
          * use the following CSS properties:
@@ -163,9 +179,9 @@ export const FormLayoutMixin = (superClass) =>
 
         /**
          * When `autoResponsive` is enabled, specifies whether the columns should expand
-         * in width to evenly fill any remaining space after the layout has created as
-         * many fixed-width (`columnWidth`) columns as possible within the `maxColumns`
-         * limit. The default value is `false`.
+         * in width to evenly fill any remaining space after all columns have been created.
+         *
+         * The default value is `false`.
          *
          * @attr {boolean} expand-columns
          */
@@ -179,7 +195,9 @@ export const FormLayoutMixin = (superClass) =>
         /**
          * When `autoResponsive` is enabled, specifies whether fields should stretch
          * to take up all available space within columns. This setting also applies
-         * to fields inside `<vaadin-form-item>` elements. The default value is `false`.
+         * to fields inside `<vaadin-form-item>` elements.
+         *
+         * The default value is `false`.
          *
          * @attr {boolean} expand-fields
          */

--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -104,7 +104,17 @@ export const FormLayoutMixin = (superClass) =>
         autoResponsive: {
           type: Boolean,
           sync: true,
-          value: false,
+          value: () => {
+            if (
+              window.Vaadin &&
+              window.Vaadin.featureFlags &&
+              window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout
+            ) {
+              return true;
+            }
+
+            return false;
+          },
           reflectToAttribute: true,
         },
 

--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -32,6 +32,14 @@ export const FormLayoutMixin = (superClass) =>
          * with `minWidth` CSS length, `columns` number, and optional
          * `labelsPosition` string of `"aside"` or `"top"`. At least one item is required.
          *
+         * NOTE: Responsive steps are ignored in auto-responsive mode, which may be
+         * enabled explicitly via the `autoResponsive` property or implicitly
+         * if the following feature flag is set:
+         *
+         * ```
+         * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true
+         * ```
+         *
          * #### Examples
          *
          * ```javascript
@@ -80,7 +88,8 @@ export const FormLayoutMixin = (superClass) =>
          * When set to `true`, the component automatically creates and adjusts columns based on
          * the container's width. Columns have a fixed width defined by `columnWidth` and their
          * number increases up to the limit set by `maxColumns`. The component dynamically adjusts
-         * the number of columns as the container size changes.
+         * the number of columns as the container size changes. When this mode is enabled,
+         * `responsiveSteps` are ignored.
          *
          * By default, each field is placed on a new row. To organize fields into rows, there are
          * two options:
@@ -92,7 +101,7 @@ export const FormLayoutMixin = (superClass) =>
          *
          * The auto-responsive mode is disabled by default. To enable it for an individual instance,
          * use this property. Alternatively, if you want it to be enabled for all instances by default,
-         * activate the `defaultAutoResponsiveFormLayout` feature flag before `<vaadin-form-layout>`
+         * enable the `defaultAutoResponsiveFormLayout` feature flag before `<vaadin-form-layout>`
          * elements are added to the DOM:
          *
          * ```js

--- a/packages/form-layout/src/vaadin-form-layout.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout.d.ts
@@ -109,8 +109,8 @@ export * from './vaadin-form-layout-mixin.js';
  * </vaadin-form-layout>
  * ```
  *
- * You can also enable it for all instances by activating the `defaultAutoResponsiveFormLayout`
- * feature flag before `<vaadin-form-layout>` elements are added to the DOM:
+ * You can also enable it for all instances by enabling the following feature flag
+ * before `<vaadin-form-layout>` elements are added to the DOM:
  *
  * ```js
  * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;
@@ -191,6 +191,8 @@ export * from './vaadin-form-layout-mixin.js';
  * ---|---|---
  * `--vaadin-form-layout-column-spacing` | Length of the spacing between columns | `2em`
  * `--vaadin-form-layout-row-spacing` | Length of the spacing between rows | `1em`
+ * `--vaadin-form-layout-label-width` | Width of the label when labels are displayed aside | `8em`
+ * `--vaadin-form-layout-label-spacing` | Length of the spacing between the label and the input when labels are displayed aside | `1em`
  */
 declare class FormLayout extends FormLayoutMixin(ElementMixin(ThemableMixin(HTMLElement))) {}
 

--- a/packages/form-layout/src/vaadin-form-layout.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout.d.ts
@@ -98,12 +98,22 @@ export * from './vaadin-form-layout-mixin.js';
  * [`maxColumns`](#/elements/vaadin-form-layout#property-maxColumns) properties control the column width
  * (13em by default) and the maximum number of columns (10 by default) that the Form Layout can create.
  *
+ * The auto-responsive mode is disabled by default. To enable it for an individual instance, set the
+ * `auto-responsive` attribute:
+ *
  * ```html
  * <vaadin-form-layout auto-responsive>
  *   <vaadin-text-field label="First Name"></vaadin-text-field>
  *   <vaadin-text-field label="Last Name"></vaadin-text-field>
  *   <vaadin-text-area label="Address" colspan="2"></vaadin-text-area>
  * </vaadin-form-layout>
+ * ```
+ *
+ * You can also enable it for all instances by activating the `defaultAutoResponsiveFormLayout`
+ * feature flag before `<vaadin-form-layout>` elements are added to the DOM:
+ *
+ * ```js
+ * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;
  * ```
  *
  * #### Organizing Fields into Rows

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -101,12 +101,22 @@ registerStyles('vaadin-form-layout', formLayoutStyles, { moduleId: 'vaadin-form-
  * [`maxColumns`](#/elements/vaadin-form-layout#property-maxColumns) properties control the column width
  * (13em by default) and the maximum number of columns (10 by default) that the Form Layout can create.
  *
+ * The auto-responsive mode is disabled by default. To enable it for an individual instance, set the
+ * `auto-responsive` attribute:
+ *
  * ```html
  * <vaadin-form-layout auto-responsive>
  *   <vaadin-text-field label="First Name"></vaadin-text-field>
  *   <vaadin-text-field label="Last Name"></vaadin-text-field>
  *   <vaadin-text-area label="Address" colspan="2"></vaadin-text-area>
  * </vaadin-form-layout>
+ * ```
+ *
+ * You can also enable it for all instances by activating the `defaultAutoResponsiveFormLayout`
+ * feature flag before `<vaadin-form-layout>` elements are added to the DOM:
+ *
+ * ```js
+ * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;
  * ```
  *
  * #### Organizing Fields into Rows

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -112,8 +112,8 @@ registerStyles('vaadin-form-layout', formLayoutStyles, { moduleId: 'vaadin-form-
  * </vaadin-form-layout>
  * ```
  *
- * You can also enable it for all instances by activating the `defaultAutoResponsiveFormLayout`
- * feature flag before `<vaadin-form-layout>` elements are added to the DOM:
+ * You can also enable it for all instances by enabling the following feature flag
+ * before `<vaadin-form-layout>` elements are added to the DOM:
  *
  * ```js
  * window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;

--- a/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
+++ b/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
@@ -298,3 +298,13 @@ snapshots["vaadin-form-layout auto-responsive shadow explicit rows maxColumns > 
 `;
 /* end snapshot vaadin-form-layout auto-responsive shadow explicit rows maxColumns > number of columns */
 
+snapshots["vaadin-form-layout defaultAutoResponsiveFormLayout feature flag default"] = 
+`<vaadin-form-layout
+  auto-responsive=""
+  style="--_column-width: 13em; --_max-columns: 1;"
+>
+  <input placeholder="First name">
+</vaadin-form-layout>
+`;
+/* end snapshot vaadin-form-layout defaultAutoResponsiveFormLayout feature flag default */
+

--- a/packages/form-layout/test/dom/form-layout.test.js
+++ b/packages/form-layout/test/dom/form-layout.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { fixtureSync, nextResize } from '@vaadin/testing-helpers';
 import '../../src/vaadin-form-layout.js';
 
 describe('vaadin-form-layout', () => {
@@ -16,7 +16,7 @@ describe('vaadin-form-layout', () => {
             <input placeholder="Phone" />
           </vaadin-form-layout>
         `);
-        await nextFrame();
+        await nextResize(layout);
       });
 
       describe('host', () => {
@@ -82,7 +82,7 @@ describe('vaadin-form-layout', () => {
                 <input placeholder="Address" colspan="2"/>
               </vaadin-form-layout>
             `);
-            await nextFrame();
+            await nextResize(layout);
           });
 
           it('default', async () => {
@@ -114,7 +114,7 @@ describe('vaadin-form-layout', () => {
                 </vaadin-form-row>
               </vaadin-form-layout>
             `);
-            await nextFrame();
+            await nextResize(layout);
           });
 
           it('default', async () => {
@@ -132,6 +132,31 @@ describe('vaadin-form-layout', () => {
           });
         });
       });
+    });
+  });
+
+  describe('defaultAutoResponsiveFormLayout feature flag', () => {
+    before(() => {
+      window.Vaadin ??= {};
+      window.Vaadin.featureFlags ??= {};
+      window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = true;
+    });
+
+    after(() => {
+      window.Vaadin.featureFlags.defaultAutoResponsiveFormLayout = false;
+    });
+
+    beforeEach(async () => {
+      layout = fixtureSync(`
+        <vaadin-form-layout>
+          <input placeholder="First name" />
+        </vaadin-form-layout>
+      `);
+      await nextResize(layout);
+    });
+
+    it('default', async () => {
+      await expect(layout).dom.to.equalSnapshot();
     });
   });
 });


### PR DESCRIPTION
## Description

Adds support for the `defaultAutoResponsiveFormLayout ` feature flag to allow developers to enable the auto-responsive mode for all form layouts by default.

Part of https://github.com/vaadin/flow-components/issues/7164

## Type of change

- [x] Docs
