### PR TITLE
test: import unstyled avatar-group component in unit tests

### DIFF
--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -44,6 +44,7 @@
     "@vaadin/item": "24.8.0-alpha12",
     "@vaadin/list-box": "24.8.0-alpha12",
     "@vaadin/overlay": "24.8.0-alpha12",
+    "@vaadin/tooltip": "24.8.0-alpha12",
     "@vaadin/vaadin-lumo-styles": "24.8.0-alpha12",
     "@vaadin/vaadin-material-styles": "24.8.0-alpha12",
     "@vaadin/vaadin-themable-mixin": "24.8.0-alpha12",

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
 import '@vaadin/avatar/src/vaadin-avatar.js';
 import './vaadin-avatar-group-menu.js';
 import './vaadin-avatar-group-menu-item.js';

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -3,8 +3,8 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/tooltip/src/vaadin-tooltip.js';
 import '@vaadin/avatar/src/vaadin-avatar.js';
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
 import './vaadin-avatar-group-menu.js';
 import './vaadin-avatar-group-menu-item.js';
 import './vaadin-avatar-group-overlay.js';

--- a/packages/avatar-group/src/vaadin-lit-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-lit-avatar-group.js
@@ -3,8 +3,8 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import '@vaadin/tooltip/src/vaadin-lit-tooltip.js';
 import '@vaadin/avatar/src/vaadin-lit-avatar.js';
+import '@vaadin/tooltip/src/vaadin-lit-tooltip.js';
 import './vaadin-lit-avatar-group-menu.js';
 import './vaadin-lit-avatar-group-menu-item.js';
 import './vaadin-lit-avatar-group-overlay.js';

--- a/packages/avatar-group/src/vaadin-lit-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-lit-avatar-group.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/tooltip/src/vaadin-lit-tooltip.js';
 import '@vaadin/avatar/src/vaadin-lit-avatar.js';
 import './vaadin-lit-avatar-group-menu.js';
 import './vaadin-lit-avatar-group-menu-item.js';

--- a/packages/avatar-group/test/avatar-group-test-styles.js
+++ b/packages/avatar-group/test/avatar-group-test-styles.js
@@ -1,0 +1,22 @@
+import { addLumoGlobalStyles } from '@vaadin/vaadin-lumo-styles/global.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin';
+
+registerStyles(
+  'vaadin-avatar-group',
+  css`
+    :host {
+      --vaadin-avatar-size: 2.25rem;
+    }
+  `,
+);
+
+addLumoGlobalStyles(
+  '',
+  css`
+    :host {
+      --vaadin-user-color-0: #000;
+      --vaadin-user-color-1: #000;
+      --vaadin-user-color-2: #000;
+    }
+  `,
+);

