### PR TITLE
feat: add `component-base/style-props.js`

### DIFF
--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';
+// TODO: add themable-mixin as a dependency to package.json
 import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 addGlobalThemeStyles(

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+addGlobalThemeStyles(
+  'vaadin-base',
+  css`
+    @layer vaadin.base {
+      html {
+        /* Background color */
+        --_vaadin-bg: hsl(0 0 100);
+      }
+    }
+  `,
+);


### PR DESCRIPTION
Add the file where base style properties are added. Includes one property which is intended to be used for all surfaces where components are displayed (page, overlays, dialogs, etc).