### PR TITLE
test: disable animation on infinite scrollers

### DIFF
--- a/packages/date-picker/test/visual/common.js
+++ b/packages/date-picker/test/visual/common.js
@@ -27,6 +27,18 @@ registerStyles(
   `,
 );
 
+registerStyles(
+  'vaadin-date-picker-overlay-content',
+  css`
+    /* Disable animation */
+    ::slotted([slot='years']),
+    ::slotted([slot='months']) {
+      animation: none !important;
+      transition: none !important;
+    }
+  `,
+);
+
 /* Stop focused day animation */
 registerStyles(
   'vaadin-month-calendar',


### PR DESCRIPTION
## Description

To improve the stability of visual tests, the PR disables the [animation](https://github.com/vaadin/web-components/blob/9939fbc29849369208c7efc07cec7c8f760faf85/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js#L57-L60) applied to the year and month date-picker scrollers. This change also helps work around a [browser crash](https://github.com/vaadin/web-components/pull/9138#issuecomment-2880047587) that occurs when using CSSInjector in Sauce Labs with Chrome 130 on Windows.

Part of https://github.com/vaadin/web-components/issues/9082

## Type of change

- [x] Internal
