### PR TITLE
fix: make dialog and confirm-dialog tests pass with base styles

### DIFF
--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -660,7 +660,8 @@ describe('vaadin-confirm-dialog', () => {
         await nextFrame();
         const footer = overlay.$.overlay.querySelector('[part="footer"]');
         const overlayRect = overlay.$.overlay.getBoundingClientRect();
-        expect(footer.getBoundingClientRect().bottom).to.be.closeTo(overlayRect.bottom, 0.1);
+        const borderWidth = parseInt(getComputedStyle(overlay.$.overlay).borderBottomWidth);
+        expect(footer.getBoundingClientRect().bottom).to.be.closeTo(overlayRect.bottom - borderWidth, 0.1);
       });
     });
 

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -323,6 +323,10 @@ describe('resizable', () => {
     });
     resize(overlayPart.querySelector('.w'), -dx, 0);
 
+    // Take the default `inset` set in the overlay base styles into account
+    const insetLeft = parseInt(getComputedStyle(dialog.$.overlay).left);
+    const insetTop = parseInt(getComputedStyle(dialog.$.overlay).top);
+
     const resizedBounds = overlayPart.getBoundingClientRect();
     const contentStyles = getComputedStyle(content);
     const verticalPadding =
@@ -335,8 +339,8 @@ describe('resizable', () => {
     expect(onResize.calledOnce).to.be.true;
     expect(Math.floor(resizedBounds.width)).to.be.eql(parseInt(detail.width));
     expect(Math.floor(resizedBounds.height)).to.be.eql(parseInt(detail.height));
-    expect(Math.floor(resizedBounds.left)).to.be.eql(parseInt(detail.left));
-    expect(Math.floor(resizedBounds.top)).to.be.eql(parseInt(detail.top));
+    expect(Math.floor(resizedBounds.left)).to.be.eql(parseInt(detail.left) + insetLeft);
+    expect(Math.floor(resizedBounds.top)).to.be.eql(parseInt(detail.top) + insetTop);
     expect(parseInt(detail.contentWidth)).to.be.eql(parseInt(contentStyles.width));
     expect(parseInt(detail.contentHeight)).to.be.eql(parseInt(contentStyles.height) - verticalPadding);
   });
@@ -602,8 +606,11 @@ describe('draggable', () => {
     await nextRender();
     const overlay = dialog.$.overlay.$.overlay;
     const bounds = overlay.getBoundingClientRect();
-    expect(dialog.top).to.be.equal(bounds.top);
-    expect(dialog.left).to.be.equal(bounds.left);
+    // Take the default `inset` set in the overlay base styles into account
+    const insetLeft = parseInt(getComputedStyle(dialog.$.overlay).left);
+    const insetTop = parseInt(getComputedStyle(dialog.$.overlay).top);
+    expect(dialog.top).to.be.equal(bounds.top - insetTop);
+    expect(dialog.left).to.be.equal(bounds.left - insetLeft);
   });
 
   it('should fire "dragged" event on drag', async () => {


### PR DESCRIPTION
## Description

In the date-picker base styles PR https://github.com/vaadin/web-components/pull/8928 there were some overlay style changes:

- Changed from `inset: 0` to `inset: 8px`
- Added `1px` border on the overlay part

Updated some failing tests in dialog and confirm-dialog packages to pass with these changes.

## Type of change

- Test