### PR TITLE
feat: make root heading level on dashboard customizable

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-helpers.js
+++ b/packages/dashboard/src/vaadin-dashboard-helpers.js
@@ -101,3 +101,31 @@ export function fireResize(element, colspanDelta, rowspanDelta) {
 export function fireRemove(element) {
   element.dispatchEvent(new CustomEvent('item-remove', { bubbles: true }));
 }
+
+/**
+ * Walks up the DOM tree starting from `node`, returning the first ancestor which is an instance of the given `baseClass`.
+ *
+ * @param {Node} node - starting node
+ * @param {Function} baseClass - constructor, e.g. `Dashboard`
+ * @returns {HTMLElement | null}
+ */
+export function findAncestorInstance(node, baseClass) {
+  while (node) {
+    if (node instanceof baseClass) {
+      return node;
+    }
+    if (node instanceof ShadowRoot) {
+      node = node.host;
+    } else {
+      const rootNode = node.getRootNode();
+      if (rootNode instanceof ShadowRoot) {
+        node = rootNode.host;
+      } else if (node.parentNode) {
+        node = node.parentNode;
+      } else {
+        node = null;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -13,8 +13,6 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { Dashboard } from './vaadin-dashboard.js';
-import { findAncestorInstance } from './vaadin-dashboard-helpers.js';
 import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
 import { hasWidgetWrappers } from './vaadin-dashboard-styles.js';
@@ -210,32 +208,6 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
       this.setAttribute('role', 'section');
     }
   }
-
-  connectedCallback() {
-    super.connectedCallback();
-    const dashboard = findAncestorInstance(this, Dashboard);
-    if (dashboard) {
-      this.__rootHeadingLevel = dashboard.rootHeadingLevel;
-      this.__rootHeadingLevelChangedHandler = (e) => {
-        if (this.__rootHeadingLevel !== e.detail.value) {
-          this.__rootHeadingLevel = e.detail.value;
-        }
-      };
-      dashboard.addEventListener('root-heading-level-changed', this.__rootHeadingLevelChangedHandler);
-    }
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    const dashboard = findAncestorInstance(this, Dashboard);
-    if (dashboard && this.__rootHeadingLevelChangedHandler) {
-      dashboard.removeEventListener('root-heading-level-changed', this.__rootHeadingLevelChangedHandler);
-      this.__rootHeadingLevelChangedHandler = null;
-    }
-  }
-
-  /** @private */
-  __renderSectionTitle() {}
 }
 
 defineCustomElement(DashboardSection);

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -189,7 +189,9 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
 
         <header part="header">
           ${this.__renderDragHandle()}
-          <div id="title" aria-level=${this.__rootHeadingLevel || 2} part="title">${this.sectionTitle}</div>
+          <div id="title" role="heading" aria-level=${this.__rootHeadingLevel || 2} part="title"
+            >${this.sectionTitle}</div
+          >
           ${this.__renderRemoveButton()}
         </header>
       </div>

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -104,7 +104,6 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
         }
 
         ::slotted(*) {
-          --_vaadin-dashboard-nested-widget: true;
           --_vaadin-dashboard-item-column: span
             min(
               var(--vaadin-dashboard-item-colspan, 1),

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -168,7 +168,6 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
       /* @private */
       __rootHeadingLevel: {
         type: Number,
-        value: 2,
       },
 
       /** @private */

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -13,7 +13,6 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { css, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { Dashboard } from './vaadin-dashboard.js';
 import { findAncestorInstance, SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
@@ -245,24 +244,14 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
         this.toggleAttribute(attr, !!wrapper[attr]);
       });
       this.__i18n = wrapper.i18n;
+      this.__rootHeadingLevel = wrapper.__rootHeadingLevel;
     }
 
-    this.__initRootHeadingLevelChangeListener();
     const undefinedAncestor = this.closest('*:not(:defined)');
     if (undefinedAncestor) {
-      customElements
-        .whenDefined(undefinedAncestor.localName)
-        .then(() => queueMicrotask(() => this.__initRootHeadingLevelChangeListener()));
-    }
-  }
-
-  /** @protected */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    const dashboard = findAncestorInstance(this, Dashboard);
-    if (dashboard && this.__rootHeadingLevelChangedHandler) {
-      dashboard.removeEventListener('root-heading-level-changed', this.__rootHeadingLevelChangedHandler);
-      this.__rootHeadingLevelChangedHandler = null;
+      customElements.whenDefined(undefinedAncestor.localName).then(() => queueMicrotask(() => this.__updateTitle()));
+    } else {
+      this.__updateTitle();
     }
   }
 
