### PR TITLE
feat: add vertical orientation support to master-detail-layout

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -6,11 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Master Detail Layout</title>
     <script type="module" src="./common.js"></script>
-
   </head>
 
   <body>
     <style>
+      html,
+      body {
+        height: 100%;
+      }
+
       vaadin-master-detail-layout {
         border: solid 1px #ccc;
       }
@@ -40,6 +44,7 @@
       <vaadin-checkbox id="masterMinSize" label="Set master min-size"></vaadin-checkbox>
       <vaadin-checkbox id="vertical" label="Use vertical orientation"></vaadin-checkbox>
       <vaadin-checkbox id="maxWidth" label="Use max-width on the host"></vaadin-checkbox>
+      <vaadin-checkbox id="maxHeight" label="Use max-height on the host"></vaadin-checkbox>
     </p>
 
     <vaadin-master-detail-layout>
@@ -89,6 +94,14 @@
           layout.style.maxWidth = '800px';
         } else {
           layout.style.maxWidth = '';
+        }
+      });
+
+      document.querySelector('#maxHeight').addEventListener('change', (e) => {
+        if (e.target.checked) {
+          layout.style.maxHeight = '600px';
+        } else {
+          layout.style.maxHeight = '';
         }
       });
     </script>

--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -21,7 +21,14 @@
 
       vaadin-master-detail-layout[overlay]::part(detail) {
         background: #fff;
-        border-left: solid 1px #ccc;
+      }
+
+      vaadin-master-detail-layout:not([orientation='vertical'])[overlay]::part(detail) {
+        border-inline-start: solid 1px #ccc;
+      }
+
+      vaadin-master-detail-layout[orientation='vertical'][overlay]::part(detail) {
+        border-block-start: solid 1px #ccc;
       }
     </style>
 
@@ -31,6 +38,8 @@
       <vaadin-checkbox id="detailMinSize" label="Set detail min-size"></vaadin-checkbox>
       <vaadin-checkbox id="masterSize" label="Set master size"></vaadin-checkbox>
       <vaadin-checkbox id="masterMinSize" label="Set master min-size"></vaadin-checkbox>
+      <vaadin-checkbox id="vertical" label="Use vertical orientation"></vaadin-checkbox>
+      <vaadin-checkbox id="maxWidth" label="Use max-width on the host"></vaadin-checkbox>
     </p>
 
     <vaadin-master-detail-layout>
@@ -69,6 +78,18 @@
 
       document.querySelector('#masterMinSize').addEventListener('change', (e) => {
         layout.masterMinSize = e.target.checked ? '300px' : null;
+      });
+
+      document.querySelector('#vertical').addEventListener('change', (e) => {
+        layout.orientation = e.target.checked ? 'vertical' : null;
+      });
+
+      document.querySelector('#maxWidth').addEventListener('change', (e) => {
+        if (e.target.checked) {
+          layout.style.maxWidth = '800px';
+        } else {
+          layout.style.maxWidth = '';
+        }
       });
     </script>
   </body>

--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -27,7 +27,7 @@
         background: #fff;
       }
 
