### PR TITLE
refactor: replace usage of Polymer helpers in charts

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -28,12 +28,11 @@ import 'highcharts/es-modules/masters/modules/xrange.src.js';
 import 'highcharts/es-modules/masters/modules/bullet.src.js';
 import 'highcharts/es-modules/masters/modules/gantt.src.js';
 import 'highcharts/es-modules/masters/modules/draggable-points.src.js';
-import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
-import { beforeNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import Pointer from 'highcharts/es-modules/Core/Pointer.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
+import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { deepMerge, inflateFunctions } from './helpers.js';
 
 ['exportChart', 'exportChartLocal', 'getSVG'].forEach((methodName) => {
@@ -753,7 +752,7 @@ export const ChartMixin = (superClass) =>
     connectedCallback() {
       super.connectedCallback();
       this.__updateStyles();
-      beforeNextRender(this, () => {
+      queueMicrotask(() => {
         // Detect if the chart had already been initialized. This might happen in
         // environments where the chart is lazily attached (e.g Grid).
         if (this.configuration) {
@@ -803,7 +802,7 @@ export const ChartMixin = (superClass) =>
 
     /** @private */
     __addChildObserver() {
-      this._childObserver = new FlattenedNodesObserver(this.$.slot, (info) => {
+      this._childObserver = new SlotObserver(this.$.slot, (info) => {
         this.__addSeries(info.addedNodes.filter(this.__filterSeriesNodes));
         this.__removeSeries(info.removedNodes.filter(this.__filterSeriesNodes));
         this.__cleanupAfterSeriesRemoved(info.removedNodes.filter(this.__filterSeriesNodes));
@@ -1048,7 +1047,7 @@ export const ChartMixin = (superClass) =>
       inflateFunctions(configCopy);
       this._jsonConfigurationBuffer = this.__makeConfigurationBuffer(this._jsonConfigurationBuffer, configCopy);
 
-      beforeNextRender(this, () => {
+      queueMicrotask(() => {
         if (!this.configuration || !this._jsonConfigurationBuffer) {
           return;
         }


### PR DESCRIPTION
## Description

- Replaced usage of `FlattenedNodesObserver` with `SlotObserver` that has identical API
- Replaced usage of `beforeNextRender` with `queueMicrotask` (which makes tests pass)

Note, Polymer uses `requestAnimationFrame()` internally in `beforeNextRender()` but that breaks tests:

```
packages/charts/test/chart-element.test.js:

 ❌ vaadin-chart > resize > should update chart width when container width changes
      TypeError: Cannot read properties of undefined (reading 'chartWidth')
        at n.<anonymous> (packages/charts/test/chart-element.test.js:339:38)

 ❌ vaadin-chart > resize > should update chart height when container height changes
      TypeError: Cannot read properties of undefined (reading 'chartHeight')
        at n.<anonymous> (packages/charts/test/chart-element.test.js:352:38)
```

Using `queueMicrotask` seems to follow current timings. Also it's already used on chart disconnect, see https://github.com/vaadin/web-components/pull/8117.

## Type of change

- Refactor