### PR TITLE
feat: support partial i18n in rich text editor

### DIFF
--- a/packages/rich-text-editor/src/vaadin-lit-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-lit-rich-text-editor.js
@@ -56,7 +56,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-undo"
               @click="${this._undo}"
             ></button>
-            <vaadin-tooltip for="btn-undo" .text="${this.i18n.undo}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-undo" .text="${this.__effectiveI18n.undo}"></vaadin-tooltip>
 
             <button
               id="btn-redo"
@@ -64,25 +64,25 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-redo"
               @click="${this._redo}"
             ></button>
-            <vaadin-tooltip for="btn-redo" .text="${this.i18n.redo}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-redo" .text="${this.__effectiveI18n.redo}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-emphasis">
             <!-- Bold -->
             <button id="btn-bold" class="ql-bold" part="toolbar-button toolbar-button-bold"></button>
-            <vaadin-tooltip for="btn-bold" .text="${this.i18n.bold}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-bold" .text="${this.__effectiveI18n.bold}"></vaadin-tooltip>
 
             <!-- Italic -->
             <button id="btn-italic" class="ql-italic" part="toolbar-button toolbar-button-italic"></button>
-            <vaadin-tooltip for="btn-italic" .text="${this.i18n.italic}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-italic" .text="${this.__effectiveI18n.italic}"></vaadin-tooltip>
 
             <!-- Underline -->
             <button id="btn-underline" class="ql-underline" part="toolbar-button toolbar-button-underline"></button>
-            <vaadin-tooltip for="btn-underline" .text="${this.i18n.underline}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-underline" .text="${this.__effectiveI18n.underline}"></vaadin-tooltip>
 
             <!-- Strike -->
             <button id="btn-strike" class="ql-strike" part="toolbar-button toolbar-button-strike"></button>
-            <vaadin-tooltip for="btn-strike" .text="${this.i18n.strike}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-strike" .text="${this.__effectiveI18n.strike}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-style">
@@ -93,7 +93,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-color"
               @click="${this.__onColorClick}"
             ></button>
-            <vaadin-tooltip for="btn-color" .text="${this.i18n.color}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-color" .text="${this.__effectiveI18n.color}"></vaadin-tooltip>
             <!-- Background -->
             <button
               id="btn-background"
@@ -101,7 +101,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-background"
               @click="${this.__onBackgroundClick}"
             ></button>
-            <vaadin-tooltip for="btn-background" .text="${this.i18n.background}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-background" .text="${this.__effectiveI18n.background}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-heading">
@@ -113,7 +113,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="1"
               part="toolbar-button toolbar-button-h1"
             ></button>
-            <vaadin-tooltip for="btn-h1" .text="${this.i18n.h1}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-h1" .text="${this.__effectiveI18n.h1}"></vaadin-tooltip>
             <button
               id="btn-h2"
               type="button"
@@ -121,7 +121,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="2"
               part="toolbar-button toolbar-button-h2"
             ></button>
-            <vaadin-tooltip for="btn-h2" .text="${this.i18n.h2}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-h2" .text="${this.__effectiveI18n.h2}"></vaadin-tooltip>
             <button
               id="btn-h3"
               type="button"
@@ -129,7 +129,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="3"
               part="toolbar-button toolbar-button-h3"
             ></button>
-            <vaadin-tooltip for="btn-h3" .text="${this.i18n.h3}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-h3" .text="${this.__effectiveI18n.h3}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-glyph-transformation">
@@ -140,14 +140,14 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="sub"
               part="toolbar-button toolbar-button-subscript"
             ></button>
-            <vaadin-tooltip for="btn-subscript" .text="${this.i18n.subscript}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-subscript" .text="${this.__effectiveI18n.subscript}"></vaadin-tooltip>
             <button
               id="btn-superscript"
               class="ql-script"
               value="super"
               part="toolbar-button toolbar-button-superscript"
             ></button>
