### PR TITLE
refactor: simplify menu-bar Tab navigation submenu logic

### DIFF
--- a/packages/a11y-base/test/keyboard-direction-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-direction-mixin.test.js
@@ -7,6 +7,7 @@ import {
   endKeyDown,
   fixtureSync,
   homeKeyDown,
+  tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
@@ -32,6 +33,10 @@ customElements.define(
 
     get _vertical() {
       return this.hasAttribute('vertical');
+    }
+
+    get _tabNavigation() {
+      return this.hasAttribute('tab-navigation');
     }
   },
 );
@@ -86,10 +91,21 @@ describe('keyboard-direction-mixin', () => {
           expect(element.focused).to.be.equal(items[1]);
         });
 
-        it('should move focus to prev element on "arrow-right" keydown in LTR', () => {
+        it('should move focus to prev element on "arrow-left" keydown in LTR', () => {
           arrowRightKeyDown(items[0]);
           arrowLeftKeyDown(items[1]);
           expect(element.focused).to.be.equal(items[0]);
+        });
+
+        it('should move focus to last element on first element "arrow-left" keydown', () => {
+          arrowLeftKeyDown(items[0]);
+          expect(element.focused).to.equal(items[5]);
+        });
+
+        it('should move focus to first element on last element "arrow-right" keydown', () => {
+          arrowLeftKeyDown(items[0]);
+          arrowRightKeyDown(items[5]);
+          expect(element.focused).to.equal(items[0]);
         });
       });
 
@@ -107,6 +123,17 @@ describe('keyboard-direction-mixin', () => {
           arrowLeftKeyDown(items[0]);
           arrowRightKeyDown(items[1]);
           expect(element.focused).to.be.equal(items[0]);
+        });
+
+        it('should move focus to last element on first element "arrow-right" keydown', () => {
+          arrowRightKeyDown(items[0]);
+          expect(element.focused).to.equal(items[5]);
+        });
+
+        it('should move focus to first element on last element "arrow-left" keydown', () => {
+          arrowRightKeyDown(items[0]);
+          arrowLeftKeyDown(items[5]);
+          expect(element.focused).to.equal(items[0]);
         });
       });
     });
@@ -187,6 +214,35 @@ describe('keyboard-direction-mixin', () => {
         arrowRightKeyDown(items[0]);
         expect(element.focused).to.be.equal(items[3]);
       });
+    });
+  });
+
+  describe('Tab navigation', () => {
+    beforeEach(() => {
+      element.setAttribute('tab-navigation', '');
+      element.focus();
+    });
+
+    it('should move focus to next element on Tab keydown', () => {
+      tabKeyDown(items[0]);
+      expect(element.focused).to.be.equal(items[1]);
+    });
+
+    it('should move focus to prev element on Shift + Tab keydown', () => {
+      tabKeyDown(items[0]);
+      tabKeyDown(items[1], ['shift']);
+      expect(element.focused).to.be.equal(items[0]);
+    });
+
+    it('should not move focus to last element on first element Shift + Tab keydown', () => {
+      tabKeyDown(items[0], ['shift']);
+      expect(element.focused).to.not.equal(items[5]);
+    });
+
+    it('should not move focus to first element on last element Tab keydown', () => {
+      items[5].focus();
+      tabKeyDown(items[5]);
+      expect(element.focused).to.not.equal(items[0]);
     });
   });
 });

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -5,7 +5,7 @@
  */
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
-import { isElementFocused, isElementHidden, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
@@ -233,6 +233,17 @@ export const MenuBarMixin = (superClass) =>
      */
     get _vertical() {
       return false;
+    }
+
+    /**
+     * Override getter from `KeyboardDirectionMixin`.
+     *
+     * @return {boolean}
+     * @protected
+     * @override
+     */
+    get _tabNavigation() {
+      return this.tabNavigation;
     }
 
     /**
@@ -759,12 +770,7 @@ export const MenuBarMixin = (superClass) =>
      */
     _setFocused(focused) {
       if (focused) {
-        let target = this.querySelector('[tabindex="0"]');
-        if (this.tabNavigation) {
-          // Switch submenu on menu button Tab / Shift Tab
-          target = this.querySelector('[focused]');
-          this.__switchSubMenu(target);
-        }
+        const target = this.tabNavigation ? this.querySelector('[focused]') : this.querySelector('[tabindex="0"]');
         if (target) {
           this._buttons.forEach((btn) => {
             this._setTabindex(btn, btn === target);
@@ -883,38 +889,15 @@ export const MenuBarMixin = (superClass) =>
         if (e.keyCode === 38 && item === list.items[0]) {
           this._close(true);
         }
-        // ArrowLeft, or ArrowRight on non-parent submenu item
+        // ArrowLeft, or ArrowRight on non-parent submenu item,
         if (e.keyCode === 37 || (e.keyCode === 39 && !item._item.children)) {
           // Prevent ArrowLeft from being handled in context-menu
           e.stopImmediatePropagation();
           this._onKeyDown(e);
-        } else if (e.keyCode === 9 && this.tabNavigation) {
-          // Switch opened submenu on submenu item Tab / Shift Tab
-          const items = this._getItems() || [];
-          const currentIdx = items.indexOf(this.focused);
-          const increment = e.shiftKey ? -1 : 1;
-          let idx = currentIdx + increment;
-          idx = this._getAvailableIndex(items, idx, increment, (item) => !isElementHidden(item));
-
-          if ((idx > currentIdx && e.shiftKey) || (idx < currentIdx && !e.shiftKey)) {
-            // Prevent "roving tabindex" logic and let the normal Tab behavior if
-            // - currently in the first button submenu and Shift + Tab is pressed,
-            // - currently in the last button submenu and Tab is pressed.
-            return;
-          }
-
-          this.__switchSubMenu(items[idx]);
         }
-      }
-    }
 
-    /** @private */
-    __switchSubMenu(target) {
-      const wasExpanded = this._expandedButton != null && this._expandedButton !== target;
-      if (wasExpanded) {
-        this._close();
-        if (target.item && target.item.children) {
-          this.__openSubMenu(target, true, { keepFocus: true });
+        if (e.key === 'Tab' && this.tabNavigation) {
+          this._onKeyDown(e);
         }
       }
     }


### PR DESCRIPTION
## Description

Currently, `vaadin-menu-bar` has some special logic in `tabNavigation` mode for switching submenu (so that e.g. pressing <kbd>Tab</kbd> on the submenu item focuses the next root level button and opens its submenu, if any).

This isn't very clean since it basically copies some of `KeyboardDirectionMixin` logic for Arrow Left / Arrow Right.

Updated logic to integrate "Tab navigation" into the mixin so that switching submenu can be handled by existing logic:

https://github.com/vaadin/web-components/blob/f903c63170fc3855c721c03fc79ac0798cb24d0b/packages/menu-bar/src/vaadin-menu-bar-mixin.js#L739-L740

## Type of change

- Refactor