### PR TITLE
refactor: rename master-detail-layout overlay mode to drawer

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout-transition-styles.js
@@ -23,43 +23,43 @@ export const transitionStyles = css`
     animation-duration: var(--vaadin-master-detail-layout-transition-duration, 300ms);
   }
 
-  /* Overlay - horizontal - add */
+  /* Drawer - horizontal - add */
 
-  vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='add']::part(detail) {
-    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-add;
+  vaadin-master-detail-layout[drawer][orientation='horizontal'][transition='add']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-drawer-horizontal-detail-add;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
+  ::view-transition-group(vaadin-master-detail-layout-drawer-horizontal-detail-add) {
     clip-path: inset(0);
   }
 
-  ::view-transition-new(vaadin-master-detail-layout-overlay-horizontal-detail-add) {
+  ::view-transition-new(vaadin-master-detail-layout-drawer-horizontal-detail-add) {
     animation: var(--vaadin-master-detail-layout-transition-duration, 300ms) ease both
-      vaadin-master-detail-layout-overlay-horizontal-detail-add;
+      vaadin-master-detail-layout-drawer-horizontal-detail-add;
   }
 
-  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-add {
+  @keyframes vaadin-master-detail-layout-drawer-horizontal-detail-add {
     from {
       transform: translateX(calc(100% * var(--_vaadin-master-detail-layout-dir-multiplier)));
     }
   }
 
-  /* Overlay - horizontal - remove */
+  /* Drawer - horizontal - remove */
 
-  vaadin-master-detail-layout[overlay][orientation='horizontal'][transition='remove']::part(detail) {
-    view-transition-name: vaadin-master-detail-layout-overlay-horizontal-detail-remove;
+  vaadin-master-detail-layout[drawer][orientation='horizontal'][transition='remove']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-drawer-horizontal-detail-remove;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+  ::view-transition-group(vaadin-master-detail-layout-drawer-horizontal-detail-remove) {
     clip-path: inset(0);
   }
 
-  ::view-transition-old(vaadin-master-detail-layout-overlay-horizontal-detail-remove) {
+  ::view-transition-old(vaadin-master-detail-layout-drawer-horizontal-detail-remove) {
     animation: var(--vaadin-master-detail-layout-transition-duration, 300ms) ease both
-      vaadin-master-detail-layout-overlay-horizontal-detail-remove;
+      vaadin-master-detail-layout-drawer-horizontal-detail-remove;
   }
 
-  @keyframes vaadin-master-detail-layout-overlay-horizontal-detail-remove {
+  @keyframes vaadin-master-detail-layout-drawer-horizontal-detail-remove {
     to {
       transform: translateX(calc(100% * var(--_vaadin-master-detail-layout-dir-multiplier)));
     }
@@ -155,43 +155,43 @@ export const transitionStyles = css`
       vaadin-master-detail-layout-stack-horizontal-remove-old;
   }
 
-  /* Overlay - vertical - add */
+  /* Drawer - vertical - add */
 
