### PR TITLE
[select] Base styles: remove unnecessary styles

### DIFF
--- a/packages/select/src/vaadin-lit-select.js
+++ b/packages/select/src/vaadin-lit-select.js
@@ -39,10 +39,6 @@ class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(Lit
       inputFieldShared,
       screenReaderOnly,
       css`
-        :host {
-          position: relative;
-        }
-
         ::slotted([slot='value']) {
           flex: 1;
         }


### PR DESCRIPTION
I assume `position: relative` is not actually needed, and it was accidentally left over from existing core styles. At least I don't notice any difference in behavior when I remove it.