### PR TITLE
refactor: disable change-in-update warnings for Lit components

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -45,6 +45,13 @@ function getOrCreateMap(obj, name) {
 
 const PolylitMixinImplementation = (superclass) => {
   class PolylitMixinClass extends superclass {
+    // PolylitMixin, and components using it, force synchronous updates
+    // in connectedCallback and for properties that are configured to
+    // be sync. This causes Lit's `change-in-update` warning to be
+    // logged for almost every component when Lit runs in development
+    // mode. Since we intentionally force updates, disable the warning.
+    static enabledWarnings = [];
+
     static createProperty(name, options) {
       if ([String, Boolean, Number, Array].includes(options)) {
         options = {


### PR DESCRIPTION
## Description

Since we intentionally force synchronous renders in Lit-based components, let's consider dropping the warning about this resulting in inefficient rendering. Otherwise pretty much every components logs these warnings, spamming the browser console and confusing application developers whether something is wrong either with their app or our components.

Part of https://github.com/vaadin/platform/issues/7334

## Type of change

- Refactor