### PR TITLE
chore: allow running visual tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,13 @@ analysis.json
 yarn-error.log
 .env
 
-# Failures from visual tests
+# Failed screenshots from Sauce Labs visual test runs
 packages/*/test/visual/screenshots/failed
 packages/*/test/visual/*/screenshots/*/failed
-packages/icons/test/visual/screenshots/failed
 
+# Screenshots from local visual test runs
 packages/*/test/visual/screenshots/local-*
 packages/*/test/visual/*/screenshots/*/local-*
-packages/icons/test/visual/screenshots/local-*
 
 # Generated Lit test files
 packages/*/test/*.generated.*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,13 @@ packages/*/test/visual/screenshots/failed
 packages/*/test/visual/*/screenshots/*/failed
 packages/icons/test/visual/screenshots/failed
 
+packages/*/test/visual/screenshots/local-*
+packages/*/test/visual/*/screenshots/*/local-*
+packages/icons/test/visual/screenshots/local-*
+packages/*/test/visual/screenshots/local-*
+packages/*/test/visual/*/screenshots/*/local-*
+packages/icons/test/visual/screenshots/local-*
+
 # Generated Lit test files
 packages/*/test/*.generated.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ packages/icons/test/visual/screenshots/failed
 packages/*/test/visual/screenshots/local-*
 packages/*/test/visual/*/screenshots/*/local-*
 packages/icons/test/visual/screenshots/local-*
-packages/*/test/visual/screenshots/local-*
-packages/*/test/visual/*/screenshots/*/local-*
-packages/icons/test/visual/screenshots/local-*
 
 # Generated Lit test files
 packages/*/test/*.generated.*

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "test:firefox": "yarn test --config web-test-runner-firefox.config.js",
     "test:it": "yarn test --config web-test-runner-it.config.js",
     "test:lumo": "yarn test --config web-test-runner-lumo.config.js",
+    "test:local:lumo": "yarn test --config web-test-runner-lumo.config.js --local",
     "test:material": "yarn test --config web-test-runner-material.config.js",
     "test:snapshots": "yarn test --config web-test-runner-snapshots.config.js",
     "test:webkit": "yarn test --config web-test-runner-webkit.config.js",
+    "update:local:lumo": "TEST_ENV=update yarn test --config web-test-runner-lumo-local.config.js --local",
     "update:lumo": "TEST_ENV=update yarn test --config web-test-runner-lumo.config.js",
     "update:material": "TEST_ENV=update yarn test --config web-test-runner-material.config.js",
     "update:snapshots": "yarn test --config web-test-runner-snapshots.config.js --update-snapshots"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:material": "yarn test --config web-test-runner-material.config.js",
     "test:snapshots": "yarn test --config web-test-runner-snapshots.config.js",
     "test:webkit": "yarn test --config web-test-runner-webkit.config.js",
-    "update:local:lumo": "TEST_ENV=update yarn test --config web-test-runner-lumo-local.config.js --local",
+    "update:local:lumo": "TEST_ENV=update yarn test --config web-test-runner-lumo.config.js --local",
     "update:lumo": "TEST_ENV=update yarn test --config web-test-runner-lumo.config.js",
     "update:material": "TEST_ENV=update yarn test --config web-test-runner-material.config.js",
     "update:snapshots": "yarn test --config web-test-runner-snapshots.config.js --update-snapshots"


### PR DESCRIPTION
## Description

The PR adds two new yarn commands: `update:local:lumo` and `test:local:lumo`. These commands let you run visual tests using the locally installed Chrome browser instead of Sauce Labs which is too slow to use during active development cycles such as the Lumo refactoring.

Example of usage:

1. Run `yarn update:local:lumo` on a reference branch (e.g., main) to generate baseline screenshots.
2. Switch to your branch and run `yarn test:local:lumo` to compare your changes against the baseline.

## Type of change

- [x] Internal
