### PR TITLE
Disable Lumo and Material tests, fix Base visual tests

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -42,77 +42,77 @@ jobs:
           name: screenshots
           path: |
             packages/*/test/visual/base/screenshots/*/failed/*.png
-  lumo:
-    name: Lumo
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install Dependencies
-        run: yarn --frozen-lockfile --no-progress --non-interactive
-
-      - name: Visual tests
-        uses: nick-fields/retry@v3
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: yarn test:lumo
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
-        with:
-          name: screenshots
-          path: |
-            packages/*/test/visual/lumo/screenshots/*/failed/*.png
-            packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png
-  material:
-    name: Material
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install Dependencies
-        run: yarn --frozen-lockfile --no-progress --non-interactive
-
-      - name: Visual tests
-        uses: nick-fields/retry@v3
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: yarn test:material
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
-        with:
-          name: screenshots
-          path: |
-            packages/*/test/visual/material/screenshots/*/failed/*.png
-            packages/vaadin-material-styles/test/visual/screenshots/failed/*.png
+##  lumo:
+#    name: Lumo
+#    runs-on: ubuntu-latest
+#    if: github.repository_owner == 'vaadin'
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: '0'
+#
+#      - name: Setup Node
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: '20'
+#          cache: 'yarn'
+#
+#      - name: Install Dependencies
+#        run: yarn --frozen-lockfile --no-progress --non-interactive
+#
+#      - name: Visual tests
+#        uses: nick-fields/retry@v3
+#        env:
+#          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+#          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+#        with:
+#          timeout_minutes: 20
+#          retry_wait_seconds: 60
+#          max_attempts: 3
+#          command: yarn test:lumo
+#
+#      - uses: actions/upload-artifact@v4
+#        if: ${{ failure() }}
+#        with:
+#          name: screenshots
+#          path: |
+#            packages/*/test/visual/lumo/screenshots/*/failed/*.png
+#            packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png
+#  material:
+#    name: Material
+#    runs-on: ubuntu-latest
+#    if: github.repository_owner == 'vaadin'
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: '0'
+#
+#      - name: Setup Node
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: '20'
+#          cache: 'yarn'
+#
+#      - name: Install Dependencies
+#        run: yarn --frozen-lockfile --no-progress --non-interactive
+#
+#      - name: Visual tests
+#        uses: nick-fields/retry@v3
+#        env:
+#          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+#          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+#        with:
+#          timeout_minutes: 20
+#          retry_wait_seconds: 60
+#          max_attempts: 3
+#          command: yarn test:material
+#
+#      - uses: actions/upload-artifact@v4
+#        if: ${{ failure() }}
+#        with:
+#          name: screenshots
+#          path: |
+#            packages/*/test/visual/material/screenshots/*/failed/*.png
+#            packages/vaadin-material-styles/test/visual/screenshots/failed/*.png

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -95,6 +95,15 @@ const getAllVisualPackages = () => {
 };
 
 /**
+ * Get all available packages with visual tests for base styles.
+ */
+const getAllBasePackages = () => {
+  return fs
+    .readdirSync('packages')
+    .filter((dir) => fs.statSync(`packages/${dir}`).isDirectory() && fs.existsSync(`packages/${dir}/test/visual/base`));
+};
+
+/**
  * Get packages for running tests.
  */
 const getTestPackages = (allPackages) => {
@@ -157,16 +166,26 @@ const getUnitTestGroups = (packages) => {
  * Get visual test groups based on packages.
  */
 const getVisualTestGroups = (packages, theme) => {
-  return packages
+  const themePackages = packages
     .filter(
-      (pkg) => !pkg.includes('icons') && !pkg.includes(theme) && !pkg.includes(theme === 'lumo' ? 'material' : 'lumo'),
+      (pkg) =>
+        !pkg.includes('icons') &&
+        (theme === 'base'
+          ? !pkg.includes('lumo') && !pkg.includes('material')
+          : !pkg.includes(theme) && !pkg.includes(theme === 'lumo' ? 'material' : 'lumo')),
     )
     .map((pkg) => {
       return {
         name: pkg,
         files: `packages/${pkg}/test/visual/${theme}/*.test.{js,ts}`,
       };
-    })
+    });
+
+  if (theme === 'base') {
+    return themePackages;
+  }
+
+  return themePackages
     .concat({
       name: `vaadin-${theme}-styles`,
       files: `packages/vaadin-${theme}-styles/test/visual/*.test.{js,ts}`,
@@ -268,7 +287,7 @@ const createUnitTestsConfig = (config) => {
 };
 
 const createVisualTestsConfig = (theme, browserVersion) => {
-  const visualPackages = getAllVisualPackages();
+  const visualPackages = theme === 'base' ? getAllBasePackages() : getAllVisualPackages();
   const packages = getTestPackages(visualPackages);
   const groups = getVisualTestGroups(packages, theme);
 


### PR DESCRIPTION
## Description

- Disabled Lumo and Material visual tests for `base-styles` branch
- Updated to only run Base styles visual tests for packages that have them

## Type of change

- Tests