### PR TITLE
test: replace Polymer based fixture elements in grid tests

### DIFF
--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../all-imports.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
   getBodyCellContent,
@@ -13,52 +12,30 @@ import {
   infiniteDataProvider,
 } from './helpers.js';
 
-class GridContainer extends PolymerElement {
-  static get template() {
-    return html`
-      <vaadin-grid id="grid" size="10">
-        <vaadin-grid-column-group header="group header1">
-          <vaadin-grid-column
-            header="header1"
-            footerRenderer="[[footerRenderer1]]"
-            renderer="[[cellRenderer]]"
-          ></vaadin-grid-column>
-
-          <vaadin-grid-column
-            header="header2"
-            footerRenderer="[[footerRenderer2]]"
-            renderer="[[cellRenderer]]"
-          ></vaadin-grid-column>
-        </vaadin-grid-column-group>
-
-        <vaadin-grid-column id="emptycolumn"></vaadin-grid-column>
-      </vaadin-grid>
-    `;
-  }
-
-  footerRenderer1(root) {
-    root.textContent = 'footer1';
-  }
-
-  footerRenderer2(root) {
-    root.textContent = 'footer2';
-  }
-
-  cellRenderer(root) {
-    root.textContent = 'cell';
-  }
-}
-
-customElements.define('grid-container', GridContainer);
-
 describe('column', () => {
-  let container, column, grid, emptyColumn;
+  let grid, columns, column, emptyColumn;
 
   beforeEach(() => {
-    container = fixtureSync('<grid-container></grid-container>');
-    grid = container.$.grid;
+    grid = fixtureSync(`
+      <vaadin-grid id="grid" size="10">
+        <vaadin-grid-column-group header="group header1">
+          <vaadin-grid-column header="header1"></vaadin-grid-column>
+          <vaadin-grid-column header="header2"></vaadin-grid-column>
+        </vaadin-grid-column-group>
+        <vaadin-grid-column id="emptycolumn"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
     grid.dataProvider = infiniteDataProvider;
-    column = grid.querySelector('vaadin-grid-column');
+    columns = [...grid.querySelectorAll('vaadin-grid-column[header]')];
+    columns.forEach((col, i) => {
+      col.renderer = (root) => {
+        root.textContent = 'cell';
+      };
+      col.footerRenderer = (root) => {
+        root.textContent = `footer${i + 1}`;
+      };
+    });
+    column = columns[0];
     emptyColumn = grid.querySelector('#emptycolumn');
     flushGrid(grid);
   });

--- a/packages/grid/test/light-dom-observing.test.js
+++ b/packages/grid/test/light-dom-observing.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../all-imports.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   attributeRenderer,
   flushGrid,
@@ -14,34 +13,38 @@ import {
   scrollToEnd,
 } from './helpers.js';
 
-class GridWrapper extends PolymerElement {
-  static get template() {
-    return html`
+class GridWrapper extends HTMLElement {
+  constructor() {
+    super();
+
+    this.attachShadow({ mode: 'open' });
+
+    this.shadowRoot.innerHTML = `
       <vaadin-grid id="grid" size="10">
         <slot name="grid"></slot>
-        <vaadin-grid-column-group header="wrapper group header" footerRenderer="[[groupFooterRenderer]]">
+        <vaadin-grid-column-group header="wrapper group header">
           <slot name="group"></slot>
 
           <vaadin-grid-column
             header="wrapper column header"
-            footerRenderer="[[columnFooterRenderer]]"
-            renderer="[[columnRenderer]]"
           ></vaadin-grid-column>
         </vaadin-grid-column-group>
       </vaadin-grid>
     `;
-  }
 
-  groupFooterRenderer(root) {
-    root.textContent = 'wrapper group footer';
-  }
+    const group = this.shadowRoot.querySelector('vaadin-grid-column-group');
+    group.footerRenderer = (root) => {
+      root.textContent = 'wrapper group footer';
+    };
 
-  columnFooterRenderer(root, _column) {
-    root.textContent = 'wrapper column footer';
-  }
+    const column = group.querySelector('vaadin-grid-column');
+    column.footerRenderer = (root) => {
+      root.textContent = 'wrapper column footer';
+    };
 
-  columnRenderer(root, _column, model) {
-    root.textContent = `wrapper column body${model.item.value}`;
+    column.renderer = (root, _column, model) => {
+      root.textContent = `wrapper column body${model.item.value}`;
+    };
   }
 }
 
@@ -339,7 +342,7 @@ describe('light dom observing', () => {
               column.footerRenderer = attributeRenderer('footer');
             });
 
-            grid = wrapper.$.grid;
+            grid = wrapper.shadowRoot.querySelector('vaadin-grid');
 
             grid.dataProvider = infiniteDataProvider;
           });
@@ -402,7 +405,7 @@ describe('light dom observing', () => {
               group.footerRenderer = attributeRenderer('footer');
             });
 
-            grid = wrapper.$.grid;
+            grid = wrapper.shadowRoot.querySelector('vaadin-grid');
 
             grid.dataProvider = infiniteDataProvider;
 

--- a/packages/grid/test/resizing.test.js
+++ b/packages/grid/test/resizing.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../all-imports.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   flushGrid,
   getContainerCellContent,
@@ -15,44 +14,28 @@ import {
   scrollToEnd,
 } from './helpers.js';
 
-class TestComponent extends PolymerElement {
-  static get template() {
-    return html`
-      <style>
-        :host {
-          display: block;
-        }
-      </style>
-
-      <vaadin-grid id="grid" style="width: 200px; height: 400px;" size="10" hidden>
-        <vaadin-grid-column id="column" header="header"></vaadin-grid-column>
-      </vaadin-grid>
-    `;
-  }
-
-  ready() {
-    super.ready();
-
-    this.$.grid.rowDetailsRenderer = (root, _, model) => {
-      root.textContent = model.index;
-    };
-    this.$.column.renderer = (root, _, model) => {
-      root.textContent = model.index;
-    };
-    this.$.column.footerRenderer = (root) => {
-      root.textContent = 'footer';
-    };
-  }
-}
-
-customElements.define('test-component', TestComponent);
-
 describe('resizing', () => {
-  let component, grid;
+  let component, grid, column;
 
   beforeEach(async () => {
-    component = fixtureSync('<test-component></test-component>');
-    grid = component.$.grid;
+    component = fixtureSync(`
+      <div>
+        <vaadin-grid id="grid" style="width: 200px; height: 400px;" size="10" hidden>
+          <vaadin-grid-column id="column" header="header"></vaadin-grid-column>
+        </vaadin-grid>
+      </div>
+    `);
+    grid = component.firstElementChild;
+    grid.rowDetailsRenderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
+    column = grid.querySelector('vaadin-grid-column');
+    column.renderer = (root, _, model) => {
+      root.textContent = model.index;
+    };
+    column.footerRenderer = (root) => {
+      root.textContent = 'footer';
+    };
     grid.dataProvider = infiniteDataProvider;
     await nextFrame();
     grid.hidden = false;
@@ -120,7 +103,7 @@ describe('resizing', () => {
   it('should have correct layout after column width change', async () => {
     grid.style.height = '';
     grid.allRowsVisible = true;
-    grid.querySelector('vaadin-grid-column').width = '300px';
+    column.width = '300px';
     // Before next render
     await nextFrame();
     // After next render

--- a/packages/grid/test/row-details.test.js
+++ b/packages/grid/test/row-details.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, click, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-grid.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import {
   buildDataSet,
   flushGrid,
@@ -22,26 +21,6 @@ function simpleDetailsRenderer(root, _, { index }) {
 function indexRenderer(root, _, { index }) {
   root.textContent = index;
 }
-
-class GridDetailsWrapper extends PolymerElement {
-  static get template() {
-    return html`
-      <vaadin-grid id="grid" style="width: 50px; height: 400px" row-details-renderer="[[rowDetailsRenderer]]">
-        <vaadin-grid-column renderer="[[renderer]]"></vaadin-grid-column>
-      </vaadin-grid>
-    `;
-  }
-
-  rowDetailsRenderer(root, _, model) {
-    simpleDetailsRenderer(root, _, model);
-  }
-
-  renderer(root, _, model) {
-    indexRenderer(root, _, model);
-  }
-}
-
-customElements.define('grid-details-wrapper', GridDetailsWrapper);
 
 describe('row details', () => {
   let grid;
@@ -219,31 +198,6 @@ describe('row details', () => {
       grid.renderer.args.forEach(([_root, _owner, model]) => {
         expect(model.detailsOpened).to.be.false;
       });
-    });
-  });
-
-  describe('inside a parent scope', () => {
-    let container;
-
-    beforeEach(() => {
-      container = fixtureSync('<grid-details-wrapper></grid-details-wrapper>');
-      grid = container.$.grid;
-      grid.items = ['foo', 'bar', 'baz'];
-      flushGrid(grid);
-      bodyRows = getRows(grid.$.items);
-    });
-
-    it('should have the correct index on details', () => {
-      // Open details for item 0
-      grid.openItemDetails('foo');
-
-      // Open details for item 1
-      grid.openItemDetails('bar');
-
-      const firstRowCells = getRowCells(bodyRows[0]);
-      const secondRowCells = getRowCells(bodyRows[1]);
-      expect(getCellContent(firstRowCells[1]).textContent.trim()).to.equal('0-details');
-      expect(getCellContent(secondRowCells[1]).textContent.trim()).to.equal('1-details');
     });
   });
 


### PR DESCRIPTION
## Description

Replaced usage of `PolymerElement` in context-menu tests and inlined some fixtures.

Also removed one test which was added in https://github.com/vaadin/vaadin-grid/pull/840 and was specific to the `<template>` logic - it's no longer relevant since https://github.com/vaadin/web-components/pull/5473. Also we have other test "should render the details" checking for `textContent`.

## Type of change

- Test