### PR TITLE
fix: remove responsive step styles when switching to auto-responsive

### DIFF
--- a/packages/form-layout/src/layouts/responsive-steps-layout.js
+++ b/packages/form-layout/src/layouts/responsive-steps-layout.js
@@ -46,8 +46,29 @@ export class ResponsiveStepsLayout extends AbstractLayout {
 
     super.connect();
 
+    this.__selectResponsiveStep();
+    this.updateLayout();
+
     requestAnimationFrame(() => this.__selectResponsiveStep());
     requestAnimationFrame(() => this.updateLayout());
+  }
+
+  /** @override */
+  disconnect() {
+    if (!this.isConnected) {
+      return;
+    }
+
+    super.disconnect();
+
+    const { host } = this;
+    host.$.layout.style.removeProperty('opacity');
+    [...host.children].forEach((child) => {
+      child.style.removeProperty('width');
+      child.style.removeProperty('margin-left');
+      child.style.removeProperty('margin-right');
+      child.removeAttribute('label-position');
+    });
   }
 
   /** @override */

--- a/packages/form-layout/src/layouts/responsive-steps-layout.js
+++ b/packages/form-layout/src/layouts/responsive-steps-layout.js
@@ -46,9 +46,6 @@ export class ResponsiveStepsLayout extends AbstractLayout {
 
     super.connect();
 
-    this.__selectResponsiveStep();
-    this.updateLayout();
-
     requestAnimationFrame(() => this.__selectResponsiveStep());
     requestAnimationFrame(() => this.updateLayout());
   }
