### PR TITLE
test: update form layout snapshots

### DIFF
--- a/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
+++ b/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
@@ -325,7 +325,7 @@ snapshots["vaadin-form-layout responsive-steps host default"] =
 snapshots["vaadin-form-layout responsive-steps host switching to autoResponsive"] = 
 `<vaadin-form-layout
   auto-responsive=""
-  style="--_column-width: 13em; --_max-columns: 1;"
+  style="--_max-columns: 1;"
 >
   <input
     placeholder="First name"


### PR DESCRIPTION
Fixes a snapshot introduced in https://github.com/vaadin/web-components/pull/8860 that for some reason doesn't match expectations:
```
 ❌ vaadin-form-layout > responsive-steps > host > switching to autoResponsive
      AssertionError: Snapshot vaadin-form-layout responsive-steps host switching to autoResponsive does not match the saved snapshot on disk
      + expected - actual
      
       <vaadin-form-layout
         auto-responsive=""
      -  style="--_max-columns: 1;"
      +  style="--_column-width: 13em; --_max-columns: 1;"
       >
```