### PR TITLE
refactor: remove ControllerMixin usage from Lit based icon

### DIFF
--- a/packages/icon/src/vaadin-lit-icon.js
+++ b/packages/icon/src/vaadin-lit-icon.js
@@ -6,7 +6,6 @@
 import './vaadin-iconset.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -23,7 +22,7 @@ import { iconStyles } from './vaadin-icon-styles.js';
  * There is no ETA regarding specific Vaadin version where it'll land.
  * Feel free to try this code in your apps as per Apache 2.0 license.
  */
-class Icon extends IconMixin(ControllerMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class Icon extends IconMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static styles = iconStyles;
 
   /** @protected */


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/9145

Removed not needed `ControllerMixin` from LitElement based version of `vaadin-icon` element.

## Type of change

- Refactor