### PR TITLE
refactor!: Base combo box styles

### DIFF
--- a/dev/combo-box.html
+++ b/dev/combo-box.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -29,7 +29,8 @@
         value="Value"
         clear-button-visible
         error-message="You need to write something in this field."
-        required>
+        required
+      >
         <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
       </vaadin-combo-box>
     </section>
@@ -43,7 +44,8 @@
         clear-button-visible
         error-message="You need to write something in this field."
         required
-        readonly>
+        readonly
+      >
         <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
       </vaadin-combo-box>
 
@@ -54,13 +56,14 @@
         clear-button-visible
         error-message="You need to write something in this field."
         required
-        disabled>
+        disabled
+      >
         <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
       </vaadin-combo-box>
     </section>
 
     <script type="module">
-      document.querySelectorAll('vaadin-combo-box').forEach(comboBox => {
+      document.querySelectorAll('vaadin-combo-box').forEach((comboBox) => {
         comboBox.dataProvider = async (params, callback) => {
           const index = params.page * params.pageSize;
           const response = await fetch(
@@ -73,7 +76,7 @@
               callback(result, size);
             }, 1000);
           }
-        }
+        };
       });
     </script>
   </body>

--- a/dev/combo-box.html
+++ b/dev/combo-box.html
@@ -17,7 +17,7 @@
   <body>
     <section>
       <h2>Plain</h2>
-      <vaadin-combo-box value="Value"></vaadin-combo-box>
+      <vaadin-combo-box></vaadin-combo-box>
       <vaadin-combo-box placeholder="Placeholder"></vaadin-combo-box>
     </section>
 
@@ -26,7 +26,6 @@
       <vaadin-combo-box
         label="Label"
         helper-text="Description for this field."
-        value="Value"
         clear-button-visible
         error-message="You need to write something in this field."
         required
@@ -40,7 +39,6 @@
       <vaadin-combo-box
         label="Read-only"
         helper-text="Description for this field."
-        value="Value"
         clear-button-visible
         error-message="You need to write something in this field."
         required
@@ -52,7 +50,6 @@
       <vaadin-combo-box
         label="Disabled"
         helper-text="Description for this field."
-        value="Value"
         clear-button-visible
         error-message="You need to write something in this field."
         required
@@ -77,6 +74,10 @@
             }, 1000);
           }
         };
+
+        if (!comboBox.placeholder) {
+          comboBox.selectedItem = 'Andorra';
+        }
       });
     </script>
   </body>

--- a/dev/combo-box.html
+++ b/dev/combo-box.html
@@ -4,42 +4,77 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Combo box</title>
+    <title>Combo Box</title>
     <script type="module" src="./common.js"></script>
+
     <script type="module">
-      import '@vaadin/combo-box';
-      import '@vaadin/combo-box/vaadin-combo-box-light.js';
-      import '@vaadin/tooltip';
+      import '@vaadin/combo-box/src/vaadin-lit-combo-box.js';
+      import '@vaadin/icon/src/vaadin-lit-icon.js';
+      import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
+      import '@vaadin/icons';
     </script>
   </head>
   <body>
-    <vaadin-combo-box label="Country">
-      <vaadin-tooltip slot="tooltip" text="Loading might take time"></vaadin-tooltip>
-    </vaadin-combo-box>
+    <section>
+      <h2>Plain</h2>
+      <vaadin-combo-box value="Value"></vaadin-combo-box>
+      <vaadin-combo-box placeholder="Placeholder"></vaadin-combo-box>
+    </section>
+
+    <section>
+      <h2>Bells & Whistles</h2>
+      <vaadin-combo-box
+        label="Label"
+        helper-text="Description for this field."
+        value="Value"
+        clear-button-visible
+        error-message="You need to write something in this field."
+        required>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-combo-box>
+    </section>
+
+    <section>
+      <h2>States</h2>
+      <vaadin-combo-box
+        label="Read-only"
+        helper-text="Description for this field."
+        value="Value"
+        clear-button-visible
+        error-message="You need to write something in this field."
+        required
+        readonly>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-combo-box>
+
+      <vaadin-combo-box
+        label="Disabled"
+        helper-text="Description for this field."
+        value="Value"
+        clear-button-visible
+        error-message="You need to write something in this field."
+        required
+        disabled>
+        <vaadin-icon icon="vaadin:search" slot="prefix"></vaadin-icon>
+      </vaadin-combo-box>
+    </section>
 
     <script type="module">
