### PR TITLE
fix: add missing .js extension to form-layout imports

### DIFF
--- a/packages/form-layout/src/layouts/auto-responsive-layout.js
+++ b/packages/form-layout/src/layouts/auto-responsive-layout.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils';
+import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils.js';
 import { AbstractLayout } from './abstract-layout.js';
 
 /**

--- a/packages/form-layout/src/layouts/responsive-steps-layout.js
+++ b/packages/form-layout/src/layouts/responsive-steps-layout.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils';
+import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils.js';
 import { AbstractLayout } from './abstract-layout.js';
 
 function isValidCSSLength(value) {


### PR DESCRIPTION
## Description

Fixed a missing `.js` extension in two imports to avoid errors with webpack.

## Type of change

- Bugfix