### PR TITLE
fix: remove notify: true from cardTitle property

### DIFF
--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -291,7 +291,6 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
        */
       cardTitle: {
         type: String,
-        notify: true,
         observer: '__cardTitleChanged',
       },
 


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/flow-components/pull/7225#discussion_r2020491069 this was a leftover, so let's remove `notify: true` since it breaks React components release.

## Type of change

- Bugfix