### PR TITLE
chore: update README files to not mention theme entrypoints

### DIFF
--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -35,29 +35,6 @@ Once installed, import the component in your application:
 import '@vaadin/accordion';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/accordion/vaadin-accordion.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/accordion/theme/material/vaadin-accordion.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/accordion/theme/lumo/vaadin-accordion.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/accordion/src/vaadin-accordion.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/app-layout/README.md
+++ b/packages/app-layout/README.md
@@ -47,32 +47,6 @@ import '@vaadin/app-layout';
 import '@vaadin/app-layout/vaadin-drawer-toggle.js';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/app-layout/vaadin-app-layout.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the components from the `theme/material` folder:
-
-```js
-import '@vaadin/app-layout/theme/material/vaadin-app-layout.js';
-import '@vaadin/app-layout/theme/material/vaadin-drawer-toggle.js';
-```
-
-You can also import the Lumo version of the components explicitly:
-
-```js
-import '@vaadin/app-layout/theme/lumo/vaadin-app-layout.js';
-import '@vaadin/app-layout/theme/lumo/vaadin-drawer-toggle.js';
-```
-
-Finally, you can import the un-themed components from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/app-layout/src/vaadin-app-layout.js';
-import '@vaadin/app-layout/src/vaadin-drawer-toggle.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/avatar-group/README.md
+++ b/packages/avatar-group/README.md
@@ -34,29 +34,6 @@ Once installed, import the component in your application:
 import '@vaadin/avatar-group';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/avatar-group/vaadin-avatar-group.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/avatar-group/theme/material/vaadin-avatar-group.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/avatar-group/theme/lumo/vaadin-avatar-group.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/avatar-group/src/vaadin-avatar-group.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/avatar';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/avatar/vaadin-avatar.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/avatar/theme/material/vaadin-avatar.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/avatar/theme/lumo/vaadin-avatar.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/avatar/src/vaadin-avatar.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/button';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/button/vaadin-button.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/button/theme/material/vaadin-button.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/button/theme/lumo/vaadin-button.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/button/src/vaadin-button.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/checkbox-group/README.md
+++ b/packages/checkbox-group/README.md
@@ -29,29 +29,6 @@ Once installed, import the component in your application:
 import '@vaadin/checkbox-group';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/checkbox-group/vaadin-checkbox-group.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/checkbox-group/theme/material/vaadin-checkbox-group.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/checkbox-group/theme/lumo/vaadin-checkbox-group.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/checkbox-group/src/vaadin-checkbox-group.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/checkbox';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/checkbox/vaadin-checkbox.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/checkbox/theme/material/vaadin-checkbox.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/checkbox/theme/lumo/vaadin-checkbox.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/checkbox/src/vaadin-checkbox.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/combo-box/README.md
+++ b/packages/combo-box/README.md
@@ -39,29 +39,6 @@ Once installed, import the component in your application:
 import '@vaadin/combo-box';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/combo-box/vaadin-combo-box.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/combo-box/theme/material/vaadin-combo-box.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/combo-box/theme/lumo/vaadin-combo-box.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/combo-box/src/vaadin-combo-box.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/confirm-dialog/README.md
+++ b/packages/confirm-dialog/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/confirm-dialog';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/confirm-dialog/vaadin-confirm-dialog.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/confirm-dialog/theme/material/vaadin-confirm-dialog.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/confirm-dialog/theme/lumo/vaadin-confirm-dialog.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/confirm-dialog/src/vaadin-confirm-dialog.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/context-menu/README.md
+++ b/packages/context-menu/README.md
@@ -50,29 +50,6 @@ Once installed, import the component in your application:
 import '@vaadin/context-menu';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/context-menu/vaadin-context-menu.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/context-menu/theme/material/vaadin-context-menu.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/context-menu/theme/lumo/vaadin-context-menu.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/context-menu/src/vaadin-context-menu.js';
