### PR TITLE
feat: add masterSize and detailSize properties to master-detail-layout

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -7,15 +7,51 @@
     <title>Master Detail Layout</title>
     <script type="module" src="./common.js"></script>
 
-    <script type="module">
-      import '@vaadin/master-detail-layout';
-    </script>
   </head>
 
   <body>
+    <style>
+      vaadin-master-detail-layout {
+        border: solid 1px #ccc;
+      }
+    </style>
+
+    <p>
+      <vaadin-checkbox id="detailSize" label="Set detail size"></vaadin-checkbox>
+      <vaadin-checkbox id="detailMinSize" label="Set detail min size"></vaadin-checkbox>
+      <vaadin-checkbox id="masterSize" label="Set master size"></vaadin-checkbox>
+      <vaadin-checkbox id="masterMinSize" label="Set master min size"></vaadin-checkbox>
+
+    </p>
+
     <vaadin-master-detail-layout>
-      <div>Master content</div>
-      <div slot="detail">Detail content</div>
+      <master-content></master-content>
+      <detail-content slot="detail"></detail-content>
     </vaadin-master-detail-layout>
+
+    <script type="module">
+      import '@vaadin/checkbox';
+      import '@vaadin/master-detail-layout';
+      import '@vaadin/master-detail-layout/test/helpers/master-content.js';
+      import '@vaadin/master-detail-layout/test/helpers/detail-content.js';
+
+      const layout = document.querySelector('vaadin-master-detail-layout');
+
+      document.querySelector('#detailSize').addEventListener('change', (e) => {
+        layout.detailSize = e.target.checked ? '300px' : null;
+      });
+
+      document.querySelector('#detailMinSize').addEventListener('change', (e) => {
+        layout.detailMinSize = e.target.checked ? '300px' : null;
+      });
+
+      document.querySelector('#masterSize').addEventListener('change', (e) => {
+        layout.masterSize = e.target.checked ? '300px' : null;
+      });
+
+      document.querySelector('#masterMinSize').addEventListener('change', (e) => {
+        layout.masterMinSize = e.target.checked ? '300px' : null;
+      });
+    </script>
   </body>
 </html>

--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -18,10 +18,7 @@
 
     <p>
       <vaadin-checkbox id="detailSize" label="Set detail size"></vaadin-checkbox>
-      <vaadin-checkbox id="detailMinSize" label="Set detail min size"></vaadin-checkbox>
       <vaadin-checkbox id="masterSize" label="Set master size"></vaadin-checkbox>
-      <vaadin-checkbox id="masterMinSize" label="Set master min size"></vaadin-checkbox>
-
     </p>
 
     <vaadin-master-detail-layout>
@@ -41,16 +38,8 @@
         layout.detailSize = e.target.checked ? '300px' : null;
       });
 
