### PR TITLE
fix: copy styles from adoptedStyleSheets for chart exporting

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -1211,6 +1211,12 @@ export const ChartMixin = (superClass) =>
                   effectiveCss += style.textContent;
                 });
 
+                if (self.shadowRoot.adoptedStyleSheets) {
+                  self.shadowRoot.adoptedStyleSheets.forEach((sheet) => {
+                    effectiveCss += [...sheet.cssRules].map((rule) => rule.cssText).join('\n');
+                  });
+                }
+
                 // Strip off host selectors that target individual instances
                 effectiveCss = effectiveCss.replace(/:host\(.+?\)/gu, (match) => {
                   const selector = match.substr(6, match.length - 7);

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -34,15 +34,17 @@ describe('vaadin-chart exporting', () => {
 
   it('should temporarily copy shadow styles to the body before export', async () => {
     let styleCopiedToBody = false;
+    let styleContent;
 
     // Track style movement into the document body
     const observer = new MutationObserver((mutations) => {
-      styleCopiedToBody ||= mutations.some(
-        (mutation) =>
-          Array.from(mutation.addedNodes)
-            .map((node) => node.tagName.toLowerCase())
-            .indexOf('style') >= 0,
-      );
+      mutations.forEach((mutation) => {
+        const styleTag = [...mutation.addedNodes].find((node) => node instanceof HTMLStyleElement);
+        if (styleTag) {
+          styleCopiedToBody = true;
+          styleContent = styleTag.textContent;
+        }
+      });
     });
 
     observer.observe(document.body, { childList: true });
@@ -57,6 +59,7 @@ describe('vaadin-chart exporting', () => {
     expect(fireEventSpy.firstCall.args[1]).to.be.equal('beforeExport');
     await nextRender(chart);
     expect(styleCopiedToBody).to.be.true;
+    expect(styleContent).to.include('.highcharts-color-0');
   });
 
   it('should remove shadow styles from body after export', async () => {


### PR DESCRIPTION
## Description

Fixes #9137

Updated logic for gathering styles to be copied to `<body>` to also include styles from `adoptedStyleSheets`.
Also modified a test to ensure CSS added in `exporting-styles` is actually present in the `<style>` content.

Note: the test styles were added in https://github.com/vaadin/vaadin-charts/pull/397 and presumably tested manually.
I couldn't get exporting to work in dev page as https://export.highcharts.com returns 403 forbidden.

## Type of change

- Bugfix