### PR TITLE
fix: properly handle functions in partial I18N types

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.d.ts
@@ -4,11 +4,11 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 
-export type AppLayoutI18n = PartialI18n<{
-  drawer: string;
-}>;
+export interface AppLayoutI18n {
+  drawer?: string;
+}
 
 export declare function AppLayoutMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.d.ts
@@ -5,20 +5,18 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { AvatarI18n } from '@vaadin/avatar/src/vaadin-avatar.js';
-import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
-export type AvatarGroupI18n = PartialI18n<
-  {
-    activeUsers: {
-      one: string;
-      many: string;
-    };
-    joined: string;
-    left: string;
-  } & AvatarI18n
->;
+export interface AvatarGroupI18n extends AvatarI18n {
+  activeUsers?: {
+    one?: string;
+    many?: string;
+  };
+  joined?: string;
+  left?: string;
+}
 
 export interface AvatarGroupItem {
   name?: string;

--- a/packages/avatar/src/vaadin-avatar-mixin.d.ts
+++ b/packages/avatar/src/vaadin-avatar-mixin.d.ts
@@ -5,11 +5,11 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
-import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 
-export type AvatarI18n = PartialI18n<{
-  anonymous: string;
-}>;
+export interface AvatarI18n {
+  anonymous?: string;
+}
 
 /**
  * A mixin providing common avatar functionality.

--- a/packages/component-base/src/i18n-mixin.d.ts
+++ b/packages/component-base/src/i18n-mixin.d.ts
@@ -6,17 +6,6 @@
 import type { Constructor } from '@open-wc/dedupe-mixin';
 
 /**
- * Recursively makes all properties of an i18n object optional.
- *
- * For internal use only.
- */
-export type PartialI18n<T> = T extends object
-  ? {
-      [P in keyof T]?: PartialI18n<T[P]>;
-    }
-  : T;
-
-/**
  * A mixin that allows to set partial I18N properties.
  */
 export declare function I18nMixin<I, T extends Constructor<HTMLElement>>(

--- a/packages/crud/src/vaadin-crud-mixin.d.ts
+++ b/packages/crud/src/vaadin-crud-mixin.d.ts
@@ -9,7 +9,7 @@
  * license.
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { GridFilterDefinition, GridSorterDefinition } from '@vaadin/grid/src/vaadin-grid.js';
 
 export type CrudDataProviderCallback<T> = (items: T[], size?: number) => void;
@@ -25,32 +25,32 @@ export type CrudDataProvider<T> = (params: CrudDataProviderParams, callback: Cru
 
 export type CrudEditorPosition = '' | 'aside' | 'bottom';
 
-export type CrudI18n = PartialI18n<{
-  newItem: string;
-  editItem: string;
-  saveItem: string;
-  cancel: string;
-  deleteItem: string;
-  editLabel: string;
-  confirm: {
-    delete: {
-      title: string;
-      content: string;
-      button: {
-        confirm: string;
-        dismiss: string;
+export interface CrudI18n {
+  newItem?: string;
+  editItem?: string;
+  saveItem?: string;
+  cancel?: string;
+  deleteItem?: string;
+  editLabel?: string;
+  confirm?: {
+    delete?: {
+      title?: string;
+      content?: string;
+      button?: {
+        confirm?: string;
+        dismiss?: string;
       };
     };
-    cancel: {
-      title: string;
-      content: string;
-      button: {
-        confirm: string;
-        dismiss: string;
+    cancel?: {
+      title?: string;
+      content?: string;
+      button?: {
+        confirm?: string;
+        dismiss?: string;
       };
     };
   };
-}>;
+}
 
 /**
  * Fired when the `editorOpened` property changes.

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -11,7 +11,7 @@
 import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-section.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
-import type { I18nMixin, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin';
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 
@@ -134,21 +134,21 @@ export interface DashboardCustomEventMap<TItem extends DashboardItem> {
 
 export type DashboardEventMap<TItem extends DashboardItem> = DashboardCustomEventMap<TItem> & HTMLElementEventMap;
 
-export type DashboardI18n = PartialI18n<{
-  selectWidget: string;
-  selectSection: string;
-  remove: string;
-  resize: string;
-  resizeApply: string;
-  resizeShrinkWidth: string;
-  resizeGrowWidth: string;
-  resizeShrinkHeight: string;
-  resizeGrowHeight: string;
-  move: string;
-  moveApply: string;
-  moveForward: string;
-  moveBackward: string;
-}>;
+export interface DashboardI18n {
+  selectWidget?: string;
+  selectSection?: string;
+  remove?: string;
+  resize?: string;
+  resizeApply?: string;
+  resizeShrinkWidth?: string;
+  resizeGrowWidth?: string;
+  resizeShrinkHeight?: string;
+  resizeGrowHeight?: string;
+  move?: string;
+  moveApply?: string;
+  moveForward?: string;
+  moveBackward?: string;
+}
 
 /**
  * A responsive, grid-based dashboard layout component

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -8,7 +8,7 @@ import type { DelegateFocusMixinClass } from '@vaadin/a11y-base/src/delegate-foc
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
-import type { I18nMixinClass, PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { OverlayClassMixinClass } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import type { InputConstraintsMixinClass } from '@vaadin/field-base/src/input-constraints-mixin.js';
 import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
@@ -19,35 +19,35 @@ export interface DatePickerDate {
   year: number;
 }
 
-export type DatePickerI18n = PartialI18n<{
+export interface DatePickerI18n {
   /**
    * An array with the full names of months starting
    * with January.
    */
-  monthNames: string[];
+  monthNames?: string[];
   /**
    * An array of weekday names starting with Sunday. Used
    * in screen reader announcements.
    */
-  weekdays: string[];
+  weekdays?: string[];
   /**
    * An array of short weekday names starting with Sunday.
    * Displayed in the calendar.
    */
-  weekdaysShort: string[];
+  weekdaysShort?: string[];
   /**
    * An integer indicating the first day of the week
    * (0 = Sunday, 1 = Monday, etc.).
    */
-  firstDayOfWeek: number;
+  firstDayOfWeek?: number;
   /**
    * Translation of the Today shortcut button text.
    */
-  today: string;
+  today?: string;
   /**
    * Translation of the Cancel button text.
    */
-  cancel: string;
+  cancel?: string;
   /**
    * Used for adjusting the year value when parsing dates with short years.
    * The year values between 0 and 99 are evaluated and adjusted.
@@ -58,7 +58,7 @@ export type DatePickerI18n = PartialI18n<{
    * Supported date format: ISO 8601 `"YYYY-MM-DD"` (default)
    * The default value is the current date.
    */
-  referenceDate: string;
+  referenceDate?: string;
 
   /**
    * A function to parse the given text to an `Object` in the format `{ day: ..., month: ..., year: ... }`.
@@ -67,7 +67,7 @@ export type DatePickerI18n = PartialI18n<{
    * Note: The argument month is 0-based. This means that January = 0 and December = 11.
    * @param date
    */
-  parseDate(date: string): DatePickerDate | undefined;
+  parseDate?(date: string): DatePickerDate | undefined;
 
   /**
    * A function to format given `Object` as
@@ -75,7 +75,7 @@ export type DatePickerI18n = PartialI18n<{
    * Note: The argument month is 0-based. This means that January = 0 and December = 11.
    * @param date
    */
-  formatDate(date: DatePickerDate): string;
+  formatDate?(date: DatePickerDate): string;
 
   /**
    * A function to format given `monthName` and
@@ -83,8 +83,8 @@ export type DatePickerI18n = PartialI18n<{
    * @param monthName
    * @param fullYear
    */
-  formatTitle(monthName: string, fullYear: number): string;
-}>;
+  formatTitle?(monthName: string, fullYear: number): string;
+}
 
 export declare function DatePickerMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/login/src/vaadin-login-mixin.d.ts
+++ b/packages/login/src/vaadin-login-mixin.d.ts
@@ -4,19 +4,18 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
-import type { PartialI18n } from '@vaadin/component-base/src/i18n-mixin.js';
 
-export type LoginI18n = PartialI18n<{
-  form: {
-    title: string;
-    username: string;
-    password: string;
-    submit: string;
-    forgotPassword: string;
+export interface LoginI18n {
+  form?: {
+    title?: string;
+    username?: string;
+    password?: string;
+    submit?: string;
+    forgotPassword?: string;
   };
-  errorMessage: {
-    title: string;
-    message: string;
+  errorMessage?: {
+    title?: string;
+    message?: string;
     username?: string;
     password?: string;
   };
@@ -25,7 +24,7 @@ export type LoginI18n = PartialI18n<{
     description?: string;
   };
   additionalInformation?: string;
-}>;
+}
 
 export declare function LoginMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<LoginMixinClass> & T;
 


### PR DESCRIPTION
## Description

Removes usage of the `PartialI18n` type helper and instead update I18N types manually to be deep partial. Also changes the types back to use an interface to align with the remaining I18N types that haven't been updated so far.

Fixes https://github.com/vaadin/web-components/issues/8792

## Type of change

- Bugfix
