### PR TITLE
feat: add RTL support to master-detail-layout transitions

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -6,18 +6,21 @@
 import { css } from 'lit';
 
 export const transitionStyles = css`
+  html:not([dir='rtl']) {
+    --_vaadin-master-detail-layout-dir-multiplier: 1;
+  }
+
+  html[dir='rtl'] {
+    --_vaadin-master-detail-layout-dir-multiplier: -1;
+  }
+
   /* Overlay - horizontal - add */
 
   vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='add']::part(detail) {
     view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add;
   }
 
-  vaadin-master-detail-layout[dir='rtl'][overlay][orientation='horizontal'][transition='add']::part(detail) {
-    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl;
-  }
-
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add),
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl) {
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
     clip-path: inset(0);
   }
 
@@ -25,19 +28,9 @@ export const transitionStyles = css`
     animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add;
   }
 
-  ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl) {
-    animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl;
-  }
-
   @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add {
     from {
-      transform: translateX(100%);
-    }
-  }
-
-  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl {
-    from {
-      transform: translateX(-100%);
+      transform: translateX(calc(100% * var(--_vaadin-master-detail-layout-dir-multiplier)));
     }
   }
 
@@ -47,12 +40,7 @@ export const transitionStyles = css`
     view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove;
   }
 
-  vaadin-master-detail-layout[dir='rtl'][overlay][orientation='horizontal'][transition='remove']::part(detail) {
-    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl;
-  }
-
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove),
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl) {
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
     clip-path: inset(0);
   }
 
@@ -60,19 +48,9 @@ export const transitionStyles = css`
     animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove;
   }
 
-  ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl) {
-    animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl;
-  }
-
   @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove {
     to {
-      transform: translateX(100%);
-    }
-  }
-
-  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl {
-    to {
-      transform: translateX(-100%);
+      transform: translateX(calc(100% * var(--_vaadin-master-detail-layout-dir-multiplier)));
     }
   }
 
@@ -82,12 +60,7 @@ export const transitionStyles = css`
     view-transition-name: vaadin-master-detail-layout-stack-horizontal-add;
   }
 
-  vaadin-master-detail-layout[dir='rtl'][stack][orientation='horizontal'][transition='add'] {
-    view-transition-name: vaadin-master-detail-layout-stack-horizontal-add-rtl;
-  }
-
-  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add),
-  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add-rtl) {
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add) {
     clip-path: inset(0);
   }
 
@@ -99,38 +72,16 @@ export const transitionStyles = css`
     animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old;
   }
 
-  ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-add-rtl) {
-    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-new-rtl;
-  }
-
-  ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-add-rtl) {
-    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old-rtl;
-  }
-
   @keyframes vaadin-master-detail-layout-stack-horizontal-add-new {
     from {
-      transform: translateX(100px);
+      transform: translateX(calc(100px * var(--_vaadin-master-detail-layout-dir-multiplier)));
       opacity: 0;
     }
   }
 
   @keyframes vaadin-master-detail-layout-stack-horizontal-add-old {
     to {
-      transform: translateX(-100px);
-      opacity: 0;
-    }
-  }
-
-  @keyframes vaadin-master-detail-layout-stack-horizontal-add-new-rtl {
-    from {
-      transform: translateX(-100px);
-      opacity: 0;
-    }
-  }
-
-  @keyframes vaadin-master-detail-layout-stack-horizontal-add-old-rtl {
-    to {
-      transform: translateX(100px);
+      transform: translateX(calc(-100px * var(--_vaadin-master-detail-layout-dir-multiplier)));
       opacity: 0;
     }
   }
@@ -141,12 +92,7 @@ export const transitionStyles = css`
     view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove;
   }
 
-  vaadin-master-detail-layout[dir='rtl'][stack][orientation='horizontal'][transition='remove'] {
-    view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove-rtl;
-  }
-
-  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove),
-  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove-rtl) {
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove) {
     clip-path: inset(0);
   }
 
@@ -158,38 +104,16 @@ export const transitionStyles = css`
     animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old;
   }
 
