### PR TITLE
fix: use data transfer files if items contain no folders (#8918) (CP: 24.7)

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -606,6 +606,19 @@ export const UploadMixin = (superClass) =>
         }
       }
 
+      // In some cases (like dragging attachments from Outlook on Windows), "webkitGetAsEntry"
+      // can return null for "dataTransfer" items. Also, there is no reason to check for
+      // "webkitGetAsEntry" when there are no folders. Therefore, "dataTransfer.files" is used
+      // to handle such cases.
+      const containsFolders = Array.from(dropEvent.dataTransfer.items)
+        .filter((item) => !!item)
+        .filter((item) => typeof item.webkitGetAsEntry === 'function')
+        .map((item) => item.webkitGetAsEntry())
+        .some((entry) => !!entry && entry.isDirectory);
+      if (!containsFolders) {
+        return Promise.resolve(dropEvent.dataTransfer.files ? Array.from(dropEvent.dataTransfer.files) : []);
+      }
+
       const filePromises = Array.from(dropEvent.dataTransfer.items)
         .map((item) => item.webkitGetAsEntry())
         .filter((entry) => !!entry)


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/web-components/pull/8918 to v24.7.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.