### PR TITLE
test: update remaining field-base tests to also run with Lit

### DIFF
--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -1,27 +1,24 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-customElements.define(
-  'input-controller-element',
-  class extends InputMixin(ControllerMixin(PolymerElement)) {
-    static get template() {
-      return html`<slot name="input"></slot>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'input-mixin',
+    `<slot name="input"></slot>`,
+    (Base) => class extends InputMixin(baseMixin(Base)) {},
+  );
 
-describe('input-controller', () => {
   describe('default', () => {
     let element, controller, input;
 
     beforeEach(() => {
-      element = fixtureSync('<input-controller-element></input-controller-element>');
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new InputController(element, (node) => {
         element._setInputElement(node);
       });
@@ -50,7 +47,7 @@ describe('input-controller', () => {
     let element, input;
 
     beforeEach(() => {
-      element = fixtureSync('<input-controller-element value="foo"></input-controller-element>');
+      element = fixtureSync(`<${tag} value="foo"></${tag}>`);
     });
 
     it('should forward value attribute to the input', () => {
@@ -64,7 +61,7 @@ describe('input-controller', () => {
     let element, input;
 
     beforeEach(() => {
-      element = fixtureSync('<input-controller-element></input-controller-element>');
+      element = fixtureSync(`<${tag}></${tag}>`);
       element.value = 'foo';
     });
 
@@ -94,7 +91,7 @@ describe('input-controller', () => {
     let element, input;
 
     beforeEach(() => {
-      element = fixtureSync('<input-controller-element value="foo"></input-controller-element>');
+      element = fixtureSync(`<${tag}></${tag}>`);
     });
 
     it('should set input type based on the property', () => {
@@ -108,13 +105,13 @@ describe('input-controller', () => {
   describe('unique id', () => {
     let wrapper, elements;
 
-    const ID_REGEX = /^input-input-controller-element-\d+$/u;
+    const ID_REGEX = new RegExp(`^input-${tag}-\\d+$`, 'u');
 
     beforeEach(() => {
       wrapper = fixtureSync(`
         <div>
-          <input-controller-element></input-controller-element>
-          <input-controller-element></input-controller-element>
+          <${tag}></${tag}>
+          <${tag}></${tag}>
         </div>
       `);
       elements = wrapper.children;
@@ -130,4 +127,12 @@ describe('input-controller', () => {
       expect(input1.id).to.not.equal(input2.id);
     });
   });
+};
+
+describe('InputController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('InputController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/labelled-input-controller.test.js
+++ b/packages/field-base/test/labelled-input-controller.test.js
@@ -1,37 +1,31 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
 import { LabelledInputController } from '../src/labelled-input-controller.js';
 
-customElements.define(
-  'label-for-input-mixin-element',
-  class extends LabelMixin(InputMixin(ControllerMixin(PolymerElement))) {
-    static get template() {
-      return html`<slot name="label"></slot><slot name="input"></slot>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const inputTag = defineHelper(
+    'input',
+    `<slot name="label"></slot><slot name="input"></slot>`,
+    (Base) => class extends InputMixin(LabelMixin(baseMixin(Base))) {},
+  );
 
-customElements.define(
-  'label-for-textarea-mixin-element',
-  class extends LabelMixin(InputMixin(ControllerMixin(PolymerElement))) {
-    static get template() {
-      return html`<slot name="label"></slot><slot name="textarea"></slot>`;
-    }
-  },
-);
+  const textareaTag = defineHelper(
+    'textarea',
+    `<slot name="label"></slot><slot name="textarea"></slot>`,
+    (Base) => class extends InputMixin(LabelMixin(baseMixin(Base))) {},
+  );
 
-describe('labelled-input-controller', () => {
   let element, target, label;
 
-  ['input', 'textarea'].forEach((el) => {
+  Object.entries({ input: inputTag, textarea: textareaTag }).forEach(([el, tag]) => {
     describe(el, () => {
       beforeEach(() => {
-        element = fixtureSync(`<label-for-${el}-mixin-element label="label"></label-for-${el}-mixin-element>`);
+        element = fixtureSync(`<${tag} label="label"></${tag}>`);
         label = element.querySelector('[slot=label]');
         target = document.createElement(el);
         target.setAttribute('slot', el);
@@ -75,4 +69,12 @@ describe('labelled-input-controller', () => {
       });
     });
   });
+};
+
+describe('LabelledInputController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('LabelledInputController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/text-area-controller.test.js
+++ b/packages/field-base/test/text-area-controller.test.js
@@ -1,25 +1,22 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 import { TextAreaController } from '../src/text-area-controller.js';
 
-customElements.define(
-  'textarea-controller-element',
-  class extends InputMixin(ControllerMixin(PolymerElement)) {
-    static get template() {
-      return html`<slot name="textarea"></slot>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'input-mixin',
+    `<slot name="textarea"></slot>`,
+    (Base) => class extends InputMixin(baseMixin(Base)) {},
+  );
 
-describe('text-area-controller', () => {
   describe('default', () => {
     let element, controller, textarea;
 
     beforeEach(() => {
-      element = fixtureSync('<textarea-controller-element></textarea-controller-element>');
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new TextAreaController(element, (node) => {
         element._setInputElement(node);
       });
@@ -48,7 +45,7 @@ describe('text-area-controller', () => {
     let element, textarea;
 
     beforeEach(() => {
-      element = fixtureSync('<textarea-controller-element name="foo"></textarea-controller-element>');
+      element = fixtureSync(`<${tag} name="foo"></${tag}>`);
     });
 
     it('should forward name attribute to the textarea', () => {
@@ -62,7 +59,7 @@ describe('text-area-controller', () => {
     let element, textarea;
 
     beforeEach(() => {
-      element = fixtureSync('<textarea-controller-element value="foo"></textarea-controller-element>');
+      element = fixtureSync(`<${tag} value="foo"></${tag}>`);
     });
 
     it('should forward value attribute to the textarea', () => {
@@ -75,13 +72,13 @@ describe('text-area-controller', () => {
   describe('unique id', () => {
     let wrapper, elements;
 
-    const ID_REGEX = /^textarea-textarea-controller-element-\d+$/u;
+    const ID_REGEX = new RegExp(`^textarea-${tag}-\\d+$`, 'u');
 
     beforeEach(() => {
       wrapper = fixtureSync(`
         <div>
-          <textarea-controller-element></textarea-controller-element>
-          <textarea-controller-element></textarea-controller-element>
+          <${tag}></${tag}>
+          <${tag}></${tag}>
         </div>
       `);
       elements = wrapper.children;
@@ -97,4 +94,12 @@ describe('text-area-controller', () => {
       expect(textarea1.id).to.not.equal(textarea2.id);
     });
   });
+};
+
+describe('TextAreaController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('TextAreaController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });


### PR DESCRIPTION
## Description

Changed tests for remaining field-base mixins and controllers to use `runTests` with Polymer + Lit consistently.

## Type of change

- Test