### PR TITLE
feat: add method for starting view transitions

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -48,6 +48,9 @@
       <vaadin-checkbox id="maxHeight" label="Use max-height on the host"></vaadin-checkbox>
       <vaadin-checkbox id="forceOverlay" label="Force overlay"></vaadin-checkbox>
       <vaadin-checkbox id="stack" label="Set stack threshold"></vaadin-checkbox>
+      <button id="set-small-detail">Set small detail</button>
+      <button id="set-large-detail">Set large detail</button>
+      <button id="clear-detail">Clear detail</button>
     </p>
 
     <vaadin-master-detail-layout>
@@ -118,6 +121,22 @@
 
       document.querySelector('#stack').addEventListener('change', (e) => {
         layout.stackThreshold = e.target.checked ? '30rem' : null;
+      });
+
+      document.querySelector('#set-small-detail').addEventListener('click', () => {
+        const detail = document.createElement('detail-content');
+        detail.style.width = '200px';
+        layout.setDetail(detail);
+      });
+
+      document.querySelector('#set-large-detail').addEventListener('click', () => {
+        const detail = document.createElement('detail-content');
+        detail.style.width = '600px';
+        layout.setDetail(detail);
+      });
+
+      document.querySelector('#clear-detail').addEventListener('click', () => {
+        layout.setDetail(null);
       });
     </script>
   </body>

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -8,7 +8,7 @@ export const transitionStyles = css`
   }
 
   ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
-    clip-path: inset(0px);
+    clip-path: inset(0);
   }
 
   ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
@@ -28,7 +28,7 @@ export const transitionStyles = css`
   }
 
   ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
-    clip-path: inset(0px);
+    clip-path: inset(0);
   }
 
   ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
