### PR TITLE
fix: use padding instead of margin to avoid overflow

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -15,10 +15,10 @@ const requiredField = css`
     color: var(--vaadin-input-field-label-color, var(--lumo-secondary-text-color));
     font-weight: var(--vaadin-input-field-label-font-weight, 500);
     font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
-    margin-left: calc(var(--lumo-border-radius-m) / 4);
     transition: color 0.2s;
     line-height: 1;
     padding-right: 1em;
+    padding-left: calc(var(--lumo-border-radius-m) / 4);
     padding-bottom: 0.5em;
     /* As a workaround for diacritics being cut off, add a top padding and a
     negative margin to compensate */

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -17,8 +17,8 @@ const requiredField = css`
     font-size: var(--vaadin-input-field-label-font-size, var(--lumo-font-size-s));
     transition: color 0.2s;
     line-height: 1;
-    padding-right: 1em;
-    padding-left: calc(var(--lumo-border-radius-m) / 4);
+    padding-inline-start: calc(var(--lumo-border-radius-m) / 4);
+    padding-inline-end: 1em;
     padding-bottom: 0.5em;
     /* As a workaround for diacritics being cut off, add a top padding and a
     negative margin to compensate */
@@ -101,16 +101,6 @@ const requiredField = css`
   }
 
   /* RTL specific styles */
-
-  :host([dir='rtl']) [part='label'] {
-    margin-left: 0;
-    margin-right: calc(var(--lumo-border-radius-m) / 4);
-  }
-
-  :host([dir='rtl']) [part='label'] {
-    padding-left: 1em;
-    padding-right: 0;
-  }
 
   :host([dir='rtl']) [part='required-indicator']::after {
     right: auto;


### PR DESCRIPTION
## Description

The `calc(var(--lumo-border-radius-m) / 4)` calculation can produce a fractional value, which causes an overflow when used as the value of `margin-left`:

https://github.com/user-attachments/assets/30119584-acfc-4c9e-8eb7-e77c6fefa443

The PR replaces `margin-left` with `padding-left`, which prevents the overflow.

## Type of change

- [x] Bugfix
