### PR TITLE
fix: forward tabIndex to panel heading button

### DIFF
--- a/packages/accordion/src/vaadin-accordion-panel-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-panel-mixin.js
@@ -57,6 +57,18 @@ export const AccordionPanelMixin = (superClass) =>
       this._tooltipController.setPosition('bottom-start');
     }
 
+    // /**@protected */
+    __forwardTabIndex(tabindex) {
+      super.__forwardTabIndex(tabindex);
+      if (tabindex !== undefined && this.focusElement) {
+        // Forward the tabIndex to the button inside the heading
+        // instead of the heading itself
+        this.focusElement.$.button.tabIndex = tabindex;
+        // Revert the tabIndex value of the heading
+        this.focusElement.tabIndex = -1;
+      }
+    }
+
     /** @protected */
     ready() {
       super.ready();

--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -150,6 +150,28 @@ describe('vaadin-accordion-panel', () => {
         expect(heading.hasAttribute('disabled')).to.be.false;
       });
 
+      it(`should not modify tabIndex attribute to ${type} heading`, async () => {
+        const initialTabIndex = heading.tabIndex;
+        panel.disabled = true;
+        await nextUpdate(panel);
+        expect(heading.tabIndex).to.be.equal(initialTabIndex);
+
+        panel.disabled = false;
+        await nextUpdate(panel);
+        expect(heading.tabIndex).to.be.equal(initialTabIndex);
+      });
+
+      it(`should  modify tabIndex attribute to ${type} heading button`, async () => {
+        const button = heading.$.button;
+        panel.disabled = true;
+        await nextUpdate(panel);
+        expect(button.tabIndex).to.be.equal(-1);
+
+        panel.disabled = false;
+        await nextUpdate(panel);
+        expect(button.tabIndex).to.be.equal(0);
+      });
+
       it(`should propagate theme attribute to ${type} heading`, async () => {
         panel.setAttribute('theme', 'filled');
         await nextUpdate(panel);


### PR DESCRIPTION
## Description

Change `AccordionPanel` to not modify the `tabIndex` value of the `AccordionHeading` element but instead make it change the property of the `<button>` element inside the heading.

That should fix an issue when a `tabIndex` is wrongly set to the `AccordionHeading` element breaking keyboard navigation in some cases as reported in https://github.com/vaadin/flow-components/issues/6529.

Fixes https://github.com/vaadin/flow-components/issues/6529

## Type of change

- Bugfix