@@ -48,7 +48,7 @@ export const transitionStyles = css`
   }
 
   ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add) {
-    clip-path: inset(0px);
+    clip-path: inset(0);
   }
 
   ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-add) {
@@ -80,7 +80,7 @@ export const transitionStyles = css`
   }
 
   ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove) {
-    clip-path: inset(0px);
+    clip-path: inset(0);
   }
 
   ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-remove) {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2025 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
 import { css } from 'lit';
 
 export const transitionStyles = css`

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -1,0 +1,107 @@
+import { css } from 'lit';
+
+export const transitionStyles = css`
+  /* Overlay - horizontal - add */
+
+  vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='add']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
+    clip-path: inset(0px);
+  }
+
+  ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
+    animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add;
+  }
+
+  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add {
+    from {
+      transform: translateX(100%);
+    }
+  }
+
+  /* Overlay - horizontal - remove */
+
+  vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='remove']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+    clip-path: inset(0px);
+  }
+
+  ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+    animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove;
+  }
+
+  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove {
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  /* Stack - horizontal - add */
+
+  vaadin-master-detail-layout[stack][orientation='horizontal'][transition='add'] {
+    view-transition-name: vaadin-master-detail-layout-stack-horizontal-add;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add) {
+    clip-path: inset(0px);
+  }
+
+  ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-add) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-new;
+  }
+
+  ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-add) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old;
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-add-new {
+    from {
+      transform: translateX(100px);
+      opacity: 0;
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-add-old {
+    to {
+      transform: translateX(-100px);
+      opacity: 0;
+    }
+  }
+
+  /* Stack - horizontal - remove */
+
+  vaadin-master-detail-layout[stack][orientation='horizontal'][transition='remove'] {
+    view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove) {
+    clip-path: inset(0px);
+  }
+
+  ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-remove) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-new;
+  }
+
+  ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-remove) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old;
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new {
+    from {
+      transform: translateX(-100px);
+      opacity: 0;
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old {
+    to {
+      transform: translateX(100px);
+      opacity: 0;
+    }
+  }
+`;

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -85,6 +85,18 @@ declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(
    * @attr {string} stack-threshold
    */
   stackThreshold: string | null | undefined;
+
+  /**
+   * Sets the detail element to be displayed in the detail area and starts a
+   * view transition that animates adding, replacing or removing the detail
+   * area. During the view transition, the element is added to the DOM and
+   * assigned to the `detail` slot. Any previous detail element is removed.
+   * When passing null as the element, the current detail element is removed.
+   *
+   * If the browser does not support view transitions, the respective updates
+   * are applied immediately without starting a transition.
+   */
+  setDetail(detail: HTMLElement | null | undefined): Promise<void>;
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -5,6 +5,7 @@
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
+import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
@@ -12,7 +13,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * (or primary) area and a detail (or secondary) area that is displayed next to, or
  * overlaid on top of, the master area, depending on configuration and viewport size.
  */
-declare class MasterDetailLayout extends ResizeMixin(ThemableMixin(ElementMixin(HTMLElement))) {
+declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**
    * Fixed size (in CSS length units) to be set on the detail area.
    * When specified, it prevents the detail area from growing or

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -97,7 +97,7 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * If the browser does not support view transitions, the respective updates
    * are applied immediately without starting a transition.
    */
-  setDetail(detail: HTMLElement | null | undefined): Promise<void>;
+  setDetail(detail: HTMLElement | null): Promise<void>;
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -311,7 +311,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
 
   /** @override */
   get slotStyles() {
-    return [transitionStyles.toString()];
+    return [transitionStyles];
   }
 
   /** @protected */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -524,7 +524,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       }
     };
 
-    if (document.startViewTransition) {
+    if (typeof document.startViewTransition === 'function') {
       const hasDetail = !!currentDetail;
       const transitionType = hasDetail && element ? 'replace' : hasDetail ? 'remove' : 'add';
       this.setAttribute('transition', transitionType);

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -509,7 +509,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
    */
   async setDetail(element) {
     // Don't start a transition if detail didn't change
-    const currentDetail = this.querySelector('[slot="detail"]') || null;
+    const currentDetail = this.querySelector('[slot="detail"]');
     if ((element || null) === currentDetail) {
       return;
     }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -597,6 +597,12 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
   }
 
   async setDetail(element) {
+    // Don't start a transition if detail didn't change
+    const currentDetail = this.querySelector('[slot="detail"]') || null;
+    if ((element || null) === currentDetail) {
+      return;
+    }
+
     const updateSlot = () => {
       // Remove old content
       this.querySelectorAll('[slot="detail"]').forEach((oldElement) => oldElement.remove());
@@ -608,7 +614,7 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     };
 
     if (document.startViewTransition) {
-      const hasDetail = !!this.querySelector('[slot="detail"]');
+      const hasDetail = !!currentDetail;
       const transitionType = hasDetail && element ? 'replace' : hasDetail ? 'remove' : 'add';
       this.setAttribute('transition', transitionType);
       const transition = document.startViewTransition(updateSlot);

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -9,117 +9,9 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-
-addGlobalThemeStyles(
-  'master-detail-layout-view-transitions',
-  css`
-    /* Overlay - horizontal - add */
-
-    vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='add']::part(detail) {
-      view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add;
-    }
-
-    ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
-      animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add;
-    }
-
-    @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add {
-      from {
-        transform: translateX(100%);
-      }
-    }
-
-    /* Overlay - horizontal - remove */
-
-    vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='remove']::part(detail) {
-      view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove;
-    }
-
-    ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
-      animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove;
-    }
-
-    @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove {
-      to {
-        transform: translateX(100%);
-      }
-    }
-
-    /* Stack - horizontal - add */
-
-    vaadin-master-detail-layout[stack][orientation='horizontal'][transition='add'] {
-      view-transition-name: vaadin-master-detail-layout-stack-horizontal-add;
-    }
-
-    ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-add) {
-      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-new;
-    }
-
-    ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-add) {
-      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old;
-    }
-
-    @keyframes vaadin-master-detail-layout-stack-horizontal-add-new {
-      from {
-        transform: translateX(100px);
-        opacity: 0;
-      }
-    }
-
-    @keyframes vaadin-master-detail-layout-stack-horizontal-add-old {
-      to {
-        transform: translateX(-100px);
-        opacity: 0;
-      }
-    }
-
-    /* Stack - horizontal - remove */
-
-    vaadin-master-detail-layout[stack][orientation='horizontal'][transition='remove'] {
-      view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove;
-    }
-
-    ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-remove) {
-      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-new;
-    }
-
-    ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-remove) {
-      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old;
-    }
-
-    @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new {
-      from {
-        transform: translateX(-100px);
-        opacity: 0;
-      }
-    }
-
-    @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old {
-      to {
-        transform: translateX(100px);
-        opacity: 0;
-      }
-    }
-  `,
-);
+import { transitionStyles } from './vaadin-master-detail-layout-transition-styles.js';
 
 /**
  * `<vaadin-master-detail-layout>` is a web component for building UIs with a master
@@ -131,8 +23,9 @@ addGlobalThemeStyles(
  * @mixes ThemableMixin
  * @mixes ElementMixin
  * @mixes ResizeMixin
+ * @mixes SlotStylesMixin
  */
-class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
   static get is() {
     return 'vaadin-master-detail-layout';
   }
@@ -414,6 +307,11 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
         sync: true,
       },
     };
+  }
+
+  /** @override */
+  get slotStyles() {
+    return [transitionStyles.toString()];
   }
 
   /** @protected */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -596,6 +596,19 @@ class MasterDetailLayout extends ResizeMixin(ElementMixin(ThemableMixin(PolylitM
     return parseFloat(backgroundPositionY);
   }
 
+  /**
+   * Sets the detail element to be displayed in the detail area and starts a
+   * view transition that animates adding, replacing or removing the detail
+   * area. During the view transition, the element is added to the DOM and
+   * assigned to the `detail` slot. Any previous detail element is removed.
+   * When passing null as the element, the current detail element is removed.
+   *
+   * If the browser does not support view transitions, the respective updates
+   * are applied immediately without starting a transition.
+   *
+   * @param element the new detail element, or null to remove the current detail
+   * @returns {Promise<void>}
+   */
   async setDetail(element) {
     // Don't start a transition if detail didn't change
     const currentDetail = this.querySelector('[slot="detail"]') || null;

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -15,96 +15,104 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 addGlobalThemeStyles(
   'master-detail-layout-view-transitions',
   css`
