### PR TITLE
refactor!: Button base styles

### DIFF
--- a/dev/button.html
+++ b/dev/button.html
@@ -1,22 +1,94 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Button</title>
-    <script type="module" src="./common.js"></script>
 
-    <script type="module">
-      import '@vaadin/button';
-      import '@vaadin/tooltip';
-    </script>
-  </head>
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button</title>
+  <script type="module" src="./common.js"></script>
 
-  <body>
+  <script type="module">
+    window.Vaadin = {};
+    window.Vaadin.featureFlags = {};
+    window.Vaadin.featureFlags.accessibleDisabledButtons = true;
+  </script>
+  <script type="module">
+    import '@vaadin/button/src/vaadin-lit-button.js';
+    import '@vaadin/tooltip/src/vaadin-lit-tooltip.js';
+    import '@vaadin/icon/src/vaadin-lit-icon.js';
+    import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+    import '@vaadin/icons';
+  </script>
+</head>
+
+<body>
+
+  <section>
+    <h2>Label & Icon</h2>
+    <vaadin-button>Reply</vaadin-button>
     <vaadin-button>
-      Edit
-      <vaadin-tooltip slot="tooltip" text="Click to edit"></vaadin-tooltip>
+      <vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>
+      Reply
     </vaadin-button>
-  </body>
+    <vaadin-button aria-label="Reply">
+      <vaadin-icon icon="vaadin:reply"></vaadin-icon>
+      <vaadin-tooltip slot="tooltip" text="Reply"></vaadin-tooltip>
+    </vaadin-button>
+  </section>
+
+  <section>
+    <h2>Primary</h2>
+    <vaadin-button theme="primary">Reply</vaadin-button>
+    <vaadin-button theme="primary">
+      <vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>
+      Reply
+    </vaadin-button>
+    <vaadin-button theme="primary" aria-label="Reply">
+      <vaadin-icon icon="vaadin:reply"></vaadin-icon>
+      <vaadin-tooltip slot="tooltip" text="Reply"></vaadin-tooltip>
+    </vaadin-button>
+  </section>
+
+  <section>
+    <h2>Tertiary</h2>
+    <vaadin-button theme="tertiary">Reply</vaadin-button>
+    <vaadin-button theme="tertiary">
+      <vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>
+      Reply
+    </vaadin-button>
+    <vaadin-button theme="tertiary" aria-label="Reply">
+      <vaadin-icon icon="vaadin:reply"></vaadin-icon>
+      <vaadin-tooltip slot="tooltip" text="Reply"></vaadin-tooltip>
+    </vaadin-button>
+  </section>
+
+  <section>
+    <h2>Disabled</h2>
+    <vaadin-button theme="primary" disabled>Primary</vaadin-button>
+    <vaadin-button disabled>Secondary</vaadin-button>
+    <vaadin-button theme="tertiary" disabled>Tertiary</vaadin-button>
+  </section>
+
+  <section>
+    <h2>Custom Layout</h2>
+    <vaadin-button style="width: 150px">Reply</vaadin-button>
+    <vaadin-button style="width: 150px">
+      <vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>
+      Reply
+    </vaadin-button>
+    <vaadin-button style="width: 150px" aria-label="Reply">
+      <vaadin-icon icon="vaadin:reply"></vaadin-icon>
+    </vaadin-button>
+    <vaadin-button style="width: 150px; justify-content: start;">
+      <vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>
+      Reply
+    </vaadin-button>
+    <vaadin-button style="flex-direction: column;">
+      <vaadin-icon icon="vaadin:reply"></vaadin-icon>
+      Reply
+    </vaadin-button>
+  </section>
+</body>
+
 </html>