-  ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-remove-rtl) {
-    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-new-rtl;
-  }
-
-  ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-remove-rtl) {
-    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old-rtl;
-  }
-
   @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new {
     from {
-      transform: translateX(-100px);
+      transform: translateX(calc(-100px * var(--_vaadin-master-detail-layout-dir-multiplier)));
       opacity: 0;
     }
   }
 
   @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old {
     to {
-      transform: translateX(100px);
-      opacity: 0;
-    }
-  }
-
-  @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new-rtl {
-    from {
-      transform: translateX(100px);
-      opacity: 0;
-    }
-  }
-
-  @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old-rtl {
-    to {
-      transform: translateX(-100px);
+      transform: translateX(calc(100px * var(--_vaadin-master-detail-layout-dir-multiplier)));
       opacity: 0;
     }
   }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -12,7 +12,12 @@ export const transitionStyles = css`
     view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
+  vaadin-master-detail-layout[dir='rtl'][overlay][orientation='horizontal'][transition='add']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add),
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl) {
     clip-path: inset(0);
   }
 
@@ -20,9 +25,19 @@ export const transitionStyles = css`
     animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add;
   }
 
+  ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl) {
+    animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl;
+  }
+
   @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add {
     from {
       transform: translateX(100%);
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add-rtl {
+    from {
+      transform: translateX(-100%);
     }
   }
 
@@ -32,7 +47,12 @@ export const transitionStyles = css`
     view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+  vaadin-master-detail-layout[dir='rtl'][overlay][orientation='horizontal'][transition='remove']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove),
+  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl) {
     clip-path: inset(0);
   }
 
@@ -40,9 +60,19 @@ export const transitionStyles = css`
     animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove;
   }
 
+  ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl) {
+    animation: 300ms ease both vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl;
+  }
+
   @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove {
     to {
       transform: translateX(100%);
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove-rtl {
+    to {
+      transform: translateX(-100%);
     }
   }
 
@@ -52,7 +82,12 @@ export const transitionStyles = css`
     view-transition-name: vaadin-master-detail-layout-stack-horizontal-add;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add) {
+  vaadin-master-detail-layout[dir='rtl'][stack][orientation='horizontal'][transition='add'] {
+    view-transition-name: vaadin-master-detail-layout-stack-horizontal-add-rtl;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add),
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-add-rtl) {
     clip-path: inset(0);
   }
 
@@ -62,6 +97,14 @@ export const transitionStyles = css`
 
   ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-add) {
     animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old;
+  }
+
+  ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-add-rtl) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-new-rtl;
+  }
+
+  ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-add-rtl) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-add-old-rtl;
   }
 
   @keyframes vaadin-master-detail-layout-stack-horizontal-add-new {
@@ -78,13 +121,32 @@ export const transitionStyles = css`
     }
   }
 
+  @keyframes vaadin-master-detail-layout-stack-horizontal-add-new-rtl {
+    from {
+      transform: translateX(-100px);
+      opacity: 0;
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-add-old-rtl {
+    to {
+      transform: translateX(100px);
+      opacity: 0;
+    }
+  }
+
   /* Stack - horizontal - remove */
 
   vaadin-master-detail-layout[stack][orientation='horizontal'][transition='remove'] {
     view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove) {
+  vaadin-master-detail-layout[dir='rtl'][stack][orientation='horizontal'][transition='remove'] {
+    view-transition-name: vaadin-master-detail-layout-stack-horizontal-remove-rtl;
+  }
+
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove),
+  ::view-transition-group(vaadin-master-detail-layout-stack-horizontal-remove-rtl) {
     clip-path: inset(0);
   }
 
@@ -94,6 +156,14 @@ export const transitionStyles = css`
 
   ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-remove) {
     animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old;
+  }
+
+  ::view-transition-new(vaadin-master-detail-layout-stack-horizontal-remove-rtl) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-new-rtl;
+  }
+
+  ::view-transition-old(vaadin-master-detail-layout-stack-horizontal-remove-rtl) {
+    animation: 300ms ease both vaadin-master-detail-layout-stack-horizontal-remove-old-rtl;
   }
 
   @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new {
@@ -106,6 +176,20 @@ export const transitionStyles = css`
   @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old {
     to {
       transform: translateX(100px);
+      opacity: 0;
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-remove-new-rtl {
+    from {
+      transform: translateX(100px);
+      opacity: 0;
+    }
+  }
+
+  @keyframes vaadin-master-detail-layout-stack-horizontal-remove-old-rtl {
+    to {
+      transform: translateX(-100px);
       opacity: 0;
     }
   }


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/8811

Added separate view transitions for MDL using `dir="rtl"` which uses opposite `translateX` property values.

## Type of change

- Feature