-  vaadin-master-detail-layout[overlay][orientation='vertical'][transition='add']::part(detail) {
-    view-transition-name: vaadin-master-detail-layout-overlay-vertical-detail-add;
+  vaadin-master-detail-layout[drawer][orientation='vertical'][transition='add']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-drawer-vertical-detail-add;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-overlay-vertical-detail-add) {
+  ::view-transition-group(vaadin-master-detail-layout-drawer-vertical-detail-add) {
     clip-path: inset(0);
   }
 
-  ::view-transition-new(vaadin-master-detail-layout-overlay-vertical-detail-add) {
+  ::view-transition-new(vaadin-master-detail-layout-drawer-vertical-detail-add) {
     animation: var(--vaadin-master-detail-layout-transition-duration, 300ms) ease both
-      vaadin-master-detail-layout-overlay-vertical-detail-add;
+      vaadin-master-detail-layout-drawer-vertical-detail-add;
   }
 
-  @keyframes vaadin-master-detail-layout-overlay-vertical-detail-add {
+  @keyframes vaadin-master-detail-layout-drawer-vertical-detail-add {
     from {
       transform: translateY(100%);
     }
   }
 
-  /* Overlay - vertical - remove */
+  /* Drawer - vertical - remove */
 
-  vaadin-master-detail-layout[overlay][orientation='vertical'][transition='remove']::part(detail) {
-    view-transition-name: vaadin-master-detail-layout-overlay-vertical-detail-remove;
+  vaadin-master-detail-layout[drawer][orientation='vertical'][transition='remove']::part(detail) {
+    view-transition-name: vaadin-master-detail-layout-drawer-vertical-detail-remove;
   }
 
-  ::view-transition-group(vaadin-master-detail-layout-overlay-vertical-detail-remove) {
+  ::view-transition-group(vaadin-master-detail-layout-drawer-vertical-detail-remove) {
     clip-path: inset(0);
   }
 
-  ::view-transition-old(vaadin-master-detail-layout-overlay-vertical-detail-remove) {
+  ::view-transition-old(vaadin-master-detail-layout-drawer-vertical-detail-remove) {
     animation: var(--vaadin-master-detail-layout-transition-duration, 300ms) ease both
-      vaadin-master-detail-layout-overlay-vertical-detail-remove;
+      vaadin-master-detail-layout-drawer-vertical-detail-remove;
   }
 
-  @keyframes vaadin-master-detail-layout-overlay-vertical-detail-remove {
+  @keyframes vaadin-master-detail-layout-drawer-vertical-detail-remove {
     to {
       transform: translateY(100%);
     }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -128,9 +128,9 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   containment: 'layout' | 'viewport';
 
   /**
-   * When true, the layout in the overlay mode is rendered as a "stack",
+   * When true, the layout in the overlay mode is rendered as a stack,
    * making detail area fully cover the master area. Otherwise, it is
-   * rendered as a "drawer" and has a visual backdrop.
+   * rendered as a drawer and has a visual backdrop.
    *
    * In order to enforce the stack mode, use this property together with
    * `forceOverlay` property and set both to `true`.

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -34,7 +34,7 @@ export interface MasterDetailLayoutEventMap extends HTMLElementEventMap, MasterD
  *
  * Part name      | Description
  * ---------------|----------------------
- * `backdrop`     | Backdrop covering the master area in the overlay mode
+ * `backdrop`     | Backdrop covering the master area in the drawer mode
  * `master`       | The master area
  * `detail`       | The detail area
  *
@@ -45,12 +45,12 @@ export interface MasterDetailLayoutEventMap extends HTMLElementEventMap, MasterD
  * `containment`  | Set to `layout` or `viewport` depending on the containment.
  * `orientation`  | Set to `horizontal` or `vertical` depending on the orientation.
  * `has-detail`   | Set when the detail content is provided.
- * `overlay`      | Set when the layout is using the overlay mode.
+ * `drawer`       | Set when the layout is using the drawer mode.
  * `stack`        | Set when the layout is using the stack mode.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the overlay mode.
+ * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the drawer mode.
  * @fires {CustomEvent} detail-escape-press - Fired when the user presses Escape in the detail area.
  */
 declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMixin(ElementMixin(HTMLElement)))) {
@@ -58,7 +58,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Fixed size (in CSS length units) to be set on the detail area.
    * When specified, it prevents the detail area from growing or
    * shrinking. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode.
+   * areas next to each other, the layout switches to the overlay mode:
+   * either drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} detail-size
    */
@@ -68,7 +69,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Minimum size (in CSS length units) to be set on the detail area.
    * When specified, it prevents the detail area from shrinking below
    * this size. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode.
+   * areas next to each other, the layout switches to the overlay mode:
+   * either drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} detail-min-size
    */
@@ -78,7 +80,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Fixed size (in CSS length units) to be set on the master area.
    * When specified, it prevents the master area from growing or
    * shrinking. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode.
+   * areas next to each other, the layout switches to the overlay mode:
+   * either drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} master-size
    */
@@ -88,7 +91,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Minimum size (in CSS length units) to be set on the master area.
    * When specified, it prevents the master area from shrinking below
    * this size. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode.
+   * areas next to each other, the layout switches to the overlay mode:
+   * either drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} master-min-size
    */
@@ -103,8 +107,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   orientation: 'horizontal' | 'vertical';
 
   /**
-   * When specified, forces the layout to use overlay mode, even if
-   * there is enough space for master and detail to be shown next to
+   * When specified, forces the layout to use overlay (either drawer or stack),
+   * even if there is enough space for master and detail to be shown next to
    * each other using the default (split) mode.
    *
    * In order to enforce the stack mode, use this property together with
@@ -124,7 +128,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
 
   /**
    * When true, the layout in the overlay mode is rendered as a "stack",
-   * making detail area fully cover the master area.
+   * making detail area fully cover the master area. Otherwise, it is
+   * rendered as a "drawer" and has a visual backdrop.
    *
    * In order to enforce the stack mode, use this property together with
    * `forceOverlay` property and set both to `true`.

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -58,8 +58,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Fixed size (in CSS length units) to be set on the detail area.
    * When specified, it prevents the detail area from growing or
    * shrinking. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode:
-   * either drawer or stack, depending on the `stackOverlay` property.
+   * areas next to each other, the details are shown as an overlay:
+   * either as drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} detail-size
    */
@@ -69,8 +69,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Minimum size (in CSS length units) to be set on the detail area.
    * When specified, it prevents the detail area from shrinking below
    * this size. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode:
-   * either drawer or stack, depending on the `stackOverlay` property.
+   * areas next to each other, the details are shown as an overlay:
+   * either as drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} detail-min-size
    */
@@ -80,8 +80,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Fixed size (in CSS length units) to be set on the master area.
    * When specified, it prevents the master area from growing or
    * shrinking. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode:
-   * either drawer or stack, depending on the `stackOverlay` property.
+   * areas next to each other, the details are shown as an overlay:
+   * either as drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} master-size
    */
@@ -91,8 +91,8 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
    * Minimum size (in CSS length units) to be set on the master area.
    * When specified, it prevents the master area from shrinking below
    * this size. If there is not enough space to show master and detail
-   * areas next to each other, the layout switches to the overlay mode:
-   * either drawer or stack, depending on the `stackOverlay` property.
+   * areas next to each other, the details are shown as an overlay:
+   * either as drawer or stack, depending on the `stackOverlay` property.
    *
    * @attr {string} master-min-size
    */
@@ -107,9 +107,10 @@ declare class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ThemableMix
   orientation: 'horizontal' | 'vertical';
 
   /**
-   * When specified, forces the layout to use overlay (either drawer or stack),
-   * even if there is enough space for master and detail to be shown next to
-   * each other using the default (split) mode.
+   * When specified, forces the details to be shown as an overlay
+   * (either as drawer or stack), even if there is enough space for
+   * master and detail to be shown next to each other using the default
+   * (split) mode.
    *
    * In order to enforce the stack mode, use this property together with
    * `stackOverlay` property and set both to `true`.

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -219,8 +219,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Fixed size (in CSS length units) to be set on the detail area.
        * When specified, it prevents the detail area from growing or
        * shrinking. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode:
-       * either drawer or stack, depending on the `stackOverlay` property.
+       * areas next to each other, the details are shown as an overlay:
+       * either as drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} detail-size
        */
@@ -234,8 +234,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Minimum size (in CSS length units) to be set on the detail area.
        * When specified, it prevents the detail area from shrinking below
        * this size. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode:
-       * either drawer or stack, depending on the `stackOverlay` property.
+       * areas next to each other, the details are shown as an overlay:
+       * either as drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} detail-min-size
        */
