### PR TITLE
test: refactor select unit tests to not use Lumo entrypoints

### DIFF
--- a/packages/select/test/accessibility.test.js
+++ b/packages/select/test/accessibility.test.js
@@ -3,8 +3,8 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../src/vaadin-select.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 
 describe('accessibility', () => {
   let select, valueButton;

--- a/packages/select/test/renderer.test.js
+++ b/packages/select/test/renderer.test.js
@@ -3,8 +3,8 @@ import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-select.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 
 describe('renderer', () => {
   let select;

--- a/packages/select/test/select-test-styles.test.js
+++ b/packages/select/test/select-test-styles.test.js
@@ -1,0 +1,12 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+// TODO: subset of Lumo needed for unit tests to pass.
+// These should be eventually covered by base styles.
+registerStyles(
+  'vaadin-item',
+  css`
+    :host {
+      display: flex;
+    }
+  `,
+);

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -14,9 +14,10 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
+import './select-test-styles.test.js';
 import '../src/vaadin-select.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 import { html, render } from 'lit';
 
 describe('vaadin-select', () => {

--- a/packages/select/test/validation.test.js
+++ b/packages/select/test/validation.test.js
@@ -4,8 +4,8 @@ import { fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testi
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-select.js';
-import '@vaadin/item/vaadin-item.js';
-import '@vaadin/list-box/vaadin-list-box.js';
+import '@vaadin/item/src/vaadin-item.js';
+import '@vaadin/list-box/src/vaadin-list-box.js';
 
 describe('validation', () => {
   let select, validateSpy, valueChangedSpy, changeSpy;


### PR DESCRIPTION
## Description

Updated `vaadin-select` tests to use `src` version of item and list-box, added item styles to make overlay width tests pass.

## Type of change

- Test