### PR TITLE
fix: add hostConnected to virtualizer, use it in virtual-list and grid

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -178,6 +178,16 @@ export class IronListAdapter {
     }
   }
 
+  hostConnected() {
+    // Restore scroll position, which is reset when host is removed from DOM,
+    // since virtualizer doesn't re-render when adding it to the DOM again.
+    // If the scroll target isn't visible and its `offsetParent` is `null`, wait
+    // for the ResizeObserver to handle this case (hiding -> moving -> showing).
+    if (this.scrollTarget.offsetParent && this.scrollTarget.scrollTop !== this._scrollPosition) {
+      this.scrollTarget.scrollTop = this._scrollPosition;
+    }
+  }
+
   update(startIndex = 0, endIndex = this.size - 1) {
     const updatedElements = [];
     this.__getVisibleElements().forEach((el) => {

--- a/packages/component-base/src/virtualizer.js
+++ b/packages/component-base/src/virtualizer.js
@@ -80,4 +80,13 @@ export class Virtualizer {
   flush() {
     this.__adapter.flush();
   }
+
+  /**
+   * Notifies the virtualizer about its host element connected to the DOM.
+   *
+   * @method hostConnected
+   */
+  hostConnected() {
+    this.__adapter.hostConnected();
+  }
 }

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -366,6 +366,21 @@ describe('virtualizer', () => {
     expect(scrollTarget.scrollTop).to.equal(100);
   });
 
+  it('should restore scroll position on hostConnected after moving within DOM', async () => {
+    scrollTarget.scrollTop = 100;
+    await oneEvent(scrollTarget, 'scroll');
+
+    await nextResize(scrollTarget);
+
+    const wrapper = fixtureSync('<div></div>');
+    wrapper.appendChild(scrollTarget);
+
+    await nextResize(scrollTarget);
+    virtualizer.hostConnected();
+
+    expect(scrollTarget.scrollTop).to.equal(100);
+  });
+
   describe('lazy rendering', () => {
     let render = false;
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -197,6 +197,7 @@ export const GridMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       this.isAttached = true;
+      this.__virtualizer.hostConnected();
     }
 
     /** @protected */

--- a/packages/grid/test/basic.test.js
+++ b/packages/grid/test/basic.test.js
@@ -131,6 +131,16 @@ describe('basic features', () => {
     expect(top).to.be.greaterThan(0);
   });
 
+  it('should restore scroll position when moving within DOM', () => {
+    grid.scrollToIndex(99);
+    const top = grid.$.table.scrollTop;
+
+    const wrapper = fixtureSync('<div></div>');
+    wrapper.appendChild(grid);
+
+    expect(grid.$.table.scrollTop).to.eql(top);
+  });
+
   it('reset items', () => {
     grid.size = 100;
 

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -104,6 +104,7 @@ export const VirtualListMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       document.addEventListener('dragstart', this.__onDocumentDragStart, { capture: true });
+      this.__virtualizer.hostConnected();
     }
 
     /** @protected */

--- a/packages/virtual-list/test/virtual-list.test.js
+++ b/packages/virtual-list/test/virtual-list.test.js
@@ -177,5 +177,17 @@ describe('virtual-list', () => {
         expect(list.getAttribute('overflow')).to.equal('top');
       });
     });
+
+    describe('scroll restoration', () => {
+      it('should restore scroll position when moving within DOM', () => {
+        list.scrollToIndex(50);
+        const top = list.scrollTop;
+
+        const wrapper = fixtureSync('<div></div>');
+        wrapper.appendChild(list);
+
+        expect(list.scrollTop).to.equal(top);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes #8630 

This fixes the case from https://github.com/vaadin/web-components/issues/8630#issuecomment-2636265294 based on the previous idea from https://github.com/vaadin/web-components/commit/324e4ad1534fb6dcf50650ca92b96de283c2d9df

The original fix that landed in #8642 only coverer case of "hiding -> moving -> showing" the virtualizer scroll target.
However, it won't work if the component is moved without changing visibility (e.g. attached to overlay after it fully opens).

## Type of change

- Bugfix