### PR TITLE
refactor: update menu-bar properties to use sync: true

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -150,6 +150,7 @@ export const MenuBarMixin = (superClass) =>
          */
         items: {
           type: Array,
+          sync: true,
           value: () => [],
         },
 
@@ -178,6 +179,7 @@ export const MenuBarMixin = (superClass) =>
          */
         reverseCollapse: {
           type: Boolean,
+          sync: true,
         },
 
         /**
@@ -187,6 +189,7 @@ export const MenuBarMixin = (superClass) =>
          */
         tabNavigation: {
           type: Boolean,
+          sync: true,
         },
 
         /**
@@ -207,6 +210,7 @@ export const MenuBarMixin = (superClass) =>
         /** @protected */
         _container: {
           type: Object,
+          sync: true,
         },
       };
     }

--- a/packages/menu-bar/test/a11y.test.js
+++ b/packages/menu-bar/test/a11y.test.js
@@ -36,38 +36,33 @@ describe('a11y', () => {
       });
     });
 
-    it('should set role attribute on host element in tabNavigation', async () => {
+    it('should set role attribute on host element in tabNavigation', () => {
       menu.tabNavigation = true;
-      await nextRender(menu);
       expect(menu.getAttribute('role')).to.equal('group');
     });
 
-    it('should set role attribute on menu bar buttons in tabNavigation', async () => {
+    it('should set role attribute on menu bar buttons in tabNavigation', () => {
       menu.tabNavigation = true;
-      await nextRender(menu);
       buttons.forEach((btn) => {
         expect(btn.getAttribute('role')).to.equal('button');
       });
     });
 
-    it('should update role attribute on menu bar buttons when changing items', async () => {
+    it('should update role attribute on menu bar buttons when changing items', () => {
       menu.items = [...menu.items, { text: 'New item' }];
-      await nextRender(menu);
       menu._buttons.forEach((btn) => {
         expect(btn.getAttribute('role')).to.equal('menuitem');
       });
     });
 
-    it('should update role attribute on menu bar buttons when changing items in tabNavigation', async () => {
+    it('should update role attribute on menu bar buttons when changing items in tabNavigation', () => {
       menu.tabNavigation = true;
-      await nextRender(menu);
       menu.items = [...menu.items, { text: 'New item' }];
-      await nextRender(menu);
       menu._buttons.forEach((btn) => {
         expect(btn.getAttribute('role')).to.equal('button');
       });
+
       menu.tabNavigation = false;
-      await nextRender(menu);
       menu._buttons.forEach((btn) => {
         expect(btn.getAttribute('role')).to.equal('menuitem');
       });

--- a/packages/menu-bar/test/keyboard-navigation.test.js
+++ b/packages/menu-bar/test/keyboard-navigation.test.js
@@ -7,9 +7,8 @@ import '../src/vaadin-menu-bar.js';
 describe('keyboard navigation', () => {
   let menu, buttons, firstGlobalFocusable, lastGlobalFocusable;
 
-  async function updateItemsAndButtons() {
+  function updateItemsAndButtons() {
     menu.items = [...menu.items];
-    await nextUpdate(menu);
     buttons = menu._buttons;
   }
 
@@ -59,7 +58,7 @@ describe('keyboard navigation', () => {
 
         it('should move focus to second button if first is disabled on Home keydown', async () => {
           menu.items[0].disabled = true;
-          await updateItemsAndButtons();
+          updateItemsAndButtons();
           buttons[3].focus();
           const spy = sinon.spy(buttons[1], 'focus');
           await sendKeys({ press: 'Home' });
@@ -77,7 +76,7 @@ describe('keyboard navigation', () => {
 
         it('should move focus to the closest enabled button if last is disabled on End keydown', async () => {
           menu.items[3].disabled = true;
-          await updateItemsAndButtons();
+          updateItemsAndButtons();
           buttons[0].focus();
           const spy = sinon.spy(buttons[1], 'focus');
           await sendKeys({ press: 'End' });
@@ -420,7 +419,7 @@ describe('keyboard navigation', () => {
 
       it('should move focus out of the menu bar on last available submenu item Tab', async () => {
         menu.items[3].disabled = true;
-        await updateItemsAndButtons();
+        updateItemsAndButtons();
 
         buttons[2].focus();
         await sendKeys({ press: 'ArrowDown' });
@@ -439,7 +438,7 @@ describe('keyboard navigation', () => {
       it('should move focus out of the menu bar on first available submenu item Tab', async () => {
         menu.items[0].disabled = true;
         menu.items[1].disabled = true;
-        await updateItemsAndButtons();
+        updateItemsAndButtons();
 
         buttons[2].focus();
         await sendKeys({ press: 'ArrowDown' });

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -22,9 +22,8 @@ describe('custom element definition', () => {
 describe('root menu layout', () => {
   let menu, buttons;
 
-  async function updateItemsAndButtons() {
+  function updateItemsAndButtons() {
     menu.items = [...menu.items];
-    await nextUpdate(menu);
     buttons = menu._buttons;
   }
 
@@ -50,21 +49,20 @@ describe('root menu layout', () => {
     });
   });
 
-  it('should disable all buttons when menu-bar disabled is set to true', async () => {
+  it('should disable all buttons when menu-bar disabled is set to true', () => {
     menu.disabled = true;
-    await nextUpdate(menu);
     buttons.forEach((btn) => {
       expect(btn.disabled).to.be.true;
     });
   });
 
-  it('should keep previously disabled buttons disabled when re-enabling the menu-bar', async () => {
+  it('should keep previously disabled buttons disabled when re-enabling the menu-bar', () => {
     expect(buttons[2].disabled).to.be.true;
+
     menu.disabled = true;
-    await nextUpdate(menu);
     expect(buttons[2].disabled).to.be.true;
+
     menu.disabled = false;
-    await nextUpdate(menu);
     expect(buttons[2].disabled).to.be.true;
   });
 
@@ -80,9 +78,8 @@ describe('root menu layout', () => {
     });
   });
 
-  it('should set tabindex to 0 when the button is not disabled in tab navigation', async () => {
+  it('should set tabindex to 0 when the button is not disabled in tab navigation', () => {
     menu.tabNavigation = true;
-    await nextUpdate(menu);
     buttons.forEach((btn) => {
       if (btn.disabled) {
         expect(btn.getAttribute('tabindex')).to.equal('-1');
@@ -92,11 +89,10 @@ describe('root menu layout', () => {
     });
   });
 
-  it('should reset tabindex after switching back from tab navigation', async () => {
+  it('should reset tabindex after switching back from tab navigation', () => {
     menu.tabNavigation = true;
-    await nextUpdate(menu);
+
     menu.tabNavigation = false;
-    await nextUpdate(menu);
     expect(buttons[0].getAttribute('tabindex')).to.equal('0');
     buttons.slice(1).forEach((btn) => {
       expect(btn.getAttribute('tabindex')).to.equal('-1');
@@ -111,15 +107,13 @@ describe('root menu layout', () => {
   });
 
   describe('updating items', () => {
-    it('should remove buttons when setting empty array', async () => {
+    it('should remove buttons when setting empty array', () => {
       menu.items = [];
-      await nextUpdate(menu);
       expect(menu._buttons.filter((b) => b !== menu._overflow).length).to.eql(0);
     });
 
-    it('should remove buttons when setting falsy items property', async () => {
+    it('should remove buttons when setting falsy items property', () => {
       menu.items = undefined;
-      await nextUpdate(menu);
       expect(menu._buttons.filter((b) => b !== menu._overflow).length).to.eql(0);
     });
   });
@@ -149,8 +143,10 @@ describe('root menu layout', () => {
 
     it('should override the theme attribute of the component with the item.theme property', async () => {
       menu.setAttribute('theme', 'contained');
+      await nextUpdate(menu);
+
       menu.items[1].theme = 'item-theme';
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[0].getAttribute('theme')).to.equal('contained');
       expect(buttons[1].getAttribute('theme')).to.equal('item-theme');
@@ -162,37 +158,39 @@ describe('root menu layout', () => {
       expect(buttons[1].getAttribute('theme')).to.equal('item-theme');
     });
 
-    it('should support setting multiple themes with an array', async () => {
+    it('should support setting multiple themes with an array', () => {
       menu.items[1].theme = ['theme-1', 'theme-2'];
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[1].getAttribute('theme')).to.equal('theme-1 theme-2');
 
       menu.items[1].theme = [];
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[1].hasAttribute('theme')).to.be.false;
     });
 
     it('should override the theme attribute of the component with an empty item.theme property', async () => {
       menu.setAttribute('theme', 'contained');
+      await nextUpdate(menu);
+
       menu.items[0].theme = '';
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[0].hasAttribute('theme')).to.be.false;
 
       menu.items[0].theme = [];
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[0].hasAttribute('theme')).to.be.false;
 
       menu.items[0].theme = [''];
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[0].hasAttribute('theme')).to.be.false;
 
       menu.items[0].theme = null;
-      await updateItemsAndButtons();
+      updateItemsAndButtons();
 
       expect(buttons[0].getAttribute('theme')).to.equal('contained');
     });

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { arrowRight, fixtureSync, nextFrame, nextRender, nextResize, nextUpdate } from '@vaadin/testing-helpers';
+import { arrowRight, fixtureSync, nextRender, nextResize, nextUpdate } from '@vaadin/testing-helpers';
 import './menu-bar-test-styles.js';
 import '../src/vaadin-menu-bar.js';
 
@@ -31,7 +31,6 @@ describe('overflow', () => {
       menu = wrapper.querySelector('vaadin-menu-bar');
       await nextRender(menu);
       menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }, { text: 'Item 5' }];
-      await nextUpdate(menu);
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
     });
@@ -51,9 +50,8 @@ describe('overflow', () => {
       expect(overflow.item.children[2]).to.deep.equal(menu.items[4]);
     });
 
-    it('should show overflow button after assigning the same items', async () => {
+    it('should show overflow button after assigning the same items', () => {
       menu.items = [...menu.items];
-      await nextUpdate(menu);
       expect(overflow.hasAttribute('hidden')).to.be.false;
     });
 
@@ -109,10 +107,9 @@ describe('overflow', () => {
       expect(overflow.item.children.length).to.equal(0);
     });
 
-    it('should hide overflow button and reset its items when all buttons fit after changing items', async () => {
+    it('should hide overflow button and reset its items when all buttons fit after changing items', () => {
       // See https://github.com/vaadin/vaadin-menu-bar/issues/133
       menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }];
-      await nextRender(menu);
       buttons = menu._buttons;
       overflow = buttons[2];
       assertVisible(buttons[1]);
@@ -161,24 +158,21 @@ describe('overflow', () => {
       expect(buttons[0].getAttribute('tabindex')).to.equal('0');
     });
 
-    it('should set the aria-label of the overflow button according to the i18n of the menu bar', async () => {
+    it('should set the aria-label of the overflow button according to the i18n of the menu bar', () => {
       const moreOptionsSv = 'Fler alternativ';
       expect(overflow.getAttribute('aria-label')).to.equal('More options');
       menu.i18n = { ...menu.i18n, moreOptions: moreOptionsSv };
-      await nextUpdate(menu);
       expect(overflow.getAttribute('aria-label')).to.equal(moreOptionsSv);
     });
 
-    it('should remove the aria-label from the overflow button when empty i18n string is set', async () => {
+    it('should remove the aria-label from the overflow button when empty i18n string is set', () => {
       menu.i18n = { ...menu.i18n, moreOptions: '' };
-      await nextUpdate(menu);
       expect(overflow.hasAttribute('aria-label')).to.be.false;
     });
 
     describe('reverse-collapse', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         menu.reverseCollapse = true;
-        await nextUpdate(menu);
       });
 
       it('should show overflow button and hide the buttons which do not fit', () => {
@@ -200,9 +194,8 @@ describe('overflow', () => {
         expect(overflow.item.children[2]).to.deep.equal(menu.items[2]);
       });
 
-      it('should update overflow when reverseCollapse changes', async () => {
+      it('should update overflow when reverseCollapse changes', () => {
         menu.reverseCollapse = false;
-        await nextUpdate(menu);
         assertVisible(buttons[0]);
         assertVisible(buttons[1]);
         assertHidden(buttons[2]);
@@ -258,9 +251,8 @@ describe('overflow', () => {
       expect(menu.hasAttribute('has-single-button')).to.be.true;
     });
 
-    it('should set when changing items to only have one button', async () => {
+    it('should set when changing items to only have one button', () => {
       menu.items = [{ text: 'Actions' }];
-      await nextUpdate(menu);
       expect(menu.hasAttribute('has-single-button')).to.be.true;
     });
 
@@ -269,16 +261,13 @@ describe('overflow', () => {
       await nextResize(menu);
 
       menu.items = [{ text: 'Actions' }];
-      await nextUpdate(menu);
       expect(menu.hasAttribute('has-single-button')).to.be.true;
     });
 
-    it('should remove when changing items to have more than one button', async () => {
+    it('should remove when changing items to have more than one button', () => {
       menu.items = [{ text: 'Actions' }];
-      await nextFrame();
 
       menu.items = [{ text: 'Edit' }, { text: 'Delete' }];
-      await nextUpdate(menu);
       expect(menu.hasAttribute('has-single-button')).to.be.false;
     });
   });


### PR DESCRIPTION
## Description

Updated to use `sync: true` and removed `await` from tests where possible.

## Type of change

- Refactor