### PR TITLE
refactor: fix accordion base styles, remove open / close transition

### DIFF
--- a/dev/accordion.html
+++ b/dev/accordion.html
@@ -25,6 +25,9 @@
       <vaadin-accordion-panel summary="Panel 3">
         <div>Panel 3 content</div>
       </vaadin-accordion-panel>
+      <vaadin-accordion-panel summary="Panel 4 (disabled)" disabled>
+        <div>Panel 4 content</div>
+      </vaadin-accordion-panel>
     </vaadin-accordion>
   </body>
 </html>

--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -35,6 +35,7 @@ export const accordionHeading = css`
     appearance: none;
     background: transparent;
     border: 0;
+    color: inherit;
     display: flex;
     font: inherit;
     gap: inherit;
@@ -68,6 +69,14 @@ export const accordionHeading = css`
     mask-image: var(--_vaadin-icon-chevron-down);
     width: var(--vaadin-icon-size, 1lh);
     rotate: -90deg;
+  }
+
+  :host([disabled]) {
+    color: var(--_vaadin-color-subtle);
+  }
+
+  :host([disabled]) [part='toggle'] {
+    opacity: 0.5;
   }
 
   :host([dir='rtl']) [part='toggle']::before {

--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -48,6 +48,13 @@ export const accordionHeading = css`
     [part='toggle'] {
       transition-property: rotate;
       transition-duration: 150ms;
+      animation: delay-initial-transition 1ms;
+    }
+
+    @keyframes delay-initial-transition {
+      0% {
+        rotate: 0deg;
+      }
     }
   }
 

--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -22,6 +22,7 @@ export const accordionHeading = css`
     outline: calc(var(--vaadin-focus-ring-width) * var(--_focus-ring, 0)) solid var(--vaadin-focus-ring-color);
     outline-offset: 1px;
     padding: var(--vaadin-accordion-heading-padding, var(--_vaadin-padding-container));
+    -webkit-tap-highlight-color: transparent;
     -webkit-user-select: none;
     user-select: none;
   }
@@ -41,6 +42,7 @@ export const accordionHeading = css`
     gap: inherit;
     outline: none;
     padding: 0;
+    touch-action: manipulation;
   }
 
   [part='toggle'] {

--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -81,4 +81,10 @@ export const accordionHeading = css`
   :host([dir='rtl'][opened]) [part='toggle'] {
     rotate: -90deg;
   }
+
+  @media (forced-colors: active) {
+    [part='toggle']::before {
+      background: CanvasText;
+    }
+  }
 `;

--- a/packages/accordion/src/vaadin-accordion-heading-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-styles.js
@@ -8,8 +8,20 @@ import { css } from 'lit';
 
 export const accordionHeading = css`
   :host {
+    background: var(--vaadin-accordion-heading-background, transparent);
+    background-origin: border-box;
+    border: var(--vaadin-accordion-heading-border, none);
+    border-radius: var(--vaadin-accordion-heading-border-radius, var(--_vaadin-radius-m));
+    box-sizing: border-box;
+    color: var(--vaadin-accordion-heading-text-color, var(--_vaadin-color-strong));
     display: block;
-    outline: none;
+    font-size: var(--vaadin-accordion-heading-font-size, inherit);
+    font-weight: var(--vaadin-accordion-heading-font-weight, 500);
+    gap: var(--vaadin-accordion-heading-gap, 0 var(--_vaadin-gap-container-inline));
+    height: var(--vaadin-accordion-heading-height, auto);
+    outline: calc(var(--vaadin-focus-ring-width) * var(--_focus-ring, 0)) solid var(--vaadin-focus-ring-color);
+    outline-offset: 1px;
+    padding: var(--vaadin-accordion-heading-padding, var(--_vaadin-padding-container));
     -webkit-user-select: none;
     user-select: none;
   }
@@ -19,25 +31,15 @@ export const accordionHeading = css`
   }
 
   button {
+    align-items: center;
     appearance: none;
-    background: var(--vaadin-accordion-heading-background, transparent);
-    background-origin: border-box;
-    border: var(--vaadin-accordion-heading-border, none);
-    border-radius: var(--vaadin-accordion-heading-border-radius, var(--_vaadin-radius-m));
-    color: var(--vaadin-accordion-heading-text-color, var(--_vaadin-color-strong));
+    background: transparent;
+    border: 0;
     display: flex;
     font: inherit;
-    font-size: var(--vaadin-accordion-heading-font-size, inherit);
-    font-weight: var(--vaadin-accordion-heading-font-weight, 500);
-    gap: var(--vaadin-accordion-heading-gap, 0 var(--_vaadin-gap-container-inline));
-    height: var(--vaadin-accordion-heading-height, auto);
-    padding: var(--vaadin-accordion-heading-padding, var(--_vaadin-padding-container));
-    width: 100%;
-  }
-
-  button:focus-visible {
-    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
-    outline-offset: 1px;
+    gap: inherit;
+    outline: none;
+    padding: 0;
   }
 
   [part='toggle'] {

--- a/packages/accordion/src/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/src/vaadin-accordion-panel-styles.js
@@ -20,7 +20,21 @@ export const accordionPanel = css`
 
   :host(:not([opened])) [part='content'] {
     content-visibility: hidden;
+    contain-intrinsic-height: auto none;
     opacity: 0;
+  }
+
+  /*
+  Safari doesn't transition content-visibility gracefully,
+  even with 'transition-behavior: allow-discrete'.
+  Let Safari transition display instead.
+  Using 'display: none' breaks the transition in Firefox.
+  */
+  @supports (font: -apple-system-body) {
+    :host(:not([opened])) [part='content'] {
+      content-visibility: initial;
+      display: none;
+    }
   }
 
   @media (prefers-reduced-motion: no-preference) {
@@ -30,7 +44,8 @@ export const accordionPanel = css`
       transition-duration: 150ms;
       grid-template-rows: min-content 0fr;
       @starting-style {
-        grid-template-rows: min-content auto;
+        /* Needed for Safari, which otherwise transitions the initial rendered state */
+        grid-template-rows: min-content 1fr;
       }
     }
 
@@ -41,7 +56,7 @@ export const accordionPanel = css`
     [part='content'] {
       transition-behavior: allow-discrete;
       transition-duration: inherit;
-      transition-property: content-visibility, opacity;
+      transition-property: display, content-visibility, opacity;
     }
   }
 

