### PR TITLE
test: import unstyled app-layout component in unit tests

### DIFF
--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -11,8 +11,8 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
-import '../vaadin-app-layout.js';
-import '../vaadin-drawer-toggle.js';
+import '../src/vaadin-app-layout.js';
+import '../src/vaadin-drawer-toggle.js';
 
 describe('vaadin-app-layout', () => {
   let layout;

--- a/packages/app-layout/test/drawer-toggle.test.js
+++ b/packages/app-layout/test/drawer-toggle.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { enter, fixtureSync, nextFrame, space } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-drawer-toggle.js';
+import '../src/vaadin-drawer-toggle.js';
 
 describe('drawer-toggle', () => {
   let toggle;

--- a/packages/app-layout/test/keyboard-desktop.test.js
+++ b/packages/app-layout/test/keyboard-desktop.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import '../vaadin-app-layout.js';
-import '../vaadin-drawer-toggle.js';
+import '../src/vaadin-app-layout.js';
+import '../src/vaadin-drawer-toggle.js';
 import { tab } from './helpers.js';
 
 describe('desktop navigation', () => {

--- a/packages/app-layout/test/keyboard-mobile.test.js
+++ b/packages/app-layout/test/keyboard-mobile.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import '../vaadin-app-layout.js';
-import '../vaadin-drawer-toggle.js';
+import '../src/vaadin-app-layout.js';
+import '../src/vaadin-drawer-toggle.js';
 import { esc, shiftTab, tab } from './helpers.js';
 
 describe('mobile navigation', () => {


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
