### PR TITLE
fix: cancel vaadin-overlay-open event when opened set to false

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -265,7 +265,7 @@ export const OverlayMixin = (superClass) =>
 
         this._animatedOpening();
 
-        requestAnimationFrame(() => {
+        this.__scheduledOpen = requestAnimationFrame(() => {
           setTimeout(() => {
             this._trapFocus();
 
@@ -279,6 +279,11 @@ export const OverlayMixin = (superClass) =>
           this._addGlobalListeners();
         }
       } else if (wasOpened) {
+        if (this.__scheduledOpen) {
+          cancelAnimationFrame(this.__scheduledOpen);
+          this.__scheduledOpen = null;
+        }
+
         this._resetFocus();
 
         this._animatedClosing();

--- a/packages/overlay/test/basic.test.js
+++ b/packages/overlay/test/basic.test.js
@@ -1,10 +1,42 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, isIOS, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, isIOS, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('vaadin-overlay', () => {
+  describe('vaadin-overlay-open event', () => {
+    let overlay, spy;
+
+    beforeEach(() => {
+      overlay = fixtureSync('<vaadin-overlay></vaadin-overlay>');
+      overlay.renderer = (root) => {
+        root.textContent = 'overlay content';
+      };
+      spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-open', spy);
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should fire when after a delay when setting opened property to true', async () => {
+      overlay.opened = true;
+      await nextFrame();
+      await aTimeout(0);
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should not fire when immediately setting opened property back to false', async () => {
+      overlay.opened = true;
+      overlay.opened = false;
+      await nextFrame();
+      await aTimeout(0);
+      expect(spy).to.not.be.called;
+    });
+  });
+
   describe('moving overlay', () => {
     let parent, overlay;
 


### PR DESCRIPTION
## Description

This should prevent some errors in tests where `opened` is changed to `true` and back to `false`, for example:

```
packages/date-time-picker/test/value-commit-lit.generated.test.js:
 🚧 Browser logs:
      Error: [object HTMLInputElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
      Error: [object HTMLElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
      Error: [object HTMLInputElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
      Error: [object HTMLElement] is not contained inside [object HTMLBodyElement]. Skip setting aria-hidden.
```

## Type of change

- Bugfix