### PR TITLE
fix: dashboard theme import order

### DIFF
--- a/packages/dashboard/theme/lumo/vaadin-dashboard.js
+++ b/packages/dashboard/theme/lumo/vaadin-dashboard.js
@@ -1,4 +1,4 @@
-import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-section.js';
+import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-styles.js';
 import '../../src/vaadin-dashboard.js';

--- a/packages/dashboard/theme/material/vaadin-dashboard.js
+++ b/packages/dashboard/theme/material/vaadin-dashboard.js
@@ -1,3 +1,3 @@
-import './vaadin-dashboard-widget.js';
 import './vaadin-dashboard-section.js';
+import './vaadin-dashboard-widget.js';
 import '../../src/vaadin-dashboard.js';


### PR DESCRIPTION
## Description

Platform validation for `24.8.0-alpha9` currently fails with this error:
> [pool-1-thread-1] WARN com.vaadin.platform.test.ChromeComponentsIT - This message in browser log console may be a potential error: '[2025-04-09T10:59:47.072Z] [WARNING] http://172.16.1.174:8080/prod-mode/VAADIN/build/indexhtml-D0Ob28c6.js 8122:18 "The custom element definition for \"vaadin-dashboard-section\" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting \"window.Vaadin.suppressPostFinalizeStylesWarning = true\"."'

That seems to be a regression from https://github.com/vaadin/web-components/pull/8885, which adds an import from `src/vaadin-dashboard-widget.js` to `src/vaadin-dashboard-section.js`. Since the theme-specific modules import widget first this also results in defining the section element before section styles can be loaded.

This switches the import order in the theme modules so that the section theme module is imported before the widget theme module.

## Type of change

- Bugfix