-            <vaadin-tooltip for="btn-superscript" text="${this.i18n.superscript}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-superscript" text="${this.__effectiveI18n.superscript}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-list">
@@ -159,7 +159,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="ordered"
               part="toolbar-button toolbar-button-list-ordered"
             ></button>
-            <vaadin-tooltip for="btn-ol" text="${this.i18n.listOrdered}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-ol" text="${this.__effectiveI18n.listOrdered}"></vaadin-tooltip>
             <button
               id="btn-ul"
               type="button"
@@ -167,7 +167,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="bullet"
               part="toolbar-button toolbar-button-list-bullet"
             ></button>
-            <vaadin-tooltip for="btn-ul" text="${this.i18n.listBullet}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-ul" text="${this.__effectiveI18n.listBullet}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-alignment">
@@ -179,7 +179,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value=""
               part="toolbar-button toolbar-button-align-left"
             ></button>
-            <vaadin-tooltip for="btn-left" .text="${this.i18n.alignLeft}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-left" .text="${this.__effectiveI18n.alignLeft}"></vaadin-tooltip>
             <button
               id="btn-center"
               type="button"
@@ -187,7 +187,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="center"
               part="toolbar-button toolbar-button-align-center"
             ></button>
-            <vaadin-tooltip for="btn-center" .text="${this.i18n.alignCenter}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-center" .text="${this.__effectiveI18n.alignCenter}"></vaadin-tooltip>
             <button
               id="btn-right"
               type="button"
@@ -195,7 +195,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="right"
               part="toolbar-button toolbar-button-align-right"
             ></button>
-            <vaadin-tooltip for="btn-right" .text="${this.i18n.alignRight}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-right" .text="${this.__effectiveI18n.alignRight}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-rich-text">
@@ -207,7 +207,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               @touchend="${this._onImageTouchEnd}"
               @click="${this._onImageClick}"
             ></button>
-            <vaadin-tooltip for="btn-image" .text="${this.i18n.image}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-image" .text="${this.__effectiveI18n.image}"></vaadin-tooltip>
             <!-- Link -->
             <button
               id="btn-link"
@@ -215,7 +215,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-link"
               @click="${this._onLinkClick}"
             ></button>
-            <vaadin-tooltip for="btn-link" .text="${this.i18n.link}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-link" .text="${this.__effectiveI18n.link}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-block">
@@ -226,7 +226,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               class="ql-blockquote"
               part="toolbar-button toolbar-button-blockquote"
             ></button>
-            <vaadin-tooltip for="btn-blockquote" .text="${this.i18n.blockquote}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-blockquote" .text="${this.__effectiveI18n.blockquote}"></vaadin-tooltip>
             <!-- Code block -->
             <button
               id="btn-code"
@@ -234,13 +234,13 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               class="ql-code-block"
               part="toolbar-button toolbar-button-code-block"
             ></button>
-            <vaadin-tooltip for="btn-code" .text="${this.i18n.codeBlock}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-code" .text="${this.__effectiveI18n.codeBlock}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-format">
             <!-- Clean -->
             <button id="btn-clean" type="button" class="ql-clean" part="toolbar-button toolbar-button-clean"></button>
-            <vaadin-tooltip for="btn-clean" .text="${this.i18n.clean}"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-clean" .text="${this.__effectiveI18n.clean}"></vaadin-tooltip>
           </span>
 
           <input
@@ -259,7 +259,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
       <vaadin-confirm-dialog
         id="linkDialog"
         .opened="${this._linkEditing}"
-        .header="${this.i18n.linkDialogTitle}"
+        .header="${this.__effectiveI18n.linkDialogTitle}"
         @opened-changed="${this._onLinkEditingChanged}"
       >
         <vaadin-text-field
@@ -270,7 +270,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
           @value-changed="${this._onLinkUrlChanged}"
         ></vaadin-text-field>
         <vaadin-button id="confirmLink" slot="confirm-button" theme="primary" @click="${this._onLinkEditConfirm}">
