### PR TITLE
fix: only set has-bounds-set attribute on dialog resize

### DIFF
--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.js
@@ -204,7 +204,6 @@ export const DialogOverlayMixin = (superClass) =>
 
       if (absolute && overlay.style.position !== 'absolute') {
         overlay.style.position = 'absolute';
-        this.setAttribute('has-bounds-set', '');
       }
 
       Object.keys(parsedBounds).forEach((arg) => {

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -75,6 +75,10 @@ export const DialogResizableMixin = (superClass) =>
         if (this.$.overlay.$.overlay.style.position !== 'absolute' || this.width || this.height) {
           this.$.overlay.setBounds(this._originalBounds);
         }
+
+        if (!this.$.overlay.hasAttribute('has-bounds-set')) {
+          this.$.overlay.setAttribute('has-bounds-set', '');
+        }
       }
     }
 

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -76,9 +76,7 @@ export const DialogResizableMixin = (superClass) =>
           this.$.overlay.setBounds(this._originalBounds);
         }
 
-        if (!this.$.overlay.hasAttribute('has-bounds-set')) {
-          this.$.overlay.setAttribute('has-bounds-set', '');
-        }
+        this.$.overlay.setAttribute('has-bounds-set', '');
       }
     }
 

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -368,6 +368,12 @@ describe('resizable', () => {
     await nextRender();
     expect(Math.floor(bounds.width)).to.equal(parseInt(overlay.style.width));
   });
+
+  it('should set overlay max-width to none on resize', async () => {
+    resize(overlayPart.querySelector('.s'), 0, dx);
+    await nextRender();
+    expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('none');
+  });
 });
 
 describe('draggable', () => {
@@ -610,6 +616,12 @@ describe('draggable', () => {
     const { detail } = onDragged.args[0][0];
     expect(detail.top).to.be.equal(dialog.top);
     expect(detail.left).to.be.equal(dialog.left);
+  });
+
+  it('should not set overlay max-width to none on drag', async () => {
+    drag(container);
+    await nextRender();
+    expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('100%');
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #8790

Follow-up to #8722

Looks like we only need to apply `has-bounds-set` on resize, as pointed out by the issue creator. This PR does that.
Note: we could rename attribute as it's now set outside of `setBounds()` method but maybe it's ok to keep it as is.

## Type of change

- Bugfix