### PR TITLE
refactor: remove unnecessary logic covered by resize observer

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2020 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, render } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { announce } from '@vaadin/a11y-base/src/announce.js';
@@ -193,10 +192,6 @@ export const AvatarGroupMixin = (superClass) =>
       const overlay = this.$.overlay;
       overlay.renderer = this.__overlayRenderer.bind(this);
       this._overlayElement = overlay;
-
-      afterNextRender(this, () => {
-        this.__setItemsInView();
-      });
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

The call to `__setItemsInView()` was added when implementing overflow avatar logic in https://github.com/vaadin/vaadin-avatar/pull/57.
Back then, the component was using `iron-resize` event, which was replaced by `ResizeObserver` in https://github.com/vaadin/web-components/pull/3150.

Tested manually and waiting for `afterNextRender()` is redundant as it's always followed by call in `_onResize()` which is triggered also after rendering the component initially (so that `__setItemsInView()` is called twice after initial render).

## Type of change

- Refactor