### PR TITLE
fix: use data transfer files if items contain no folders

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -608,6 +608,15 @@ export const UploadMixin = (superClass) =>
         }
       }
 
+      const containsFolders = Array.from(dropEvent.dataTransfer.items)
+        .filter((item) => !!item)
+        .filter((item) => typeof item.webkitGetAsEntry === 'function')
+        .map((item) => item.webkitGetAsEntry())
+        .some((entry) => !!entry && entry.isDirectory);
+      if (!containsFolders) {
+        return Promise.resolve(dropEvent.dataTransfer.files ? Array.from(dropEvent.dataTransfer.files) : []);
+      }
+
       const filePromises = Array.from(dropEvent.dataTransfer.items)
         .map((item) => item.webkitGetAsEntry())
         .filter((entry) => !!entry)

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -608,6 +608,7 @@ export const UploadMixin = (superClass) =>
         }
       }
 
+      // In some cases (like dragging attachments from Outlook on Windows), "webkitGetAsEntry" can return null for "dataTransfer" items. Also, there is no reason to check for "webkitGetAsEntry" when there are no folders. Therefore, "dataTransfer.files" is used to handle such cases.
       const containsFolders = Array.from(dropEvent.dataTransfer.items)
         .filter((item) => !!item)
         .filter((item) => typeof item.webkitGetAsEntry === 'function')

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -608,7 +608,10 @@ export const UploadMixin = (superClass) =>
         }
       }
 
-      // In some cases (like dragging attachments from Outlook on Windows), "webkitGetAsEntry" can return null for "dataTransfer" items. Also, there is no reason to check for "webkitGetAsEntry" when there are no folders. Therefore, "dataTransfer.files" is used to handle such cases.
+      // In some cases (like dragging attachments from Outlook on Windows), "webkitGetAsEntry"
+      // can return null for "dataTransfer" items. Also, there is no reason to check for
+      // "webkitGetAsEntry" when there are no folders. Therefore, "dataTransfer.files" is used
+      // to handle such cases.
       const containsFolders = Array.from(dropEvent.dataTransfer.items)
         .filter((item) => !!item)
         .filter((item) => typeof item.webkitGetAsEntry === 'function')

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -67,7 +67,8 @@ describe('adding files', () => {
           return entry;
         },
       }));
-      e.dataTransfer = { items };
+      const files = entries.filter((entry) => !!entry).map((entry) => entry._file);
+      e.dataTransfer = { items, files };
       return e;
     }
 
@@ -199,6 +200,20 @@ describe('adding files', () => {
 
       expect(upload.files.length).to.equal(1);
       expect(upload.files).to.include(fileEntry._file);
+    });
+
+    it('should handle files that do not correspond to items with entries on drop', async () => {
+      const file1 = createFile(100, 'image/jpeg');
+      const file2 = createFile(200, 'text/plain');
+      const dropEvent = new Event('drop');
+      dropEvent.dataTransfer = { items: [{}, {}], files: [file1, file2] };
+      upload.dispatchEvent(dropEvent);
+      await nextUpdate(upload);
+      await nextFrame();
+
+      expect(upload.files.length).to.equal(2);
+      expect(upload.files).to.include(file1);
+      expect(upload.files).to.include(file2);
     });
 
     it('should handle errors when reading from files or directories on drop', async () => {

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -202,11 +202,21 @@ describe('adding files', () => {
       expect(upload.files).to.include(fileEntry._file);
     });
 
-    it('should handle files that do not correspond to items with entries on drop', async () => {
+    it('should read files from dataTransfer.files if there are no directories', async () => {
+      const fileEntry = createFileSystemFileEntry(100, 'text/plain');
       const file1 = createFile(100, 'image/jpeg');
       const file2 = createFile(200, 'text/plain');
       const dropEvent = new Event('drop');
-      dropEvent.dataTransfer = { items: [{}, {}], files: [file1, file2] };
+      dropEvent.dataTransfer = {
+        items: [
+          {
+            webkitGetAsEntry() {
+              return fileEntry;
+            },
+          },
+        ],
+        files: [file1, file2],
+      };
       upload.dispatchEvent(dropEvent);
       await nextUpdate(upload);
       await nextFrame();
@@ -214,6 +224,30 @@ describe('adding files', () => {
       expect(upload.files.length).to.equal(2);
       expect(upload.files).to.include(file1);
       expect(upload.files).to.include(file2);
+    });
+
+    it('should read files from dataTransfer.items if there are directories', async () => {
+      const fileEntry = createFileSystemFileEntry(100, 'text/plain');
+      const directoryEntry = createFileSystemDirectoryEntry([fileEntry]);
+      const file1 = createFile(100, 'image/jpeg');
+      const file2 = createFile(200, 'text/plain');
+      const dropEvent = new Event('drop');
+      dropEvent.dataTransfer = {
+        items: [
+          {
+            webkitGetAsEntry() {
+              return directoryEntry;
+            },
+          },
+        ],
+        files: [file1, file2],
+      };
+      upload.dispatchEvent(dropEvent);
+      await nextUpdate(upload);
+      await nextFrame();
+
+      expect(upload.files.length).to.equal(1);
+      expect(upload.files).to.include(fileEntry._file);
     });
 
     it('should handle errors when reading from files or directories on drop', async () => {


### PR DESCRIPTION
## Description

In some cases, `webkitGetAsEntry` can return `null` for `dataTransfer` items. Before the [folder drop feature](https://github.com/vaadin/web-components/pull/8032), the files were directly accessed through `dataTransfer.files`.

This PR checks if the items contain any folders, and if not, falls back to the original logic of `dataTransfer.files`. When there are no folders, there is no reason to check for `webkitGetAsEntry`. Also, currently there are no alternatives to `webkitGetAsEntry` which is widely supported.

Fixes:
- Dragging inline files from Outlook new on Windows

Does not fix (does not work in any component):
- Attachment&inline dragging from Thunderbird on MacOS 
- Dragging attachment files from Outlook new on Windows (only works when dropped on Windows explorer)
- Dragging inline files from Outlook classic on Windows

Does not change (already works):
- Attachment&inline dragging from Mail on MacOS
- Attachment&inline dragging from Thunderbird on Windows
- Dragging attachment files from Outlook classic on Windows

Fixes #7618 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.