### PR TITLE
chore: do not run playwright-install for Chrome in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
-      - name: Install Playwright
-        run: npx playwright install chrome --with-deps
-
       - name: Test
         run: yarn test
   firefox:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -65,8 +65,5 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
-      - name: Install Playwright
-        run: npx playwright install chrome --with-deps
-
       - name: Test
         run: yarn test:it


### PR DESCRIPTION
## Description

I noticed that we have `npx playwright install chrome` in "Integration tests" and sometimes it takes more than 5 minutes.
This shouldn't be needed as we run against the Chrome already installed on the machine using `channel` option.

For example, Snapshot tests job doesn't have this step and tests pass there. Let's see if we can remove it.

## Type of change

- Internal change