### PR TITLE
refactor: update menu-bar submenu to open synchronously

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -268,8 +268,9 @@ export const ItemsMixin = (superClass) =>
           // Close the menu
           this.close();
           this.listenOn.focus();
-        } else if (key === 'Tab') {
-          // Close all menus
+        } else if (key === 'Tab' && !event.defaultPrevented) {
+          // Close all menus unless the Tab key was handled separately
+          // which is the case e.g. in menu-bar with Tab navigation.
           this.dispatchEvent(new CustomEvent('close-all-menus'));
         }
       });

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -942,31 +942,21 @@ export const MenuBarMixin = (superClass) =>
       const overlay = subMenu._overlayElement;
       overlay.noVerticalOverlap = true;
 
+      this._hideTooltip(true);
+
       this._expandedButton = button;
-
-      requestAnimationFrame(() => {
-        // After changing items, buttons are recreated so the old button is
-        // no longer in the DOM. Reset position target to null to prevent
-        // overlay from closing due to target width / height equal to 0.
-        if (overlay.positionTarget && !overlay.positionTarget.isConnected) {
-          overlay.positionTarget = null;
-        }
-
-        button.dispatchEvent(
-          new CustomEvent('opensubmenu', {
-            detail: {
-              children: items,
-            },
-          }),
-        );
-        this._hideTooltip(true);
-
-        this._setExpanded(button, true);
-
-        overlay.positionTarget = button;
-      });
+      this._setExpanded(button, true);
 
       this.style.pointerEvents = 'auto';
+      overlay.positionTarget = button;
+
+      button.dispatchEvent(
+        new CustomEvent('opensubmenu', {
+          detail: {
+            children: items,
+          },
+        }),
+      );
 
       overlay.addEventListener(
         'vaadin-overlay-open',

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -59,7 +59,6 @@ snapshots["menu-bar basic"] =
 snapshots["menu-bar overlay"] = 
 `<vaadin-menu-bar-overlay
   opened=""
-  right-aligned=""
   start-aligned=""
   top-aligned=""
 >
@@ -95,7 +94,6 @@ snapshots["menu-bar overlay class"] =
 `<vaadin-menu-bar-overlay
   class="custom menu-bar-overlay"
   opened=""
-  right-aligned=""
   start-aligned=""
   top-aligned=""
 >

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -158,11 +158,10 @@ describe('sub-menu', () => {
 
   it('should focus first sub-menu item when opened on arrow down', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
-    expect(subMenu.opened).to.be.true;
+    await nextUpdate(subMenu);
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     const spy = sinon.spy(item, 'focus');
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(spy.calledOnce).to.be.true;
   });
 
@@ -182,12 +181,11 @@ describe('sub-menu', () => {
 
   it('should open sub-menu and focus last item on arrow up', async () => {
     arrowUp(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
-    expect(subMenu.opened).to.be.true;
+    await nextUpdate(subMenu);
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     const spy = sinon.spy(last, 'focus');
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(spy.calledOnce).to.be.true;
   });
 
@@ -226,7 +224,7 @@ describe('sub-menu', () => {
 
   it('should close sub-menu on first item arrow up', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     expect(item).to.be.ok;
     await nextRender(subMenu);
@@ -237,7 +235,7 @@ describe('sub-menu', () => {
 
   it('should focus first item on arrow down after opened on arrow left', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
     let item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     await nextRender(subMenu);
@@ -251,7 +249,7 @@ describe('sub-menu', () => {
 
   it('should focus last item on arrow up after opened on arrow left', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     await nextRender(subMenu);
@@ -266,7 +264,7 @@ describe('sub-menu', () => {
 
   it('should close submenu on Esc after switch on arrow left', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
     await nextRender(subMenu);
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
@@ -321,7 +319,7 @@ describe('sub-menu', () => {
 
   it('should not close on parent item click', async () => {
     arrowUp(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     await nextRender(subMenu);
@@ -648,8 +646,7 @@ describe('touch', () => {
 
   (isSafari ? it.skip : it)('should close submenu on mobile when selecting an item in the nested one', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const subMenu2 = subMenuOverlay.querySelector('vaadin-menu-bar-submenu');
     items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
@@ -666,8 +663,7 @@ describe('touch', () => {
 
   it('should not close submenu on mobile when opening the nested submenu', async () => {
     arrowDown(buttons[0]);
-    await oneEvent(subMenu, 'opened-changed');
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const subMenu2 = subMenuOverlay.querySelector('vaadin-menu-bar-submenu');
     items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];


### PR DESCRIPTION
## Description

Depends on #8908 (this is an independent change but some Tab navigation tests would fail until that PR is merged).

Wrapping opening submenu event with `requestAnimationFrame()` was added in https://github.com/vaadin/vaadin-menu-bar/pull/12. It seems unnecessary since there is no need to delay opening overlay (the very first revision at https://github.com/vaadin/vaadin-menu-bar/pull/12/commits/3bdc2791a8d110546e423753468ef907dd979557 had an additional `before-open` event with some logic, but that was changed in a subsequent commit).

Tested this change with Flow components and it seems to make ITs more reliable in terms of timeouts.

## Type of change

- Refactor