### PR TITLE
feat: cursor properties for interactive elements

### DIFF
--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -19,7 +19,7 @@ export const buttonStyles = css`
       -webkit-tap-highlight-color: transparent;
       -webkit-user-select: none;
       user-select: none;
-      cursor: pointer;
+      cursor: var(--vaadin-clickable-cursor);
       box-sizing: border-box;
       vertical-align: middle;
       flex-shrink: 0;
@@ -71,7 +71,7 @@ export const buttonStyles = css`
 
     :host([disabled]) {
       pointer-events: var(--_vaadin-button-disabled-pointer-events, none);
-      cursor: not-allowed;
+      cursor: var(--vaadin-disabled-cursor);
       opacity: 0.5;
     }
 

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -57,6 +57,10 @@ addGlobalThemeStyles(
         --_vaadin-icon-minus: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14" /></svg>');
         --_vaadin-icon-plus: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>');
         --_vaadin-icon-warn: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>');
+
+        /* Cursors for interactive elements */
+        --vaadin-clickable-cursor: pointer;
+        --vaadin-disabled-cursor: not-allowed;
       }
 
       @media (forced-colors: active) {

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js
@@ -48,7 +48,7 @@ export const overlayContentStyles = css`
     line-height: var(--vaadin-button-line-height, inherit);
     padding: var(--vaadin-button-padding, var(--_vaadin-padding-container));
     z-index: 1;
-    cursor: pointer;
+    cursor: var(--vaadin-clickable-cursor);
   }
 
   :host([years-visible]) [part='years-toggle-button'] {

--- a/packages/date-picker/src/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/src/vaadin-month-calendar-styles.js
@@ -75,7 +75,7 @@ export const monthCalendarStyles = css`
     position: relative;
     width: var(--vaadin-date-picker-date-width, 2rem);
     height: var(--vaadin-date-picker-date-height, 2rem);
-    cursor: pointer;
+    cursor: var(--vaadin-clickable-cursor);
     outline: none;
   }
 
@@ -107,7 +107,7 @@ export const monthCalendarStyles = css`
   }
 
   [disabled] {
-    cursor: not-allowed;
+    cursor: var(--vaadin-disabled-cursor);
     color: var(--vaadin-date-picker-date-disabled-color, var(--_vaadin-color-subtle));
     opacity: 0.7;
   }

--- a/packages/details/src/vaadin-details-summary-styles.js
+++ b/packages/details/src/vaadin-details-summary-styles.js
@@ -15,6 +15,7 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
     border-radius: var(--${unsafeCSS(partName)}-border-radius, var(--_vaadin-radius-m));
     box-sizing: border-box;
     color: var(--${unsafeCSS(partName)}-text-color, var(--_vaadin-color-strong));
+    cursor: var(--vaadin-clickable-cursor);
     display: flex;
     font-size: var(--${unsafeCSS(partName)}-font-size, inherit);
     font-weight: var(--${unsafeCSS(partName)}-font-weight, 500);
@@ -66,7 +67,7 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
 
   :host([disabled]) {
     opacity: 0.5;
-    cursor: not-allowed;
+    cursor: var(--vaadin-disabled-cursor);
   }
 
   :host([dir='rtl']) [part='toggle']::before {

--- a/packages/field-base/src/styles/button-styles.js
+++ b/packages/field-base/src/styles/button-styles.js
@@ -13,6 +13,7 @@ export const button = css`
     -webkit-tap-highlight-color: transparent;
     -webkit-user-select: none;
     user-select: none;
+    cursor: var(--vaadin-clickable-cursor);
   }
 
   /* Icon */
@@ -34,7 +35,7 @@ export const button = css`
 
   :host(:is([readonly], [disabled])) [part$='button'] {
     color: var(--_vaadin-color-subtle);
-    cursor: not-allowed;
+    cursor: var(--vaadin-disabled-cursor);
   }
 
   @media (forced-colors: active) {

--- a/packages/field-base/src/styles/field-shared-styles.js
+++ b/packages/field-base/src/styles/field-shared-styles.js
@@ -50,6 +50,14 @@ export const fieldShared = css`
     display: none;
   }
 
+  :host([readonly]) [part='input-field'] {
+    cursor: default;
+  }
+
+  :host([disabled]) [part='input-field'] {
+    cursor: var(--vaadin-disabled-cursor);
+  }
+
   [part='helper-text'] {
     font-size: var(--vaadin-input-field-helper-font-size, inherit);
     line-height: var(--vaadin-input-field-helper-line-height, inherit);

--- a/packages/input-container/src/vaadin-input-container-styles.js
+++ b/packages/input-container/src/vaadin-input-container-styles.js
@@ -21,6 +21,7 @@ export const inputContainerStyles = css`
     border: var(--vaadin-input-field-border-width, 1px) solid
       var(--vaadin-input-field-border-color, var(--_vaadin-border-color-strong));
     box-sizing: border-box;
+    cursor: text;
     padding: var(--vaadin-input-field-padding, var(--_vaadin-padding-container));
     gap: var(--vaadin-input-field-gap, var(--_vaadin-gap-container-inline));
     background: var(--vaadin-input-field-background, var(--_vaadin-background));
@@ -61,6 +62,7 @@ export const inputContainerStyles = css`
     font: inherit;
     color: inherit;
     background: transparent;
+    cursor: inherit;
   }
 
   ::slotted(*) {

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -12,7 +12,7 @@ export const itemStyles = css`
       align-items: center;
       border-radius: var(--vaadin-item-border-radius, var(--_vaadin-radius-m));
       box-sizing: border-box;
-      cursor: pointer;
+      cursor: var(--vaadin-clickable-cursor);
       display: flex;
       gap: var(--vaadin-item-gap, 0 var(--_vaadin-gap-container-inline));
       height: var(--vaadin-item-height, auto);
@@ -25,7 +25,7 @@ export const itemStyles = css`
     }
 
     :host([disabled]) {
-      cursor: not-allowed;
+      cursor: var(--vaadin-disabled-cursor);
       opacity: 0.5;
     }
 

--- a/packages/password-field/src/vaadin-lit-password-field-button.js
+++ b/packages/password-field/src/vaadin-lit-password-field-button.js
@@ -36,7 +36,7 @@ class PasswordFieldButton extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixi
           --vaadin-button-padding: 0;
           color: inherit;
           display: block;
-          cursor: default;
+          cursor: var(--vaadin-clickable-cursor);
         }
 
         :host::before {

--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -47,6 +47,10 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
           flex: 1;
         }
 
+        [part='input-field'] {
+          cursor: var(--vaadin-clickable-cursor);
+        }
+
         [part='toggle-button']::before {
           mask-image: var(--_vaadin-icon-chevron-down);
         }

--- a/packages/select/src/vaadin-select-value-button-styles.js
+++ b/packages/select/src/vaadin-select-value-button-styles.js
@@ -16,6 +16,7 @@ export const valueButton = css`
 
   ::slotted(*) {
     padding: 0;
+    cursor: inherit;
   }
 
   .vaadin-button-container,


### PR DESCRIPTION
Introduce two new custom properties for controlling the mouse cursors:

- `--vaadin-clickable-cursor`: essentially the same as we have in Lumo, controls what cursor to use when hovering over interactive/clickable elements.
- `--vaadin-disabled-cursor`:  controls what cursor to use when hovering over a disabled interactive element.

Updates all existing base styles to use these properties consistently.