### PR TITLE
refactor!: remove swipe gesture for toggling year scroller

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -7,7 +7,7 @@ import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
-import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures.js';
+import { addListener } from '@vaadin/component-base/src/gestures.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import {
@@ -174,8 +174,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @protected */
     _addListeners() {
-      setTouchAction(this.$.scrollers, 'pan-y');
-
       addListener(this.shadowRoot.querySelector('[part="clear-button"]'), 'tap', this._clear.bind(this));
       addListener(this.shadowRoot.querySelector('[part="toggle-button"]'), 'tap', this._cancel.bind(this));
       addListener(

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -77,14 +77,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
           value: '(min-width: 375px)',
         },
 
-        _translateX: {
-          observer: '_translateXChanged',
-        },
-
-        _yearScrollerWidth: {
-          value: 48,
-        },
-
         i18n: {
           type: Object,
         },
@@ -184,7 +176,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     _addListeners() {
       setTouchAction(this.$.scrollers, 'pan-y');
 
-      addListener(this.$.scrollers, 'track', this._track.bind(this));
       addListener(this.shadowRoot.querySelector('[part="clear-button"]'), 'tap', this._clear.bind(this));
       addListener(this.shadowRoot.querySelector('[part="toggle-button"]'), 'tap', this._cancel.bind(this));
       addListener(
@@ -232,7 +223,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     reset() {
       this._closeYearScroller();
-      this._toggleAnimateClass(true);
     }
 
     /**
@@ -650,98 +640,13 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     }
 
     /** @private */
-    _limit(value, range) {
-      return Math.min(range.max, Math.max(range.min, value));
-    }
-
-    /** @private */
-    _handleTrack(e) {
-      // Check if horizontal movement threshold (dx) not exceeded or
-      // scrolling fast vertically (ddy).
-      if (Math.abs(e.detail.dx) < 10 || Math.abs(e.detail.ddy) > 10) {
-        return;
-      }
-
-      // If we're flinging quickly -> start animating already.
-      if (Math.abs(e.detail.ddx) > this._yearScrollerWidth / 3) {
-        this._toggleAnimateClass(true);
-      }
-
-      const newTranslateX = this._translateX + e.detail.ddx;
-      this._translateX = this._limit(newTranslateX, {
-        min: 0,
-        max: this._yearScrollerWidth,
-      });
-    }
-
-    /** @private */
-    _track(e) {
-      if (this._desktopMode) {
-        // No need to track for swipe gestures on desktop.
-        return;
-      }
-
-      switch (e.detail.state) {
-        case 'start':
-          this._toggleAnimateClass(false);
-          break;
-        case 'track':
-          this._handleTrack(e);
-          break;
-        case 'end':
-          this._toggleAnimateClass(true);
-          if (this._translateX >= this._yearScrollerWidth / 2) {
-            this._closeYearScroller();
-          } else {
-            this._openYearScroller();
-          }
-          break;
-        default:
-          break;
-      }
-    }
-
-    /** @private */
-    _toggleAnimateClass(enable) {
-      if (enable) {
-        this.classList.add('animate');
-      } else {
-        this.classList.remove('animate');
-      }
-    }
-
-    /** @private */
     _toggleYearScroller() {
-      if (this._isYearScrollerVisible()) {
-        this._closeYearScroller();
-      } else {
-        this._openYearScroller();
-      }
-    }
-
-    /** @private */
-    _openYearScroller() {
-      this._translateX = 0;
-      this.setAttribute('years-visible', '');
+      this.toggleAttribute('years-visible');
     }
 
     /** @private */
     _closeYearScroller() {
       this.removeAttribute('years-visible');
-      this._translateX = this._yearScrollerWidth;
-    }
-
-    /** @private */
-    _isYearScrollerVisible() {
-      return this._translateX < this._yearScrollerWidth / 2;
-    }
-
-    /** @private */
-    _translateXChanged(x) {
-      if (!this._desktopMode) {
-        this._monthScroller.style.transform = `translateX(${x - this._yearScrollerWidth}px)`;
-        this._yearScroller.style.transform = `translateX(${x}px)`;
-      }
     }
 
     /** @private */

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -294,7 +294,6 @@ snapshots["vaadin-date-picker host opened overlay"] =
   top-aligned=""
 >
   <vaadin-date-picker-overlay-content
-    class="animate"
     desktop=""
     role="dialog"
   >
@@ -456,7 +455,6 @@ snapshots["vaadin-date-picker host opened overlay class"] =
   top-aligned=""
 >
   <vaadin-date-picker-overlay-content
-    class="animate"
     desktop=""
     role="dialog"
   >
@@ -618,7 +616,6 @@ snapshots["vaadin-date-picker host opened overlay theme"] =
   top-aligned=""
 >
   <vaadin-date-picker-overlay-content
-    class="animate"
     desktop=""
     role="dialog"
     theme="custom"

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -532,7 +532,6 @@ snapshots["vaadin-date-time-picker host overlay class date-picker"] =
   top-aligned=""
 >
   <vaadin-date-picker-overlay-content
-    class="animate"
     desktop=""
     role="dialog"
   >


### PR DESCRIPTION
## Description

When the date-picker is in the fullscreen mode with screen less than `375px` width, year scroller is hidden by default.
Currently in the Lumo version we have `track` gesture added in https://github.com/vaadin/vaadin-date-picker/pull/49 to toggle year scroller:


https://github.com/user-attachments/assets/08845995-fa8b-4b15-b058-f8b331a7066b

The gesture is using `transform: translateX()` for smooth transitions. This stopped working since https://github.com/vaadin/web-components/pull/8928 where the overlay content has been updated to use CSS grid and uses `grid-template-columns` to determine whether to show year scroller.


Removed all the logic related to this (the base styles PR removed `_translateXChanged` observer which broke tests so I added it back in #8995 but in fact it's not needed). Also `animate` class was related to this logic so I removed it too.

## Type of change

- Behavior altering change