### PR TITLE
test: update popover tests to use vaadin-overlay-open event

### DIFF
--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -87,19 +87,19 @@ describe('a11y', () => {
 
         it(`should set aria-expanded attribute on the ${prop} when opened`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
           expect(element.getAttribute('aria-expanded')).to.equal('true');
         });
 
         it(`should set aria-controls attribute on the ${prop} when opened`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
           expect(element.getAttribute('aria-controls')).to.equal(overlay.id);
         });
 
         it(`should remove aria-controls attribute from the ${prop} when closed`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           popover.opened = false;
           await nextUpdate(popover);
@@ -114,7 +114,7 @@ describe('a11y', () => {
 
         it(`should remove aria-controls attribute from ${prop} when target is cleared`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           popover.target = null;
           await nextUpdate(popover);
@@ -198,7 +198,7 @@ describe('a11y', () => {
         await nextUpdate(popover);
 
         target.focus();
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
       it('should restore focus on Esc with trigger set to focus', async () => {
@@ -256,7 +256,7 @@ describe('a11y', () => {
         await nextUpdate(popover);
 
         target.click();
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
       it('should restore focus on Esc with trigger set to click', async () => {
@@ -296,7 +296,7 @@ describe('a11y', () => {
 
       it('should not restore focus on Esc with trigger set to hover', async () => {
         mouseenter(target);
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
 
         const focusSpy = sinon.spy(target, 'focus');
         overlay.$.overlay.focus();
@@ -311,7 +311,7 @@ describe('a11y', () => {
         await nextUpdate(popover);
 
         mouseenter(target);
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
 
         expect(target.style.pointerEvents).to.equal('auto');
       });
@@ -321,7 +321,7 @@ describe('a11y', () => {
         await nextUpdate(popover);
 
         mouseenter(target);
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
 
         mouseleave(target);
         await nextRender();
@@ -336,7 +336,7 @@ describe('a11y', () => {
         await nextUpdate(popover);
 
         target.focus();
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
       it('should not restore focus when re-opening on hover after being restored', async () => {
@@ -388,7 +388,7 @@ describe('a11y', () => {
 
             popover.target = wrapper;
           }
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
         });
 
         it('should focus the overlay content part on target Tab', async () => {
@@ -460,7 +460,7 @@ describe('a11y', () => {
           await nextUpdate(popover);
 
           target.focus();
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           // Move focus back from the target
           await sendKeys({ press: 'Shift+Tab' });

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { esc, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
+import { esc, fixtureSync, nextRender, nextUpdate, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-popover.js';
 
@@ -175,13 +175,13 @@ describe('popover', () => {
 
     it('should open overlay on target click by default', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
     it('should close overlay on subsequent target click', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       target.click();
       await nextRender();
@@ -190,7 +190,7 @@ describe('popover', () => {
 
     it('should close overlay on outside click by default', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       outsideClick();
       await nextRender();
@@ -202,7 +202,7 @@ describe('popover', () => {
       await nextUpdate(popover);
 
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       outsideClick();
       await nextRender();
@@ -215,7 +215,7 @@ describe('popover', () => {
       await nextUpdate(popover);
 
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       outsideClick();
       await nextRender();
@@ -224,7 +224,7 @@ describe('popover', () => {
 
     it('should close overlay when popover is detached', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       popover.remove();
       await nextRender();
@@ -233,7 +233,7 @@ describe('popover', () => {
 
     it('should not close overlay when popover is moved in DOM', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       const parent = popover.parentElement;
       popover.remove();
@@ -253,7 +253,7 @@ describe('popover', () => {
     describe('Escape press', () => {
       beforeEach(async () => {
         target.click();
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
       it('should close overlay on global Escape press by default', async () => {
@@ -308,11 +308,11 @@ describe('popover', () => {
 
         // Open the first popover
         target.click();
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
 
         // Open the second popover
         secondTarget.click();
-        await nextRender();
+        await oneEvent(secondPopover._overlayElement, 'vaadin-overlay-open');
 
         // Expect both popovers to be opened
         expect(popover.opened).to.be.true;
@@ -452,7 +452,7 @@ describe('popover', () => {
 
     beforeEach(async () => {
       popover.opened = true;
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
     it('should update width after opening the popover', async () => {
@@ -498,7 +498,7 @@ describe('popover', () => {
         root.textContent = new Array(2000).fill('foo').join(' ');
       };
       popover.opened = true;
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
     it('should limit overlay height if content overflows the viewport', () => {
@@ -513,7 +513,7 @@ describe('popover', () => {
   describe('closed event', () => {
     beforeEach(async () => {
       popover.opened = true;
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
     });
 
     it('should dispatch closed event when closed', async () => {

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -8,6 +8,7 @@ import {
   mousedown,
   nextRender,
   nextUpdate,
+  oneEvent,
   outsideClick,
 } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
@@ -47,13 +48,13 @@ describe('trigger', () => {
 
     it('should open on target click', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
     it('should close on target click', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       target.click();
       await nextRender();
@@ -73,7 +74,7 @@ describe('trigger', () => {
       target.parentNode.appendChild(popover);
 
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
@@ -85,7 +86,7 @@ describe('trigger', () => {
 
     it('should not close on target mouseleave', async () => {
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseenter(target);
       mouseleave(target);
@@ -102,13 +103,13 @@ describe('trigger', () => {
 
     it('should open on target mouseenter', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
     it('should close on target mouseleave', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseleave(target);
       await nextUpdate(popover);
@@ -118,7 +119,7 @@ describe('trigger', () => {
 
     it('should not close on mouseleave from target to overlay', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseleave(target, overlay);
       await nextUpdate(popover);
@@ -128,7 +129,7 @@ describe('trigger', () => {
 
     it('should close on overlay mouseleave', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseenter(overlay);
       mouseleave(overlay);
@@ -139,7 +140,7 @@ describe('trigger', () => {
 
     it('should not close on mouseleave from overlay back to target', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseleave(target, overlay);
       mouseleave(overlay, target);
@@ -161,7 +162,7 @@ describe('trigger', () => {
       target.parentNode.appendChild(popover);
 
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
   });
@@ -174,13 +175,13 @@ describe('trigger', () => {
 
     it('should open on target focusin', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
     it('should close on target focusout', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusout(target);
       await nextUpdate(popover);
@@ -196,7 +197,7 @@ describe('trigger', () => {
 
     it('should not close on target focusout to the overlay', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusout(target, overlay);
       await nextUpdate(popover);
@@ -205,7 +206,7 @@ describe('trigger', () => {
 
     it('should close on overlay focusout', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusout(target, overlay);
       focusout(overlay);
@@ -215,7 +216,7 @@ describe('trigger', () => {
 
     it('should not close on overlay focusout to the overlay content', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusout(overlay, overlay.firstElementChild);
       await nextUpdate(popover);
@@ -224,7 +225,7 @@ describe('trigger', () => {
 
     it('should not close on overlay focusout back to the target', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusout(target, overlay);
       focusout(overlay, target);
@@ -245,7 +246,7 @@ describe('trigger', () => {
       target.parentNode.appendChild(popover);
 
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
@@ -257,7 +258,7 @@ describe('trigger', () => {
         target.parentNode.appendChild(input);
 
         target.focus();
-        await nextRender();
+        await oneEvent(overlay, 'vaadin-overlay-open');
       });
 
       afterEach(async () => {
@@ -321,19 +322,19 @@ describe('trigger', () => {
 
     it('should open on target mouseenter', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
     it('should open on target focusin', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
     it('should not close on target focusout if target has hover', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseenter(target);
       focusout(target);
@@ -343,7 +344,7 @@ describe('trigger', () => {
 
     it('should close on target focusout if target has lost hover', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseenter(target);
       mouseleave(target);
@@ -354,7 +355,7 @@ describe('trigger', () => {
 
     it('should not close on target focusout if overlay has hover', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseenter(overlay);
       focusout(target);
@@ -364,7 +365,7 @@ describe('trigger', () => {
 
     it('should close on target focusout if overlay has lost hover', async () => {
       focusin(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       mouseenter(overlay);
       mouseleave(overlay);
@@ -375,7 +376,7 @@ describe('trigger', () => {
 
     it('should not close on target mouseleave if target has focus', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusin(target);
       mouseleave(target);
@@ -385,7 +386,7 @@ describe('trigger', () => {
 
     it('should not close on target mouseleave if overlay has focus', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusin(overlay);
       mouseleave(target);
@@ -395,7 +396,7 @@ describe('trigger', () => {
 
     it('should not close on overlay mouseleave if overlay has focus', async () => {
       mouseenter(target);
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       focusin(overlay);
       mouseenter(overlay);
@@ -415,7 +416,7 @@ describe('trigger', () => {
       mousedown(target);
       target.focus();
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
       expect(overlay.opened).to.be.true;
     });
 
@@ -423,7 +424,7 @@ describe('trigger', () => {
       mousedown(target);
       target.focus();
       target.click();
-      await nextRender();
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
       target.click();
       await nextRender();
@@ -461,13 +462,13 @@ describe('trigger', () => {
 
         it(`should open on setting opened to true with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
           expect(overlay.opened).to.be.true;
         });
 
         it(`should not close on target mouseleave with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           mouseenter(target);
           mouseleave(target);
@@ -477,7 +478,7 @@ describe('trigger', () => {
 
         it(`should not close on target focusout with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           focusin(target);
           focusout(target);
@@ -487,7 +488,7 @@ describe('trigger', () => {
 
         it(`should close on global Escape press with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           esc(document.body);
           await nextUpdate(popover);
@@ -496,7 +497,7 @@ describe('trigger', () => {
 
         it(`should close on target Escape press with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           esc(target);
           await nextUpdate(popover);
@@ -506,7 +507,7 @@ describe('trigger', () => {
         it(`should close on global Escape press when modal with trigger set to ${trigger}`, async () => {
           popover.modal = true;
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           esc(document.body);
           await nextUpdate(popover);
@@ -515,7 +516,7 @@ describe('trigger', () => {
 
         it(`should close on outside click when not modal with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           outsideClick();
           await nextUpdate(popover);
@@ -525,7 +526,7 @@ describe('trigger', () => {
         it(`should close on outside click when modal with trigger set to ${trigger}`, async () => {
           popover.modal = true;
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           outsideClick();
           await nextUpdate(popover);
@@ -534,7 +535,7 @@ describe('trigger', () => {
 
         it(`should close when setting opened to false with trigger set to ${trigger}`, async () => {
           popover.opened = true;
-          await nextRender();
+          await oneEvent(overlay, 'vaadin-overlay-open');
 
           popover.opened = false;
           await nextUpdate(popover);


### PR DESCRIPTION
## Description

Related to #9041

Updated popover tests to wait for `vaadin-overlay-open` event explicitly instead of `nextRender`.

## Type of change

- Test