### PR TITLE
test: import unstyled context-menu component in unit tests

### DIFF
--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import '../src/vaadin-context-menu.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { getMenuItems } from './helpers.js';
 

--- a/packages/context-menu/test/context-menu-test-styles.js
+++ b/packages/context-menu/test/context-menu-test-styles.js
@@ -1,0 +1,13 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+// TODO: subset of Lumo needed for unit tests to pass.
+// These should be eventually covered by base styles.
+registerStyles(
+  'vaadin-context-menu-overlay',
+  css`
+    :host([phone]) {
+      align-items: stretch;
+      justify-content: flex-end;
+    }
+  `,
+);

--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -1,10 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '../src/vaadin-context-menu.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class XFoo extends PolymerElement {

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import '../src/vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class MenuWrapper extends PolymerElement {

--- a/packages/context-menu/test/items-theme.test.js
+++ b/packages/context-menu/test/items-theme.test.js
@@ -1,9 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '../src/vaadin-context-menu.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
 

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -14,10 +14,9 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '../src/vaadin-context-menu.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
 
@@ -104,7 +103,7 @@ describe('items', () => {
   (isTouch ? it.skip : it)('should open the subMenu on the right side', () => {
     const rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
     const subItemRect = getMenuItems(subMenu)[0].getBoundingClientRect();
-    expect(subItemRect.left).to.be.above(rootItemRect.right);
+    expect(subItemRect.left).to.be.at.least(rootItemRect.right);
   });
 
   (isTouch ? it.skip : it)('should open the subMenu on the left side', async () => {
@@ -114,7 +113,7 @@ describe('items', () => {
     await openMenu(getMenuItems(rootMenu)[0]);
     rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
     const subItemRect = getMenuItems(subMenu)[0].getBoundingClientRect();
-    expect(subItemRect.right).to.be.below(rootItemRect.left);
+    expect(subItemRect.right).to.be.at.most(rootItemRect.left);
   });
 
   (isTouch ? it.skip : it)('should open the subMenu on the top if root menu is bottom-aligned', async () => {
@@ -125,7 +124,7 @@ describe('items', () => {
     await openMenu(getMenuItems(rootMenu)[0]);
     const rootMenuRect = rootOverlay.getBoundingClientRect();
     const subMenuRect = subOverlay1.getBoundingClientRect();
-    expect(subMenuRect.bottom).to.be.below(rootMenuRect.bottom);
+    expect(subMenuRect.bottom).to.be.at.most(rootMenuRect.bottom);
   });
 
   (isTouch ? it.skip : it)('should open the subMenu on the left if root menu is end-aligned', async () => {

--- a/packages/context-menu/test/lit-renderer-directives.test.js
+++ b/packages/context-menu/test/lit-renderer-directives.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import '../src/vaadin-context-menu.js';
 import { html, nothing, render } from 'lit';
 import { contextMenuRenderer } from '../lit.js';
 

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { esc, fire, fixtureSync, isIOS, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import '../src/vaadin-context-menu.js';
 
 describe('overlay', () => {
   let menu, overlay, content, viewHeight, viewWidth;

--- a/packages/context-menu/test/properties.test.js
+++ b/packages/context-menu/test/properties.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import '../src/vaadin-context-menu.js';
 
 describe('properties', () => {
   let menu;

--- a/packages/context-menu/test/renderer.test.js
+++ b/packages/context-menu/test/renderer.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import '../src/vaadin-context-menu.js';
 
 describe('renderer', () => {
   let menu, target, overlay;

--- a/packages/context-menu/test/selection.test.js
+++ b/packages/context-menu/test/selection.test.js
@@ -1,10 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { click, enter, fire, fixtureSync, isIOS, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '../src/vaadin-context-menu.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 
 describe('selection', () => {
   let menu, overlay;

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -11,8 +11,8 @@ import {
   touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-context-menu.js';
+import './context-menu-test-styles.js';
+import '../src/vaadin-context-menu.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { gestures } from '@vaadin/component-base/src/gestures.js';
 


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
