### PR TITLE
fix: add missing type definitions for Lit element entry points

### DIFF
--- a/packages/crud/vaadin-lit-crud-edit-column.d.ts
+++ b/packages/crud/vaadin-lit-crud-edit-column.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-crud-edit-column.js';

--- a/packages/crud/vaadin-lit-crud-edit.d.ts
+++ b/packages/crud/vaadin-lit-crud-edit.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-crud-edit.js';

--- a/packages/crud/vaadin-lit-crud.d.ts
+++ b/packages/crud/vaadin-lit-crud.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-crud.js';

--- a/packages/grid/vaadin-lit-grid-column-group.d.ts
+++ b/packages/grid/vaadin-lit-grid-column-group.d.ts
@@ -1,1 +1,1 @@
-export * from './src/vaadin-lit-grid-column-group.js';
+export * from './src/vaadin-grid-column-group.js';


### PR DESCRIPTION
## Description

Looking into https://github.com/vaadin/react-components/issues/320 I first tried to update the generator to use Lit element versions of components if they exist. That seems to work fine, except that some Lit element entry points have missing or invalid type definitions. This change fixes those.

## Type of change

- Bugfix
