### PR TITLE
test: fix date-picker dropdown test to pass with base styles

### DIFF
--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -21,9 +21,10 @@ describe('dropdown', () => {
   });
 
   it('should update position of the overlay after changing opened property', async () => {
+    const inputField = datePicker.shadowRoot.querySelector('[part="input-field"]');
     datePicker.opened = true;
     await oneEvent(overlay, 'vaadin-overlay-open');
-    expect(input.getBoundingClientRect().bottom).to.be.closeTo(overlay.getBoundingClientRect().top, 0.01);
+    expect(inputField.getBoundingClientRect().bottom).to.be.closeTo(overlay.getBoundingClientRect().top, 0.01);
   });
 
   it('should detach overlay on datePicker detach', async () => {


### PR DESCRIPTION
## Description

In the base styles, there is some padding on `vaadin-input-container` causing the test to fail.
Changed to use input container instead of the input element to fix the test.

## Type of change

- Test