--- a/packages/avatar-group/test/avatar-group-test-styles.js
+++ b/packages/avatar-group/test/avatar-group-test-styles.js
@@ -1,5 +1,4 @@
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { addGlobalThemeStyles, css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-avatar-group',

--- a/packages/avatar-group/test/avatar-group-test-styles.js
+++ b/packages/avatar-group/test/avatar-group-test-styles.js
@@ -1,5 +1,5 @@
-import { addLumoGlobalStyles } from '@vaadin/vaadin-lumo-styles/global.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin';
+import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 
 registerStyles(
   'vaadin-avatar-group',
@@ -10,7 +10,7 @@ registerStyles(
   `,
 );
 
-addLumoGlobalStyles(
+addGlobalThemeStyles(
   '',
   css`
     :host {

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -11,7 +11,8 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-avatar-group.js';
+import './avatar-group-test-styles.js';
+import '../src/vaadin-avatar-group.js';
 
 describe('avatar-group', () => {
   let group;

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -14,6 +14,12 @@ snapshots["vaadin-avatar-group default"] =
     tabindex="0"
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-0"
+        role="tooltip"
+        slot="sr-label"
+      >
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
 </vaadin-avatar-group>
@@ -24,16 +30,25 @@ snapshots["vaadin-avatar-group items"] =
 `<vaadin-avatar-group aria-label="Currently 2 active users">
   <vaadin-avatar
     abbr="YY"
+    aria-describedby="vaadin-tooltip-2"
     aria-label="YY"
     role="img"
     tabindex="0"
     with-tooltip=""
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-2"
+        role="tooltip"
+        slot="sr-label"
+      >
+        YY
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
   <vaadin-avatar
     abbr="TV"
+    aria-describedby="vaadin-tooltip-3"
     aria-label="TV"
     name="Tomi Virkki"
     role="img"
@@ -41,10 +56,18 @@ snapshots["vaadin-avatar-group items"] =
     with-tooltip=""
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-3"
+        role="tooltip"
+        slot="sr-label"
+      >
+        Tomi Virkki
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
   <vaadin-avatar
     abbr="+2"
+    aria-describedby="vaadin-tooltip-1"
     aria-expanded="false"
     aria-haspopup="menu"
     aria-label="+2"
@@ -54,6 +77,14 @@ snapshots["vaadin-avatar-group items"] =
     tabindex="0"
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-1"
+        role="tooltip"
+        slot="sr-label"
+      >
+        YY
+Tomi Virkki
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
 </vaadin-avatar-group>
@@ -67,6 +98,7 @@ snapshots["vaadin-avatar-group theme"] =
 >
   <vaadin-avatar
     abbr="YY"
+    aria-describedby="vaadin-tooltip-5"
     aria-label="YY"
     role="img"
     tabindex="0"
@@ -74,10 +106,18 @@ snapshots["vaadin-avatar-group theme"] =
     with-tooltip=""
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-5"
+        role="tooltip"
+        slot="sr-label"
+      >
+        YY
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
   <vaadin-avatar
     abbr="TV"
+    aria-describedby="vaadin-tooltip-6"
     aria-label="TV"
     name="Tomi Virkki"
     role="img"
@@ -86,10 +126,18 @@ snapshots["vaadin-avatar-group theme"] =
     with-tooltip=""
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-6"
+        role="tooltip"
+        slot="sr-label"
+      >
+        Tomi Virkki
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
   <vaadin-avatar
     abbr="+2"
+    aria-describedby="vaadin-tooltip-4"
     aria-expanded="false"
     aria-haspopup="menu"
     aria-label="+2"
@@ -100,6 +148,14 @@ snapshots["vaadin-avatar-group theme"] =
     theme="small"
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-4"
+        role="tooltip"
+        slot="sr-label"
+      >
+        YY
+Tomi Virkki
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
 </vaadin-avatar-group>
@@ -110,6 +166,7 @@ snapshots["vaadin-avatar-group opened default"] =
 `<vaadin-avatar-group aria-label="Currently 4 active users">
   <vaadin-avatar
     abbr="AD"
+    aria-describedby="vaadin-tooltip-8"
     aria-label="AD"
     name="Abc Def"
     role="img"
@@ -117,10 +174,18 @@ snapshots["vaadin-avatar-group opened default"] =
     with-tooltip=""
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-8"
+        role="tooltip"
+        slot="sr-label"
+      >
+        Abc Def
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
   <vaadin-avatar
     abbr="GJ"
+    aria-describedby="vaadin-tooltip-9"
     aria-label="GJ"
     name="Ghi Jkl"
     role="img"
@@ -128,10 +193,18 @@ snapshots["vaadin-avatar-group opened default"] =
     with-tooltip=""
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-9"
+        role="tooltip"
+        slot="sr-label"
+      >
+        Ghi Jkl
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
   <vaadin-avatar
     abbr="+2"
+    aria-describedby="vaadin-tooltip-7"
     aria-expanded="false"
     aria-haspopup="menu"
     aria-label="+2"
@@ -141,6 +214,14 @@ snapshots["vaadin-avatar-group opened default"] =
     tabindex="0"
   >
     <vaadin-tooltip slot="tooltip">
+      <div
+        id="vaadin-tooltip-7"
+        role="tooltip"
+        slot="sr-label"
+      >
+        Mno Pqr
+Stu Vwx
+      </div>
     </vaadin-tooltip>
   </vaadin-avatar>
 </vaadin-avatar-group>

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
 import './vaadin-avatar-icons.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';

--- a/packages/avatar/src/vaadin-lit-avatar.js
+++ b/packages/avatar/src/vaadin-lit-avatar.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/tooltip/src/vaadin-lit-tooltip.js';
 import './vaadin-avatar-icons.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusin, focusout, mousedown, nextUpdate, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-avatar.js';
-import { Tooltip } from '@vaadin/tooltip';
+import { Tooltip } from '@vaadin/tooltip/src/vaadin-tooltip.js';
 
 describe('vaadin-avatar', () => {
   let avatar, imgElement, iconElement, abbrElement;

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusin, focusout, mousedown, nextUpdate, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-avatar.js';
-import '@vaadin/tooltip/vaadin-tooltip.js';
 import { Tooltip } from '@vaadin/tooltip';
 
 describe('vaadin-avatar', () => {


### PR DESCRIPTION
## Description

Unit tests should import unstyled components or explicitly define only the styles needed for testing to make theme refactoring easier.

Part of https://github.com/vaadin/platform/issues/7456

## Type of change

- [x] Internal