-      vaadin-master-detail-layout:not([orientation='vertical'])[overlay]::part(detail) {
+      vaadin-master-detail-layout[orientation='horizontal'][overlay]::part(detail) {
         border-inline-start: solid 1px #ccc;
       }
 
@@ -86,7 +86,7 @@
       });
 
       document.querySelector('#vertical').addEventListener('change', (e) => {
-        layout.orientation = e.target.checked ? 'vertical' : null;
+        layout.orientation = e.target.checked ? 'vertical' : 'horizontal';
       });
 
       document.querySelector('#maxWidth').addEventListener('change', (e) => {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -57,9 +57,9 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * Define how master and detail areas are shown next to each other,
    * and the way how size and min-size properties are applied to them.
    * Possible values are: `horizontal` or `vertical`.
-   * When not specified, defaults to horizontal.
+   * Defaults to horizontal.
    */
-  orientation: 'horizontal' | 'vertical' | undefined;
+  orientation: 'horizontal' | 'vertical';
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -38,7 +38,10 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * When specified, it prevents the master area from growing or
    * shrinking. If there is not enough space to show master and detail
    * areas next to each other, the layout switches to the overlay mode.
-   * Setting `100%` enforces the overlay mode to be used by default.
+   *
+   * This property can be used to enforce the overlay mode to be used.
+   * In order to do it, set `100%` with default (horizontal) orientation
+   * or `100vh` with vertical orientation.
    *
    * @attr {string} master-size
    */
@@ -49,11 +52,22 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * When specified, it prevents the master area from shrinking below
    * this size. If there is not enough space to show master and detail
    * areas next to each other, the layout switches to the overlay mode.
-   * Setting `100%` enforces the overlay mode to be used by default.
+   *
+   * This property can be used to enforce the overlay mode to be used.
+   * In order to do it, set `100%` with default (horizontal) orientation
+   * or `100vh` with vertical orientation.
    *
    * @attr {string} master-min-size
    */
   masterMinSize: string | null | undefined;
+
+  /**
+   * Define how master and detail areas are shown next to each other,
+   * and the way how size and min-size properties are applied to them.
+   * Possible values are: `horizontal` or `vertical`.
+   * When not specified, defaults to horizontal.
+   */
+  orientation: 'horizontal' | 'vertical' | undefined;
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -39,9 +39,9 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * shrinking. If there is not enough space to show master and detail
    * areas next to each other, the layout switches to the overlay mode.
    *
-   * This property can be used to enforce the overlay mode to be used.
-   * In order to do it, set `100%` with default (horizontal) orientation
-   * or `100vh` with vertical orientation.
+   * This property can be used to enforce overlay mode by setting it
+   * to `100%` with the default (horizontal) orientation, or `100vh`
+   * with vertical orientation.
    *
    * @attr {string} master-size
    */
@@ -53,9 +53,9 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * this size. If there is not enough space to show master and detail
    * areas next to each other, the layout switches to the overlay mode.
    *
-   * This property can be used to enforce the overlay mode to be used.
-   * In order to do it, set `100%` with default (horizontal) orientation
-   * or `100vh` with vertical orientation.
+   * This property can be used to enforce overlay mode by setting it
+   * to `100%` with the default (horizontal) orientation, or `100vh`
+   * with vertical orientation.
    *
    * @attr {string} master-min-size
    */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -39,10 +39,6 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * shrinking. If there is not enough space to show master and detail
    * areas next to each other, the layout switches to the overlay mode.
    *
-   * This property can be used to enforce overlay mode by setting it
-   * to `100%` with the default (horizontal) orientation, or `100vh`
-   * with vertical orientation.
-   *
    * @attr {string} master-size
    */
   masterSize: string | null | undefined;
@@ -52,10 +48,6 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * When specified, it prevents the master area from shrinking below
    * this size. If there is not enough space to show master and detail
    * areas next to each other, the layout switches to the overlay mode.
-   *
-   * This property can be used to enforce overlay mode by setting it
-   * to `100%` with the default (horizontal) orientation, or `100vh`
-   * with vertical orientation.
    *
    * @attr {string} master-min-size
    */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -330,20 +330,17 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
 
   /** @private */
   __detectVerticalMode() {
-    // Set position to static temporarily to detect if there is enough space
+    // Remove overlay attribute temporarily to detect if there is enough space
     // for both areas so that layout could switch back to the split mode.
-    if (this.hasAttribute('overlay') && !this.masterMinSize) {
-      this.$.detail.style.position = 'static';
+    if (this.hasAttribute('overlay')) {
+      this.removeAttribute('overlay');
     }
     const masterHeight = this.$.master.clientHeight;
-    this.$.detail.style.position = '';
 
     // If the combined minimum size of both the master and the detail content
     // exceeds the available height, the layout changes to the overlay mode.
     if (this.offsetHeight < masterHeight + this.$.detail.clientHeight) {
       this.setAttribute('overlay', '');
-    } else {
-      this.removeAttribute('overlay');
     }
   }
 }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -217,14 +217,6 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     };
   }
 
