### PR TITLE
test: improve test for trapping focus after focusing element

### DIFF
--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -90,7 +90,7 @@ const runTests = (defineHelper, baseMixin) => {
     });
 
     it('should keep focus on the element when it is inside the trap node', () => {
-      const input = element.querySelector('#trap-input-1');
+      const input = element.querySelector('#trap-input-2');
       input.focus();
       controller.trapFocus(trap);
       expect(document.activeElement).to.equal(input);


### PR DESCRIPTION
## Description

This test is intended to cover the following logic in the controller:

https://github.com/vaadin/web-components/blob/abc511948a01c22bb1500492a17b16680a2e1e17/packages/a11y-base/src/focus-trap-controller.js#L89-L91

However, currently removing `if (this.__focusedElementIndex === -1) {` doesn't break it because the element that we focus manually before trapping focus is the first one. Let's update the test to focus the second element instead.

Note: this was originally fixed in https://github.com/vaadin/vaadin-overlay/pull/74.

## Type of change

- Test