### PR TITLE
fix: do not generate effective i18n if custom i18n reference didn't chance

### DIFF
--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -90,6 +90,9 @@ export const I18nMixin = (defaultI18n, superClass) =>
      * @param {Object} value
      */
     set i18n(value) {
+      if (value === this.__customI18n) {
+        return;
+      }
       this.__customI18n = value;
       this.__effectiveI18n = deepMerge({}, defaultI18n, this.__customI18n);
     }

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -77,6 +77,17 @@ const runTests = (baseClass) => {
     element.i18n = { bar: { baz: null } };
     expect(element.__effectiveI18n).to.deep.equal(DEFAULT_I18N);
   });
+
+  it('should not refresh i18n when setting property to same reference', () => {
+    const customI18n = { foo: 'Custom Foo' };
+    element.i18n = customI18n;
+
+    const effectiveI18n = element.__effectiveI18n;
+
+    element.i18n = customI18n;
+
+    expect(element.__effectiveI18n).to.equal(effectiveI18n);
+  });
 };
 
 describe('I18nMixin + Polymer', () => {


### PR DESCRIPTION
## Description

React components seem to set the same element property in every render cycle regardless whether the reference has changed. The `i18n` property currently doesn't handle that properly and regenerates `__effectiveI18n` again, triggering the next render cycle, and potentially starting an infinite loop.

This fixes the issue by checking the custom I18N reference before regenerating `__effectiveI18n`.

Fixes https://github.com/vaadin/web-components/issues/8869

## Type of change

- Bugfix