--- a/dev/common.js
+++ b/dev/common.js
@@ -1,2 +1,31 @@
-// Add standard Lumo styles to the page. NOTE: the autoload helper is not intended for public use.
-import '@vaadin/vaadin-lumo-styles/test/autoload.js';
+import '@vaadin/component-base/src/style-props.js';
+import { css } from 'lit';
+import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+addGlobalThemeStyles(
+  'dev-common',
+  css`
+    body {
+      font-family: system-ui, sans-serif;
+      font-size: calc(14 / 16 * 1rem);
+      line-height: calc(18 / 16 * 1rem);
+      color: var(--_vaadin-color);
+      background: var(--_vaadin-bg);
+      margin: 2rem;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: var(--_vaadin-color-strong);
+      font-weight: 600;
+      font-size: calc(18 / 16 * 1rem);
+      line-height: calc(20 / 16 * 1rem);
+      margin: 2em 0 1.25em;
+      text-box: cap alphabetic;
+    }
+  `,
+);

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -3,70 +3,86 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const buttonStyles = css`
-  :host {
-    display: inline-block;
-    position: relative;
-    outline: none;
-    white-space: nowrap;
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  :host([disabled]) {
-    pointer-events: var(--_vaadin-button-disabled-pointer-events, none);
-    cursor: not-allowed;
-  }
-
-  /* Aligns the button with form fields when placed on the same line.
-  Note, to make it work, the form fields should have the same "::before" pseudo-element. */
-  .vaadin-button-container::before {
-    content: '\\2003';
-    display: inline-block;
-    width: 0;
-    max-height: 100%;
-  }
-
-  .vaadin-button-container {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    width: 100%;
-    height: 100%;
-    min-height: inherit;
-    text-shadow: inherit;
-  }
-
-  [part='prefix'],
-  [part='suffix'] {
-    flex: none;
-  }
-
-  [part='label'] {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  @media (forced-colors: active) {
+  @layer base {
     :host {
-      outline: 1px solid;
-      outline-offset: -1px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      gap: var(--vaadin-button-gap, 0 var(--_vaadin-gap-icon));
+
+      white-space: nowrap;
+      -webkit-tap-highlight-color: transparent;
+      -webkit-user-select: none;
+      user-select: none;
+      cursor: pointer;
+      box-sizing: border-box;
+      vertical-align: middle;
+      flex-shrink: 0;
+      height: var(--vaadin-button-height, auto);
+      margin: var(--vaadin-button-margin, 0);
+      padding: var(--vaadin-button-padding, var(--_vaadin-padding-container-text));
+      font-family: var(--vaadin-button-font-family, inherit);
+      font-size: var(--vaadin-button-font-size, inherit);
+      line-height: var(--vaadin-button-line-height, inherit);
+      font-weight: var(--vaadin-button-font-weight, 500);
+      color: var(--vaadin-button-text-color, var(--_vaadin-color-strong));
+      background: var(--vaadin-button-background, var(--_vaadin-bg-container));
+      background-origin: border-box;
+      border: var(
+        --vaadin-button-border,
+        var(--vaadin-button-border-width, 1px) solid var(--vaadin-button-border-color, var(--_vaadin-border-color))
+      );
+      border-radius: var(--vaadin-button-border-radius, var(--_vaadin-radius-m));
     }
 
-    :host([focused]) {
-      outline-width: 2px;
+    :host([hidden]) {
+      display: none !important;
+    }
+
+    .vaadin-button-container,
+    [part='prefix'],
+    [part='suffix'],
+    [part='label'] {
+      display: contents;
+    }
+
+    :host([focus-ring]) {
+      outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+      outline-offset: 1px;
+    }
+
+    :host([theme~='primary']) {
+      --vaadin-button-background: var(--_vaadin-color-strong);
+      --vaadin-button-text-color: var(--_vaadin-bg);
+      --vaadin-button-border-color: transparent;
+    }
+
+    :host([theme~='tertiary']) {
+      --vaadin-button-text-color: var(--_vaadin-button-text-color);
+      --vaadin-button-background: transparent;
+      --vaadin-button-border-color: transparent;
     }
 
     :host([disabled]) {
-      outline-color: GrayText;
+      pointer-events: var(--_vaadin-button-disabled-pointer-events, none);
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    :host([disabled][theme~='primary']) {
+      --vaadin-button-text-color: var(--_vaadin-bg-container-strong);
+      --vaadin-button-background: var(--_vaadin-color-weak);
+    }
+
+    @media (forced-colors: active) {
+      :host {
+        border: 1px solid;
+      }
     }
   }
 `;

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -13,7 +13,7 @@ export const buttonStyles = css`
       align-items: center;
       justify-content: center;
       text-align: center;
-      gap: var(--vaadin-button-gap, 0 var(--_vaadin-gap-icon));
+      gap: var(--vaadin-button-gap, 0 var(--_vaadin-gap-container));
 
       white-space: nowrap;
       -webkit-tap-highlight-color: transparent;
@@ -25,13 +25,13 @@ export const buttonStyles = css`
       flex-shrink: 0;
       height: var(--vaadin-button-height, auto);
       margin: var(--vaadin-button-margin, 0);
