### PR TITLE
refactor: align select shared styles with other components

### DIFF
--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -14,8 +14,7 @@ import { screenReaderOnly } from '@vaadin/a11y-base/src/styles/sr-only-styles.js
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { fieldShared } from '@vaadin/field-base/src/styles/field-shared-styles.js';
-import { inputFieldContainer } from '@vaadin/field-base/src/styles/input-field-container-styles.js';
+import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
 
@@ -37,8 +36,7 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
 
   static get styles() {
     return [
-      fieldShared,
-      inputFieldContainer,
+      inputFieldShared,
       screenReaderOnly,
       css`
         :host {

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -13,14 +13,11 @@ import { screenReaderOnly } from '@vaadin/a11y-base/src/styles/sr-only-styles.js
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
-import { fieldShared } from '@vaadin/field-base/src/styles/field-shared-styles.js';
-import { inputFieldContainer } from '@vaadin/field-base/src/styles/input-field-container-styles.js';
+import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { registerStyles, ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
 
-registerStyles('vaadin-select', [fieldShared, inputFieldContainer, screenReaderOnly], {
-  moduleId: 'vaadin-select-styles',
-});
+registerStyles('vaadin-select', [inputFieldShared, screenReaderOnly], { moduleId: 'vaadin-select-styles' });
 
 /**
  * `<vaadin-select>` is a Web Component for selecting values from a list of items.


### PR DESCRIPTION
## Description

This change is needed in preparation for adding base styles. Currently, select imports only two CSS modules it needs:

https://github.com/vaadin/web-components/blob/abc511948a01c22bb1500492a17b16680a2e1e17/packages/field-base/src/styles/input-field-shared-styles.js#L6-L10

This is because `vaadin-select` doesn't have a clear button. However, in `base-styles` branch that file has been renamed to `button` and also provides toggle button styles. Also, e.g. `vaadin-date-time-picker` already imports all of these.

Let's update to use `inputFieldShared` in select to be aligned with all other field components.

## Type of change

- Refactor