### PR TITLE
refactor!: Base text field styles

### DIFF
--- a/dev/common.js
+++ b/dev/common.js
@@ -10,7 +10,7 @@ addGlobalThemeStyles(
       font-size: calc(14 / 16 * 1rem);
       line-height: calc(18 / 16 * 1rem);
       color: var(--_vaadin-color);
-      background: var(--_vaadin-bg);
+      background: var(--_vaadin-background);
       margin: 2rem;
     }
 

--- a/dev/text-field.html
+++ b/dev/text-field.html
@@ -30,16 +30,7 @@
           value="Value"
           clear-button-visible
           error-message="You need to write something in this field."
-          has-error-message
           required>
-        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
-      </vaadin-text-field>
-    </section>
-
-    <section>
-      <h2>Helper Above Field</h2>
-      <vaadin-text-field theme="helper-above-field" label="Label" helper-text="Description for this field." value="Value" clear-button-visible
-        error-message="You need to write something in this field." has-error-message required>
         <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
       </vaadin-text-field>
     </section>
@@ -52,7 +43,6 @@
           value="Value"
           clear-button-visible
           error-message="You need to write something in this field."
-          has-error-message
           required
           readonly>
         <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
@@ -64,10 +54,38 @@
           value="Value"
           clear-button-visible
           error-message="You need to write something in this field."
-          has-error-message
           required
           disabled>
         <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-text-field>
+    </section>
+
+    <section>
+      <h2>Helper Above Field</h2>
+      <vaadin-text-field
+          theme="helper-above-field"
+          label="Label"
+          helper-text="Description for this field."
+          value="Value"
+          clear-button-visible
+          error-message="You need to write something in this field."
+          required>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-text-field>
+    </section>
+
+    <section>
+      <h2>Content &amp; Layout Variations</h2>
+      <p>Resize the field to test how content flows.</p>
+      <vaadin-text-field
+          label="A very long label for this field"
+          helper-text="If the label wasn't enough to tell what you should input here, then this long description should be."
+          value="I’m not sure what I should write here"
+          placeholder="Perhaps this gives you an idea what to write?"
+          clear-button-visible
+          error-message="In case you didn't write anything in this required field, this error message is here to let you know that you really should write something in this field."
+          required style="resize: horizontal; overflow: hidden; padding: 1px;">
+        <vaadin-icon icon="vaadin:envelope-o" slot="prefix"></vaadin-icon>
       </vaadin-text-field>
     </section>
   </body>

--- a/dev/text-field.html
+++ b/dev/text-field.html
@@ -37,6 +37,14 @@
     </section>
 
     <section>
+      <h2>Helper Above Field</h2>
+      <vaadin-text-field theme="helper-above-field" label="Label" helper-text="Description for this field." value="Value" clear-button-visible
+        error-message="You need to write something in this field." has-error-message required>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-text-field>
+    </section>
+
+    <section>
       <h2>States</h2>
       <vaadin-text-field
           label="Read-only"

--- a/dev/text-field.html
+++ b/dev/text-field.html
@@ -4,18 +4,63 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Text field</title>
+    <title>Text Field</title>
     <script type="module" src="./common.js"></script>
 
     <script type="module">
-      import '@vaadin/text-field';
-      import '@vaadin/tooltip';
+      import '@vaadin/text-field/src/vaadin-lit-text-field.js';
+      import '@vaadin/icon/src/vaadin-lit-icon.js';
+      import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+      import '@vaadin/icons';
     </script>
   </head>
 
   <body>
