### PR TITLE
feat: add stack mode to master-detail-layout

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -23,6 +23,10 @@
         background: #fff;
         border-left: solid 1px #ccc;
       }
+
+      vaadin-master-detail-layout[stack]::part(detail) {
+        background: #fff;
+      }
     </style>
 
     <p>

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -230,6 +230,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
   __detectLayoutMode() {
     if (!this.hasAttribute('has-detail')) {
       this.removeAttribute('overlay');
+      this.removeAttribute('stack');
       return;
     }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -42,12 +42,12 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         display: none;
       }
 
-      /* Overlay mode */
-      :host([overlay][has-detail]) {
+      /* Overlay / stack mode */
+      :host(:is([overlay], [stack])) {
         position: relative;
       }
 
-      :host([overlay]) [part='detail'] {
+      :host(:is([overlay], [stack])) [part='detail'] {
         position: absolute;
         inset-inline-end: 0;
         height: 100%;
@@ -55,7 +55,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         max-width: 100%;
       }
 
-      :host([overlay]) [part='master'] {
+      :host(:is([overlay], [stack])) [part='master'] {
         max-width: 100%;
       }
 
@@ -88,11 +88,11 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
       }
 
       /* Min size */
-      :host([has-master-min-size]:not([overlay])) [part='master'] {
+      :host([has-master-min-size]:not([overlay]):not([stack])) [part='master'] {
         min-width: var(--_master-min-size);
       }
 
-      :host([has-detail-min-size]:not([overlay])) [part='detail'] {
+      :host([has-detail-min-size]:not([overlay]):not([stack])) [part='detail'] {
         min-width: var(--_detail-min-size);
       }
 
@@ -257,6 +257,13 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     // scroll. Check if that is the case and if so, preserve the overlay mode.
     if (this.offsetWidth < this.scrollWidth) {
       this.setAttribute('overlay', '');
+    }
+
+    // Switch to the stack mode if the detail area fully covers the layout.
+    const stackReached = this.$.detail.clientWidth === this.clientWidth;
+    this.toggleAttribute('stack', stackReached);
+    if (stackReached) {
+      this.removeAttribute('overlay');
     }
   }
 }

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -199,10 +199,8 @@ describe('vaadin-master-detail-layout', () => {
       expect(layout.hasAttribute('overlay')).to.be.true;
     });
 
-    it('should not overflow in the overlay mode when detailMinSize is set', async () => {
+    it('should not overflow in the overlay mode when masterSize is set', async () => {
       layout.masterSize = '500px';
-      layout.detailMinSize = '500px';
-
       await nextResize(layout);
 
       // Resize so that min size is bigger than layout size.
@@ -210,7 +208,7 @@ describe('vaadin-master-detail-layout', () => {
       await nextResize(layout);
 
       expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(master).width).to.equal(`${layout.offsetWidth}px`);
       expect(getComputedStyle(detail).maxWidth).to.equal('100%');
     });
 
@@ -252,6 +250,91 @@ describe('vaadin-master-detail-layout', () => {
       await nextRender();
 
       expect(layout.hasAttribute('overlay')).to.be.false;
+    });
+  });
+
+  describe('stack', () => {
+    let width, height;
+
+    before(() => {
+      width = window.innerWidth;
+      height = window.innerHeight;
+    });
+
+    afterEach(async () => {
+      await setViewport({ width, height });
+    });
+
+    it('should switch to the stack mode when detailSize is set to 100%', async () => {
+      layout.detailSize = '100%';
+      await nextResize(layout);
+      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('stack')).to.be.true;
+    });
+
+    it('should switch to the stack mode when detailMinSize is set to 100%', async () => {
+      layout.detailMinSize = '100%';
+      await nextResize(layout);
+      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('stack')).to.be.true;
+    });
+
+    it('should not overflow in the stack mode when detailSize is set', async () => {
+      layout.detailSize = '500px';
+      await nextResize(layout);
+
+      // Resize so that min size is bigger than layout size.
+      await setViewport({ width: 480, height });
+      await nextResize(layout);
+
+      expect(layout.hasAttribute('stack')).to.be.true;
+      expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(detail).maxWidth).to.equal('100%');
+    });
+
+    it('should not overflow in the stack mode when detailMinSize is set', async () => {
+      layout.detailMinSize = '500px';
+      await nextResize(layout);
+
+      // Resize so that min size is bigger than layout size.
+      await setViewport({ width: 480, height });
+      await nextResize(layout);
+
+      expect(layout.hasAttribute('stack')).to.be.true;
+      expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(detail).maxWidth).to.equal('100%');
+    });
+
+    it('should not overflow in the stack mode when masterSize and detailSize are set', async () => {
+      layout.masterSize = '500px';
+      layout.detailSize = '500px';
+      await nextResize(layout);
+
+      // Resize so that min size is bigger than layout size.
+      await setViewport({ width: 480, height });
+      await nextResize(layout);
+
+      expect(layout.hasAttribute('stack')).to.be.true;
+      expect(getComputedStyle(master).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(master).maxWidth).to.equal('100%');
+      expect(getComputedStyle(detail).maxWidth).to.equal('100%');
+    });
+
+    it('should not overflow in the stack mode when masterMinSize and detailMinSize are set', async () => {
+      layout.masterMinSize = '500px';
+      layout.detailMinSize = '500px';
+      await nextResize(layout);
+
+      // Resize so that min size is bigger than layout size.
+      await setViewport({ width: 480, height });
+      await nextResize(layout);
+
+      expect(layout.hasAttribute('stack')).to.be.true;
+      expect(getComputedStyle(master).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
+      expect(getComputedStyle(master).maxWidth).to.equal('100%');
+      expect(getComputedStyle(detail).maxWidth).to.equal('100%');
     });
   });
 });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -336,5 +336,26 @@ describe('vaadin-master-detail-layout', () => {
       expect(getComputedStyle(master).maxWidth).to.equal('100%');
       expect(getComputedStyle(detail).maxWidth).to.equal('100%');
     });
+
+    it('should update stack mode when adding and removing details', async () => {
+      layout.detailSize = '500px';
+      await nextResize(layout);
+
+      // Resize so that min size is bigger than layout size.
+      await setViewport({ width: 480, height });
+      await nextResize(layout);
+
+      // Remove details
+      detailContent.remove();
+      await nextRender();
+
+      expect(layout.hasAttribute('stack')).to.be.false;
+
+      // Append details
+      layout.appendChild(detailContent);
+      await nextRender();
+
+      expect(layout.hasAttribute('stack')).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
## Description

Depends on #8789

While the above PR uses `max-width` to not overflow, we should still have separate `stack` mode - from Rolf:

> Right now I'm thinking that stack mode is just an API feature that's for all practical purposes the same as overlay mode, but sized to always cover the layout/viewport. An overlay becomes a stack simply by reaching its 100% max size.
> i.e. setting stack mode via API is same as setting overlay mode and setting the overlay's size to 100%

> That being said. we might want to do some styling tweaks in stack compared to overlay, so it would be nice if we could target that state in css somehow anyway

Note: while we don't have API for setting overlay size, it's still possible to enforce `stack` by using `detailSize` or `detailMinSize` to 100% with the current implementation.

Also, originally I wanted to not use `position: absolute` for `stack` and just hide the master area instead.
However, based on some manual testing using the dev page, it could again cause jumpiness issue again. 
So I decided to reuse `overlay` positioning logic which also helps to keeps styles a bit more readable.

## Type of change

- Feature