### PR TITLE
feat: support partial i18n in side nav

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-children-mixin.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-children-mixin.d.ts
@@ -4,21 +4,21 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 
 export interface SideNavI18n {
-  toggle: string;
+  toggle?: string;
 }
 
 export declare function SideNavChildrenMixin<T extends Constructor<HTMLElement>>(
   base: T,
-): Constructor<SideNavChildrenMixinClass> & T;
+): Constructor<SideNavChildrenMixinClass> & Constructor<I18nMixinClass<SideNavI18n>> & T;
 
 export declare class SideNavChildrenMixinClass {
   /**
-   * The object used to localize this component.
-   *
-   * To change the default localization, replace the entire
-   * `i18n` object with a custom one.
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
    *
    * The object has the following structure and default values:
    * ```

--- a/packages/side-nav/src/vaadin-side-nav-children-mixin.js
+++ b/packages/side-nav/src/vaadin-side-nav-children-mixin.js
@@ -3,7 +3,12 @@
  * Copyright (c) 2023 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
+
+const DEFAULT_I18N = {
+  toggle: 'Toggle child items',
+};
 
 /**
  * A controller that manages the item content children slot.
@@ -34,34 +39,9 @@ class ChildrenController extends SlotController {
  * @polymerMixin
  */
 export const SideNavChildrenMixin = (superClass) =>
-  class SideNavChildrenMixin extends superClass {
+  class SideNavChildrenMixin extends I18nMixin(DEFAULT_I18N, superClass) {
     static get properties() {
       return {
-        /**
-         * The object used to localize this component.
-         *
-         * To change the default localization, replace the entire
-         * `i18n` object with a custom one.
-         *
-         * The object has the following structure and default values:
-         * ```
-         * {
-         *   toggle: 'Toggle child items'
-         * }
-         * ```
-         *
-         * @type {SideNavI18n}
-         * @default {English/US}
-         */
-        i18n: {
-          type: Object,
-          value: () => {
-            return {
-              toggle: 'Toggle child items',
-            };
-          },
-        },
-
         /**
          * Count of child items.
          * @protected
@@ -77,6 +57,27 @@ export const SideNavChildrenMixin = (superClass) =>
       super();
 
       this._childrenController = new ChildrenController(this, this._itemsSlotName);
+    }
+
+    /**
+     * The object used to localize this component. To change the default
+     * localization, replace this with an object that provides all properties, or
+     * just the individual properties you want to change.
+     *
+     * The object has the following structure and default values:
+     * ```
+     * {
+     *   toggle: 'Toggle child items'
+     * }
+     * ```
+     * @return {!SideNavI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
     }
 
     /**
@@ -125,9 +126,9 @@ export const SideNavChildrenMixin = (superClass) =>
       }
 
       // Propagate i18n object to all the child items
-      if (props.has('_itemsCount') || props.has('i18n')) {
+      if (props.has('_itemsCount') || props.has('__effectiveI18n')) {
         this._items.forEach((item) => {
-          item.i18n = this.i18n;
+          item.i18n = this.__effectiveI18n;
         });
       }
     }

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -270,7 +270,7 @@ class SideNavItem extends SideNavChildrenMixin(DisabledMixin(ElementMixin(Themab
       <ul part="children" role="list" ?hidden="${!this.expanded}" aria-hidden="${this.expanded ? 'false' : 'true'}">
         <slot name="children"></slot>
       </ul>
-      <div hidden id="i18n">${this.i18n.toggle}</div>
+      <div hidden id="i18n">${this.__effectiveI18n.toggle}</div>
     `;
   }
 

--- a/packages/side-nav/test/typings/side-nav.types.ts
+++ b/packages/side-nav/test/typings/side-nav.types.ts
@@ -2,6 +2,7 @@ import '../../vaadin-side-nav.js';
 import '../../vaadin-side-nav-item.js';
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { NavigateEvent, SideNav, SideNavCollapsedChangedEvent, SideNavI18n } from '../../src/vaadin-side-nav';
 import type { SideNavChildrenMixinClass } from '../../src/vaadin-side-nav-children-mixin.js';
@@ -18,6 +19,7 @@ assertType<SideNavI18n>(sideNav.i18n);
 
 // Mixins
 assertType<ElementMixinClass>(sideNav);
+assertType<I18nMixinClass<SideNavI18n>>(sideNav);
 assertType<ThemableMixinClass>(sideNav);
 assertType<SideNavChildrenMixinClass>(sideNav);
 
@@ -62,3 +64,7 @@ sideNavItem.addEventListener('expanded-changed', (event) => {
   assertType<SideNavItemExpandedChangedEvent>(event);
   assertType<boolean>(event.detail.value);
 });
+
+// I18n
+assertType<SideNavI18n>({});
+assertType<SideNavI18n>({ toggle: 'toggle' });


### PR DESCRIPTION
## Description

Adds support for partial I18N objects to side nav. This allows setting an I18N object that only overrides some of the translations and uses default translations as fallback.

## Type of change

- Feature
