### PR TITLE
docs: remove Polymer specific items API from JSDoc examples

### DIFF
--- a/packages/crud/src/vaadin-crud-edit-column.d.ts
+++ b/packages/crud/src/vaadin-crud-edit-column.d.ts
@@ -18,7 +18,7 @@ import { GridColumn } from '@vaadin/grid/src/vaadin-grid-column.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-crud-edit-column></vaadin-crud-edit-column>
  *
  *  <vaadin-grid-column>

--- a/packages/crud/src/vaadin-crud-edit-column.js
+++ b/packages/crud/src/vaadin-crud-edit-column.js
@@ -21,7 +21,7 @@ import { editColumnDefaultRenderer } from './vaadin-crud-helpers.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-crud-edit-column></vaadin-crud-edit-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -22,7 +22,7 @@ export * from './vaadin-grid-pro-edit-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid-pro items="[[items]]">
+ * <vaadin-grid-pro>
  *  <vaadin-grid-pro-edit-column path="name.first"></vaadin-grid-pro-edit-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -23,7 +23,7 @@ import { GridProEditColumnMixin } from './vaadin-grid-pro-edit-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid-pro items="[[items]]">
+ * <vaadin-grid-pro>
  *  <vaadin-grid-pro-edit-column path="name.first"></vaadin-grid-pro-edit-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/grid/src/vaadin-grid-filter-column.d.ts
@@ -15,7 +15,7 @@ export * from './vaadin-grid-filter-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-filter-column path="name.first"></vaadin-grid-filter-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-filter-column.js
+++ b/packages/grid/src/vaadin-grid-filter-column.js
@@ -14,7 +14,7 @@ import { GridFilterColumnMixin } from './vaadin-grid-filter-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-filter-column path="name.first"></vaadin-grid-filter-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -19,7 +19,7 @@ export * from './vaadin-grid-selection-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-selection-column frozen auto-select></vaadin-grid-selection-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -14,7 +14,7 @@ import { GridSelectionColumnMixin } from './vaadin-grid-selection-column-mixin.j
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-selection-column frozen auto-select></vaadin-grid-selection-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-column.d.ts
@@ -15,7 +15,7 @@ export * from './vaadin-grid-sort-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-sort-column path="name.first" direction="asc"></vaadin-grid-sort-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-sort-column.js
+++ b/packages/grid/src/vaadin-grid-sort-column.js
@@ -14,7 +14,7 @@ import { GridSortColumnMixin } from './vaadin-grid-sort-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-sort-column path="name.first" direction="asc"></vaadin-grid-sort-column>
  *
  *  <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-column.d.ts
@@ -13,14 +13,13 @@ import type { GridTreeColumnMixinClass } from './vaadin-grid-tree-column-mixin.j
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-tree-column path="name.first"></vaadin-grid-tree-column>
  *
  *  <vaadin-grid-column>
  *    ...
  * ```
  */
-
 declare class GridTreeColumn<TItem = GridDefaultItem> extends HTMLElement {}
 
 interface GridTreeColumn<TItem = GridDefaultItem>

--- a/packages/grid/src/vaadin-grid-tree-column.js
+++ b/packages/grid/src/vaadin-grid-tree-column.js
@@ -14,7 +14,7 @@ import { GridTreeColumnMixin } from './vaadin-grid-tree-column-mixin.js';
  *
  * #### Example:
  * ```html
- * <vaadin-grid items="[[items]]">
+ * <vaadin-grid>
  *  <vaadin-grid-tree-column path="name.first"></vaadin-grid-tree-column>
  *
  *  <vaadin-grid-column>


### PR DESCRIPTION
## Description

Removed Polymer specific data binding to items from JSDoc.

## Type of change

- Docs