### PR TITLE
fix: do not prevent closing on backdrop click

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css, html, LitElement } from 'lit';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -107,24 +106,6 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
         <div part="content" id="content"><slot></slot></div>
       </div>
     `;
-  }
-
-  /**
-   * Override method inherited from `OverlayMixin` to not close
-   * modal popover on outside click when opening on focus.
-   *
-   * @param {Event} event
-   * @return {boolean}
-   * @protected
-   */
-  _shouldCloseOnOutsideClick(event) {
-    // When opening a modal popover on mouse focusin, the focus moves to the overlay
-    // and then outside click listener is fired. Detect this case and prevent closing.
-    if (this.owner.__hasTrigger('focus') && isElementFocused(this)) {
-      return false;
-    }
-
-    return super._shouldCloseOnOutsideClick(event);
   }
 }
 

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -232,20 +232,6 @@ describe('trigger', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should open on target focusin followed by click when modal', async () => {
-      popover.modal = true;
-      await nextUpdate(popover);
-
-      target.focus();
-      // Wait for open focus trap
-      await nextRender();
-
-      // Emulate click without focus change
-      target.click();
-      await nextRender();
-      expect(overlay.opened).to.be.true;
-    });
-
     it('should not open on target focusin when detached', async () => {
       popover.remove();
       focusin(target);


### PR DESCRIPTION
## Description

The PR fixes the issue where focus-triggered modal popovers didn't close on backdrop click. 

The issue was caused by the `_shouldCloseOnOutsideClick` override in `PopoverOverlay`.  This override was originally added (according to the code comment) to prevent modal popovers from unexpected closing after receiving focus. However, this behavior doesn't actually happen without the override, while the related test seems artificial – it asserts that the second click on the target doesn't close the popover, which doesn't make practical sense since `pointer-events: none` prevents interacting with the target when the popover is open anyway. So, the override seems safe to be removed.

Fixes https://github.com/vaadin/web-components/issues/8784

## Type of change

- [x] Bugfix