--- a/packages/accordion/src/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/src/vaadin-accordion-panel-styles.js
@@ -15,49 +15,11 @@ export const accordionPanel = css`
   }
 
   [part='content'] {
-    overflow: hidden;
+    box-sizing: border-box;
   }
 
   :host(:not([opened])) [part='content'] {
-    content-visibility: hidden;
-    contain-intrinsic-height: auto none;
-    opacity: 0;
-  }
-
-  /*
-  Safari doesn't transition content-visibility gracefully,
-  even with 'transition-behavior: allow-discrete'.
-  Let Safari transition display instead.
-  Using 'display: none' breaks the transition in Firefox.
-  */
-  @supports (font: -apple-system-body) {
-    :host(:not([opened])) [part='content'] {
-      content-visibility: initial;
-      display: none;
-    }
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    :host {
-      display: grid;
-      transition-property: grid-template-rows;
-      transition-duration: 150ms;
-      grid-template-rows: min-content 0fr;
-      @starting-style {
-        /* Needed for Safari, which otherwise transitions the initial rendered state */
-        grid-template-rows: min-content 1fr;
-      }
-    }
-
-    :host([opened]) {
-      grid-template-rows: min-content 1fr;
-    }
-
-    [part='content'] {
-      transition-behavior: allow-discrete;
-      transition-duration: inherit;
-      transition-property: display, content-visibility, opacity;
-    }
+    display: none !important;
   }
 
   :host([focus-ring]) {

--- a/packages/accordion/src/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/src/vaadin-accordion-panel-styles.js
@@ -19,22 +19,30 @@ export const accordionPanel = css`
   }
 
   :host(:not([opened])) [part='content'] {
-    display: none;
-    height: 0;
+    content-visibility: hidden;
     opacity: 0;
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    [part='content'] {
-      interpolate-size: allow-keywords;
-      transition-behavior: allow-discrete;
+    :host {
+      display: grid;
+      transition-property: grid-template-rows;
       transition-duration: 150ms;
-      transition-property: height, opacity, display;
-
+      grid-template-rows: min-content 0fr;
       @starting-style {
-        height: 0;
-        opacity: 0;
+        grid-template-rows: min-content auto;
       }
     }
+
+    :host([opened]) {
+      grid-template-rows: min-content 1fr;
+    }
+
+    [part='content'] {
+      transition-behavior: allow-discrete;
+      transition-duration: inherit;
+      transition-property: content-visibility, opacity;
+    }
+  }
   }
 `;

--- a/packages/accordion/src/vaadin-accordion-panel-styles.js
+++ b/packages/accordion/src/vaadin-accordion-panel-styles.js
@@ -44,5 +44,8 @@ export const accordionPanel = css`
       transition-property: content-visibility, opacity;
     }
   }
+
+  :host([focus-ring]) {
+    --_focus-ring: 1;
   }
 `;

--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -32,9 +32,7 @@ describe('vaadin-accordion-panel', () => {
     });
 
     it('should hide the content when opened is false', () => {
-      expect(getComputedStyle(contentPart)).to.satisfy(
-        (cs) => cs.display === 'none' || cs.contentVisibility === 'hidden',
-      );
+      expect(getComputedStyle(contentPart).display).to.equal('none');
     });
 
     it('should show the content when opened is true', async () => {

--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -32,7 +32,9 @@ describe('vaadin-accordion-panel', () => {
     });
 
     it('should hide the content when opened is false', () => {
-      expect(getComputedStyle(contentPart).display).to.equal('none');
+      expect(getComputedStyle(contentPart)).to.satisfy(
+        (cs) => cs.display === 'none' || cs.contentVisibility === 'hidden',
+      );
     });
 
     it('should show the content when opened is true', async () => {

--- a/test/integration/dialog-accordion.test.js
+++ b/test/integration/dialog-accordion.test.js
@@ -24,11 +24,6 @@ describe('accordion in dialog', () => {
             <div>Content 2</div>
           </vaadin-accordion-panel>
         </vaadin-accordion>
-        <style>
-          vaadin-accordion-panel::part(content) {
-            transition: none;
-          }
-        </style>
       `;
     };
     await nextRender();


### PR DESCRIPTION
- Move most summary/heading styles from the internal button to the host.
- Fix disabled panel styles.
- Fix forced color mode styles.
