### PR TITLE
test: fix multi-select-combo-box chips test with base styles

### DIFF
--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -181,7 +181,7 @@ describe('chips', () => {
       });
 
       it('should update overflow chip on clear button state change', async () => {
-        comboBox.style.width = '340px';
+        comboBox.style.width = '350px';
         await nextResize(comboBox);
 
         comboBox.clearButtonVisible = true;

--- a/packages/multi-select-combo-box/test/multi-select-combo-box-test-styles.js
+++ b/packages/multi-select-combo-box/test/multi-select-combo-box-test-styles.js
@@ -38,15 +38,6 @@ registerStyles(
 );
 
 registerStyles(
-  'vaadin-multi-select-combo-box-container',
-  css`
-    :host {
-      padding: 0 6px;
-    }
-  `,
-);
-
-registerStyles(
   'vaadin-multi-select-combo-box-chip',
   css`
     :host {

--- a/packages/multi-select-combo-box/test/multi-select-combo-box-test-styles.js
+++ b/packages/multi-select-combo-box/test/multi-select-combo-box-test-styles.js
@@ -7,7 +7,7 @@ registerStyles(
   css`
     ::slotted([slot='chip']),
     ::slotted([slot='overflow']) {
-      padding: 0.3125em 0.5625em;
+      padding: 0 0.5625em;
     }
 
     ::slotted([slot='chip']:not(:last-of-type)),
@@ -19,20 +19,17 @@ registerStyles(
       padding-inline-end: 0;
     }
 
-    ::slotted(input) {
-      padding: 0 0.25em;
+    [part='toggle-button'] {
+      color: var(--_vaadin-color-subtle);
     }
 
-    [part$='button'] {
-      flex: none;
-      font-size: 1.5em;
-      width: 1em;
-      height: 1em;
-    }
-
-    [part$='button']::before {
+    [part='toggle-button']::before {
+      background: currentColor;
+      content: '';
       display: block;
-      height: 100%;
+      height: var(--vaadin-icon-size, 1lh);
+      mask-image: var(--_vaadin-icon-chevron-down);
+      width: var(--vaadin-icon-size, 1lh);
     }
   `,
 );
@@ -50,10 +47,17 @@ registerStyles(
     }
 
     [part='remove-button'] {
-      display: flex;
-      width: 1.25em;
-      height: 1.25em;
+      color: var(--_vaadin-color-subtle);
       font-size: 1.5em;
+    }
+
+    [part='remove-button']::before {
+      background: currentColor;
+      content: '';
+      display: block;
+      height: var(--vaadin-icon-size, 1lh);
+      mask-image: var(--_vaadin-icon-cross);
+      width: var(--vaadin-icon-size, 1lh);
     }
   `,
 );


### PR DESCRIPTION
## Description

- Removed custom padding from the MSCB input container to use the one provided by base styles,
- Changed the width back to `350px` used initially to verify that showing clear button causes overflow:

| No clear button | With clear button |
| ----------------|------------------| 
| ![no-clear-btn](https://github.com/user-attachments/assets/2e67e569-5eff-4d95-8565-87b7bc0bf471) | ![with-clear-button](https://github.com/user-attachments/assets/460418ce-198e-4832-afa4-c98714c901ac) |

## Type of change

- Test