### PR TITLE
fix: set z-index on details part in stack mode

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -101,7 +101,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         z-index: 1;
       }
 
-      :host([overlay]) [part='detail'] {
+      :host(:is([overlay], [stack])) [part='detail'] {
         z-index: 1;
       }
 


### PR DESCRIPTION
## Description

Also set `z-index` on the details part in stack mode, so that it covers the app layout navbar when using viewport containment.

Fixes https://github.com/vaadin/web-components/issues/8960

## Type of change

- Bugfix
