### PR TITLE
fix: apply view transition name only to layout that started transition

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -15,13 +15,13 @@ export const transitionStyles = css`
   }
 
   /* Default cross-fade animation */
-  vaadin-master-detail-layout {
+  vaadin-master-detail-layout[transition] {
     view-transition-name: vaadin-master-detail-layout;
   }
 
   ::view-transition-group(vaadin-master-detail-layout) {
     animation-duration: var(--vaadin-master-detail-layout-transition-duration, 300ms);
-
+  }
 
   /* Overlay - horizontal - add */
 


### PR DESCRIPTION
## Description

The current transition styles apply the `vaadin-master-detail-layout` view transition name to all layouts. This breaks if there is more than one layout, as view transition names must only applied to a single element:
```
Unexpected duplicate view-transition-name: vaadin-master-detail-layout
```

This applies the transition name only to the layout that started the transition. Also fixes a CSS rule that was not properly closed.

## Type of change

- Bugfix
