### PR TITLE
feat: add noAnimation property to master-detail-layout

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -111,7 +111,7 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   /**
    * When true, the layout does not use animated transitions for the detail area.
    *
-   * @attr {boolean} no-animations
+   * @attr {boolean} no-animation
    */
   noAnimation: boolean;
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -109,6 +109,13 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   stackThreshold: string | null | undefined;
 
   /**
+   * When true, the layout does not use animated transitions for the detail area.
+   *
+   * @attr {boolean} no-animations
+   */
+  noAnimation: boolean;
+
+  /**
    * Sets the detail element to be displayed in the detail area and starts a
    * view transition that animates adding, replacing or removing the detail
    * area. During the view transition, the element is added to the DOM and

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -305,6 +305,16 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       },
 
       /**
+       * When true, the layout does not use animated transitions for the detail area.
+       *
+       * @attr {boolean} no-animation
+       */
+      noAnimation: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
        * When true, the component uses the overlay mode. This property is read-only.
        * In order to enforce the overlay mode, use `forceOverlay` property.
        * @protected
@@ -545,7 +555,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       }
     };
 
-    if (typeof document.startViewTransition === 'function') {
+    if (typeof document.startViewTransition === 'function' && !this.noAnimation) {
       const hasDetail = !!currentDetail;
       const transitionType = hasDetail && element ? 'replace' : hasDetail ? 'remove' : 'add';
       this.setAttribute('transition', transitionType);

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -18,3 +18,4 @@ assertType<string | null | undefined>(layout.masterMinSize);
 assertType<'horizontal' | 'vertical'>(layout.orientation);
 assertType<boolean>(layout.forceOverlay);
 assertType<string | null | undefined>(layout.stackThreshold);
+assertType<boolean>(layout.noAnimation);

--- a/packages/master-detail-layout/test/view-transitions.test.js
+++ b/packages/master-detail-layout/test/view-transitions.test.js
@@ -136,4 +136,21 @@ describe('View transitions', () => {
       expect(layout.hasAttribute('transition')).to.be.false;
     });
   });
+
+  describe('noAnimation', () => {
+    it('should not start view transition when noAnimation is set to true', async () => {
+      layout.noAnimation = true;
+
+      const detail = document.createElement('detail-content');
+      await layout.setDetail(detail);
+
+      expect(startViewTransitionSpy.called).to.be.false;
+
+      layout.noAnimation = false;
+
+      await layout.setDetail(null);
+
+      expect(startViewTransitionSpy.calledOnce).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/7173

Added `noAnimation` property which prevents calling `startViewTransition()`.

The name can be discussed, the only similar case we have is `no-anim` attribute used internally by `vaadin-app-layout`.

## Type of change

- Feature