### PR TITLE
refactor!: Base checkbox styles

### DIFF
--- a/dev/checkbox.html
+++ b/dev/checkbox.html
@@ -8,15 +8,76 @@
     <script type="module" src="./common.js"></script>
 
     <script type="module">
-      import '@vaadin/checkbox';
-      import '@vaadin/tooltip';
+      import '@vaadin/checkbox/src/vaadin-lit-checkbox.js';
+      import '@vaadin/checkbox-group/src/vaadin-lit-checkbox-group.js';
     </script>
   </head>
 
   <body>
-    <vaadin-checkbox>
-      <label slot="label">I accept <a href="http://vaadin.com">the terms and conditions</a></label>
-      <vaadin-tooltip slot="tooltip" text="Please read first"></vaadin-tooltip>
-    </vaadin-checkbox>
+    <section>
+      <h2>Plain</h2>
+      <vaadin-checkbox checked label="I accept the terms and conditions"></vaadin-checkbox>
+      <br>
+      <br>
+      <vaadin-checkbox-group label="Export data" theme="vertical">
+        <vaadin-checkbox label="Order ID" value="1"></vaadin-checkbox>
+        <vaadin-checkbox checked label="Product name" value="2"></vaadin-checkbox>
+        <vaadin-checkbox label="Customer" value="3"></vaadin-checkbox>
+        <vaadin-checkbox label="Status" value="4"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+    </section>
+
+    <section>
+      <h2>States</h2>
+      <vaadin-checkbox-group disabled label="Disabled" theme="vertical">
+        <vaadin-checkbox label="Engineering" value="1"></vaadin-checkbox>
+        <vaadin-checkbox checked label="Human Resources" value="2"></vaadin-checkbox>
+        <vaadin-checkbox indeterminate label="Marketing" value="3"></vaadin-checkbox>
+        <vaadin-checkbox label="Operations" value="4"></vaadin-checkbox>
+        <vaadin-checkbox label="Sales" value="5"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+      <br>
+      <br>
+      <vaadin-checkbox-group label="Read-Only" readonly theme="vertical">
+        <vaadin-checkbox label="Order ID" value="1"></vaadin-checkbox>
+        <vaadin-checkbox checked label="Product name" value="2"></vaadin-checkbox>
+        <vaadin-checkbox indeterminate label="Customer" value="3"></vaadin-checkbox>
+        <vaadin-checkbox label="Status" value="4"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+      <br>
+      <br>
+      <vaadin-checkbox error-message="This field is required" invalid label="Grant view permissions" required></vaadin-checkbox>
+      <br>
+      <br>
+      <vaadin-checkbox indeterminate label="Notify users"></vaadin-checkbox>
+    </section>
+
+    <section>
+      <h2>Orientation</h2>
+      <vaadin-checkbox-group label="Permissions">
+        <vaadin-checkbox label="Read" value="1"></vaadin-checkbox>
+        <vaadin-checkbox label="Edit" value="2"></vaadin-checkbox>
+        <vaadin-checkbox label="Delete" value="3"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+    </section>
+
+    <section>
+      <h2>Helper Text</h2>
+      <vaadin-checkbox label="Label" helper-text="Helper text"></vaadin-checkbox>
+      <br>
+      <br>
+      <vaadin-checkbox-group label="Label" helper-text="Helper text">
+        <vaadin-checkbox label="Item 1" value="1"></vaadin-checkbox>
+        <vaadin-checkbox label="Item 2" value="2"></vaadin-checkbox>
+        <vaadin-checkbox label="Item 3" value="3"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+      <br>
+      <br>
+      <vaadin-checkbox-group helper-text="Helper text" label="Label" theme="helper-above-field">
+        <vaadin-checkbox label="Item 1" value="1"></vaadin-checkbox>
+        <vaadin-checkbox label="Item 2" value="2"></vaadin-checkbox>
+        <vaadin-checkbox label="Item 3" value="3"></vaadin-checkbox>
+      </vaadin-checkbox-group>
+    </section>
   </body>
 </html>

