### PR TITLE
refactor: add APIs for starting view transition manually

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -575,7 +575,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
    * detail area. Once the transition is ready and the browser has taken a
    * snapshot of the current layout, the provided update callback is called.
    * The callback should update the DOM, which can happen asynchronously.
-   * Once the DOM is updated, the caller must call `__finishTransition`,
+   * Once the DOM is updated, the caller must call `_finishTransition`,
    * which results in the browser taking a snapshot of the new layout and
    * animating the transition.
    *


### PR DESCRIPTION
## Description

Adds APIs to `vaadin-master-detail-layout` to allow wrapping potentially asynchronous DOM updates in a view transition. The main purpose for now is to enable the React component to start a transition, then update the DOM asynchronously, and then resolve the update callback of the transition once the DOM is updated.

Part of https://github.com/vaadin/platform/issues/7173
Part of https://github.com/vaadin/web-components/issues/8812

## Type of change

- Refactor