-      const comboBox = document.querySelector('vaadin-combo-box');
-
-      /*
-      const res = await fetch('https://demo.vaadin.com/demo-data/1.0/filtered-countries?count=200');
-      const arr = await res.json();
-      comboBox.items = arr.result;
-      */
-
-      comboBox.dataProvider = async (params, callback) => {
-        console.log(JSON.stringify(params));
-        const index = params.page * params.pageSize;
-        const response = await fetch(
-          `https://demo.vaadin.com/demo-data/1.0/filtered-countries?index=${index}&count=${params.pageSize}&filter=${params.filter}`,
-        );
-        if (response.ok) {
-          const { result, size } = await response.json();
-          // Emulate network latency for demo purpose
-          setTimeout(() => {
-            callback(result, size);
-          }, 100);
+      document.querySelectorAll('vaadin-combo-box').forEach(comboBox => {
+        comboBox.dataProvider = async (params, callback) => {
+          const index = params.page * params.pageSize;
+          const response = await fetch(
+            `https://demo.vaadin.com/demo-data/1.0/filtered-countries?index=${index}&count=${params.pageSize}&filter=${params.filter}`,
+          );
+          if (response.ok) {
+            const { result, size } = await response.json();
+            // Emulate network latency for demo purpose
+            setTimeout(() => {
+              callback(result, size);
+            }, 1000);
+          }
         }
-      };
+      });
     </script>
   </body>
 </html>

--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -36,6 +36,11 @@ export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(Polyl
         padding: var(--vaadin-combo-box-item-padding, var(--_vaadin-padding-container));
       }
 
+      :host([focused]) {
+        outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+        outline-offset: calc(var(--vaadin-focus-ring-width) / -1);
+      }
+
       :host([hidden]) {
         display: none;
       }

--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -30,8 +30,9 @@ export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(Polyl
         align-items: center;
         box-sizing: border-box;
         display: flex;
-        gap: var(--_vaadin-gap-container-inline);
-        padding: var(--_vaadin-padding-container);
+        gap: var(--vaadin-combo-box-item-gap, 0 var(--_vaadin-gap-container-inline));
+        height: var(--vaadin-combo-box-item-height, auto);
+        padding: var(--vaadin-combo-box-item-padding, var(--_vaadin-padding-container));
       }
 
       :host([hidden]) {

--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -3,10 +3,11 @@
  * Copyright (c) 2015 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { itemStyles } from '@vaadin/item/src/vaadin-item-styles.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
 
@@ -25,41 +26,7 @@ export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(Polyl
   }
 
   static get styles() {
-    return css`
-      :host {
-        align-items: center;
-        border-radius: var(--vaadin-item-border-radius, var(--_vaadin-radius-m));
-        box-sizing: border-box;
-        cursor: pointer;
-        display: flex;
-        gap: var(--vaadin-item-gap, 0 var(--_vaadin-gap-container-inline));
-        height: var(--vaadin-item-height, auto);
-        padding: var(--vaadin-item-padding, var(--_vaadin-padding-container));
-      }
-
-      :host([focused]) {
-        outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
-        outline-offset: 1px;
-      }
-
-      :host([hidden]) {
-        display: none;
-      }
-
-      [part='checkmark'] {
-        height: var(--vaadin-icon-size, 1lh);
-        mask-image: var(--_vaadin-icon-checkmark);
-        width: var(--vaadin-icon-size, 1lh);
-      }
-
-      :host([selected]) [part='checkmark'] {
-        background: var(--_vaadin-color-subtle);
-      }
-
-      [part='content'] {
-        flex: 1;
-      }
-    `;
+    return itemStyles;
   }
 
   /** @protected */

--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -28,17 +28,18 @@ export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(Polyl
     return css`
       :host {
         align-items: center;
+        border-radius: var(--vaadin-item-border-radius, var(--_vaadin-radius-m));
         box-sizing: border-box;
         cursor: pointer;
         display: flex;
-        gap: var(--vaadin-combo-box-item-gap, 0 var(--_vaadin-gap-container-inline));
-        height: var(--vaadin-combo-box-item-height, auto);
-        padding: var(--vaadin-combo-box-item-padding, var(--_vaadin-padding-container));
+        gap: var(--vaadin-item-gap, 0 var(--_vaadin-gap-container-inline));
+        height: var(--vaadin-item-height, auto);
+        padding: var(--vaadin-item-padding, var(--_vaadin-padding-container));
       }
 
       :host([focused]) {
         outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
-        outline-offset: calc(var(--vaadin-focus-ring-width) / -1);
+        outline-offset: 1px;
       }
 
       :host([hidden]) {

--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -27,11 +27,29 @@ export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(Polyl
   static get styles() {
     return css`
       :host {
-        display: block;
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        gap: var(--_vaadin-gap-container-inline);
+        padding: var(--_vaadin-padding-container);
       }
 
       :host([hidden]) {
         display: none;
+      }
+
+      [part='checkmark'] {
+        height: var(--vaadin-icon-size, 1lh);
+        mask-image: var(--_vaadin-icon-checkmark);
+        width: var(--vaadin-icon-size, 1lh);
+      }
+
+      :host([selected]) [part='checkmark'] {
+        background: var(--_vaadin-color-subtle);
+      }
+
+      [part='content'] {
+        flex: 1;
       }
     `;
   }

--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -29,6 +29,7 @@ export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(Polyl
       :host {
         align-items: center;
         box-sizing: border-box;
+        cursor: pointer;
         display: flex;
         gap: var(--vaadin-combo-box-item-gap, 0 var(--_vaadin-gap-container-inline));
         height: var(--vaadin-combo-box-item-height, auto);

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -56,7 +56,7 @@ const comboBoxOverlayStyles = css`
 
   @keyframes spin {
     to {
-      transform: rotate(360deg);
+      rotate: 1turn;
     }
   }
 `;

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -13,14 +13,44 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
 
 const comboBoxOverlayStyles = css`
-  #overlay {
+  [part='overlay'] {
+    position: relative;
     width: var(--vaadin-combo-box-overlay-width, var(--_vaadin-combo-box-overlay-default-width, auto));
+  }
+
+  [part~='loader'] {
+    animation: spin 1s linear infinite;
+    border: 2px solid;
+    border-color: var(--_vaadin-background-container-strong) var(--_vaadin-background-container-strong)
+      var(--_vaadin-color-strong) var(--_vaadin-color-strong);
+    border-radius: var(--_vaadin-radius-full);
+    box-sizing: border-box;
+    display: none;
+    height: var(--vaadin-icon-size, 1lh);
+    inset: 6px 8px auto auto;
+    pointer-events: none;
+    position: absolute;
+    width: var(--vaadin-icon-size, 1lh);
   }
 
   [part='content'] {
     display: flex;
     flex-direction: column;
     height: 100%;
+  }
+
+  :host([loading]) [part~='loader'] {
+    display: block;
+  }
+
+  :host([loading]) [part~='content'] {
+    min-height: calc(var(--vaadin-icon-size, 1lh) + 12px);
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
   }
 `;
 

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -27,7 +27,8 @@ const comboBoxOverlayStyles = css`
     box-sizing: border-box;
     display: none;
     height: var(--vaadin-icon-size, 1lh);
-    inset: 6px 8px auto auto;
+    inset-block-start: calc(var(--vaadin-item-overlay-padding, 4px) + 6px);
+    inset-inline-end: 8px;
     pointer-events: none;
     position: absolute;
     width: var(--vaadin-icon-size, 1lh);
@@ -44,7 +45,7 @@ const comboBoxOverlayStyles = css`
   }
 
   :host([loading]) [part~='content'] {
-    min-height: calc(var(--vaadin-icon-size, 1lh) + 12px);
+    min-height: calc(var(--vaadin-icon-size, 1lh) + 12px + var(--vaadin-item-overlay-padding, 4px) * 2);
   }
 
   @keyframes spin {

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -13,6 +13,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
 
 const comboBoxOverlayStyles = css`
+  :host {
+    --vaadin-item-checkmark-display: block;
+  }
+
   [part='overlay'] {
     position: relative;
     width: var(--vaadin-combo-box-overlay-width, var(--_vaadin-combo-box-overlay-default-width, auto));

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -33,8 +33,9 @@ const comboBoxOverlayStyles = css`
     box-sizing: border-box;
     display: none;
     height: var(--vaadin-icon-size, 1lh);
-    inset-block-start: calc(var(--vaadin-item-overlay-padding, 4px) + 6px);
-    inset-inline-end: 8px;
+    inset: calc(var(--vaadin-item-overlay-padding, 4px) + 2px);
+    inset-block-end: auto;
+    inset-inline-start: auto;
     pointer-events: none;
     position: absolute;
     width: var(--vaadin-icon-size, 1lh);
@@ -51,7 +52,7 @@ const comboBoxOverlayStyles = css`
   }
 
   :host([loading]) [part='content'] {
-    min-height: calc(var(--vaadin-icon-size, 1lh) + 12px + var(--vaadin-item-overlay-padding, 4px) * 2);
+    --_items-min-height: calc(var(--vaadin-icon-size, 1lh) + 4px);
   }
 
   @keyframes spin {

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -18,11 +18,12 @@ const comboBoxOverlayStyles = css`
     width: var(--vaadin-combo-box-overlay-width, var(--_vaadin-combo-box-overlay-default-width, auto));
   }
 
-  [part~='loader'] {
+  [part='loader'] {
     animation: spin 1s linear infinite;
     border: 2px solid;
-    border-color: var(--_vaadin-background-container-strong) var(--_vaadin-background-container-strong)
-      var(--_vaadin-color-strong) var(--_vaadin-color-strong);
+    --_spinner-color: var(--vaadin-combo-box-spinner-color, var(--_vaadin-color-strong));
+    border-color: var(--_spinner-color) var(--_spinner-color) hsl(var(--_spinner-color) h s l / 0.5)
+      hsl(var(--_spinner-color) h s l / 0.5);
     border-radius: var(--_vaadin-radius-full);
     box-sizing: border-box;
     display: none;
@@ -40,17 +41,24 @@ const comboBoxOverlayStyles = css`
     height: 100%;
   }
 
-  :host([loading]) [part~='loader'] {
+  :host([loading]) [part='loader'] {
     display: block;
   }
 
-  :host([loading]) [part~='content'] {
+  :host([loading]) [part='content'] {
     min-height: calc(var(--vaadin-icon-size, 1lh) + 12px + var(--vaadin-item-overlay-padding, 4px) * 2);
   }
 
   @keyframes spin {
     to {
       transform: rotate(360deg);
+    }
+  }
+
+  @media (forced-colors: active) {
+    [part='loader'] {
+      border-color: CanvasText CanvasText transparent transparent;
+      forced-color-adjust: none;
     }
   }
 `;

--- a/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-overlay.js
@@ -22,8 +22,9 @@ const comboBoxOverlayStyles = css`
     animation: spin 1s linear infinite;
     border: 2px solid;
     --_spinner-color: var(--vaadin-combo-box-spinner-color, var(--_vaadin-color-strong));
-    border-color: var(--_spinner-color) var(--_spinner-color) hsl(var(--_spinner-color) h s l / 0.5)
-      hsl(var(--_spinner-color) h s l / 0.5);
+    border-color: var(--_spinner-color) var(--_spinner-color) hsl(from var(--_spinner-color) h s l / 0.2)
+      hsl(from var(--_spinner-color) h s l / 0.2);
+    forced-color-adjust: none; /* Retain border color */
     border-radius: var(--_vaadin-radius-full);
     box-sizing: border-box;
     display: none;
@@ -52,13 +53,6 @@ const comboBoxOverlayStyles = css`
   @keyframes spin {
     to {
       transform: rotate(360deg);
-    }
-  }
-
-  @media (forced-colors: active) {
-    [part='loader'] {
-      border-color: CanvasText CanvasText transparent transparent;
-      forced-color-adjust: none;
     }
   }
 `;

--- a/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
@@ -38,9 +38,9 @@ export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElem
       }
 
       #selector {
-        border-width: var(--_vaadin-combo-box-items-container-border-width);
-        border-style: var(--_vaadin-combo-box-items-container-border-style);
         border-color: var(--_vaadin-combo-box-items-container-border-color, transparent);
+        border-style: var(--_vaadin-combo-box-items-container-border-style, solid);
+        border-width: var(--_vaadin-combo-box-items-container-border-width, 4px);
         position: relative;
       }
     `;

--- a/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
@@ -36,6 +36,7 @@ export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElem
       #selector {
         border: var(--vaadin-item-overlay-padding, 4px) solid transparent;
         position: relative;
+        forced-color-adjust: none;
       }
     `;
   }

--- a/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
@@ -23,24 +23,18 @@ export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElem
   static get styles() {
     return css`
       :host {
+        --vaadin-item-checkmark-display: block;
+        /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
+        box-shadow: 0 0 0 white;
         display: block;
         min-height: 1px;
         overflow: auto;
-
         /* Fixes item background from getting on top of scrollbars on Safari */
         transform: translate3d(0, 0, 0);
-
-        /* Enable momentum scrolling on iOS */
-        -webkit-overflow-scrolling: touch;
-
-        /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
-        box-shadow: 0 0 0 white;
       }
 
       #selector {
-        border-color: var(--_vaadin-combo-box-items-container-border-color, transparent);
-        border-style: var(--_vaadin-combo-box-items-container-border-style, solid);
-        border-width: var(--_vaadin-combo-box-items-container-border-width, 4px);
+        border: var(--vaadin-item-overlay-padding, 4px) solid transparent;
         position: relative;
       }
     `;

--- a/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
@@ -23,7 +23,6 @@ export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElem
   static get styles() {
     return css`
       :host {
-        --vaadin-item-checkmark-display: block;
         /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
         box-shadow: 0 0 0 white;
         display: block;

--- a/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-scroller.js
@@ -36,6 +36,7 @@ export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElem
         border: var(--vaadin-item-overlay-padding, 4px) solid transparent;
         position: relative;
         forced-color-adjust: none;
+        min-height: var(--_items-min-height, auto);
       }
     `;
   }

--- a/packages/combo-box/src/vaadin-lit-combo-box.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box.js
@@ -45,6 +45,14 @@ class ComboBox extends ComboBoxDataProviderMixin(
         :host([opened]) {
           pointer-events: auto;
         }
+
+        [part='toggle-button'] {
+          cursor: default;
+          background: var(--_vaadin-color-subtle);
+          height: var(--vaadin-icon-size, 1lh);
+          mask-image: var(--_vaadin-icon-chevron-down);
+          width: var(--vaadin-icon-size, 1lh);
+        }
       `,
     ];
   }

--- a/packages/combo-box/src/vaadin-lit-combo-box.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box.js
@@ -46,9 +46,10 @@ class ComboBox extends ComboBoxDataProviderMixin(
           pointer-events: auto;
         }
 
-        [part='toggle-button'] {
-          cursor: default;
+        [part='toggle-button']::before {
           background: var(--_vaadin-color-subtle);
+          content: '';
+          display: inherit;
           height: var(--vaadin-icon-size, 1lh);
           mask-image: var(--_vaadin-icon-chevron-down);
           width: var(--vaadin-icon-size, 1lh);

--- a/packages/combo-box/src/vaadin-lit-combo-box.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box.js
@@ -46,13 +46,23 @@ class ComboBox extends ComboBoxDataProviderMixin(
           pointer-events: auto;
         }
 
+        [part='toggle-button'] {
+          color: var(--_vaadin-color-subtle);
+        }
+
         [part='toggle-button']::before {
-          background: var(--_vaadin-color-subtle);
+          background: currentColor;
           content: '';
-          display: inherit;
+          display: block;
           height: var(--vaadin-icon-size, 1lh);
           mask-image: var(--_vaadin-icon-chevron-down);
           width: var(--vaadin-icon-size, 1lh);
+        }
+
+        @media (forced-colors: active) {
+          [part='toggle-button']::before {
+            background: CanvasText;
+          }
         }
       `,
     ];

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -252,7 +252,7 @@ describe('pre-opened', () => {
     const comboBox = fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`);
     await nextRender();
     const expectedOverlayWidth = comboBox.clientWidth;
-    const actualOverlayWidth = comboBox.$.overlay.$.content.clientWidth;
+    const actualOverlayWidth = comboBox.$.overlay.$.overlay.offsetWidth;
     expect(actualOverlayWidth).to.eq(expectedOverlayWidth);
   });
 

--- a/packages/combo-box/test/helpers.js
+++ b/packages/combo-box/test/helpers.js
@@ -43,8 +43,11 @@ export const getAllItems = (comboBox) => {
 export const getViewportItems = (comboBox) => {
   const overlayRect = comboBox.$.overlay.$.content.getBoundingClientRect();
 
+  // Take the default 4px border width into account
+  const scrollerTop = parseInt(getComputedStyle(comboBox._scroller.$.selector).borderTopWidth);
+
   // Firefox can produce values like 19.199996948242188
-  const top = Math.round(overlayRect.top);
+  const top = Math.round(overlayRect.top) + scrollerTop;
   const bottom = Math.round(overlayRect.bottom);
 
   return getAllItems(comboBox).filter((item) => {

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -41,6 +41,8 @@ addGlobalThemeStyles(
         --vaadin-focus-ring-color: var(--_vaadin-color);
 
         --_vaadin-icon-calendar: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" /></svg>');
+        --_vaadin-icon-checkmark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/></svg>');
+        --_vaadin-icon-chevron-down: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>');
         --_vaadin-icon-cross: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>');
         --_vaadin-icon-warn: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>');
       }

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -30,7 +30,7 @@ export const itemStyles = css`
     }
 
     :host([hidden]) {
-      display: none;
+      display: none !important;
     }
 
     [part='checkmark'] {

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -19,7 +19,7 @@ export const itemStyles = css`
       padding: var(--vaadin-item-padding, var(--_vaadin-padding-container));
     }
 
-    :host([focus-ring]) {
+    :host([focused]) {
       outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
       outline-offset: calc(var(--vaadin-focus-ring-width) / -1);
     }

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -34,14 +34,22 @@ export const itemStyles = css`
     }
 
     [part='checkmark'] {
+      color: var(--vaadin-item-checkmark-color, var(--_vaadin-color-subtle));
       display: var(--vaadin-item-checkmark-display, none);
+      visibility: hidden;
+    }
+
+    [part='checkmark']::before {
+      content: '';
+      display: block;
+      background: currentColor;
       height: var(--vaadin-icon-size, 1lh);
       mask-image: var(--_vaadin-icon-checkmark);
       width: var(--vaadin-icon-size, 1lh);
     }
 
     :host([selected]) [part='checkmark'] {
-      background: var(--_vaadin-color-subtle);
+      visibility: visible;
     }
 
     [part='content'] {

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import '@vaadin/component-base/src/style-props.js';
+import { css } from 'lit';
+
+export const itemStyles = css`
+  @layer base {
+    :host {
+      align-items: center;
+      border-radius: var(--vaadin-item-border-radius, var(--_vaadin-radius-m));
+      box-sizing: border-box;
+      cursor: pointer;
+      display: flex;
+      gap: var(--vaadin-item-gap, 0 var(--_vaadin-gap-container-inline));
+      height: var(--vaadin-item-height, auto);
+      padding: var(--vaadin-item-padding, var(--_vaadin-padding-container));
+    }
+
+    :host([focus-ring]) {
+      outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+      outline-offset: calc(var(--vaadin-focus-ring-width) / -1);
+    }
+
+    :host([disabled]) {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    [part='checkmark'] {
+      display: var(--vaadin-item-checkmark-display, none);
+      height: var(--vaadin-icon-size, 1lh);
+      mask-image: var(--_vaadin-icon-checkmark);
+      width: var(--vaadin-icon-size, 1lh);
+    }
+
+    :host([selected]) [part='checkmark'] {
+      background: var(--_vaadin-color-subtle);
+    }
+
+    [part='content'] {
+      flex: 1;
+    }
+  }
+`;

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -547,13 +547,13 @@ describe('chips', () => {
 
       const overlay = document.querySelector('vaadin-multi-select-combo-box-overlay');
       const overlayPart = overlay.$.overlay;
-      const width = overlayPart.clientWidth;
+      const width = overlayPart.offsetWidth;
       expect(width).to.equal(comboBox.clientWidth);
 
       comboBox.selectedItems = ['apple', 'banana'];
       await nextRender();
-      expect(overlayPart.clientWidth).to.be.lessThan(width);
-      expect(overlayPart.clientWidth).to.be.equal(comboBox.clientWidth);
+      expect(overlayPart.offsetWidth).to.be.lessThan(width);
+      expect(overlayPart.offsetWidth).to.be.equal(comboBox.clientWidth);
     });
   });
 

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -111,6 +111,11 @@ const globals = css`
     --vaadin-input-field-value-color: var(--lumo-body-text-color);
     --vaadin-input-field-value-font-size: var(--lumo-font-size-m);
     --vaadin-input-field-value-font-weight: 500;
+    /* Combo box */
+    --vaadin-combo-box-item-gap: 0;
+    --vaadin-combo-box-item-height: auto;
+    --vaadin-combo-box-item-padding: 0.5em calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4) 0.5em
+      var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius-m) / 4));
   }
 `;
 

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -111,10 +111,11 @@ const globals = css`
     --vaadin-input-field-value-color: var(--lumo-body-text-color);
     --vaadin-input-field-value-font-size: var(--lumo-font-size-m);
     --vaadin-input-field-value-font-weight: 500;
-    /* Combo box */
-    --vaadin-combo-box-item-gap: 0;
-    --vaadin-combo-box-item-height: auto;
-    --vaadin-combo-box-item-padding: 0.5em calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4) 0.5em
+    /* Item */
+    --vaadin-item-border-radius: var(--lumo-border-radius-m);
+    --vaadin-item-gap: 0;
+    --vaadin-item-height: auto;
+    --vaadin-item-padding: 0.5em calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4) 0.5em
       var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius-m) / 4));
   }
 `;

--- a/packages/vaadin-lumo-styles/style.js
+++ b/packages/vaadin-lumo-styles/style.js
@@ -115,6 +115,7 @@ const globals = css`
     --vaadin-item-border-radius: var(--lumo-border-radius-m);
     --vaadin-item-gap: 0;
     --vaadin-item-height: auto;
+    --vaadin-item-overlay-padding: var(--lumo-space-xs);
     --vaadin-item-padding: 0.5em calc(var(--lumo-space-l) + var(--lumo-border-radius-m) / 4) 0.5em
       var(--_lumo-list-box-item-padding-left, calc(var(--lumo-border-radius-m) / 4));
   }


### PR DESCRIPTION
## New and changed base style properties

| Property | Description |
| ------------- | ------------- |
| `--_vaadin-icon-checkmark` | Data URL for an SVG icon of a checkmark. Used to indicate the selected item. |
| `--_vaadin-icon-chevron-down` | Data URL for an SVG icon of a downward-pointing chevron. Used for combo box and select dropdown indicators. |

## New Combo Box base style

![localhost_8000_dev_combo-box html](https://github.com/user-attachments/assets/24b45b7d-0172-4e76-8fcd-5f1f7ba925ac)

![localhost_8000_dev_combo-box html (1)](https://github.com/user-attachments/assets/a5c745f5-1de0-4243-a449-6c73c46bd485)

<img width="500" alt="Screenshot 2025-04-15 at 10 17 30" src="https://github.com/user-attachments/assets/52972a34-8bca-4968-ab1a-fbfb2e27a22c" />

### Supported custom properties

| Property | Description |
| -------- | ----------- |
| `--vaadin-combo-box-spinner-color` | The color of the loading spinner. |
| `--vaadin-combo-box-overlay-width` | The width of the item overlay. |
| `--vaadin-item-border-radius` | Item border radius. |
| `--vaadin-item-checkmark-color` | The color of the checkmark icon for a selected item. |
| `--vaadin-item-gap` | Space between the checkmark and content. |
| `--vaadin-item-height` | Item height. |
| `--vaadin-item-overlay-padding` | Item container padding. |
| `--vaadin-item-padding` | Item padding. |