--- a/dev/checkbox.html
+++ b/dev/checkbox.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -17,8 +17,8 @@
     <section>
       <h2>Plain</h2>
       <vaadin-checkbox checked label="I accept the terms and conditions"></vaadin-checkbox>
-      <br>
-      <br>
+      <br />
+      <br />
       <vaadin-checkbox-group label="Export data" theme="vertical">
         <vaadin-checkbox label="Order ID" value="1"></vaadin-checkbox>
         <vaadin-checkbox checked label="Product name" value="2"></vaadin-checkbox>
@@ -36,19 +36,24 @@
         <vaadin-checkbox label="Operations" value="4"></vaadin-checkbox>
         <vaadin-checkbox label="Sales" value="5"></vaadin-checkbox>
       </vaadin-checkbox-group>
-      <br>
-      <br>
+      <br />
+      <br />
       <vaadin-checkbox-group label="Read-Only" readonly theme="vertical">
         <vaadin-checkbox label="Order ID" value="1"></vaadin-checkbox>
         <vaadin-checkbox checked label="Product name" value="2"></vaadin-checkbox>
         <vaadin-checkbox indeterminate label="Customer" value="3"></vaadin-checkbox>
         <vaadin-checkbox label="Status" value="4"></vaadin-checkbox>
       </vaadin-checkbox-group>
-      <br>
-      <br>
-      <vaadin-checkbox error-message="This field is required" invalid label="Grant view permissions" required></vaadin-checkbox>
-      <br>
-      <br>
+      <br />
+      <br />
+      <vaadin-checkbox
+        error-message="This field is required"
+        invalid
+        label="Grant view permissions"
+        required
+      ></vaadin-checkbox>
+      <br />
+      <br />
       <vaadin-checkbox indeterminate label="Notify users"></vaadin-checkbox>
     </section>
 
@@ -64,15 +69,15 @@
     <section>
       <h2>Helper Text</h2>
       <vaadin-checkbox label="Label" helper-text="Helper text"></vaadin-checkbox>
-      <br>
-      <br>
+      <br />
+      <br />
       <vaadin-checkbox-group label="Label" helper-text="Helper text">
         <vaadin-checkbox label="Item 1" value="1"></vaadin-checkbox>
         <vaadin-checkbox label="Item 2" value="2"></vaadin-checkbox>
         <vaadin-checkbox label="Item 3" value="3"></vaadin-checkbox>
       </vaadin-checkbox-group>
-      <br>
-      <br>
+      <br />
+      <br />
       <vaadin-checkbox-group helper-text="Helper text" label="Label" theme="helper-above-field">
         <vaadin-checkbox label="Item 1" value="1"></vaadin-checkbox>
         <vaadin-checkbox label="Item 2" value="2"></vaadin-checkbox>

--- a/packages/checkbox-group/src/vaadin-checkbox-group-styles.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group-styles.js
@@ -6,32 +6,17 @@
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const checkboxGroupStyles = css`
-  :host {
-    display: inline-flex;
-  }
-
-  :host::before {
-    content: '\\2003';
-    width: 0;
-    display: inline-block;
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
   .vaadin-group-field-container {
-    display: flex;
-    flex-direction: column;
     width: 100%;
   }
 
   [part='group-field'] {
     display: flex;
     flex-wrap: wrap;
+    gap: var(--vaadin-checkbox-group-gap, 0.5em 1em);
   }
 
-  :host(:not([has-label])) [part='label'] {
-    display: none;
+  :host([theme~='vertical']) [part='group-field'] {
+    flex-direction: column;
   }
 `;

