### PR TITLE
chore: use assert instead of with to support Node 18.17

### DIFF
--- a/scripts/generateReleaseNotes.js
+++ b/scripts/generateReleaseNotes.js
@@ -12,7 +12,7 @@
  */
 import { exec as execCallback } from 'node:child_process';
 import { promisify } from 'node:util';
-import lerna from '../lerna.json' with { type: 'json' };
+import lerna from '../lerna.json' assert { type: 'json' };
 
 const { version } = lerna;
 const exec = promisify(execCallback);

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'cross-spawn';
 import replace from 'replace-in-file';
-import lerna from '../lerna.json' with { type: 'json' };
+import lerna from '../lerna.json' assert { type: 'json' };
 
 const { version: oldVersion } = lerna;
 


### PR DESCRIPTION
## Description

Node 18.17, which we use in release builds, only supports an old `assert` syntax for importing json via ES modules.

Fixes regression from #9047 

## Type of change

- [x] Internal
