### PR TITLE
refactor: replace Polymer mixin helper with the open-wc

### DIFF
--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { FocusMixin } from './focus-mixin.js';
 import { TabindexMixin } from './tabindex-mixin.js';
 
@@ -14,7 +14,7 @@ import { TabindexMixin } from './tabindex-mixin.js';
  * @mixes FocusMixin
  * @mixes TabindexMixin
  */
-export const DelegateFocusMixin = dedupingMixin(
+export const DelegateFocusMixin = dedupeMixin(
   (superclass) =>
     class DelegateFocusMixinClass extends FocusMixin(TabindexMixin(superclass)) {
       static get properties() {

--- a/packages/a11y-base/src/disabled-mixin.js
+++ b/packages/a11y-base/src/disabled-mixin.js
@@ -3,14 +3,14 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide disabled property for field components.
  *
  * @polymerMixin
  */
-export const DisabledMixin = dedupingMixin(
+export const DisabledMixin = dedupeMixin(
   (superclass) =>
     class DisabledMixinClass extends superclass {
       static get properties() {

--- a/packages/a11y-base/src/focus-mixin.js
+++ b/packages/a11y-base/src/focus-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { isKeyboardActive } from './focus-utils.js';
 
 /**
@@ -11,7 +11,7 @@ import { isKeyboardActive } from './focus-utils.js';
  *
  * @polymerMixin
  */
-export const FocusMixin = dedupingMixin(
+export const FocusMixin = dedupeMixin(
   (superclass) =>
     class FocusMixinClass extends superclass {
       /**

--- a/packages/a11y-base/src/keyboard-mixin.js
+++ b/packages/a11y-base/src/keyboard-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin that manages keyboard handling.
@@ -12,7 +12,7 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
  *
  * @polymerMixin
  */
-export const KeyboardMixin = dedupingMixin(
+export const KeyboardMixin = dedupeMixin(
   (superclass) =>
     class KeyboardMixinClass extends superclass {
       /** @protected */

--- a/packages/component-base/src/controller-mixin.js
+++ b/packages/component-base/src/controller-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * @typedef ReactiveController
@@ -15,7 +15,7 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
  *
  * @polymerMixin
  */
-export const ControllerMixin = dedupingMixin((superClass) => {
+export const ControllerMixin = dedupeMixin((superClass) => {
   // If the superclass extends from LitElement,
   // use its own controllers implementation.
   if (typeof superClass.prototype.addController === 'function') {

--- a/packages/component-base/src/delegate-state-mixin.js
+++ b/packages/component-base/src/delegate-state-mixin.js
@@ -3,14 +3,14 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to delegate properties and attributes to a target element.
  *
  * @polymerMixin
  */
-export const DelegateStateMixin = dedupingMixin(
+export const DelegateStateMixin = dedupeMixin(
   (superclass) =>
     class DelegateStateMixinClass extends superclass {
       static get properties() {

--- a/packages/component-base/src/resize-mixin.js
+++ b/packages/component-base/src/resize-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 const observer = new ResizeObserver((entries) => {
   setTimeout(() => {
@@ -29,7 +29,7 @@ const observer = new ResizeObserver((entries) => {
  *
  * @polymerMixin
  */
-export const ResizeMixin = dedupingMixin(
+export const ResizeMixin = dedupeMixin(
   (superclass) =>
     class ResizeMixinClass extends superclass {
       /**

--- a/packages/component-base/src/slot-styles-mixin.js
+++ b/packages/component-base/src/slot-styles-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 const stylesMap = new WeakMap();
 
@@ -42,7 +42,7 @@ function insertStyles(styles, root) {
  *
  * @polymerMixin
  */
-export const SlotStylesMixin = dedupingMixin(
+export const SlotStylesMixin = dedupeMixin(
   (superclass) =>
     class SlotStylesMixinClass extends superclass {
       /**

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
@@ -16,7 +16,7 @@ import { InputMixin } from './input-mixin.js';
  * @mixes DisabledMixin
  * @mixes InputMixin
  */
-export const CheckedMixin = dedupingMixin(
+export const CheckedMixin = dedupeMixin(
   (superclass) =>
     class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
       static get properties() {

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
 import { ValidateMixin } from './validate-mixin.js';
@@ -16,7 +16,7 @@ import { ValidateMixin } from './validate-mixin.js';
  * @mixes InputMixin
  * @mixes ValidateMixin
  */
-export const InputConstraintsMixin = dedupingMixin(
+export const InputConstraintsMixin = dedupeMixin(
   (superclass) =>
     class InputConstraintsMixinClass extends DelegateStateMixin(ValidateMixin(InputMixin(superclass))) {
       /**

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to store the reference to an input element
@@ -11,7 +11,7 @@ import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
  *
  * @polymerMixin
  */
-export const InputMixin = dedupingMixin(
+export const InputMixin = dedupeMixin(
   (superclass) =>
     class InputMixinClass extends superclass {
       static get properties() {

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { LabelController } from './label-controller.js';
 
@@ -13,7 +13,7 @@ import { LabelController } from './label-controller.js';
  * @polymerMixin
  * @mixes ControllerMixin
  */
-export const LabelMixin = dedupingMixin(
+export const LabelMixin = dedupeMixin(
   (superclass) =>
     class LabelMixinClass extends ControllerMixin(superclass) {
       static get properties() {

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -3,14 +3,14 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide required state and validation logic.
  *
  * @polymerMixin
  */
-export const ValidateMixin = dedupingMixin(
+export const ValidateMixin = dedupeMixin(
   (superclass) =>
     class ValidateMixinClass extends superclass {
       static get properties() {


### PR DESCRIPTION
## Description

Part of #6860

Replaced `dedupingMixin` helper from Polymer with an identical `dedupeMixin` from `@open-wc`.
Note: this npm package is already a dependency but until now it was only used in type definitions.

## Type of change

- Refactor