### PR TITLE
test: update visual tests to use sendMouseToElement command

### DIFF
--- a/packages/field-highlighter/test/visual/lumo/field-highlighter.test.js
+++ b/packages/field-highlighter/test/visual/lumo/field-highlighter.test.js
@@ -1,4 +1,4 @@
-import { sendKeys, sendMouse } from '@vaadin/test-runner-commands';
+import { sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/checkbox/theme/lumo/vaadin-checkbox.js';
@@ -216,15 +216,13 @@ describe('field-highlighter', () => {
     });
 
     it('pointer focus-ring disabled', async () => {
-      const bounds = element.getBoundingClientRect();
-      await sendMouse({ type: 'click', position: [bounds.left + 5, bounds.top + 5] });
+      await sendMouseToElement({ type: 'click', element });
       await visualDiff(div, 'text-field-pointer-focus-ring-disabled');
     });
 
     it('pointer focus-ring enabled', async () => {
       element.style.setProperty('--lumo-input-field-pointer-focus-visible', '1');
-      const bounds = element.getBoundingClientRect();
-      await sendMouse({ type: 'click', position: [bounds.left + 5, bounds.top + 5] });
+      await sendMouseToElement({ type: 'click', element });
       await visualDiff(div, 'text-field-pointer-focus-ring-enabled');
     });
   });

--- a/packages/text-field/test/visual/lumo/text-field.test.js
+++ b/packages/text-field/test/visual/lumo/text-field.test.js
@@ -1,4 +1,4 @@
-import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/test/autoload.js';
@@ -226,8 +226,7 @@ describe('text-field', () => {
     it('pointer focus-ring enabled, invalid', async () => {
       element.invalid = true;
       element.style.setProperty('--lumo-input-field-pointer-focus-visible', '1');
-      const bounds = element.getBoundingClientRect();
-      await sendMouse({ type: 'click', position: [bounds.left + 5, bounds.top + 5] });
+      await sendMouseToElement({ type: 'click', element });
       await visualDiff(div, 'pointer-focus-ring-enabled-invalid');
     });
   });


### PR DESCRIPTION
## Description

Most of pointer focus-ring visual tests were updated to use new command in #8566 but a few were not. This PR fixes that.

## Type of change

- Test