-    vaadin-master-detail-layout[orientation='horizontal'][overlay][transition='add']::part(detail) {
-      view-transition-name: overlay-horizontal-detail-add;
+    /* Overlay - horizontal - add */
+
+    vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='add']::part(detail) {
+      view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add;
     }
 
-    vaadin-master-detail-layout[orientation='horizontal'][overlay][transition='remove']::part(detail) {
-      view-transition-name: overlay-horizontal-detail-remove;
-    }
-
-    vaadin-master-detail-layout[orientation='horizontal'][stack][transition='add'] {
-      view-transition-name: stack-horizontal-add;
-    }
-
-    vaadin-master-detail-layout[orientation='horizontal'][stack][transition='remove'] {
-      view-transition-name: stack-horizontal-remove;
-    }
-
-    ::view-transition-group(overlay-horizontal-detail-add) {
+    ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
       clip-path: inset(0px);
     }
 
-    ::view-transition-new(overlay-horizontal-detail-add) {
-      animation: 300ms ease both overlay-horizontal-detail-add;
+    ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
+      animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add;
     }
 
-    ::view-transition-group(overlay-horizontal-detail-remove) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-old(overlay-horizontal-detail-remove) {
-      animation: 300ms ease both overlay-horizontal-detail-remove;
-    }
-
-    ::view-transition-group(stack-horizontal-add) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-new(stack-horizontal-add) {
-      animation: 300ms ease both stack-horizontal-add-new;
-    }
-
-    ::view-transition-old(stack-horizontal-add) {
-      animation: 300ms ease both stack-horizontal-add-old;
-    }
-
-    ::view-transition-group(stack-horizontal-remove) {
-      clip-path: inset(0px);
-    }
-
-    ::view-transition-new(stack-horizontal-remove) {
-      animation: 300ms ease both stack-horizontal-remove-new;
-    }
-
-    ::view-transition-old(stack-horizontal-remove) {
-      animation: 300ms ease both stack-horizontal-remove-old;
-    }
-
-    @keyframes overlay-horizontal-detail-add {
+    @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add {
       from {
         transform: translateX(100%);
       }
     }
 
-    @keyframes overlay-horizontal-detail-remove {
+    /* Overlay - horizontal - remove */
+
+    vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='remove']::part(detail) {
+      view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove;
+    }
+
+    ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+      clip-path: inset(0px);
+    }
+
+    ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+      animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove;
+    }
+
+    @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove {
       to {
         transform: translateX(100%);
       }
     }
 
