### PR TITLE
fix: provide i18n property declaration

### DIFF
--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -42,6 +42,16 @@ export const I18nMixin = (defaultI18n, superClass) =>
     static get properties() {
       return {
         /** @private */
+        // Technically declaring a Polymer property is not needed, as we have a
+        // getter/setter for it below. However, the React components currently
+        // rely on the Polymer property declaration to detect which properties
+        // are available on a custom element, so we add a dummy declaration for
+        // it.
+        i18n: {
+          type: Object,
+        },
+
+        /** @private */
         __effectiveI18n: {
           type: Object,
           sync: true,


### PR DESCRIPTION
## Description

Vaadin React components currently detect which properties are available on a custom element by [using Polymer property declarations](https://github.com/vaadin/react-components/blob/44d700a681869a02cb145a60cf81f179a340222b/packages/react-components/src/utils/createComponent.ts#L92-L105). Since the `i18n` property is not declared as a Polymer property it is not recognized by the React component as a property and is treated as an attribute instead.

Providing a Polymer property should solve the issue and also doesn't seem to interfere with the custom `i18n` getter and setter.

## Type of change

- Bugfix
