### PR TITLE
chore: simplify getVisualTestGroups in wtr-utils.js

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -164,22 +164,14 @@ const getUnitTestGroups = (packages) => {
  */
 const getVisualTestGroups = (packages, theme) => {
   return packages
-    .filter(
-      (pkg) => !pkg.includes('icons') && !pkg.includes(theme) && !pkg.includes(theme === 'lumo' ? 'material' : 'lumo'),
-    )
+    .filter((pkg) => {
+      return !pkg.includes(theme === 'lumo' ? 'material' : 'lumo');
+    })
     .map((pkg) => {
       return {
         name: pkg,
-        files: `packages/${pkg}/test/visual/${theme}/*.test.{js,ts}`,
+        files: [`packages/${pkg}/test/visual/*.test.{js,ts}`, `packages/${pkg}/test/visual/${theme}/*.test.{js,ts}`],
       };
-    })
-    .concat({
-      name: `vaadin-${theme}-styles`,
-      files: `packages/vaadin-${theme}-styles/test/visual/*.test.{js,ts}`,
-    })
-    .concat({
-      name: `icons`,
-      files: `packages/icons/test/visual/*.test.{js,ts}`,
     });
 };
 


### PR DESCRIPTION
## Description

Simplifies the `getVisualTestGroups` helper in `wtr-utils.js`

Part of #9082 

## Type of change

- [x] Internal
