### PR TITLE
feat: add stackThreshold property to master-detail-layout

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -23,7 +23,7 @@
         background-color: var(--lumo-shade-20pct);
       }
 
-      vaadin-master-detail-layout[overlay]::part(detail) {
+      vaadin-master-detail-layout:is([overlay], [stack])::part(detail) {
         background: #fff;
       }
 
@@ -47,6 +47,7 @@
       <vaadin-checkbox id="maxWidth" label="Use max-width on the host"></vaadin-checkbox>
       <vaadin-checkbox id="maxHeight" label="Use max-height on the host"></vaadin-checkbox>
       <vaadin-checkbox id="forceOverlay" label="Force overlay"></vaadin-checkbox>
+      <vaadin-checkbox id="stack" label="Set stack threshold"></vaadin-checkbox>
     </p>
 
     <vaadin-master-detail-layout>
@@ -113,6 +114,10 @@
 
       document.querySelector('#forceOverlay').addEventListener('change', (e) => {
         layout.forceOverlay = e.target.checked;
+      });
+
+      document.querySelector('#stack').addEventListener('change', (e) => {
+        layout.stackThreshold = e.target.checked ? '30rem' : null;
       });
     </script>
   </body>

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -77,6 +77,14 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * browser's viewport. Defaults to `layout`.
    */
   containment: 'layout' | 'viewport';
+
+  /**
+   * The threshold (in CSS length units) at which the layout switches to
+   * the "stack" mode, making detail area fully cover the master area.
+   *
+   * @attr {string} stack-threshold
+   */
+  stackThreshold: string | null | undefined;
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -161,6 +161,10 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
       :host([stack]) [part='detail'] {
         inset: 0;
       }
+
+      [part='master']::before {
+        background-position-y: var(--_stack-threshold);
+      }
     `;
   }
 
@@ -344,6 +348,12 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
   /** @private */
   __stackThresholdChanged(threshold, oldThreshold) {
     if (threshold || oldThreshold) {
+      if (threshold) {
+        this.$.master.style.setProperty('--_stack-threshold', threshold);
+      } else {
+        this.$.master.style.removeProperty('--_stack-threshold');
+      }
+
       this.__detectLayoutMode();
     }
   }
@@ -376,7 +386,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     if (this.stackThreshold != null) {
       this.removeAttribute('stack');
 
-      const threshold = this.__getStackThreshold();
+      const threshold = this.__getStackThresholdInPixels();
       const size = this.orientation === 'vertical' ? this.offsetHeight : this.offsetWidth;
       if (size <= threshold) {
         this.removeAttribute('overlay');
@@ -438,13 +448,9 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
   }
 
   /** @private */
-  __getStackThreshold() {
-    // Use background-position temp inline style for unit conversion
-    const tmpStyleProp = 'background-position';
-    this.style.setProperty(tmpStyleProp, this.stackThreshold);
-    const stackThresholdPx = getComputedStyle(this).getPropertyValue(tmpStyleProp);
-    this.style.removeProperty(tmpStyleProp);
-    return parseFloat(stackThresholdPx);
+  __getStackThresholdInPixels() {
+    const { backgroundPositionY } = getComputedStyle(this.$.master, '::before');
+    return parseFloat(backgroundPositionY);
   }
 }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -87,7 +87,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         width: var(--_master-size);
       }
 
-      :host([has-detail-size][orientation='horizontal']) [part='detail'] {
+      :host([has-detail-size][orientation='horizontal']:not([stack])) [part='detail'] {
         width: var(--_detail-size);
       }
 
@@ -106,7 +106,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         min-width: var(--_master-min-size);
       }
 
-      :host([has-detail-min-size][orientation='horizontal']:not([overlay])) [part='detail'] {
+      :host([has-detail-min-size][orientation='horizontal']:not([overlay]):not([stack])) [part='detail'] {
         min-width: var(--_detail-min-size);
       }
 
@@ -139,7 +139,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         height: var(--_master-size);
       }
 
-      :host([has-detail-size][orientation='vertical']) [part='detail'] {
+      :host([has-detail-size][orientation='vertical']:not([stack])) [part='detail'] {
         height: var(--_detail-size);
       }
 
@@ -149,7 +149,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         min-height: var(--_master-min-size);
       }
 
-      :host([has-detail-min-size][orientation='vertical']:not([overlay])) [part='detail'] {
+      :host([has-detail-min-size][orientation='vertical']:not([overlay]):not([stack])) [part='detail'] {
         min-height: var(--_detail-min-size);
       }
 

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -571,6 +571,30 @@ describe('vaadin-master-detail-layout', () => {
         expect(layout.hasAttribute('overlay')).to.be.true;
       });
 
+      it('should not apply min-width to the detail area in the stack mode', async () => {
+        layout.detailMinSize = '500px';
+        layout.stackThreshold = '500px';
+        await nextRender();
+
+        await setViewport({ width: 450, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).width).to.equal('450px');
+      });
+
+      it('should not apply width to the detail area in the stack mode', async () => {
+        layout.detailSize = '500px';
+        layout.stackThreshold = '500px';
+        await nextRender();
+
+        await setViewport({ width: 450, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).width).to.equal('450px');
+      });
+
       it('should update stack mode when adding and removing details', async () => {
         layout.stackThreshold = '500px';
 
@@ -616,6 +640,30 @@ describe('vaadin-master-detail-layout', () => {
         expect(layout.hasAttribute('stack')).to.be.true;
         expect(getComputedStyle(detail).position).to.equal('absolute');
         expect(getComputedStyle(detail).inset).to.equal('0px');
+      });
+
+      it('should not apply min-height to the detail area in the stack mode', async () => {
+        layout.detailMinSize = '500px';
+        layout.stackThreshold = '500px';
+        await nextRender();
+
+        await setViewport({ width, height: 450 });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).height).to.equal('450px');
+      });
+
+      it('should not apply height to the detail area in the stack mode', async () => {
+        layout.detailSize = '500px';
+        layout.stackThreshold = '500px';
+        await nextRender();
+
+        await setViewport({ width, height: 450 });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).height).to.equal('450px');
       });
     });
   });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -519,4 +519,104 @@ describe('vaadin-master-detail-layout', () => {
       });
     });
   });
+
+  describe('stack', () => {
+    let width, height;
+
+    before(() => {
+      width = window.innerWidth;
+      height = window.innerHeight;
+    });
+
+    afterEach(async () => {
+      await setViewport({ width, height });
+    });
+
+    describe('default', () => {
+      it('should switch from overlay to the stack mode when the stack threshold is set', async () => {
+        // Use the threshold at which the overlay mode is on by default.
+        await setViewport({ width: 350, height });
+        await nextResize(layout);
+
+        layout.stackThreshold = '400px';
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).inset).to.equal('0px');
+      });
+
+      it('should clear the stack mode when the layout size is bigger than stack threshold', async () => {
+        layout.stackThreshold = '400px';
+        await nextRender();
+
+        await setViewport({ width: 350, height });
+        await nextResize(layout);
+
+        await setViewport({ width: 450, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.false;
+      });
+
+      it('should not switch to the stack mode when forceOverlay is set to true', async () => {
+        layout.forceOverlay = true;
+        layout.stackThreshold = '500px';
+        await nextRender();
+
+        await setViewport({ width: 450, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.false;
+        expect(layout.hasAttribute('overlay')).to.be.true;
+      });
+
+      it('should update stack mode when adding and removing details', async () => {
+        layout.stackThreshold = '500px';
+
+        // Start without details
+        detailContent.remove();
+        await nextRender();
+
+        // Shrink viewport
+        await setViewport({ width: 450, height });
+        await nextResize(layout);
+
+        expect(layout.hasAttribute('stack')).to.be.false;
+
+        // Add details
+        layout.appendChild(detailContent);
+        await nextRender();
+
+        expect(layout.hasAttribute('stack')).to.be.true;
+
+        // Remove details
+        detailContent.remove();
+        await nextRender();
+
+        expect(layout.hasAttribute('stack')).to.be.false;
+      });
+    });
+
+    describe('vertical orientation', () => {
+      beforeEach(() => {
+        layout.orientation = 'vertical';
+        layout.style.maxHeight = '500px';
+        layout.parentElement.style.height = '100%';
+      });
+
+      it('should switch from overlay to the stack mode when the stack threshold is set', async () => {
+        // Use the threshold at which the overlay mode is on by default.
+        await setViewport({ width: 500, height: 400 });
+        await nextResize(layout);
+
+        layout.stackThreshold = '400px';
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
+        expect(getComputedStyle(detail).inset).to.equal('0px');
+      });
+    });
+  });
 });

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -642,6 +642,21 @@ describe('vaadin-master-detail-layout', () => {
         expect(getComputedStyle(detail).inset).to.equal('0px');
       });
 
+      it('should use fixed position in the stack mode when viewport containment is used', async () => {
+        layout.containment = 'viewport';
+
+        // Use the threshold at which the overlay mode is on by default.
+        await setViewport({ width: 500, height: 400 });
+        await nextResize(layout);
+
+        layout.stackThreshold = '400px';
+
+        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('fixed');
+        expect(getComputedStyle(detail).inset).to.equal('0px');
+      });
+
       it('should not apply min-height to the detail area in the stack mode', async () => {
         layout.detailMinSize = '500px';
         layout.stackThreshold = '500px';

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -17,3 +17,4 @@ assertType<string | null | undefined>(layout.masterSize);
 assertType<string | null | undefined>(layout.masterMinSize);
 assertType<'horizontal' | 'vertical'>(layout.orientation);
 assertType<boolean>(layout.forceOverlay);
+assertType<string | null | undefined>(layout.stackThreshold);


### PR DESCRIPTION
## Description

Fixes #8804

Added `stachThreshold` property to control at which point the layout should switch to the stack mode.

## Type of change

- Feature