### PR TITLE
test: import unstyled board component in unit tests

### DIFF
--- a/packages/board/test/basic.test.js
+++ b/packages/board/test/basic.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-board.js';
+import '../src/vaadin-board.js';
 
 describe('vaadin-board', () => {
   let board, tagName;

--- a/packages/board/test/board-cols.test.js
+++ b/packages/board/test/board-cols.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-board-row.js';
+import '../src/vaadin-board-row.js';
 
 describe('board-cols', () => {
   let row;

--- a/packages/board/test/board-row.test.js
+++ b/packages/board/test/board-row.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-board-row.js';
+import '../src/vaadin-board-row.js';
 
 describe('vaadin-board-row', () => {
   let row;

--- a/packages/board/test/light-dom.test.js
+++ b/packages/board/test/light-dom.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-board-row.js';
+import '../src/vaadin-board-row.js';
 
 describe('light DOM children', () => {
   let row;

--- a/packages/board/test/redraw.test.js
+++ b/packages/board/test/redraw.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-board.js';
+import '../src/vaadin-board.js';
 import { allResized } from './helpers.js';
 
 describe('redraw', () => {

--- a/packages/board/test/size.test.js
+++ b/packages/board/test/size.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-board.js';
+import '../src/vaadin-board.js';
 import { allResized } from './helpers.js';
 
 describe('size', () => {


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
