### PR TITLE
refactor: remove unnecessary logic covered by resize observer

### DIFF
--- a/packages/tabs/src/vaadin-tabs-mixin.js
+++ b/packages/tabs/src/vaadin-tabs-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { ListMixin } from '@vaadin/a11y-base/src/list-mixin.js';
 import { getNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
@@ -79,11 +78,6 @@ export const TabsMixin = (superClass) =>
       this._scrollerElement.addEventListener('scroll', () => this._updateOverflow());
 
       this.setAttribute('role', 'tablist');
-
-      // Wait for the vaadin-tab elements to upgrade and get styled
-      afterNextRender(this, () => {
-        this._updateOverflow();
-      });
     }
 
     /**


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/6860

Same as #9032 but for `vaadin-tabs`.

Tested manually and waiting for `afterNextRender()` is redundant as it's always followed by call in `_onResize()` which is triggered also after rendering the component initially (so that `_updateOverflow()` is called twice after initial render).

Furthermore, there is also `__itemsResizeObserver` that observes resizing individual `vaadin-tab` elements.

## Type of change

- Refactor