@@ -297,21 +286,6 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
 
   /** @private */
   __onRootHeadingLevelChanged() {
-    this.__updateTitle();
-  }
-
-  /** @private */
-  __initRootHeadingLevelChangeListener() {
-    if (!this.__rootHeadingLevelChangedHandler) {
-      const dashboard = findAncestorInstance(this, Dashboard);
-      if (dashboard) {
-        this.__rootHeadingLevel = dashboard.rootHeadingLevel;
-        this.__rootHeadingLevelChangedHandler = (e) => {
-          this.__rootHeadingLevel = e.detail.value;
-        };
-        dashboard.addEventListener('root-heading-level-changed', this.__rootHeadingLevelChangedHandler);
-      }
-    }
     this.__updateTitle();
   }
 

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -194,13 +194,11 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
       widgetTitle: {
         type: String,
         value: '',
-        observer: '__onWidgetTitleChanged',
       },
 
       /* @private */
       __rootHeadingLevel: {
         type: Number,
-        observer: '__onRootHeadingLevelChanged',
       },
 
       /* @private */
@@ -247,11 +245,12 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
       this.__rootHeadingLevel = wrapper.__rootHeadingLevel;
     }
 
+    this.__updateNestedState();
     const undefinedAncestor = this.closest('*:not(:defined)');
     if (undefinedAncestor) {
-      customElements.whenDefined(undefinedAncestor.localName).then(() => queueMicrotask(() => this.__updateTitle()));
-    } else {
-      this.__updateTitle();
+      customElements.whenDefined(undefinedAncestor.localName).then(() => {
+        queueMicrotask(() => this.__updateNestedState());
+      });
     }
   }
 
@@ -280,17 +279,7 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
   }
 
   /** @private */
-  __onWidgetTitleChanged() {
-    this.__updateTitle();
-  }
-
-  /** @private */
-  __onRootHeadingLevelChanged() {
-    this.__updateTitle();
-  }
-
-  /** @private */
-  __updateTitle() {
+  __updateNestedState() {
     this.__isNestedWidget = !!findAncestorInstance(this, DashboardSection);
   }
 }

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -17,6 +17,7 @@ import { Dashboard } from './vaadin-dashboard.js';
 import { findAncestorInstance, SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
 import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
 import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
+import { DashboardSection } from './vaadin-dashboard-section.js';
 
 /**
  * A Widget component for use with the Dashboard component
@@ -316,7 +317,7 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
 
   /** @private */
   __updateTitle() {
-    this.__isNestedWidget = !!getComputedStyle(this).getPropertyValue('--_vaadin-dashboard-nested-widget');
+    this.__isNestedWidget = !!findAncestorInstance(this, DashboardSection);
   }
 }
 

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -246,13 +246,12 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
       this.__i18n = wrapper.i18n;
     }
 
+    this.__initRootHeadingLevelChangeListener();
     const undefinedAncestor = this.closest('*:not(:defined)');
     if (undefinedAncestor) {
       customElements
         .whenDefined(undefinedAncestor.localName)
         .then(() => queueMicrotask(() => this.__initRootHeadingLevelChangeListener()));
-    } else {
-      this.__initRootHeadingLevelChangeListener();
     }
   }
 
