### PR TITLE
refactor: do not disable buttons when moving to overflow

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -216,7 +216,7 @@ export const MenuBarMixin = (superClass) =>
         '_themeChanged(_theme, _overflow, _container)',
         '__hasOverflowChanged(_hasOverflow, _overflow)',
         '__i18nChanged(__effectiveI18n, _overflow)',
-        '_menuItemsChanged(items, _overflow, _container)',
+        '__updateButtons(items, disabled, _overflow, _container)',
         '_reverseCollapseChanged(reverseCollapse, _overflow, _container)',
         '_tabNavigationChanged(tabNavigation, _overflow, _container)',
       ];
@@ -382,23 +382,6 @@ export const MenuBarMixin = (superClass) =>
     }
 
     /**
-     * Override method inherited from `DisabledMixin`
-     * to update the `disabled` property for the buttons
-     * whenever the property changes on the menu bar.
-     *
-     * @param {boolean} newValue the new disabled value
-     * @param {boolean} oldValue the previous disabled value
-     * @override
-     * @protected
-     */
-    _disabledChanged(newValue, oldValue) {
-      super._disabledChanged(newValue, oldValue);
-      if (oldValue !== newValue) {
-        this.__updateButtonsDisabled(newValue);
-      }
-    }
-
-    /**
      * A callback for the `_theme` property observer.
      * It propagates the host theme to the buttons and the sub menu.
      *
@@ -456,7 +439,7 @@ export const MenuBarMixin = (superClass) =>
     }
 
     /** @private */
