### PR TITLE
fix: restore incorrectly removed observer, update tests

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -737,6 +737,14 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     }
 
     /** @private */
+    _translateXChanged(x) {
+      if (!this._desktopMode) {
+        this._monthScroller.style.transform = `translateX(${x - this._yearScrollerWidth}px)`;
+        this._yearScroller.style.transform = `translateX(${x}px)`;
+      }
+    }
+
+    /** @private */
     _yearAfterXMonths(months) {
       return dateAfterXMonths(months).getFullYear();
     }

--- a/packages/date-picker/test/overlay-content.test.js
+++ b/packages/date-picker/test/overlay-content.test.js
@@ -465,7 +465,7 @@ describe('overlay', () => {
       it('should scroll when the month is below the visible area', () => {
         const position = monthScroller.position;
         overlay.revealDate(new Date(2021, 3, 1), false);
-        expect(monthScroller.position).to.equal(position + 1);
+        expect(monthScroller.position).to.be.closeTo(position + 1, 0.1);
       });
     });
 
@@ -494,7 +494,7 @@ describe('overlay', () => {
       it('should scroll when the month is below the visible area', () => {
         const position = monthScroller.position;
         overlay.revealDate(new Date(2021, 3, 1), false);
-        expect(monthScroller.position).to.equal(position + 0.6 /* The bottom 10% offset is ensured by JS */);
+        expect(monthScroller.position).to.be.closeTo(position + 0.6, 0.1 /* The bottom 10% offset is ensured by JS */);
       });
     });
   });


### PR DESCRIPTION
## Description

The observer removed in https://github.com/vaadin/web-components/pull/8928 caused lots of tests to fail. Let's restore it.

## Type of change

- Bugfix