@@ -249,8 +249,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Fixed size (in CSS length units) to be set on the master area.
        * When specified, it prevents the master area from growing or
        * shrinking. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode:
-       * either drawer or stack, depending on the `stackOverlay` property.
+       * areas next to each other, the details are shown as an overlay:
+       * either as drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} master-size
        */
@@ -264,8 +264,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Minimum size (in CSS length units) to be set on the master area.
        * When specified, it prevents the master area from shrinking below
        * this size. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode:
-       * either drawer or stack, depending on the `stackOverlay` property.
+       * areas next to each other, the details are shown as an overlay:
+       * either as drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} master-min-size
        */
@@ -290,9 +290,10 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       },
 
       /**
-       * When specified, forces the layout to use overlay (either drawer or stack),
-       * even if there is enough space for master and detail to be shown next to
-       * each other using the default (split) mode.
+       * When specified, forces the details to be shown as an overlay
+       * (either as drawer or stack), even if there is enough space for
+       * master and detail to be shown next to each other using the default
+       * (split) mode.
        *
        * In order to enforce the stack mode, use this property together with
        * `stackOverlay` property and set both to `true`.

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -321,9 +321,9 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       },
 
       /**
-       * When true, the layout in the overlay mode is rendered as a "stack",
+       * When true, the layout in the overlay mode is rendered as a stack,
        * making detail area fully cover the master area. Otherwise, it is
-       * rendered as a "drawer" and has a visual backdrop.
+       * rendered as a drawer and has a visual backdrop.
        *
        * In order to enforce the stack mode, use this property together with
        * `forceOverlay` property and set both to `true`.

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -31,7 +31,7 @@ import { transitionStyles } from './vaadin-master-detail-layout-transition-style
  *
  * Part name      | Description
  * ---------------|----------------------
- * `backdrop`     | Backdrop covering the master area in the overlay mode
+ * `backdrop`     | Backdrop covering the master area in the drawer mode
  * `master`       | The master area
  * `detail`       | The detail area
  *
@@ -42,12 +42,12 @@ import { transitionStyles } from './vaadin-master-detail-layout-transition-style
  * `containment`  | Set to `layout` or `viewport` depending on the containment.
  * `orientation`  | Set to `horizontal` or `vertical` depending on the orientation.
  * `has-detail`   | Set when the detail content is provided.
- * `overlay`      | Set when the layout is using the overlay mode.
+ * `drawer`       | Set when the layout is using the drawer mode.
  * `stack`        | Set when the layout is using the stack mode.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the overlay mode.
+ * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the drawer mode.
  * @fires {CustomEvent} detail-escape-press - Fired when the user presses Escape in the detail area.
  *
  * @customElement
@@ -83,39 +83,39 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         max-width: 100%;
       }
 
-      /* Overlay mode */
-      :host(:is([overlay], [stack])) {
+      /* Drawer mode */
+      :host(:is([drawer], [stack])) {
         position: relative;
       }
 
-      :host(:is([overlay], [stack])[containment='layout']) [part='detail'],
-      :host([overlay][containment='layout']) [part='backdrop'] {
+      :host(:is([drawer], [stack])[containment='layout']) [part='detail'],
+      :host([drawer][containment='layout']) [part='backdrop'] {
         position: absolute;
       }
 
-      :host(:is([overlay], [stack])[containment='viewport']) [part='detail'],
-      :host([overlay][containment='viewport']) [part='backdrop'] {
+      :host(:is([drawer], [stack])[containment='viewport']) [part='detail'],
+      :host([drawer][containment='viewport']) [part='backdrop'] {
         position: fixed;
       }
 
-      :host([overlay][has-detail]) [part='backdrop'] {
+      :host([drawer][has-detail]) [part='backdrop'] {
         display: block;
         inset: 0;
         z-index: 1;
       }
 
-      :host(:is([overlay], [stack])) [part='detail'] {
+      :host(:is([drawer], [stack])) [part='detail'] {
         z-index: 1;
       }
 
-      :host([overlay][orientation='horizontal']) [part='detail'] {
+      :host([drawer][orientation='horizontal']) [part='detail'] {
         inset-inline-end: 0;
         height: 100%;
         width: var(--_detail-min-size, min-content);
         max-width: 100%;
       }
 
-      :host([overlay][orientation='horizontal'][containment='viewport']) [part='detail'] {
+      :host([drawer][orientation='horizontal'][containment='viewport']) [part='detail'] {
         inset-block-start: 0;
       }
 
@@ -151,11 +151,11 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       }
 
       /* Min size */
-      :host([has-master-min-size][has-detail][orientation='horizontal']:not([overlay]):not([stack])) [part='master'] {
+      :host([has-master-min-size][has-detail][orientation='horizontal']:not([drawer]):not([stack])) [part='master'] {
         min-width: var(--_master-min-size);
       }
 
-      :host([has-detail-min-size][orientation='horizontal']:not([overlay]):not([stack])) [part='detail'] {
+      :host([has-detail-min-size][orientation='horizontal']:not([drawer]):not([stack])) [part='detail'] {
         min-width: var(--_detail-min-size);
       }
 
@@ -169,17 +169,17 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         flex-direction: column;
       }
 
-      :host([orientation='vertical'][overlay]) [part='master'] {
+      :host([orientation='vertical'][drawer]) [part='master'] {
         max-height: 100%;
       }
 
-      :host([orientation='vertical'][overlay]) [part='detail'] {
+      :host([orientation='vertical'][drawer]) [part='detail'] {
         inset-block-end: 0;
         width: 100%;
         height: var(--_detail-min-size, min-content);
       }
 
-      :host([overlay][orientation='vertical'][containment='viewport']) [part='detail'] {
+      :host([drawer][orientation='vertical'][containment='viewport']) [part='detail'] {
         inset-inline-start: 0;
       }
 
@@ -193,12 +193,12 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       }
 
       /* Min size */
-      :host([has-master-min-size][orientation='vertical']:not([overlay])) [part='master'],
-      :host([has-master-min-size][orientation='vertical'][overlay]) {
+      :host([has-master-min-size][orientation='vertical']:not([drawer])) [part='master'],
+      :host([has-master-min-size][orientation='vertical'][drawer]) {
         min-height: var(--_master-min-size);
       }
 
-      :host([has-detail-min-size][orientation='vertical']:not([overlay]):not([stack])) [part='detail'] {
+      :host([has-detail-min-size][orientation='vertical']:not([drawer]):not([stack])) [part='detail'] {
         min-height: var(--_detail-min-size);
       }
 
@@ -219,7 +219,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Fixed size (in CSS length units) to be set on the detail area.
        * When specified, it prevents the detail area from growing or
        * shrinking. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode.
+       * areas next to each other, the layout switches to the overlay mode:
+       * either drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} detail-size
        */
@@ -233,7 +234,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Minimum size (in CSS length units) to be set on the detail area.
        * When specified, it prevents the detail area from shrinking below
        * this size. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode.
+       * areas next to each other, the layout switches to the overlay mode:
+       * either drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} detail-min-size
        */
@@ -247,7 +249,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Fixed size (in CSS length units) to be set on the master area.
        * When specified, it prevents the master area from growing or
        * shrinking. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode.
+       * areas next to each other, the layout switches to the overlay mode:
+       * either drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} master-size
        */
@@ -261,7 +264,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
        * Minimum size (in CSS length units) to be set on the master area.
        * When specified, it prevents the master area from shrinking below
        * this size. If there is not enough space to show master and detail
-       * areas next to each other, the layout switches to the overlay mode.
+       * areas next to each other, the layout switches to the overlay mode:
+       * either drawer or stack, depending on the `stackOverlay` property.
        *
        * @attr {string} master-min-size
        */
@@ -286,8 +290,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       },
 
       /**
-       * When specified, forces the layout to use overlay mode, even if
-       * there is enough space for master and detail to be shown next to
+       * When specified, forces the layout to use overlay (either drawer or stack),
+       * even if there is enough space for master and detail to be shown next to
        * each other using the default (split) mode.
        *
        * In order to enforce the stack mode, use this property together with
@@ -317,7 +321,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
 
       /**
        * When true, the layout in the overlay mode is rendered as a "stack",
-       * making detail area fully cover the master area.
+       * making detail area fully cover the master area. Otherwise, it is
+       * rendered as a "drawer" and has a visual backdrop.
        *
        * In order to enforce the stack mode, use this property together with
        * `forceOverlay` property and set both to `true`.
@@ -342,12 +347,12 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       },
 
       /**
-       * When true, the component uses the overlay mode. This property is read-only.
+       * When true, the component uses the drawer mode. This property is read-only.
        * @protected
        */
-      _overlay: {
+      _drawer: {
         type: Boolean,
-        attribute: 'overlay',
+        attribute: 'drawer',
         reflectToAttribute: true,
         sync: true,
       },
@@ -389,14 +394,14 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   render() {
     return html`
       <div part="backdrop" @click="${this.__onBackdropClick}"></div>
-      <div id="master" part="master" ?inert="${this._hasDetail && this._overlay && this.containment === 'layout'}">
+      <div id="master" part="master" ?inert="${this._hasDetail && this._drawer && this.containment === 'layout'}">
         <slot></slot>
       </div>
       <div
         id="detail"
         part="detail"
-        role="${this._overlay || this._stack ? 'dialog' : nothing}"
-        aria-modal="${this._overlay && this.containment === 'viewport' ? 'true' : nothing}"
+        role="${this._drawer || this._stack ? 'dialog' : nothing}"
+        aria-modal="${this._drawer && this.containment === 'viewport' ? 'true' : nothing}"
         @keydown="${this.__onDetailKeydown}"
       >
         <slot name="detail" @slotchange="${this.__onDetailSlotChange}"></slot>
@@ -412,8 +417,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
     this.__detectLayoutMode();
 
     // Move focus to the detail area when it is added to the DOM,
-    // in case if the layout is using overlay or stack mode.
-    if ((this.hasAttribute('overlay') || this.hasAttribute('stack')) && children.length > 0) {
+    // in case if the layout is using drawer or stack mode.
+    if ((this._drawer || this._stack) && children.length > 0) {
       const focusables = getFocusableElements(children[0]);
       if (focusables.length) {
         focusables[0].focus();
@@ -504,13 +509,13 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
     if (this.stackOverlay) {
       this._stack = value;
     } else {
-      this._overlay = value;
+      this._drawer = value;
     }
   }
 
   /** @private */
   __detectLayoutMode() {
-    this._overlay = false;
+    this._drawer = false;
     this._stack = false;
 
     if (this.forceOverlay) {
@@ -676,7 +681,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
 
   /**
    * @event backdrop-click
-   * Fired when the user clicks the backdrop in the overlay mode.
+   * Fired when the user clicks the backdrop in the drawer mode.
    */
 
   /**

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -23,7 +23,7 @@ describe('ARIA', () => {
     detail = layout.shadowRoot.querySelector('[part="detail"]');
   });
 
-  it('should set role to dialog on the detail part in the overlay mode', () => {
+  it('should set role to dialog on the detail part in the drawer mode', () => {
     layout.forceOverlay = true;
     expect(detail.getAttribute('role')).to.equal('dialog');
 

--- a/packages/master-detail-layout/test/drawer-mode.test.js
+++ b/packages/master-detail-layout/test/drawer-mode.test.js
@@ -9,7 +9,7 @@ window.Vaadin ||= {};
 window.Vaadin.featureFlags ||= {};
 window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
 
-describe('overlay mode', () => {
+describe('drawer mode', () => {
   let layout, master, detail, detailContent;
   let width, height;
 
@@ -36,90 +36,90 @@ describe('overlay mode', () => {
   });
 
   describe('default', () => {
-    it('should switch to the overlay when there is not enough space for both areas', async () => {
-      // Use the threshold at which the overlay mode is on by default.
+    it('should switch to the drawer mode when there is not enough space for both areas', async () => {
+      // Use the threshold at which the drawer mode is on by default.
       await setViewport({ width: 350, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
     });
 
-    it('should switch to the overlay mode if not enough space when masterSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should switch to the drawer mode if not enough space when masterSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting fixed size on the master area.
       await setViewport({ width: 400, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.masterSize = '300px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
     });
 
-    it('should switch to the overlay mode if not enough space when masterMinSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should switch to the drawer mode if not enough space when masterMinSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting fixed size on the master area.
       await setViewport({ width: 400, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.masterMinSize = '300px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
     });
 
-    it('should set detail area width in overlay mode when detailSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should set detail area width in drawer mode when detailSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting fixed size on the detail area.
       await setViewport({ width: 500, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.detailSize = '300px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
       expect(getComputedStyle(detail).width).to.equal('300px');
     });
 
-    it('should set detail area width in overlay mode when detailMinSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should set detail area width in drawer mode when detailMinSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting min size on the detail area.
       await setViewport({ width: 500, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.detailMinSize = '300px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
       expect(getComputedStyle(detail).width).to.equal('300px');
     });
 
-    it('should switch to the overlay mode when masterSize is set to 100%', async () => {
+    it('should switch to the drawer mode when masterSize is set to 100%', async () => {
       layout.masterSize = '100%';
       await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
     });
 
-    it('should switch to the overlay mode when masterMinSize is set to 100%', async () => {
+    it('should switch to the drawer mode when masterMinSize is set to 100%', async () => {
       layout.masterMinSize = '100%';
       await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
     });
 
-    it('should not overflow in the overlay mode when detailMinSize is set', async () => {
+    it('should not overflow in the drawer mode when detailMinSize is set', async () => {
       layout.masterSize = '500px';
       layout.detailMinSize = '500px';
 
@@ -129,12 +129,12 @@ describe('overlay mode', () => {
       await setViewport({ width: 480, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).width).to.equal(`${layout.offsetWidth}px`);
       expect(getComputedStyle(detail).maxWidth).to.equal('100%');
     });
 
-    it('should not overflow in the overlay mode when masterMinSize is set', async () => {
+    it('should not overflow in the drawer mode when masterMinSize is set', async () => {
       layout.masterMinSize = '500px';
       await nextResize(layout);
 
@@ -142,12 +142,12 @@ describe('overlay mode', () => {
       await setViewport({ width: 480, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(master).width).to.equal(`${layout.offsetWidth}px`);
       expect(getComputedStyle(detail).maxWidth).to.equal('100%');
     });
 
-    it('should update overlay mode when adding and removing details', async () => {
+    it('should update drawer mode when adding and removing details', async () => {
       // Start without details
       detailContent.remove();
       await nextRender();
@@ -157,13 +157,13 @@ describe('overlay mode', () => {
       await setViewport({ width: 500, height });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       // Add details
       layout.appendChild(detailContent);
       await nextRender();
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
       expect(getComputedStyle(detail).width).to.equal('300px');
 
@@ -171,35 +171,35 @@ describe('overlay mode', () => {
       detailContent.remove();
       await nextRender();
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
 
-    it('should enforce the overlay mode when forceOverlay is set to true', async () => {
+    it('should enforce the drawer mode when forceOverlay is set to true', async () => {
       layout.forceOverlay = true;
       await nextRender();
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
 
       layout.forceOverlay = false;
       await nextRender();
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
 
-    it('should preserve the overlay mode with forceOverlay after removing details', async () => {
+    it('should preserve the drawer mode with forceOverlay after removing details', async () => {
       layout.forceOverlay = true;
       await nextRender();
 
       detailContent.remove();
       await nextRender();
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
 
       layout.appendChild(detailContent);
       await nextRender();
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
     });
 
-    it('should focus detail content when adding details in the overlay mode', async () => {
+    it('should focus detail content when adding details in the drawer mode', async () => {
       // Start without details
       detailContent.remove();
       await nextRender();
@@ -223,96 +223,96 @@ describe('overlay mode', () => {
       await nextResize(layout);
     });
 
-    it('should switch to the overlay when there is not enough space for both areas', async () => {
-      // Use the threshold at which the overlay mode is on by default.
+    it('should switch to the drawer mode when there is not enough space for both areas', async () => {
+      // Use the threshold at which the drawer mode is on by default.
       await setViewport({ width: 500, height: 400 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
     });
 
-    it('should set detail area height in overlay mode when detailSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should set detail area height in drawer mode when detailSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting fixed size on the detail area.
       await setViewport({ width: 700, height: 600 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.detailSize = '250px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
       expect(getComputedStyle(detail).height).to.equal('250px');
 
       layout.detailSize = '';
       await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
 
-    it('should set detail area height in overlay mode when detailMinSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should set detail area height in drawer mode when detailMinSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting min size on the detail area.
       await setViewport({ width: 700, height: 600 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.detailMinSize = '250px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
       expect(getComputedStyle(detail).position).to.equal('absolute');
       expect(getComputedStyle(detail).height).to.equal('250px');
 
       layout.detailMinSize = '';
       await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
 
-    it('should switch to the overlay mode when masterSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should switch to the drawer mode when masterSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting fixed size on the master area.
       await setViewport({ width: 700, height: 600 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.masterSize = '450px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
 
       layout.masterSize = '';
       await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
 
-    it('should switch to the overlay mode when masterMinSize is set', async () => {
-      // Use the threshold at which the overlay mode isn't on by default,
+    it('should switch to the drawer mode when masterMinSize is set', async () => {
+      // Use the threshold at which the drawer mode isn't on by default,
       // but will be on after setting min size on the master area.
       await setViewport({ width: 700, height: 600 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.masterMinSize = '450px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
 
       layout.masterMinSize = '';
       await nextResize(layout);
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
 
-    it('should update switch to the overlay mode when both sizes are set with border', async () => {
-      // Add border to the detail area in the overlay mode.
+    it('should update switch to the drawer mode when both sizes are set with border', async () => {
+      // Add border to the detail area in the drawer mode.
       fixtureSync(`
         <style>
-          vaadin-master-detail-layout[overlay]::part(detail) {
+          vaadin-master-detail-layout[drawer]::part(detail) {
             border-top: solid 1px #ccc;
           }
         </style>
@@ -321,18 +321,18 @@ describe('overlay mode', () => {
       await setViewport({ width: 800, height: 490 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
 
       layout.masterSize = '250px';
       layout.detailMinSize = '250px';
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(layout.hasAttribute('drawer')).to.be.true;
 
       await setViewport({ width: 800, height: 600 });
       await nextResize(layout);
 
-      expect(layout.hasAttribute('overlay')).to.be.false;
+      expect(layout.hasAttribute('drawer')).to.be.false;
     });
   });
 
@@ -348,14 +348,14 @@ describe('overlay mode', () => {
 
     describe('horizontal orientation', () => {
       beforeEach(async () => {
-        // Use the threshold at which the overlay mode is on by default.
+        // Use the threshold at which the drawer mode is on by default.
         await setViewport({ width: 350, height });
         await nextResize(layout);
 
-        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(layout.hasAttribute('drawer')).to.be.true;
       });
 
-      it('should contain overlay to layout by default', () => {
+      it('should contain drawer to layout by default', () => {
         const layoutBounds = layout.getBoundingClientRect();
         const detailBounds = detail.getBoundingClientRect();
 
@@ -365,7 +365,7 @@ describe('overlay mode', () => {
         expect(detailBounds.right).to.equal(layoutBounds.right);
       });
 
-      it('should contain overlay to viewport when configured', async () => {
+      it('should contain drawer to viewport when configured', async () => {
         layout.containment = 'viewport';
         await nextRender();
 
@@ -385,11 +385,11 @@ describe('overlay mode', () => {
         layout.style.maxHeight = '500px';
         layout.parentElement.style.height = '100%';
 
-        // Use the threshold at which the overlay mode is on by default.
+        // Use the threshold at which the drawer mode is on by default.
         await setViewport({ width: 500, height: 400 });
         await nextResize(layout);
 
-        expect(layout.hasAttribute('overlay')).to.be.true;
+        expect(layout.hasAttribute('drawer')).to.be.true;
       });
 
       it('should contain overlay to layout by default', () => {

--- a/packages/master-detail-layout/test/events.test.js
+++ b/packages/master-detail-layout/test/events.test.js
@@ -29,7 +29,7 @@ describe('events', () => {
         await resetMouse();
       });
 
-      it('should fire backdrop-click event on backdrop click in overlay mode', async () => {
+      it('should fire backdrop-click event on backdrop click in drawer mode', async () => {
         layout.forceOverlay = true;
 
         const spy = sinon.spy();
@@ -60,7 +60,7 @@ describe('events', () => {
         expect(spy).to.be.calledOnce;
       });
 
-      it('should fire detail-escape-press event on pressing Escape in overlay mode', async () => {
+      it('should fire detail-escape-press event on pressing Escape in drawer mode', async () => {
         layout.forceOverlay = true;
 
         const spy = sinon.spy();

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -127,7 +127,7 @@ describe('vaadin-master-detail-layout', () => {
         await setViewport({ width: 480, height });
         await nextResize(layout);
 
-        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('drawer')).to.be.false;
         expect(layout.offsetWidth).to.equal(480);
         expect(master.offsetWidth).to.equal(layout.offsetWidth);
       });
@@ -141,7 +141,7 @@ describe('vaadin-master-detail-layout', () => {
         await setViewport({ width: 480, height });
         await nextResize(layout);
 
-        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('drawer')).to.be.false;
         expect(layout.offsetWidth).to.equal(480);
         expect(master.offsetWidth).to.equal(layout.offsetWidth);
       });

--- a/packages/master-detail-layout/test/stack-mode.test.js
+++ b/packages/master-detail-layout/test/stack-mode.test.js
@@ -38,14 +38,14 @@ describe('stack mode', () => {
     });
 
     describe('horizontal orientation', () => {
-      it('should switch from overlay to the stack mode when the stackOverlay is set', async () => {
-        // Use the threshold at which the overlay mode is on by default.
+      it('should switch from drawer to the stack mode when the stackOverlay is set', async () => {
+        // Use the threshold at which the drawer mode is on by default.
         await setViewport({ width: 350, height });
         await nextResize(layout);
 
         layout.stackOverlay = true;
 
-        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('drawer')).to.be.false;
         expect(layout.hasAttribute('stack')).to.be.true;
         expect(getComputedStyle(detail).position).to.equal('absolute');
         expect(getComputedStyle(detail).inset).to.equal('0px');
@@ -73,7 +73,7 @@ describe('stack mode', () => {
         await nextResize(layout);
 
         expect(layout.hasAttribute('stack')).to.be.true;
-        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('drawer')).to.be.false;
       });
 
       it('should not apply min-width to the detail area in the stack mode', async () => {
@@ -211,14 +211,14 @@ describe('stack mode', () => {
         layout.parentElement.style.height = '100%';
       });
 
-      it('should switch from overlay to the stack mode when the stackOverlay is set', async () => {
-        // Use the threshold at which the overlay mode is on by default.
+      it('should switch from drawer to the stack mode when the stackOverlay is set', async () => {
+        // Use the threshold at which the drawer mode is on by default.
         await setViewport({ width: 500, height: 400 });
         await nextResize(layout);
 
         layout.stackOverlay = true;
 
-        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('drawer')).to.be.false;
         expect(layout.hasAttribute('stack')).to.be.true;
         expect(getComputedStyle(detail).position).to.equal('absolute');
         expect(getComputedStyle(detail).inset).to.equal('0px');
@@ -227,13 +227,13 @@ describe('stack mode', () => {
       it('should use fixed position in the stack mode when viewport containment is used', async () => {
         layout.containment = 'viewport';
 
-        // Use the threshold at which the overlay mode is on by default.
+        // Use the threshold at which the drawer mode is on by default.
         await setViewport({ width: 500, height: 400 });
         await nextResize(layout);
 
         layout.stackOverlay = true;
 
-        expect(layout.hasAttribute('overlay')).to.be.false;
+        expect(layout.hasAttribute('drawer')).to.be.false;
         expect(layout.hasAttribute('stack')).to.be.true;
         expect(getComputedStyle(detail).position).to.equal('fixed');
         expect(getComputedStyle(detail).inset).to.equal('0px');
@@ -293,7 +293,7 @@ describe('stack mode', () => {
       await setViewport({ width: 800, height });
       await nextResize(nested);
 
-      expect(nested.hasAttribute('overlay')).to.be.false;
+      expect(nested.hasAttribute('drawer')).to.be.false;
       expect(nested.hasAttribute('stack')).to.be.false;
 
       // Stack mode

--- a/packages/master-detail-layout/theme/lumo/vaadin-master-detail-layout-styles.js
+++ b/packages/master-detail-layout/theme/lumo/vaadin-master-detail-layout-styles.js
@@ -4,23 +4,23 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-master-detail-layout',
   css`
-    :host(:is([overlay], [stack])) [part='detail'] {
+    :host(:is([drawer], [stack])) [part='detail'] {
       background-color: var(--lumo-base-color);
     }
 
-    :host([overlay]) [part='detail'] {
+    :host([drawer]) [part='detail'] {
       box-shadow: var(--lumo-box-shadow-s);
     }
 
-    :host([overlay][orientation='horizontal']) [part='detail'] {
+    :host([drawer][orientation='horizontal']) [part='detail'] {
       border-inline-start: 1px solid var(--lumo-contrast-10pct);
     }
 
-    :host([overlay][orientation='vertical']) [part='detail'] {
+    :host([drawer][orientation='vertical']) [part='detail'] {
       border-block-start: 1px solid var(--lumo-contrast-10pct);
     }
 
-    :host([overlay]) [part='backdrop'] {
+    :host([drawer]) [part='backdrop'] {
       background-color: var(--lumo-shade-20pct);
     }
   `,

--- a/packages/master-detail-layout/theme/material/vaadin-master-detail-layout-styles.js
+++ b/packages/master-detail-layout/theme/material/vaadin-master-detail-layout-styles.js
@@ -5,23 +5,23 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-master-detail-layout',
   css`
-    :host(:is([overlay], [stack])) [part='detail'] {
+    :host(:is([drawer], [stack])) [part='detail'] {
       background-color: var(--material-background-color);
     }
 
-    :host([overlay]) [part='detail'] {
+    :host([drawer]) [part='detail'] {
       box-shadow: var(--material-shadow-elevation-4dp);
     }
 
-    :host([overlay][orientation='horizontal']) [part='detail'] {
+    :host([drawer][orientation='horizontal']) [part='detail'] {
       border-inline-start: 1px solid var(--material-divider-color);
     }
 
-    :host([overlay][orientation='vertical']) [part='detail'] {
+    :host([drawer][orientation='vertical']) [part='detail'] {
       border-block-start: 1px solid var(--material-divider-color);
     }
 
-    :host([overlay]) [part='backdrop'] {
+    :host([drawer]) [part='backdrop'] {
       background-color: var(--material-secondary-background-color);
       opacity: 0.5;
     }


### PR DESCRIPTION
## Description

Based on the internal discussion, let's reconsider the naming and use `drawer` instead of the `overlay`.
Technically `drawer` and `stack` are two different types of the overlay mode, see also https://github.com/vaadin/flow-components/pull/7419.

## Type of change

- Behavior altering change