### PR TITLE
refactor: remove usage of afterNextRender helper in CRUD

### DIFF
--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -8,7 +8,6 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { FocusRestorationController } from '@vaadin/a11y-base/src/focus-restoration-controller.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
@@ -451,7 +450,7 @@ export const CrudMixin = (superClass) =>
         return;
       }
 
-      afterNextRender(grid, () => {
+      queueMicrotask(() => {
         Array.from(grid.querySelectorAll('vaadin-crud-edit-column')).forEach((column) => {
           column.ariaLabel = effectiveI18n.editLabel;
         });


### PR DESCRIPTION
## Description

Part of #6860

Replaced `afterNextRender()` with `queueMicrotask()` that should be enough for column element to be in the DOM.

## Type of change

- Refactor