### PR TITLE
refactor: remove chart import from Lit based chart-series

### DIFF
--- a/packages/charts/src/vaadin-lit-chart-series.js
+++ b/packages/charts/src/vaadin-lit-chart-series.js
@@ -8,7 +8,6 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import './vaadin-lit-chart.js';
 import { LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';


### PR DESCRIPTION
## Description

There `vaadin-chart` imports `vaadin-chart-series`, there is no need for extra import (it's not present in Polymer version).

## Type of change

- Refactor