### PR TITLE
feat: add events for backdrop click and detail Escape press

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -8,6 +8,14 @@ import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
+export interface MasterDetailLayoutCustomEventMap {
+  'backdrop-click': Event;
+
+  'detail-escape-press': Event;
+}
+
+export interface MasterDetailLayoutEventMap extends HTMLElementEventMap, MasterDetailLayoutCustomEventMap {}
+
 /**
  * `<vaadin-master-detail-layout>` is a web component for building UIs with a master
  * (or primary) area and a detail (or secondary) area that is displayed next to, or
@@ -41,6 +49,9 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * `stack`        | Set when the layout is using the stack mode.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the overlay mode.
+ * @fires {CustomEvent} detail-escape-press - Fired when the user presses Escape in the detail area.
  */
 declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
   /**
@@ -128,6 +139,18 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * @attr {boolean} no-animation
    */
   noAnimation: boolean;
+
+  addEventListener<K extends keyof MasterDetailLayoutEventMap>(
+    type: K,
+    listener: (this: MasterDetailLayout, ev: MasterDetailLayoutEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof MasterDetailLayoutEventMap>(
+    type: K,
+    listener: (this: MasterDetailLayout, ev: MasterDetailLayoutEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
 }
 
 declare global {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -47,6 +47,9 @@ import { transitionStyles } from './vaadin-master-detail-layout-transition-style
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the overlay mode.
+ * @fires {CustomEvent} detail-escape-press - Fired when the user presses Escape in the detail area.
+ *
  * @customElement
  * @extends HTMLElement
  * @mixes ThemableMixin
@@ -385,7 +388,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   /** @protected */
   render() {
     return html`
-      <div part="backdrop"></div>
+      <div part="backdrop" @click="${this.__onBackdropClick}"></div>
       <div id="master" part="master" ?inert="${this._hasDetail && this._overlay && this.containment === 'layout'}">
         <slot></slot>
       </div>
@@ -394,6 +397,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         part="detail"
         role="${this._overlay || this._stack ? 'dialog' : nothing}"
         aria-modal="${this._overlay && this.containment === 'viewport' ? 'true' : nothing}"
+        @keydown="${this.__onDetailKeydown}"
       >
         <slot name="detail" @slotchange="${this.__onDetailSlotChange}"></slot>
       </div>
@@ -414,6 +418,26 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       if (focusables.length) {
         focusables[0].focus();
       }
+    }
+  }
+
+  /** @private */
+  __onBackdropClick() {
+    this.dispatchEvent(
+      new CustomEvent('backdrop-click', {
+        bubbles: true,
+      }),
+    );
+  }
+
+  /** @private */
+  __onDetailKeydown(event) {
+    if (event.key === 'Escape') {
+      this.dispatchEvent(
+        new CustomEvent('detail-escape-press', {
+          bubbles: true,
+        }),
+      );
     }
   }
 
@@ -655,6 +679,16 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
     this.__transition = null;
     this.__resolveUpdateCallback = null;
   }
+
+  /**
+   * @event backdrop-click
+   * Fired when the user clicks the backdrop in the overlay mode.
+   */
+
+  /**
+   * @event detail-escape-press
+   * Fired when the user presses Escape in the detail area.
+   */
 }
 
 defineCustomElement(MasterDetailLayout);

--- a/packages/master-detail-layout/test/events.test.js
+++ b/packages/master-detail-layout/test/events.test.js
@@ -1,0 +1,87 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-master-detail-layout.js';
+import './helpers/master-content.js';
+import './helpers/detail-content.js';
+
+window.Vaadin ||= {};
+window.Vaadin.featureFlags ||= {};
+window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
+
+describe('events', () => {
+  let layout;
+
+  beforeEach(async () => {
+    layout = fixtureSync(`
+      <vaadin-master-detail-layout>
+        <master-content></master-content>
+        <detail-content slot="detail"></detail-content>
+      </vaadin-master-detail-layout>
+    `);
+    await nextRender();
+  });
+
+  describe('backdrop click', () => {
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should fire backdrop-click event on backdrop click in overlay mode', async () => {
+      layout.forceOverlay = true;
+
+      const spy = sinon.spy();
+      layout.addEventListener('backdrop-click', spy);
+
+      const backdrop = layout.shadowRoot.querySelector('[part="backdrop"]');
+      await sendMouseToElement({ type: 'click', element: backdrop });
+
+      expect(spy).to.be.calledOnce;
+    });
+  });
+
+  describe('Escape press', () => {
+    let detail, focusable;
+
+    beforeEach(() => {
+      detail = layout.querySelector('[slot="detail"]');
+      focusable = detail.shadowRoot.querySelector('input');
+    });
+
+    it('should fire detail-escape-press event on pressing Escape in split mode', async () => {
+      const spy = sinon.spy();
+      layout.addEventListener('detail-escape-press', spy);
+
+      focusable.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire detail-escape-press event on pressing Escape in overlay mode', async () => {
+      layout.forceOverlay = true;
+
+      const spy = sinon.spy();
+      layout.addEventListener('detail-escape-press', spy);
+
+      focusable.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire detail-escape-press event on pressing Escape in stack mode', async () => {
+      layout.forceOverlay = true;
+      layout.stackOverlay = true;
+
+      const spy = sinon.spy();
+      layout.addEventListener('detail-escape-press', spy);
+
+      focusable.focus();
+      await sendKeys({ press: 'Escape' });
+
+      expect(spy).to.be.calledOnce;
+    });
+  });
+});

--- a/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
+++ b/packages/master-detail-layout/test/typings/master-detail-layout.types.ts
@@ -19,3 +19,12 @@ assertType<'horizontal' | 'vertical'>(layout.orientation);
 assertType<boolean>(layout.forceOverlay);
 assertType<boolean>(layout.stackOverlay);
 assertType<boolean>(layout.noAnimation);
+
+// Events
+layout.addEventListener('backdrop-click', (event) => {
+  assertType<Event>(event);
+});
+
+layout.addEventListener('detail-escape-press', (event) => {
+  assertType<Event>(event);
+});


### PR DESCRIPTION
## Description

Part of #9049

Added two events that can be used to determine if the detail content should be removed:

- `backdrop-click` (only in the overlay mode)
- `detail-esape-press` (in all modes)

Note: in the overlay mode some users might expect global <kbd>Escape</kbd> to work the same as in overlay, i.e. without the need to have detail area focused (which can happen if you click on the blank space below inputs in `detail-content`).

However, implementing that would be somewhat tricky as the global `keydown` listener could interfere with `vaadin-overlay-escape-press` event - so we would need to have some way to detect if <kbd>Escape</kbd> is being handled elsewhere. This would also require integration tests for all components that handle <kbd>Escape</kbd> internally, using it for clear button and closing overlay.

So IMO it's easier to add explicit `keydown` listener on the detail part for now, and discuss the above case separately.

## Type of change

- Feature