### PR TITLE
refactor: remove ControllerMixin usage from Lit based CRUD

### DIFF
--- a/packages/crud/src/vaadin-lit-crud.js
+++ b/packages/crud/src/vaadin-lit-crud.js
@@ -15,7 +15,6 @@ import './vaadin-lit-crud-grid.js';
 import './vaadin-lit-crud-form.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -31,7 +30,7 @@ import { crudStyles } from './vaadin-crud-styles.js';
  * This component is an experiment and not yet a part of Vaadin platform.
  * There is no ETA regarding specific Vaadin version where it'll land.
  */
-class Crud extends ControllerMixin(ElementMixin(ThemableMixin(CrudMixin(PolylitMixin(LitElement))))) {
+class Crud extends CrudMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get styles() {
     return crudStyles;
   }


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/9145

Removed not needed `ControllerMixin` from LitElement based version of `vaadin-crud` element.

## Type of change

- Refactor