-      document.querySelector('#detailMinSize').addEventListener('change', (e) => {
-        layout.detailMinSize = e.target.checked ? '300px' : null;
-      });
-
       document.querySelector('#masterSize').addEventListener('change', (e) => {
         layout.masterSize = e.target.checked ? '300px' : null;
-      });
-
-      document.querySelector('#masterMinSize').addEventListener('change', (e) => {
-        layout.masterMinSize = e.target.checked ? '300px' : null;
       });
     </script>
   </body>

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -13,16 +13,16 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  */
 declare class MasterDetailLayout extends ThemableMixin(ElementMixin(HTMLElement)) {
   /**
-   * Fixed size (in CSS length units) to be set on the detail pane.
-   * When specified, it prevents the detail pane from growing.
+   * Fixed size (in CSS length units) to be set on the detail area.
+   * When specified, it prevents the detail area from growing.
    *
    * @attr {string} detail-size
    */
   detailSize: string | null | undefined;
 
   /**
-   * Fixed size (in CSS length units) to be set on the master pane.
-   * When specified, it prevents the master pane from growing.
+   * Fixed size (in CSS length units) to be set on the master area.
+   * When specified, it prevents the master area from growing.
    *
    * @attr {string} master-size
    */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -11,7 +11,37 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * (or primary) area and a detail (or secondary) area that is displayed next to, or
  * overlaid on top of, the master area, depending on configuration and viewport size.
  */
-declare class MasterDetailLayout extends ThemableMixin(ElementMixin(HTMLElement)) {}
+declare class MasterDetailLayout extends ThemableMixin(ElementMixin(HTMLElement)) {
+  /**
+   * Fixed size (in CSS length units) to be set on the detail pane.
+   * When specified, it prevents the detail pane from growing.
+   *
+   * @attr {string} detail-size
+   */
+  detailSize: string | null | undefined;
+
+  /**
+   * Minimum size (in CSS length units) to be set on the detail pane.
+   *
+   * @attr {string} detail-min-size
+   */
+  detailMinSize: string | null | undefined;
+
+  /**
+   * Fixed size (in CSS length units) to be set on the master pane.
+   * When specified, it prevents the master pane from growing.
+   *
+   * @attr {string} master-size
+   */
+  masterSize: string | null | undefined;
+
+  /**
+   * Minimum size (in CSS length units) to be set on the master pane.
+   *
+   * @attr {string} master-min-size
+   */
+  masterMinSize: string | null | undefined;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -21,26 +21,12 @@ declare class MasterDetailLayout extends ThemableMixin(ElementMixin(HTMLElement)
   detailSize: string | null | undefined;
 
   /**
-   * Minimum size (in CSS length units) to be set on the detail pane.
-   *
-   * @attr {string} detail-min-size
-   */
-  detailMinSize: string | null | undefined;
-
-  /**
    * Fixed size (in CSS length units) to be set on the master pane.
    * When specified, it prevents the master pane from growing.
    *
    * @attr {string} master-size
    */
   masterSize: string | null | undefined;
-
-  /**
-   * Minimum size (in CSS length units) to be set on the master pane.
-   *
-   * @attr {string} master-min-size
-   */
-  masterMinSize: string | null | undefined;
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -41,11 +41,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       }
 
       /* No fixed size */
-      :host(:not([has-master-size])) [part='master'] {
-        flex-grow: 1;
-        flex-basis: 50%;
-      }
-
+      :host(:not([has-master-size])) [part='master'],
       :host(:not([has-detail-size])) [part='detail'] {
         flex-grow: 1;
         flex-basis: 50%;
@@ -60,6 +56,16 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       :host([has-detail-size]) [part='detail'] {
         width: var(--_detail-size);
         flex-shrink: 0;
+      }
+
+      :host([has-master-size][has-detail-size]) [part='master'] {
+        flex-grow: 1;
+        flex-basis: var(--_master-size);
+      }
+
+      :host([has-master-size][has-detail-size]) [part='detail'] {
+        flex-grow: 1;
+        flex-basis: var(--_detail-size);
       }
     `;
   }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -27,13 +27,91 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   static get styles() {
     return css`
       :host {
-        display: block;
+        display: flex;
+        box-sizing: border-box;
+        height: 100%;
       }
 
       :host([hidden]) {
         display: none !important;
       }
+
+      :host(:not([has-detail])) [part='detail'] {
+        display: none;
+      }
+
+      /* No fixed size */
+      :host(:not([has-master-size])) [part='master'] {
+        flex-grow: 1;
+        flex-basis: var(--_master-min-size, 50%);
+      }
+
+      :host(:not([has-detail-size])) [part='detail'] {
+        flex-grow: 1;
+        flex-basis: var(--_detail-min-size, 50%);
+      }
+
+      /* Fixed size */
+      :host([has-master-size]) [part='master'] {
+        width: var(--_master-size);
+        flex-shrink: 0;
+      }
+
+      :host([has-detail-size]) [part='detail'] {
+        width: var(--_detail-size);
+        flex-shrink: 0;
+      }
     `;
+  }
+
+  static get properties() {
+    return {
+      /**
+       * Fixed size (in CSS length units) to be set on the detail pane.
+       * When specified, it prevents the detail pane from growing.
+       *
+       * @attr {string} detail-size
+       */
+      detailSize: {
+        type: String,
+        sync: true,
+        observer: '__detailSizeChanged',
+      },
+
+      /**
+       * Minimum size (in CSS length units) to be set on the detail pane.
+       *
+       * @attr {string} detail-min-size
+       */
+      detailMinSize: {
+        type: String,
+        sync: true,
+        observer: '__detailMinSizeChanged',
+      },
+
+      /**
+       * Fixed size (in CSS length units) to be set on the master pane.
+       * When specified, it prevents the master pane from growing.
+       *
+       * @attr {string} master-size
+       */
+      masterSize: {
+        type: String,
+        sync: true,
+        observer: '__masterSizeChanged',
+      },
+
+      /**
+       * Minimum size (in CSS length units) to be set on the master pane.
+       *
+       * @attr {string} master-min-size
+       */
+      masterMinSize: {
+        type: String,
+        sync: true,
+        observer: '__masterMinSizeChanged',
+      },
+    };
   }
 
   /** @protected */
@@ -43,9 +121,45 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
         <slot></slot>
       </div>
       <div part="detail">
-        <slot name="detail"></slot>
+        <slot name="detail" @slotchange="${this.__onDetailSlotChange}"></slot>
       </div>
     `;
+  }
+
+  /** @private */
+  __onDetailSlotChange(e) {
+    this.toggleAttribute('has-detail', e.target.assignedNodes().length > 0);
+  }
+
+  /** @private */
+  __detailSizeChanged(size, oldSize) {
+    this.toggleAttribute('has-detail-size', !!size);
+    this.__updateStyleProperty('detail-size', size, oldSize);
+  }
+
+  /** @private */
+  __detailMinSizeChanged(size, oldSize) {
+    this.__updateStyleProperty('detail-min-size', size, oldSize);
+  }
+
+  /** @private */
+  __masterSizeChanged(size, oldSize) {
+    this.toggleAttribute('has-master-size', !!size);
+    this.__updateStyleProperty('master-size', size, oldSize);
+  }
+
+  /** @private */
+  __masterMinSizeChanged(size, oldSize) {
+    this.__updateStyleProperty('master-min-size', size, oldSize);
+  }
+
+  /** @private */
+  __updateStyleProperty(prop, size, oldSize) {
+    if (size) {
+      this.style.setProperty(`--_${prop}`, size);
+    } else if (oldSize) {
+      this.style.removeProperty(`--_${prop}`);
+    }
   }
 }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -43,12 +43,12 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       /* No fixed size */
       :host(:not([has-master-size])) [part='master'] {
         flex-grow: 1;
-        flex-basis: var(--_master-min-size, 50%);
+        flex-basis: 50%;
       }
 
       :host(:not([has-detail-size])) [part='detail'] {
         flex-grow: 1;
-        flex-basis: var(--_detail-min-size, 50%);
+        flex-basis: 50%;
       }
 
       /* Fixed size */
@@ -79,17 +79,6 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       },
 
       /**
-       * Minimum size (in CSS length units) to be set on the detail pane.
-       *
-       * @attr {string} detail-min-size
-       */
-      detailMinSize: {
-        type: String,
-        sync: true,
-        observer: '__detailMinSizeChanged',
-      },
-
-      /**
        * Fixed size (in CSS length units) to be set on the master pane.
        * When specified, it prevents the master pane from growing.
        *
@@ -99,17 +88,6 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
         type: String,
         sync: true,
         observer: '__masterSizeChanged',
-      },
-
-      /**
-       * Minimum size (in CSS length units) to be set on the master pane.
-       *
-       * @attr {string} master-min-size
-       */
-      masterMinSize: {
-        type: String,
-        sync: true,
-        observer: '__masterMinSizeChanged',
       },
     };
   }