-    <vaadin-text-field label="User name" required>
-      <vaadin-tooltip slot="tooltip" text="Other users will see this"></vaadin-tooltip>
-    </vaadin-text-field>
+    <section>
+      <h2>Plain</h2>
+      <vaadin-text-field value="Value"></vaadin-text-field>
+      <vaadin-text-field placeholder="Placeholder"></vaadin-text-field>
+    </section>
+
+    <section>
+      <h2>Bells & Whistles</h2>
+      <vaadin-text-field
+          label="Label"
+          helper-text="Description for this field."
+          value="Value"
+          clear-button-visible
+          error-message="You need to write something in this field."
+          has-error-message
+          required>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-text-field>
+    </section>
+
+    <section>
+      <h2>States</h2>
+      <vaadin-text-field
+          label="Read-only"
+          helper-text="Description for this field."
+          value="Value"
+          clear-button-visible
+          error-message="You need to write something in this field."
+          has-error-message
+          required
+          readonly>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-text-field>
+
+      <vaadin-text-field
+          label="Disabled"
+          helper-text="Description for this field."
+          value="Value"
+          clear-button-visible
+          error-message="You need to write something in this field."
+          has-error-message
+          required
+          disabled>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-text-field>
+    </section>
   </body>
 </html>

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -13,7 +13,7 @@ export const buttonStyles = css`
       align-items: center;
       justify-content: center;
       text-align: center;
-      gap: var(--vaadin-button-gap, 0 var(--_vaadin-gap-container));
+      gap: var(--vaadin-button-gap, 0 var(--_vaadin-gap-container-inline));
 
       white-space: nowrap;
       -webkit-tap-highlight-color: transparent;

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -29,7 +29,8 @@ addGlobalThemeStyles(
         --_vaadin-padding: 8px;
         --_vaadin-padding-container: 6px 8px;
 
-        --_vaadin-gap-container: 0.5em;
+        --_vaadin-gap-container-inline: 0.5em;
+        --_vaadin-gap-container-block: 0.5em;
 
         --_vaadin-radius-s: 3px;
         --_vaadin-radius-m: 6px;
@@ -38,6 +39,9 @@ addGlobalThemeStyles(
 
         --vaadin-focus-ring-width: 2px;
         --vaadin-focus-ring-color: var(--_vaadin-color);
+
+        --_vaadin-icon-cross: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>');
+        --_vaadin-icon-warn: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>');
       }
     }
   `,

