### PR TITLE
test: try to prevent focus-trap errors in crud-editor test

### DIFF
--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -73,6 +73,7 @@ describe('crud editor', () => {
         flushGrid(crud._grid);
 
         crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
+        await nextRender(crud);
         dialog = crud.$.dialog;
         overlay = dialog.$.overlay;
         form = crud.querySelector('[slot=form]');


### PR DESCRIPTION
## Description

Follow-up to #8980

Trying to fix the following error:

```
❌ crud editor > default form > should move default form when editorPosition changes from bottom to default
      Error: Error: The trap node should have at least one focusable descendant or be focusable itself. (http://localhost:8000/packages/a11y-base/src/focus-trap-controller.js:84)
```

## Type of change

- Test