-          ${this.i18n.ok}
+          ${this.__effectiveI18n.ok}
         </vaadin-button>
         <vaadin-button
           id="removeLink"
@@ -279,10 +279,10 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
           @click="${this._onLinkEditRemove}"
           ?hidden="${!this._linkRange}"
         >
-          ${this.i18n.remove}
+          ${this.__effectiveI18n.remove}
         </vaadin-button>
         <vaadin-button id="cancelLink" slot="cancel-button" @click="${this._onLinkEditCancel}">
-          ${this.i18n.cancel}
+          ${this.__effectiveI18n.cancel}
         </vaadin-button>
       </vaadin-confirm-dialog>
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.d.ts
@@ -9,35 +9,36 @@
  * license.
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 
 export interface RichTextEditorI18n {
-  undo: string;
-  redo: string;
-  bold: string;
-  italic: string;
-  underline: string;
-  strike: string;
-  color: string;
-  background: string;
-  h1: string;
-  h2: string;
-  h3: string;
-  subscript: string;
-  superscript: string;
-  listOrdered: string;
-  listBullet: string;
-  alignLeft: string;
-  alignCenter: string;
-  alignRight: string;
-  image: string;
-  link: string;
-  blockquote: string;
-  codeBlock: string;
-  clean: string;
-  linkDialogTitle: string;
-  ok: string;
-  cancel: string;
-  remove: string;
+  undo?: string;
+  redo?: string;
+  bold?: string;
+  italic?: string;
+  underline?: string;
+  strike?: string;
+  color?: string;
+  background?: string;
+  h1?: string;
+  h2?: string;
+  h3?: string;
+  subscript?: string;
+  superscript?: string;
+  listOrdered?: string;
+  listBullet?: string;
+  alignLeft?: string;
+  alignCenter?: string;
+  alignRight?: string;
+  image?: string;
+  link?: string;
+  blockquote?: string;
+  codeBlock?: string;
+  clean?: string;
+  linkDialogTitle?: string;
+  ok?: string;
+  cancel?: string;
+  remove?: string;
 }
 
 /**
@@ -58,7 +59,7 @@ export interface RichTextEditorCustomEventMap {
 
 export declare function RichTextEditorMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<RichTextEditorMixinClass> & T;
+): Constructor<RichTextEditorMixinClass> & I18nMixinClass<RichTextEditorI18n> & T;
 
 export declare class RichTextEditorMixinClass {
   /**
@@ -93,8 +94,12 @@ export declare class RichTextEditorMixinClass {
   readonly: boolean;
 
   /**
-   * An object used to localize this component. The properties are used
-   * e.g. as the tooltips for the editor toolbar buttons.
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
+   *
+   * The properties are used e.g. as the tooltips for the editor toolbar
+   * buttons.
    */
   i18n: RichTextEditorI18n;
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -12,6 +12,7 @@ import '../vendor/vaadin-quill.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { isFirefox } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 
 const Quill = window.Quill;
 
