### PR TITLE
docs: update JSDoc for internal Lit based custom elements

### DIFF
--- a/packages/combo-box/src/vaadin-lit-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-lit-combo-box-item.js
@@ -11,13 +11,31 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
 
 /**
- * LitElement based version of `<vaadin-combo-box-item>` web component.
+ * An item element used by the `<vaadin-combo-box>` dropdown.
  *
- * ## Disclaimer
+ * ### Styling
  *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name   | Description
+ * ------------|--------------
+ * `checkmark` | The graphical checkmark shown for a selected item
+ * `content`   | The element that wraps the item content
+ *
+ * The following state attributes are exposed for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `selected`   | Set when the item is selected
+ * `focused`    | Set when the item is focused
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @customElement
+ * @mixes ComboBoxItemMixin
+ * @mixes ThemableMixin
+ * @mixes DirMixin
+ * @private
  */
 export class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/multi-select-combo-box/src/vaadin-lit-multi-select-combo-box-chip.js
+++ b/packages/multi-select-combo-box/src/vaadin-lit-multi-select-combo-box-chip.js
@@ -10,13 +10,22 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { multiSelectComboBoxChip } from './vaadin-multi-select-combo-box-styles.js';
 
 /**
- * LitElement based version of `<vaadin-multi-select-combo-box-chip>` web component.
+ * An element used by `<vaadin-multi-select-combo-box>` to display selected items.
  *
- * ## Disclaimer
+ * ### Styling
  *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name        | Description
+ * -----------------|-------------
+ * `label`          | Element containing the label
+ * `remove-button`  | Remove button
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @private
  */
 class MultiSelectComboBoxChip extends ThemableMixin(PolylitMixin(LitElement)) {
   static get is() {

--- a/packages/multi-select-combo-box/src/vaadin-lit-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-lit-multi-select-combo-box-item.js
@@ -11,13 +11,31 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * LitElement based version of `<vaadin-multi-select-combo-box-item>` web component.
+ * An item element used by the `<vaadin-multi-select-combo-box>` dropdown.
  *
- * ## Disclaimer
+ * ### Styling
  *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name   | Description
+ * ------------|--------------
+ * `checkmark` | The graphical checkmark shown for a selected item
+ * `content`   | The element that wraps the item content
+ *
+ * The following state attributes are exposed for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `selected`   | Set when the item is selected
+ * `focused`    | Set when the item is focused
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @customElement
+ * @mixes ComboBoxItemMixin
+ * @mixes ThemableMixin
+ * @mixes DirMixin
+ * @private
  */
 export class MultiSelectComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/time-picker/src/vaadin-lit-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-lit-time-picker-item.js
@@ -11,13 +11,31 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * LitElement based version of `<vaadin-time-picker-item>` web component.
+ * An item element used by the `<vaadin-time-picker>` dropdown.
  *
- * ## Disclaimer
+ * ### Styling
  *
- * This component is an experiment and not yet a part of Vaadin platform.
- * There is no ETA regarding specific Vaadin version where it'll land.
- * Feel free to try this code in your apps as per Apache 2.0 license.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name   | Description
+ * ------------|--------------
+ * `checkmark` | The graphical checkmark shown for a selected item
+ * `content`   | The element that wraps the item content
+ *
+ * The following state attributes are exposed for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `selected`   | Set when the item is selected
+ * `focused`    | Set when the item is focused
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @customElement
+ * @mixes ComboBoxItemMixin
+ * @mixes ThemableMixin
+ * @mixes DirMixin
+ * @private
  */
 export class TimePickerItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))) {
   static get is() {


### PR DESCRIPTION
## Description

Updated JSDoc annotation for components that are marked as `@private` - they would not end up in API docs anyway.
Will update the public components separately as a preparation for switching to Lit based versions later.

## Type of change

- Documentation