-  /**
-   * @return {boolean}
-   * @protected
-   */
-  get _vertical() {
-    return this.orientation === 'vertical';
-  }
-
   /** @protected */
   render() {
     return html`
@@ -300,7 +292,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
       return;
     }
 
-    if (this._vertical) {
+    if (this.orientation === 'vertical') {
       this.__detectVerticalMode();
     } else {
       this.__detectHorizontalMode();

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -247,10 +247,17 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
   }
 
   /** @protected */
-  ready() {
-    super.ready();
+  connectedCallback() {
+    super.connectedCallback();
 
     window.addEventListener('resize', this.__onWindowResize);
+  }
+
+  /** @protected */
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    window.removeEventListener('resize', this.__onWindowResize);
   }
 
   /** @private */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -112,6 +112,10 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         flex-direction: column;
       }
 
+      :host([orientation='vertical'][overlay]) [part='master'] {
+        max-height: 100%;
+      }
+
       :host([orientation='vertical'][overlay]) [part='detail'] {
         inset-block-end: 0;
         width: 100%;
@@ -175,10 +179,6 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
        * shrinking. If there is not enough space to show master and detail
        * areas next to each other, the layout switches to the overlay mode.
        *
-       * This property can be used to enforce overlay mode by setting it
-       * to `100%` with the default (horizontal) orientation, or `100vh`
-       * with vertical orientation.
-       *
        * @attr {string} master-size
        */
       masterSize: {
@@ -192,10 +192,6 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
        * When specified, it prevents the master area from shrinking below
        * this size. If there is not enough space to show master and detail
        * areas next to each other, the layout switches to the overlay mode.
-       *
-       * This property can be used to enforce overlay mode by setting it
-       * to `100%` with the default (horizontal) orientation, or `100vh`
-       * with vertical orientation.
        *
        * @attr {string} master-min-size
        */
@@ -370,12 +366,15 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
 
   /** @private */
   __detectVerticalMode() {
-    // Detect potentially available height in the viewport.
-    const maxHeight = window.innerHeight - this.getBoundingClientRect().top;
+    // Set position to static temporarily to detect if there is enough space
+    // for both areas so that layout could switch back to the split mode.
+    this.$.detail.style.position = 'static';
+    const masterHeight = this.$.master.offsetHeight;
+    this.$.detail.style.position = '';
 
     // If the combined minimum size of both the master and the detail content
     // exceeds the available height, the layout changes to the overlay mode.
-    if (maxHeight < this.$.master.offsetHeight + this.$.detail.offsetHeight) {
+    if (this.offsetHeight < masterHeight + this.$.detail.offsetHeight) {
       this.setAttribute('overlay', '');
     } else {
       this.removeAttribute('overlay');

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -335,12 +335,12 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     if (this.hasAttribute('overlay') && !this.masterMinSize) {
       this.$.detail.style.position = 'static';
     }
-    const masterHeight = this.$.master.offsetHeight;
+    const masterHeight = this.$.master.clientHeight;
     this.$.detail.style.position = '';
 
     // If the combined minimum size of both the master and the detail content
     // exceeds the available height, the layout changes to the overlay mode.
-    if (this.offsetHeight < masterHeight + this.$.detail.offsetHeight) {
+    if (this.offsetHeight < masterHeight + this.$.detail.clientHeight) {
       this.setAttribute('overlay', '');
     } else {
       this.removeAttribute('overlay');

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -332,7 +332,9 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
   __detectVerticalMode() {
     // Set position to static temporarily to detect if there is enough space
     // for both areas so that layout could switch back to the split mode.
-    this.$.detail.style.position = 'static';
+    if (this.hasAttribute('overlay') && !this.masterMinSize) {
+      this.$.detail.style.position = 'static';
+    }
     const masterHeight = this.$.master.offsetHeight;
     this.$.detail.style.position = '';
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -175,9 +175,9 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
        * shrinking. If there is not enough space to show master and detail
        * areas next to each other, the layout switches to the overlay mode.
        *
-       * This property can be used to enforce the overlay mode to be used.
-       * In order to do it, set `100%` with default (horizontal) orientation
-       * or `100vh` with vertical orientation.
+       * This property can be used to enforce overlay mode by setting it
+       * to `100%` with the default (horizontal) orientation, or `100vh`
+       * with vertical orientation.
        *
        * @attr {string} master-size
        */
@@ -193,9 +193,9 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
        * this size. If there is not enough space to show master and detail
        * areas next to each other, the layout switches to the overlay mode.
        *
-       * This property can be used to enforce the overlay mode to be used.
-       * In order to do it, set `100%` with default (horizontal) orientation
-       * or `100vh` with vertical orientation.
+       * This property can be used to enforce overlay mode by setting it
+       * to `100%` with the default (horizontal) orientation, or `100vh`
+       * with vertical orientation.
        *
        * @attr {string} master-min-size
        */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -217,12 +217,6 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     };
   }
 
-  constructor() {
-    super();
-
-    this.__onWindowResize = this.__onWindowResize.bind(this);
-  }
-
   /**
    * @return {boolean}
    * @protected
@@ -243,20 +237,6 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     `;
   }
 
-  /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    window.addEventListener('resize', this.__onWindowResize);
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    window.removeEventListener('resize', this.__onWindowResize);
-  }
-
   /** @private */
   __onDetailSlotChange(e) {
     this.toggleAttribute('has-detail', e.target.assignedNodes().length > 0);
@@ -269,15 +249,6 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
    */
   _onResize() {
     this.__detectLayoutMode();
-  }
-
-  /** @private */
-  __onWindowResize() {
-    // On window resize, the component does not necessarily get resized
-    // when already in vertical overlay mode, so we have this listener.
-    if (this._vertical) {
-      this.__detectVerticalMode();
-    }
   }
 
   /** @private */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -51,14 +51,14 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         position: absolute;
       }
 
