### PR TITLE
refactor: cache column group widths in auto-width calculation

### DIFF
--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -100,7 +100,7 @@ export const ColumnAutoWidthMixin = (superClass) =>
 
       const columnWidth = Math.max(
         this.__getIntrinsicWidth(col),
-        this.__getDistributedWidth((col.assignedSlot || col).parentElement, col),
+        this.__getDistributedWidth(this.__getParentColumnGroup(col), col),
       );
 
       // We're processing a regular grid-column and not a grid-column-group
@@ -153,13 +153,35 @@ export const ColumnAutoWidthMixin = (superClass) =>
       const lvi = this._lastVisibleIndex;
       this.__viewportRowsCache = this._getRenderedRows().filter((row) => row.index >= fvi && row.index <= lvi);
 
-      // Pre-cache the intrinsic width of each column
+      // Get columns with autoWidth
       const cols = this.__getAutoWidthColumns();
-      this.__calculateAndCacheIntrinsicWidths(cols);
+
+      // Get all ancestor groups of the columns
+      const ancestorColumnGroups = new Set();
+      for (const col of cols) {
+        let parent = this.__getParentColumnGroup(col);
+        while (parent && !ancestorColumnGroups.has(parent)) {
+          ancestorColumnGroups.add(parent);
+          parent = this.__getParentColumnGroup(parent);
+        }
+      }
+
+      // Pre-cache the intrinsic width of each column and ancestor group
+      this.__calculateAndCacheIntrinsicWidths([...cols, ...ancestorColumnGroups]);
 
       cols.forEach((col) => {
         col.width = `${this.__getDistributedWidth(col)}px`;
       });
+    }
+
+    /**
+     * Returns the parent column group of the given column.
+     *
+     * @private
+     */
+    __getParentColumnGroup(col) {
+      const parent = (col.assignedSlot || col).parentElement;
+      return parent && parent !== this ? parent : null;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -172,6 +172,9 @@ export const ColumnAutoWidthMixin = (superClass) =>
       cols.forEach((col) => {
         col.width = `${this.__getDistributedWidth(col)}px`;
       });
+
+      // Clear the column-width cache to avoid a memory leak
+      this.__intrinsicWidthCache.clear();
     }
 
     /**


### PR DESCRIPTION
## Description

Grid's column auto-width calculation logic currently [caches](https://github.com/vaadin/web-components/blob/3d0496e24d90cddd14189c1d55094caf377530b1/packages/grid/src/vaadin-grid-column-auto-width-mixin.js#L158) the intrinsic width of each column in a single batch before [applying](https://github.com/vaadin/web-components/blob/3d0496e24d90cddd14189c1d55094caf377530b1/packages/grid/src/vaadin-grid-column-auto-width-mixin.js#L161) the updated widths. This helps avoid layout reflows between individual column updates.

However, the existing implementation does not pre-cache the widths of the columns' parent groups. As a result, the [group](https://github.com/vaadin/web-components/blob/3d0496e24d90cddd14189c1d55094caf377530b1/packages/grid/src/vaadin-grid-column-auto-width-mixin.js#L103) widths are dynamically calculated during the update process. This can lead to rendering performance bottlenecks in grids that use column groups alongside auto-width columns, as each group triggers an additional reflow.

The image below illustrates the column width recalculation process in a grid with 10 column groups that include auto-width columns. It shows 10 extra reflows — one for each group.

![recalc-before](https://github.com/user-attachments/assets/ca387e4f-5803-4a44-ae13-f498273e3dbd)

This PR updates the logic to also pre-cache the widths of the columns' ancestor groups. The second image demonstrates the same scenario with the updated logic, where the additional reflows are eliminated.

![recalc-after](https://github.com/user-attachments/assets/67d5305a-bc52-49f5-945f-605fc7924c41)

This change should also have a positive impact on the Grid benchmark tests where the combination of auto-width columns and groups is used.

## Type of change

Refactor / performance enhancement