### PR TITLE
feat: focus detail content when using overlay or stack mode

### DIFF
--- a/packages/master-detail-layout/package.json
+++ b/packages/master-detail-layout/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@vaadin/a11y-base": "24.8.0-alpha3",
     "@vaadin/component-base": "24.8.0-alpha3",
     "@vaadin/vaadin-lumo-styles": "24.8.0-alpha3",
     "@vaadin/vaadin-material-styles": "24.8.0-alpha3",

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css, html, LitElement } from 'lit';
+import { getFocusableElements } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -295,8 +296,19 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
 
   /** @private */
   __onDetailSlotChange(e) {
-    this.toggleAttribute('has-detail', e.target.assignedNodes().length > 0);
+    const children = e.target.assignedNodes();
+
+    this.toggleAttribute('has-detail', children.length > 0);
     this.__detectLayoutMode();
+
+    // Move focus to the detail area when it is added to the DOM,
+    // in case if the layout is using overlay or stack mode.
+    if ((this.hasAttribute('overlay') || this.hasAttribute('stack')) && children.length > 0) {
+      const focusables = getFocusableElements(children[0]);
+      if (focusables.length) {
+        focusables[0].focus();
+      }
+    }
   }
 
   /**

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -240,6 +240,25 @@ describe('vaadin-master-detail-layout', () => {
 
         expect(layout.hasAttribute('stack')).to.be.false;
       });
+
+      it('should focus detail content when adding details in the stack mode', async () => {
+        layout.stackThreshold = '500px';
+
+        // Start without details
+        detailContent.remove();
+        await nextRender();
+
+        // Shrink viewport
+        await setViewport({ width: 450, height });
+        await nextResize(layout);
+
+        // Add details
+        layout.appendChild(detailContent);
+        await nextRender();
+
+        const input = detailContent.shadowRoot.querySelector('input');
+        expect(detailContent.shadowRoot.activeElement).to.equal(input);
+      });
     });
 
     describe('vertical orientation', () => {

--- a/packages/master-detail-layout/test/overlay-mode.test.js
+++ b/packages/master-detail-layout/test/overlay-mode.test.js
@@ -194,6 +194,21 @@ describe('overlay mode', () => {
 
       expect(layout.hasAttribute('overlay')).to.be.true;
     });
+
+    it('should focus detail content when adding details in the overlay mode', async () => {
+      // Start without details
+      detailContent.remove();
+      await nextRender();
+
+      layout.forceOverlay = true;
+
+      // Add details
+      layout.appendChild(detailContent);
+      await nextRender();
+
+      const input = detailContent.shadowRoot.querySelector('input');
+      expect(detailContent.shadowRoot.activeElement).to.equal(input);
+    });
   });
 
   describe('vertical', () => {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/7173

Implemented the following behavior according to PRD:

> In Stack and Overlay modes, keyboard focus automatically moves to the detail area when it is displayed.

## Type of change

- Feature