### PR TITLE
fix: close popover immediately on mouseleave while opening

### DIFF
--- a/packages/popover/test/timers.test.js
+++ b/packages/popover/test/timers.test.js
@@ -269,6 +269,20 @@ describe('timers', () => {
       await nextUpdate(popover);
       expect(overlay.opened).to.be.false;
     });
+
+    it('should close the overlay immediately on subsequent mouseleave during hover delay', async () => {
+      popover.hoverDelay = 5;
+
+      mouseenter(target);
+      mouseleave(target);
+      await nextUpdate(popover);
+
+      mouseenter(target);
+      mouseleave(target);
+      await nextUpdate(popover);
+
+      expect(overlay.opened).to.be.false;
+    });
   });
 
   describe('setDefaultHoverDelay', () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/7085

Here's the original problem with the current incorrect logic:

1. Popover has both `hoverDelay` and `hideDelay` set to e.g. 500ms (default),
2. User moves mouse quickly over the target -> hover delay schedules opening -> hide delay schedules closing,
3. User moves mouse over the target again -> overlay is opened due to the `__closeTimeout` check below.

https://github.com/vaadin/web-components/blob/b839b64a8a5aeb9e6b5d0f110a4d0e465bb13f3a/packages/popover/src/vaadin-popover.js#L74

This check was added as part of "abort closing on overlay mouseenter" covering by the following test:

https://github.com/vaadin/web-components/blob/b839b64a8a5aeb9e6b5d0f110a4d0e465bb13f3a/packages/popover/test/timers.test.js#L227

IMO the current logic is confusing as we don't need to open the overlay if it's already opened, we only need to abort closing. So I have updated the `open()` method in the popover opened state controller to do that explicitly.

As for the actual fix, previously the `hideDelay` presence was causing the closing to be scheduled even if the opening was still in progress. This was changed to close immediately and is covered with a new test with subsequent events.

## Type of change

- Bugfix