### PR TITLE
test: import unstyled grid component in unit tests

### DIFF
--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
-import '../vaadin-grid-column-group.js';
+import '../src/vaadin-grid.js';
+import '../src/vaadin-grid-column-group.js';
 import {
   attributeRenderer,
   flushGrid,

--- a/packages/grid/test/deprecated-api.test.js
+++ b/packages/grid/test/deprecated-api.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid } from './helpers.js';
 
 describe('deprecated API', () => {

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -2,7 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import './grid-test-styles.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, getBodyCellContent, getFirstCell, getRowBodyCells, getRows } from './helpers.js';
 
 describe('drag and drop', () => {

--- a/packages/grid/test/dynamic-item-size.test.js
+++ b/packages/grid/test/dynamic-item-size.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { css } from 'lit';
 import { flushGrid, getFirstVisibleItem, infiniteDataProvider } from './helpers.js';
 

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -78,13 +78,15 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
         let containerElement;
         let containerRows;
         let scrollbarWidth;
+        let borderWidth;
         let translateValue;
 
         beforeEach(() => {
           containerElement = grid.shadowRoot.querySelector(container === 'header' ? 'thead' : 'tbody#items');
           containerRows = getRows(containerElement);
           scrollbarWidth = grid.$.table.offsetWidth - grid.$.table.clientWidth;
-          translateValue = isRTL ? -defaultCellWidth : defaultCellWidth;
+          borderWidth = parseInt(getComputedStyle(grid).getPropertyValue('--_lumo-grid-border-width'));
+          translateValue = isRTL ? -(defaultCellWidth + 2 * borderWidth) : defaultCellWidth;
         });
 
         it('should have a frozen cell in a row', () => {
@@ -221,13 +223,15 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
         let containerElement;
         let containerRows;
         let scrollbarWidth;
+        let borderWidth;
         let translateValue;
 
         beforeEach(() => {
           containerElement = grid.shadowRoot.querySelector(container === 'header' ? 'thead' : 'tbody');
           containerRows = getRows(containerElement);
           scrollbarWidth = grid.$.table.offsetWidth - grid.$.table.clientWidth;
-          const offset = defaultCellWidth + scrollbarWidth;
+          borderWidth = parseInt(getComputedStyle(grid).getPropertyValue('--_lumo-grid-border-width'));
+          const offset = defaultCellWidth + scrollbarWidth + 2 * borderWidth;
           translateValue = isRTL ? offset : -offset;
         });
 

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -2,7 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, listenOnce, nextRender, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import './grid-test-styles.js';
+import '../src/vaadin-grid.js';
 import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import { flushGrid, getRowCells, getRows, infiniteDataProvider, isWithinParentConstraints } from './helpers.js';
@@ -77,15 +78,13 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
         let containerElement;
         let containerRows;
         let scrollbarWidth;
-        let borderWidth;
         let translateValue;
 
         beforeEach(() => {
           containerElement = grid.shadowRoot.querySelector(container === 'header' ? 'thead' : 'tbody#items');
           containerRows = getRows(containerElement);
           scrollbarWidth = grid.$.table.offsetWidth - grid.$.table.clientWidth;
-          borderWidth = parseInt(getComputedStyle(grid).getPropertyValue('--_lumo-grid-border-width'));
-          translateValue = isRTL ? -(defaultCellWidth + 2 * borderWidth) : defaultCellWidth;
+          translateValue = isRTL ? -defaultCellWidth : defaultCellWidth;
         });
 
         it('should have a frozen cell in a row', () => {
@@ -222,15 +221,13 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
         let containerElement;
         let containerRows;
         let scrollbarWidth;
-        let borderWidth;
         let translateValue;
 
         beforeEach(() => {
           containerElement = grid.shadowRoot.querySelector(container === 'header' ? 'thead' : 'tbody');
           containerRows = getRows(containerElement);
           scrollbarWidth = grid.$.table.offsetWidth - grid.$.table.clientWidth;
-          borderWidth = parseInt(getComputedStyle(grid).getPropertyValue('--_lumo-grid-border-width'));
-          const offset = defaultCellWidth + scrollbarWidth + 2 * borderWidth;
+          const offset = defaultCellWidth + scrollbarWidth;
           translateValue = isRTL ? offset : -offset;
         });
 

--- a/packages/grid/test/grid-test-styles.js
+++ b/packages/grid/test/grid-test-styles.js
@@ -1,0 +1,20 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+// TODO: subset of Lumo needed for unit tests to pass.
+// These should be eventually covered by base styles.
+registerStyles(
+  'vaadin-grid',
+  css`
+    [part~='cell'] {
+      min-height: 2.25rem;
+    }
+
+    [part~='cell'] ::slotted(vaadin-grid-cell-content) {
+      padding: 0.25rem 1rem;
+    }
+
+    [part~='row']:only-child [part~='header-cell'] {
+      min-height: 3.5rem;
+    }
+  `,
+);

--- a/packages/grid/test/grid-test-styles.js
+++ b/packages/grid/test/grid-test-styles.js
@@ -5,6 +5,10 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-grid',
   css`
+    :host {
+      --_lumo-grid-border-width: 0px;
+    }
+
     [part~='cell'] {
       min-height: 2.25rem;
     }

--- a/packages/grid/test/hidden-grid.test.js
+++ b/packages/grid/test/hidden-grid.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { fire, flushGrid, getBodyCellContent, getHeaderCell, infiniteDataProvider } from './helpers.js';
 
 describe('hidden grid', () => {

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { arrowLeft, arrowRight, aTimeout, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid } from './helpers.js';
 
 let grid;

--- a/packages/grid/test/lit-renderer-directives.test.js
+++ b/packages/grid/test/lit-renderer-directives.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { html, render } from 'lit';
 import { columnBodyRenderer, columnFooterRenderer, columnHeaderRenderer, gridRowDetailsRenderer } from '../lit.js';
 import { getCellContent, getContainerCell } from './helpers.js';

--- a/packages/grid/test/min-height.test.js
+++ b/packages/grid/test/min-height.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import './grid-test-styles.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, infiniteDataProvider } from './helpers.js';
 
 describe('min-height', () => {

--- a/packages/grid/test/physical-count.test.js
+++ b/packages/grid/test/physical-count.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { css } from 'lit';
 import {
   flushGrid,

--- a/packages/grid/test/renderers.test.js
+++ b/packages/grid/test/renderers.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, isIOS, keyDownOn, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, getBodyCellContent, getCell, getContainerCell } from './helpers.js';
 
 function getHeaderCell(grid, index = 0) {

--- a/packages/grid/test/row-details.test.js
+++ b/packages/grid/test/row-details.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   buildDataSet,

--- a/packages/grid/test/row-height.test.js
+++ b/packages/grid/test/row-height.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, getRowCells, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 const fixtures = {

--- a/packages/grid/test/scroll-into-view.test.js
+++ b/packages/grid/test/scroll-into-view.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, getContainerCell, getLastVisibleItem, getPhysicalItems } from './helpers.js';
 
 describe('scroll into view', () => {
@@ -82,7 +82,7 @@ describe('scroll into view', () => {
 
   it('should not change scroll position when focusing details cell with click', async () => {
     // Make details cell partially visible for clicking
-    grid.style.height = '240px';
+    grid.style.height = '220px';
     await nextFrame();
 
     verifyRowNotFullyVisible(grid, 1);

--- a/packages/grid/test/scroll-into-view.test.js
+++ b/packages/grid/test/scroll-into-view.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
 import { flushGrid, getContainerCell, getLastVisibleItem, getPhysicalItems } from './helpers.js';
 
@@ -82,7 +83,7 @@ describe('scroll into view', () => {
 
   it('should not change scroll position when focusing details cell with click', async () => {
     // Make details cell partially visible for clicking
-    grid.style.height = '220px';
+    grid.style.height = '240px';
     await nextFrame();
 
     verifyRowNotFullyVisible(grid, 1);

--- a/packages/grid/test/scroll-restoration.test.js
+++ b/packages/grid/test/scroll-restoration.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, isFirefox } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { fire, flushGrid, infiniteDataProvider } from './helpers.js';
 
 if (isFirefox) {

--- a/packages/grid/test/scrolling-mode.test.js
+++ b/packages/grid/test/scrolling-mode.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, listenOnce, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 describe('scrolling mode', () => {

--- a/packages/grid/test/selection-column-lazy-import.test.js
+++ b/packages/grid/test/selection-column-lazy-import.test.js
@@ -8,6 +8,6 @@ it('should not throw when grid with items imported lazily after selection column
   `);
 
   // The order of imports matters in this test
-  await import('../vaadin-grid-selection-column.js');
-  await import('../vaadin-grid.js');
+  await import('../src/vaadin-grid-selection-column.js');
+  await import('../src/vaadin-grid.js');
 });

--- a/packages/grid/test/styling.test.js
+++ b/packages/grid/test/styling.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-grid.js';
+import '../src/vaadin-grid.js';
 import { flushGrid, getContainerCell, getRows, infiniteDataProvider, scrollToEnd } from './helpers.js';
 
 describe('styling', () => {


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7456

## Type of change

- [x] Internal
