### PR TITLE
test: update date-time-picker snapshot test to wait for render

### DIFF
--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -566,7 +566,7 @@ snapshots["vaadin-date-time-picker host overlay class date-picker"] =
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-15">
-        <vaadin-month-calendar aria-hidden="true">
+        <vaadin-month-calendar>
         </vaadin-month-calendar>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-16">
@@ -599,55 +599,84 @@ snapshots["vaadin-date-time-picker host overlay class date-picker"] =
         </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-22">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-23">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-24">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-25">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-26">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-27">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-28">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-29">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-30">
-        <vaadin-date-picker-year
-          current=""
-          selected=""
-        >
+        <vaadin-date-picker-year current="">
         </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-31">
-        <vaadin-date-picker-year selected="">
+        <vaadin-date-picker-year>
         </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-32">
-        <vaadin-date-picker-year selected="">
+        <vaadin-date-picker-year>
         </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-33">
-        <vaadin-date-picker-year selected="">
+        <vaadin-date-picker-year>
         </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-34">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-35">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-36">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-37">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-38">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-39">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-40">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
       <div slot="vaadin-infinite-scroller-item-content-41">
+        <vaadin-date-picker-year>
+        </vaadin-date-picker-year>
       </div>
     </vaadin-date-picker-year-scroller>
   </vaadin-date-picker-overlay-content>

--- a/packages/date-time-picker/test/dom/date-time-picker.test.js
+++ b/packages/date-time-picker/test/dom/date-time-picker.test.js
@@ -2,6 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-date-time-picker.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+import { open } from '@vaadin/date-picker/test/helpers.js';
 
 describe('vaadin-date-time-picker', () => {
   let dateTimePicker;
@@ -62,8 +63,7 @@ describe('vaadin-date-time-picker', () => {
 
       it('date-picker', async () => {
         const datePicker = dateTimePicker.querySelector('[slot="date-picker"]');
-        datePicker.opened = true;
-        await nextRender();
+        await open(datePicker);
         await expect(datePicker.$.overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
       });
 


### PR DESCRIPTION
## Description

Updated `vaadin-date-time-picker` snapshot tests to use `open()` helper that waits for `untilOvelayRendered()`.
This should make it more reliable since there are currently some failures in `base-styles` branch.

## Type of change

- Test