### PR TITLE
refactor: remove not needed usage of Polymer mixin helper

### DIFF
--- a/packages/icon/src/vaadin-icon-font-size-mixin.js
+++ b/packages/icon/src/vaadin-icon-font-size-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { needsFontIconSizingFallback } from './vaadin-icon-helpers.js';
@@ -29,7 +28,7 @@ if (usesFontIconSizingFallback) {
  *
  * @polymerMixin
  */
-export const IconFontSizeMixin = dedupingMixin((superclass) =>
+export const IconFontSizeMixin = (superclass) =>
   !usesFontIconSizingFallback
     ? superclass
     : class extends ResizeMixin(superclass) {
@@ -72,5 +71,4 @@ export const IconFontSizeMixin = dedupingMixin((superclass) =>
             this.style.setProperty('--_vaadin-font-icon-size', `${fontIconSize}px`);
           }
         }
-      },
-);
+      };


### PR DESCRIPTION
## Description

The `dedupingMixin` helper is intended only for mixins that can be applied multiple times in the prototype chain (e.g. some basic mixins like `KeyboardMixin` use that). Let's remove it from here since `IconFontSizeMixin` is only applied once.

Side note: according to https://github.com/vaadin/web-components/pull/6442 we could probably remove `IconFontSizeMixin` altogether in V25 as we drop Safari 15.

## Type of change

- Refactor