### PR TITLE
chore: ban ES2020-2021 operators only in component files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,8 @@
         // Ban ES2020, ES2021 operators in source component files, as they aren't supported by Polymer analyzer
         "es/no-optional-chaining": "error",
         "es/no-nullish-coalescing-operators": "error",
-        "es/no-logical-assignment-operators": "error"
+        "es/no-logical-assignment-operators": "error",
+        "logical-assignment-operators": "off"
       }
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,10 +61,17 @@
   },
   "overrides": [
     {
+      "files": ["packages/**/vaadin-*.js"],
+      "rules": {
+        // Ban ES2020, ES2021 operators in source component files, as they aren't supported by Polymer analyzer
+        "es/no-optional-chaining": "error",
+        "es/no-nullish-coalescing-operators": "error",
+        "es/no-logical-assignment-operators": "error"
+      }
+    },
+    {
       "files": ["packages/*/src/**/*.js"],
       "rules": {
-        // Prevent using optional-chaining in source files, as it is not supported by Polymer analyzer
-        "es/no-optional-chaining": "error",
         "no-restricted-syntax": [
           "error",
           {

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
@@ -102,7 +102,7 @@ export const GridProEditSelectMixin = (superClass) =>
           value: option,
         }));
 
-        this._overlayElement ||= this.shadowRoot.querySelector('vaadin-select-overlay');
+        this._overlayElement = this._overlayElement || this.shadowRoot.querySelector('vaadin-select-overlay');
         this._overlayElement.addEventListener('vaadin-overlay-outside-click', () => {
           this._grid._stopEdit();
         });

--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -144,7 +144,8 @@ export const ColumnAutoWidthMixin = (superClass) =>
         }
       });
 
-      this.__hasHadRenderedRowsForColumnWidthCalculation ||= this._getRenderedRows().length > 0;
+      this.__hasHadRenderedRowsForColumnWidthCalculation =
+        this.__hasHadRenderedRowsForColumnWidthCalculation || this._getRenderedRows().length > 0;
 
       this.__intrinsicWidthCache = new Map();
       // Cache the viewport rows to avoid unnecessary reflows while measuring the column widths

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -215,7 +215,7 @@ export class ColumnObserver {
   __onMutation() {
     // Detect if this is the initial call
     const initialCall = !this.__currentColumns;
-    this.__currentColumns ||= [];
+    this.__currentColumns = this.__currentColumns || [];
 
     // Detect added and removed columns or if the columns order has changed
     const columns = ColumnObserver.getColumns(this.__host);


### PR DESCRIPTION
ES2020–2021 operators must be banned only in component files, as only those are passed to Polymer analyzer:

```
polymer analyze packages/**/vaadin-*.js > analysis.json
```