@@ -206,6 +203,10 @@ export class ResponsiveStepsLayout extends AbstractLayout {
 
   /** @private */
   __selectResponsiveStep() {
+    if (!this.isConnected) {
+      return;
+    }
+
     const { host, props } = this;
     // Iterate through responsiveSteps and choose the step
     let selectedStep;

--- a/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
+++ b/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
@@ -322,7 +322,7 @@ snapshots["vaadin-form-layout responsive-steps host default"] =
 `;
 /* end snapshot vaadin-form-layout responsive-steps host default */
 
-snapshots["vaadin-form-layout responsive-steps host autoResponsive"] = 
+snapshots["vaadin-form-layout responsive-steps host switching to autoResponsive"] = 
 `<vaadin-form-layout
   auto-responsive=""
   style="--_column-width: 13em; --_max-columns: 1;"
@@ -337,17 +337,20 @@ snapshots["vaadin-form-layout responsive-steps host autoResponsive"] =
   >
 </vaadin-form-layout>
 `;
-/* end snapshot vaadin-form-layout responsive-steps host autoResponsive */
+/* end snapshot vaadin-form-layout responsive-steps host switching to autoResponsive */
 
 snapshots["vaadin-form-layout responsive-steps shadow default"] = 
-`<div id="layout">
+`<div
+  id="layout"
+  style=""
+>
   <slot id="slot">
   </slot>
 </div>
 `;
 /* end snapshot vaadin-form-layout responsive-steps shadow default */
 
-snapshots["vaadin-form-layout responsive-steps shadow autoResponsive"] = 
+snapshots["vaadin-form-layout responsive-steps shadow switching to autoResponsive"] = 
 `<div
   id="layout"
   style="--_grid-rendered-column-count: 1;"
@@ -356,5 +359,5 @@ snapshots["vaadin-form-layout responsive-steps shadow autoResponsive"] =
   </slot>
 </div>
 `;
-/* end snapshot vaadin-form-layout responsive-steps shadow autoResponsive */
+/* end snapshot vaadin-form-layout responsive-steps shadow switching to autoResponsive */
 

--- a/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
+++ b/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
@@ -308,3 +308,53 @@ snapshots["vaadin-form-layout defaultAutoResponsiveFormLayout feature flag defau
 `;
 /* end snapshot vaadin-form-layout defaultAutoResponsiveFormLayout feature flag default */
 
+snapshots["vaadin-form-layout responsive-steps host default"] = 
+`<vaadin-form-layout>
+  <input
+    placeholder="First name"
+    style="width: calc(50% - 1em); margin-left: 0px;"
+  >
+  <input
+    placeholder="Last name"
+    style="width: calc(50% - 1em); margin-right: 0px;"
+  >
+</vaadin-form-layout>
+`;
+/* end snapshot vaadin-form-layout responsive-steps host default */
+
+snapshots["vaadin-form-layout responsive-steps host autoResponsive"] = 
+`<vaadin-form-layout
+  auto-responsive=""
+  style="--_column-width: 13em; --_max-columns: 1;"
+>
+  <input
+    placeholder="First name"
+    style=""
+  >
+  <input
+    placeholder="Last name"
+    style=""
+  >
+</vaadin-form-layout>
+`;
+/* end snapshot vaadin-form-layout responsive-steps host autoResponsive */
+
+snapshots["vaadin-form-layout responsive-steps shadow default"] = 
+`<div id="layout">
+  <slot id="slot">
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-form-layout responsive-steps shadow default */
+
+snapshots["vaadin-form-layout responsive-steps shadow autoResponsive"] = 
+`<div
+  id="layout"
+  style="--_grid-rendered-column-count: 1;"
+>
+  <slot id="slot">
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-form-layout responsive-steps shadow autoResponsive */
+

--- a/packages/form-layout/test/dom/form-layout.test.js
+++ b/packages/form-layout/test/dom/form-layout.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextResize } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import '../../src/vaadin-form-layout.js';
 
 describe('vaadin-form-layout', () => {
@@ -157,6 +157,43 @@ describe('vaadin-form-layout', () => {
 
     it('default', async () => {
       await expect(layout).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('responsive-steps', () => {
+    beforeEach(async () => {
+      layout = fixtureSync(`
+        <vaadin-form-layout>
+          <input placeholder="First name" />
+          <input placeholder="Last name" />
+        </vaadin-form-layout>
+      `);
+      layout.responsiveSteps = [{ columns: 2, labelsPosition: 'top' }];
+      await nextFrame();
+    });
+
+    describe('host', () => {
+      it('default', async () => {
+        await expect(layout).dom.to.equalSnapshot();
+      });
+
+      it('switching to autoResponsive', async () => {
+        layout.autoResponsive = true;
+        await nextResize(layout);
+        await expect(layout).dom.to.equalSnapshot();
+      });
+    });
+
+    describe('shadow', () => {
+      it('default', async () => {
+        await expect(layout).shadowDom.to.equalSnapshot();
+      });
+
+      it('switching to autoResponsive', async () => {
+        layout.autoResponsive = true;
+        await nextResize(layout);
+        await expect(layout).shadowDom.to.equalSnapshot();
+      });
     });
   });
 });

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -206,7 +206,7 @@ describe('form layout', () => {
   describe('colspan', () => {
     let layout;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       layout = fixtureSync(`
         <vaadin-form-layout responsive-steps='[{"columns": 3}]'>
           <vaadin-text-field></vaadin-text-field>
@@ -217,7 +217,6 @@ describe('form layout', () => {
           <vaadin-text-field colspan="non-number"></vaadin-text-field>
         </vaadin-form-layout>
       `);
-      await nextRender();
     });
 
     function estimateEffectiveColspan(el) {

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -206,7 +206,7 @@ describe('form layout', () => {
   describe('colspan', () => {
     let layout;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       layout = fixtureSync(`
         <vaadin-form-layout responsive-steps='[{"columns": 3}]'>
           <vaadin-text-field></vaadin-text-field>
@@ -217,6 +217,7 @@ describe('form layout', () => {
           <vaadin-text-field colspan="non-number"></vaadin-text-field>
         </vaadin-form-layout>
       `);
+      await nextRender();
     });
 
     function estimateEffectiveColspan(el) {


### PR DESCRIPTION
This change ensures that styles applied by _responsive steps_ mode are properly removed when switching to _auto-responsive_ mode in order to avoid unintended side effects. This is specifically important in React wrappers. They use `@lit/react` which applies web component properties and attributes after the component has already connected to the DOM. As a result, there is a short window during which responsive steps styles can be applied.

An alternative solution could be to delay the initialization of responsive steps styles, but this causes some tests to fail, so I think it's safer to leave it as is for now even though it may be less optimal from the performance perspective.

Related to https://github.com/vaadin/platform/issues/7172