-      padding: var(--vaadin-button-padding, var(--_vaadin-padding-container-text));
+      padding: var(--vaadin-button-padding, var(--_vaadin-padding-container));
       font-family: var(--vaadin-button-font-family, inherit);
       font-size: var(--vaadin-button-font-size, inherit);
       line-height: var(--vaadin-button-line-height, inherit);
       font-weight: var(--vaadin-button-font-weight, 500);
       color: var(--vaadin-button-text-color, var(--_vaadin-color-strong));
-      background: var(--vaadin-button-background, var(--_vaadin-bg-container));
+      background: var(--vaadin-button-background, var(--_vaadin-background-container));
       background-origin: border-box;
       border: var(
         --vaadin-button-border,
@@ -58,7 +58,7 @@ export const buttonStyles = css`
 
     :host([theme~='primary']) {
       --vaadin-button-background: var(--_vaadin-color-strong);
-      --vaadin-button-text-color: var(--_vaadin-bg);
+      --vaadin-button-text-color: var(--_vaadin-background);
       --vaadin-button-border-color: transparent;
     }
 
@@ -75,8 +75,8 @@ export const buttonStyles = css`
     }
 
     :host([disabled][theme~='primary']) {
-      --vaadin-button-text-color: var(--_vaadin-bg-container-strong);
-      --vaadin-button-background: var(--_vaadin-color-weak);
+      --vaadin-button-text-color: var(--_vaadin-background-container-strong);
+      --vaadin-button-background: var(--_vaadin-color-subtle);
     }
 
     @media (forced-colors: active) {

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -14,6 +14,32 @@ addGlobalThemeStyles(
       html {
         /* Background color */
         --_vaadin-bg: hsl(0 0 100);
+
+        /* Foreground/content colors */
+        --_vaadin-bg-container: hsl(0 0 95);
+        --_vaadin-bg-container-strong: hsl(0 0 90);
+
+        --_vaadin-border-color: hsl(0 0 75);
+        --_vaadin-border-color-strong: hsl(0 0 58); /* Above 3:1 contrast */
+
+        --_vaadin-color-weak: hsl(0 0 58); /* Above 3:1 contrast */
+        --_vaadin-color: hsl(0 0 44); /* Above 4.5:1 contrast */
+        --_vaadin-color-strong: hsl(0 0 12); /* Above 7:1 contrast */
+
+        --_vaadin-padding-container: 8px;
+        --_vaadin-padding-container-text: 6px 8px;
+
+        --_vaadin-gap-icon: 0.5em;
+
+        --_vaadin-radius-s: 3px;
+        --_vaadin-radius-m: 6px;
+        --_vaadin-radius-l: 12px;
+        --_vaadin-radius-full: 999px;
+
+        --vaadin-focus-ring-width: 2px;
+        --vaadin-focus-ring-color: var(--_vaadin-color);
+
+        --vaadin-icon-size: calc(1lh - 2px); /* Seems too fragile to repeat all over the place */
       }
     }
   `,

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -38,8 +38,6 @@ addGlobalThemeStyles(
 
         --vaadin-focus-ring-width: 2px;
         --vaadin-focus-ring-color: var(--_vaadin-color);
-
-        --vaadin-icon-size: calc(1lh - 2px); /* Seems too fragile to repeat all over the place */
       }
     }
   `,

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -13,23 +13,23 @@ addGlobalThemeStyles(
     @layer vaadin.base {
       html {
         /* Background color */
-        --_vaadin-bg: hsl(0 0 100);
+        --_vaadin-background: hsl(0 0 100);
 
         /* Foreground/content colors */
-        --_vaadin-bg-container: hsl(0 0 95);
-        --_vaadin-bg-container-strong: hsl(0 0 90);
+        --_vaadin-background-container: hsl(0 0 95);
+        --_vaadin-background-container-strong: hsl(0 0 90);
 
         --_vaadin-border-color: hsl(0 0 75);
         --_vaadin-border-color-strong: hsl(0 0 58); /* Above 3:1 contrast */
 
-        --_vaadin-color-weak: hsl(0 0 58); /* Above 3:1 contrast */
+        --_vaadin-color-subtle: hsl(0 0 58); /* Above 3:1 contrast */
         --_vaadin-color: hsl(0 0 44); /* Above 4.5:1 contrast */
         --_vaadin-color-strong: hsl(0 0 12); /* Above 7:1 contrast */
 
-        --_vaadin-padding-container: 8px;
-        --_vaadin-padding-container-text: 6px 8px;
+        --_vaadin-padding: 8px;
+        --_vaadin-padding-container: 6px 8px;
 
-        --_vaadin-gap-icon: 0.5em;
+        --_vaadin-gap-container: 0.5em;
 
         --_vaadin-radius-s: 3px;
         --_vaadin-radius-m: 6px;

--- a/packages/icon/src/vaadin-icon-styles.js
+++ b/packages/icon/src/vaadin-icon-styles.js
@@ -12,10 +12,11 @@ export const iconStyles = css`
     align-items: center;
     box-sizing: border-box;
     vertical-align: middle;
-    width: 24px;
-    height: 24px;
-    fill: currentColor;
+    width: var(--vaadin-icon-size, calc(1lh - 2px));
+    height: var(--vaadin-icon-size, calc(1lh - 2px));
+    fill: var(--vaadin-icon-color, currentColor);
     container-type: size;
+    contain: layout;
   }
 
   :host::after,

--- a/packages/icon/src/vaadin-icon-styles.js
+++ b/packages/icon/src/vaadin-icon-styles.js
@@ -12,8 +12,8 @@ export const iconStyles = css`
     align-items: center;
     box-sizing: border-box;
     vertical-align: middle;
-    width: var(--vaadin-icon-size, calc(1lh - 2px));
-    height: var(--vaadin-icon-size, calc(1lh - 2px));
+    width: var(--vaadin-icon-size, 1lh);
+    height: var(--vaadin-icon-size, 1lh);
     fill: var(--vaadin-icon-color, currentColor);
     container-type: size;
     contain: layout;


### PR DESCRIPTION
## New base style properties

| Property | Description
| --- | ---
| `--_vaadin-background-container` | Background color for components that contain text (like a button).
| `--_vaadin-background-container-strong` | A stronger background color for components that contain text.
| `--_vaadin-border-color` | Color for decorative borders.
| `--_vaadin-border-color-strong` | Color for identifiable borders (at least 3:1 contrast).
| `--_vaadin-color-subtle` | Color for decorative/disabled text (at least 3:1 contrast).
| `--_vaadin-color` | Color for text content (at least 4.5:1 contrast).
| `--_vaadin-color-strong` | Color for text with strong contrast requirements (at least 7:1).
| `--_vaadin-padding` | Padding for component containers. Applies a uniform padding on all sides.
| `--_vaadin-padding-container` | Padding for components that contain only text (and icons). [^1]
| `--_vaadin-gap-container` | Gap between text and an icon.
| `--_vaadin-radius-s` | Border radius for small components.
| `--_vaadin-radius-m` | Border radius for most components.
| `--_vaadin-radius-l` | Border radius for “surfaces” (broadly, things that contain other components).
| `--_vaadin-radius-full` | Radius that creates either a circle or a “pill” shape.
| `--vaadin-focus-ring-width` | The width of the keyboard focus outline.
| `--vaadin-focus-ring-color` | The color of the keyboard focus outline.

The properties that are prefixed with `--_vaadin` _are not_ meant to be used from/by themes. They are used to avoid repetition within the base styles, and are considered private/internal.

[^1]: Applies a smaller vertical padding to compensate for line-height which would otherwise make the padding not look uniform between the edge of the container and the text content. Ideally, we would use the `text-box` CSS property to control this, but support is not good enough yet.

# New Button base style

<img width="288" alt="Screenshot 2025-04-07 at 13 21 25" src="https://github.com/user-attachments/assets/7b569843-540d-438b-bf69-11f9067da7bb" />


Supported custom properties, which should be self-explanatory.

| Property 
| --- 
| `--vaadin-button-gap` 
| `--vaadin-button-padding` 
| `--vaadin-button-height` 
| `--vaadin-button-margin` 
| `--vaadin-button-font-family` 
| `--vaadin-button-font-size` 
| `--vaadin-button-font-weight` 
| `--vaadin-button-line-height` 
| `--vaadin-button-text-color` 
| `--vaadin-button-background` 
| `--vaadin-button-border` 
| `--vaadin-button-border-color` 
| `--vaadin-button-border-width` 
| `--vaadin-button-border-radius` 

Built-in variants, that all themes are expected to support:

- `theme="primary"`
- `theme="tertiary"`

Perhaps the most notable part of this change is that the `.vaadin-button-container` and the parts are all `display: contents`. This aims to simplify the styling of buttons, so that all flex properties can be applied directly on the host to align the label and icons within.