### PR TITLE
fix: avoid removing selected ranges on component initialization

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -279,7 +279,8 @@ export const ContextMenuMixin = (superClass) =>
     }
 
     /** @private */
-    _setListenOnUserSelect(value) {
+    __setListenOnUserSelect(opened) {
+      const value = opened ? 'none' : '';
       // Note: these styles don't seem to work in Firefox on iOS.
       this.listenOn.style.webkitTouchCallout = value;
       this.listenOn.style.webkitUserSelect = value; // Chrome, Safari, Firefox
@@ -288,7 +289,9 @@ export const ContextMenuMixin = (superClass) =>
       // Note: because user-selection is disabled on the overlay
       // before opening the menu the text could be already selected
       // so we need to clear that selection
-      document.getSelection().removeAllRanges();
+      if (opened) {
+        document.getSelection().removeAllRanges();
+      }
     }
 
     /** @private */
@@ -318,11 +321,11 @@ export const ContextMenuMixin = (superClass) =>
     _openedChanged(opened) {
       if (opened) {
         document.documentElement.addEventListener('contextmenu', this._boundOnGlobalContextMenu, true);
-        this._setListenOnUserSelect('none');
       } else {
         document.documentElement.removeEventListener('contextmenu', this._boundOnGlobalContextMenu, true);
-        this._setListenOnUserSelect('');
       }
+
+      this.__setListenOnUserSelect(opened);
 
       // Has to be set after instance has been created
       this._overlayElement.opened = opened;

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -43,6 +43,23 @@ describe('overlay', () => {
     return e;
   }
 
+  describe('initialization', () => {
+    beforeEach(() => {
+      menu = document.createElement('vaadin-context-menu');
+    });
+
+    afterEach(() => {
+      menu.remove();
+    });
+
+    it('should not clear selected ranges on initialization', () => {
+      const input = fixtureSync('<input value="foo">');
+      input.select();
+      document.body.appendChild(menu);
+      expect(window.getSelection().rangeCount).to.equal(1);
+    });
+  });
+
   describe('opening', () => {
     it('should be invisible before open', async () => {
       menu.openOn = 'foobar';


### PR DESCRIPTION
## Description

The PR fixes an issue where adding a `<vaadin-context-menu>` dynamically to the DOM removed the text cursor from a focused HTML input, stopping the user from typing further. 

The problem was caused by `document.getSelection().removeAllRanges()`, which was called not only when the overlay opened or closed but also when the component was just added to the DOM.

Fixes #8780 

## Type of change

- [x] Bugfix
