### PR TITLE
refactor: suppress Lit warnings about overriding static methods

### DIFF
--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -75,6 +75,13 @@ const PolylitMixinImplementation = (superclass) => {
      * @override
      */
     static finalize() {
+      // Suppress warnings about deprecated overriding ReactiveElement methods
+      // as the mixin requires those. See https://github.com/lit/lit/pull/4901
+      if (window.litIssuedWarnings) {
+        window.litIssuedWarnings.add('no-override-create-property');
+        window.litIssuedWarnings.add('no-override-get-property-descriptor');
+      }
+
       super.finalize();
 
       if (Array.isArray(this.observers)) {

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -21,7 +21,6 @@ const HIDDEN_WARNINGS = [
   /^WARNING: Since Vaadin .* is deprecated.*/u,
   /^WARNING: <template> inside <[^>]+> is deprecated and will be removed in Vaadin 25./u,
   /Lit is in dev mode/u,
-  /Overriding ReactiveElement/u,
 ];
 
 const filterBrowserLogs = (log) => {


### PR DESCRIPTION
## Description

Thanks to https://github.com/lit/lit/pull/4901 landed in Lit `3.3.0` it's now possible to suppress some warnings.
Let's set flags to prevent warnings that are caused by the structure of `PolylitMixin`:

```
Overriding ReactiveElement.createProperty() is deprecated. The override will not be called with standard decorators See https://lit.dev/msg/no-override-create-property for more information.
Overriding ReactiveElement.getPropertyDescriptor() is deprecated. The override will not be called with standard decorators See https://lit.dev/msg/no-override-get-property-descriptor for more information.
```

## Type of change

- Refactor