@@ -138,19 +116,9 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   }
 
   /** @private */
-  __detailMinSizeChanged(size, oldSize) {
-    this.__updateStyleProperty('detail-min-size', size, oldSize);
-  }
-
-  /** @private */
   __masterSizeChanged(size, oldSize) {
     this.toggleAttribute('has-master-size', !!size);
     this.__updateStyleProperty('master-size', size, oldSize);
-  }
-
-  /** @private */
-  __masterMinSizeChanged(size, oldSize) {
-    this.__updateStyleProperty('master-min-size', size, oldSize);
   }
 
   /** @private */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -73,8 +73,8 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   static get properties() {
     return {
       /**
-       * Fixed size (in CSS length units) to be set on the detail pane.
-       * When specified, it prevents the detail pane from growing.
+       * Fixed size (in CSS length units) to be set on the detail area.
+       * When specified, it prevents the detail area from growing.
        *
        * @attr {string} detail-size
        */
@@ -85,8 +85,8 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       },
 
       /**
-       * Fixed size (in CSS length units) to be set on the master pane.
-       * When specified, it prevents the master pane from growing.
+       * Fixed size (in CSS length units) to be set on the master area.
+       * When specified, it prevents the master area from growing.
        *
        * @attr {string} master-size
        */

--- a/packages/master-detail-layout/test/helpers/detail-content.js
+++ b/packages/master-detail-layout/test/helpers/detail-content.js
@@ -1,0 +1,44 @@
+import { css, html, LitElement } from 'lit';
+
+customElements.define(
+  'detail-content',
+  class extends LitElement {
+    static get styles() {
+      return css`
+        :host {
+          display: block;
+        }
+
+        .form {
+          display: flex;
+          flex-wrap: wrap;
+          padding: 0.5rem;
+          gap: 0.5rem;
+        }
+
+        input {
+          width: 8rem;
+        }
+      `;
+    }
+
+    render() {
+      return html`
+        <div class="form">
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+          <div class="field"><input type="text" /></div>
+        </div>
+      `;
+    }
+  },
+);

--- a/packages/master-detail-layout/test/helpers/master-content.js
+++ b/packages/master-detail-layout/test/helpers/master-content.js
@@ -1,0 +1,61 @@
+import { css, html, LitElement } from 'lit';
+
+customElements.define(
+  'master-content',
+  class extends LitElement {
+    static get styles() {
+      return css`
+        :host {
+          display: block;
+        }
+
+        .list {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+          padding: 0.5rem;
+          grid-gap: 0.25rem;
+        }
+
+        .item {
+          padding: 1rem;
+          border: solid 1px #e2e2e2;
+        }
+
+        h3 {
+          margin: 0 0 0.25rem;
+        }
+      `;
+    }
+
+    render() {
+      return html`
+        <div class="list">
+          <div class="item">
+            <h3>Lorem</h3>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur et quisquam obcaecati!</p>
+          </div>
+          <div class="item">
+            <h3>Lorem</h3>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur et quisquam obcaecati!</p>
+          </div>
+          <div class="item">
+            <h3>Lorem</h3>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur et quisquam obcaecati!</p>
+          </div>
+          <div class="item">
+            <h3>Lorem</h3>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur et quisquam obcaecati!</p>
+          </div>
+          <div class="item">
+            <h3>Lorem</h3>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur et quisquam obcaecati!</p>
+          </div>
+          <div class="item">
+            <h3>Lorem</h3>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Consectetur et quisquam obcaecati!</p>
+          </div>
+        </div>
+      `;
+    }
+  },
+);

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -64,7 +64,7 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(detail).flexGrow).to.equal('1');
     });
 
