### PR TITLE
fix: reset width on menu-bar buttons when restoring them

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -452,6 +452,7 @@ export const MenuBarMixin = (superClass) =>
         button.disabled = (button.item && button.item.disabled) || this.disabled;
         button.style.visibility = '';
         button.style.position = '';
+        button.style.width = '';
 
         // Teleport item component back from "overflow" sub-menu
         const item = button.item && button.item.component;

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -149,6 +149,22 @@ describe('overflow', () => {
       expect(overflow.hasAttribute('hidden')).to.be.false;
     });
 
+    it('should reset buttons after moving back from the overflow menu', async () => {
+      menu.style.width = '400px';
+      await nextResize(menu);
+
+      // Set theme to make button hidden
+      menu.setAttribute('theme', 'big');
+      await nextUpdate(menu);
+
+      // Reset width to make button visible
+      menu.style.width = 'auto';
+      await nextResize(menu);
+
+      assertVisible(buttons[3]);
+      expect(buttons[3].offsetWidth).to.equal(100);
+    });
+
     it('should set tabindex on the last remaining button when width decreased', async () => {
       buttons[0].focus();
       arrowRight(buttons[0]);


### PR DESCRIPTION
## Description

The `width` property on menu-bar buttons is set when they no longer fit and are moved to the overflow. However, currently it is not reset when they become visible again, which can fix override some theme styles. This PR fixes that. 

## Type of change

- Bugfix