### PR TITLE
test: import unstyled components in unit tests

### DIFF
--- a/packages/card/test/accessibility.test.js
+++ b/packages/card/test/accessibility.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import '../vaadin-card.js';
+import '../src/vaadin-card.js';
 
 window.Vaadin.featureFlags ||= {};
 window.Vaadin.featureFlags.cardComponent = true;

--- a/packages/cookie-consent/test/cookie-consent.test.js
+++ b/packages/cookie-consent/test/cookie-consent.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, keyboardEventFor } from '@vaadin/testing-helpers';
-import '../vaadin-cookie-consent.js';
+import '../src/vaadin-cookie-consent.js';
 
 describe('vaadin-cookie-consent', () => {
   describe('custom element definition', () => {

--- a/packages/form-layout/test/form-item.test.js
+++ b/packages/form-layout/test/form-item.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-form-item.js';
-import '@vaadin/custom-field';
-import '@vaadin/text-field';
+import '../src/vaadin-form-item.js';
+import '@vaadin/custom-field/src/vaadin-custom-field.js';
+import '@vaadin/text-field/src/vaadin-text-field.js';
 
 describe('form-item', () => {
   let item, label, input;

--- a/packages/icon/test/icon-font.test.js
+++ b/packages/icon/test/icon-font.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isChrome, nextFrame, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-icon.js';
+import '../src/vaadin-icon.js';
 import { needsFontIconSizingFallback, supportsCQUnitsForPseudoElements } from '../src/vaadin-icon-helpers.js';
 import { iconFontCss } from './test-icon-font.js';
 

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-icon.js';
+import '../src/vaadin-icon.js';
 import { unsafeSvgLiteral } from '../src/vaadin-icon-svg.js';
 
 const ANGLE_DOWN = '<path d="M13 4v2l-5 5-5-5v-2l5 5z"></path>';

--- a/packages/icon/test/iconset-lazy-upgrade.test.js
+++ b/packages/icon/test/iconset-lazy-upgrade.test.js
@@ -28,7 +28,7 @@ describe('vaadin-iconset lazy upgrade', () => {
     const icon = fixtureSync('<vaadin-icon icon="vaadin:caret-down"></vaadin-icon>');
 
     // Import vaadin-icon, which also imports vaadin-iconset internally.
-    await import('../vaadin-icon.js');
+    await import('../src/vaadin-icon.js');
 
     const svgElement = icon.shadowRoot.querySelector('svg');
 

--- a/packages/icon/test/iconset.test.js
+++ b/packages/icon/test/iconset.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { isValidSvg } from '../src/vaadin-icon-svg.js';
-import { Iconset } from '../vaadin-iconset.js';
+import { Iconset } from '../src/vaadin-iconset.js';
 
 describe('vaadin-iconset', () => {
   let iconset;

--- a/packages/list-box/test/list-box.test.js
+++ b/packages/list-box/test/list-box.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '@vaadin/item/vaadin-item.js';
-import '../vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '../src/vaadin-list-box.js';
 
 describe('vaadin-list-box', () => {
   let listBox, tagName;

--- a/packages/list-box/test/missing-import-polymer.test.js
+++ b/packages/list-box/test/missing-import-polymer.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-list-box.js';
+import '../src/vaadin-list-box.js';
 
 describe('missing import', () => {
   let listBox;

--- a/packages/map/test/map.test.js
+++ b/packages/map/test/map.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-map.js';
+import '../src/vaadin-map.js';
 import TileLayer from 'ol/layer/Tile';
 import Map from 'ol/Map';
 import OSM from 'ol/source/OSM';

--- a/packages/map/test/styles.test.js
+++ b/packages/map/test/styles.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-map.js';
+import '../src/vaadin-map.js';
 
 describe('vaadin-map styles', () => {
   let map;

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-master-detail-layout.js';
+import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
 import './helpers/detail-content.js';
 

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '../vaadin-master-detail-layout.js';
+import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
 import './helpers/detail-content.js';
 

--- a/packages/master-detail-layout/test/overlay-mode.test.js
+++ b/packages/master-detail-layout/test/overlay-mode.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-master-detail-layout.js';
+import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
 import './helpers/detail-content.js';
 

--- a/packages/master-detail-layout/test/stack-mode.test.js
+++ b/packages/master-detail-layout/test/stack-mode.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-master-detail-layout.js';
+import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
 import './helpers/detail-content.js';
 

--- a/packages/master-detail-layout/test/view-transitions.test.js
+++ b/packages/master-detail-layout/test/view-transitions.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-master-detail-layout.js';
+import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
 import './helpers/detail-content.js';
 

--- a/packages/overlay/test/basic.test.js
+++ b/packages/overlay/test/basic.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isIOS, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
+import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('vaadin-overlay', () => {

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
-import '../vaadin-overlay.js';
+import '../src/vaadin-overlay.js';
 import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('focus-trap', () => {

--- a/packages/overlay/test/interactions.test.js
+++ b/packages/overlay/test/interactions.test.js
@@ -11,7 +11,7 @@ import {
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
+import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('interactions', () => {

--- a/packages/overlay/test/lit.test.js
+++ b/packages/overlay/test/lit.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-overlay.js';
+import '../src/vaadin-overlay.js';
 import { html, render } from 'lit';
 
 describe('lit', () => {

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { click, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
+import '../src/vaadin-overlay.js';
 import { setNestedOverlay } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
 import { createOverlay } from './helpers.js';
 

--- a/packages/overlay/test/renderer.test.js
+++ b/packages/overlay/test/renderer.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-overlay.js';
+import '../src/vaadin-overlay.js';
 
 describe('renderer', () => {
   let overlay, content;

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -11,9 +11,8 @@ import {
   tab,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { Popover } from '../vaadin-popover.js';
+import { Popover } from '../src/vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
 describe('a11y', () => {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-popover.js';
+import '../src/vaadin-popover.js';
 
 describe('popover', () => {
   let popover, overlay;

--- a/packages/popover/test/lit-renderer-directives.test.js
+++ b/packages/popover/test/lit-renderer-directives.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-popover.js';
+import '../src/vaadin-popover.js';
 import { html, nothing, render } from 'lit';
 import { popoverRenderer } from '../lit.js';
 

--- a/packages/popover/test/nested.test.js
+++ b/packages/popover/test/nested.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import { Popover } from '../vaadin-popover.js';
+import { Popover } from '../src/vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
 describe('nested popover', () => {

--- a/packages/popover/test/position.test.js
+++ b/packages/popover/test/position.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
 import '../src/vaadin-popover.js';
 
 describe('position', () => {

--- a/packages/popover/test/timers.test.js
+++ b/packages/popover/test/timers.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, esc, fixtureSync, focusout, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
 import { Popover } from '../src/vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';
 

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -10,8 +10,7 @@ import {
   nextUpdate,
   outsideClick,
 } from '@vaadin/testing-helpers';
-import './not-animated-styles.js';
-import { Popover } from '../vaadin-popover.js';
+import { Popover } from '../src/vaadin-popover.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
 describe('trigger', () => {

--- a/packages/side-nav/test/accessibility.test.js
+++ b/packages/side-nav/test/accessibility.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import '../vaadin-side-nav-item.js';
-import '../vaadin-side-nav.js';
+import '../src/vaadin-side-nav-item.js';
+import '../src/vaadin-side-nav.js';
 
 describe('accessibility', () => {
   describe('ARIA roles', () => {

--- a/packages/side-nav/test/navigation-callback.test.js
+++ b/packages/side-nav/test/navigation-callback.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-side-nav-item.js';
-import '../vaadin-side-nav.js';
+import '../src/vaadin-side-nav-item.js';
+import '../src/vaadin-side-nav.js';
 
 describe('navigation callback', () => {
   let sideNav, sideNavItem;

--- a/packages/side-nav/test/navigation.test.js
+++ b/packages/side-nav/test/navigation.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '../vaadin-side-nav-item.js';
-import '../vaadin-side-nav.js';
+import '../src/vaadin-side-nav-item.js';
+import '../src/vaadin-side-nav.js';
 
 describe('navigation', () => {
   let sideNav, items;

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-side-nav-item.js';
+import '../src/vaadin-side-nav-item.js';
 import { location } from '../src/location.js';
 
 describe('side-nav-item', () => {

--- a/packages/side-nav/test/side-nav.test.js
+++ b/packages/side-nav/test/side-nav.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-side-nav.js';
+import '../src/vaadin-side-nav.js';
 
 describe('side-nav', () => {
   let sideNav;

--- a/packages/virtual-list/test/drag-and-drop.test.js
+++ b/packages/virtual-list/test/drag-and-drop.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-virtual-list.js';
+import '../src/vaadin-virtual-list.js';
 
 describe('drag and drop', () => {
   let virtualList;

--- a/packages/virtual-list/test/lit-renderer-directives.test.js
+++ b/packages/virtual-list/test/lit-renderer-directives.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-virtual-list.js';
+import '../src/vaadin-virtual-list.js';
 import { html, render } from 'lit';
 import { virtualListRenderer } from '../lit.js';
 

--- a/packages/virtual-list/test/lit.test.js
+++ b/packages/virtual-list/test/lit.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-virtual-list.js';
+import '../src/vaadin-virtual-list.js';
 import { html, render } from 'lit';
 
 describe('lit', () => {

--- a/packages/virtual-list/test/virtual-list.test.js
+++ b/packages/virtual-list/test/virtual-list.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-virtual-list.js';
+import '../src/vaadin-virtual-list.js';
 
 describe('virtual-list', () => {
   let list;


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
