### PR TITLE
fix: publish vaadin-themable-mixin src folder to npm

### DIFF
--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -20,6 +20,7 @@
   "module": "vaadin-themable-mixin.js",
   "type": "module",
   "files": [
+    "src",
     "*.d.ts",
     "register-styles.js",
     "vaadin-*.js"


### PR DESCRIPTION
## Description

The `src` folder was not added to `"files"` and not published to npm. This PR fixes that.
 
## Type of change

- Bugfix