### PR TITLE
fix: don't apply `inert` on master if there is no detail

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -358,6 +358,17 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         reflectToAttribute: true,
         sync: true,
       },
+
+      /**
+       * When true, the component has the detail content provided.
+       * @protected
+       */
+      _hasDetail: {
+        type: Boolean,
+        attribute: 'has-detail',
+        reflectToAttribute: true,
+        sync: true,
+      },
     };
   }
 
@@ -370,11 +381,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   render() {
     return html`
       <div part="backdrop"></div>
-      <div
-        id="master"
-        part="master"
-        ?inert="${this.querySelector('[slot="detail"]') && this._overlay && this.containment === 'layout'}"
-      >
+      <div id="master" part="master" ?inert="${this._hasDetail && this._overlay && this.containment === 'layout'}">
         <slot></slot>
       </div>
       <div
@@ -392,7 +399,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   __onDetailSlotChange(e) {
     const children = e.target.assignedNodes();
 
-    this.toggleAttribute('has-detail', children.length > 0);
+    this._hasDetail = children.length > 0;
     this.__detectLayoutMode();
 
     // Move focus to the detail area when it is added to the DOM,
@@ -499,7 +506,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       }
     }
 
-    if (!this.hasAttribute('has-detail')) {
+    if (!this._hasDetail) {
       return;
     }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -370,7 +370,11 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   render() {
     return html`
       <div part="backdrop"></div>
-      <div id="master" part="master" ?inert="${this._overlay && this.containment === 'layout'}">
+      <div
+        id="master"
+        part="master"
+        ?inert="${this.querySelector('[slot="detail"]') && this._overlay && this.containment === 'layout'}"
+      >
         <slot></slot>
       </div>
       <div

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -57,4 +57,20 @@ describe('ARIA', () => {
     layout.containment = 'viewport';
     expect(master.hasAttribute('inert')).to.be.false;
   });
+
+  it('should not set inert on the master part with the detail removed', async () => {
+    layout.forceOverlay = true;
+    layout.containment = 'layout';
+
+    const detailContent = layout.querySelector('[slot="detail"]');
+    detailContent.remove();
+    await nextRender();
+
+    expect(master.hasAttribute('inert')).to.be.false;
+
+    layout.appendChild(detailContent);
+    await nextRender();
+
+    expect(master.hasAttribute('inert')).to.be.true;
+  });
 });


### PR DESCRIPTION
When `forceOverlay` was set to `true`, the `inert` attribute would always be set on the master part making it inaccessible even when there was no detail element in the layout.