### PR TITLE
chore: add tsconfig.build.tsbuildinfo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ packages/vaadin-lumo-styles/auto-complete.css
 
 # Generated release check
 scripts/check-releases.html
+
+# TypeScript output
+tsconfig.build.tsbuildinfo


### PR DESCRIPTION
## Description

This file is produced by TS when running `build:ts` script as part of building theme typings. Let's add it to `.gitignore`.

## Type of change

- Internal change