### PR TITLE
refactor: remove usage of afterNextRender helper from overlay

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures.js';
@@ -936,10 +935,12 @@ export const DatePickerOverlayContentMixin = (superClass) =>
       // Wait for `vaadin-month-calendar` elements to be rendered
       if (!this.calendars.length) {
         await new Promise((resolve) => {
-          afterNextRender(this, () => {
-            // Force dom-repeat elements to render
-            flush();
-            resolve();
+          requestAnimationFrame(() => {
+            setTimeout(() => {
+              // Force dom-repeat elements to render
+              flush();
+              resolve();
+            });
           });
         });
       }

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
@@ -266,11 +265,12 @@ export const OverlayMixin = (superClass) =>
 
         this._animatedOpening();
 
-        afterNextRender(this, () => {
-          this._trapFocus();
+        requestAnimationFrame(() => {
+          setTimeout(() => {
+            this._trapFocus();
 
-          const evt = new CustomEvent('vaadin-overlay-open', { bubbles: true });
-          this.dispatchEvent(evt);
+            this.dispatchEvent(new CustomEvent('vaadin-overlay-open', { bubbles: true }));
+          });
         });
 
         document.addEventListener('keydown', this._boundKeydownListener);

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { escKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import './animated-styles.js';
 import '../src/vaadin-overlay.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { createOverlay } from './helpers.js';
 
@@ -89,7 +88,11 @@ function afterOverlayOpeningFinished(overlay, callback) {
 
     if (isOverlayOpened) {
       observer.disconnect();
-      afterNextRender(overlay, callback);
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          callback();
+        });
+      });
     }
   });
   observer.observe(overlay, { attributes: true, attributeFilter: ['opening'] });
@@ -103,7 +106,11 @@ function afterOverlayClosingFinished(overlay, callback) {
 
     if (isOverlayClosed) {
       observer.disconnect();
-      afterNextRender(overlay, callback);
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          callback();
+        });
+      });
     }
   });
   observer.observe(overlay, { attributes: true, attributeFilter: ['closing'] });


### PR DESCRIPTION
## Description

Replaced `afterNextRender` with combination of `requestAnimationFrame` + `setTimeout` to preserve event timings.

## Type of change

- Refactor