### PR TITLE
test: update remaining component-base tests to also run with Lit

### DIFF
--- a/packages/component-base/test/media-query-controller.test.js
+++ b/packages/component-base/test/media-query-controller.test.js
@@ -1,24 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { MediaQueryController } from '../src/media-query-controller.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
 
-customElements.define(
-  'media-query-element',
-  class extends ControllerMixin(PolymerElement) {
-    static get template() {
-      return html`<slot></slot>`;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper('media-query-controller', `<slot></slot>`, (Base) => class extends baseMixin(Base) {});
 
-describe('media-query-controller', () => {
   let element, controller;
 
   beforeEach(() => {
-    element = fixtureSync(`<media-query-element></media-query-element>`);
+    element = fixtureSync(`<${tag}></${tag}>`);
   });
 
   it('should return true when media query matches', () => {
@@ -48,4 +41,12 @@ describe('media-query-controller', () => {
 
     expect(stub.calledTwice).to.be.true;
   });
+};
+
+describe('MediaQueryController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('MediaQueryController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/overflow-controller.test.js
+++ b/packages/component-base/test/overflow-controller.test.js
@@ -1,81 +1,75 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { OverflowController } from '../src/overflow-controller.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
 
-customElements.define(
-  'overflow-element',
-  class OverflowElement extends ControllerMixin(PolymerElement) {
-    static get template() {
-      return html`
-        <style>
-          :host {
-            display: flex;
-            overflow: auto;
-          }
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'overflow',
+    `
+      <style>
+        :host {
+          display: flex;
+          overflow: auto;
+        }
 
-          ::slotted(*) {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-width: 40px;
-            height: 40px;
-            flex-shrink: 0;
-          }
-        </style>
+        ::slotted(*) {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 40px;
+          height: 40px;
+          flex-shrink: 0;
+        }
+      </style>
+      <slot></slot>
+    `,
+    (Base) => class extends baseMixin(Base) {},
+  );
+
+  const wrapperTag = defineHelper(
+    'overflow-wrapper',
+    `
+      <style>
+        :host {
+          display: block;
+        }
+
+        #scroller {
+          overflow: auto;
+          width: 100%;
+          height: 100%;
+        }
+
+        ::slotted(*) {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 40px;
+          height: 40px;
+          flex-shrink: 0;
+        }
+      </style>
+      <div id="scroller">
         <slot></slot>
-      `;
-    }
-  },
-);
+      </div>
+    `,
+    (Base) => class extends baseMixin(Base) {},
+  );
 
-customElements.define(
-  'overflow-wrapper-element',
-  class OverflowWrapperElement extends ControllerMixin(PolymerElement) {
-    static get template() {
-      return html`
-        <style>
-          :host {
-            display: block;
-          }
-
-          #scroller {
-            overflow: auto;
-            width: 100%;
-            height: 100%;
-          }
-
-          ::slotted(*) {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-width: 40px;
-            height: 40px;
-            flex-shrink: 0;
-          }
-        </style>
-        <div id="scroller">
-          <slot></slot>
-        </div>
-      `;
-    }
-  },
-);
-
-describe('overflow-controller', () => {
   describe('default', () => {
     let element, items, controller;
 
     describe('horizontal', () => {
       beforeEach(async () => {
         element = fixtureSync(`
-          <overflow-element>
+          <${tag}>
             <div>1</div>
             <div>2</div>
             <div>3</div>
             <div>4</div>
-          </overflow-element>
+          </${tag}>
         `);
         // Wait for initial update
         await nextRender();
@@ -170,13 +164,13 @@ describe('overflow-controller', () => {
     describe('vertical', () => {
       beforeEach(async () => {
         element = fixtureSync(`
-          <overflow-element style="display: block;">
+          <${tag} style="display: block;">
             <div>1</div>
             <div>2</div>
             <div>3</div>
             <div>4</div>
             <div>5</div>
-          </overflow-element>
+          </${tag}>
         `);
         await nextFrame();
         items = Array.from(element.children);
@@ -246,12 +240,12 @@ describe('overflow-controller', () => {
 
     beforeEach(async () => {
       element = fixtureSync(`
-        <overflow-wrapper-element>
+        <${wrapperTag}>
           <div>1</div>
           <div>2</div>
           <div>3</div>
           <div>4</div>
-        </overflow-wrapper-element>
+        </${wrapperTag}>
       `);
       await nextFrame();
       items = Array.from(element.children);
@@ -289,4 +283,12 @@ describe('overflow-controller', () => {
       });
     });
   });
+};
+
+describe('OverflowController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('OverflowController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/resize-mixin.test.js
+++ b/packages/component-base/test/resize-mixin.test.js
@@ -1,36 +1,35 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, defineLit, definePolymer, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ControllerMixin } from '../src/controller-mixin.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
 import { ResizeMixin } from '../src/resize-mixin.js';
 
-describe('resize-mixin', () => {
-  let element, observeParent;
+const runTests = (defineHelper, baseMixin) => {
+  let observeParent;
 
-  before(() => {
-    customElements.define(
-      'resize-mixin-element',
-      class extends ResizeMixin(PolymerElement) {
-        static get template() {
-          return html`
-            <style>
-              :host {
-                display: block;
-              }
-            </style>
-            <div></div>
-          `;
+  const tag = defineHelper(
+    'resize-mixin',
+    `
+      <style>
+        :host {
+          display: block;
         }
-
+      </style>
+      <div></div>
+    `,
+    (Base) =>
+      class extends ResizeMixin(baseMixin(Base)) {
         get _observeParent() {
           return observeParent;
         }
       },
-    );
-  });
+  );
+
+  let element;
 
   beforeEach(async () => {
-    element = fixtureSync(`<resize-mixin-element></resize-mixin-element>`);
+    element = fixtureSync(`<${tag}></${tag}>`);
     // Wait for the initial resize.
     await nextResize(element);
   });
@@ -120,4 +119,12 @@ describe('resize-mixin', () => {
       });
     });
   });
+};
+
+describe('ResizeMixin + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('ResizeMixin + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -1,23 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineCE, defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html as legacyHtml, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { html, LitElement } from 'lit';
 import { ControllerMixin } from '../src/controller-mixin.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
 import { SlotController } from '../src/slot-controller.js';
 
-class SlotControllerHost extends ControllerMixin(PolymerElement) {
-  static get template() {
-    return legacyHtml`
-      <slot name="foo"></slot>
-      <slot></slot>
-    `;
-  }
-}
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'slot-controller',
+    `<slot name="foo"></slot><slot></slot>`,
+    (Base) => class extends baseMixin(Base) {},
+  );
 
-customElements.define('slot-controller-element', SlotControllerHost);
-
-describe('slot-controller', () => {
   let element, child, controller;
 
   describe('named slot', () => {
@@ -25,7 +19,7 @@ describe('slot-controller', () => {
 
     describe('default content', () => {
       beforeEach(() => {
-        element = fixtureSync('<slot-controller-element></slot-controller-element>');
+        element = fixtureSync(`<${tag}></${tag}>`);
         initializeSpy = sinon.stub().callsFake((node) => {
           node.textContent = 'foo';
         });
@@ -57,9 +51,9 @@ describe('slot-controller', () => {
     describe('custom content', () => {
       beforeEach(() => {
         element = fixtureSync(`
-          <slot-controller-element>
+          <${tag}>
             <div slot="foo">bar</div>
-          </slot-controller-element>
+          </${tag}>
         `);
         // Get element reference before adding the controller
         child = element.querySelector('[slot="foo"]');
@@ -94,7 +88,7 @@ describe('slot-controller', () => {
       let initializeSpy;
 
       beforeEach(() => {
-        element = fixtureSync('<slot-controller-element></slot-controller-element>');
+        element = fixtureSync(`<${tag}></${tag}>`);
         initializeSpy = sinon.stub().callsFake((node) => {
           node.textContent = 'bar';
         });
@@ -128,28 +122,31 @@ describe('slot-controller', () => {
 
       const initializeSpy = sinon.spy();
 
-      customElements.define(
-        'default-slot-element',
-        class extends SlotControllerHost {
-          ready() {
-            super.ready();
+      const innerTag = defineHelper(
+        'slot-controller-inner',
+        `<slot></slot>`,
+        (Base) =>
+          class extends baseMixin(Base) {
+            ready() {
+              super.ready();
 
-            controller = new SlotController(this, '', 'div', { initializer: initializeSpy });
-            this.addController(controller);
-          }
-        },
+              controller = new SlotController(this, '', 'div', { initializer: initializeSpy });
+              this.addController(controller);
+            }
+          },
       );
 
-      customElements.define(
-        'custom-default-wrapper',
-        class extends LitElement {
-          render() {
-            return html`
-              <default-slot-element>
+      const wrapperTag = defineCE(
+        class extends HTMLElement {
+          constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+            this.shadowRoot.innerHTML = `
+              <${innerTag}>
                 <!-- Keep this comment and surrounding whitespace text nodes -->
                 <div>baz</div>
                 <!-- Keep this comment and surrounding whitespace text nodes -->
-              </default-slot-element>
+              </${innerTag}>
             `;
           }
         },
@@ -157,9 +154,10 @@ describe('slot-controller', () => {
 
       beforeEach(async () => {
         initializeSpy.resetHistory();
-        wrapper = fixtureSync('<custom-default-wrapper></custom-default-wrapper>');
-        await wrapper.updateComplete;
-        element = wrapper.shadowRoot.querySelector('default-slot-element');
+        wrapper = fixtureSync(`<${wrapperTag}></${wrapperTag}>`);
+        // Wait for initial slotchange event
+        await nextFrame();
+        element = wrapper.shadowRoot.querySelector(innerTag);
         child = element.querySelector(':not([slot])');
       });
 
@@ -187,7 +185,7 @@ describe('slot-controller', () => {
       let initializeSpy;
 
       beforeEach(() => {
-        element = fixtureSync('<slot-controller-element>baz</slot-controller-element>');
+        element = fixtureSync(`<${tag}>baz</${tag}>`);
         initializeSpy = sinon.spy();
         controller = new SlotController(element, '', 'div', { initializer: initializeSpy });
         element.addController(controller);
@@ -217,7 +215,7 @@ describe('slot-controller', () => {
 
     describe('empty text node', () => {
       beforeEach(() => {
-        element = fixtureSync('<slot-controller-element> </slot-controller-element>');
+        element = fixtureSync(`<${tag}> </${tag}>`);
         child = element.firstChild;
       });
 
@@ -237,7 +235,7 @@ describe('slot-controller', () => {
     let defaultNode;
 
     beforeEach(async () => {
-      element = fixtureSync('<slot-controller-element></slot-controller-element>');
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new SlotController(element, 'foo', 'div', {
         initializer: (node) => {
           node.textContent = 'bar';
@@ -290,7 +288,7 @@ describe('slot-controller', () => {
     let defaultNode;
 
     beforeEach(async () => {
-      element = fixtureSync('<slot-controller-element></slot-controller-element>');
+      element = fixtureSync(`<${tag}></${tag}>`);
       controller = new SlotController(element, 'foo', 'div', {
         observe: false,
         initializer: (node) => {
@@ -343,7 +341,7 @@ describe('slot-controller', () => {
 
     describe('default', () => {
       beforeEach(async () => {
-        element = fixtureSync('<slot-controller-element></slot-controller-element>');
+        element = fixtureSync(`<${tag}></${tag}>`);
         initializeSpy = sinon.spy();
         controller = new SlotController(element, '', 'button', {
           initializer: initializeSpy,
@@ -411,7 +409,7 @@ describe('slot-controller', () => {
 
     describe('custom', () => {
       beforeEach(async () => {
-        element = fixtureSync('<slot-controller-element><div>foo</div><div>bar</div></slot-controller-element>');
+        element = fixtureSync(`<${tag}><div>foo</div><div>bar</div></${tag}>`);
         initializeSpy = sinon.spy();
         controller = new SlotController(element, '', 'button', {
           initializer: initializeSpy,
@@ -468,7 +466,7 @@ describe('slot-controller', () => {
 
     describe('no tag node', () => {
       beforeEach(async () => {
-        element = fixtureSync('<slot-controller-element></slot-controller-element>');
+        element = fixtureSync(`<${tag}></${tag}>`);
         initializeSpy = sinon.spy();
         controller = new SlotController(element, '', null, {
           multiple: true,
@@ -486,4 +484,12 @@ describe('slot-controller', () => {
       });
     });
   });
+};
+
+describe('SlotController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('SlotController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -1,32 +1,27 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { ControllerMixin } from '../src/controller-mixin.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
 import { TooltipController } from '../src/tooltip-controller.js';
 
-customElements.define(
-  'tooltip-host',
-  class extends ControllerMixin(PolymerElement) {
-    static get template() {
-      return html`
-        <slot></slot>
-        <slot name="tooltip"></slot>
-      `;
-    }
-  },
-);
+const runTests = (defineHelper, baseMixin) => {
+  const tag = defineHelper(
+    'tooltip-host',
+    `<slot></slot><slot name="tooltip"></slot>
+    `,
+    (Base) => class extends baseMixin(Base) {},
+  );
 
-describe('TooltipController', () => {
   let host, tooltip, controller;
 
   describe('slotted tooltip', () => {
     beforeEach(() => {
       host = fixtureSync(`
-        <tooltip-host>
+        <${tag}>
           <div>Target</div>
           <vaadin-tooltip slot="tooltip"></vaadin-tooltip>
-        </tooltip-host>
+        </${tag}>
       `);
       tooltip = host.querySelector('vaadin-tooltip');
       controller = new TooltipController(host);
@@ -89,12 +84,12 @@ describe('TooltipController', () => {
     });
   });
 
-  describe('slotted tooltip', () => {
+  describe('lazy tooltip', () => {
     beforeEach(() => {
       host = fixtureSync(`
-        <tooltip-host>
+        <${tag}>
           <div>Target</div>
-        </tooltip-host>
+        </${tag}>
       `);
       controller = new TooltipController(host);
       host.addController(controller);
@@ -191,4 +186,12 @@ describe('TooltipController', () => {
       expect(spy).to.be.calledTwice;
     });
   });
+};
+
+describe('TooltipController + Polymer', () => {
+  runTests(definePolymer, ControllerMixin);
+});
+
+describe('TooltipController + Lit', () => {
+  runTests(defineLit, PolylitMixin);
 });


### PR DESCRIPTION
## Description

Changed tests for remaining field-base mixins and controllers to use `runTests` with Polymer + Lit consistently.

Didn't update `ElementMixin` tests since it would require some rewrrite due to `window.Vaadin.registrations`.
Verified that replacing `PolymerElement` with `LitElement` there works. Let's update it when switching to Lit. 

Also didn't update `templates.test.js` - that test suite will be dropped with removal of `polymer-legacy-adapter`.

## Type of change

- Test