### PR TITLE
feat: support partial i18n in menu bar

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
@@ -9,6 +9,7 @@ import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { KeyboardDirectionMixinClass } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import type { KeyboardMixinClass } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 
 export type MenuBarItem<TItemData extends object = object> = {
@@ -56,7 +57,7 @@ export type SubMenuItem<TItemData extends object = object> = {
 } & TItemData;
 
 export interface MenuBarI18n {
-  moreOptions: string;
+  moreOptions?: string;
 }
 
 export declare function MenuBarMixin<T extends Constructor<HTMLElement>, TItem extends MenuBarItem = MenuBarItem>(
@@ -64,6 +65,7 @@ export declare function MenuBarMixin<T extends Constructor<HTMLElement>, TItem e
 ): Constructor<ControllerMixinClass> &
   Constructor<DisabledMixinClass> &
   Constructor<FocusMixinClass> &
+  Constructor<I18nMixinClass<MenuBarI18n>> &
   Constructor<KeyboardDirectionMixinClass> &
   Constructor<KeyboardMixinClass> &
   Constructor<MenuBarMixinClass<TItem>> &
@@ -121,17 +123,9 @@ export declare class MenuBarMixinClass<TItem extends MenuBarItem = MenuBarItem> 
   items: TItem[];
 
   /**
-   * The object used to localize this component.
-   * To change the default localization, replace the entire
-   * `i18n` object with a custom one.
-   *
-   * To update individual properties, extend the existing i18n object like so:
-   * ```
-   * menuBar.i18n = {
-   *   ...menuBar.i18n,
-   *   moreOptions: 'More options'
-   * }
-   * ```
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
    *
    * The object has the following JSON structure and default values:
    * ```

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -8,20 +8,27 @@ import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { isElementFocused, isElementHidden, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
+const DEFAULT_I18N = {
+  moreOptions: 'More options',
+};
+
 /**
  * @polymerMixin
- * @mixes DisabledMixin
  * @mixes ControllerMixin
+ * @mixes DisabledMixin
  * @mixes FocusMixin
+ * @mixes I18nMixin
  * @mixes KeyboardDirectionMixin
  * @mixes ResizeMixin
  */
 export const MenuBarMixin = (superClass) =>
-  class MenuBarMixinClass extends KeyboardDirectionMixin(
-    ResizeMixin(FocusMixin(DisabledMixin(ControllerMixin(superClass)))),
+  class MenuBarMixinClass extends I18nMixin(
+    DEFAULT_I18N,
+    KeyboardDirectionMixin(ResizeMixin(FocusMixin(DisabledMixin(ControllerMixin(superClass))))),
   ) {
     static get properties() {
       return {
@@ -109,38 +116,6 @@ export const MenuBarMixin = (superClass) =>
         },
 
         /**
-         * The object used to localize this component.
-         * To change the default localization, replace the entire
-         * `i18n` object with a custom one.
-         *
-         * To update individual properties, extend the existing i18n object like so:
-         * ```
-         * menuBar.i18n = {
-         *   ...menuBar.i18n,
-         *   moreOptions: 'More options'
-         * }
-         * ```
-         *
-         * The object has the following JSON structure and default values:
-         * ```
-         * {
-         *   moreOptions: 'More options'
-         * }
-         * ```
-         *
-         * @type {!MenuBarI18n}
-         * @default {English/US}
-         */
-        i18n: {
-          type: Object,
-          value: () => {
-            return {
-              moreOptions: 'More options',
-            };
-          },
-        },
-
-        /**
          * A space-delimited list of CSS class names
          * to set on each sub-menu overlay element.
          *
@@ -202,11 +177,32 @@ export const MenuBarMixin = (superClass) =>
       return [
         '_themeChanged(_theme, _overflow, _container)',
         '__hasOverflowChanged(_hasOverflow, _overflow)',
-        '__i18nChanged(i18n, _overflow)',
+        '__i18nChanged(__effectiveI18n, _overflow)',
         '_menuItemsChanged(items, _overflow, _container)',
         '_reverseCollapseChanged(reverseCollapse, _overflow, _container)',
         '_tabNavigationChanged(tabNavigation, _overflow, _container)',
       ];
+    }
+
+    /**
+     * The object used to localize this component. To change the default
+     * localization, replace this with an object that provides all properties, or
+     * just the individual properties you want to change.
+     *
+     * The object has the following JSON structure and default values:
+     * ```
+     * {
+     *   moreOptions: 'More options'
+     * }
+     * ```
+     * @return {!MenuBarI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
     }
 
     constructor() {
@@ -423,10 +419,10 @@ export const MenuBarMixin = (superClass) =>
     }
 
     /** @private */
-    __i18nChanged(i18n, overflow) {
-      if (overflow && i18n && i18n.moreOptions !== undefined) {
-        if (i18n.moreOptions) {
-          overflow.setAttribute('aria-label', i18n.moreOptions);
+    __i18nChanged(effectiveI18n, overflow) {
+      if (overflow && effectiveI18n && effectiveI18n.moreOptions !== undefined) {
+        if (effectiveI18n.moreOptions) {
+          overflow.setAttribute('aria-label', effectiveI18n.moreOptions);
         } else {
           overflow.removeAttribute('aria-label');
         }

--- a/packages/menu-bar/test/typings/menu-bar.types.ts
+++ b/packages/menu-bar/test/typings/menu-bar.types.ts
@@ -3,13 +3,14 @@ import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 import type { ListMixinClass } from '@vaadin/a11y-base/src/list-mixin.js';
 import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 import type { DirMixinClass } from '@vaadin/component-base/src/dir-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
 import type { ItemMixinClass } from '@vaadin/item/src/vaadin-item-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { MenuBarItem } from '../../src/vaadin-menu-bar-item.js';
 import type { MenuBarListBox } from '../../src/vaadin-menu-bar-list-box.js';
-import type { MenuBarMixinClass } from '../../src/vaadin-menu-bar-mixin.js';
+import type { MenuBarI18n, MenuBarMixinClass } from '../../src/vaadin-menu-bar-mixin.js';
 import type { MenuBar, MenuBarItem as MenuItem, MenuBarItemSelectedEvent } from '../../vaadin-menu-bar.js';
 
 const menu = document.createElement('vaadin-menu-bar');
@@ -24,6 +25,7 @@ assertType<string>(menu.overlayClass);
 assertType<ResizeMixinClass>(menu);
 assertType<ControllerMixinClass>(menu);
 assertType<FocusMixinClass>(menu);
+assertType<I18nMixinClass<MenuBarI18n>>(menu);
 assertType<MenuBarMixinClass>(menu);
 assertType<ThemableMixinClass>(menu);
 assertType<ThemePropertyMixinClass>(menu);
@@ -57,6 +59,10 @@ assertType<ItemData>(narrowedMenu.items[0].children![0].children![0]);
 narrowedMenu.addEventListener('item-selected', (event) => {
   assertType<ItemData>(event.detail.value);
 });
+
+// I18n
+assertType<MenuBarI18n>({});
+assertType<MenuBarI18n>({ moreOptions: 'More' });
 
 // Item
 const item = document.createElement('vaadin-menu-bar-item');


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to menu bar. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