@@ -71,11 +72,41 @@ const STATE = {
 
 const TAB_KEY = 9;
 
+const DEFAULT_I18N = {
+  undo: 'undo',
+  redo: 'redo',
+  bold: 'bold',
+  italic: 'italic',
+  underline: 'underline',
+  strike: 'strike',
+  color: 'color',
+  background: 'background',
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  subscript: 'subscript',
+  superscript: 'superscript',
+  listOrdered: 'list ordered',
+  listBullet: 'list bullet',
+  alignLeft: 'align left',
+  alignCenter: 'align center',
+  alignRight: 'align right',
+  image: 'image',
+  link: 'link',
+  blockquote: 'blockquote',
+  codeBlock: 'code block',
+  clean: 'clean',
+  linkDialogTitle: 'Link address',
+  ok: 'OK',
+  cancel: 'Cancel',
+  remove: 'Remove',
+};
+
 /**
  * @polymerMixin
  */
 export const RichTextEditorMixin = (superClass) =>
-  class RichTextEditorMixinClass extends superClass {
+  class RichTextEditorMixinClass extends I18nMixin(DEFAULT_I18N, superClass) {
     static get properties() {
       return {
         /**
@@ -127,48 +158,6 @@ export const RichTextEditorMixin = (superClass) =>
           type: Boolean,
           value: false,
           reflectToAttribute: true,
-        },
-
-        /**
-         * An object used to localize this component. The properties are used
-         * e.g. as the tooltips for the editor toolbar buttons.
-         *
-         * @type {!RichTextEditorI18n}
-         * @default {English/US}
-         */
-        i18n: {
-          type: Object,
-          value: () => {
-            return {
-              undo: 'undo',
-              redo: 'redo',
-              bold: 'bold',
-              italic: 'italic',
-              underline: 'underline',
-              strike: 'strike',
-              color: 'color',
-              background: 'background',
-              h1: 'h1',
-              h2: 'h2',
-              h3: 'h3',
-              subscript: 'subscript',
-              superscript: 'superscript',
-              listOrdered: 'list ordered',
-              listBullet: 'list bullet',
-              alignLeft: 'align left',
-              alignCenter: 'align center',
-              alignRight: 'align right',
-              image: 'image',
-              link: 'link',
-              blockquote: 'blockquote',
-              codeBlock: 'code block',
-              clean: 'clean',
-              linkDialogTitle: 'Link address',
-              ok: 'OK',
-              cancel: 'Cancel',
-              remove: 'Remove',
-            };
-          },
         },
 
         /**
@@ -263,6 +252,24 @@ export const RichTextEditorMixin = (superClass) =>
 
     static get observers() {
       return ['_valueChanged(value, _editor)', '_disabledChanged(disabled, readonly, _editor)'];
+    }
+
+    /**
+     * The object used to localize this component. To change the default
+     * localization, replace this with an object that provides all properties, or
+     * just the individual properties you want to change.
+     *
+     * The properties are used e.g. as the tooltips for the editor toolbar
+     * buttons.
+     *
+     * @return {!RichTextEditorI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
     }
 
     /** @private */

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -110,28 +110,28 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
           <span part="toolbar-group toolbar-group-history">
             <!-- Undo and Redo -->
             <button id="btn-undo" type="button" part="toolbar-button toolbar-button-undo" on-click="_undo"></button>
-            <vaadin-tooltip for="btn-undo" text="[[i18n.undo]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-undo" text="[[__effectiveI18n.undo]]"></vaadin-tooltip>
 
             <button id="btn-redo" type="button" part="toolbar-button toolbar-button-redo" on-click="_redo"></button>
-            <vaadin-tooltip for="btn-redo" text="[[i18n.redo]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-redo" text="[[__effectiveI18n.redo]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-emphasis">
             <!-- Bold -->
             <button id="btn-bold" class="ql-bold" part="toolbar-button toolbar-button-bold"></button>
-            <vaadin-tooltip for="btn-bold" text="[[i18n.bold]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-bold" text="[[__effectiveI18n.bold]]"></vaadin-tooltip>
 
             <!-- Italic -->
             <button id="btn-italic" class="ql-italic" part="toolbar-button toolbar-button-italic"></button>
-            <vaadin-tooltip for="btn-italic" text="[[i18n.italic]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-italic" text="[[__effectiveI18n.italic]]"></vaadin-tooltip>
 
             <!-- Underline -->
             <button id="btn-underline" class="ql-underline" part="toolbar-button toolbar-button-underline"></button>
-            <vaadin-tooltip for="btn-underline" text="[[i18n.underline]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-underline" text="[[__effectiveI18n.underline]]"></vaadin-tooltip>
 
             <!-- Strike -->
             <button id="btn-strike" class="ql-strike" part="toolbar-button toolbar-button-strike"></button>
-            <vaadin-tooltip for="btn-strike" text="[[i18n.strike]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-strike" text="[[__effectiveI18n.strike]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-style">
@@ -142,7 +142,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-color"
               on-click="__onColorClick"
             ></button>
-            <vaadin-tooltip for="btn-color" text="[[i18n.color]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-color" text="[[__effectiveI18n.color]]"></vaadin-tooltip>
             <!-- Background -->
             <button
               id="btn-background"
@@ -150,7 +150,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-background"
               on-click="__onBackgroundClick"
             ></button>
-            <vaadin-tooltip for="btn-background" text="[[i18n.background]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-background" text="[[__effectiveI18n.background]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-heading">
@@ -162,7 +162,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="1"
               part="toolbar-button toolbar-button-h1"
             ></button>
-            <vaadin-tooltip for="btn-h1" text="[[i18n.h1]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-h1" text="[[__effectiveI18n.h1]]"></vaadin-tooltip>
             <button
               id="btn-h2"
               type="button"
@@ -170,7 +170,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="2"
               part="toolbar-button toolbar-button-h2"
             ></button>
-            <vaadin-tooltip for="btn-h2" text="[[i18n.h2]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-h2" text="[[__effectiveI18n.h2]]"></vaadin-tooltip>
             <button
               id="btn-h3"
               type="button"
@@ -178,7 +178,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="3"
               part="toolbar-button toolbar-button-h3"
             ></button>
-            <vaadin-tooltip for="btn-h3" text="[[i18n.h3]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-h3" text="[[__effectiveI18n.h3]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-glyph-transformation">
@@ -189,14 +189,14 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="sub"
               part="toolbar-button toolbar-button-subscript"
             ></button>
-            <vaadin-tooltip for="btn-subscript" text="[[i18n.subscript]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-subscript" text="[[__effectiveI18n.subscript]]"></vaadin-tooltip>
             <button
               id="btn-superscript"
               class="ql-script"
               value="super"
               part="toolbar-button toolbar-button-superscript"
             ></button>
-            <vaadin-tooltip for="btn-superscript" text="[[i18n.superscript]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-superscript" text="[[__effectiveI18n.superscript]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-list">
@@ -208,7 +208,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="ordered"
               part="toolbar-button toolbar-button-list-ordered"
             ></button>
-            <vaadin-tooltip for="btn-ol" text="[[i18n.listOrdered]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-ol" text="[[__effectiveI18n.listOrdered]]"></vaadin-tooltip>
             <button
               id="btn-ul"
               type="button"
@@ -216,7 +216,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="bullet"
               part="toolbar-button toolbar-button-list-bullet"
             ></button>
-            <vaadin-tooltip for="btn-ul" text="[[i18n.listBullet]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-ul" text="[[__effectiveI18n.listBullet]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-alignment">
@@ -228,7 +228,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value=""
               part="toolbar-button toolbar-button-align-left"
             ></button>
-            <vaadin-tooltip for="btn-left" text="[[i18n.alignLeft]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-left" text="[[__effectiveI18n.alignLeft]]"></vaadin-tooltip>
             <button
               id="btn-center"
               type="button"
@@ -236,7 +236,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="center"
               part="toolbar-button toolbar-button-align-center"
             ></button>
-            <vaadin-tooltip for="btn-center" text="[[i18n.alignCenter]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-center" text="[[__effectiveI18n.alignCenter]]"></vaadin-tooltip>
             <button
               id="btn-right"
               type="button"
@@ -244,7 +244,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               value="right"
               part="toolbar-button toolbar-button-align-right"
             ></button>
-            <vaadin-tooltip for="btn-right" text="[[i18n.alignRight]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-right" text="[[__effectiveI18n.alignRight]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-rich-text">
@@ -256,7 +256,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               on-touchend="_onImageTouchEnd"
               on-click="_onImageClick"
             ></button>
-            <vaadin-tooltip for="btn-image" text="[[i18n.image]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-image" text="[[__effectiveI18n.image]]"></vaadin-tooltip>
             <!-- Link -->
             <button
               id="btn-link"
@@ -264,7 +264,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               part="toolbar-button toolbar-button-link"
               on-click="_onLinkClick"
             ></button>
-            <vaadin-tooltip for="btn-link" text="[[i18n.link]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-link" text="[[__effectiveI18n.link]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-block">
@@ -275,7 +275,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               class="ql-blockquote"
               part="toolbar-button toolbar-button-blockquote"
             ></button>
-            <vaadin-tooltip for="btn-blockquote" text="[[i18n.blockquote]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-blockquote" text="[[__effectiveI18n.blockquote]]"></vaadin-tooltip>
             <!-- Code block -->
             <button
               id="btn-code"
@@ -283,13 +283,13 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
               class="ql-code-block"
               part="toolbar-button toolbar-button-code-block"
             ></button>
-            <vaadin-tooltip for="btn-code" text="[[i18n.codeBlock]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-code" text="[[__effectiveI18n.codeBlock]]"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-format">
             <!-- Clean -->
             <button id="btn-clean" type="button" class="ql-clean" part="toolbar-button toolbar-button-clean"></button>
-            <vaadin-tooltip for="btn-clean" text="[[i18n.clean]]"></vaadin-tooltip>
+            <vaadin-tooltip for="btn-clean" text="[[__effectiveI18n.clean]]"></vaadin-tooltip>
           </span>
 
           <input
@@ -305,7 +305,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
         <div class="announcer" aria-live="polite"></div>
       </div>
 
-      <vaadin-confirm-dialog id="linkDialog" opened="{{_linkEditing}}" header="[[i18n.linkDialogTitle]]">
+      <vaadin-confirm-dialog id="linkDialog" opened="{{_linkEditing}}" header="[[__effectiveI18n.linkDialogTitle]]">
         <vaadin-text-field
           id="linkUrl"
           value="{{_linkUrl}}"
@@ -313,7 +313,7 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
           on-keydown="_onLinkKeydown"
         ></vaadin-text-field>
         <vaadin-button id="confirmLink" slot="confirm-button" theme="primary" on-click="_onLinkEditConfirm">
-          [[i18n.ok]]
+          [[__effectiveI18n.ok]]
         </vaadin-button>
         <vaadin-button
           id="removeLink"
@@ -322,10 +322,10 @@ class RichTextEditor extends RichTextEditorMixin(ElementMixin(ThemableMixin(Poly
           on-click="_onLinkEditRemove"
           hidden$="[[!_linkRange]]"
         >
-          [[i18n.remove]]
+          [[__effectiveI18n.remove]]
         </vaadin-button>
         <vaadin-button id="cancelLink" slot="cancel-button" on-click="_onLinkEditCancel">
-          [[i18n.cancel]]
+          [[__effectiveI18n.cancel]]
         </vaadin-button>
       </vaadin-confirm-dialog>
 

--- a/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
+++ b/packages/rich-text-editor/test/typings/rich-text-editor.types.ts
@@ -1,14 +1,19 @@
 import '../../vaadin-rich-text-editor.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type {
   RichTextEditor,
   RichTextEditorChangeEvent,
   RichTextEditorHtmlValueChangedEvent,
+  RichTextEditorI18n,
   RichTextEditorValueChangedEvent,
 } from '../../vaadin-rich-text-editor.js';
 
 const richTextEditor = document.createElement('vaadin-rich-text-editor');
 
 const assertType = <TExpected>(actual: TExpected) => actual;
+
+// Mixins
+assertType<I18nMixinClass<RichTextEditorI18n>>(richTextEditor);
 
 // Events
 richTextEditor.addEventListener('change', (event) => {
@@ -25,3 +30,7 @@ richTextEditor.addEventListener('value-changed', (event) => {
   assertType<RichTextEditorValueChangedEvent>(event);
   assertType<string>(event.detail.value);
 });
+
+// I18n
+assertType<RichTextEditorI18n>({});
+assertType<RichTextEditorI18n>({ undo: 'Undo' });


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to rich text editor. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