-      :host([overlay]:not([orientation='vertical'])) [part='detail'] {
+      :host([overlay][orientation='horizontal']) [part='detail'] {
         inset-inline-end: 0;
         height: 100%;
         width: var(--_detail-min-size, min-content);
         max-width: 100%;
       }
 
-      :host([overlay]:not([orientation='vertical'])) [part='master'] {
+      :host([overlay][orientation='horizontal']) [part='master'] {
         max-width: 100%;
       }
 
@@ -75,11 +75,11 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         flex-shrink: 0;
       }
 
-      :host([has-master-size]:not([orientation='vertical'])) [part='master'] {
+      :host([has-master-size][orientation='horizontal']) [part='master'] {
         width: var(--_master-size);
       }
 
-      :host([has-detail-size]:not([orientation='vertical'])) [part='detail'] {
+      :host([has-detail-size][orientation='horizontal']) [part='detail'] {
         width: var(--_detail-size);
       }
 
@@ -94,11 +94,11 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
       }
 
       /* Min size */
-      :host([has-master-min-size]:not([overlay]):not([orientation='vertical'])) [part='master'] {
+      :host([has-master-min-size][orientation='horizontal']:not([overlay])) [part='master'] {
         min-width: var(--_master-min-size);
       }
 
-      :host([has-detail-min-size]:not([overlay]):not([orientation='vertical'])) [part='detail'] {
+      :host([has-detail-min-size][orientation='horizontal']:not([overlay])) [part='detail'] {
         min-width: var(--_detail-min-size);
       }
 
@@ -205,10 +205,11 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
        * Define how master and detail areas are shown next to each other,
        * and the way how size and min-size properties are applied to them.
        * Possible values are: `horizontal` or `vertical`.
-       * When not specified, defaults to horizontal.
+       * Defaults to horizontal.
        */
       orientation: {
         type: String,
+        value: 'horizontal',
         reflectToAttribute: true,
         observer: '__orientationChanged',
         sync: true,

--- a/packages/master-detail-layout/test/helpers/master-content.js
+++ b/packages/master-detail-layout/test/helpers/master-content.js
@@ -7,6 +7,8 @@ customElements.define(
       return css`
         :host {
           display: block;
+          height: 100%;
+          overflow: auto;
         }
 
         .list {

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -56,51 +56,87 @@ describe('vaadin-master-detail-layout', () => {
   });
 
   describe('size properties', () => {
-    it('should set flex-basis to 50% on the master and detail by default', () => {
-      expect(getComputedStyle(master).flexBasis).to.equal('50%');
-      expect(getComputedStyle(detail).flexBasis).to.equal('50%');
+    describe('default', () => {
+      it('should set flex-basis to 50% on the master and detail by default', () => {
+        expect(getComputedStyle(master).flexBasis).to.equal('50%');
+        expect(getComputedStyle(detail).flexBasis).to.equal('50%');
+      });
+
+      it('should set flex-grow to 1 on the master and detail by default', () => {
+        expect(getComputedStyle(master).flexGrow).to.equal('1');
+        expect(getComputedStyle(detail).flexGrow).to.equal('1');
+      });
+
+      it('should set fixed width on the master area when masterSize is set', () => {
+        layout.masterSize = '300px';
+        expect(getComputedStyle(master).width).to.equal('300px');
+        expect(getComputedStyle(master).flexBasis).to.equal('auto');
+        expect(getComputedStyle(master).flexGrow).to.equal('0');
+        expect(getComputedStyle(master).flexShrink).to.equal('0');
+      });
+
+      it('should set fixed width on the detail area when detailSize is set', () => {
+        layout.detailSize = '300px';
+        expect(getComputedStyle(detail).width).to.equal('300px');
+        expect(getComputedStyle(detail).flexBasis).to.equal('auto');
+        expect(getComputedStyle(detail).flexGrow).to.equal('0');
+        expect(getComputedStyle(detail).flexShrink).to.equal('0');
+      });
+
+      it('should use size as flex-basis when both masterSize and detailSize are set', () => {
+        layout.masterSize = '300px';
+        layout.detailSize = '300px';
+        expect(getComputedStyle(master).flexBasis).to.equal('300px');
+        expect(getComputedStyle(master).flexGrow).to.equal('1');
+        expect(getComputedStyle(detail).flexBasis).to.equal('300px');
+        expect(getComputedStyle(detail).flexGrow).to.equal('1');
+      });
+
+      it('should use masterMinSize as min-width and disable flex-shrink', () => {
+        layout.masterMinSize = '300px';
+        expect(getComputedStyle(master).minWidth).to.equal('300px');
+        expect(getComputedStyle(master).flexShrink).to.equal('0');
+      });
+
+      it('should use detailMinSize as min-width and disable flex-shrink', () => {
+        layout.detailMinSize = '300px';
+        expect(getComputedStyle(detail).minWidth).to.equal('300px');
+        expect(getComputedStyle(detail).flexShrink).to.equal('0');
+      });
     });
 
-    it('should set flex-grow to 1 on the master and detail by default', () => {
-      expect(getComputedStyle(master).flexGrow).to.equal('1');
-      expect(getComputedStyle(detail).flexGrow).to.equal('1');
-    });
+    describe('vertical', () => {
+      beforeEach(() => {
+        layout.orientation = 'vertical';
+      });
 
-    it('should set fixed width on the master area when masterSize is set', () => {
-      layout.masterSize = '300px';
-      expect(getComputedStyle(master).width).to.equal('300px');
-      expect(getComputedStyle(master).flexBasis).to.equal('auto');
-      expect(getComputedStyle(master).flexGrow).to.equal('0');
-      expect(getComputedStyle(master).flexShrink).to.equal('0');
-    });
+      it('should set fixed height on the master area when masterSize is set', () => {
+        layout.masterSize = '200px';
+        expect(getComputedStyle(master).height).to.equal('200px');
+        expect(getComputedStyle(master).flexBasis).to.equal('auto');
+        expect(getComputedStyle(master).flexGrow).to.equal('0');
+        expect(getComputedStyle(master).flexShrink).to.equal('0');
+      });
 
-    it('should set fixed width on the detail area when detailSize is set', () => {
-      layout.detailSize = '300px';
-      expect(getComputedStyle(detail).width).to.equal('300px');
-      expect(getComputedStyle(detail).flexBasis).to.equal('auto');
-      expect(getComputedStyle(detail).flexGrow).to.equal('0');
-      expect(getComputedStyle(detail).flexShrink).to.equal('0');
-    });
+      it('should set fixed height on the detail area when detailSize is set', () => {
+        layout.detailSize = '200px';
+        expect(getComputedStyle(detail).height).to.equal('200px');
+        expect(getComputedStyle(detail).flexBasis).to.equal('auto');
+        expect(getComputedStyle(detail).flexGrow).to.equal('0');
+        expect(getComputedStyle(detail).flexShrink).to.equal('0');
+      });
 
-    it('should use size as flex-basis when both masterSize and detailSize are set', () => {
-      layout.masterSize = '300px';
-      layout.detailSize = '300px';
-      expect(getComputedStyle(master).flexBasis).to.equal('300px');
-      expect(getComputedStyle(master).flexGrow).to.equal('1');
-      expect(getComputedStyle(detail).flexBasis).to.equal('300px');
-      expect(getComputedStyle(detail).flexGrow).to.equal('1');
-    });
+      it('should use masterMinSize as min-height and disable flex-shrink', () => {
+        layout.masterMinSize = '200px';
+        expect(getComputedStyle(master).minHeight).to.equal('200px');
+        expect(getComputedStyle(master).flexShrink).to.equal('0');
+      });
 
-    it('should use masterMinSize as min-width and disable flex-shrink', () => {
-      layout.masterMinSize = '300px';
-      expect(getComputedStyle(master).minWidth).to.equal('300px');
-      expect(getComputedStyle(master).flexShrink).to.equal('0');
-    });
-
-    it('should use detailMinSize as min-width and disable flex-shrink', () => {
-      layout.detailMinSize = '300px';
-      expect(getComputedStyle(detail).minWidth).to.equal('300px');
-      expect(getComputedStyle(detail).flexShrink).to.equal('0');
+      it('should use detailMinSize as min-height and disable flex-shrink', () => {
+        layout.detailMinSize = '200px';
+        expect(getComputedStyle(detail).minHeight).to.equal('200px');
+        expect(getComputedStyle(detail).flexShrink).to.equal('0');
+      });
     });
   });
 
@@ -116,142 +152,233 @@ describe('vaadin-master-detail-layout', () => {
       await setViewport({ width, height });
     });
 
-    it('should switch to the overlay when there is not enough space for both areas', async () => {
-      // Use the threshold at which the overlay mode is on by default.
-      await setViewport({ width: 350, height });
-      await nextResize(layout);
+    describe('default', () => {
+      it('should switch to the overlay when there is not enough space for both areas', async () => {
+        // Use the threshold at which the overlay mode is on by default.
+        await setViewport({ width: 350, height });
+        await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+      });
+
+      it('should switch to the overlay mode if not enough space when masterSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the master area.
+        await setViewport({ width: 400, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.masterSize = '300px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+      });
+
+      it('should switch to the overlay mode if not enough space when masterMinSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the master area.
+        await setViewport({ width: 400, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.masterMinSize = '300px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+      });
+
+      it('should set detail area width in overlay mode when detailSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the detail area.
+        await setViewport({ width: 500, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.detailSize = '300px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).width).to.equal('300px');
+      });
+
+      it('should set detail area width in overlay mode when detailMinSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting min size on the detail area.
+        await setViewport({ width: 500, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.detailMinSize = '300px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).width).to.equal('300px');
+      });
+
+      it('should switch to the overlay mode when masterSize is set to 100%', async () => {
+        layout.masterSize = '100%';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+      });
+
+      it('should switch to the overlay mode when masterMinSize is set to 100%', async () => {
+        layout.masterMinSize = '100%';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+      });
+
+      it('should not overflow in the overlay mode when detailMinSize is set', async () => {
+        layout.masterSize = '500px';
+        layout.detailMinSize = '500px';
+
+        await nextResize(layout);
+
+        // Resize so that min size is bigger than layout size.
+        await setViewport({ width: 480, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
+        expect(getComputedStyle(detail).maxWidth).to.equal('100%');
+      });
+
+      it('should not overflow in the overlay mode when masterMinSize is set', async () => {
+        layout.masterMinSize = '500px';
+        await nextResize(layout);
+
+        // Resize so that min size is bigger than layout size.
+        await setViewport({ width: 480, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(master).width).to.equal(`${layout.offsetWidth}px`);
+        expect(getComputedStyle(detail).maxWidth).to.equal('100%');
+      });
+
+      it('should update overlay mode when adding and removing details', async () => {
+        // Start without details
+        detailContent.remove();
+        await nextRender();
+
+        // Shrink viewport
+        layout.detailMinSize = '300px';
+        await setViewport({ width: 500, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        // Add details
+        layout.appendChild(detailContent);
+        await nextRender();
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).width).to.equal('300px');
+
+        // Remove details
+        detailContent.remove();
+        await nextRender();
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+      });
     });
 
-    it('should switch to the overlay mode if not enough space when masterSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
-      // but will be on after setting fixed size on the master area.
-      await setViewport({ width: 400, height });
-      await nextResize(layout);
+    describe('vertical', () => {
+      beforeEach(() => {
+        layout.orientation = 'vertical';
+      });
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      it('should switch to the overlay when there is not enough space for both areas', async () => {
+        // Use the threshold at which the overlay mode is on by default.
+        await setViewport({ width: 500, height: 400 });
+        await nextResize(layout);
 
-      layout.masterSize = '300px';
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+      });
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).position).to.equal('absolute');
-    });
+      it('should switch to the overlay mode if not enough space when masterSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the master area.
+        await setViewport({ width: 800, height: 600 });
+        await nextResize(layout);
 
-    it('should switch to the overlay mode if not enough space when masterMinSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
-      // but will be on after setting fixed size on the master area.
-      await setViewport({ width: 400, height });
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.false;
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+        layout.masterSize = '550px';
+        await nextResize(layout);
 
-      layout.masterMinSize = '300px';
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+      });
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).position).to.equal('absolute');
-    });
+      it('should switch to the overlay mode if not enough space when masterMinSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the master area.
+        await setViewport({ width: 800, height: 600 });
+        await nextResize(layout);
 
-    it('should set detail area width in overlay mode when detailSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
-      // but will be on after setting fixed size on the detail area.
-      await setViewport({ width: 500, height });
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.false;
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+        layout.masterMinSize = '550px';
+        await nextResize(layout);
 
-      layout.detailSize = '300px';
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+      });
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).position).to.equal('absolute');
-      expect(getComputedStyle(detail).width).to.equal('300px');
-    });
+      it('should set detail area height in overlay mode when detailSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the detail area.
+        await setViewport({ width: 800, height: 600 });
+        await nextResize(layout);
 
-    it('should set detail area width in overlay mode when detailMinSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
-      // but will be on after setting min size on the detail area.
-      await setViewport({ width: 500, height });
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.false;
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+        layout.detailSize = '300px';
+        await nextResize(layout);
 
-      layout.detailMinSize = '300px';
-      await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).height).to.equal('300px');
+      });
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).position).to.equal('absolute');
-      expect(getComputedStyle(detail).width).to.equal('300px');
-    });
+      it('should set detail area height in overlay mode when detailMinSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting min size on the detail area.
+        await setViewport({ width: 800, height: 600 });
+        await nextResize(layout);
 
-    it('should switch to the overlay mode when masterSize is set to 100%', async () => {
-      layout.masterSize = '100%';
-      await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.true;
-    });
+        expect(layout.hasAttribute('overlay')).to.be.false;
 
-    it('should switch to the overlay mode when masterMinSize is set to 100%', async () => {
-      layout.masterMinSize = '100%';
-      await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.true;
-    });
+        layout.detailMinSize = '300px';
+        await nextResize(layout);
 
-    it('should not overflow in the overlay mode when detailMinSize is set', async () => {
-      layout.masterSize = '500px';
-      layout.detailMinSize = '500px';
+        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).height).to.equal('300px');
+      });
 
-      await nextResize(layout);
+      it('should switch to the overlay mode when masterSize is set to 100vh', async () => {
+        layout.masterSize = '100vh';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+      });
 
-      // Resize so that min size is bigger than layout size.
-      await setViewport({ width: 480, height });
-      await nextResize(layout);
-
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
-      expect(getComputedStyle(detail).maxWidth).to.equal('100%');
-    });
-
-    it('should not overflow in the overlay mode when masterMinSize is set', async () => {
-      layout.masterMinSize = '500px';
-      await nextResize(layout);
-
-      // Resize so that min size is bigger than layout size.
-      await setViewport({ width: 480, height });
-      await nextResize(layout);
-
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(master).width).to.equal(`${layout.offsetWidth}px`);
-      expect(getComputedStyle(detail).maxWidth).to.equal('100%');
-    });
-
-    it('should update overlay mode when adding and removing details', async () => {
-      // Start without details
-      detailContent.remove();
-      await nextRender();
-
-      // Shrink viewport
-      layout.detailMinSize = '300px';
-      await setViewport({ width: 500, height });
-      await nextResize(layout);
-
-      expect(layout.hasAttribute('overlay')).to.be.false;
-
-      // Add details
-      layout.appendChild(detailContent);
-      await nextRender();
-
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(detail).position).to.equal('absolute');
-      expect(getComputedStyle(detail).width).to.equal('300px');
-
-      // Remove details
-      detailContent.remove();
-      await nextRender();
-
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      it('should switch to the overlay mode when masterMinSize is set to 100%', async () => {
+        layout.masterMinSize = '100vh';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.true;
+      });
     });
   });
 });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -384,6 +384,33 @@ describe('vaadin-master-detail-layout', () => {
         await nextResize(layout);
         expect(layout.hasAttribute('overlay')).to.be.false;
       });
+
+      it('should update switch to the overlay mode when both sizes are set with border', async () => {
+        // Add border to the detail area in the overlay mode.
+        fixtureSync(`
+          <style>
+            vaadin-master-detail-layout[overlay]::part(detail) {
+              border-top: solid 1px #ccc;
+            }
+          </style>
+        `);
+
+        await setViewport({ width: 800, height: 490 });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.masterSize = '250px';
+        layout.detailMinSize = '250px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+
+        await setViewport({ width: 800, height: 600 });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+      });
     });
   });
 });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -293,8 +293,11 @@ describe('vaadin-master-detail-layout', () => {
     });
 
     describe('vertical', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         layout.orientation = 'vertical';
+        layout.style.maxHeight = '500px';
+        layout.parentElement.style.height = '100%';
+        await nextResize(layout);
       });
 
       it('should switch to the overlay when there is not enough space for both areas', async () => {
@@ -306,78 +309,44 @@ describe('vaadin-master-detail-layout', () => {
         expect(getComputedStyle(detail).position).to.equal('absolute');
       });
 
-      it('should switch to the overlay mode if not enough space when masterSize is set', async () => {
-        // Use the threshold at which the overlay mode isn't on by default,
-        // but will be on after setting fixed size on the master area.
-        await setViewport({ width: 800, height: 600 });
-        await nextResize(layout);
-
-        expect(layout.hasAttribute('overlay')).to.be.false;
-
-        layout.masterSize = '550px';
-        await nextResize(layout);
-
-        expect(layout.hasAttribute('overlay')).to.be.true;
-        expect(getComputedStyle(detail).position).to.equal('absolute');
-      });
-
-      it('should switch to the overlay mode if not enough space when masterMinSize is set', async () => {
-        // Use the threshold at which the overlay mode isn't on by default,
-        // but will be on after setting fixed size on the master area.
-        await setViewport({ width: 800, height: 600 });
-        await nextResize(layout);
-
-        expect(layout.hasAttribute('overlay')).to.be.false;
-
-        layout.masterMinSize = '550px';
-        await nextResize(layout);
-
-        expect(layout.hasAttribute('overlay')).to.be.true;
-        expect(getComputedStyle(detail).position).to.equal('absolute');
-      });
-
       it('should set detail area height in overlay mode when detailSize is set', async () => {
         // Use the threshold at which the overlay mode isn't on by default,
         // but will be on after setting fixed size on the detail area.
-        await setViewport({ width: 800, height: 600 });
+        await setViewport({ width: 700, height: 600 });
         await nextResize(layout);
 
         expect(layout.hasAttribute('overlay')).to.be.false;
 
-        layout.detailSize = '300px';
+        layout.detailSize = '250px';
         await nextResize(layout);
 
         expect(layout.hasAttribute('overlay')).to.be.true;
         expect(getComputedStyle(detail).position).to.equal('absolute');
-        expect(getComputedStyle(detail).height).to.equal('300px');
+        expect(getComputedStyle(detail).height).to.equal('250px');
+
+        layout.detailSize = '';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.false;
       });
 
       it('should set detail area height in overlay mode when detailMinSize is set', async () => {
         // Use the threshold at which the overlay mode isn't on by default,
         // but will be on after setting min size on the detail area.
-        await setViewport({ width: 800, height: 600 });
+        await setViewport({ width: 700, height: 600 });
         await nextResize(layout);
 
         expect(layout.hasAttribute('overlay')).to.be.false;
 
-        layout.detailMinSize = '300px';
+        layout.detailMinSize = '250px';
         await nextResize(layout);
 
         expect(layout.hasAttribute('overlay')).to.be.true;
         expect(getComputedStyle(detail).position).to.equal('absolute');
-        expect(getComputedStyle(detail).height).to.equal('300px');
-      });
+        expect(getComputedStyle(detail).height).to.equal('250px');
 
-      it('should switch to the overlay mode when masterSize is set to 100vh', async () => {
-        layout.masterSize = '100vh';
+        layout.detailMinSize = '';
         await nextResize(layout);
-        expect(layout.hasAttribute('overlay')).to.be.true;
-      });
-
-      it('should switch to the overlay mode when masterMinSize is set to 100%', async () => {
-        layout.masterMinSize = '100vh';
-        await nextResize(layout);
-        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(layout.hasAttribute('overlay')).to.be.false;
       });
     });
   });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -380,7 +380,7 @@ describe('vaadin-master-detail-layout', () => {
 
         expect(layout.hasAttribute('overlay')).to.be.true;
 
-        layout.masterSize = '';
+        layout.masterMinSize = '';
         await nextResize(layout);
         expect(layout.hasAttribute('overlay')).to.be.false;
       });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -348,6 +348,42 @@ describe('vaadin-master-detail-layout', () => {
         await nextResize(layout);
         expect(layout.hasAttribute('overlay')).to.be.false;
       });
+
+      it('should switch to the overlay mode when masterSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting fixed size on the master area.
+        await setViewport({ width: 700, height: 600 });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.masterSize = '450px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+
+        layout.masterSize = '';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.false;
+      });
+
+      it('should switch to the overlay mode when masterMinSize is set', async () => {
+        // Use the threshold at which the overlay mode isn't on by default,
+        // but will be on after setting min size on the master area.
+        await setViewport({ width: 700, height: 600 });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+
+        layout.masterMinSize = '450px';
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('overlay')).to.be.true;
+
+        layout.masterSize = '';
+        await nextResize(layout);
+        expect(layout.hasAttribute('overlay')).to.be.false;
+      });
     });
   });
 });

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -15,3 +15,4 @@ assertType<string | null | undefined>(layout.detailSize);
 assertType<string | null | undefined>(layout.detailMinSize);
 assertType<string | null | undefined>(layout.masterSize);
 assertType<string | null | undefined>(layout.masterMinSize);
+assertType<'horizontal' | 'vertical' | undefined>(layout.orientation);

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -15,4 +15,4 @@ assertType<string | null | undefined>(layout.detailSize);
 assertType<string | null | undefined>(layout.detailMinSize);
 assertType<string | null | undefined>(layout.masterSize);
 assertType<string | null | undefined>(layout.masterMinSize);
-assertType<'horizontal' | 'vertical' | undefined>(layout.orientation);
+assertType<'horizontal' | 'vertical'>(layout.orientation);


### PR DESCRIPTION
## Description

Fixes #8808

Added `orientation` property that can be set to `vertical` to use vertical orientation.

Note: I was unable to make enforcing the overlay mode work using `masterSize = '100%'` so I documented that `100vh` can be used instead. This probably makes sense for common cases where MDL is expected to take the full page height.

## Type of change

- Feature