### PR TITLE
test: update remaining a11y-base tests to also run with Lit

### DIFF
--- a/packages/a11y-base/test/active-mixin.test.js
+++ b/packages/a11y-base/test/active-mixin.test.js
@@ -1,28 +1,30 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync, isIOS, mousedown, mouseup, touchend, touchstart } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import {
+  defineLit,
+  definePolymer,
+  fixtureSync,
+  mousedown,
+  mouseup,
+  touchend,
+  touchstart,
+} from '@vaadin/testing-helpers';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ActiveMixin } from '../src/active-mixin.js';
 
-customElements.define(
-  'active-mixin-element',
-  class extends ActiveMixin(PolymerElement) {
-    static get template() {
-      return html`<div></div>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper('active-mixin', '<slot></slot>', (Base) => class extends ActiveMixin(baseMixin(Base)) {});
 
-describe('active-mixin', () => {
   let element;
 
   beforeEach(() => {
     // Sets tabindex to 0 in order to make the element focusable for the time of testing.
-    element = fixtureSync(`<active-mixin-element tabindex="0"></active-mixin-element>`);
+    element = fixtureSync(`<${tag} tabindex="0"></{tag}>`);
     element.focus();
   });
 
-  (isIOS ? describe.skip : describe)('mouse', () => {
+  describe('mouse', () => {
     it('should set active attribute on mousedown', () => {
       mousedown(element);
       expect(element.hasAttribute('active')).to.be.true;
@@ -119,4 +121,12 @@ describe('active-mixin', () => {
     element.parentNode.removeChild(element);
     expect(element.hasAttribute('active')).to.be.false;
   });
+};
+
+describe('ActiveMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('ActiveMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/focus-mixin.test.js
+++ b/packages/a11y-base/test/focus-mixin.test.js
@@ -1,28 +1,35 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, focusin, focusout, keyDownOn, mousedown } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import {
+  defineLit,
+  definePolymer,
+  fixtureSync,
+  focusin,
+  focusout,
+  keyDownOn,
+  mousedown,
+} from '@vaadin/testing-helpers';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FocusMixin } from '../src/focus-mixin.js';
 
-customElements.define(
-  'focus-mixin-element',
-  class extends FocusMixin(PolymerElement) {
-    static get template() {
-      return html`<slot></slot>`;
-    }
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'focus-mixin',
+    '<slot></slot>',
+    (Base) =>
+      class extends FocusMixin(baseMixin(Base)) {
+        ready() {
+          super.ready();
+          const input = document.createElement('input');
+          this.appendChild(input);
+        }
+      },
+  );
 
-    ready() {
-      super.ready();
-      const input = document.createElement('input');
-      this.appendChild(input);
-    }
-  },
-);
-
-describe('focus-mixin', () => {
   let element, input;
 
   beforeEach(() => {
-    element = fixtureSync(`<focus-mixin-element></focus-mixin-element>`);
+    element = fixtureSync(`<${tag}></${tag}>`);
     input = element.querySelector('input');
   });
 
@@ -58,4 +65,12 @@ describe('focus-mixin', () => {
     focusin(input);
     expect(element.hasAttribute('focus-ring')).to.be.false;
   });
+};
+
+describe('FocusMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('FocusMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -1,56 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FocusTrapController } from '../src/focus-trap-controller.js';
-
-customElements.define(
-  'focus-trap-wrapper',
-  class FocusTrapWrapper extends ControllerMixin(PolymerElement) {
-    static get template() {
-      return html`<slot></slot>`;
-    }
-
-    ready() {
-      super.ready();
-      this.innerHTML = `
-        <div id="outer-trap">
-          <focus-trap-element></focus-trap-element>
-        </div>
-      `;
-    }
-  },
-);
-
-customElements.define(
-  'focus-trap-element',
-  class FocusTrapElement extends ControllerMixin(PolymerElement) {
-    static get template() {
-      return html`<slot></slot>`;
-    }
-
-    ready() {
-      super.ready();
-      this.innerHTML = `
-        <div id="outside">
-          <input id="outside-input-1" />
-
-          <div id="trap">
-            <input id="trap-input-1" />
-            <input id="trap-input-2" />
-            <div id="parent">
-              <textarea id="trap-input-3"></textarea>
-            </div>
-          </div>
-
-          <input id="outside-input-2" />
-        </div>
-      `;
-    }
-  },
-);
 
 async function tab() {
   await sendKeys({ press: 'Tab' });
@@ -62,12 +16,54 @@ async function shiftTab() {
   return document.activeElement;
 }
 
-describe('focus-trap-controller', () => {
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'focus-trap',
+    '<slot></slot>',
+    (Base) =>
+      class extends baseMixin(Base) {
+        ready() {
+          super.ready();
+          this.innerHTML = `
+            <div id="outside">
+              <input id="outside-input-1" />
+
+              <div id="trap">
+                <input id="trap-input-1" />
+                <input id="trap-input-2" />
+                <div id="parent">
+                  <textarea id="trap-input-3"></textarea>
+                </div>
+              </div>
+
+              <input id="outside-input-2" />
+            </div>
+          `;
+        }
+      },
+  );
+
+  const wrapperTag = defineHelper(
+    'focus-trap-wrapper',
+    '<slot></slot>',
+    (Base) =>
+      class extends baseMixin(Base) {
+        ready() {
+          super.ready();
+          this.innerHTML = `
+            <div id="outer-trap">
+              <${tag}></${tag}>
+            </div>
+          `;
+        }
+      },
+  );
+
   let element, controller, trap;
 
   describe('trapFocus', () => {
     beforeEach(() => {
-      element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new FocusTrapController(element);
       element.addController(controller);
       trap = element.querySelector('#trap');
@@ -130,7 +126,7 @@ describe('focus-trap-controller', () => {
 
   describe('releaseFocus', () => {
     beforeEach(() => {
-      element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new FocusTrapController(element);
       element.addController(controller);
       trap = element.querySelector('#trap');
@@ -145,7 +141,7 @@ describe('focus-trap-controller', () => {
     let trapInput1, trapInput2, trapInput3;
 
     beforeEach(() => {
-      element = fixtureSync(`<focus-trap-element></focus-trap-element>`);
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new FocusTrapController(element);
       element.addController(controller);
       trap = element.querySelector('#trap');
@@ -313,12 +309,12 @@ describe('focus-trap-controller', () => {
     let wrapper, wrapperController, wrapperTrap, trapInput1, trapInput2, trapInput3;
 
     beforeEach(() => {
-      wrapper = fixtureSync(`<focus-trap-wrapper></focus-trap-wrapper>`);
+      wrapper = fixtureSync(`<${wrapperTag}></${wrapperTag}>`);
       wrapperController = new FocusTrapController(element);
       wrapper.addController(wrapperController);
       wrapperTrap = wrapper.querySelector('#outer-trap');
 
-      element = wrapper.querySelector('focus-trap-element');
+      element = wrapper.querySelector(tag);
       controller = new FocusTrapController(element);
       element.addController(controller);
       trap = element.querySelector('#trap');
@@ -356,4 +352,12 @@ describe('focus-trap-controller', () => {
       expect(document.activeElement).to.equal(trapInput1);
     });
   });
+};
+
+describe('FocusTrapController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('FocusTrapController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/keyboard-direction-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-direction-mixin.test.js
@@ -4,56 +4,57 @@ import {
   arrowLeftKeyDown,
   arrowRightKeyDown,
   arrowUpKeyDown,
+  defineLit,
+  definePolymer,
   endKeyDown,
   fixtureSync,
   homeKeyDown,
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { KeyboardDirectionMixin } from '../src/keyboard-direction-mixin.js';
 
-customElements.define(
-  'keyboard-direction-mixin-element',
-  class extends KeyboardDirectionMixin(PolymerElement) {
-    static get template() {
-      return html`
-        <style>
-          ::slotted(.hidden) {
-            display: none;
-          }
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'keyboard-direction-mixin',
+    `
+      <style>
+        ::slotted(.hidden) {
+          display: none;
+        }
 
-          :host(:not([vertical])) {
-            display: flex;
-          }
-        </style>
-        <slot></slot>
-      `;
-    }
+        :host(:not([vertical])) {
+          display: flex;
+        }
+      </style>
+      <slot></slot>
+    `,
+    (Base) =>
+      class extends KeyboardDirectionMixin(baseMixin(Base)) {
+        get _vertical() {
+          return this.hasAttribute('vertical');
+        }
 
-    get _vertical() {
-      return this.hasAttribute('vertical');
-    }
+        get _tabNavigation() {
+          return this.hasAttribute('tab-navigation');
+        }
+      },
+  );
 
-    get _tabNavigation() {
-      return this.hasAttribute('tab-navigation');
-    }
-  },
-);
-
-describe('keyboard-direction-mixin', () => {
   let element, items;
 
   beforeEach(() => {
     element = fixtureSync(`
-      <keyboard-direction-mixin-element>
+      <${tag}>
         <div tabindex="0">Foo</div>
         <div tabindex="0">Bar</div>
         <div disabled>Baz</div>
         <div tabindex="0">Qux</div>
         <div tabindex="0">Xyz</div>
         <div tabindex="0">Abc</div>
-      </keyboard-direction-mixin-element>
+      </${tag}>
     `);
     items = element.children;
   });
@@ -245,4 +246,12 @@ describe('keyboard-direction-mixin', () => {
       expect(element.focused).to.not.equal(items[0]);
     });
   });
+};
+
+describe('KeyboardDirectionMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('KeyboardDirectionMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/keyboard-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-mixin.test.js
@@ -1,26 +1,19 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { KeyboardMixin } from '../src/keyboard-mixin.js';
 
-describe('keyboard-mixin', () => {
+const runTests = (defineHelper, baseMixin) => {
   let element, enterSpy, escapeSpy, keyDownSpy, keyUpSpy;
 
-  before(() => {
-    keyDownSpy = sinon.spy();
-    keyUpSpy = sinon.spy();
-    escapeSpy = sinon.spy();
-    enterSpy = sinon.spy();
-
-    customElements.define(
-      'keyboard-mixin-element',
-      class extends KeyboardMixin(PolymerElement) {
-        static get template() {
-          return html`<div></div>`;
-        }
-
+  const tag = defineHelper(
+    'keyboard-mixin',
+    '<slot></slot>',
+    (Base) =>
+      class extends KeyboardMixin(baseMixin(Base)) {
         _onKeyDown(event) {
           super._onKeyDown(event);
 
@@ -39,12 +32,18 @@ describe('keyboard-mixin', () => {
           enterSpy(event);
         }
       },
-    );
+  );
+
+  before(() => {
+    keyDownSpy = sinon.spy();
+    keyUpSpy = sinon.spy();
+    escapeSpy = sinon.spy();
+    enterSpy = sinon.spy();
   });
 
   beforeEach(() => {
     // Sets tabindex to 0 in order to make the element focusable for the time of testing.
-    element = fixtureSync(`<keyboard-mixin-element tabindex="0"></keyboard-mixin-element>`);
+    element = fixtureSync(`<${tag} tabindex="0"></${tag}>`);
     element.focus();
   });
 
@@ -84,4 +83,12 @@ describe('keyboard-mixin', () => {
     expect(enterSpy.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
     expect(enterSpy.args[0][0].type).to.equal('keydown');
   });
+};
+
+describe('KeyboardMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('KeyboardMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });


### PR DESCRIPTION
## Description

Changed tests for remaining a11y-base mixins and controllers to use `runTests` with Polymer + Lit consistently.

## Type of change

- Test