### PR TITLE
refactor: use Lit for rendering menu-bar buttons

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -429,7 +429,7 @@ export const MenuBarMixin = (superClass) =>
 
         // Close sub-menu if the corresponding button is no longer in the DOM,
         // or if the item on it has been changed to no longer have children.
-        if (!button.isConnected || !button.item.children) {
+        if (!button.isConnected || !Array.isArray(button.item.children) || button.item.children.length === 0) {
           subMenu.close();
         }
       }

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -379,7 +379,7 @@ describe('item components', () => {
   });
 
   it('should render the component inside the menu-bar item', () => {
-    const item = buttons[2].firstChild;
+    const item = buttons[2].firstElementChild;
     expect(item).to.equal(buttons[2].item.component);
     expect(item.localName).to.equal('vaadin-menu-bar-item');
     const div = item.firstChild;
@@ -390,10 +390,10 @@ describe('item components', () => {
   });
 
   it('should override the component text when defined on the item', () => {
-    const item = buttons[3].firstChild;
+    const item = buttons[3].firstElementChild;
     expect(item).to.equal(buttons[3].item.component);
     expect(item.localName).to.equal('vaadin-menu-bar-item');
-    const div = item.firstChild;
+    const div = item.firstElementChild;
     expect(div).to.equal(menu.items[3].component);
     expect(div.localName).to.equal('div');
     expect(div.textContent).to.equal('Item 4 text');
@@ -401,7 +401,7 @@ describe('item components', () => {
   });
 
   it('should render provided menu-bar item as a component', () => {
-    expect(buttons[4].firstChild).to.equal(buttons[4].item.component);
+    expect(buttons[4].firstElementChild).to.equal(buttons[4].item.component);
     expect(buttons[4].item.component).to.equal(menu.items[4].component);
     expect(buttons[4].item.component.children.length).to.equal(0);
     expect(buttons[4].item.component.textContent).to.equal('Item 5');

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -492,13 +492,13 @@ describe('overflow', () => {
       await nextUpdate(menu);
       menu.style.width = 'auto';
       await nextResize(menu);
-      const item = buttons[2].firstChild;
+      const item = buttons[2].firstElementChild;
       expect(item).to.equal(buttons[2].item.component);
       expect(item.getAttribute('role')).to.not.equal('menuitem');
     });
 
     it('should restore menu bar item attribute state when moved from sub-menu back to menu bar', async () => {
-      const item = buttons[5].firstChild;
+      const item = buttons[5].firstElementChild;
       const itemAttributes = item.getAttributeNames();
       overflow.click();
       await nextRender(subMenu);
@@ -511,7 +511,7 @@ describe('overflow', () => {
 
     it('should keep the class names when moved to sub-menu and back', async () => {
       // Simulate a custom class name being added through the Flow menu bar item component
-      const item = buttons[5].firstChild;
+      const item = buttons[5].firstElementChild;
       item.classList.add('test-class-1');
       overflow.click();
       await nextRender(subMenu);

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -532,6 +532,15 @@ describe('sub-menu', () => {
     expect(subMenu.opened).to.be.false;
   });
 
+  it('should close sub-menu on items change if item has empty children', async () => {
+    buttons[0].click();
+    await nextRender(subMenu);
+
+    menu.items = [{ text: 'Menu Item 0', children: [] }, ...menu.items];
+    await nextRender(subMenu);
+    expect(subMenu.opened).to.be.false;
+  });
+
   describe('expanded attribute', () => {
     it('should toggle expanded attribute on button with nested items clicked', async () => {
       buttons[0].click();

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -514,11 +514,20 @@ describe('sub-menu', () => {
     });
   });
 
-  it('should close sub-menu on items change', async () => {
+  it('should not close sub-menu on items change if item has not changed', async () => {
     buttons[0].click();
     await nextRender(subMenu);
 
     menu.items = [...menu.items, { text: 'Menu Item 1' }];
+    await nextRender(subMenu);
+    expect(subMenu.opened).to.be.true;
+  });
+
+  it('should close sub-menu on items change if item no longer has children', async () => {
+    buttons[0].click();
+    await nextRender(subMenu);
+
+    menu.items = [{ text: 'Menu Item 0' }, ...menu.items];
     await nextRender(subMenu);
     expect(subMenu.opened).to.be.false;
   });


### PR DESCRIPTION
## Description

Fixes #8827

Note: this needs some manual testing with the Flow counterpart. In theory this shouldn't be a breaking change but it can be considered as "behavior altering" - for example, I had to update a few tests using `button.firstChild` since there are now comment nodes created by Lit, and this could potentially affect some users who do the same in tests.

## Type of change

- Refactor