### PR TITLE
chore: update --glob arg examples in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,12 +114,12 @@ Run or debug specific test files filtered by a glob pattern:
 
 ```sh
 yarn test --group combo-box --glob="data-provider*" # all data provider tests
-yarn test --group combo-box --glob="*polymer.test.js" # all polymer tests
-yarn test --group combo-box --glob="*lit.test.js" # all lit tests
+yarn test --group combo-box --glob="!(*-lit.generated)" # all polymer tests
+yarn test --group combo-box --glob="*-lit.generated" # all lit tests
 
 yarn debug --group combo-box --glob="data-provider*" # all data provider tests
-yarn debug --group combo-box --glob="*polymer.test.js" # all polymer tests
-yarn debug --group combo-box --glob="*lit.test.js" # all lit tests
+yarn debug --group combo-box --glob="!(*-lit.generated)" # all polymer tests
+yarn debug --group combo-box --glob="*-lit.generated" # all lit tests
 ```
 
 Run tests with code coverage:


### PR DESCRIPTION
Since Lit tests are now auto-generated and renamed, the `--glob` argument examples need to be updated accordingly