### PR TITLE
test: import unstyled combo-box component in unit tests

### DIFF
--- a/packages/combo-box/test/aria.test.js
+++ b/packages/combo-box/test/aria.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, escKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
 import '../src/vaadin-combo-box.js';
 import { getAllItems } from './helpers.js';
 

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { getViewportItems, setInputValue } from './helpers.js';
 
 describe('basic features', () => {

--- a/packages/combo-box/test/combo-box-light-validation.test.js
+++ b/packages/combo-box/test/combo-box-light-validation.test.js
@@ -2,8 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box-light.js';
+import '../src/vaadin-combo-box-light.js';
 
 describe('vaadin-combo-box-light - validation', () => {
   let comboBox, input;

--- a/packages/combo-box/test/combo-box-light.test.js
+++ b/packages/combo-box/test/combo-box-light.test.js
@@ -14,9 +14,8 @@ import {
   touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box-light.js';
-import '@vaadin/text-field/vaadin-text-field.js';
+import '../src/vaadin-combo-box-light.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getFirstItem } from './helpers.js';

--- a/packages/combo-box/test/data-provider-dynamic-size.test.js
+++ b/packages/combo-box/test/data-provider-dynamic-size.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import '@vaadin/text-field/vaadin-text-field.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
 import '../src/vaadin-combo-box.js';
 import '../src/vaadin-combo-box-light.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';

--- a/packages/combo-box/test/data-provider-filtering.test.js
+++ b/packages/combo-box/test/data-provider-filtering.test.js
@@ -1,10 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '@vaadin/text-field/vaadin-text-field.js';
-import '../vaadin-combo-box-light.js';
-import '../vaadin-combo-box.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
+import '../src/vaadin-combo-box-light.js';
+import '../src/vaadin-combo-box.js';
 import { setInputValue } from './helpers.js';
 
 const TEMPLATES = {

--- a/packages/combo-box/test/data-provider.test.js
+++ b/packages/combo-box/test/data-provider.test.js
@@ -1,11 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, aTimeout, enterKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
 import './data-provider-styles.js';
-import '@vaadin/text-field/vaadin-text-field.js';
-import '../vaadin-combo-box-light.js';
-import '../vaadin-combo-box.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
+import '../src/vaadin-combo-box-light.js';
+import '../src/vaadin-combo-box.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import {
   clickItem,

--- a/packages/combo-box/test/events.test.js
+++ b/packages/combo-box/test/events.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusout, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { clickItem, setInputValue } from './helpers.js';
 
 describe('events', () => {

--- a/packages/combo-box/test/external-filtering.test.js
+++ b/packages/combo-box/test/external-filtering.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, enter, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { getAllItems, getFocusedItemIndex, setInputValue } from './helpers.js';
 
 describe('external filtering', () => {

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import {
   aTimeout,
   click,
@@ -15,8 +15,7 @@ import {
   touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getFirstItem, setInputValue } from './helpers.js';
 
@@ -217,15 +216,14 @@ describe('interactions', () => {
       it('should restore focus to the input on outside click', async () => {
         comboBox.focus();
         comboBox.open();
-        await sendMouse({ type: 'click', position: [200, 200] });
+        await sendMouseToElement({ type: 'click', element: document.body });
         expect(document.activeElement).to.equal(input);
       });
 
       it('should keep focus in the input on toggle button click', async () => {
         comboBox.focus();
         comboBox.open();
-        const rect = comboBox._toggleElement.getBoundingClientRect();
-        await sendMouse({ type: 'click', position: [rect.x, rect.y] });
+        await sendMouseToElement({ type: 'click', element: comboBox._toggleElement });
         expect(document.activeElement).to.equal(input);
       });
 
@@ -233,7 +231,7 @@ describe('interactions', () => {
         comboBox.focus();
         comboBox.setAttribute('focus-ring', '');
         comboBox.open();
-        await sendMouse({ type: 'click', position: [200, 200] });
+        await sendMouseToElement({ type: 'click', element: document.body });
         expect(comboBox.hasAttribute('focus-ring')).to.be.true;
       });
     });

--- a/packages/combo-box/test/internal-filtering.test.js
+++ b/packages/combo-box/test/internal-filtering.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import { getAllItems, getFocusedItemIndex, getViewportItems, makeItems, onceOpened, setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/item-class-name-generator.test.js
+++ b/packages/combo-box/test/item-class-name-generator.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { getAllItems } from './helpers.js';
 
 describe('itemClassNameGenerator', () => {

--- a/packages/combo-box/test/item-renderer.test.js
+++ b/packages/combo-box/test/item-renderer.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { getAllItems, getFirstItem, setInputValue } from './helpers.js';
 
 describe('item renderer', () => {

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -12,7 +12,6 @@ import {
   nextRender,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
 import '../src/vaadin-combo-box.js';
 import { getViewportItems, getVisibleItemsCount, scrollToIndex, setInputValue } from './helpers.js';
 

--- a/packages/combo-box/test/lit-renderer-directives.test.js
+++ b/packages/combo-box/test/lit-renderer-directives.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { html, render } from 'lit';
 import { comboBoxRenderer } from '../lit.js';
 import { flushComboBox, getAllItems } from './helpers.js';

--- a/packages/combo-box/test/lit.test.js
+++ b/packages/combo-box/test/lit.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { html, LitElement, render } from 'lit';
 import { getViewportItems } from './helpers.js';
 

--- a/packages/combo-box/test/object-values.test.js
+++ b/packages/combo-box/test/object-values.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
 import '../src/vaadin-combo-box.js';
 import { clickItem, getFirstItem, getViewportItems } from './helpers.js';
 

--- a/packages/combo-box/test/overlay-opening.test.js
+++ b/packages/combo-box/test/overlay-opening.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { arrowDownKeyDown, arrowUpKeyDown, click, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { setInputValue } from './helpers.js';
 
 describe('overlay opening', () => {

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { makeItems, setInputValue } from './helpers.js';
 
 describe('overlay position', () => {

--- a/packages/combo-box/test/selecting-items.test.js
+++ b/packages/combo-box/test/selecting-items.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fire, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 import { clickItem, getAllItems, getFirstItem, onceScrolled, scrollToIndex, setInputValue } from './helpers.js';
 
 describe('selecting items', () => {

--- a/packages/combo-box/test/validation.test.js
+++ b/packages/combo-box/test/validation.test.js
@@ -2,8 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-combo-box.js';
+import '../src/vaadin-combo-box.js';
 
 describe('validation', () => {
   let comboBox, input;


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
