### PR TITLE
test: improve context-menu test helpers structure and usage

### DIFF
--- a/packages/context-menu/test/a11y.test.js
+++ b/packages/context-menu/test/a11y.test.js
@@ -1,13 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import '../src/vaadin-context-menu.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { getMenuItems } from './helpers.js';
 
 describe('a11y', () => {
   describe('focus restoration', () => {
-    let contextMenu, contextMenuButton, firstGlobalFocusable, lastGlobalFocusable;
+    let contextMenu, contextMenuButton, overlay, firstGlobalFocusable, lastGlobalFocusable;
 
     beforeEach(async () => {
       const wrapper = fixtureSync(`
@@ -22,20 +22,21 @@ describe('a11y', () => {
       [firstGlobalFocusable, contextMenu, lastGlobalFocusable] = wrapper.children;
       contextMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', children: [{ text: 'Item 1/0' }] }];
       await nextRender();
+      overlay = contextMenu._overlayElement;
       contextMenuButton = contextMenu.querySelector('button');
       contextMenuButton.focus();
     });
 
     it('should move focus to the menu on open', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       const menuItem = getMenuItems(contextMenu)[0];
       expect(getDeepActiveElement()).to.equal(menuItem);
     });
 
     it('should restore focus on outside click', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       outsideClick();
       await nextRender();
       expect(getDeepActiveElement()).to.equal(contextMenuButton);
@@ -43,7 +44,7 @@ describe('a11y', () => {
 
     it('should restore focus on outside click when a sub-menu is open', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       // Move focus to Item 1
       await sendKeys({ press: 'ArrowDown' });
       // Open Item 1
@@ -56,7 +57,7 @@ describe('a11y', () => {
 
     it('should restore focus on root menu item selection', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       // Select Item 0
       await sendKeys({ press: 'Enter' });
       await nextRender();
@@ -65,7 +66,7 @@ describe('a11y', () => {
 
     it('should restore focus on sub-menu item selection', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       // Move focus to Item 1
       await sendKeys({ press: 'ArrowDown' });
       // Open Item 1
@@ -79,14 +80,14 @@ describe('a11y', () => {
 
     it('should move focus to the prev element outside the menu on Shift+Tab pressed inside', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       await sendKeys({ press: 'Shift+Tab' });
       expect(getDeepActiveElement()).to.equal(firstGlobalFocusable);
     });
 
     it('should move focus to the next element outside the menu on Tab pressed inside', async () => {
       contextMenuButton.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       await sendKeys({ press: 'Tab' });
       expect(getDeepActiveElement()).to.equal(lastGlobalFocusable);
     });

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -1,14 +1,22 @@
-import { fire, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fire, oneEvent } from '@vaadin/testing-helpers';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
-export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
-  const menu = target.closest('vaadin-context-menu');
-  if (menu) {
-    menu.__openListenerActive = true;
-  }
+export function activateItem(target, event = isTouch ? 'click' : 'mouseover') {
   const { right, bottom } = target.getBoundingClientRect();
   fire(target, event, { x: right, y: bottom });
-  await nextRender();
+}
+
+export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
+  let menu = target.closest('vaadin-context-menu');
+  if (!menu) {
+    // If the target is a menu item, get reference to the submenu.
+    const overlay = target.closest('vaadin-context-menu-overlay');
+    menu = overlay.querySelector('vaadin-context-menu');
+  }
+  // Disable logic that delays opening submenu
+  menu.__openListenerActive = true;
+  activateItem(target, event);
+  await oneEvent(menu._overlayElement, 'vaadin-overlay-open');
 }
 
 export function getMenuItems(menu) {

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -18,7 +18,7 @@ import '../src/vaadin-context-menu.js';
 import '@vaadin/item/src/vaadin-item.js';
 import '@vaadin/list-box/src/vaadin-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
+import { activateItem, getMenuItems, getSubMenu, openMenu } from './helpers.js';
 
 describe('items', () => {
   let rootMenu, subMenu, target, rootOverlay, subOverlay1;
@@ -183,6 +183,7 @@ describe('items', () => {
 
   it('should clear selections on reopen', async () => {
     getMenuItems(subMenu)[0].click();
+    await openMenu(target);
     await openMenu(getMenuItems(rootMenu)[0]);
     expect(getMenuItems(subMenu)[0].selected).to.be.false;
   });
@@ -249,16 +250,16 @@ describe('items', () => {
     expect(getMenuItems(subMenu)[1].disabled).to.be.true;
   });
 
-  it('should close the submenu', async () => {
-    await openMenu(getMenuItems(rootMenu)[1]);
+  it('should close the submenu on activating non-parent item', () => {
+    activateItem(getMenuItems(rootMenu)[1]);
     expect(subMenu.opened).to.be.false;
   });
 
-  (isTouch ? it.skip : it)('should focus closed parent item when hovering on non-parent item', async () => {
+  (isTouch ? it.skip : it)('should focus closed parent item when hovering on non-parent item', () => {
     const parent = getMenuItems(rootMenu)[0];
     const nonParent = getMenuItems(rootMenu)[1];
     const focusSpy = sinon.spy(parent, 'focus');
-    await openMenu(nonParent);
+    activateItem(nonParent);
     expect(focusSpy.called).to.be.true;
   });
 
@@ -267,14 +268,14 @@ describe('items', () => {
     await openMenu(parent);
     const nonParent = getMenuItems(rootMenu)[1];
     const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
-    await openMenu(nonParent);
+    activateItem(nonParent);
     expect(focusSpy.called).to.be.true;
   });
 
-  (isTouch ? it.skip : it)('should not focus overlay part if the parent menu list-box has focus', async () => {
-    await openMenu(getMenuItems(rootMenu)[1]);
+  (isTouch ? it.skip : it)('should not focus overlay part if the parent menu list-box has focus', () => {
+    activateItem(getMenuItems(rootMenu)[1]);
     const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
-    await openMenu(getMenuItems(rootMenu)[2]);
+    activateItem(getMenuItems(rootMenu)[2]);
     expect(focusSpy.called).to.be.false;
   });
 


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/9041

- Updated `a11y` tests to wait for `vaadin-overlay-open` event to ensure focus logic works properly
- Updated `openMenu` test helper to only use it for items that have submenu (i.e. "parent items")
- Changed `openMenu` to also wait for `vaadin-overlay-open` instead of waiting for `nextRender`
- Added `activateItem` test helper to be used by items without submenu (i.e. "non-parent items")

## Type of change

- Test