### PR TITLE
docs: add backdrop to the list of app-layout shadow parts

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -74,6 +74,7 @@ export type AppLayoutEventMap = AppLayoutCustomEventMap & HTMLElementEventMap;
  *
  * Part name     | Description
  * --------------|---------------------------------------------------------|
+ * `backdrop`    | Backdrop covering the layout when drawer is open as an overlay
  * `navbar`      | Container for the navigation bar
  * `drawer`      | Container for the drawer area
  *

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -54,6 +54,7 @@ registerStyles('vaadin-app-layout', appLayoutStyles, { moduleId: 'vaadin-app-lay
  *
  * Part name     | Description
  * --------------|---------------------------------------------------------|
+ * `backdrop`    | Backdrop covering the layout when drawer is open as an overlay
  * `navbar`      | Container for the navigation bar
  * `drawer`      | Container for the drawer area
  *


### PR DESCRIPTION
## Description

It turns out `backdrop` part is not listed in stylable parts docs for `vaadin-app-layout`. This PR fixes that.

## Type of change

- Documentation