### PR TITLE
fix: do not use transitions for detail on initial rendering

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -37,7 +37,6 @@
     </style>
 
     <p>
-      <vaadin-checkbox id="showDetail" label="Show detail" checked></vaadin-checkbox>
       <vaadin-checkbox id="detailSize" label="Set detail size"></vaadin-checkbox>
       <vaadin-checkbox id="detailMinSize" label="Set detail min-size"></vaadin-checkbox>
       <vaadin-checkbox id="masterSize" label="Set master size"></vaadin-checkbox>
@@ -55,7 +54,6 @@
 
     <vaadin-master-detail-layout>
       <master-content></master-content>
-      <detail-content slot="detail"></detail-content>
     </vaadin-master-detail-layout>
 
     <script type="module">
@@ -66,14 +64,6 @@
 
       const layout = document.querySelector('vaadin-master-detail-layout');
       const detailContent = document.querySelector('detail-content');
-
-      document.querySelector('#showDetail').addEventListener('change', (e) => {
-        if (e.target.checked) {
-          layout.append(detailContent);
-        } else {
-          detailContent.remove();
-        }
-      });
 
       document.querySelector('#detailSize').addEventListener('change', (e) => {
         layout.detailSize = e.target.checked ? '300px' : null;
@@ -138,6 +128,10 @@
       document.querySelector('#clear-detail').addEventListener('click', () => {
         layout.setDetail(null);
       });
+
+      // Set initial detail
+      const detail = document.createElement('detail-content');
+      layout.setDetail(detail);
     </script>
   </body>
 </html>

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -352,6 +352,17 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
     `;
   }
 
+  /** @protected */
+  async connectedCallback() {
+    super.connectedCallback();
+
+    // Do not use a view transition when rendering a view initially.
+    this.__blockAnimation = true;
+
+    await this.updateComplete;
+    this.__blockAnimation = false;
+  }
+
   /** @private */
   __onDetailSlotChange(e) {
     const children = e.target.assignedNodes();
@@ -545,7 +556,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       }
     };
 
-    if (typeof document.startViewTransition === 'function') {
+    if (!this.__blockAnimation && typeof document.startViewTransition === 'function') {
       const hasDetail = !!currentDetail;
       const transitionType = hasDetail && element ? 'replace' : hasDetail ? 'remove' : 'add';
       this.setAttribute('transition', transitionType);

--- a/packages/master-detail-layout/test/view-transitions.test.js
+++ b/packages/master-detail-layout/test/view-transitions.test.js
@@ -136,4 +136,30 @@ describe('View transitions', () => {
       expect(layout.hasAttribute('transition')).to.be.false;
     });
   });
+
+  describe('initial rendering', () => {
+    beforeEach(() => {
+      layout = document.createElement('vaadin-master-detail-layout');
+    });
+
+    afterEach(() => {
+      layout.remove();
+    });
+
+    it('should not use view transition during initial rendering', async () => {
+      document.body.appendChild(layout);
+
+      const detail = document.createElement('detail-content');
+      await layout.setDetail(detail);
+
+      expect(startViewTransitionSpy.called).to.be.false;
+
+      // Wait for initial render to complete.
+      await layout.updateComplete;
+
+      await layout.setDetail(null);
+
+      expect(startViewTransitionSpy.calledOnce).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/7173

Added logic to set a flag in `connectedCallback()` to avoid starting a view transition during initial layout rendering.
This covers the case where `setDetail()` is called before adding layout to the DOM or immediately after adding it.

## Type of change

- Fix / refactor