### PR TITLE
fix: set max-width on multi-select-combo-box to fix Chrome 136

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-styles.js
@@ -7,6 +7,7 @@ import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 export const multiSelectComboBox = css`
   :host {
+    max-width: 100%;
     --input-min-width: var(--vaadin-multi-select-combo-box-input-min-width, 4em);
     --_chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, 50px);
   }


### PR DESCRIPTION
## Description

This test started to fail in Chrome in CI due to `offsetWidth` of combo-box exceeding parent width:

```
packages/multi-select-combo-box/test/chips.test.js:

 ❌ chips > autoExpandHorizontally > should collapse chips to overflow when max-width is set on the parent
      AssertionError: expected 5 to equal 3
      + expected - actual
      
      -5
      +3
      
      at n.<anonymous> (packages/multi-select-combo-box/test/chips.test.js:526:44)
```

Added `max-width: 100%` on the `vaadin-multli-select-combo-box` to prevent possible problems. 

UPD: seems to be related to Chrome version update. CI uses `Google Chrome 136.0.7103.59`
I was able to reproduce this locally with Chrome `136.0.7103.49` on Mac OS Sonoma:

![Screenshot 2025-05-05 at 12 17 01](https://github.com/user-attachments/assets/0ff924db-686a-4c41-9b85-d3e84a58770e)

## Type of change

- Test