### PR TITLE
test: replace Polymer based fixture elements in context-menu tests

### DIFF
--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -4,11 +4,12 @@ import sinon from 'sinon';
 import '../src/vaadin-context-menu.js';
 import '@vaadin/item/src/vaadin-item.js';
 import '@vaadin/list-box/src/vaadin-list-box.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-class XFoo extends PolymerElement {
-  static get template() {
-    return html`
+class XFoo extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
       <div id="wrapper">
         <div id="content"></div>
       </div>
@@ -19,7 +20,7 @@ class XFoo extends PolymerElement {
 customElements.define('x-foo', XFoo);
 
 describe('context', () => {
-  let menu, foo, target, another;
+  let menu, foo, fooContent, target, another;
 
   beforeEach(async () => {
     menu = fixtureSync(`
@@ -40,6 +41,7 @@ describe('context', () => {
     };
     await nextRender();
     foo = document.querySelector('x-foo');
+    fooContent = foo.shadowRoot.querySelector('#content');
     target = document.querySelector('#target');
     another = document.querySelector('#another');
   });
@@ -68,14 +70,14 @@ describe('context', () => {
   });
 
   it('should use local target when targeting inside shadow root', () => {
-    fire(foo.$.content, 'contextmenu');
+    fire(fooContent, 'contextmenu');
 
     expect(menu._context.target).to.eql(foo);
   });
 
   it('should not penetrate shadow root to change context', () => {
     menu.selector = '#content';
-    fire(foo.$.content, 'contextmenu');
+    fire(fooContent, 'contextmenu');
 
     expect(menu._context.target).to.be.undefined;
   });
@@ -89,14 +91,14 @@ describe('context', () => {
 
   it('should not open if no context available', () => {
     menu.selector = 'foobar';
-    fire(foo.$.content, 'contextmenu');
+    fire(fooContent, 'contextmenu');
 
     expect(menu.opened).to.eql(false);
   });
 
   it('should not prevent default if no context available', () => {
     menu.selector = 'foobar';
-    const evt = fire(foo.$.content, 'contextmenu');
+    const evt = fire(fooContent, 'contextmenu');
 
     expect(evt.defaultPrevented).to.eql(false);
   });

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -1,39 +1,25 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, isIOS, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-context-menu.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-
-class MenuWrapper extends PolymerElement {
-  static get template() {
-    return html`
-      <vaadin-context-menu id="menu" renderer="[[_renderer]]"></vaadin-context-menu>
-      <button on-click="_showMenu" id="button" style="margin: 20px">Show context menu</button>
-    `;
-  }
-
-  constructor() {
-    super();
-
-    this._renderer = (root) => {
-      root.textContent = 'foo';
-    };
-  }
-
-  _showMenu(e) {
-    this.$.menu.open(e);
-  }
-}
-
-customElements.define('menu-wrapper', MenuWrapper);
 
 describe('integration', () => {
   let wrapper, menu, button, overlay;
 
   beforeEach(async () => {
-    wrapper = fixtureSync('<menu-wrapper></menu-wrapper>');
+    wrapper = fixtureSync(`
+      <div>
+        <vaadin-context-menu></vaadin-context-menu>
+        <button style="margin: 20px">Show context menu</button>
+      </div>
+    `);
     await nextRender();
-    menu = wrapper.$.menu;
-    button = wrapper.$.button;
+    [menu, button] = wrapper.children;
+    menu.renderer = (root) => {
+      root.textContent = 'foo';
+    };
+    button.addEventListener('click', (e) => {
+      menu.open(e);
+    });
     overlay = menu._overlayElement;
   });
 

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -13,37 +13,22 @@ import {
 import sinon from 'sinon';
 import './context-menu-test-styles.js';
 import '../src/vaadin-context-menu.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { gestures } from '@vaadin/component-base/src/gestures.js';
-
-class MenuTouchWrapper extends PolymerElement {
-  static get template() {
-    return html`
-      <vaadin-context-menu selector="#target" id="menu" renderer="[[_renderer]]">
-        <div id="target">Target</div>
-      </vaadin-context-menu>
-    `;
-  }
-
-  constructor() {
-    super();
-
-    this._renderer = (root) => {
-      root.innerHTML = '<div>Menu Content</div>';
-    };
-  }
-}
-
-customElements.define('menu-touch-wrapper', MenuTouchWrapper);
 
 describe('mobile support', () => {
   let menu, target;
 
   beforeEach(async () => {
-    const testWrapper = fixtureSync('<menu-touch-wrapper></menu-touch-wrapper>');
+    menu = fixtureSync(`
+      <vaadin-context-menu selector="#target">
+        <div id="target">Target</div>
+      </vaadin-context-menu>
+    `);
     await nextRender();
-    menu = testWrapper.$.menu;
     target = menu.querySelector('#target');
+    menu.renderer = (root) => {
+      root.innerHTML = '<div>Menu Content</div>';
+    };
     menu._phone = true;
   });
 


### PR DESCRIPTION
## Description

Replaced usage of `PolymerElement` in context-menu tests and inlined some fixtures.

## Type of change

- Test