--- a/packages/checkbox-group/src/vaadin-lit-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-lit-checkbox-group.js
@@ -8,6 +8,8 @@ import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { fieldShared } from '@vaadin/field-base/src/styles/field-shared-styles.js';
+import { inputFieldContainer } from '@vaadin/field-base/src/styles/input-field-container-styles.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { CheckboxGroupMixin } from './vaadin-checkbox-group-mixin.js';
 import { checkboxGroupStyles } from './vaadin-checkbox-group-styles.js';
@@ -27,7 +29,7 @@ class CheckboxGroup extends CheckboxGroupMixin(ElementMixin(ThemableMixin(Polyli
   }
 
   static get styles() {
-    return checkboxGroupStyles;
+    return [fieldShared, inputFieldContainer, checkboxGroupStyles];
   }
 
   /** @protected */

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -7,21 +7,23 @@ import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const checkboxStyles = css`
   :host {
-    display: inline-block;
+    align-items: baseline;
+    display: inline-grid;
+    gap: var(--vaadin-checkbox-gap, 0 var(--_vaadin-gap-container-inline));
+    grid-template-columns: auto 1fr;
   }
 
   :host([hidden]) {
-    display: none !important;
+    display: none;
   }
 
-  :host([disabled]) {
-    -webkit-tap-highlight-color: transparent;
+  :host([focus-ring]) [part='checkbox'] {
+    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+    outline-offset: 1px;
   }
 
   .vaadin-checkbox-container {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    align-items: baseline;
+    display: contents;
   }
 
   [part='checkbox'],
@@ -46,28 +48,106 @@ export const checkboxStyles = css`
   }
 
   [part='checkbox'] {
-    width: var(--vaadin-checkbox-size, 1em);
+    background-color: var(--vaadin-checkbox-background, transparent);
+    border: var(--vaadin-checkbox-border-width, 1px) solid
+      var(--vaadin-checkbox-border-color, var(--_vaadin-border-color-strong));
+    border-radius: var(--vaadin-checkbox-border-radius, var(--_vaadin-radius-s));
+    color: var(--vaadin-checkbox-color, transparent);
     height: var(--vaadin-checkbox-size, 1em);
-    --_input-border-width: var(--vaadin-input-field-border-width, 0);
-    --_input-border-color: var(--vaadin-input-field-border-color, transparent);
-    box-shadow: inset 0 0 0 var(--_input-border-width, 0) var(--_input-border-color);
+    position: relative;
+    width: var(--vaadin-checkbox-size, 1em);
   }
 
   [part='checkbox']::before {
-    display: block;
-    content: '\\202F';
-    line-height: var(--vaadin-checkbox-size, 1em);
     contain: paint;
+    content: '\\202F';
+    display: block;
+    line-height: var(--vaadin-checkbox-size, 1em);
   }
 
-  /* visually hidden */
+  [part='checkbox']::after {
+    content: '';
+    height: var(--vaadin-checkbox-size, 1em);
+    inset: 0;
+    position: absolute;
+    width: var(--vaadin-checkbox-size, 1em);
+  }
+
+  /* Checked, indeterminate */
+  :host(:is([checked], [indeterminate])) {
+    --vaadin-checkbox-background: var(--_vaadin-color-strong);
+    --vaadin-checkbox-border-color: transparent;
+    --vaadin-checkbox-color: var(--_vaadin-background);
+  }
+
+  :host([checked]) [part='checkbox']::after {
+    background: currentColor;
+    mask-image: var(--_vaadin-icon-checkmark);
+  }
+
+  :host([indeterminate]) [part='checkbox']::after {
+    background: currentColor;
+    mask-image: var(--_vaadin-icon-minus);
+  }
+
+  /* Read-only */
+  :host([readonly]) {
+    --vaadin-checkbox-background: transparent;
+    --vaadin-checkbox-border-color: var(--_vaadin-border-color-strong);
+    --vaadin-checkbox-color: var(--_vaadin-color-strong);
+  }
+
+  :host([readonly]) [part='checkbox'] {
+    border-style: dashed;
+  }
+
+  /* Disabled */
+  :host([disabled]) {
+    --vaadin-checkbox-background: var(
+      --vaadin-input-field-disabled-background,
+      var(--_vaadin-background-container-strong)
+    );
+    --vaadin-checkbox-border-color: transparent;
+    --vaadin-checkbox-color: var(--_vaadin-color-strong);
+    --vaadin-checkbox-label-color: var(--vaadin-input-field-disabled-text-color, var(--_vaadin-color-subtle));
+  }
+
+  /* Visually hidden */
   ::slotted(input) {
-    cursor: inherit;
-    margin: 0;
     align-self: stretch;
-    -webkit-appearance: none;
-    width: initial;
+    appearance: none;
+    cursor: inherit;
     height: initial;
+    margin: 0;
+    width: initial;
+  }
+
+  [part='label'] {
+    color: var(--vaadin-checkbox-label-color, var(--_vaadin-color-strong));
+    display: inline-block;
+    font-size: var(--vaadin-checkbox-label-font-size, inherit);
+    font-weight: var(--vaadin-checkbox-label-font-weight, 400);
+    line-height: var(--vaadin-checkbox-label-line-height, inherit);
+  }
+
+  [part='required-indicator'] {
+    color: var(--vaadin-input-field-required-indicator-color, inherit);
+    display: none;
+  }
+
+  [part='required-indicator']::after {
+    content: var(--vaadin-input-field-required-indicator, '*');
+  }
+
+  :host([required]) [part='required-indicator'] {
+    display: inline-block;
+  }
+
+  [part='helper-text'] {
+    color: var(--vaadin-checkbox-helper-color, var(--_vaadin-color));
+    font-size: var(--vaadin-checkbox-helper-font-size, inherit);
+    font-weight: var(--vaadin-checkbox-helper-font-weight, 400);
+    line-height: var(--vaadin-checkbox-helper-line-height, inherit);
   }
 
   @media (forced-colors: active) {
@@ -82,9 +162,9 @@ export const checkboxStyles = css`
     }
 
     :host(:is([checked], [indeterminate])) [part='checkbox']::after {
+      border-radius: inherit;
       outline: 1px solid;
       outline-offset: -1px;
-      border-radius: inherit;
     }
 
     :host([focused]) [part='checkbox'],

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/component-base/src/style-props.js';
 import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const checkboxStyles = css`

--- a/packages/checkbox/src/vaadin-checkbox-styles.js
+++ b/packages/checkbox/src/vaadin-checkbox-styles.js
@@ -9,8 +9,12 @@ export const checkboxStyles = css`
   :host {
     align-items: baseline;
     display: inline-grid;
-    gap: var(--vaadin-checkbox-gap, 0 var(--_vaadin-gap-container-inline));
+    gap: var(--vaadin-checkbox-gap, 0.5em);
     grid-template-columns: auto 1fr;
+  }
+
+  :host::before {
+    content: none;
   }
 
   :host([hidden]) {
@@ -123,31 +127,15 @@ export const checkboxStyles = css`
   }
 
   [part='label'] {
-    color: var(--vaadin-checkbox-label-color, var(--_vaadin-color-strong));
-    display: inline-block;
-    font-size: var(--vaadin-checkbox-label-font-size, inherit);
-    font-weight: var(--vaadin-checkbox-label-font-weight, 400);
-    line-height: var(--vaadin-checkbox-label-line-height, inherit);
+    --vaadin-input-field-label-color: var(--vaadin-checkbox-label-color, var(--_vaadin-color-strong));
+    --vaadin-input-field-label-font-size: var(--vaadin-checkbox-label-font-size, inherit);
+    --vaadin-input-field-label-font-weight: var(--vaadin-checkbox-label-font-weight, 400);
+    --vaadin-input-field-label-line-height: var(--vaadin-checkbox-label-line-height, inherit);
+    padding: var(--vaadin-checkbox-label-padding, 0);
   }
 
   [part='required-indicator'] {
-    color: var(--vaadin-input-field-required-indicator-color, inherit);
-    display: none;
-  }
-
-  [part='required-indicator']::after {
-    content: var(--vaadin-input-field-required-indicator, '*');
-  }
-
-  :host([required]) [part='required-indicator'] {
     display: inline-block;
-  }
-
-  [part='helper-text'] {
-    color: var(--vaadin-checkbox-helper-color, var(--_vaadin-color));
-    font-size: var(--vaadin-checkbox-helper-font-size, inherit);
-    font-weight: var(--vaadin-checkbox-helper-font-weight, 400);
-    line-height: var(--vaadin-checkbox-helper-line-height, inherit);
   }
 
   @media (forced-colors: active) {

--- a/packages/checkbox/src/vaadin-lit-checkbox.js
+++ b/packages/checkbox/src/vaadin-lit-checkbox.js
@@ -8,6 +8,7 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { fieldShared } from '@vaadin/field-base/src/styles/field-shared-styles.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
 import { checkboxStyles } from './vaadin-checkbox-styles.js';
@@ -27,7 +28,7 @@ export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMi
   }
 
   static get styles() {
-    return checkboxStyles;
+    return [fieldShared, checkboxStyles];
   }
 
   /** @protected */

--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -36,7 +36,13 @@ before(() => {
 [
   { tagName: Button.is },
   { tagName: Checkbox.is, ariaTargetSelector: 'input' },
-  { tagName: CheckboxGroup.is },
+  {
+    tagName: CheckboxGroup.is,
+    children: `
+      <vaadin-checkbox value="foo" label="Foo"></vaadin-checkbox>
+      <vaadin-checkbox value="bar" label="Bar"></vaadin-checkbox>
+    `,
+  },
   {
     tagName: ComboBox.is,
     position: 'top',


### PR DESCRIPTION
## New Checkbox base style

![localhost_8000_dev_checkbox html (1)](https://github.com/user-attachments/assets/dcfceb15-2282-4b03-83d5-b8827e9e68c0)

### Supported custom properties

| Property | Description |
| -------- | ----------- |
| `--vaadin-checkbox-background` | Background color of the checkbox. |
| `--vaadin-checkbox-border-color` | Border color of the checkbox. |
| `--vaadin-checkbox-border-radius` | Border radius of the checkbox. |
| `--vaadin-checkbox-border-width` | Border width of the checkbox. |
| `--vaadin-checkbox-color` | Color used for the checkmark or indeterminate icon. |
| `--vaadin-checkbox-gap` | Gap between the checkbox and the label. |
| `--vaadin-checkbox-label-color` | Text color of the checkbox label. |
| `--vaadin-checkbox-label-font-size` | Font size of the checkbox label. |
| `--vaadin-checkbox-label-font-weight` | Font weight of the checkbox label. |
| `--vaadin-checkbox-label-line-height` | Line height of the checkbox label. |
| `--vaadin-checkbox-label-padding` | Padding around the checkbox label. |
| `--vaadin-checkbox-size` | Size (width and height) of the checkbox. |

## General concerns

1. Some of the properties listed at [Checkbox Properties](https://vaadin.com/docs/latest/components/checkbox/styling#checkbox-properties) are not used:

- `--vaadin-checkbox-background-hover`
- `--vaadin-checkbox-disabled-background`
- `--vaadin-checkbox-checkmark-char`
- `--vaadin-checkbox-checkmark-char-indeterminate`
- `--vaadin-checkbox-checkmark-color`
- `--vaadin-checkbox-disabled-checkmark-color`
- `--vaadin-checkbox-checkmark-size`

2. To use or not to use `field-shared-styles.js`?

**Pros**: Provides styling for the `required-indicator`, `helper-text`, and `error-message` parts.  
**Cons**: If we need `--vaadin-checkbox-label-*` properties, we’ll have to override the label part styles from `field-shared-styles.js`.