--- a/packages/field-base/src/styles/clear-button-styles.js
+++ b/packages/field-base/src/styles/clear-button-styles.js
@@ -3,16 +3,17 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const clearButton = css`
   [part='clear-button'] {
     display: none;
     cursor: default;
-  }
-
-  [part='clear-button']::before {
-    content: '\\2715';
+    mask-image: var(--_vaadin-icon-cross);
+    background: var(--_vaadin-color-subtle);
+    width: var(--vaadin-icon-size, 1lh);
+    height: var(--vaadin-icon-size, 1lh);
   }
 
   :host([clear-button-visible][has-value]:not([disabled]):not([readonly])) [part='clear-button'] {

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const fieldShared = css`
@@ -23,20 +24,52 @@ export const fieldShared = css`
     display: none !important;
   }
 
-  :host(:not([has-label])) [part='label'] {
+  :host(:not([has-label])) [part='label'],
+  :host(:not([has-helper])) [part='helper-text'],
+  :host(:not([has-error-message])) [part='error-message'] {
     display: none;
   }
 
-  @media (forced-colors: active) {
-    :host(:not([readonly])) [part='input-field'] {
-      outline: 1px solid;
-      outline-offset: -1px;
-    }
-    :host([focused]) [part='input-field'] {
-      outline-width: 2px;
-    }
-    :host([disabled]) [part='input-field'] {
-      outline-color: GrayText;
-    }
+  [part='label'] {
+    font-size: var(--vaadin-input-field-label-font-size, inherit);
+    line-height: var(--vaadin-input-field-label-line-height, inherit);
+    font-weight: var(--vaadin-input-field-label-font-weight, 500);
+    color: var(--vaadin-input-field-label-color, var(--_vaadin-color-strong));
+    order: var(--vaadin-input-field-helper-order);
+  }
+
+  :host([required]) [part='required-indicator']::after {
+    content: var(--vaadin-input-field-required-indicator, '*');
+  }
+
+  [part='helper-text'] {
+    font-size: var(--vaadin-input-field-helper-font-size, inherit);
+    line-height: var(--vaadin-input-field-helper-line-height, inherit);
+    font-weight: var(--vaadin-input-field-helper-font-weight, 400);
+    color: var(--vaadin-input-field-helper-color, var(--_vaadin-color));
+    order: var(--vaadin-input-field-helper-order);
+  }
+
+  [part='error-message'] {
+    font-size: var(--vaadin-input-field-error-font-size, inherit);
+    line-height: var(--vaadin-input-field-error-line-height, inherit);
+    font-weight: var(--vaadin-input-field-error-font-weight, 400);
+    color: var(--vaadin-input-field-error-color, var(--_vaadin-color-strong));
+    display: flex;
+    gap: var(--_vaadin-gap-container-inline);
+  }
+
+  [part='error-message']::before {
+    content: '';
+    display: inline-block;
+    flex: none;
+    width: var(--vaadin-icon-size, 1lh);
+    height: var(--vaadin-icon-size, 1lh);
+    mask-image: var(--_vaadin-icon-warn);
+    background: currentColor;
+  }
+
+  :host([theme~='helper-above-field']) {
+    --vaadin-input-field-helper-order: -1;
   }
 `;

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -38,8 +38,16 @@ export const fieldShared = css`
     order: var(--vaadin-input-field-helper-order);
   }
 
-  :host([required]) [part='required-indicator']::after {
+  [part='required-indicator'] {
+    color: var(--vaadin-input-field-required-indicator-color, inherit);
+  }
+
+  [part='required-indicator']::after {
     content: var(--vaadin-input-field-required-indicator, '*');
+  }
+
+  :host(:not([required])) [part='required-indicator'] {
+    display: none;
   }
 
   [part='helper-text'] {

--- a/packages/field-base/src/styles/input-field-container-styles.js
+++ b/packages/field-base/src/styles/input-field-container-styles.js
@@ -3,12 +3,14 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const inputFieldContainer = css`
   [class$='container'] {
     display: flex;
     flex-direction: column;
+    gap: var(--vaadin-input-field-container-gap, var(--_vaadin-gap-container-block));
     min-width: 100%;
     max-width: 100%;
     width: var(--vaadin-field-default-width, 12em);

--- a/packages/input-container/src/vaadin-input-container-styles.js
+++ b/packages/input-container/src/vaadin-input-container-styles.js
@@ -87,6 +87,11 @@ export const inputContainerStyles = css`
     border-style: dashed;
   }
 
+  :host([readonly]:focus-within) {
+    outline-style: dashed;
+    --vaadin-input-field-border-color: transparent;
+  }
+
   :host([disabled]) {
     --vaadin-input-field-value-color: var(--vaadin-input-field-disabled-text-color, var(--_vaadin-color-subtle));
     --vaadin-input-field-background: var(

--- a/packages/input-container/src/vaadin-input-container-styles.js
+++ b/packages/input-container/src/vaadin-input-container-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const inputContainerStyles = css`
@@ -10,26 +11,33 @@ export const inputContainerStyles = css`
     display: flex;
     align-items: center;
     flex: 0 1 auto;
+    --_radius: var(--vaadin-input-field-border-radius, var(--_vaadin-radius-m));
     border-radius:
-            /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius */
-      var(--vaadin-input-field-top-start-radius, var(--__border-radius))
-      var(--vaadin-input-field-top-end-radius, var(--__border-radius))
-      var(--vaadin-input-field-bottom-end-radius, var(--__border-radius))
-      var(--vaadin-input-field-bottom-start-radius, var(--__border-radius));
-    --_border-radius: var(--vaadin-input-field-border-radius, 0);
-    --_input-border-width: var(--vaadin-input-field-border-width, 0px);
-    --_input-border-color: var(--vaadin-input-field-border-color, transparent);
-    /* stylelint-disable-next-line length-zero-no-unit */
-    box-shadow: inset 0 0 0 var(--_input-border-width, 0) var(--_input-border-color);
+      /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius */
+      var(--vaadin-input-field-top-start-radius, var(--_radius))
+      var(--vaadin-input-field-top-end-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-end-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-start-radius, var(--_radius));
+    border: var(--vaadin-input-field-border-width, 1px) solid
+      var(--vaadin-input-field-border-color, var(--_vaadin-border-color-strong));
+    box-sizing: border-box;
+    padding: var(--vaadin-input-field-padding, var(--_vaadin-padding-container));
+    gap: var(--vaadin-input-field-gap, var(--_vaadin-gap-container-inline));
+    background: var(--vaadin-input-field-background, var(--_vaadin-background));
+    color: var(--vaadin-input-field-value-color, var(--_vaadin-color-strong));
+    font-size: var(--vaadin-input-field-value-font-size, inherit);
+    line-height: var(--vaadin-input-field-value-line-height, inherit);
+    font-weight: var(--vaadin-input-field-value-font-weight, 400);
   }
 
   :host([dir='rtl']) {
+    --_radius: var(--vaadin-input-field-border-radius, var(--_vaadin-radius-m));
     border-radius:
-            /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
-      var(--vaadin-input-field-top-end-radius, var(--_border-radius))
-      var(--vaadin-input-field-top-start-radius, var(--_border-radius))
-      var(--vaadin-input-field-bottom-start-radius, var(--_border-radius))
-      var(--vaadin-input-field-bottom-end-radius, var(--_border-radius));
+      /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
+      var(--vaadin-input-field-top-end-radius, var(--_radius))
+      var(--vaadin-input-field-top-start-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-start-radius, var(--_radius))
+      var(--vaadin-input-field-bottom-end-radius, var(--_radius));
   }
 
   :host([hidden]) {
@@ -38,13 +46,12 @@ export const inputContainerStyles = css`
 
   /* Reset the native input styles */
   ::slotted(input) {
-    -webkit-appearance: none;
-    -moz-appearance: none;
+    appearance: none;
     flex: auto;
     white-space: nowrap;
     overflow: hidden;
     width: 100%;
-    height: 100%;
+    height: auto;
     outline: none;
     margin: 0;
     padding: 0;
@@ -52,11 +59,8 @@ export const inputContainerStyles = css`
     border-radius: 0;
     min-width: 0;
     font: inherit;
-    line-height: normal;
     color: inherit;
-    background-color: transparent;
-    /* Disable default invalid style in Firefox */
-    box-shadow: none;
+    background: transparent;
   }
 
   ::slotted(*) {
@@ -69,6 +73,28 @@ export const inputContainerStyles = css`
     font: inherit;
     color: inherit;
     /* Override default opacity in Firefox */
-    opacity: 1;
+    /* opacity: 1; */
+  }
+
+  ::slotted(input:placeholder-shown) {
+    color: var(--vaadin-input-field-placeholder-color, var(--_vaadin-color));
+  }
+
+  :host(:focus-within) {
+    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+    outline-offset: calc(var(--vaadin-input-field-border-width, 1px) * -1);
+  }
+
+  :host([readonly]) {
+    border-style: dashed;
+  }
+
+  :host([disabled]) {
+    --vaadin-input-field-value-color: var(--vaadin-input-field-disabled-text-color, var(--_vaadin-color-subtle));
+    --vaadin-input-field-background: var(
+      --vaadin-input-field-disabled-background,
+      var(--_vaadin-background-container-strong)
+    );
+    --vaadin-input-field-border-color: transparent;
   }
 `;

--- a/packages/input-container/src/vaadin-input-container-styles.js
+++ b/packages/input-container/src/vaadin-input-container-styles.js
@@ -72,8 +72,6 @@ export const inputContainerStyles = css`
     /* because ::slotted(...)::placeholder does not work in Safari. */
     font: inherit;
     color: inherit;
-    /* Override default opacity in Firefox */
-    /* opacity: 1; */
   }
 
   ::slotted(input:placeholder-shown) {


### PR DESCRIPTION
## New and changed base style properties

| Property | Description
| --- | ---
| `--_vaadin-gap-container-inline` | Renamed from `--_vaadin-gap-container`. Inline gap between textual elements inside a component that contains mainly text and icons.
| `--_vaadin-gap-container-block` | Vertical gap between text elements inside a component that contains textual elements and other containers.
| `--_vaadin-icon-cross` | Data URL for an SVG icon of a cross. Used for the clear button inside the text field.
| `--_vaadin-icon-warn` | Data URL for an SVG icon of a warning sign. Used for the field error message.

## New Text Field base style

<img width="350" alt="Screenshot 2025-04-08 at 12 48 46" src="https://github.com/user-attachments/assets/6f31e46a-2e5c-44f0-bd3f-ed31b2da900f" />


### Supported custom properties

Most of these should be self explanatory (and most are pre-existing from V24).

| Property | Description
| --- | ---
| `--vaadin-input-field-container-gap` | The gap between the field label, input field, helper, and error message elements.
| `--vaadin-input-field-border-radius` | Properties for `top-start`, `top-end`, etc. radius are also available.
| `--vaadin-input-field-border-width` | 
| `--vaadin-input-field-border-color` | 
| `--vaadin-input-field-padding` | 
| `--vaadin-input-field-gap` | 
| `--vaadin-input-field-background` | 
| `--vaadin-input-field-value-font-size` | 
| `--vaadin-input-field-value-font-weight` | 
| `--vaadin-input-field-value-line-height` | 
| `--vaadin-input-field-value-color` | 
| `--vaadin-input-field-placeholder-color` | 
| `--vaadin-input-field-label-font-size` | 
| `--vaadin-input-field-label-font-weight` | 
| `--vaadin-input-field-label-line-height` | 
| `--vaadin-input-field-label-color` | 
| `--vaadin-input-field-helper-font-size` | 
| `--vaadin-input-field-helper-font-weight` | 
| `--vaadin-input-field-helper-line-height` | 
| `--vaadin-input-field-helper-color` | 
| `--vaadin-input-field-error-font-size` | 
| `--vaadin-input-field-error-font-weight` | 
| `--vaadin-input-field-error-line-height` | 
| `--vaadin-input-field-error-color` | 
| `--vaadin-input-field-required-indicator` | The character used for the required indicator.
| `--vaadin-input-field-required-indicator-color` | The color of the required indicator character.
| `--vaadin-input-field-helper-order` | Set to `-1` to show the helper above the field. Use by the `helper-above-field` variant.

### Built-in variants

All themes are expected to support these:

- `theme="helper-above-field"`