### PR TITLE
refactor: update tabindex logic to work with Lit, add sync: true

### DIFF
--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -42,6 +42,7 @@ export const DelegateFocusMixin = dedupeMixin(
             type: Object,
             readOnly: true,
             observer: '_focusElementChanged',
+            sync: true,
           },
 
           /**
@@ -227,6 +228,11 @@ export const DelegateFocusMixin = dedupeMixin(
             this._lastTabIndex = tabindex;
           }
           this.tabindex = undefined;
+        }
+
+        // Lit does not remove attribute when setting property to undefined
+        if (tabindex === undefined && this.hasAttribute('tabindex')) {
+          this.removeAttribute('tabindex');
         }
       }
     },

--- a/packages/a11y-base/src/tabindex-mixin.js
+++ b/packages/a11y-base/src/tabindex-mixin.js
@@ -27,6 +27,7 @@ export const TabindexMixin = (superclass) =>
           type: Number,
           reflectToAttribute: true,
           observer: '_tabindexChanged',
+          sync: true,
         },
 
         /**
@@ -60,9 +61,13 @@ export const TabindexMixin = (superclass) =>
         if (this.tabindex !== undefined) {
           this._lastTabIndex = this.tabindex;
         }
-        this.tabindex = -1;
+        this.setAttribute('tabindex', '-1');
       } else if (oldDisabled) {
-        this.tabindex = this._lastTabIndex;
+        if (this._lastTabIndex !== undefined) {
+          this.setAttribute('tabindex', this._lastTabIndex);
+        } else {
+          this.tabindex = undefined;
+        }
       }
     }
 
@@ -80,7 +85,7 @@ export const TabindexMixin = (superclass) =>
 
       if (this.disabled && tabindex !== -1) {
         this._lastTabIndex = tabindex;
-        this.tabindex = -1;
+        this.setAttribute('tabindex', '-1');
       }
     }
 

--- a/packages/a11y-base/test/tabindex-mixin.test.js
+++ b/packages/a11y-base/test/tabindex-mixin.test.js
@@ -1,23 +1,21 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { TabindexMixin } from '../src/tabindex-mixin.js';
 
-customElements.define(
-  'tabindex-mixin-element',
-  class extends TabindexMixin(PolymerElement) {
-    static get template() {
-      return html`<div></div>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'tabindex-mixin',
+    '<slot></slot>',
+    (Base) => class extends TabindexMixin(baseMixin(Base)) {},
+  );
 
-describe('tabindex-mixin', () => {
   let element;
 
   describe('default', () => {
     beforeEach(() => {
-      element = fixtureSync(`<tabindex-mixin-element></tabindex-mixin-element>`);
+      element = fixtureSync(`<${tag}></${tag}>`);
     });
 
     it('should not have tabindex attribute by default', () => {
@@ -84,11 +82,19 @@ describe('tabindex-mixin', () => {
 
   describe('custom', () => {
     beforeEach(() => {
-      element = fixtureSync(`<tabindex-mixin-element tabindex="1"></tabindex-mixin-element>`);
+      element = fixtureSync(`<${tag} tabindex="1"></${tag}>`);
     });
 
     it('should set tabindex property to the custom value', () => {
       expect(element.tabindex).to.equal(1);
     });
   });
+};
+
+describe('TabindexMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('TabindexMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });


### PR DESCRIPTION
## Description

These two mixins currently have some complexity due to `tabindex` property being used. In case of Lit, it can go out of sync with the native `tabIndex` so it requires calling `setAttribute()` to make sure removing / restoring attribute works.

Maybe we can try replacing `tabindex` when switching to Lit. The fact that lowercase property is used is most probably related to the Polymer limitation where `reflectToAttribute` would convert camel-cased property to dash-case attribute.
IMO it should be possible to use `attribute: 'tabindex'` plus a custom converter to handle setting values correctly.

## Type of change

- Refactor