### PR TITLE
fix: avoid defining public focus-ring CSS properties

### DIFF
--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -53,9 +53,8 @@ export const buttonStyles = css`
     }
 
     :host([focus-ring]) {
-      outline-style: solid;
-      outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
-      outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+      outline: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) solid
+        var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
       outline-offset: 1px;
     }
 

--- a/packages/button/src/vaadin-button-base.js
+++ b/packages/button/src/vaadin-button-base.js
@@ -53,7 +53,9 @@ export const buttonStyles = css`
     }
 
     :host([focus-ring]) {
-      outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+      outline-style: solid;
+      outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
+      outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
       outline-offset: 1px;
     }
 

--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -43,8 +43,8 @@ addGlobalThemeStyles(
         --_vaadin-radius-full: 999px;
 
         /* Focus outline */
-        --vaadin-focus-ring-width: 2px;
-        --vaadin-focus-ring-color: var(--_vaadin-color);
+        --_vaadin-focus-ring-width: 2px;
+        --_vaadin-focus-ring-color: var(--_vaadin-color);
 
         /* Icons, used as mask-image */
         --_vaadin-icon-calendar: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" /></svg>');

--- a/packages/date-picker/src/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/src/vaadin-month-calendar-styles.js
@@ -89,9 +89,8 @@ export const monthCalendarStyles = css`
   }
 
   :where([part~='date']:focus)::after {
-    outline-style: solid;
-    outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
-    outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+    outline: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) solid
+      var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
     outline-offset: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * -1);
   }
 

--- a/packages/date-picker/src/vaadin-month-calendar-styles.js
+++ b/packages/date-picker/src/vaadin-month-calendar-styles.js
@@ -89,8 +89,10 @@ export const monthCalendarStyles = css`
   }
 
   :where([part~='date']:focus)::after {
-    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
-    outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
+    outline-style: solid;
+    outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
+    outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+    outline-offset: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * -1);
   }
 
   [part~='today'] {

--- a/packages/details/src/vaadin-details-summary-styles.js
+++ b/packages/details/src/vaadin-details-summary-styles.js
@@ -21,9 +21,8 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
     font-weight: var(--${unsafeCSS(partName)}-font-weight, 500);
     gap: var(--${unsafeCSS(partName)}-gap, 0 var(--_vaadin-gap-container-inline));
     height: var(--${unsafeCSS(partName)}-height, auto);
-    outline-style: solid;
-    outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
-    outline-width: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * var(--_focus-ring, 0));
+    outline: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * var(--_focus-ring, 0)) solid
+      var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
     outline-offset: 1px;
     padding: var(--${unsafeCSS(partName)}-padding, var(--_vaadin-padding-container));
     -webkit-tap-highlight-color: transparent;

--- a/packages/details/src/vaadin-details-summary-styles.js
+++ b/packages/details/src/vaadin-details-summary-styles.js
@@ -21,7 +21,9 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
     font-weight: var(--${unsafeCSS(partName)}-font-weight, 500);
     gap: var(--${unsafeCSS(partName)}-gap, 0 var(--_vaadin-gap-container-inline));
     height: var(--${unsafeCSS(partName)}-height, auto);
-    outline: calc(var(--vaadin-focus-ring-width) * var(--_focus-ring, 0)) solid var(--vaadin-focus-ring-color);
+    outline-style: solid;
+    outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+    outline-width: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * var(--_focus-ring, 0));
     outline-offset: 1px;
     padding: var(--${unsafeCSS(partName)}-padding, var(--_vaadin-padding-container));
     -webkit-tap-highlight-color: transparent;

--- a/packages/input-container/src/vaadin-input-container-styles.js
+++ b/packages/input-container/src/vaadin-input-container-styles.js
@@ -85,7 +85,9 @@ export const inputContainerStyles = css`
   }
 
   :host(:focus-within) {
-    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+    outline-style: solid;
+    outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
+    outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
     outline-offset: calc(var(--vaadin-input-field-border-width, 1px) * -1);
   }
 

--- a/packages/input-container/src/vaadin-input-container-styles.js
+++ b/packages/input-container/src/vaadin-input-container-styles.js
@@ -85,9 +85,8 @@ export const inputContainerStyles = css`
   }
 
   :host(:focus-within) {
-    outline-style: solid;
-    outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
-    outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+    outline: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) solid
+      var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
     outline-offset: calc(var(--vaadin-input-field-border-width, 1px) * -1);
   }
 

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -20,8 +20,10 @@ export const itemStyles = css`
     }
 
     :host([focused]) {
-      outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
-      outline-offset: calc(var(--vaadin-focus-ring-width) / -1);
+      outline-style: solid;
+      outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
+      outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+      outline-offset: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * -1);
     }
 
     :host([disabled]) {

--- a/packages/item/src/vaadin-item-styles.js
+++ b/packages/item/src/vaadin-item-styles.js
@@ -20,9 +20,8 @@ export const itemStyles = css`
     }
 
     :host([focused]) {
-      outline-style: solid;
-      outline-width: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width));
-      outline-color: var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
+      outline: var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) solid
+        var(--vaadin-focus-ring-color, var(--_vaadin-focus-ring-color));
       outline-offset: calc(var(--vaadin-focus-ring-width, var(--_vaadin-focus-ring-width)) * -1);
     }
 


### PR DESCRIPTION
## Description

The PR modifies base styles to avoid defining focus-ring properties that conflict with the Lumo theme, which also uses them.

## Type of change

- [x] Bugfix
