### PR TITLE
refactor: remove usage of Polymer helpers from app-layout

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2018 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { afterNextRender, beforeNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { AriaModalController } from '@vaadin/a11y-base/src/aria-modal-controller.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
@@ -144,7 +143,9 @@ export const AppLayoutMixin = (superclass) =>
       window.addEventListener('resize', this.__boundResizeListener);
       this.addEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
 
-      beforeNextRender(this, this._afterFirstRender);
+      requestAnimationFrame(() => {
+        this._updateOffsetSize();
+      });
 
       this._updateTouchOptimizedMode();
       this._updateDrawerSize();
@@ -253,12 +254,6 @@ export const AppLayoutMixin = (superclass) =>
      */
     __i18nChanged() {
       this.__updateDrawerAriaAttributes();
-    }
-
-    /** @protected */
-    _afterFirstRender() {
-      this._blockAnimationUntilAfterNextRender();
-      this._updateOffsetSize();
     }
 
     /** @private */
@@ -508,8 +503,11 @@ export const AppLayoutMixin = (superclass) =>
     /** @protected */
     _blockAnimationUntilAfterNextRender() {
       this.setAttribute('no-anim', '');
-      afterNextRender(this, () => {
-        this.removeAttribute('no-anim');
+
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          this.removeAttribute('no-anim');
+        });
       });
     }
 

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -5,6 +5,8 @@
  */
 import { AriaModalController } from '@vaadin/a11y-base/src/aria-modal-controller.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
+import { animationFrame } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 
 /**
@@ -504,7 +506,7 @@ export const AppLayoutMixin = (superclass) =>
     _blockAnimationUntilAfterNextRender() {
       this.setAttribute('no-anim', '');
 
-      requestAnimationFrame(() => {
+      this.__debounceAnimation = Debouncer.debounce(this.__debounceAnimation, animationFrame, () => {
         setTimeout(() => {
           this.removeAttribute('no-anim');
         });


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/6860

Replaced `afterNextRender` with combination of `requestAnimationFrame` + `setTimeout` [used in Polymer](https://github.com/Polymer/polymer/blob/26171d33853460066fb866e4c72a5b2d3b758e2a/lib/utils/render-status.js#L26-L33). 
Note: Polymer has some logic to queue invocations but IMO we don't need that.

Also removed the call to `_blockAnimationUntilAfterNextRender` from `_afterFirstRender` - it seems to be redundant, at least in dev page the unwanted initial drawer transition is prevented using the single call in `connectedCallback()`.

## Type of change

- Refactor