### PR TITLE
fix: collapse all chips to overflow if there is not enough width

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -872,23 +872,31 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       }
 
       // Add chips until remaining width is exceeded
-      for (let i = items.length - 1, refNode = null; i >= 0; i--) {
+      for (let i = items.length - 1, previousChip = null; i >= 0; i--) {
         const chip = this.__createChip(items[i]);
-        this.insertBefore(chip, refNode);
+        this.insertBefore(chip, previousChip);
 
         // When auto expanding vertically, no need to measure remaining width
         if (!this.autoExpandVertically && this.$.chips.clientWidth > remainingWidth) {
-          // Always show at least last selected item as a chip
-          if (refNode === null) {
-            chip.style.maxWidth = `${Math.max(chipMinWidth, remainingWidth)}px`;
-          } else {
+          // If there is no more space for chips, collapse to overflow
+          if (remainingWidth < chipMinWidth) {
+            chip.remove();
+            break;
+          }
+
+          // If there is still space, show at least one chip and set
+          // max-width on it to ensure it doesn't overflow the input
+          const lastChip = previousChip || chip;
+          lastChip.style.maxWidth = `${remainingWidth}px`;
+
+          if (previousChip) {
             chip.remove();
             break;
           }
         }
 
         items.pop();
-        refNode = chip;
+        previousChip = chip;
       }
 
       this._overflowItems = items;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -877,17 +877,20 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         this.insertBefore(chip, refNode);
 
         // When auto expanding vertically, no need to measure remaining width
-        if (!this.autoExpandVertically && this.$.chips.clientWidth > remainingWidth) {
-          // If there is no more space for chips, or if there is at least one
-          // chip already shown, collapse all remaining chips to the overflow
-          if (remainingWidth < chipMinWidth || refNode !== null) {
-            chip.remove();
-            break;
+        if (!this.autoExpandVertically) {
+          if (this.$.chips.clientWidth > remainingWidth) {
+            // If there is no more space for chips, or if there is at least one
+            // chip already shown, collapse all remaining chips to the overflow
+            if (remainingWidth < chipMinWidth || refNode !== null) {
+              chip.remove();
+              break;
+            }
           }
+
+          chip.style.maxWidth = `${remainingWidth}px`;
         }
 
         items.pop();
-        chip.style.maxWidth = `${remainingWidth}px`;
         refNode = chip;
       }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -872,31 +872,23 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       }
 
       // Add chips until remaining width is exceeded
-      for (let i = items.length - 1, previousChip = null; i >= 0; i--) {
+      for (let i = items.length - 1, refNode = null; i >= 0; i--) {
         const chip = this.__createChip(items[i]);
-        this.insertBefore(chip, previousChip);
+        this.insertBefore(chip, refNode);
 
         // When auto expanding vertically, no need to measure remaining width
         if (!this.autoExpandVertically && this.$.chips.clientWidth > remainingWidth) {
-          // If there is no more space for chips, collapse to overflow
-          if (remainingWidth < chipMinWidth) {
-            chip.remove();
-            break;
-          }
-
-          // If there is still space, show at least one chip and set
-          // max-width on it to ensure it doesn't overflow the input
-          const lastChip = previousChip || chip;
-          lastChip.style.maxWidth = `${remainingWidth}px`;
-
-          if (previousChip) {
+          // If there is no more space for chips, or if there is at least one
+          // chip already shown, collapse all remaining chips to the overflow
+          if (remainingWidth < chipMinWidth || refNode !== null) {
             chip.remove();
             break;
           }
         }
 
         items.pop();
-        previousChip = chip;
+        chip.style.maxWidth = `${remainingWidth}px`;
+        refNode = chip;
       }
 
       this._overflowItems = items;

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -217,7 +217,7 @@ describe('chips', () => {
         expect(overflow.hasAttribute('hidden')).to.be.false;
       });
 
-      it('should set show max width on the chip based on CSS property', async () => {
+      it('should set max width on the chip based on the remaining space', async () => {
         comboBox.style.width = 'auto';
         await nextResize(comboBox);
 

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -193,7 +193,7 @@ describe('chips', () => {
         expect(overflow.hasAttribute('hidden')).to.be.true;
       });
 
-      it('should always show at least one chip in addition to overflow', async () => {
+      it('should always show at least one chip in addition to overflow if there is enough space', async () => {
         comboBox.style.width = 'auto';
         await nextResize(comboBox);
 
@@ -205,9 +205,20 @@ describe('chips', () => {
         expect(getChipContent(chips[1])).to.equal('orange');
       });
 
+      it('should move all chips to the overflow if there is not enough space for a single chip', async () => {
+        comboBox.style.width = '100px';
+        await nextResize(comboBox);
+
+        comboBox.selectedItems = ['apple', 'orange'];
+        await nextRender();
+
+        const chips = getChips(comboBox);
+        expect(chips.length).to.equal(1);
+        expect(overflow.hasAttribute('hidden')).to.be.false;
+      });
+
       it('should set show max width on the chip based on CSS property', async () => {
         comboBox.style.width = 'auto';
-        comboBox.clearButtonVisible = true;
         await nextResize(comboBox);
 
         comboBox.selectedItems = ['apple', 'orange'];
@@ -216,7 +227,7 @@ describe('chips', () => {
         const chips = getChips(comboBox);
         const minWidth = getComputedStyle(comboBox).getPropertyValue('--_chip-min-width');
         expect(minWidth).to.be.ok;
-        expect(chips[1].style.maxWidth).to.equal(minWidth);
+        expect(parseInt(chips[1].style.maxWidth)).to.be.greaterThan(parseInt(minWidth));
       });
     });
   });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/7446

This change fixes a problem introduced in https://github.com/vaadin/web-components/issues/4821 where enforcing at least one chip to be shown next to overflow didn't take remaining width into account.

Here's the overview of how this will affect the component:

### Before

| Default size | Clear button | 100px width |
| ------------ | ------------ | ------------ |
| ![mscb-before-default](https://github.com/user-attachments/assets/d3c09921-83dc-4d32-81b8-2a95f78187c9) | ![mscb-before](https://github.com/user-attachments/assets/b1de838a-679b-4361-9d05-f829acf7f16e) | ![mscb-before-100px](https://github.com/user-attachments/assets/056598d6-a24f-4e00-99d3-07101ec7ed51)

### After

| Default size | Clear button | 100px width |
| ------------ | ------------ | ------------ |
| ![mscb-after-clear](https://github.com/user-attachments/assets/7796babb-23ed-4d07-bf60-1a01132faac8) | ![mscb-after](https://github.com/user-attachments/assets/47556450-0cbb-4894-8233-952475e6b912) | ![mscb-after-100px](https://github.com/user-attachments/assets/3cf5aad1-55d2-4b51-9434-c1922adb44de) |


## Type of change

- Bugfix