### PR TITLE
fix: set z-index on backdrop and detail parts in overlay mode

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -86,6 +86,11 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         position: absolute;
       }
 
+      :host([overlay]) [part='detail'],
+      :host([overlay]) [part='backdrop'] {
+        z-index: 1;
+      }
+
       :host(:is([overlay], [stack])[containment='viewport']) [part='detail'],
       :host([overlay][containment='viewport']) [part='backdrop'] {
         position: fixed;

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -86,11 +86,6 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         position: absolute;
       }
 
-      :host([overlay]) [part='detail'],
-      :host([overlay]) [part='backdrop'] {
-        z-index: 1;
-      }
-
       :host(:is([overlay], [stack])[containment='viewport']) [part='detail'],
       :host([overlay][containment='viewport']) [part='backdrop'] {
         position: fixed;
@@ -99,6 +94,11 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       :host([overlay][has-detail]) [part='backdrop'] {
         display: block;
         inset: 0;
+        z-index: 1;
+      }
+
+      :host([overlay]) [part='detail'] {
+        z-index: 1;
       }
 
       :host([overlay][orientation='horizontal']) [part='detail'] {


### PR DESCRIPTION
## Description

Fixes #8898

Added `z-index` similar to the that `vaadin-app-layout` uses in its overlay mode.

## Type of change

- Bugfix