@@ -302,13 +301,15 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
 
   /** @private */
   __initRootHeadingLevelChangeListener() {
-    const dashboard = findAncestorInstance(this, Dashboard);
-    if (dashboard) {
-      this.__rootHeadingLevel = dashboard.rootHeadingLevel;
-      this.__rootHeadingLevelChangedHandler = (e) => {
-        this.__rootHeadingLevel = e.detail.value;
-      };
-      dashboard.addEventListener('root-heading-level-changed', this.__rootHeadingLevelChangedHandler);
+    if (!this.__rootHeadingLevelChangedHandler) {
+      const dashboard = findAncestorInstance(this, Dashboard);
+      if (dashboard) {
+        this.__rootHeadingLevel = dashboard.rootHeadingLevel;
+        this.__rootHeadingLevelChangedHandler = (e) => {
+          this.__rootHeadingLevel = e.detail.value;
+        };
+        dashboard.addEventListener('root-heading-level-changed', this.__rootHeadingLevelChangedHandler);
+      }
     }
     this.__updateTitle();
   }

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -273,7 +273,12 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
     if (this.__isNestedWidget) {
       effectiveHeadingLevel += 1;
     }
-    return html`<div id="title" part="title" aria-level=${effectiveHeadingLevel} .hidden=${!this.widgetTitle}
+    return html`<div
+      id="title"
+      part="title"
+      role="heading"
+      aria-level=${effectiveHeadingLevel}
+      .hidden=${!this.widgetTitle}
       >${this.widgetTitle}</div
     >`;
   }

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -202,11 +202,12 @@ export interface DashboardI18n {
  *
  * The following state attributes are available for styling:
  *
- * Attribute      | Description
- * ---------------|-------------
- * `editable`     | Set when the dashboard is editable.
- * `dense-layout` | Set when the dashboard is in dense mode.
- * `item-selected`| Set when an item is selected.
+ * Attribute            | Description
+ * ---------------------|-------------
+ * `editable`           | Set when the dashboard is editable.
+ * `dense-layout`       | Set when the dashboard is in dense mode.
+ * `item-selected`      | Set when an item is selected.
+ * `root-heading-level` | Set root heading level for sections and widgets.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
@@ -242,6 +243,15 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
    * Whether the dashboard is editable.
    */
   editable: boolean;
+
+  /**
+   * Root heading level for sections and widgets. Defaults to 2.
+   *
+   * If changed to e.g. 1:
+   * - sections will render as <h1>
+   * - widgets will render as <h2> if inside sections, <h1> otherwise
+   */
+  rootHeadingLevel: number | null | undefined;
 
   /**
    * The object used to localize this component. To change the default

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -248,8 +248,9 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
    * Root heading level for sections and widgets. Defaults to 2.
    *
    * If changed to e.g. 1:
-   * - sections will render as <h1>
-   * - widgets will render as <h2> if inside sections, <h1> otherwise
+   * - sections will have the attribute `aria-level` with value 1
+   * - non-nested widgets will have the attribute `aria-level` with value 1
+   * - nested widgets will have the attribute `aria-level` with value 2
    */
   rootHeadingLevel: number | null | undefined;
 

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -207,7 +207,6 @@ export interface DashboardI18n {
  * `editable`           | Set when the dashboard is editable.
  * `dense-layout`       | Set when the dashboard is in dense mode.
  * `item-selected`      | Set when an item is selected.
- * `root-heading-level` | Set root heading level for sections and widgets.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -182,7 +182,6 @@ class Dashboard extends DashboardLayoutMixin(
         value: 2,
         sync: true,
         reflectToAttribute: true,
-        observer: '__rootHeadingLevelChanged',
       },
 
       /** @private */
@@ -194,7 +193,7 @@ class Dashboard extends DashboardLayoutMixin(
   }
 
   static get observers() {
-    return ['__itemsOrRendererChanged(items, renderer, editable, __effectiveI18n)'];
+    return ['__itemsOrRendererChanged(items, renderer, editable, __effectiveI18n, rootHeadingLevel)'];
   }
 
   /**
@@ -280,6 +279,7 @@ class Dashboard extends DashboardLayoutMixin(
           wrapper.firstElementChild.toggleAttribute(attr, !!wrapper[attr]);
         });
         wrapper.firstElementChild.__i18n = this.__effectiveI18n;
+        wrapper.firstElementChild.__rootHeadingLevel = this.rootHeadingLevel;
       }
     });
   }
@@ -323,6 +323,7 @@ class Dashboard extends DashboardLayoutMixin(
 
         SYNCHRONIZED_ATTRIBUTES.forEach((attr) => section.toggleAttribute(attr, !!wrapper[attr]));
         section.__i18n = this.__effectiveI18n;
+        section.__rootHeadingLevel = this.rootHeadingLevel;
 
         // Render the subitems
         section.__childCount = item.items.length;
@@ -447,6 +448,7 @@ class Dashboard extends DashboardLayoutMixin(
     wrapper['first-child'] = item === getItemsArrayOfItem(item, this.items)[0];
     wrapper['last-child'] = item === getItemsArrayOfItem(item, this.items).slice(-1)[0];
     wrapper.i18n = this.__effectiveI18n;
+    wrapper.__rootHeadingLevel = this.rootHeadingLevel;
   }
 
   /** @private */
@@ -511,11 +513,6 @@ class Dashboard extends DashboardLayoutMixin(
         }
       });
     }
-  }
-
-  /** @private */
-  __rootHeadingLevelChanged(rootHeadingLevel) {
-    this.dispatchEvent(new CustomEvent('root-heading-level-changed', { detail: { value: rootHeadingLevel } }));
   }
 
   /**

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -87,7 +87,6 @@ import { WidgetResizeController } from './widget-resize-controller.js';
  * `editable`           | Set when the dashboard is editable.
  * `dense-layout`       | Set when the dashboard is in dense mode.
  * `item-selected`      | Set when an item is selected.
- * `root-heading-level` | Set root heading level for sections and widgets.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
@@ -174,14 +173,11 @@ class Dashboard extends DashboardLayoutMixin(
        * - sections will have the attribute `aria-level` with value 1
        * - non-nested widgets will have the attribute `aria-level` with value 1
        * - nested widgets will have the attribute `aria-level` with value 2
-       *
-       * @attr {number} root-heading-level
        */
       rootHeadingLevel: {
         type: Number,
         value: 2,
         sync: true,
-        reflectToAttribute: true,
       },
 
       /** @private */

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -82,11 +82,12 @@ import { WidgetResizeController } from './widget-resize-controller.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute      | Description
- * ---------------|-------------
- * `editable`     | Set when the dashboard is editable.
- * `dense-layout` | Set when the dashboard is in dense mode.
- * `item-selected`| Set when an item is selected.
+ * Attribute            | Description
+ * ---------------------|-------------
+ * `editable`           | Set when the dashboard is editable.
+ * `dense-layout`       | Set when the dashboard is in dense mode.
+ * `item-selected`      | Set when an item is selected.
+ * `root-heading-level` | Set root heading level for sections and widgets.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
@@ -164,6 +165,23 @@ class Dashboard extends DashboardLayoutMixin(
        */
       editable: {
         type: Boolean,
+      },
+
+      /**
+       * Root heading level for sections and widgets. Defaults to 2.
+       *
+       * If changed to e.g. 1:
+       * - sections will render as <h1>
+       * - widgets will render as <h2> if inside sections, <h1> otherwise
+       *
+       * @attr {number} root-heading-level
+       */
+      rootHeadingLevel: {
+        type: Number,
+        value: 2,
+        sync: true,
+        reflectToAttribute: true,
+        observer: '__rootHeadingLevelChanged',
       },
 
       /** @private */
@@ -492,6 +510,11 @@ class Dashboard extends DashboardLayoutMixin(
         }
       });
     }
+  }
+
+  /** @private */
+  __rootHeadingLevelChanged(rootHeadingLevel) {
+    this.dispatchEvent(new CustomEvent('root-heading-level-changed', { detail: { value: rootHeadingLevel } }));
   }
 
   /**

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -171,8 +171,9 @@ class Dashboard extends DashboardLayoutMixin(
        * Root heading level for sections and widgets. Defaults to 2.
        *
        * If changed to e.g. 1:
-       * - sections will render as <h1>
-       * - widgets will render as <h2> if inside sections, <h1> otherwise
+       * - sections will have the attribute `aria-level` with value 1
+       * - non-nested widgets will have the attribute `aria-level` with value 1
+       * - nested widgets will have the attribute `aria-level` with value 2
        *
        * @attr {number} root-heading-level
        */

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-widget.js';
-import { Dashboard } from '../src/vaadin-dashboard';
 import { DashboardSection } from '../vaadin-dashboard-section.js';
 import { DashboardWidget } from '../vaadin-dashboard-widget.js';
 import {
@@ -266,78 +265,5 @@ describe('widget title level', () => {
 
     const title = getTitleElement(widget);
     expect(title?.getAttribute('aria-level')).to.equal('3');
-  });
-
-  it('should use custom title heading level when set on dashboard', async () => {
-    const dashboard = fixtureSync(`
-      <vaadin-dashboard root-heading-level="4">
-        <vaadin-dashboard-section section-title="foo">
-          <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
-        </vaadin-dashboard-section>
-      </vaadin-dashboard>
-    `);
-    await nextFrame();
-
-    const sectionTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-section')!);
-    expect(sectionTitle?.getAttribute('aria-level')).to.equal('4');
-
-    const widgetTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-widget')!);
-    expect(widgetTitle?.getAttribute('aria-level')).to.equal('5');
-  });
-
-  it('should update title heading level when set on dashboard', async () => {
-    const dashboard = fixtureSync(`
-      <vaadin-dashboard>
-        <vaadin-dashboard-section section-title="foo">
-          <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
-        </vaadin-dashboard-section>
-      </vaadin-dashboard>
-    `) as Dashboard;
-    await nextFrame();
-
-    dashboard.rootHeadingLevel = 4;
-    await nextFrame();
-
-    const sectionTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-section')!);
-    expect(sectionTitle?.getAttribute('aria-level')).to.equal('4');
-
-    const widgetTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-widget')!);
-    expect(widgetTitle?.getAttribute('aria-level')).to.equal('5');
-  });
-
-  it('should use default title heading level when not set on dashboard', async () => {
-    const dashboard = fixtureSync(`
-      <vaadin-dashboard root-heading-level="4">
-        <vaadin-dashboard-section section-title="foo">
-          <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
-        </vaadin-dashboard-section>
-      </vaadin-dashboard>
-    `) as Dashboard;
-    await nextFrame();
-
-    dashboard.rootHeadingLevel = null;
-    await nextFrame();
-
-    const sectionTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-section')!);
-    expect(sectionTitle?.getAttribute('aria-level')).to.equal('2');
-
-    const widgetTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-widget')!);
-    expect(widgetTitle?.getAttribute('aria-level')).to.equal('3');
-  });
-
-  it('should have custom title heading level after defining parent dashboard', async () => {
-    const widget = fixtureSync(`
-      <my-custom-dashboard root-heading-level="4">
-        <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
-      </my-custom-dashboard>
-    `).querySelector('vaadin-dashboard-widget')!;
-    await nextFrame();
-
-    class MyCustomDashboard extends Dashboard {}
-    customElements.define('my-custom-dashboard', MyCustomDashboard);
-    await nextFrame();
-
-    const title = getTitleElement(widget);
-    expect(title?.getAttribute('aria-level')).to.equal('4');
   });
 });

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-widget.js';
+import { Dashboard } from '../src/vaadin-dashboard';
 import { DashboardSection } from '../vaadin-dashboard-section.js';
 import { DashboardWidget } from '../vaadin-dashboard-widget.js';
 import {
@@ -152,23 +153,23 @@ describe('dashboard widget', () => {
 });
 
 describe('widget title level', () => {
-  it('should have h2 title by default', async () => {
+  it('should have title heading level 2 by default', async () => {
     const widget = fixtureSync(`<vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>`);
     await nextFrame();
 
     const title = getTitleElement(widget as DashboardWidget);
-    expect(title?.localName).to.equal('h2');
+    expect(title?.getAttribute('aria-level')).to.equal('2');
   });
 
-  it('should have h2 title by default on the section', async () => {
+  it('should have title heading level 2 by default on the section', async () => {
     const section = fixtureSync(`<vaadin-dashboard-section section-title="foo"></vaadin-dashboard-section>`);
     await nextFrame();
 
     const title = getTitleElement(section as DashboardSection);
-    expect(title?.localName).to.equal('h2');
+    expect(title?.getAttribute('aria-level')).to.equal('2');
   });
 
-  it('should have h3 title when rendered inside a section', async () => {
+  it('should have title heading level 3 when rendered inside a section', async () => {
     const widget = fixtureSync(`
       <vaadin-dashboard-section>
         <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
@@ -177,10 +178,10 @@ describe('widget title level', () => {
     await nextFrame();
 
     const title = getTitleElement(widget);
-    expect(title?.localName).to.equal('h3');
+    expect(title?.getAttribute('aria-level')).to.equal('3');
   });
 
-  it('should have h2 title after moving out of a section', async () => {
+  it('should have title heading level 2 after moving out of a section', async () => {
     const widget = fixtureSync(`
       <div>
         <vaadin-dashboard-section>
@@ -195,10 +196,10 @@ describe('widget title level', () => {
     await nextFrame();
 
     const title = getTitleElement(widget);
-    expect(title?.localName).to.equal('h2');
+    expect(title?.getAttribute('aria-level')).to.equal('2');
   });
 
-  it('should have h3 title after moving into a section', async () => {
+  it('should have title heading level 3 after moving into a section', async () => {
     const widget = fixtureSync(`
       <div>
         <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
@@ -212,10 +213,10 @@ describe('widget title level', () => {
     await nextFrame();
 
     const title = getTitleElement(widget);
-    expect(title?.localName).to.equal('h3');
+    expect(title?.getAttribute('aria-level')).to.equal('3');
   });
 
-  it('should have h3 title after defining parent section', async () => {
+  it('should have title heading level 3 after defining parent section', async () => {
     const widget = fixtureSync(`
       <my-custom-section>
         <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
@@ -228,10 +229,10 @@ describe('widget title level', () => {
     await nextFrame();
 
     const title = getTitleElement(widget);
-    expect(title?.localName).to.equal('h3');
+    expect(title?.getAttribute('aria-level')).to.equal('3');
   });
 
-  it('should have h3 title after defining the widget', async () => {
+  it('should have title heading level 3 after defining the widget', async () => {
     const widget = fixtureSync(`
       <vaadin-dashboard-section>
         <my-custom-widget widget-title="foo"></my-custom-widget>
@@ -244,10 +245,10 @@ describe('widget title level', () => {
     await nextFrame();
 
     const title = getTitleElement(widget as DashboardWidget);
-    expect(title?.localName).to.equal('h3');
+    expect(title?.getAttribute('aria-level')).to.equal('3');
   });
 
-  it('should have h3 title after moving a wrapped widget into a section', async () => {
+  it('should have title heading level 3 after moving a wrapped widget into a section', async () => {
     const widget = fixtureSync(`
       <div>
         <div id="wrapper">
@@ -264,6 +265,79 @@ describe('widget title level', () => {
     await nextFrame();
 
     const title = getTitleElement(widget);
-    expect(title?.localName).to.equal('h3');
+    expect(title?.getAttribute('aria-level')).to.equal('3');
+  });
+
+  it('should use custom title heading level when set on dashboard', async () => {
+    const dashboard = fixtureSync(`
+      <vaadin-dashboard root-heading-level="4">
+        <vaadin-dashboard-section section-title="foo">
+          <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
+        </vaadin-dashboard-section>
+      </vaadin-dashboard>
+    `);
+    await nextFrame();
+
+    const sectionTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-section')!);
+    expect(sectionTitle?.getAttribute('aria-level')).to.equal('4');
+
+    const widgetTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-widget')!);
+    expect(widgetTitle?.getAttribute('aria-level')).to.equal('5');
+  });
+
+  it('should update title heading level when set on dashboard', async () => {
+    const dashboard = fixtureSync(`
+      <vaadin-dashboard>
+        <vaadin-dashboard-section section-title="foo">
+          <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
+        </vaadin-dashboard-section>
+      </vaadin-dashboard>
+    `) as Dashboard;
+    await nextFrame();
+
+    dashboard.rootHeadingLevel = 4;
+    await nextFrame();
+
+    const sectionTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-section')!);
+    expect(sectionTitle?.getAttribute('aria-level')).to.equal('4');
+
+    const widgetTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-widget')!);
+    expect(widgetTitle?.getAttribute('aria-level')).to.equal('5');
+  });
+
+  it('should use default title heading level when not set on dashboard', async () => {
+    const dashboard = fixtureSync(`
+      <vaadin-dashboard root-heading-level="4">
+        <vaadin-dashboard-section section-title="foo">
+          <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
+        </vaadin-dashboard-section>
+      </vaadin-dashboard>
+    `) as Dashboard;
+    await nextFrame();
+
+    dashboard.rootHeadingLevel = null;
+    await nextFrame();
+
+    const sectionTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-section')!);
+    expect(sectionTitle?.getAttribute('aria-level')).to.equal('2');
+
+    const widgetTitle = getTitleElement(dashboard.querySelector('vaadin-dashboard-widget')!);
+    expect(widgetTitle?.getAttribute('aria-level')).to.equal('3');
+  });
+
+  it('should have custom title heading level after defining parent dashboard', async () => {
+    const widget = fixtureSync(`
+      <my-custom-dashboard root-heading-level="4">
+        <vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>
+      </my-custom-dashboard>
+    `).querySelector('vaadin-dashboard-widget')!;
+    await nextFrame();
+
+    class MyCustomDashboard extends Dashboard {}
+    customElements.define('my-custom-dashboard', MyCustomDashboard);
+    await nextFrame();
+
+    const title = getTitleElement(widget);
+    expect(title?.getAttribute('aria-level')).to.equal('4');
   });
 });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -15,6 +15,7 @@ import {
   getRemoveButton,
   getResizeHandle,
   getScrollingContainer,
+  getTitleElement,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
@@ -761,6 +762,46 @@ describe('dashboard', () => {
         dashboard.items = dashboard.items.slice(1);
         await renderAndFocusRestore();
       });
+    });
+  });
+
+  describe('root heading level', () => {
+    beforeEach(async () => {
+      dashboard.rootHeadingLevel = 4;
+      await updateComplete(dashboard);
+      dashboard.items = [{ id: '0' }, { title: 'Section', items: [{ id: '1' }] }];
+      await updateComplete(dashboard);
+    });
+
+    function assertHeadingLevels(expectedRootHeadingLevel: number) {
+      const nonNestedWidget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
+      expect(getTitleElement(nonNestedWidget)?.getAttribute('aria-level')).to.equal(
+        expectedRootHeadingLevel.toString(),
+      );
+
+      const nestedWidget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
+      expect(getTitleElement(nestedWidget)?.getAttribute('aria-level')).to.equal(
+        (expectedRootHeadingLevel + 1).toString(),
+      );
+
+      const section = nestedWidget?.closest('vaadin-dashboard-section') as DashboardSection;
+      expect(getTitleElement(section)?.getAttribute('aria-level')).to.equal(expectedRootHeadingLevel.toString());
+    }
+
+    it('should use custom title heading level when set on dashboard', () => {
+      assertHeadingLevels(4);
+    });
+
+    it('should update title heading level when set on dashboard', async () => {
+      dashboard.rootHeadingLevel = 1;
+      await updateComplete(dashboard);
+      assertHeadingLevels(1);
+    });
+
+    it('should use default title heading level when not set on dashboard', async () => {
+      dashboard.rootHeadingLevel = null;
+      await updateComplete(dashboard);
+      assertHeadingLevels(2);
     });
   });
 });


### PR DESCRIPTION
## Description

This PR makes the heading level for the dashboard sections and widgets customizable by adding a property `rootHeadingLevel` to `Dashboard`.

- The defaults are unchanged. 
- The titles are now rendered as `div`s instead of `h2` and `h3`. Instead, the level is applied using the `aria-level` attribute on the title element.

Part of #8779 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.