### PR TITLE
test: refactor tabs unit tests to not use Lumo entrypoints

### DIFF
--- a/packages/tabs/test/scroll.test.js
+++ b/packages/tabs/test/scroll.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { arrowDown, arrowLeft, arrowRight, arrowUp, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-tabs.js';
+import './tabs-test-styles.js';
+import '../src/vaadin-tabs.js';
 
 describe('scrollable tabs', () => {
   let tabs, items, scroller;
@@ -112,7 +112,7 @@ describe('scrollable tabs', () => {
         beforeEach(async () => {
           itemsInViewport = new Set();
           tabs.setAttribute('dir', dir);
-          await nextFrame();
+          await nextRender();
         });
 
         it('should have displayed all the items fully when scrolled forward to the end via button', async () => {

--- a/packages/tabs/test/tabs-test-styles.js
+++ b/packages/tabs/test/tabs-test-styles.js
@@ -1,0 +1,65 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+// TODO: subset of Lumo needed for unit tests to pass.
+// These should be eventually covered by base styles.
+registerStyles(
+  'vaadin-tabs',
+  css`
+    ::slotted(vaadin-tab) {
+      display: flex;
+      box-sizing: border-box;
+      padding: 0.5rem 0.75rem;
+      font-family: -apple-system, 'system-ui', Roboto, 'Segoe UI', Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      font-weight: 500;
+    }
+
+    ::slotted(vaadin-tab[orientation='vertical']) {
+      padding: 0.25rem 1rem;
+    }
+
+    :host(:not([orientation='vertical'])) {
+      position: relative;
+      min-height: 2.75rem;
+    }
+
+    :host([orientation='horizontal']) [part='tabs'] {
+      margin: 0 0.75rem;
+    }
+
+    [part='forward-button'],
+    [part='back-button'] {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      font-size: 24px;
+      width: 1.5em;
+    }
+
+    :host(:not([dir='rtl'])) [part='forward-button'] {
+      right: 0;
+    }
+
+    :host([dir='rtl']) [part='forward-button'] {
+      left: 0;
+    }
+
+    /* Used by "separator" element in scroll tests */
+    :host(:not([dir='rtl'])) ::slotted(:not(vaadin-tab)) {
+      margin-left: 1rem;
+    }
+
+    :host([dir='rtl']) ::slotted(:not(vaadin-tab)) {
+      margin-right: 1rem;
+    }
+
+    /* Lumo-specific, should it be in base styles? */
+    :host([theme~='equal-width-tabs']) {
+      flex: auto;
+    }
+
+    :host([theme~='equal-width-tabs']) [part='tabs'] ::slotted(vaadin-tab) {
+      flex: 1 0 0%;
+    }
+  `,
+);

--- a/packages/tabs/test/tabs.test.js
+++ b/packages/tabs/test/tabs.test.js
@@ -5,13 +5,13 @@ import {
   enter,
   fixtureSync,
   listenOnce,
-  nextFrame,
   nextRender,
   nextResize,
   space,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-tabs.js';
+import './tabs-test-styles.js';
+import '../src/vaadin-tabs.js';
 
 describe('tabs', () => {
   let tabs;
@@ -103,7 +103,7 @@ describe('tabs', () => {
               tabs.style.height = '100px';
             }
             await nextResize(tabs);
-            await nextFrame();
+            await nextRender();
           });
 
           afterEach(() => {
@@ -181,7 +181,7 @@ describe('tabs', () => {
 
           it('should update overflow on items change', async () => {
             tabs.items.forEach((item) => item.remove());
-            await nextFrame();
+            await nextRender();
             expect(tabs.hasAttribute('overflow')).to.be.false;
           });
         });
@@ -247,6 +247,7 @@ describe('flex child tabs', () => {
   });
 });
 
+// TODO: should be either covered by base styles or moved to visual tests
 describe('flex equal width tabs', () => {
   let wrapper, tabs;
 


### PR DESCRIPTION
## Description

Updated `vaadin-tabs` styles to use `src` version and added a subset of Lumo to make sure unit tests pass.

## Type of change

- Test