### PR TITLE
fix: restore user-select: none on step buttons

### DIFF
--- a/packages/number-field/src/vaadin-number-field-styles.js
+++ b/packages/number-field/src/vaadin-number-field-styles.js
@@ -13,6 +13,8 @@ export const numberFieldStyles = css`
   [part='decrease-button'],
   [part='increase-button'] {
     color: var(--_vaadin-color-subtle);
+    -webkit-user-select: none;
+    user-select: none;
   }
 
   :is([part='decrease-button'], [part='increase-button'])::before {


### PR DESCRIPTION
## Description

Restores `user-select: none` to prevent value text selection when clicking on increase/decrease button.

https://github.com/user-attachments/assets/dcf84fd5-fdb9-4843-bcec-0d0c2be12003

## Type of change

- [x] Bugfix