-```
-
 ## License
 
 Apache License 2.0

--- a/packages/crud/README.md
+++ b/packages/crud/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/crud';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/crud/vaadin-crud.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/crud/theme/material/vaadin-crud.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/crud/theme/lumo/vaadin-crud.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/crud/src/vaadin-crud.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/custom-field/README.md
+++ b/packages/custom-field/README.md
@@ -30,29 +30,6 @@ Once installed, import the component in your application:
 import '@vaadin/custom-field';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/custom-field/vaadin-custom-field.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/custom-field/theme/material/vaadin-custom-field.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/custom-field/theme/lumo/vaadin-custom-field.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/custom-field/src/vaadin-custom-field.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -26,29 +26,6 @@ Once installed, import the component in your application:
 import '@vaadin/date-picker';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/date-picker/vaadin-date-picker.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/date-picker/theme/material/vaadin-date-picker.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/date-picker/theme/lumo/vaadin-date-picker.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/date-picker/src/vaadin-date-picker.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/date-time-picker/README.md
+++ b/packages/date-time-picker/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/date-time-picker';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/date-time-picker/vaadin-date-time-picker.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/date-time-picker/theme/material/vaadin-date-time-picker.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/date-time-picker/theme/lumo/vaadin-date-time-picker.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/date-time-picker/src/vaadin-date-time-picker.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/details/README.md
+++ b/packages/details/README.md
@@ -29,29 +29,6 @@ Once installed, import the component in your application:
 import '@vaadin/details';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/details/vaadin-details.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/details/theme/material/vaadin-details.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/details/theme/lumo/vaadin-details.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/details/src/vaadin-details.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -33,29 +33,6 @@ Once installed, import the component in your application:
 import '@vaadin/dialog';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/dialog/vaadin-dialog.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/dialog/theme/material/vaadin-dialog.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/dialog/theme/lumo/vaadin-dialog.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/dialog/src/vaadin-dialog.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/email-field/README.md
+++ b/packages/email-field/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/email-field';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/email-field/vaadin-email-field.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/email-field/theme/material/vaadin-email-field.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/email-field/theme/lumo/vaadin-email-field.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/email-field/src/vaadin-email-field.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/form-layout/README.md
+++ b/packages/form-layout/README.md
@@ -30,29 +30,6 @@ Once installed, import the component in your application:
 import '@vaadin/form-layout';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/form-layout/vaadin-form-layout.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/form-layout/theme/material/vaadin-form-layout.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/form-layout/theme/lumo/vaadin-form-layout.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/form-layout/src/vaadin-form-layout.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/grid-pro/README.md
+++ b/packages/grid-pro/README.md
@@ -40,32 +40,6 @@ import '@vaadin/grid-pro';
 import '@vaadin/grid-pro/vaadin-grid-pro-edit-column.js';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/grid-pro/vaadin-grid-pro.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the components from the `theme/material` folder:
-
-```js
-import '@vaadin/grid-pro/theme/material/vaadin-grid-pro.js';
-import '@vaadin/grid-pro/theme/material/vaadin-grid-pro-edit-column.js';
-```
-
-You can also import the Lumo version of the components explicitly:
-
-```js
-import '@vaadin/grid-pro/theme/lumo/vaadin-grid-pro.js';
-import '@vaadin/grid-pro/theme/lumo/vaadin-grid-pro-edit-column.js';
-```
-
-Finally, you can import the un-themed components from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/grid-pro/src/vaadin-grid-pro.js';
-import '@vaadin/grid-pro/src/vaadin-grid-pro-edit-column.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -49,42 +49,6 @@ import '@vaadin/grid/vaadin-grid-sort-column.js';
 import '@vaadin/grid/vaadin-grid-tree-column.js';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/grid/vaadin-grid.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the components from the `theme/material` folder:
-
-```js
-import '@vaadin/grid/theme/material/vaadin-grid.js';
-import '@vaadin/grid/theme/material/vaadin-grid-filter-column.js';
-import '@vaadin/grid/theme/material/vaadin-grid-selection-column.js';
-import '@vaadin/grid/theme/material/vaadin-grid-sort-column.js';
-import '@vaadin/grid/theme/material/vaadin-grid-tree-column.js';
-```
-
-You can also import the Lumo version of the components explicitly:
-
-```js
-import '@vaadin/grid/theme/lumo/vaadin-grid.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-filter-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-selection-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-sort-column.js';
-import '@vaadin/grid/theme/lumo/vaadin-grid-tree-column.js';
-```
-
-Finally, you can import the un-themed components from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/grid/src/vaadin-grid.js';
-import '@vaadin/grid/src/vaadin-grid-column-group.js';
-import '@vaadin/grid/src/vaadin-grid-filter-column.js';
-import '@vaadin/grid/src/vaadin-grid-selection-column.js';
-import '@vaadin/grid/src/vaadin-grid-sort-column.js';
-import '@vaadin/grid/src/vaadin-grid-tree-column.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/horizontal-layout/README.md
+++ b/packages/horizontal-layout/README.md
@@ -27,29 +27,6 @@ Once installed, import the component in your application:
 import '@vaadin/horizontal-layout';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/horizontal-layout/vaadin-horizontal-layout.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/horizontal-layout/theme/material/vaadin-horizontal-layout.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/horizontal-layout/theme/lumo/vaadin-horizontal-layout.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/horizontal-layout/src/vaadin-horizontal-layout.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/icon';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/icon/vaadin-icon.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/icon/theme/material/vaadin-icon.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/icon/theme/lumo/vaadin-icon.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/icon/src/vaadin-icon.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/integer-field/README.md
+++ b/packages/integer-field/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/integer-field';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/integer-field/vaadin-integer-field.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/integer-field/theme/material/vaadin-integer-field.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/integer-field/theme/lumo/vaadin-integer-field.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/integer-field/src/vaadin-integer-field.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/item/README.md
+++ b/packages/item/README.md
@@ -26,29 +26,6 @@ Once installed, import the component in your application:
 import '@vaadin/item';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/item/vaadin-item.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/item/theme/material/vaadin-item.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/item/theme/lumo/vaadin-item.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/item/src/vaadin-item.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/list-box/README.md
+++ b/packages/list-box/README.md
@@ -33,29 +33,6 @@ Once installed, import the component in your application:
 import '@vaadin/list-box';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/list-box/vaadin-list-box.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/list-box/theme/material/vaadin-list-box.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/list-box/theme/lumo/vaadin-list-box.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/list-box/src/vaadin-list-box.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/login/README.md
+++ b/packages/login/README.md
@@ -26,32 +26,6 @@ Once installed, import the component in your application:
 import '@vaadin/login';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/list-box/vaadin-list-box.js) of the package uses Lumo theme.
-
-To use the Material theme, import the components from the `theme/material` folder:
-
-```js
-import '@vaadin/login/theme/material/vaadin-login-overlay.js';
-import '@vaadin/login/theme/material/vaadin-login-form.js';
-```
-
-You can also import the Lumo version of the components explicitly:
-
-```js
-import '@vaadin/login/theme/lumo/vaadin-login-overlay.js';
-import '@vaadin/login/theme/lumo/vaadin-login-form.js';
-```
-
-Finally, you can import the un-themed components from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/login/src/vaadin-login-overlay.js';
-import '@vaadin/login/src/vaadin-login-form.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/master-detail-layout/README.md
+++ b/packages/master-detail-layout/README.md
@@ -25,29 +25,6 @@ Once installed, import the component in your application:
 import '@vaadin/master-detail-layout';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/master-detail-layout/vaadin-master-detail-layout.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/master-detail-layout/theme/material/vaadin-master-detail-layout.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/master-detail-layout/theme/lumo/vaadin-master-detail-layout.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/master-detail-layout/src/vaadin-master-detail-layout.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/menu-bar/README.md
+++ b/packages/menu-bar/README.md
@@ -38,29 +38,6 @@ Once installed, import the component in your application:
 import '@vaadin/menu-bar';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/menu-bar/vaadin-menu-bar.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/menu-bar/theme/material/vaadin-menu-bar.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/menu-bar/theme/lumo/vaadin-menu-bar.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/menu-bar/src/vaadin-menu-bar.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/message-input/README.md
+++ b/packages/message-input/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/message-input';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/message-input/vaadin-message-input.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/message-input/theme/material/vaadin-message-input.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/message-input/theme/lumo/vaadin-message-input.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/message-input/src/vaadin-message-input.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/message-list/README.md
+++ b/packages/message-list/README.md
@@ -32,29 +32,6 @@ Once installed, import the component in your application:
 import '@vaadin/message-list';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/message-list/vaadin-message-list.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/message-list/theme/material/vaadin-message-list.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/message-list/theme/lumo/vaadin-message-list.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/message-list/src/vaadin-message-list.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/multi-select-combo-box/README.md
+++ b/packages/multi-select-combo-box/README.md
@@ -29,29 +29,6 @@ Once installed, import the component in your application:
 import '@vaadin/multi-select-combo-box';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/multi-select-combo-box/vaadin-multi-select-combo-box.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/multi-select-combo-box/theme/material/vaadin-multi-select-combo-box.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/multi-select-combo-box/src/vaadin-multi-select-combo-box.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/notification/README.md
+++ b/packages/notification/README.md
@@ -34,29 +34,6 @@ Once installed, import the component in your application:
 import '@vaadin/notification';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/notification/vaadin-notification.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/notification/theme/material/vaadin-notification.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/notification/theme/lumo/vaadin-notification.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/notification/src/vaadin-notification.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/number-field';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/number-field/vaadin-number-field.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/number-field/theme/material/vaadin-number-field.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/number-field/theme/lumo/vaadin-number-field.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/number-field/src/vaadin-number-field.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/password-field/README.md
+++ b/packages/password-field/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/password-field';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/password-field/vaadin-password-field.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/password-field/theme/material/vaadin-password-field.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/password-field/theme/lumo/vaadin-password-field.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/password-field/src/vaadin-password-field.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -20,29 +20,6 @@ Once installed, import the component in your application:
 import '@vaadin/popover';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/popover/vaadin-popover.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/popover/theme/material/vaadin-popover.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/popover/theme/lumo/vaadin-popover.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/popover/src/vaadin-popover.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/progress-bar';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/progress-bar/vaadin-progress-bar.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/progress-bar/theme/material/vaadin-progress-bar.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/progress-bar/theme/lumo/vaadin-progress-bar.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/progress-bar/src/vaadin-progress-bar.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/radio-group/README.md
+++ b/packages/radio-group/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/radio-group';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/radio-group/vaadin-radio-group.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/radio-group/theme/material/vaadin-radio-group.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/radio-group/theme/lumo/vaadin-radio-group.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/radio-group/src/vaadin-radio-group.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/rich-text-editor/README.md
+++ b/packages/rich-text-editor/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/rich-text-editor';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/rich-text-editor/vaadin-rich-text-editor.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/rich-text-editor/theme/material/vaadin-rich-text-editor.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/rich-text-editor/theme/lumo/vaadin-rich-text-editor.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/scroller/README.md
+++ b/packages/scroller/README.md
@@ -34,29 +34,6 @@ Once installed, import the component in your application:
 import '@vaadin/scroller';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/scroller/vaadin-scroller.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/scroller/theme/material/vaadin-scroller.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/scroller/theme/lumo/vaadin-scroller.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/scroller/src/vaadin-scroller.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -39,35 +39,6 @@ Install the component:
 npm i @vaadin/select
 ```
 
