### PR TITLE
chore: update deprecation warning in polymer-legacy-adapter

### DIFF
--- a/packages/polymer-legacy-adapter/src/template-renderer.js
+++ b/packages/polymer-legacy-adapter/src/template-renderer.js
@@ -42,7 +42,7 @@ function showTemplateWarning(component) {
   }
 
   console.warn(
-    `WARNING: <template> inside <${component.localName}> is deprecated. Use a renderer function instead (see https://vaad.in/template-renderer)`,
+    `WARNING: <template> inside <${component.localName}> is deprecated and will be removed in Vaadin 25. Use a renderer function instead.`,
   );
 
   component.__suppressTemplateWarning = true;

--- a/packages/polymer-legacy-adapter/test/warning.test.js
+++ b/packages/polymer-legacy-adapter/test/warning.test.js
@@ -24,7 +24,7 @@ describe('warning', () => {
 
     expect(stub.calledOnce).to.be.true;
     expect(stub.args[0][0]).to.equal(
-      'WARNING: <template> inside <mock-component> is deprecated. Use a renderer function instead (see https://vaad.in/template-renderer)',
+      'WARNING: <template> inside <mock-component> is deprecated and will be removed in Vaadin 25. Use a renderer function instead.',
     );
   });
 

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -19,7 +19,7 @@ const HIDDEN_WARNINGS = [
   'The <vaadin-grid> needs the total number of items in order to display rows, which you can specify either by setting the `size` property, or by providing it to the second argument of the `dataProvider` function `callback` call.',
   'The Material theme is deprecated and will be removed in Vaadin 25.',
   /^WARNING: Since Vaadin .* is deprecated.*/u,
-  /^WARNING: <template> inside <[^>]+> is deprecated. Use a renderer function instead/u,
+  /^WARNING: <template> inside <[^>]+> is deprecated and will be removed in Vaadin 25./u,
   /Lit is in dev mode/u,
   /Overriding ReactiveElement/u,
   /Element .* scheduled an update/u,


### PR DESCRIPTION
## Description

This warning has been there for a while, let's add a mention about removal in V25.
Also removed the docs link which appears to be no longer working anyway.

## Type of change

- Internal change