### PR TITLE
test: simplify date-time-picker i18n tests to not use Polymer

### DIFF
--- a/packages/date-time-picker/test/i18n.test.js
+++ b/packages/date-time-picker/test/i18n.test.js
@@ -1,88 +1,33 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-date-time-picker.js';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { formatISOTime, parseISOTime } from '@vaadin/time-picker/src/vaadin-time-picker-helper.js';
-
-customElements.define(
-  'dtp-i18n-default',
-  class extends PolymerElement {
-    static get template() {
-      return html`<vaadin-date-time-picker id="dateTimePicker" i18n="[[i18n]]"></vaadin-date-time-picker>`;
-    }
-
-    static get properties() {
-      return {
-        i18n: {
-          type: Object,
-          value: () => {
-            return {
-              cancel: 'Peruuta', // For date picker
-
-              // formatTime and parseTime are needed so that time picker doesn't throw errors on init
-              formatTime: formatISOTime,
-              parseTime: parseISOTime,
-            };
-          },
-        },
-      };
-    }
-  },
-);
-
-customElements.define(
-  'dtp-i18n-slotted',
-  class extends PolymerElement {
-    static get template() {
-      return html`
-        <vaadin-date-time-picker id="dateTimePicker">
-          <vaadin-date-picker slot="date-picker" i18n="[[dpI18n]]"></vaadin-date-picker>
-          <vaadin-time-picker slot="time-picker" i18n="[[tpI18n]]"></vaadin-time-picker>
-        </vaadin-date-time-picker>
-      `;
-    }
-
-    static get properties() {
-      return {
-        dpI18n: {
-          type: Object,
-          value: () => {
-            return {
-              cancel: 'Peruuta',
-            };
-          },
-        },
-        tpI18n: {
-          type: Object,
-          value: () => {
-            return {
-              formatTime: formatISOTime,
-              parseTime: parseISOTime,
-            };
-          },
-        },
-      };
-    }
-  },
-);
 
 ['default', 'slotted'].forEach((set) => {
   describe(`i18n property (${set})`, () => {
-    let dateTimePicker;
-    let datePicker;
+    let dateTimePicker, datePicker;
 
-    // No need for "beforeEach" to recreate the fixture before every test since these tests do not
-    // modify the state but only check the initial state.
-    before(async () => {
-      const element = fixtureSync(`<dtp-i18n-${set}></dtp-i18n-${set}>`);
+    const CUSTOM_I18N = { cancel: 'Peruuta' };
+
+    beforeEach(async () => {
+      const i18nProp = JSON.stringify(CUSTOM_I18N);
+
+      if (set === 'default') {
+        dateTimePicker = fixtureSync(`<vaadin-date-time-picker i18n='${i18nProp}'></vaadin-date-time-picker>`);
+      } else {
+        dateTimePicker = fixtureSync(`
+          <vaadin-date-time-picker>
+            <vaadin-date-picker slot="date-picker" i18n='${i18nProp}'></vaadin-date-picker>
+            <vaadin-time-picker slot="time-picker"></vaadin-time-picker>
+          </vaadin-date-time-picker>
+        `);
+      }
       await nextRender();
-      dateTimePicker = element.$.dateTimePicker;
       datePicker = dateTimePicker.querySelector('[slot="date-picker"]');
     });
 
     it('should have initial value for i18n', () => {
-      expect(dateTimePicker.i18n).to.have.property('cancel', 'Peruuta');
-      expect(datePicker.i18n).to.have.property('cancel', 'Peruuta');
+      expect(dateTimePicker.i18n).to.have.property('cancel', CUSTOM_I18N.cancel);
+      expect(datePicker.i18n).to.have.property('cancel', CUSTOM_I18N.cancel);
     });
   });
 });


### PR DESCRIPTION
## Description

Replaced date-time-picker `i18n` tests to not use Polymer fixtures and instead set custom `i18n` via template.
Setting `i18n` on the time-picker seems no longer needed - tests pass without it, and don't check for it either.

## Type of change

- Test