-    _menuItemsChanged(items, overflow, container) {
+    __updateButtons(items, disabled, overflow, container) {
       if (!overflow || !container) {
         return;
       }
@@ -465,6 +448,12 @@ export const MenuBarMixin = (superClass) =>
         this._oldItems = items;
         this.__renderButtons(items);
         this.__detectOverflow();
+      }
+
+      if (disabled !== this._oldDisabled) {
+        this._oldDisabled = disabled;
+        this.__renderButtons(items);
+        overflow.toggleAttribute('disabled', disabled);
       }
 
       const subMenu = this._subMenu;
@@ -499,7 +488,6 @@ export const MenuBarMixin = (superClass) =>
     /** @private */
     __restoreButtons(buttons) {
       buttons.forEach((button) => {
-        button.disabled = (button.item && button.item.disabled) || this.disabled;
         button.style.visibility = '';
         button.style.position = '';
         button.style.width = '';
@@ -520,14 +508,6 @@ export const MenuBarMixin = (superClass) =>
       item.removeAttribute('aria-expanded');
       item.removeAttribute('aria-haspopup');
       item.removeAttribute('tabindex');
-    }
-
-    /** @private */
-    __updateButtonsDisabled(disabled) {
-      this._buttons.forEach((btn) => {
-        // Disable the button if the entire menu-bar is disabled or the item alone is disabled
-        btn.disabled = disabled || (btn.item && btn.item.disabled);
-      });
     }
 
     /** @private */
@@ -563,7 +543,6 @@ export const MenuBarMixin = (superClass) =>
 
           // Save width for buttons with component
           btn.style.width = getComputedStyle(btn).width;
-          btn.disabled = true;
           btn.style.visibility = 'hidden';
           btn.style.position = 'absolute';
         }
@@ -662,7 +641,7 @@ export const MenuBarMixin = (superClass) =>
             return html`
               <vaadin-menu-bar-button
                 .item="${itemCopy}"
-                .disabled="${item.disabled}"
+                .disabled="${this.disabled || item.disabled}"
                 role="${this.tabNavigation ? 'button' : 'menuitem'}"
                 aria-haspopup="${ifDefined(hasChildren ? 'true' : nothing)}"
                 aria-expanded="${ifDefined(hasChildren ? 'false' : nothing)}"

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -30,13 +30,7 @@ describe('overflow', () => {
       `);
       menu = wrapper.querySelector('vaadin-menu-bar');
       await nextRender(menu);
-      menu.items = [
-        { text: 'Item 1' },
-        { text: 'Item 2' },
-        { text: 'Item 3' },
-        { text: 'Item 4' },
-        { text: 'Item 5', disabled: true },
-      ];
+      menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }, { text: 'Item 5' }];
       await nextUpdate(menu);
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
@@ -44,9 +38,7 @@ describe('overflow', () => {
 
     it('should show overflow button and hide the buttons which do not fit', () => {
       assertHidden(buttons[2]);
-      expect(buttons[2].disabled).to.be.true;
       assertHidden(buttons[3]);
-      expect(buttons[3].disabled).to.be.true;
       expect(overflow.hasAttribute('hidden')).to.be.false;
     });
 
@@ -69,9 +61,7 @@ describe('overflow', () => {
       menu.style.width = '350px';
       await nextResize(menu);
       assertVisible(buttons[2]);
-      expect(buttons[2].disabled).to.not.be.true;
       assertVisible(buttons[3]);
-      expect(buttons[3].disabled).to.not.be.true;
       expect(overflow.item.children.length).to.equal(1);
       expect(overflow.item.children[0]).to.deep.equal(menu.items[4]);
     });
@@ -81,9 +71,7 @@ describe('overflow', () => {
       menu.style.width = '350px';
       await nextResize(menu);
       assertVisible(buttons[2]);
-      expect(buttons[2].disabled).to.not.be.true;
       assertVisible(buttons[3]);
-      expect(buttons[3].disabled).to.not.be.true;
       expect(overflow.item.children.length).to.equal(1);
       expect(overflow.item.children[0]).to.deep.equal(menu.items[4]);
     });
@@ -92,7 +80,6 @@ describe('overflow', () => {
       menu.style.width = '150px';
       await nextResize(menu);
       assertHidden(buttons[1]);
-      expect(buttons[1].disabled).to.be.true;
       expect(overflow.item.children.length).to.equal(4);
       expect(overflow.item.children[0]).to.deep.equal(menu.items[1]);
       expect(overflow.item.children[1]).to.deep.equal(menu.items[2]);
@@ -105,7 +92,6 @@ describe('overflow', () => {
       menu.style.width = '150px';
       await nextResize(menu);
       assertHidden(buttons[1]);
-      expect(buttons[1].disabled).to.be.true;
       expect(overflow.item.children.length).to.equal(4);
       expect(overflow.item.children[0]).to.deep.equal(menu.items[1]);
       expect(overflow.item.children[1]).to.deep.equal(menu.items[2]);
@@ -117,11 +103,8 @@ describe('overflow', () => {
       menu.style.width = 'auto';
       await nextResize(menu);
       assertVisible(buttons[2]);
-      expect(buttons[2].disabled).to.not.be.true;
       assertVisible(buttons[3]);
-      expect(buttons[3].disabled).to.not.be.true;
       assertVisible(buttons[4]);
-      expect(buttons[4].disabled).to.be.true;
       expect(overflow.hasAttribute('hidden')).to.be.true;
       expect(overflow.item.children.length).to.equal(0);
     });
@@ -176,22 +159,6 @@ describe('overflow', () => {
       await nextResize(menu);
 
       expect(buttons[0].getAttribute('tabindex')).to.equal('0');
-      expect(buttons[1].getAttribute('tabindex')).to.equal('-1');
-    });
-
-    it('should set tabindex -1 on the overflow menu in tab navigation', async () => {
-      menu.tabNavigation = true;
-      buttons[0].focus();
-      arrowRight(buttons[0]);
-
-      expect(buttons[0].getAttribute('tabindex')).to.equal('0');
-      expect(buttons[1].getAttribute('tabindex')).to.equal('0');
-
-      menu.style.width = '150px';
-      await nextResize(menu);
-
-      expect(buttons[0].getAttribute('tabindex')).to.equal('0');
-      expect(buttons[1].getAttribute('tabindex')).to.equal('-1');
     });
 
     it('should set the aria-label of the overflow button according to the i18n of the menu bar', async () => {
@@ -216,15 +183,10 @@ describe('overflow', () => {
 
       it('should show overflow button and hide the buttons which do not fit', () => {
         assertHidden(buttons[0]);
-        expect(buttons[0].disabled).to.be.true;
         assertHidden(buttons[1]);
-        expect(buttons[1].disabled).to.be.true;
         assertHidden(buttons[2]);
-        expect(buttons[2].disabled).to.be.true;
         assertVisible(buttons[3]);
-        expect(buttons[3].disabled).to.be.false;
         assertVisible(buttons[4]);
-        expect(buttons[4].disabled).to.be.true;
 
         expect(overflow.hasAttribute('hidden')).to.be.false;
       });
@@ -242,15 +204,10 @@ describe('overflow', () => {
         menu.reverseCollapse = false;
         await nextUpdate(menu);
         assertVisible(buttons[0]);
-        expect(buttons[0].disabled).to.be.false;
         assertVisible(buttons[1]);
-        expect(buttons[1].disabled).to.be.false;
         assertHidden(buttons[2]);
-        expect(buttons[2].disabled).to.be.true;
         assertHidden(buttons[3]);
-        expect(buttons[3].disabled).to.be.true;
         assertHidden(buttons[4]);
-        expect(buttons[4].disabled).to.be.true;
       });
     });
   });
@@ -337,13 +294,7 @@ describe('overflow', () => {
 
       container.style.width = '250px';
 
-      menu.items = [
-        { text: 'Item 1' },
-        { text: 'Item 2' },
-        { text: 'Item 3' },
-        { text: 'Item 4' },
-        { text: 'Item 5', disabled: true },
-      ];
+      menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }, { text: 'Item 5' }];
       await nextRender(menu);
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
@@ -357,30 +308,15 @@ describe('overflow', () => {
       container.style.width = '150px';
       await nextResize(menu);
       assertHidden(buttons[2]);
-      expect(buttons[2].disabled).to.be.true;
       assertHidden(buttons[3]);
-      expect(buttons[3].disabled).to.be.true;
 
       container.style.width = '400px';
       await nextResize(menu);
       assertVisible(buttons[2]);
-      expect(buttons[2].disabled).to.not.be.true;
       assertVisible(buttons[3]);
-      expect(buttons[3].disabled).to.not.be.true;
       assertVisible(buttons[4]);
-      expect(buttons[4].disabled).to.be.true;
       expect(overflow.hasAttribute('hidden')).to.be.true;
       expect(overflow.item.children.length).to.equal(0);
-    });
-
-    it('should keep buttons disabled when resizing', async () => {
-      menu.disabled = true;
-      await nextUpdate(menu);
-      container.style.width = '150px';
-      await nextResize(menu);
-      buttons.forEach((btn) => {
-        expect(btn.disabled).to.be.true;
-      });
     });
   });
 


### PR DESCRIPTION
## Description

Depends on #8871

The original implementation sets `button.disabled = true` when hiding buttons and moving items to the overflow menu - see https://github.com/vaadin/vaadin-menu-bar/pull/16#discussion_r268981508. It was needed because back then the menu-bar used its own version of [`_getAvailableIndex()`](https://github.com/vaadin/vaadin-menu-bar/blob/35fee93c18e2593d4e62df99ad9329aad842fe3c/src/vaadin-menu-bar-interactions-mixin.html#L222) that checked for `disabled` and `hidden` attributes but not for `visibility`.

Disabling is no longer needed since both <kbd>Tab</kbd> and arrow keys are now handled by `KeyboardDirectionMixin` which filters out hidden buttons using `isElementHidden()` and that helper checks for `visibility` property internally. 

Updated to not modify `disabled` on buttons manually so that it can be handled consistently via the Lit template, and modified the observer to call `__renderButtons()` on `disabled` property change, the same as as on `_theme` change.

Also adjusted some tests to not check for `tabindex="-1"` set on the buttons that are moved to the overflow menu.
This was a side-effect of setting `disabled`, in fact we don't need to not modify `tabindex` for those buttons.

## Type of change

- Refactor