-    it('should set fixed width on the master pane when masterSize is set', () => {
+    it('should set fixed width on the master area when masterSize is set', () => {
       layout.masterSize = '300px';
       expect(getComputedStyle(master).width).to.equal('300px');
       expect(getComputedStyle(master).flexBasis).to.equal('auto');
@@ -72,7 +72,7 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(master).flexShrink).to.equal('0');
     });
 
-    it('should set fixed width on the detail pane when detailSize is set', () => {
+    it('should set fixed width on the detail area when detailSize is set', () => {
       layout.detailSize = '300px';
       expect(getComputedStyle(detail).width).to.equal('300px');
       expect(getComputedStyle(detail).flexBasis).to.equal('auto');

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -1,17 +1,22 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../vaadin-master-detail-layout.js';
+import './helpers/master-content.js';
+import './helpers/detail-content.js';
 
 describe('vaadin-master-detail-layout', () => {
-  let layout;
+  let layout, master, detail;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     layout = fixtureSync(`
       <vaadin-master-detail-layout>
-        <div>Master content</div>
-        <div slot="detail">Detail content</div>
+        <master-content></master-content>
+        <detail-content slot="detail"></detail-content>
       </vaadin-master-detail-layout>
     `);
+    await nextRender();
+    master = layout.shadowRoot.querySelector('[part="master"]');
+    detail = layout.shadowRoot.querySelector('[part="detail"]');
   });
 
   describe('custom element definition', () => {
@@ -27,6 +32,62 @@ describe('vaadin-master-detail-layout', () => {
 
     it('should have a valid static "is" getter', () => {
       expect(customElements.get(tagName).is).to.equal(tagName);
+    });
+  });
+
+  describe('default', () => {
+    it('should set height: 100% on the host element to expand to full height', () => {
+      layout.parentElement.style.height = '1000px';
+      expect(getComputedStyle(master).height).to.equal('1000px');
+      expect(getComputedStyle(detail).height).to.equal('1000px');
+    });
+
+    it('should show the detail part with the detail child is provided', () => {
+      expect(getComputedStyle(detail).display).to.equal('block');
+    });
+
+    it('should hide the detail part after the detail child is removed', async () => {
+      layout.querySelector('[slot="detail"]').remove();
+      await nextRender();
+      expect(getComputedStyle(detail).display).to.equal('none');
+    });
+  });
+
+  describe('size properties', () => {
+    it('should set flex-basis to 50% on the master and detail by default', () => {
+      expect(getComputedStyle(master).flexBasis).to.equal('50%');
+      expect(getComputedStyle(detail).flexBasis).to.equal('50%');
+    });
+
+    it('should set flex-grow to 1% on the master and detail by default', () => {
+      expect(getComputedStyle(master).flexGrow).to.equal('1');
+      expect(getComputedStyle(detail).flexGrow).to.equal('1');
+    });
+
+    it('should update flex-basis on the master pane when masterMinSize is set', () => {
+      layout.masterMinSize = '300px';
+      expect(getComputedStyle(master).flexBasis).to.equal('300px');
+    });
+
+    it('should update flex-basis on the detail pane when detailMinSize is set', () => {
+      layout.detailMinSize = '300px';
+      expect(getComputedStyle(detail).flexBasis).to.equal('300px');
+    });
+
+    it('should set fixed width on the master pane when masterSize is set', () => {
+      layout.masterSize = '300px';
+      expect(getComputedStyle(master).width).to.equal('300px');
+      expect(getComputedStyle(master).flexBasis).to.equal('auto');
+      expect(getComputedStyle(master).flexGrow).to.equal('0');
+      expect(getComputedStyle(master).flexShrink).to.equal('0');
+    });
+
+    it('should set fixed width on the detail pane when detailSize is set', () => {
+      layout.detailSize = '300px';
+      expect(getComputedStyle(detail).width).to.equal('300px');
+      expect(getComputedStyle(detail).flexBasis).to.equal('auto');
+      expect(getComputedStyle(detail).flexGrow).to.equal('0');
+      expect(getComputedStyle(detail).flexShrink).to.equal('0');
     });
   });
 });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -64,16 +64,6 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(detail).flexGrow).to.equal('1');
     });
 
-    it('should update flex-basis on the master pane when masterMinSize is set', () => {
-      layout.masterMinSize = '300px';
-      expect(getComputedStyle(master).flexBasis).to.equal('300px');
-    });
-
-    it('should update flex-basis on the detail pane when detailMinSize is set', () => {
-      layout.detailMinSize = '300px';
-      expect(getComputedStyle(detail).flexBasis).to.equal('300px');
-    });
-
     it('should set fixed width on the master pane when masterSize is set', () => {
       layout.masterSize = '300px';
       expect(getComputedStyle(master).width).to.equal('300px');

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -42,7 +42,7 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(detail).height).to.equal('1000px');
     });
 
-    it('should show the detail part with the detail child is provided', () => {
+    it('should show the detail part with the detail child if provided', () => {
       expect(getComputedStyle(detail).display).to.equal('block');
     });
 
@@ -59,7 +59,7 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(detail).flexBasis).to.equal('50%');
     });
 
