### PR TITLE
fix: defer scrollToIndex calls until columnTree is available

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -491,7 +491,7 @@ export const DataProviderMixin = (superClass) =>
         this._scrollToFlatIndex(targetIndex);
       }
 
-      if (this._dataProviderController.isLoading() || !this.clientHeight) {
+      if (this._dataProviderController.isLoading() || !this.clientHeight || !this._columnTree) {
         this.__pendingScrollToIndexes = indexes;
       }
     }

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -557,4 +557,24 @@ describe('scroll to index', () => {
       });
     });
   });
+
+  describe('before grid is fully initialized', () => {
+    let grid;
+
+    beforeEach(async () => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      grid.items = Array.from({ length: 100 }, (_, index) => `Item ${index}`);
+      grid.scrollToIndex(50);
+      await oneEvent(grid, 'animationend');
+      await nextFrame();
+    });
+
+    it('should scroll to index after items are rendered', () => {
+      expect(getFirstVisibleItem(grid).index).to.equal(50);
+    });
+  });
 });


### PR DESCRIPTION
## Description

This fixes an issue where calling `scrollToIndex` before the column tree was available had no effect, since the call wasn't deferred.

Fixes https://github.com/vaadin/flow-components/issues/6711

## Type of change

- [x] Bugfix
