### PR TITLE
fix: use overflow hidden on icons for stretch and cover media

### DIFF
--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -232,11 +232,15 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
 
       :host(:is([theme~='cover-media'], [theme~='stretch-media']))
         ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
-        display: block;
         width: 100%;
         height: auto;
         aspect-ratio: var(--vaadin-card-media-aspect-ratio, 16/9);
         object-fit: cover;
+      }
+
+      /* Fixes an issue where an icon overflows the card boundaries on Firefox: https://github.com/vaadin/web-components/issues/8641 */
+      :host(:is([theme~='cover-media'], [theme~='stretch-media'])) ::slotted([slot='media']:is(vaadin-icon)) {
+        overflow: hidden;
       }
 
       :host([theme~='horizontal']:is([theme~='cover-media'], [theme~='stretch-media'])) {

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -232,6 +232,7 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
 
       :host(:is([theme~='cover-media'], [theme~='stretch-media']))
         ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
+        display: block;
         width: 100%;
         height: auto;
         aspect-ratio: var(--vaadin-card-media-aspect-ratio, 16/9);

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -236,10 +236,7 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
         height: auto;
         aspect-ratio: var(--vaadin-card-media-aspect-ratio, 16/9);
         object-fit: cover;
-      }
-
-      /* Fixes an issue where an icon overflows the card boundaries on Firefox: https://github.com/vaadin/web-components/issues/8641 */
-      :host(:is([theme~='cover-media'], [theme~='stretch-media'])) ::slotted([slot='media']:is(vaadin-icon)) {
+        /* Fixes an issue where an icon overflows the card boundaries on Firefox: https://github.com/vaadin/web-components/issues/8641 */
         overflow: hidden;
       }
 


### PR DESCRIPTION
## Description

When adding `inline-flex` elements like Vaadin icons in `media` slot, Firefox and Chrome works differently. As stated in the [comment](https://github.com/vaadin/web-components/issues/8641#issuecomment-2636327402) in the issue, the aspect ratio can break in Firefox. This PR adds `overflow: hidden` on icons for `stretch-media` and `cover-media`. This does not cause any changes for Chrome, but fixes the issue for Firefox.

Fixes #8641 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.