### PR TITLE
test: flush ignoreTaps debouncer after scroll

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -4,7 +4,7 @@ import { click, fixtureSync, keyboardEventFor, nextRender, oneEvent, tap } from 
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import { parseDate } from '../src/vaadin-date-picker-helper.js';
-import { open, touchTap, waitForOverlayRender } from './helpers.js';
+import { open, touchTap, untilOverlayRendered } from './helpers.js';
 
 describe('basic features', () => {
   let datePicker, input, overlay;
@@ -44,14 +44,14 @@ describe('basic features', () => {
   it('should keep focused attribute when focus moves to overlay', async () => {
     datePicker.focus();
     await sendKeys({ press: 'ArrowDown' });
-    await waitForOverlayRender();
+    await untilOverlayRendered(datePicker);
     expect(datePicker.hasAttribute('focused')).to.be.true;
   });
 
   it('should have focused attribute when closed and focused', async () => {
     datePicker.focus();
     await sendKeys({ press: 'ArrowDown' });
-    await waitForOverlayRender();
+    await untilOverlayRendered(datePicker);
     await sendKeys({ press: 'Escape' });
     expect(datePicker.hasAttribute('focused')).to.be.true;
   });
@@ -470,7 +470,7 @@ describe('required', () => {
 
   it('should focus on required indicator click', async () => {
     datePicker.shadowRoot.querySelector('[part="required-indicator"]').click();
-    await waitForOverlayRender();
+    await untilOverlayRendered(datePicker);
     expect(datePicker.hasAttribute('focused')).to.be.true;
   });
 });

--- a/packages/date-picker/test/custom-input.test.js
+++ b/packages/date-picker/test/custom-input.test.js
@@ -3,7 +3,7 @@ import { fire, fixtureSync, oneEvent, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker-light.js';
-import { open, setInputValue, waitForScrollToFinish } from './helpers.js';
+import { open, setInputValue } from './helpers.js';
 
 describe('custom input', () => {
   let datePicker, overlay;
@@ -67,8 +67,7 @@ describe('custom input', () => {
         await open(datePicker);
       });
 
-      it('should propagate theme attribute to month calendar', async () => {
-        await waitForScrollToFinish(datePicker);
+      it('should propagate theme attribute to month calendar', () => {
         const monthCalendar = datePicker._overlayContent.querySelector('vaadin-month-calendar');
         expect(monthCalendar.getAttribute('theme')).to.equal('foo');
       });

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -3,7 +3,7 @@ import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { aTimeout, fire, fixtureSync, mousedown, nextRender, oneEvent, touchstart } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
-import { getFocusableCell, monthsEqual, open, waitForOverlayRender } from './helpers.js';
+import { getFocusableCell, monthsEqual, open, untilOverlayRendered } from './helpers.js';
 
 describe('dropdown', () => {
   let datePicker, input, overlay;
@@ -94,7 +94,7 @@ describe('dropdown', () => {
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const scrolledDate = spy.firstCall.args[0];
       expect(monthsEqual(scrolledDate, new Date())).to.be.true;
@@ -107,7 +107,7 @@ describe('dropdown', () => {
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const scrolledDate = spy.firstCall.args[0];
       expect(scrolledDate).to.be.eql(new Date(2016, 0, 1));
@@ -120,7 +120,7 @@ describe('dropdown', () => {
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const scrolledDate = spy.firstCall.args[0];
       expect(monthsEqual(scrolledDate, new Date(2000, 1, 1))).to.be.true;
@@ -145,7 +145,7 @@ describe('dropdown', () => {
       // scrollTop can be reset while the dropdown is closed.
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(spy.called).to.be.true;
 
       datePicker.close();
@@ -163,7 +163,7 @@ describe('dropdown', () => {
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const scrolledDate = spy.firstCall.args[0];
       expect(scrolledDate).to.be.eql(new Date(2100, 0, 1));
@@ -176,7 +176,7 @@ describe('dropdown', () => {
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const scrolledDate = spy.firstCall.args[0];
       expect(scrolledDate).to.be.eql(new Date(2000, 0, 1));
@@ -192,7 +192,7 @@ describe('dropdown', () => {
 
       const spy = sinon.spy(datePicker._overlayContent, 'scrollToDate');
       await oneEvent(overlay, 'vaadin-overlay-open');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const scrolledDate = spy.firstCall.args[0];
       expect(scrolledDate).to.be.eql(new Date(2015, 0, 1));

--- a/packages/date-picker/test/events.test.js
+++ b/packages/date-picker/test/events.test.js
@@ -4,7 +4,7 @@ import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-date-picker.js';
-import { open, waitForScrollToFinish } from './helpers.js';
+import { open, untilOverlayScrolled } from './helpers.js';
 
 describe('events', () => {
   let datePicker;
@@ -29,7 +29,7 @@ describe('events', () => {
 
     it('should not be fired on programmatic value change when having user input', async () => {
       await sendKeys({ type: '1/2/2000' });
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
       datePicker.value = '2000-01-01';
       datePicker.close();
       expect(changeSpy.called).to.be.false;

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -4,7 +4,7 @@ import { aTimeout, fixtureSync, nextRender, outsideClick, tabKeyDown, tap } from
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-date-picker.js';
-import { getFocusableCell, open, touchTap, waitForOverlayRender } from './helpers.js';
+import { getFocusableCell, open, touchTap, untilOverlayRendered } from './helpers.js';
 
 describe('fullscreen mode', () => {
   let datePicker, input, overlay, width, height;
@@ -43,13 +43,13 @@ describe('fullscreen mode', () => {
     describe('default', () => {
       it('should open overlay on input tap', async () => {
         tap(input);
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
         expect(datePicker.opened).to.be.true;
       });
 
       it('should not focus the input on touch tap', async () => {
         touchTap(input);
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
         expect(document.activeElement).to.not.equal(input);
       });
 

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -14,8 +14,8 @@ import {
   getFocusedCell,
   idleCallback,
   open,
-  waitForOverlayRender,
-  waitForScrollToFinish,
+  untilOverlayRendered,
+  untilOverlayScrolled,
 } from './helpers.js';
 
 describe('keyboard', () => {
@@ -36,8 +36,7 @@ describe('keyboard', () => {
   describe('focused date', () => {
     it('should select focused date on Enter', async () => {
       await sendKeys({ type: '1/1/2001' });
-      await waitForOverlayRender();
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayRendered(datePicker);
       await sendKeys({ press: 'Enter' });
       expect(datePicker.value).to.equal('2001-01-01');
     });
@@ -70,60 +69,57 @@ describe('keyboard', () => {
 
     it('should add the part when entering parsable dates', async () => {
       await sendKeys({ type: '1/1/2000' });
-      await waitForOverlayRender();
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayRendered(datePicker);
       assertFocusedPart('2000-01-01');
 
       input.select();
       await sendKeys({ type: '2/2/2002' });
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
       assertFocusedPart('2002-02-02');
     });
 
     it('should not add the part when entered date is unparsable', async () => {
       await sendKeys({ type: 'foobar' });
-      await waitForOverlayRender();
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayRendered(datePicker);
       assertNoFocusedPart();
     });
 
     it('should add the part when moving focus to calendar', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       assertFocusedPart(formatISODate(new Date()));
     });
 
     it('should add the part after selecting a date with click', async () => {
       datePicker.click();
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       const cell = getFocusableCell(datePicker);
       tap(cell);
 
       datePicker.click();
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       assertFocusedPart(formatISODate(new Date()));
     });
 
     it('should update the part on value change', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       datePicker.value = '2000-01-01';
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
       assertFocusedPart('2000-01-01');
     });
 
     it('should remove the part when entered date is cleared', async () => {
       await sendKeys({ type: '1/1/2000' });
-      await waitForOverlayRender();
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayRendered(datePicker);
       assertFocusedPart('2000-01-01');
 
       input.select();
       await sendKeys({ press: 'Backspace' });
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
 
       assertNoFocusedPart();
     });
@@ -132,33 +128,33 @@ describe('keyboard', () => {
   describe('open overlay', () => {
     it('should open the overlay on input', async () => {
       await sendKeys({ type: 'j' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(datePicker.opened).to.be.true;
     });
 
     it('should open the overlay on Arrow Down', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(datePicker.opened).to.be.true;
     });
 
     it('should open the overlay on Arrow Up', async () => {
       await sendKeys({ press: 'ArrowUp' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(datePicker.opened).to.be.true;
     });
 
     it('should open on Arrow Down if autoOpenDisabled is true', async () => {
       datePicker.autoOpenDisabled = true;
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(datePicker.opened).to.be.true;
     });
 
     it('should open on Arrow Up if autoOpenDisabled is true', async () => {
       datePicker.autoOpenDisabled = true;
       await sendKeys({ press: 'ArrowUp' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(datePicker.opened).to.be.true;
     });
 
@@ -198,14 +194,14 @@ describe('keyboard', () => {
     it('should keep focused attribute when the focus moves to the overlay', async () => {
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       expect(datePicker.hasAttribute('focused')).to.be.true;
     });
 
     it('should move focus back to the input on Cancel button tap', async () => {
       // Move focus to the calendar
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const spy = sinon.spy(input, 'focus');
       tap(overlayContent._cancelButton);
       expect(spy.calledOnce).to.be.true;
@@ -214,7 +210,7 @@ describe('keyboard', () => {
     it('should move focus back to the input on Today button tap', async () => {
       // Move focus to the calendar
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const spy = sinon.spy(input, 'focus');
       tap(overlayContent._todayButton);
       expect(spy.calledOnce).to.be.true;
@@ -223,7 +219,7 @@ describe('keyboard', () => {
     it('should move focus back to the input on calendar date tap', async () => {
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const cell = getFocusedCell(datePicker);
       const spy = sinon.spy(input, 'focus');
       tap(cell);
@@ -290,7 +286,7 @@ describe('keyboard', () => {
         // Move focus to the calendar
         await sendKeys({ press: 'Tab' });
 
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         const cell = getFocusedCell(datePicker);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
@@ -304,7 +300,7 @@ describe('keyboard', () => {
         // Move focus to the calendar
         await sendKeys({ press: 'Shift+Tab' });
 
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         const cell = getFocusedCell(datePicker);
         expect(cell).to.be.instanceOf(HTMLTableCellElement);
@@ -383,7 +379,7 @@ describe('keyboard', () => {
 
     it('should parse a single digit', async () => {
       await sendKeys({ type: '20' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(today.getFullYear());
       expect(result.getMonth()).to.equal(today.getMonth());
@@ -392,7 +388,7 @@ describe('keyboard', () => {
 
     it('should parse two digits', async () => {
       await sendKeys({ type: '6/20' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(today.getFullYear());
       expect(result.getMonth()).to.equal(5);
@@ -401,7 +397,7 @@ describe('keyboard', () => {
 
     it('should parse three digits', async () => {
       await sendKeys({ type: '6/20/1999' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(1999);
       expect(result.getMonth()).to.equal(5);
@@ -410,14 +406,14 @@ describe('keyboard', () => {
 
     it('should parse three digits with small year', async () => {
       await sendKeys({ type: '6/20/0099' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(99);
     });
 
     it('should parse three digits with negative year', async () => {
       await sendKeys({ type: '6/20/-1' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(-1);
     });
@@ -428,7 +424,7 @@ describe('keyboard', () => {
         referenceDate: '2022-01-01',
       };
       await sendKeys({ type: '09/09/09' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       const result = focusedDate();
       expect(result.getFullYear()).to.equal(2009);
       expect(result.getMonth()).to.equal(8);
@@ -501,7 +497,7 @@ describe('keyboard', () => {
     it('should focus parsed date when opening overlay', async () => {
       await sendKeys({ type: '1/20/2000' });
       await open(datePicker);
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
 
       expect(focusedDate().getMonth()).to.equal(0);
       expect(focusedDate().getDate()).to.equal(20);

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -4,14 +4,7 @@ import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
-import {
-  getDefaultI18n,
-  getFocusedCell,
-  idleCallback,
-  open,
-  waitForOverlayRender,
-  waitForScrollToFinish,
-} from './helpers.js';
+import { getDefaultI18n, getFocusedCell, open, untilOverlayRendered, untilOverlayScrolled } from './helpers.js';
 
 describe('keyboard navigation', () => {
   describe('date-picker', () => {
@@ -41,7 +34,7 @@ describe('keyboard navigation', () => {
         const today = new Date();
 
         input.click();
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
 
         // Reset overlay focused date
         input.click();
@@ -109,7 +102,7 @@ describe('keyboard navigation', () => {
 
       it('should be focused on initial position when focused date is empty', async () => {
         input.click();
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
 
         // Reset overlay focused date
         input.click();
@@ -144,18 +137,18 @@ describe('keyboard navigation', () => {
 
         // Move focus inside the dropdown to the typed date.
         await sendKeys({ press: 'ArrowDown' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         // Move focus to the previous week and it should instead move to the min date
         await sendKeys({ press: 'ArrowUp' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         let cell = getFocusedCell(datePicker);
         expect(cell.date).to.eql(new Date(2010, 0, 1));
 
         // Attempt to move focus to the previous week and it should stay on the min date
         await sendKeys({ press: 'ArrowUp' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         cell = getFocusedCell(datePicker);
         expect(cell.date).to.eql(new Date(2010, 0, 1));
@@ -166,18 +159,18 @@ describe('keyboard navigation', () => {
 
         // Move focus inside the dropdown to the typed date.
         await sendKeys({ press: 'ArrowDown' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         // Move focus to the next week and it should instead move to the max date
         await sendKeys({ press: 'ArrowDown' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         let cell = getFocusedCell(datePicker);
         expect(cell.date).to.eql(new Date(2010, 0, 31));
 
         // Attempt to move focus to the next week and it should stay on the max date
         await sendKeys({ press: 'ArrowDown' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         cell = getFocusedCell(datePicker);
         expect(cell.date).to.eql(new Date(2010, 0, 31));
@@ -188,11 +181,11 @@ describe('keyboard navigation', () => {
 
         // Move focus inside the dropdown to the typed date.
         await sendKeys({ press: 'ArrowDown' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         // Move focus to a disabled date
         await sendKeys({ press: 'ArrowRight' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         const cell = getFocusedCell(datePicker);
         expect(cell.date).to.eql(new Date(2010, 0, 29));
@@ -204,7 +197,7 @@ describe('keyboard navigation', () => {
         // Move focus to a disabled date
         await sendKeys({ press: 'ArrowDown' });
         await sendKeys({ press: 'ArrowRight' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
 
         await sendKeys({ press: 'Enter' });
 
@@ -230,21 +223,20 @@ describe('keyboard navigation', () => {
       const initialDate = new Date(2000, 0, 1);
       overlay.initialPosition = initialDate;
 
-      await waitForOverlayRender();
       await overlay.focusDate(initialDate);
-      await idleCallback();
+      await untilOverlayScrolled(overlay);
     });
 
     it('should focus one week forward with arrow down', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 0, 8));
     });
 
     it('should focus one week backward with arrow up', async () => {
       await sendKeys({ press: 'ArrowUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -265,14 +257,14 @@ describe('keyboard navigation', () => {
 
         it(`should focus one day ${isRTL ? 'backward' : 'forward'} with arrow 'right'`, async () => {
           await sendKeys({ press: 'ArrowRight' });
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
           const cell = getFocusedCell(overlay);
           expect(cell.date).to.eql(isRTL ? new Date(1999, 11, 31) : new Date(2000, 0, 2));
         });
 
         it(`should focus one day ${isRTL ? 'forward' : 'backward'} with arrow left`, async () => {
           await sendKeys({ press: 'ArrowLeft' });
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
           const cell = getFocusedCell(overlay);
           expect(cell.date).to.eql(isRTL ? new Date(2000, 0, 2) : new Date(1999, 11, 31));
         });
@@ -291,7 +283,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'ArrowUp' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const e = spy.firstCall.args[0];
       expect(e.detail.position).to.be.closeTo(e.detail.oldPosition - 1, 1);
     });
@@ -299,59 +291,59 @@ describe('keyboard navigation', () => {
     it('should focus first day of the month with home', async () => {
       await sendKeys({ press: 'ArrowLeft' });
       await sendKeys({ press: 'Home' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 1));
     });
 
     it('should focus last day of the month with end', async () => {
       await sendKeys({ press: 'End' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 0, 31));
     });
 
     it('should focus next month with pagedown', async () => {
       await sendKeys({ press: 'PageDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 1, 1));
     });
 
     it('should focus previous month with pageup', async () => {
       await sendKeys({ press: 'PageUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 1));
     });
 
     it('should not skip a month', async () => {
       await overlay.focusDate(new Date(2000, 0, 31));
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       await sendKeys({ press: 'PageDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 1, 29));
     });
 
     it('should focus the previously focused date number if available', async () => {
       await overlay.focusDate(new Date(2000, 0, 31));
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       await sendKeys({ press: 'PageDown' });
       await sendKeys({ press: 'PageDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       expect(overlay.focusedDate).to.eql(new Date(2000, 2, 31));
     });
 
     it('should focus next year with shift and pagedown', async () => {
       await sendKeys({ press: 'Shift+PageDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       expect(overlay.focusedDate).to.eql(new Date(2001, 0, 1));
     });
 
     it('should focus previous year with shift and pageup', async () => {
       await sendKeys({ press: 'Shift+PageUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       expect(overlay.focusedDate).to.eql(new Date(1999, 0, 1));
     });
 
@@ -361,7 +353,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Shift+PageUp' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const e = spy.firstCall.args[0];
       expect(e.detail.position).to.be.closeTo(e.detail.oldPosition - 12, 1);
     });
@@ -380,7 +372,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Shift+PageDown' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const e = spy.firstCall.args[0];
       expect(e.detail.position).to.be.greaterThan(e.detail.oldPosition);
     });
@@ -402,14 +394,14 @@ describe('keyboard navigation', () => {
     it('should move to max date when targeted date is disabled', async () => {
       overlay.maxDate = new Date(2000, 0, 7);
       await sendKeys({ down: 'ArrowDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       expect(overlay.focusedDate).to.eql(new Date(2000, 0, 7));
     });
 
     it('should move to min date when targeted date is disabled', async () => {
       overlay.minDate = new Date(1999, 11, 26);
       await sendKeys({ down: 'ArrowUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       expect(overlay.focusedDate).to.eql(new Date(1999, 11, 26));
     });
 
@@ -417,7 +409,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 3);
       await sendKeys({ down: 'ArrowLeft' });
       await sendKeys({ down: 'Home' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 3));
     });
@@ -425,7 +417,7 @@ describe('keyboard navigation', () => {
     it('should focus max date with end', async () => {
       overlay.maxDate = new Date(2000, 0, 26);
       await sendKeys({ down: 'End' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 0, 26));
     });
@@ -433,7 +425,7 @@ describe('keyboard navigation', () => {
     it('should focus max date with pagedown', async () => {
       overlay.maxDate = new Date(2000, 0, 28);
       await sendKeys({ press: 'PageDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 0, 28));
     });
@@ -441,7 +433,7 @@ describe('keyboard navigation', () => {
     it('should focus min date with pageup', async () => {
       overlay.minDate = new Date(1999, 11, 3);
       await sendKeys({ press: 'PageUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 3));
     });
@@ -451,7 +443,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Shift+PageDown' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(2000, 11, 28));
     });
@@ -461,7 +453,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Shift+PageUp' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 5, 3));
     });
@@ -471,7 +463,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 25);
       await nextRender(overlay);
       await sendKeys({ press: 'PageUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -481,7 +473,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 25);
       await nextRender(overlay);
       await sendKeys({ press: 'PageDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -493,7 +485,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Shift+PageUp' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -505,7 +497,7 @@ describe('keyboard navigation', () => {
 
       await sendKeys({ press: 'Shift+PageDown' });
 
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -514,7 +506,7 @@ describe('keyboard navigation', () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
       await sendKeys({ press: 'Home' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -523,7 +515,7 @@ describe('keyboard navigation', () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
       await sendKeys({ press: 'End' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -533,7 +525,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 25);
       await nextRender(overlay);
       await sendKeys({ press: 'ArrowUp' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -543,7 +535,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 25);
       await nextRender(overlay);
       await sendKeys({ press: 'ArrowDown' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -553,7 +545,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 25);
       await nextRender(overlay);
       await sendKeys({ press: 'ArrowLeft' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -563,7 +555,7 @@ describe('keyboard navigation', () => {
       overlay.minDate = new Date(1999, 11, 25);
       await nextRender(overlay);
       await sendKeys({ press: 'ArrowRight' });
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
       expect(cell.date).to.eql(new Date(1999, 11, 25));
     });
@@ -572,7 +564,7 @@ describe('keyboard navigation', () => {
       const date = new Date(99, 0, 1);
       date.setFullYear(99);
       overlay.focusedDate = date;
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       await sendKeys({ press: 'ArrowRight' });
       date.setDate(2);
       expect(overlay.focusedDate).to.eql(date);
@@ -582,7 +574,7 @@ describe('keyboard navigation', () => {
       const date = new Date(99, 0, 1);
       date.setFullYear(99);
       overlay.focusedDate = date;
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       await sendKeys({ press: 'PageDown' });
       date.setMonth(1);
       expect(overlay.focusedDate).to.eql(date);
@@ -592,7 +584,7 @@ describe('keyboard navigation', () => {
       const date = new Date(99, 0, 1);
       date.setFullYear(99);
       overlay.focusedDate = date;
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
       await sendKeys({ press: 'End' });
       date.setDate(31);
       expect(overlay.focusedDate).to.eql(date);

--- a/packages/date-picker/test/overlay-content.test.js
+++ b/packages/date-picker/test/overlay-content.test.js
@@ -1,18 +1,18 @@
 import { expect } from '@vaadin/chai-plugins';
-import { click, fixtureSync, listenOnce, nextRender, tap } from '@vaadin/testing-helpers';
+import { click, fixtureSync, listenOnce, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-picker-overlay-content.js';
-import { getDefaultI18n, getFirstVisibleItem, monthsEqual, waitForScrollToFinish } from './helpers.js';
+import { getDefaultI18n, getFirstVisibleItem, monthsEqual, untilOverlayScrolled } from './helpers.js';
 
 async function customizeFixture({ initialPosition, monthScrollerItems, monthScrollerOffset }) {
   const overlay = fixtureSync(`<vaadin-date-picker-overlay-content></vaadin-date-picker-overlay-content>`);
-  await nextRender();
+  await untilOverlayScrolled(overlay);
   const monthScroller = overlay._monthScroller;
   monthScroller.style.setProperty('--vaadin-infinite-scroller-buffer-offset', monthScrollerOffset);
   monthScroller.style.height = `${270 * monthScrollerItems}px`;
   overlay.i18n = getDefaultI18n();
   overlay.initialPosition = initialPosition || new Date();
-  await nextRender();
+  await untilOverlayScrolled(overlay);
 
   return overlay;
 }
@@ -30,8 +30,7 @@ describe('overlay', () => {
       `);
       overlay.i18n = getDefaultI18n();
       overlay.initialPosition = new Date(2021, 1, 1);
-      await nextRender();
-      await waitForScrollToFinish(overlay);
+      await untilOverlayScrolled(overlay);
     });
 
     it('should mark current year', () => {
@@ -175,12 +174,12 @@ describe('overlay', () => {
       describe('today button', () => {
         it('should scroll to current date', async () => {
           overlay.scrollToDate(new Date(2000, 1, 1));
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
 
           const today = new Date();
           const spy = sinon.spy(overlay, 'scrollToDate');
           tap(overlay._todayButton);
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
 
           expect(spy.calledOnce).to.be.true;
           const date = spy.firstCall.args[0];
@@ -192,7 +191,7 @@ describe('overlay', () => {
         it('should close the overlay and select today if on current month', async () => {
           const today = new Date();
           overlay.scrollToDate(today);
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
 
           const spy = sinon.spy();
           overlay.addEventListener('close', spy);
@@ -207,7 +206,7 @@ describe('overlay', () => {
         it('should not close the overlay and not select today if not on current month', async () => {
           const today = new Date();
           overlay.scrollToDate(today);
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
 
           const spy = sinon.spy();
           overlay.addEventListener('close', spy);
@@ -222,7 +221,7 @@ describe('overlay', () => {
         it('should do nothing if disabled', async () => {
           const initialDate = new Date(2000, 1, 1);
           overlay.scrollToDate(initialDate);
-          await waitForScrollToFinish(overlay);
+          await untilOverlayScrolled(overlay);
 
           const closeSpy = sinon.spy();
           overlay.addEventListener('close', closeSpy);
@@ -285,7 +284,7 @@ describe('overlay', () => {
           it('should select today if today is max', async () => {
             overlay.maxDate = todayMidnight;
             overlay.scrollToDate(todayMidnight);
-            await waitForScrollToFinish(overlay);
+            await untilOverlayScrolled(overlay);
 
             tap(overlay._todayButton);
 
@@ -307,27 +306,27 @@ describe('overlay', () => {
       `);
       overlay.i18n = getDefaultI18n();
       overlay.initialPosition = new Date(2021, 1, 1);
-      await nextRender();
+      await untilOverlayScrolled(overlay);
     });
 
     it('should reflect the year of currently visible month on the toolbar', async () => {
       const date = new Date(2000, 1, 1);
       overlay.scrollToDate(date);
-      await nextRender();
+      await untilOverlayScrolled(overlay);
       expect(parseInt(overlay.shadowRoot.querySelector('[part="years-toggle-button"]').textContent)).to.equal(2000);
     });
 
     it('should scroll to the given date', async () => {
       const date = new Date(2000, 1, 1);
       overlay.scrollToDate(date);
-      await nextRender();
+      await untilOverlayScrolled(overlay);
       expect(monthsEqual(getFirstVisibleItem(overlay._monthScroller, 0).firstElementChild.month, date)).to.be.true;
     });
 
     it('should scroll to the given year', async () => {
       const date = new Date(2000, 1, 1);
       overlay.scrollToDate(date);
-      await nextRender();
+      await untilOverlayScrolled(overlay);
       const offset = overlay._yearScroller.clientHeight / 2;
       overlay._yearScroller._debouncerUpdateClones.flush();
       expect(getFirstVisibleItem(overlay._yearScroller, offset).firstElementChild.year).to.equal(2000);

--- a/packages/date-picker/test/theme-propagation.test.js
+++ b/packages/date-picker/test/theme-propagation.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '../src/vaadin-date-picker.js';
-import { open, waitForScrollToFinish } from './helpers.js';
+import { open, untilOverlayScrolled } from './helpers.js';
 
 describe('theme attribute', () => {
   let datePicker;
@@ -32,7 +32,7 @@ describe('theme attribute', () => {
     });
 
     it('should propagate theme attribute to month calendar', async () => {
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
       const monthCalendar = datePicker._overlayContent.querySelector('vaadin-month-calendar');
       expect(monthCalendar.getAttribute('theme')).to.equal('foo');
     });

--- a/packages/date-picker/test/validation.test.js
+++ b/packages/date-picker/test/validation.test.js
@@ -3,7 +3,7 @@ import { enter, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-help
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-date-picker.js';
-import { open, setInputValue, waitForOverlayRender } from './helpers.js';
+import { open, setInputValue, untilOverlayRendered } from './helpers.js';
 
 class DatePicker2016 extends customElements.get('vaadin-date-picker') {
   checkValidity() {
@@ -226,7 +226,7 @@ describe('validation', () => {
 
     it('should be valid when committing a valid date', async () => {
       setInputValue(datePicker, '1/1/2022');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       enter(input);
       await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.false;
@@ -234,7 +234,7 @@ describe('validation', () => {
 
     it('should be invalid when trying to commit an invalid date', async () => {
       setInputValue(datePicker, 'foo');
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       enter(input);
       await nextUpdate(datePicker);
       expect(datePicker.invalid).to.be.true;

--- a/packages/date-picker/test/value-commit.test.js
+++ b/packages/date-picker/test/value-commit.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { waitForOverlayRender, waitForScrollToFinish } from './helpers.js';
+import { untilOverlayRendered, untilOverlayScrolled } from './helpers.js';
 
 describe('value commit', () => {
   let datePicker, valueChangedSpy, validateSpy, changeSpy, unparsableChangeSpy, todayDate, yesterdayDate;
@@ -81,14 +81,14 @@ describe('value commit', () => {
 
     it('should not commit but validate on close with outside click', async () => {
       datePicker.click();
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       outsideClick();
       expectValidationOnly();
     });
 
     it('should not commit on close with Escape', async () => {
       datePicker.click();
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       await sendKeys({ press: 'Escape' });
       expectNoValueCommit();
     });
@@ -97,7 +97,7 @@ describe('value commit', () => {
   describe('parsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: '1/1/2001' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
     });
 
     it('should commit on Enter', async () => {
@@ -121,7 +121,7 @@ describe('value commit', () => {
     beforeEach(async () => {
       await sendKeys({ type: '1/1/2001' });
       await sendKeys({ press: 'Enter' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       valueChangedSpy.resetHistory();
       validateSpy.resetHistory();
       changeSpy.resetHistory();
@@ -150,7 +150,7 @@ describe('value commit', () => {
 
       it('should revert on close with Escape', async () => {
         await sendKeys({ press: 'ArrowDown' });
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
         await sendKeys({ press: 'Escape' });
         expectNoValueCommit();
       });
@@ -178,7 +178,7 @@ describe('value commit', () => {
   describe('unparsable input entered', () => {
     beforeEach(async () => {
       await sendKeys({ type: 'foo' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
     });
 
     it('should commit as unparsable value change on Enter', async () => {
@@ -204,7 +204,7 @@ describe('value commit', () => {
     beforeEach(async () => {
       await sendKeys({ type: 'foo' });
       await sendKeys({ press: 'Enter' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       validateSpy.resetHistory();
       unparsableChangeSpy.resetHistory();
     });
@@ -229,7 +229,7 @@ describe('value commit', () => {
     describe('unparsable input changed', () => {
       beforeEach(async () => {
         await sendKeys({ type: 'bar' });
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
       });
 
       it('should commit as unparsable value change on Enter', async () => {
@@ -254,10 +254,10 @@ describe('value commit', () => {
     beforeEach(async () => {
       // Open the dropdown.
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       // Focus yesterday's date.
       await sendKeys({ press: 'ArrowLeft' });
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
     });
 
     it('should commit on focused date selection with click', () => {
@@ -291,7 +291,7 @@ describe('value commit', () => {
     beforeEach(async () => {
       // Open the dropdown.
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       // Select today's date.
       await sendKeys({ press: 'Space' });
       valueChangedSpy.resetHistory();
@@ -317,7 +317,7 @@ describe('value commit', () => {
       beforeEach(async () => {
         // Focus yesterday's date.
         await sendKeys({ press: 'ArrowLeft' });
-        await waitForScrollToFinish(datePicker);
+        await untilOverlayScrolled(datePicker);
       });
 
       it('should commit on focused date selection with click', () => {
@@ -366,14 +366,14 @@ describe('value commit', () => {
 
       it('should not commit on close with outside click', async () => {
         datePicker.click();
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
         outsideClick();
         expectNoValueCommit();
       });
 
       it('should not commit on close with Escape', async () => {
         datePicker.click();
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
         await sendKeys({ press: 'Escape' });
         expectNoValueCommit();
       });
@@ -383,7 +383,7 @@ describe('value commit', () => {
       beforeEach(async () => {
         datePicker.inputElement.select();
         await sendKeys({ type: '1/1/2001' });
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
       });
 
       it('should commit on Enter', async () => {
@@ -407,7 +407,7 @@ describe('value commit', () => {
       beforeEach(async () => {
         datePicker.inputElement.select();
         await sendKeys({ type: 'foo' });
-        await waitForOverlayRender();
+        await untilOverlayRendered(datePicker);
       });
 
       it('should commit an empty value on Enter', async () => {

--- a/packages/date-time-picker/test/validation.test.js
+++ b/packages/date-time-picker/test/validation.test.js
@@ -3,7 +3,7 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { aTimeout, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-date-time-picker.js';
-import { waitForOverlayRender } from '@vaadin/date-picker/test/helpers.js';
+import { untilOverlayRendered } from '@vaadin/date-picker/test/helpers.js';
 
 class DateTimePicker2020Element extends customElements.get('vaadin-date-time-picker') {
   checkValidity() {
@@ -109,7 +109,7 @@ const fixtures = {
     it('should not validate when moving focus to the date-picker dropdown', async () => {
       datePicker.focus();
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(datePicker);
       await sendKeys({ press: 'Tab' });
       expect(validateSpy.called).to.be.false;
     });

--- a/packages/field-highlighter/test/field-components.test.js
+++ b/packages/field-highlighter/test/field-components.test.js
@@ -11,7 +11,7 @@ import '@vaadin/radio-group';
 import '@vaadin/select';
 import '@vaadin/text-field';
 import { html, render } from 'lit';
-import { waitForOverlayRender } from '@vaadin/date-picker/test/helpers.js';
+import { untilOverlayRendered } from '@vaadin/date-picker/test/helpers.js';
 import { FieldHighlighter } from '../src/vaadin-field-highlighter.js';
 
 async function waitForIntersectionObserver() {
@@ -85,21 +85,21 @@ describe('field components', () => {
       it('should not dispatch vaadin-highlight-hide event on open', async () => {
         field.focus();
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
         expect(hideSpy.callCount).to.equal(0);
       });
 
       it('should not dispatch vaadin-highlight-hide event on close without blur', async () => {
         field.focus();
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
         field.close();
         expect(hideSpy.callCount).to.equal(0);
       });
 
       it('should not dispatch vaadin-highlight-hide event on close with focus moved to the field', async () => {
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
 
         field.focus();
         field.close();
@@ -110,7 +110,7 @@ describe('field components', () => {
       it('should not dispatch vaadin-highlight-hide event on re-focusing field', async () => {
         field.focus();
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
 
         await field._overlayContent.focusDateElement();
         field.focus();
@@ -122,7 +122,7 @@ describe('field components', () => {
       it('should not dispatch second vaadin-highlight-show event on re-focusing field', async () => {
         field.focus();
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
 
         await field._overlayContent.focusDateElement();
         field.focus();
@@ -134,7 +134,7 @@ describe('field components', () => {
       it('should not dispatch vaadin-highlight-hide event on field blur if opened', async () => {
         field.focus();
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
 
         field.blur();
         field.focus();
@@ -146,7 +146,7 @@ describe('field components', () => {
       it('should dispatch vaadin-highlight-hide event on close after blur', async () => {
         field.focus();
         await open(field);
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
 
         await field._overlayContent.focusDateElement();
         outsideClick();
@@ -169,7 +169,7 @@ describe('field components', () => {
       it('should dispatch vaadin-highlight-show event on open', async () => {
         field.focus();
         field.click();
-        await waitForOverlayRender();
+        await untilOverlayRendered(field);
         expect(showSpy.callCount).to.equal(1);
       });
     });
@@ -468,7 +468,7 @@ describe('field components', () => {
     it('should dispatch vaadin-highlight-hide event on overlay focusout to time picker', async () => {
       date.focus();
       await open(date);
-      await waitForOverlayRender();
+      await untilOverlayRendered(field);
 
       // Focus date element and then time-picker
       await date._overlayContent.focusDateElement();

--- a/test/integration/dialog-date-picker.test.js
+++ b/test/integration/dialog-date-picker.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import './not-animated-styles.js';
 import '@vaadin/date-picker';
 import '@vaadin/dialog';
-import { open, waitForScrollToFinish } from '@vaadin/date-picker/test/helpers.js';
+import { open, untilOverlayScrolled } from '@vaadin/date-picker/test/helpers.js';
 
 describe('date-picker in dialog', () => {
   let dialog, datePicker;
@@ -41,7 +41,7 @@ describe('date-picker in dialog', () => {
       await sendKeys({ press: 'Tab' });
 
       await nextRender();
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
 
       // Focus the Today button
       await sendKeys({ press: 'Tab' });
@@ -61,7 +61,7 @@ describe('date-picker in dialog', () => {
       await sendKeys({ press: 'Tab' });
 
       await nextRender();
-      await waitForScrollToFinish(datePicker);
+      await untilOverlayScrolled(datePicker);
 
       const spy = sinon.spy(datePicker.inputElement, 'focus');
 

--- a/test/integration/grid-pro-custom-editor.test.js
+++ b/test/integration/grid-pro-custom-editor.test.js
@@ -9,7 +9,7 @@ import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 import '@vaadin/text-field';
 import '@vaadin/time-picker';
-import { waitForOverlayRender } from '@vaadin/date-picker/test/helpers.js';
+import { untilOverlayRendered } from '@vaadin/date-picker/test/helpers.js';
 import { flushGrid, getContainerCell } from '@vaadin/grid-pro/test/helpers.js';
 
 describe('grid-pro custom editor', () => {
@@ -132,7 +132,7 @@ describe('grid-pro custom editor', () => {
     it('should not stop editing when clicking inside the overlay but not on focusable element', async () => {
       // Open the overlay
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(cell._content.querySelector('vaadin-date-picker'));
 
       // Click between toolbar buttons
       const overlayContent = document.querySelector('vaadin-date-picker-overlay-content');
@@ -146,7 +146,7 @@ describe('grid-pro custom editor', () => {
     it('should not stop editing and update value when closing on outside click', async () => {
       // Open the overlay
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(cell._content.querySelector('vaadin-date-picker'));
 
       // Move focus back to the input
       await sendKeys({ press: 'Shift+Tab' });
@@ -253,7 +253,7 @@ describe('grid-pro custom editor', () => {
 
     it('should not stop editing and update value when closing on date-picker outside click', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await waitForOverlayRender();
+      await untilOverlayRendered(cell._content.querySelector('vaadin-date-picker'));
 
       // Move focus back to the input
       await sendKeys({ press: 'Shift+Tab' });


### PR DESCRIPTION
## Description

- Renamed `waitForScrollToFinish` to `untilOverlayScrolled`
- Renamed `waitOverlayRender` to `untilOverlayRendered`
- Ensured that the ignoreTaps debouncer is flushed at the end of `untilOverlayScrolled` to prevent potential test failures due to 300ms delay before tap events are allowed again.

Related to https://github.com/vaadin/platform/issues/7453

## Type of change

- [x] Internal