-Once installed, import the component in your application:
-
-```js
-import '@vaadin/select';
-```
-
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/select/vaadin-select.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/select/theme/material/vaadin-select.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/select/theme/lumo/vaadin-select.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/select/src/vaadin-select.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -41,29 +41,6 @@ Once installed, import the component in your application:
 import '@vaadin/side-nav';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/side-nav/vaadin-side-nav.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/side-nav/theme/material/vaadin-side-nav.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/side-nav/theme/lumo/vaadin-side-nav.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/side-nav/src/vaadin-side-nav.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/split-layout/README.md
+++ b/packages/split-layout/README.md
@@ -35,29 +35,6 @@ Once installed, import the component in your application:
 import '@vaadin/split-layout';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/split-layout/vaadin-split-layout.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/split-layout/theme/material/vaadin-split-layout.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/split-layout/theme/lumo/vaadin-split-layout.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/split-layout/src/vaadin-split-layout.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -31,29 +31,6 @@ Once installed, import the component in your application:
 import '@vaadin/tabs';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/tabs/vaadin-tabs.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/tabs/theme/material/vaadin-tabs.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/tabs/theme/lumo/vaadin-tabs.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/tabs/src/vaadin-tabs.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/tabsheet/README.md
+++ b/packages/tabsheet/README.md
@@ -36,29 +36,6 @@ Once installed, import the component in your application:
 import '@vaadin/tabsheet';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/tabsheet/vaadin-tabsheet.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/tabsheet/theme/material/vaadin-tabsheet.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/tabsheet/theme/lumo/vaadin-tabsheet.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/tabsheet/src/vaadin-tabsheet.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/text-area/README.md
