### PR TITLE
test: import unstyled chart component in unit tests

### DIFF
--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextRender, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../theme/vaadin-chart-base-theme.js';
+import '../src/vaadin-chart.js';
 
 describe('vaadin-chart', () => {
   describe('custom element definition', () => {

--- a/packages/charts/test/chart-properties.test.js
+++ b/packages/charts/test/chart-properties.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../theme/vaadin-chart-base-theme.js';
+import '../src/vaadin-chart.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 
 describe('vaadin-chart properties', () => {

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../theme/vaadin-chart-base-theme.js';
+import '../src/vaadin-chart.js';
 
 describe('vaadin-chart-series', () => {
   describe('properties', () => {

--- a/packages/charts/test/dom-repeat.test.js
+++ b/packages/charts/test/dom-repeat.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
-import '../vaadin-chart.js';
+import '../src/vaadin-chart.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 customElements.define(

--- a/packages/charts/test/events.test.js
+++ b/packages/charts/test/events.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../src/vaadin-chart.js';
 
 describe('vaadin-chart events', () => {
   let chart;

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../theme/vaadin-chart-base-theme.js';
+import '../src/vaadin-chart.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import HttpUtilities from 'highcharts/es-modules/Core/HttpUtilities.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';

--- a/packages/charts/test/private-api.test.js
+++ b/packages/charts/test/private-api.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import '../vaadin-chart.js';
+import '../src/vaadin-chart.js';
 import { inflateFunctions } from '../src/helpers.js';
 
 describe('vaadin-chart private API', () => {

--- a/packages/charts/test/reattach.test.js
+++ b/packages/charts/test/reattach.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../src/vaadin-chart.js';
 
 describe('reattach', () => {
   let wrapper, inner, chart;

--- a/packages/charts/test/styling.test.js
+++ b/packages/charts/test/styling.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '../vaadin-chart.js';
+import '../theme/vaadin-chart-base-theme.js';
+import '../src/vaadin-chart.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { chartBaseTheme } from '../theme/vaadin-chart-base-theme.js';
 

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -1,7 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-chart.js';
+import '../theme/vaadin-chart-base-theme.js';
+import '../src/vaadin-chart.js';
 
 describe('turbo-mode', () => {
   let chart;


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