-    @keyframes stack-horizontal-add-new {
+    /* Stack - horizontal - add */
+
+    vaadin-master-detail-layout[stack][orientation='horizontal'][transition='add'] {
+      view-transition-name: vaadin-master-detail-layout-stack-horizontal-add;
+    }
+
+    ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add) {
+      clip-path: inset(0px);
+    }
+
+    ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-add) {
+      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-new;
+    }
+
+    ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-add) {
+      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old;
+    }
+
+    @keyframes vaadin-master-detail-layout-stack-horizontal-add-new {
       from {
         transform: translateX(100px);
         opacity: 0;
       }
     }
 
-    @keyframes stack-horizontal-add-old {
+    @keyframes vaadin-master-detail-layout-stack-horizontal-add-old {
       to {
         transform: translateX(-100px);
         opacity: 0;
       }
     }
 
-    @keyframes stack-horizontal-remove-new {
+    /* Stack - horizontal - remove */
+
+    vaadin-master-detail-layout[stack][orientation='horizontal'][transition='remove'] {
+      view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove;
+    }
+
+    ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove) {
+      clip-path: inset(0px);
+    }
+
+    ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-remove) {
+      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-new;
+    }
+
+    ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-remove) {
+      animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old;
+    }
+
+    @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new {
       from {
         transform: translateX(-100px);
         opacity: 0;
       }
     }
 