+++ b/packages/text-area/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/text-area';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/text-area/vaadin-text-area.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/text-area/theme/material/vaadin-text-area.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/text-area/theme/lumo/vaadin-text-area.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/text-area/src/vaadin-text-area.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/text-field/README.md
+++ b/packages/text-field/README.md
@@ -24,29 +24,6 @@ Once installed, import the component in your application:
 import '@vaadin/text-field';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/text-field/vaadin-text-field.js) of the package uses Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/text-field/theme/material/vaadin-text-field.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/text-field/theme/lumo/vaadin-text-field.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/text-field/src/vaadin-text-field.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/time-picker/README.md
+++ b/packages/time-picker/README.md
@@ -26,29 +26,6 @@ Once installed, import the component in your application:
 import '@vaadin/time-picker';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/time-picker/vaadin-time-picker.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/time-picker/theme/material/vaadin-time-picker.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/time-picker/theme/lumo/vaadin-time-picker.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/time-picker/src/vaadin-time-picker.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -27,29 +27,6 @@ Once installed, import the component in your application:
 import '@vaadin/tooltip';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/tooltip/vaadin-tooltip.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/tooltip/theme/material/vaadin-tooltip.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/tooltip/theme/lumo/vaadin-tooltip.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/tooltip/src/vaadin-tooltip.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/upload/README.md
