### PR TITLE
fix: small fixes to date-picker scroller base styles

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-year-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-scroller.js
@@ -30,7 +30,7 @@ stylesTemplate.innerHTML = `
       height: 1em;
       position: absolute;
       z-index: 1;
-      transform: translate(-50%) rotate(45deg);
+      transform: translate(-50%, -50%) rotate(45deg);
       top: 50%;
       width: 1em;
       border: 1px solid var(--vaadin-date-picker-year-scroller-border-color, var(--_vaadin-border-color));

--- a/packages/date-picker/src/vaadin-date-picker-year-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-scroller.js
@@ -36,6 +36,14 @@ stylesTemplate.innerHTML = `
       border: 1px solid var(--vaadin-date-picker-year-scroller-border-color, var(--_vaadin-border-color));
     }
 
+    :host(:dir(rtl)) {
+      box-shadow: inset -1px 0 0 0 var(--vaadin-date-picker-year-scroller-border-color, var(--_vaadin-border-color));
+    }
+
+    :host(:dir(rtl))::before {
+      transform: translate(50%, -50%) rotate(45deg);
+    }
+
     @media (forced-colors: active) {
       :host {
         forced-color-adjust: none;

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -21,6 +21,7 @@ template.innerHTML = `
       height: 100%;
       overflow: auto;
       position: relative;
+      scrollbar-width: none;
     }
 
     #scroller.notouchscroll {


### PR DESCRIPTION
## Description

Fixes to date-picker styles based on visual tests:

- Updated to use `translate(-50%, -50%)` to ensure the selected year indicator is positioned vertically
- Added styles using `:dir(rtl)` to position the selected year indicator and show year scroller border
- Added `scrollbar-width` (Firefox 64+) to hide scroll bars (WebKit still needs `::-webkit-scrollbar`)

## Type of change

- Bugfix