### PR TITLE
test: update remaining multi-select-combo-box test to use src

### DIFF
--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -2,8 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './not-animated-styles.js';
-import '../vaadin-multi-select-combo-box.js';
+import './multi-select-combo-box-test-styles.js';
+import '../src/vaadin-multi-select-combo-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
 describe('basic', () => {

--- a/packages/multi-select-combo-box/test/multi-select-combo-box-test-styles.js
+++ b/packages/multi-select-combo-box/test/multi-select-combo-box-test-styles.js
@@ -66,3 +66,12 @@ registerStyles(
     }
   `,
 );
+
+registerStyles(
+  'vaadin-multi-select-combo-box-item',
+  css`
+    :host {
+      min-height: 2.25rem;
+    }
+  `,
+);


### PR DESCRIPTION
## Description

There was one test file that I missed to update to `src` version. Also needed to add item styles using `min-height` as without any defined size virtualizer would set `200` as a placeholder height and then end up with 3 items rendered instead of 4.

## Type of change

- Test