### PR TITLE
test: update menu-bar tests to use vaadin-overlay-open event

### DIFF
--- a/packages/menu-bar/test/a11y.test.js
+++ b/packages/menu-bar/test/a11y.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { arrowDown, arrowRight, enter, fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { arrowDown, arrowRight, enter, fixtureSync, nextRender, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import '../src/vaadin-menu-bar.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
@@ -84,7 +84,7 @@ describe('a11y', () => {
 
     it('should toggle aria-expanded attribute on submenu open / close', async () => {
       buttons[0].click();
-      await nextRender(subMenu);
+      await oneEvent(subMenu._overlayElement, 'vaadin-overlay-open');
       expect(buttons[0].getAttribute('aria-expanded')).to.equal('true');
 
       buttons[0].click();
@@ -117,14 +117,14 @@ describe('a11y', () => {
 
     it('should move focus to the sub-menu on open', async () => {
       buttons[0].click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(getDeepActiveElement()).to.equal(overlay.$.overlay);
     });
 
     it('should restore focus on outside click', async () => {
       // Open Item 0
       arrowDown(getDeepActiveElement());
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       outsideClick();
       await nextRender();
       expect(getDeepActiveElement()).to.equal(buttons[0]);
@@ -133,7 +133,7 @@ describe('a11y', () => {
     it('should restore focus on outside click when a sub-menu is open', async () => {
       // Open Item 0
       arrowDown(getDeepActiveElement());
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       // Move to Item 0/1
       arrowDown(getDeepActiveElement());
       await nextRender();
@@ -147,7 +147,7 @@ describe('a11y', () => {
     it('should restore focus on sub-menu item selection', async () => {
       // Open Item 0
       arrowDown(getDeepActiveElement());
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       // Select Item 0/0
       enter(getDeepActiveElement());
       await nextRender();
@@ -157,13 +157,14 @@ describe('a11y', () => {
     it('should restore focus on nested sub-menu item selection', async () => {
       // Open Item 0
       arrowDown(getDeepActiveElement());
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       // Move to Item 0/1
       arrowDown(getDeepActiveElement());
       await nextRender();
       // Open Item 0/1
       arrowRight(getDeepActiveElement());
-      await nextRender();
+      const nestedSubMenu = overlay.querySelector('vaadin-menu-bar-submenu');
+      await oneEvent(nestedSubMenu._overlayElement, 'vaadin-overlay-open');
       // Select Item 0/1/0
       enter(getDeepActiveElement());
       await nextRender();

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -120,7 +120,7 @@ describe('sub-menu', () => {
   it('should focus the overlay when sub-menu opened on click', async () => {
     const spy = sinon.spy(subMenuOverlay.$.overlay, 'focus');
     buttons[0].click();
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(spy.calledOnce).to.be.true;
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     expect(item.hasAttribute('focused')).to.be.false;
@@ -167,14 +167,14 @@ describe('sub-menu', () => {
 
   it('should focus the first item on button space', async () => {
     space(buttons[0]);
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     expect(item.hasAttribute('focused')).to.be.true;
   });
 
   it('should focus the first item on button enter', async () => {
     enter(buttons[0]);
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     expect(item.hasAttribute('focused')).to.be.true;
   });
@@ -191,7 +191,7 @@ describe('sub-menu', () => {
 
   it('should focus first item after re-opening when using components', async () => {
     arrowDown(buttons[2]);
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     arrowDown(items[0]);
@@ -200,7 +200,7 @@ describe('sub-menu', () => {
     // Close and re-open
     esc(items[1]);
     arrowDown(buttons[2]);
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
     expect(items[0].hasAttribute('focus-ring')).to.be.true;
   });
@@ -209,7 +209,7 @@ describe('sub-menu', () => {
     menu.items[2].children[0].disabled = true;
 
     arrowDown(buttons[2]);
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     expect(items[1].hasAttribute('focus-ring')).to.be.true;
@@ -217,7 +217,7 @@ describe('sub-menu', () => {
     // Close and re-open
     esc(items[1]);
     arrowDown(buttons[2]);
-    await nextRender(subMenu);
+    await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
     expect(items[1].hasAttribute('focus-ring')).to.be.true;
   });


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/9041

Updated menu-bar tests to wait for `vaadin-overlay-open` event explicitly instead of `nextRender`.

## Type of change

- Test