### PR TITLE
feat!: use stackOverlay property instead of stackThreshold

### DIFF
--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -39,7 +39,7 @@
       <vaadin-checkbox id="maxWidth" label="Use max-width on the host"></vaadin-checkbox>
       <vaadin-checkbox id="maxHeight" label="Use max-height on the host"></vaadin-checkbox>
       <vaadin-checkbox id="forceOverlay" label="Force overlay"></vaadin-checkbox>
-      <vaadin-checkbox id="stack" label="Set stack threshold"></vaadin-checkbox>
+      <vaadin-checkbox id="stack" label="Use stack mode"></vaadin-checkbox>
       <button id="set-small-detail">Set small detail</button>
       <button id="set-large-detail">Set large detail</button>
       <button id="clear-detail">Clear detail</button>
@@ -117,7 +117,7 @@
       });
 
       document.querySelector('#stack').addEventListener('change', (e) => {
-        layout.stackThreshold = e.target.checked ? '600px' : null;
+        layout.stackOverlay = e.target.checked;
       });
 
       document.querySelector('#set-small-detail').addEventListener('click', () => {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -109,12 +109,12 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   containment: 'layout' | 'viewport';
 
   /**
-   * The threshold (in CSS length units) at which the layout switches to
-   * the "stack" mode, making detail area fully cover the master area.
+   * When true, the layout in the overlay mode is rendered as a "stack",
+   * making detail area fully cover the master area.
    *
    * @attr {string} stack-threshold
    */
-  stackThreshold: string | null | undefined;
+  stackOverlay: boolean;
 
   /**
    * When true, the layout does not use animated transitions for the detail area.

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -96,6 +96,9 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * there is enough space for master and detail to be shown next to
    * each other using the default (split) mode.
    *
+   * In order to enforce the stack mode, use this property together with
+   * `stackOverlay` property and set both to `true`.
+   *
    * @attr {boolean} force-overlay
    */
   forceOverlay: boolean;
@@ -111,6 +114,9 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   /**
    * When true, the layout in the overlay mode is rendered as a "stack",
    * making detail area fully cover the master area.
+   *
+   * In order to enforce the stack mode, use this property together with
+   * `forceOverlay` property and set both to `true`.
    *
    * @attr {string} stack-threshold
    */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -287,6 +287,9 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * there is enough space for master and detail to be shown next to
        * each other using the default (split) mode.
        *
+       * In order to enforce the stack mode, use this property together with
+       * `stackOverlay` property and set both to `true`.
+       *
        * @attr {boolean} force-overlay
        */
       forceOverlay: {
@@ -313,6 +316,9 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * When true, the layout in the overlay mode is rendered as a "stack",
        * making detail area fully cover the master area.
        *
+       * In order to enforce the stack mode, use this property together with
+       * `forceOverlay` property and set both to `true`.
+       *
        * @attr {string} stack-threshold
        */
       stackOverlay: {
@@ -334,7 +340,6 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
 
       /**
        * When true, the component uses the overlay mode. This property is read-only.
-       * In order to enforce the overlay mode, use `forceOverlay` property.
        * @protected
        */
       _overlay: {
@@ -346,8 +351,6 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
 
       /**
        * When true, the component uses the stack mode. This property is read-only.
-       * In order to enforce the stack mode, set both `forceOverlay` property and
-       * `stackOverlay` properties to `true`.
        * @protected
        */
       _stack: {

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender, nextResize } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
 import './helpers/detail-content.js';
@@ -31,15 +31,12 @@ describe('ARIA', () => {
     expect(detail.hasAttribute('role')).to.be.false;
   });
 
-  it('should set role to dialog on the detail part in the stack mode', async () => {
-    layout.stackThreshold = '500px';
-    layout.style.width = '500px';
-    await nextResize(layout);
-
+  it('should set role to dialog on the detail part in the stack mode', () => {
+    layout.forceOverlay = true;
+    layout.stackOverlay = true;
     expect(detail.getAttribute('role')).to.equal('dialog');
 
-    layout.style.width = '600px';
-    await nextResize(layout);
+    layout.forceOverlay = false;
 
     expect(detail.hasAttribute('role')).to.be.false;
   });

--- a/packages/master-detail-layout/test/stack-mode.test.js
+++ b/packages/master-detail-layout/test/stack-mode.test.js
@@ -38,12 +38,12 @@ describe('stack mode', () => {
     });
 
     describe('horizontal orientation', () => {
-      it('should switch from overlay to the stack mode when the stack threshold is set', async () => {
+      it('should switch from overlay to the stack mode when the stackOverlay is set', async () => {
         // Use the threshold at which the overlay mode is on by default.
         await setViewport({ width: 350, height });
         await nextResize(layout);
 
-        layout.stackThreshold = '400px';
+        layout.stackOverlay = true;
 
         expect(layout.hasAttribute('overlay')).to.be.false;
         expect(layout.hasAttribute('stack')).to.be.true;
@@ -52,7 +52,7 @@ describe('stack mode', () => {
       });
 
       it('should clear the stack mode when the layout size is bigger than stack threshold', async () => {
-        layout.stackThreshold = '400px';
+        layout.stackOverlay = true;
         await nextRender();
 
         await setViewport({ width: 350, height });
@@ -64,21 +64,21 @@ describe('stack mode', () => {
         expect(layout.hasAttribute('stack')).to.be.false;
       });
 
-      it('should not switch to the stack mode when forceOverlay is set to true', async () => {
+      it('should switch to the stack mode when forceOverlay is set to true', async () => {
         layout.forceOverlay = true;
-        layout.stackThreshold = '500px';
+        layout.stackOverlay = true;
         await nextRender();
 
         await setViewport({ width: 450, height });
         await nextResize(layout);
 
-        expect(layout.hasAttribute('stack')).to.be.false;
-        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(layout.hasAttribute('overlay')).to.be.false;
       });
 
       it('should not apply min-width to the detail area in the stack mode', async () => {
         layout.detailMinSize = '500px';
-        layout.stackThreshold = '500px';
+        layout.stackOverlay = true;
         await nextRender();
 
         await setViewport({ width: 450, height });
@@ -90,7 +90,7 @@ describe('stack mode', () => {
 
       it('should not apply width to the detail area in the stack mode', async () => {
         layout.detailSize = '500px';
-        layout.stackThreshold = '500px';
+        layout.stackOverlay = true;
         await nextRender();
 
         await setViewport({ width: 450, height });
@@ -100,41 +100,43 @@ describe('stack mode', () => {
         expect(getComputedStyle(detail).width).to.equal('450px');
       });
 
-      it('should preserve the stack mode when adding and removing details', async () => {
-        layout.stackThreshold = '500px';
+      it('should update stack mode when adding and removing details', async () => {
+        layout.stackOverlay = true;
 
         // Start without details
         detailContent.remove();
         await nextRender();
 
         // Shrink viewport
-        await setViewport({ width: 450, height });
+        layout.detailMinSize = '300px';
+        await setViewport({ width: 500, height });
         await nextResize(layout);
 
-        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(layout.hasAttribute('stack')).to.be.false;
 
         // Add details
         layout.appendChild(detailContent);
         await nextRender();
 
         expect(layout.hasAttribute('stack')).to.be.true;
+        expect(getComputedStyle(detail).position).to.equal('absolute');
 
         // Remove details
         detailContent.remove();
         await nextRender();
 
-        expect(layout.hasAttribute('stack')).to.be.true;
+        expect(layout.hasAttribute('stack')).to.be.false;
       });
 
       it('should focus detail content when adding details in the stack mode', async () => {
-        layout.stackThreshold = '500px';
+        layout.stackOverlay = true;
 
         // Start without details
         detailContent.remove();
         await nextRender();
 
         // Shrink viewport
-        await setViewport({ width: 450, height });
+        await setViewport({ width: 350, height });
         await nextResize(layout);
 
         // Add details
@@ -146,7 +148,7 @@ describe('stack mode', () => {
       });
 
       it('should not overflow in stack mode when masterSize is set', async () => {
-        layout.stackThreshold = '500px';
+        layout.stackOverlay = true;
         layout.masterSize = '500px';
         await nextResize(layout);
 
@@ -160,7 +162,7 @@ describe('stack mode', () => {
       });
 
       it('should not overflow in stack mode when masterMinSize is set', async () => {
-        layout.stackThreshold = '500px';
+        layout.stackOverlay = true;
         layout.masterMinSize = '500px';
         await nextResize(layout);
 
@@ -174,8 +176,8 @@ describe('stack mode', () => {
       });
 
       it('should not overflow in stack mode when detailSize is set', async () => {
+        layout.stackOverlay = true;
         layout.detailSize = '500px';
-        layout.stackThreshold = '500px';
         await nextRender();
 
         // Resize so that min size is bigger than layout size
@@ -188,8 +190,8 @@ describe('stack mode', () => {
       });
 
       it('should not overflow in stack mode when detailMinSize is set', async () => {
+        layout.stackOverlay = true;
         layout.detailMinSize = '500px';
-        layout.stackThreshold = '500px';
         await nextRender();
 
         // Resize so that min size is bigger than layout size
@@ -214,7 +216,7 @@ describe('stack mode', () => {
         await setViewport({ width: 500, height: 400 });
         await nextResize(layout);
 
-        layout.stackThreshold = '400px';
+        layout.stackOverlay = true;
 
         expect(layout.hasAttribute('overlay')).to.be.false;
         expect(layout.hasAttribute('stack')).to.be.true;
@@ -229,7 +231,7 @@ describe('stack mode', () => {
         await setViewport({ width: 500, height: 400 });
         await nextResize(layout);
 
-        layout.stackThreshold = '400px';
+        layout.stackOverlay = true;
 
         expect(layout.hasAttribute('overlay')).to.be.false;
         expect(layout.hasAttribute('stack')).to.be.true;
@@ -238,8 +240,8 @@ describe('stack mode', () => {
       });
 
       it('should not apply min-height to the detail area in the stack mode', async () => {
+        layout.stackOverlay = true;
         layout.detailMinSize = '500px';
-        layout.stackThreshold = '500px';
         await nextRender();
 
         await setViewport({ width, height: 450 });
@@ -250,8 +252,8 @@ describe('stack mode', () => {
       });
 
       it('should not apply height to the detail area in the stack mode', async () => {
+        layout.stackOverlay = true;
         layout.detailSize = '500px';
-        layout.stackThreshold = '500px';
         await nextRender();
 
         await setViewport({ width, height: 450 });
@@ -274,7 +276,7 @@ describe('stack mode', () => {
             slot="detail"
             master-min-size="300px"
             detail-min-size="200px"
-            stack-threshold="400px"
+            stack-overlay
             containment="viewport"
           >
             <div>Nested master</div>

--- a/packages/master-detail-layout/test/stack-mode.test.js
+++ b/packages/master-detail-layout/test/stack-mode.test.js
@@ -51,7 +51,7 @@ describe('stack mode', () => {
         expect(getComputedStyle(detail).inset).to.equal('0px');
       });
 
-      it('should clear the stack mode when the layout size is bigger than stack threshold', async () => {
+      it('should clear the stack mode when there is enough space for both areas to fit', async () => {
         layout.stackOverlay = true;
         await nextRender();
 
@@ -211,7 +211,7 @@ describe('stack mode', () => {
         layout.parentElement.style.height = '100%';
       });
 
-      it('should switch from overlay to the stack mode when the stack threshold is set', async () => {
+      it('should switch from overlay to the stack mode when the stackOverlay is set', async () => {
         // Use the threshold at which the overlay mode is on by default.
         await setViewport({ width: 500, height: 400 });
         await nextResize(layout);

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -17,5 +17,5 @@ assertType<string | null | undefined>(layout.masterSize);
 assertType<string | null | undefined>(layout.masterMinSize);
 assertType<'horizontal' | 'vertical'>(layout.orientation);
 assertType<boolean>(layout.forceOverlay);
-assertType<string | null | undefined>(layout.stackThreshold);
+assertType<boolean>(layout.stackOverlay);
 assertType<boolean>(layout.noAnimation);


### PR DESCRIPTION
## Description

Fixes #9048

- Replaced `stackThreshold` property with `stackOverlay` that defines whether the layout should use stack mode
- The `stackOverlay` can now be used in combination with `forceOverlay` to enforce the stack mode to be used
- State attributes `overlay` and `stack` are preserved depending on which mode is used, so no changes to styling

## Type of change

- Behavior altering change