### PR TITLE
docs: update JSDoc for internal Lit based custom elements

### DIFF
--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-checkbox.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-checkbox.js
@@ -12,12 +12,11 @@ import { Checkbox } from '@vaadin/checkbox/src/vaadin-lit-checkbox.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 
 /**
- * LitElement based version of `<vaadin-grid-pro-edit-checkbox>` web component.
+ * An element used internally by `<vaadin-grid-pro>`. Not intended to be used separately.
  *
- * ## Disclaimer
- *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
+ * @customElement
+ * @extends Checkbox
+ * @private
  */
 class GridProEditCheckbox extends Checkbox {
   static get is() {

--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-select.js
@@ -13,12 +13,12 @@ import { Select } from '@vaadin/select/src/vaadin-lit-select.js';
 import { GridProEditSelectMixin } from './vaadin-grid-pro-edit-select-mixin.js';
 
 /**
- * LitElement based version of `<vaadin-grid-pro-edit-select>` web component.
+ * An element used internally by `<vaadin-grid-pro>`. Not intended to be used separately.
  *
- * ## Disclaimer
- *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
+ * @customElement
+ * @extends Select
+ * @mixes GridProEditSelectMixin
+ * @private
  */
 class GridProEditSelect extends GridProEditSelectMixin(Select) {
   static get is() {

--- a/packages/grid-pro/src/vaadin-lit-grid-pro-edit-text-field.js
+++ b/packages/grid-pro/src/vaadin-lit-grid-pro-edit-text-field.js
@@ -12,12 +12,11 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { TextField } from '@vaadin/text-field/src/vaadin-lit-text-field.js';
 
 /**
- * LitElement based version of `<vaadin-grid-pro-edit-text-field>` web component.
+ * An element used internally by `<vaadin-grid-pro>`. Not intended to be used separately.
  *
- * ## Disclaimer
- *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
+ * @customElement
+ * @extends TextField
+ * @private
  */
 class GridProEditText extends TextField {
   static get is() {


### PR DESCRIPTION
## Description

Updated JSDoc annotation for components that are marked as `@private` - they would not end up in API docs anyway.
Will update the public components separately as a preparation for switching to Lit based versions later.

## Type of change

- Documentation