-    @keyframes stack-horizontal-remove-old {
+    @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old {
       to {
         transform: translateX(100px);
         opacity: 0;

--- a/packages/master-detail-layout/test/view-transitions.test.js
+++ b/packages/master-detail-layout/test/view-transitions.test.js
@@ -16,29 +16,95 @@ describe('View transitions', () => {
     await nextRender();
   });
 
-  describe('setDetails', () => {
-    it('should update details slot', async () => {
-      // Add details
-      const detail = document.createElement('detail-content');
-      await layout.setDetail(detail);
+  ['supported', 'unsupported'].forEach((support) => {
+    describe(support, () => {
+      if (support === 'unsupported') {
+        let originalStartViewTransition;
+        before(() => {
+          originalStartViewTransition = document.startViewTransition;
+          document.startViewTransition = undefined;
+        });
 
-      const result = layout.querySelector('[slot="detail"]');
-      expect(result).to.equal(detail);
+        after(() => {
+          document.startViewTransition = originalStartViewTransition;
+        });
+      }
 
-      // Replace details
-      const newDetail = document.createElement('detail-content');
-      await layout.setDetail(newDetail);
+      it('should update details slot', async () => {
+        // Add details
+        const detail = document.createElement('detail-content');
+        await layout.setDetail(detail);
 
-      const newResult = layout.querySelector('[slot="detail"]');
-      expect(newResult).to.equal(newDetail);
-      expect(result.isConnected).to.be.false;
+        const result = layout.querySelector('[slot="detail"]');
+        expect(result).to.equal(detail);
 
-      // Remove details
-      await layout.setDetail(null);
+        // Replace details
+        const newDetail = document.createElement('detail-content');
+        await layout.setDetail(newDetail);
 
-      const emptyResult = layout.querySelector('[slot="detail"]');
-      expect(emptyResult).to.be.null;
-      expect(newResult.isConnected).to.be.false;
+        const newResult = layout.querySelector('[slot="detail"]');
+        expect(newResult).to.equal(newDetail);
+        expect(result.isConnected).to.be.false;
+
+        // Remove details
+        await layout.setDetail(null);
+
+        const emptyResult = layout.querySelector('[slot="detail"]');
+        expect(emptyResult).to.be.null;
+        expect(newResult.isConnected).to.be.false;
+      });
+    });
+  });
+
+  describe('transition types', () => {
+    let originalStartViewTransition;
+    let resolveTransition;
+
+    before(() => {
+      originalStartViewTransition = document.startViewTransition;
+      document.startViewTransition = (callback) => {
+        callback();
+        return {
+          finished: new Promise((resolve) => {
+            resolveTransition = resolve;
+          }),
+        };
+      };
+    });
+
+    after(() => {
+      document.startViewTransition = originalStartViewTransition;
+    });
+
+    it('should use the correct transition type', async () => {
+      // "add" transition
+      const addDetail = document.createElement('detail-content');
+      const addPromise = layout.setDetail(addDetail);
+
+      expect(layout.getAttribute('transition')).to.equal('add');
+
+      resolveTransition();
+      await addPromise;
+      expect(layout.hasAttribute('transition')).to.be.false;
+
+      // "replace" transition
+      const replaceDetail = document.createElement('detail-content');
+      const replacePromise = layout.setDetail(replaceDetail);
+
+      expect(layout.getAttribute('transition')).to.equal('replace');
+
+      resolveTransition();
+      await replacePromise;
+      expect(layout.hasAttribute('transition')).to.be.false;
+
+      // "remove" transition
+      const removePromise = layout.setDetail(null);
+
+      expect(layout.getAttribute('transition')).to.equal('remove');
+
+      resolveTransition();
+      await removePromise;
+      expect(layout.hasAttribute('transition')).to.be.false;
     });
   });
 });

--- a/packages/master-detail-layout/test/view-transitions.test.js
+++ b/packages/master-detail-layout/test/view-transitions.test.js
@@ -1,0 +1,44 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '../vaadin-master-detail-layout.js';
+import './helpers/master-content.js';
+import './helpers/detail-content.js';
+
+describe('View transitions', () => {
+  let layout;
+
+  beforeEach(async () => {
+    layout = fixtureSync(`
+      <vaadin-master-detail-layout>
+        <master-content></master-content>
+      </vaadin-master-detail-layout>
+    `);
+    await nextRender();
+  });
+
+  describe('setDetails', () => {
+    it('should update details slot', async () => {
+      // Add details
+      const detail = document.createElement('detail-content');
+      await layout.setDetail(detail);
+
+      const result = layout.querySelector('[slot="detail"]');
+      expect(result).to.equal(detail);
+
+      // Replace details
+      const newDetail = document.createElement('detail-content');
+      await layout.setDetail(newDetail);
+
+      const newResult = layout.querySelector('[slot="detail"]');
+      expect(newResult).to.equal(newDetail);
+      expect(result.isConnected).to.be.false;
+
+      // Remove details
+      await layout.setDetail(null);
+
+      const emptyResult = layout.querySelector('[slot="detail"]');
+      expect(emptyResult).to.be.null;
+      expect(newResult.isConnected).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a `setDetail` method for imperatively updating the detail content, and wrapping that update in a view transition if the browser supports it. During the transition a `transition` attribute is added that can be used for targeting specific types of transitions with CSS selectors. Also adds some initial animations that should be refined as a follow-up.

Part of https://github.com/vaadin/web-components/issues/8812
Part of https://github.com/vaadin/platform/issues/7173

## Type of change

- Feature