+++ b/packages/upload/README.md
@@ -28,29 +28,6 @@ Once installed, import the component in your application:
 import '@vaadin/upload';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/upload/vaadin-upload.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/upload/theme/material/vaadin-upload.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/upload/theme/lumo/vaadin-upload.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/upload/src/vaadin-upload.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/vertical-layout/README.md
+++ b/packages/vertical-layout/README.md
@@ -27,29 +27,6 @@ Once installed, import the component in your application:
 import '@vaadin/vertical-layout';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/vertical-layout/vaadin-vertical-layout.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/vertical-layout/theme/material/vaadin-vertical-layout.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/vertical-layout/theme/lumo/vaadin-vertical-layout.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/vertical-layout/src/vaadin-vertical-layout.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.

--- a/packages/virtual-list/README.md
+++ b/packages/virtual-list/README.md
@@ -32,29 +32,6 @@ Once installed, import the component in your application:
 import '@vaadin/virtual-list';
 ```
 
-## Themes
-
-Vaadin components come with two built-in [themes](https://vaadin.com/docs/latest/styling), Lumo and Material.
-The [main entrypoint](https://github.com/vaadin/web-components/blob/main/packages/virtual-list/vaadin-virtual-list.js) of the package uses the Lumo theme.
-
-To use the Material theme, import the component from the `theme/material` folder:
-
-```js
-import '@vaadin/virtual-list/theme/material/vaadin-virtual-list.js';
-```
-
-You can also import the Lumo version of the component explicitly:
-
-```js
-import '@vaadin/virtual-list/theme/lumo/vaadin-virtual-list.js';
-```
-
-Finally, you can import the un-themed component from the `src` folder to get a minimal starting point:
-
-```js
-import '@vaadin/virtual-list/src/vaadin-virtual-list.js';
-```
-
 ## Contributing
 
 Read the [contributing guide](https://vaadin.com/docs/latest/contributing) to learn about our development process, how to propose bugfixes and improvements, and how to test your changes to Vaadin components.


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/pull/9195

Updated README files to not mention Lumo and Material entrypoints for V25.

## Type of change

- Internal change