### PR TITLE
test: update RTE unit tests to not use Lumo styles

### DIFF
--- a/packages/rich-text-editor/test/attach.test.js
+++ b/packages/rich-text-editor/test/attach.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/lumo/vaadin-rich-text-editor-styles.js';
 import '../src/vaadin-rich-text-editor.js';
 
 describe('attach/detach', () => {

--- a/packages/rich-text-editor/test/auto-grow.test.js
+++ b/packages/rich-text-editor/test/auto-grow.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import '../theme/lumo/vaadin-rich-text-editor-styles.js';
+import './rte-test-styles.js';
 import '../src/vaadin-rich-text-editor.js';
 
 describe('rich text editor', () => {

--- a/packages/rich-text-editor/test/basic.test.js
+++ b/packages/rich-text-editor/test/basic.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, focusout, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/lumo/vaadin-rich-text-editor-styles.js';
 import '../src/vaadin-rich-text-editor.js';
 
 describe('rich text editor', () => {

--- a/packages/rich-text-editor/test/rte-test-styles.js
+++ b/packages/rich-text-editor/test/rte-test-styles.js
@@ -1,0 +1,12 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+// TODO: subset of Lumo needed for unit tests to pass.
+// These should be eventually covered by base styles.
+registerStyles(
+  'vaadin-rich-text-editor',
+  css`
+    :host {
+      min-height: 18rem;
+    }
+  `,
+);

--- a/packages/rich-text-editor/test/toolbar.test.js
+++ b/packages/rich-text-editor/test/toolbar.test.js
@@ -10,7 +10,7 @@ import {
   outsideClick,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/lumo/vaadin-rich-text-editor.js';
+import '../src/vaadin-rich-text-editor.js';
 import { createImage } from './helpers.js';
 
 describe('toolbar controls', () => {


### PR DESCRIPTION
## Description

Updated `vaadin-rich-text-editor` tests to remove Lumo imports and added styles needed to make auto-grow tests pass.

## Type of change

- Test