-    it('should set flex-grow to 1% on the master and detail by default', () => {
+    it('should set flex-grow to 1 on the master and detail by default', () => {
       expect(getComputedStyle(master).flexGrow).to.equal('1');
       expect(getComputedStyle(detail).flexGrow).to.equal('1');
     });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -79,5 +79,14 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(detail).flexGrow).to.equal('0');
       expect(getComputedStyle(detail).flexShrink).to.equal('0');
     });
+
+    it('should use size as flex-basis when both masterSize and detailSize are set', () => {
+      layout.masterSize = '300px';
+      layout.detailSize = '300px';
+      expect(getComputedStyle(master).flexBasis).to.equal('300px');
+      expect(getComputedStyle(master).flexGrow).to.equal('1');
+      expect(getComputedStyle(detail).flexBasis).to.equal('300px');
+      expect(getComputedStyle(detail).flexGrow).to.equal('1');
+    });
   });
 });

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -9,3 +9,9 @@ const layout = document.createElement('vaadin-master-detail-layout');
 // Mixins
 assertType<ElementMixinClass>(layout);
 assertType<ThemableMixinClass>(layout);
+
+// Properties
+assertType<string | null | undefined>(layout.detailSize);
+assertType<string | null | undefined>(layout.detailMinSize);
+assertType<string | null | undefined>(layout.masterSize);
+assertType<string | null | undefined>(layout.masterMinSize);

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -12,6 +12,4 @@ assertType<ThemableMixinClass>(layout);
 
 // Properties
 assertType<string | null | undefined>(layout.detailSize);
-assertType<string | null | undefined>(layout.detailMinSize);
 assertType<string | null | undefined>(layout.masterSize);
-assertType<string | null | undefined>(layout.masterMinSize);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/7173

Implenented APIs for setting the size of the two areas:

- `masterSize` / `detailSize` - sets a fixed size and disables flex-grow
- ~~`masterMinSize` / `detailMinSize` - will be used later to detect overlay mode~~ - will be added in the follow-up PR #8789

## Type of change

- Feature