### PR TITLE
experiment: wrap all base styles in base CSS layer

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading-base-styles.js
+++ b/packages/accordion/src/vaadin-accordion-heading-base-styles.js
@@ -9,19 +9,21 @@ import { detailsSummary } from '@vaadin/details/src/vaadin-details-summary-base-
 export const accordionHeading = [
   detailsSummary('vaadin-accordion-heading'),
   css`
-    button {
-      align-items: center;
-      appearance: none;
-      background: transparent;
-      border: 0;
-      color: inherit;
-      cursor: inherit;
-      display: flex;
-      font: inherit;
-      gap: inherit;
-      outline: none;
-      padding: 0;
-      touch-action: manipulation;
+    @layer base {
+      button {
+        align-items: center;
+        appearance: none;
+        background: transparent;
+        border: 0;
+        color: inherit;
+        cursor: inherit;
+        display: flex;
+        font: inherit;
+        gap: inherit;
+        outline: none;
+        padding: 0;
+        touch-action: manipulation;
+      }
     }
   `,
 ];

--- a/packages/accordion/src/vaadin-accordion-panel-base-styles.js
+++ b/packages/accordion/src/vaadin-accordion-panel-base-styles.js
@@ -6,23 +6,25 @@
 import { css } from 'lit';
 
 export const accordionPanel = css`
-  :host {
-    display: block;
-  }
+  @layer base {
+    :host {
+      display: block;
+    }
 
-  :host([hidden]) {
-    display: none !important;
-  }
+    :host([hidden]) {
+      display: none !important;
+    }
 
-  [part='content'] {
-    box-sizing: border-box;
-  }
+    [part='content'] {
+      box-sizing: border-box;
+    }
 
-  :host(:not([opened])) [part='content'] {
-    display: none !important;
-  }
+    :host(:not([opened])) [part='content'] {
+      display: none !important;
+    }
 
-  :host([focus-ring]) {
-    --_focus-ring: 1;
+    :host([focus-ring]) {
+      --_focus-ring: 1;
+    }
   }
 `;

--- a/packages/details/src/vaadin-details-summary-base-styles.js
+++ b/packages/details/src/vaadin-details-summary-base-styles.js
@@ -7,93 +7,95 @@ import '@vaadin/component-base/src/style-props.js';
 import { css, unsafeCSS } from 'lit';
 
 export const detailsSummary = (partName = 'vaadin-details-summary') => css`
-  :host {
-    align-items: center;
-    background: var(--${unsafeCSS(partName)}-background, transparent);
-    background-origin: border-box;
-    border: var(--${unsafeCSS(partName)}-border, none);
-    border-radius: var(--${unsafeCSS(partName)}-border-radius, var(--_vaadin-radius-m));
-    box-sizing: border-box;
-    color: var(--${unsafeCSS(partName)}-text-color, var(--_vaadin-color-strong));
-    cursor: var(--vaadin-clickable-cursor);
-    display: flex;
-    font-size: var(--${unsafeCSS(partName)}-font-size, inherit);
-    font-weight: var(--${unsafeCSS(partName)}-font-weight, 500);
-    gap: var(--${unsafeCSS(partName)}-gap, 0 var(--_vaadin-gap-container-inline));
-    height: var(--${unsafeCSS(partName)}-height, auto);
-    outline: calc(var(--vaadin-focus-ring-width) * var(--_focus-ring, 0)) solid var(--vaadin-focus-ring-color);
-    outline-offset: 1px;
-    padding: var(--${unsafeCSS(partName)}-padding, var(--_vaadin-padding-container));
-    -webkit-tap-highlight-color: transparent;
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
-  :host([focus-ring]) {
-    --_focus-ring: 1;
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  [part='toggle'] {
-    color: var(--_vaadin-color);
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    [part='toggle'] {
-      transition-property: rotate;
-      transition-duration: 150ms;
-      animation: delay-initial-transition 1ms;
+  @layer base {
+    :host {
+      align-items: center;
+      background: var(--${unsafeCSS(partName)}-background, transparent);
+      background-origin: border-box;
+      border: var(--${unsafeCSS(partName)}-border, none);
+      border-radius: var(--${unsafeCSS(partName)}-border-radius, var(--_vaadin-radius-m));
+      box-sizing: border-box;
+      color: var(--${unsafeCSS(partName)}-text-color, var(--_vaadin-color-strong));
+      cursor: var(--vaadin-clickable-cursor);
+      display: flex;
+      font-size: var(--${unsafeCSS(partName)}-font-size, inherit);
+      font-weight: var(--${unsafeCSS(partName)}-font-weight, 500);
+      gap: var(--${unsafeCSS(partName)}-gap, 0 var(--_vaadin-gap-container-inline));
+      height: var(--${unsafeCSS(partName)}-height, auto);
+      outline: calc(var(--vaadin-focus-ring-width) * var(--_focus-ring, 0)) solid var(--vaadin-focus-ring-color);
+      outline-offset: 1px;
+      padding: var(--${unsafeCSS(partName)}-padding, var(--_vaadin-padding-container));
+      -webkit-tap-highlight-color: transparent;
+      -webkit-user-select: none;
+      user-select: none;
     }
 
-    @keyframes delay-initial-transition {
-      0% {
-        rotate: 0deg;
+    :host([focus-ring]) {
+      --_focus-ring: 1;
+    }
+
+    :host([hidden]) {
+      display: none !important;
+    }
+
+    [part='toggle'] {
+      color: var(--_vaadin-color);
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      [part='toggle'] {
+        transition-property: rotate;
+        transition-duration: 150ms;
+        animation: delay-initial-transition 1ms;
+      }
+
+      @keyframes delay-initial-transition {
+        0% {
+          rotate: 0deg;
+        }
       }
     }
-  }
 
-  [part='toggle']::before {
-    background: currentColor;
-    content: '';
-    display: block;
-    height: var(--vaadin-icon-size, 1lh);
-    mask-image: var(--_vaadin-icon-chevron-down);
-    width: var(--vaadin-icon-size, 1lh);
-    rotate: -90deg;
-  }
-
-  :host([disabled]) {
-    opacity: 0.5;
-    cursor: var(--vaadin-disabled-cursor);
-  }
-
-  :host([dir='rtl']) [part='toggle']::before {
-    scale: -1;
-  }
-
-  :host([opened]) [part='toggle'] {
-    rotate: 90deg;
-  }
-
-  :host([dir='rtl'][opened]) [part='toggle'] {
-    rotate: -90deg;
-  }
-
-  @media (forced-colors: active) {
     [part='toggle']::before {
-      background: CanvasText;
+      background: currentColor;
+      content: '';
+      display: block;
+      height: var(--vaadin-icon-size, 1lh);
+      mask-image: var(--_vaadin-icon-chevron-down);
+      width: var(--vaadin-icon-size, 1lh);
+      rotate: -90deg;
     }
 
     :host([disabled]) {
-      color: GrayText;
-      opacity: 1;
+      opacity: 0.5;
+      cursor: var(--vaadin-disabled-cursor);
     }
 
-    :host([disabled]) [part='toggle']::before {
-      background: GrayText;
+    :host([dir='rtl']) [part='toggle']::before {
+      scale: -1;
+    }
+
+    :host([opened]) [part='toggle'] {
+      rotate: 90deg;
+    }
+
+    :host([dir='rtl'][opened]) [part='toggle'] {
+      rotate: -90deg;
+    }
+
+    @media (forced-colors: active) {
+      [part='toggle']::before {
+        background: CanvasText;
+      }
+
+      :host([disabled]) {
+        color: GrayText;
+        opacity: 1;
+      }
+
+      :host([disabled]) [part='toggle']::before {
+        background: GrayText;
+      }
     }
   }
 `;

--- a/packages/field-base/src/styles/button-base-styles.js
+++ b/packages/field-base/src/styles/button-base-styles.js
@@ -7,48 +7,50 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const button = css`
-  [part$='button'] {
-    color: var(--_vaadin-color);
-    cursor: var(--vaadin-clickable-cursor);
-    touch-action: manipulation;
-    -webkit-tap-highlight-color: transparent;
-    -webkit-user-select: none;
-    user-select: none;
-  }
+  @layer base {
+    [part$='button'] {
+      color: var(--_vaadin-color);
+      cursor: var(--vaadin-clickable-cursor);
+      touch-action: manipulation;
+      -webkit-tap-highlight-color: transparent;
+      -webkit-user-select: none;
+      user-select: none;
+    }
 
-  /* Icon */
-  [part$='button']::before {
-    background: currentColor;
-    content: '';
-    display: block;
-    height: var(--vaadin-icon-size, 1lh);
-    width: var(--vaadin-icon-size, 1lh);
-  }
-
-  :host(:is(:not([clear-button-visible][has-value]), [disabled], [readonly])) [part='clear-button'] {
-    display: none;
-  }
-
-  [part='clear-button']::before {
-    mask-image: var(--_vaadin-icon-cross);
-  }
-
-  :host(:is([readonly], [disabled])) [part$='button'] {
-    color: var(--_vaadin-color-subtle);
-    cursor: var(--vaadin-disabled-cursor);
-  }
-
-  @media (forced-colors: active) {
+    /* Icon */
     [part$='button']::before {
-      background: CanvasText;
+      background: currentColor;
+      content: '';
+      display: block;
+      height: var(--vaadin-icon-size, 1lh);
+      width: var(--vaadin-icon-size, 1lh);
     }
 
-    :host([disabled]) [part$='button'] {
-      color: GrayText;
+    :host(:is(:not([clear-button-visible][has-value]), [disabled], [readonly])) [part='clear-button'] {
+      display: none;
     }
 
-    :host([disabled]) [part$='button']::before {
-      background: GrayText;
+    [part='clear-button']::before {
+      mask-image: var(--_vaadin-icon-cross);
+    }
+
+    :host(:is([readonly], [disabled])) [part$='button'] {
+      color: var(--_vaadin-color-subtle);
+      cursor: var(--vaadin-disabled-cursor);
+    }
+
+    @media (forced-colors: active) {
+      [part$='button']::before {
+        background: CanvasText;
+      }
+
+      :host([disabled]) [part$='button'] {
+        color: GrayText;
+      }
+
+      :host([disabled]) [part$='button']::before {
+        background: GrayText;
+      }
     }
   }
 `;

--- a/packages/field-base/src/styles/container-base-styles.js
+++ b/packages/field-base/src/styles/container-base-styles.js
@@ -7,12 +7,14 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const container = css`
-  [class$='container'] {
-    display: flex;
-    flex-direction: column;
-    gap: var(--vaadin-input-field-container-gap, var(--_vaadin-gap-container-block));
-    min-width: 100%;
-    max-width: 100%;
-    width: var(--vaadin-field-default-width, 12em);
+  @layer base {
+    [class$='container'] {
+      display: flex;
+      flex-direction: column;
+      gap: var(--vaadin-input-field-container-gap, var(--_vaadin-gap-container-block));
+      min-width: 100%;
+      max-width: 100%;
+      width: var(--vaadin-field-default-width, 12em);
+    }
   }
 `;

--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -7,91 +7,93 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const field = css`
-  :host {
-    display: inline-flex;
-    outline: none;
-  }
+  @layer base {
+    :host {
+      display: inline-flex;
+      outline: none;
+    }
 
-  :host::before {
-    content: '\\2003';
-    width: 0;
-    display: inline-block;
-    /* Size and position this element on the same vertical position as the input-field element
-          to make vertical align for the host element work as expected */
-  }
+    :host::before {
+      content: '\\2003';
+      width: 0;
+      display: inline-block;
+      /* Size and position this element on the same vertical position as the input-field element
+            to make vertical align for the host element work as expected */
+    }
 
-  :host([hidden]) {
-    display: none !important;
-  }
+    :host([hidden]) {
+      display: none !important;
+    }
 
-  :host(:not([has-label])) [part='label'],
-  :host(:not([has-helper])) [part='helper-text'],
-  :host(:not([has-error-message])) [part='error-message'] {
-    display: none;
-  }
+    :host(:not([has-label])) [part='label'],
+    :host(:not([has-helper])) [part='helper-text'],
+    :host(:not([has-error-message])) [part='error-message'] {
+      display: none;
+    }
 
-  [part='label'] {
-    font-size: var(--vaadin-input-field-label-font-size, inherit);
-    line-height: var(--vaadin-input-field-label-line-height, inherit);
-    font-weight: var(--vaadin-input-field-label-font-weight, 500);
-    color: var(--vaadin-input-field-label-color, var(--_vaadin-color-strong));
-    order: var(--vaadin-input-field-helper-order);
-  }
+    [part='label'] {
+      font-size: var(--vaadin-input-field-label-font-size, inherit);
+      line-height: var(--vaadin-input-field-label-line-height, inherit);
+      font-weight: var(--vaadin-input-field-label-font-weight, 500);
+      color: var(--vaadin-input-field-label-color, var(--_vaadin-color-strong));
+      order: var(--vaadin-input-field-helper-order);
+    }
 
-  [part='required-indicator'] {
-    color: var(--vaadin-input-field-required-indicator-color, inherit);
-  }
+    [part='required-indicator'] {
+      color: var(--vaadin-input-field-required-indicator-color, inherit);
+    }
 
-  [part='required-indicator']::after {
-    content: var(--vaadin-input-field-required-indicator, '*');
-  }
+    [part='required-indicator']::after {
+      content: var(--vaadin-input-field-required-indicator, '*');
+    }
 
-  :host(:not([required])) [part='required-indicator'] {
-    display: none;
-  }
+    :host(:not([required])) [part='required-indicator'] {
+      display: none;
+    }
 
-  :host([readonly]) [part='input-field'] {
-    cursor: default;
-  }
+    :host([readonly]) [part='input-field'] {
+      cursor: default;
+    }
 
-  :host([disabled]) [part='input-field'] {
-    cursor: var(--vaadin-disabled-cursor);
-  }
+    :host([disabled]) [part='input-field'] {
+      cursor: var(--vaadin-disabled-cursor);
+    }
 
-  [part='helper-text'] {
-    font-size: var(--vaadin-input-field-helper-font-size, inherit);
-    line-height: var(--vaadin-input-field-helper-line-height, inherit);
-    font-weight: var(--vaadin-input-field-helper-font-weight, 400);
-    color: var(--vaadin-input-field-helper-color, var(--_vaadin-color));
-    order: var(--vaadin-input-field-helper-order);
-  }
+    [part='helper-text'] {
+      font-size: var(--vaadin-input-field-helper-font-size, inherit);
+      line-height: var(--vaadin-input-field-helper-line-height, inherit);
+      font-weight: var(--vaadin-input-field-helper-font-weight, 400);
+      color: var(--vaadin-input-field-helper-color, var(--_vaadin-color));
+      order: var(--vaadin-input-field-helper-order);
+    }
 
-  [part='error-message'] {
-    font-size: var(--vaadin-input-field-error-font-size, inherit);
-    line-height: var(--vaadin-input-field-error-line-height, inherit);
-    font-weight: var(--vaadin-input-field-error-font-weight, 400);
-    color: var(--vaadin-input-field-error-color, var(--_vaadin-color-strong));
-    display: flex;
-    gap: var(--_vaadin-gap-container-inline);
-  }
+    [part='error-message'] {
+      font-size: var(--vaadin-input-field-error-font-size, inherit);
+      line-height: var(--vaadin-input-field-error-line-height, inherit);
+      font-weight: var(--vaadin-input-field-error-font-weight, 400);
+      color: var(--vaadin-input-field-error-color, var(--_vaadin-color-strong));
+      display: flex;
+      gap: var(--_vaadin-gap-container-inline);
+    }
 
-  [part='error-message']::before {
-    content: '';
-    display: inline-block;
-    flex: none;
-    width: var(--vaadin-icon-size, 1lh);
-    height: var(--vaadin-icon-size, 1lh);
-    mask-image: var(--_vaadin-icon-warn);
-    background: currentColor;
-  }
-
-  :host([theme~='helper-above-field']) {
-    --vaadin-input-field-helper-order: -1;
-  }
-
-  @media (forced-colors: active) {
     [part='error-message']::before {
-      background: CanvasText;
+      content: '';
+      display: inline-block;
+      flex: none;
+      width: var(--vaadin-icon-size, 1lh);
+      height: var(--vaadin-icon-size, 1lh);
+      mask-image: var(--_vaadin-icon-warn);
+      background: currentColor;
+    }
+
+    :host([theme~='helper-above-field']) {
+      --vaadin-input-field-helper-order: -1;
+    }
+
+    @media (forced-colors: active) {
+      [part='error-message']::before {
+        background: CanvasText;
+      }
     }
   }
 `;

--- a/packages/input-container/src/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/vaadin-input-container-base-styles.js
@@ -7,116 +7,118 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const inputContainerStyles = css`
-  :host {
-    display: flex;
-    align-items: center;
-    flex: 0 1 auto;
-    --_radius: var(--vaadin-input-field-border-radius, var(--_vaadin-radius-m));
-    border-radius:
-      /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius */
-      var(--vaadin-input-field-top-start-radius, var(--_radius))
-      var(--vaadin-input-field-top-end-radius, var(--_radius))
-      var(--vaadin-input-field-bottom-end-radius, var(--_radius))
-      var(--vaadin-input-field-bottom-start-radius, var(--_radius));
-    border: var(--vaadin-input-field-border-width, 1px) solid
-      var(--vaadin-input-field-border-color, var(--_vaadin-border-color-strong));
-    box-sizing: border-box;
-    cursor: text;
-    padding: var(--vaadin-input-field-padding, var(--_vaadin-padding-container));
-    gap: var(--vaadin-input-field-gap, var(--_vaadin-gap-container-inline));
-    background: var(--vaadin-input-field-background, var(--_vaadin-background));
-    color: var(--vaadin-input-field-value-color, var(--_vaadin-color-strong));
-    font-size: var(--vaadin-input-field-value-font-size, inherit);
-    line-height: var(--vaadin-input-field-value-line-height, inherit);
-    font-weight: var(--vaadin-input-field-value-font-weight, 400);
-  }
-
-  :host([dir='rtl']) {
-    --_radius: var(--vaadin-input-field-border-radius, var(--_vaadin-radius-m));
-    border-radius:
-      /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
-      var(--vaadin-input-field-top-end-radius, var(--_radius))
-      var(--vaadin-input-field-top-start-radius, var(--_radius))
-      var(--vaadin-input-field-bottom-start-radius, var(--_radius))
-      var(--vaadin-input-field-bottom-end-radius, var(--_radius));
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  /* Reset the native input styles */
-  ::slotted(input) {
-    appearance: none;
-    flex: auto;
-    white-space: nowrap;
-    overflow: hidden;
-    width: 100%;
-    height: auto;
-    outline: none;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    min-width: 0;
-    font: inherit;
-    color: inherit;
-    background: transparent;
-    cursor: inherit;
-  }
-
-  ::slotted(*) {
-    flex: none;
-  }
-
-  slot {
-    cursor: auto;
-  }
-
-  ::slotted(:is(input, textarea))::placeholder {
-    /* Use ::slotted(input:placeholder-shown) in themes to style the placeholder. */
-    /* because ::slotted(...)::placeholder does not work in Safari. */
-    font: inherit;
-    color: inherit;
-  }
-
-  ::slotted(input:placeholder-shown) {
-    color: var(--vaadin-input-field-placeholder-color, var(--_vaadin-color));
-  }
-
-  :host(:focus-within) {
-    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
-    outline-offset: calc(var(--vaadin-input-field-border-width, 1px) * -1);
-  }
-
-  :host([readonly]) {
-    border-style: dashed;
-  }
-
-  :host([readonly]:focus-within) {
-    outline-style: dashed;
-    --vaadin-input-field-border-color: transparent;
-  }
-
-  :host([disabled]) {
-    --vaadin-input-field-value-color: var(--vaadin-input-field-disabled-text-color, var(--_vaadin-color-subtle));
-    --vaadin-input-field-background: var(
-      --vaadin-input-field-disabled-background,
-      var(--_vaadin-background-container-strong)
-    );
-    --vaadin-input-field-border-color: transparent;
-  }
-
-  @media (forced-colors: active) {
+  @layer base {
     :host {
-      --vaadin-input-field-background: Field;
-      --vaadin-input-field-value-color: FieldText;
-      --vaadin-input-field-placeholder-color: GrayText;
+      display: flex;
+      align-items: center;
+      flex: 0 1 auto;
+      --_radius: var(--vaadin-input-field-border-radius, var(--_vaadin-radius-m));
+      border-radius:
+      /* See https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius */
+        var(--vaadin-input-field-top-start-radius, var(--_radius))
+        var(--vaadin-input-field-top-end-radius, var(--_radius))
+        var(--vaadin-input-field-bottom-end-radius, var(--_radius))
+        var(--vaadin-input-field-bottom-start-radius, var(--_radius));
+      border: var(--vaadin-input-field-border-width, 1px) solid
+        var(--vaadin-input-field-border-color, var(--_vaadin-border-color-strong));
+      box-sizing: border-box;
+      cursor: text;
+      padding: var(--vaadin-input-field-padding, var(--_vaadin-padding-container));
+      gap: var(--vaadin-input-field-gap, var(--_vaadin-gap-container-inline));
+      background: var(--vaadin-input-field-background, var(--_vaadin-background));
+      color: var(--vaadin-input-field-value-color, var(--_vaadin-color-strong));
+      font-size: var(--vaadin-input-field-value-font-size, inherit);
+      line-height: var(--vaadin-input-field-value-line-height, inherit);
+      font-weight: var(--vaadin-input-field-value-font-weight, 400);
+    }
+
+    :host([dir='rtl']) {
+      --_radius: var(--vaadin-input-field-border-radius, var(--_vaadin-radius-m));
+      border-radius:
+      /* Don't use logical props, see https://github.com/vaadin/vaadin-time-picker/issues/145 */
+        var(--vaadin-input-field-top-end-radius, var(--_radius))
+        var(--vaadin-input-field-top-start-radius, var(--_radius))
+        var(--vaadin-input-field-bottom-start-radius, var(--_radius))
+        var(--vaadin-input-field-bottom-end-radius, var(--_radius));
+    }
+
+    :host([hidden]) {
+      display: none !important;
+    }
+
+    /* Reset the native input styles */
+    ::slotted(input) {
+      appearance: none;
+      flex: auto;
+      white-space: nowrap;
+      overflow: hidden;
+      width: 100%;
+      height: auto;
+      outline: none;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      min-width: 0;
+      font: inherit;
+      color: inherit;
+      background: transparent;
+      cursor: inherit;
+    }
+
+    ::slotted(*) {
+      flex: none;
+    }
+
+    slot {
+      cursor: auto;
+    }
+
+    ::slotted(:is(input, textarea))::placeholder {
+      /* Use ::slotted(input:placeholder-shown) in themes to style the placeholder. */
+      /* because ::slotted(...)::placeholder does not work in Safari. */
+      font: inherit;
+      color: inherit;
+    }
+
+    ::slotted(input:placeholder-shown) {
+      color: var(--vaadin-input-field-placeholder-color, var(--_vaadin-color));
+    }
+
+    :host(:focus-within) {
+      outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+      outline-offset: calc(var(--vaadin-input-field-border-width, 1px) * -1);
+    }
+
+    :host([readonly]) {
+      border-style: dashed;
+    }
+
+    :host([readonly]:focus-within) {
+      outline-style: dashed;
+      --vaadin-input-field-border-color: transparent;
     }
 
     :host([disabled]) {
-      --vaadin-input-field-value-color: GrayText;
-      --vaadin-icon-color: GrayText;
+      --vaadin-input-field-value-color: var(--vaadin-input-field-disabled-text-color, var(--_vaadin-color-subtle));
+      --vaadin-input-field-background: var(
+        --vaadin-input-field-disabled-background,
+        var(--_vaadin-background-container-strong)
+      );
+      --vaadin-input-field-border-color: transparent;
+    }
+
+    @media (forced-colors: active) {
+      :host {
+        --vaadin-input-field-background: Field;
+        --vaadin-input-field-value-color: FieldText;
+        --vaadin-input-field-placeholder-color: GrayText;
+      }
+
+      :host([disabled]) {
+        --vaadin-input-field-value-color: GrayText;
+        --vaadin-icon-color: GrayText;
+      }
     }
   }
 `;

--- a/packages/list-box/src/vaadin-list-box-base-styles.js
+++ b/packages/list-box/src/vaadin-list-box-base-styles.js
@@ -7,27 +7,29 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const listBoxStyles = css`
-  :host {
-    --vaadin-item-checkmark-display: block;
-    display: flex;
-  }
+  @layer base {
+    :host {
+      --vaadin-item-checkmark-display: block;
+      display: flex;
+    }
 
-  :host([hidden]) {
-    display: none !important;
-  }
+    :host([hidden]) {
+      display: none !important;
+    }
 
-  [part='items'] {
-    height: 100%;
-    overflow-y: auto;
-    width: 100%;
-  }
+    [part='items'] {
+      height: 100%;
+      overflow-y: auto;
+      width: 100%;
+    }
 
-  [part='items'] ::slotted(hr) {
-    border-color: var(--vaadin-divider-color, var(--_vaadin-border-color));
-    border-width: 0 0 1px;
-    margin: 4px 8px;
-    margin-inline-start: calc(
-      var(--vaadin-icon-size, 1lh) + var(--vaadin-item-gap, var(--_vaadin-gap-container-inline)) + 8px
-    );
+    [part='items'] ::slotted(hr) {
+      border-color: var(--vaadin-divider-color, var(--_vaadin-border-color));
+      border-width: 0 0 1px;
+      margin: 4px 8px;
+      margin-inline-start: calc(
+        var(--vaadin-icon-size, 1lh) + var(--vaadin-item-gap, var(--_vaadin-gap-container-inline)) + 8px
+      );
+    }
   }
 `;

--- a/packages/number-field/src/vaadin-number-field-base-styles.js
+++ b/packages/number-field/src/vaadin-number-field-base-styles.js
@@ -7,23 +7,25 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const numberFieldStyles = css`
-  :host([step-buttons-visible]) ::slotted(input) {
-    text-align: center;
-  }
+  @layer base {
+    :host([step-buttons-visible]) ::slotted(input) {
+      text-align: center;
+    }
 
-  [part='decrease-button']::before {
-    mask-image: var(--_vaadin-icon-minus);
-  }
+    [part='decrease-button']::before {
+      mask-image: var(--_vaadin-icon-minus);
+    }
 
-  [part='increase-button']::before {
-    mask-image: var(--_vaadin-icon-plus);
-  }
+    [part='increase-button']::before {
+      mask-image: var(--_vaadin-icon-plus);
+    }
 
-  :host([dir='rtl']) [part='input-field'] {
-    direction: ltr;
-  }
+    :host([dir='rtl']) [part='input-field'] {
+      direction: ltr;
+    }
 
-  :host([readonly]) [part$='button'] {
-    pointer-events: none;
+    :host([readonly]) [part$='button'] {
+      pointer-events: none;
+    }
   }
 `;

--- a/packages/overlay/src/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/vaadin-overlay-base-styles.js
@@ -7,74 +7,76 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const overlayStyles = css`
-  :host {
-    z-index: 200;
-    position: fixed;
+  @layer base {
+    :host {
+      z-index: 200;
+      position: fixed;
 
-    /* Despite of what the names say, <vaadin-overlay> is just a container
+      /* Despite of what the names say, <vaadin-overlay> is just a container
           for position/sizing/alignment. The actual overlay is the overlay part. */
 
-    /* Default position constraints. Themes can
+      /* Default position constraints. Themes can
           override this to adjust the gap between the overlay and the viewport. */
-    inset: 8px;
-    bottom: var(--vaadin-overlay-viewport-bottom);
+      inset: 8px;
+      bottom: var(--vaadin-overlay-viewport-bottom);
 
-    /* Use flexbox alignment for the overlay part. */
-    display: flex;
-    flex-direction: column; /* makes dropdowns sizing easier */
-    /* Align to center by default. */
-    align-items: center;
-    justify-content: center;
+      /* Use flexbox alignment for the overlay part. */
+      display: flex;
+      flex-direction: column; /* makes dropdowns sizing easier */
+      /* Align to center by default. */
+      align-items: center;
+      justify-content: center;
 
-    /* Allow centering when max-width/max-height applies. */
-    margin: auto;
+      /* Allow centering when max-width/max-height applies. */
+      margin: auto;
 
-    /* The host is not clickable, only the overlay part is. */
-    pointer-events: none;
+      /* The host is not clickable, only the overlay part is. */
+      pointer-events: none;
 
-    /* Remove tap highlight on touch devices. */
-    -webkit-tap-highlight-color: transparent;
+      /* Remove tap highlight on touch devices. */
+      -webkit-tap-highlight-color: transparent;
 
-    /* CSS API for host */
-    --vaadin-overlay-viewport-bottom: 8px;
-  }
-
-  :host([hidden]),
-  :host(:not([opened]):not([closing])),
-  :host(:not([opened]):not([closing])) [part='overlay'] {
-    display: none !important;
-  }
-
-  [part='overlay'] {
-    background: var(--vaadin-overlay-background, var(--_vaadin-background));
-    border: var(--vaadin-overlay-border, 1px solid var(--_vaadin-border-color));
-    border-radius: var(--vaadin-overlay-border-radius, var(--_vaadin-radius-m));
-    box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px hsl(0 0 0 / 0.3));
-    box-sizing: border-box;
-    max-width: 100%;
-    overflow: auto;
-    overscroll-behavior: contain;
-    pointer-events: auto;
-    -webkit-tap-highlight-color: initial;
-  }
-
-  [part='backdrop'] {
-    background: var(--vaadin-overlay-backdrop-background, rgba(0, 0, 0, 0.5));
-    content: '';
-    inset: 0;
-    pointer-events: auto;
-    position: fixed;
-    z-index: -1;
-  }
-
-  @media (forced-colors: active) {
-    [part='overlay'] {
-      border: 3px solid;
+      /* CSS API for host */
+      --vaadin-overlay-viewport-bottom: 8px;
     }
 
-    [part='overlay']:focus-visible {
-      outline: var(--vaadin-focus-ring-width) solid;
-      outline-offset: 1px;
+    :host([hidden]),
+    :host(:not([opened]):not([closing])),
+    :host(:not([opened]):not([closing])) [part='overlay'] {
+      display: none !important;
+    }
+
+    [part='overlay'] {
+      background: var(--vaadin-overlay-background, var(--_vaadin-background));
+      border: var(--vaadin-overlay-border, 1px solid var(--_vaadin-border-color));
+      border-radius: var(--vaadin-overlay-border-radius, var(--_vaadin-radius-m));
+      box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px hsl(0 0 0 / 0.3));
+      box-sizing: border-box;
+      max-width: 100%;
+      overflow: auto;
+      overscroll-behavior: contain;
+      pointer-events: auto;
+      -webkit-tap-highlight-color: initial;
+    }
+
+    [part='backdrop'] {
+      background: var(--vaadin-overlay-backdrop-background, rgba(0, 0, 0, 0.5));
+      content: '';
+      inset: 0;
+      pointer-events: auto;
+      position: fixed;
+      z-index: -1;
+    }
+
+    @media (forced-colors: active) {
+      [part='overlay'] {
+        border: 3px solid;
+      }
+
+      [part='overlay']:focus-visible {
+        outline: var(--vaadin-focus-ring-width) solid;
+        outline-offset: 1px;
+      }
     }
   }
 `;

--- a/packages/password-field/src/vaadin-password-field-base-styles.js
+++ b/packages/password-field/src/vaadin-password-field-base-styles.js
@@ -6,12 +6,14 @@
 import { css } from 'lit';
 
 export const passwordFieldStyles = css`
-  [part='reveal-button']::before {
-    display: none;
-  }
+  @layer base {
+    [part='reveal-button']::before {
+      display: none;
+    }
 
-  [part='input-field']:has([part='reveal-button']:focus-within) {
-    outline: none;
-    --vaadin-input-field-border-color: inherit;
+    [part='input-field']:has([part='reveal-button']:focus-within) {
+      outline: none;
+      --vaadin-input-field-border-color: inherit;
+    }
   }
 `;

--- a/packages/password-field/src/vaadin-password-field-button-base-styles.js
+++ b/packages/password-field/src/vaadin-password-field-button-base-styles.js
@@ -8,35 +8,37 @@ import { css } from 'lit';
 import { buttonStyles } from '@vaadin/button/src/vaadin-button-base-styles.js';
 
 const passwordFieldBase = css`
-  :host {
-    --vaadin-button-background: transparent;
-    --vaadin-button-border: none;
-    --vaadin-button-padding: 0;
-    color: inherit;
-    display: block;
-    cursor: var(--vaadin-clickable-cursor);
-  }
-
-  :host::before {
-    background: currentColor;
-    content: '';
-    display: block;
-    height: var(--vaadin-icon-size, 1lh);
-    mask-image: var(--_vaadin-icon-eye);
-    width: var(--vaadin-icon-size, 1lh);
-  }
-
-  :host([aria-pressed='true'])::before {
-    mask-image: var(--_vaadin-icon-eye-slash);
-  }
-
-  @media (forced-colors: active) {
-    :host::before {
-      background: CanvasText;
+  @layer base {
+    :host {
+      --vaadin-button-background: transparent;
+      --vaadin-button-border: none;
+      --vaadin-button-padding: 0;
+      color: inherit;
+      display: block;
+      cursor: var(--vaadin-clickable-cursor);
     }
 
-    :host([disabled])::before {
-      background: GrayText;
+    :host::before {
+      background: currentColor;
+      content: '';
+      display: block;
+      height: var(--vaadin-icon-size, 1lh);
+      mask-image: var(--_vaadin-icon-eye);
+      width: var(--vaadin-icon-size, 1lh);
+    }
+
+    :host([aria-pressed='true'])::before {
+      mask-image: var(--_vaadin-icon-eye-slash);
+    }
+
+    @media (forced-colors: active) {
+      :host::before {
+        background: CanvasText;
+      }
+
+      :host([disabled])::before {
+        background: GrayText;
+      }
     }
   }
 `;

--- a/packages/select/src/vaadin-select-base-styles.js
+++ b/packages/select/src/vaadin-select-base-styles.js
@@ -7,28 +7,30 @@ import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
 
 export const selectStyles = css`
-  :host {
-    position: relative;
-  }
+  @layer base {
+    :host {
+      position: relative;
+    }
 
-  ::slotted([slot='value']) {
-    flex: 1;
-  }
+    ::slotted([slot='value']) {
+      flex: 1;
+    }
 
-  :host(:not([focus-ring])) [part='input-field'] {
-    outline: none;
-  }
+    :host(:not([focus-ring])) [part='input-field'] {
+      outline: none;
+    }
 
-  :host([readonly]:not([focus-ring])) [part='input-field'] {
-    --vaadin-input-field-border-color: inherit;
-  }
+    :host([readonly]:not([focus-ring])) [part='input-field'] {
+      --vaadin-input-field-border-color: inherit;
+    }
 
-  [part='input-field'],
-  :host(:not([readonly])) ::slotted([slot='value']) {
-    cursor: var(--vaadin-clickable-cursor);
-  }
+    [part='input-field'],
+    :host(:not([readonly])) ::slotted([slot='value']) {
+      cursor: var(--vaadin-clickable-cursor);
+    }
 
-  [part='toggle-button']::before {
-    mask-image: var(--_vaadin-icon-chevron-down);
+    [part='toggle-button']::before {
+      mask-image: var(--_vaadin-icon-chevron-down);
+    }
   }
 `;

--- a/packages/select/src/vaadin-select-overlay-base-styles.js
+++ b/packages/select/src/vaadin-select-overlay-base-styles.js
@@ -6,16 +6,18 @@
 import { css } from 'lit';
 
 export const selectOverlayStyles = css`
-  :host {
-    align-items: flex-start;
-    justify-content: flex-start;
-  }
+  @layer base {
+    :host {
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
 
-  :host(:not([phone])) [part='overlay'] {
-    min-width: var(--vaadin-select-overlay-width, var(--vaadin-select-text-field-width));
-  }
+    :host(:not([phone])) [part='overlay'] {
+      min-width: var(--vaadin-select-overlay-width, var(--vaadin-select-text-field-width));
+    }
 
-  [part='content'] {
-    padding: var(--vaadin-item-overlay-padding, 4px);
+    [part='content'] {
+      padding: var(--vaadin-item-overlay-padding, 4px);
+    }
   }
 `;

--- a/packages/select/src/vaadin-select-value-button-base-styles.js
+++ b/packages/select/src/vaadin-select-value-button-base-styles.js
@@ -6,25 +6,27 @@
 import { css } from 'lit';
 
 export const valueButton = css`
-  :host {
-    min-height: 1lh;
-    outline: none;
-    overflow: hidden;
-    white-space: nowrap;
-    width: 100%;
-  }
+  @layer base {
+    :host {
+      min-height: 1lh;
+      outline: none;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 100%;
+    }
 
-  ::slotted(*) {
-    padding: 0;
-    cursor: inherit;
-  }
+    ::slotted(*) {
+      padding: 0;
+      cursor: inherit;
+    }
 
-  .vaadin-button-container,
-  [part='label'] {
-    display: contents;
-  }
+    .vaadin-button-container,
+    [part='label'] {
+      display: contents;
+    }
 
-  :host([disabled]) {
-    pointer-events: none;
+    :host([disabled]) {
+      pointer-events: none;
+    }
   }
 `;

--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -6,97 +6,101 @@
 import { css } from 'lit';
 
 export const sideNavItemBaseStyles = css`
-  :host {
-    display: block;
-  }
+  @layer base {
+    :host {
+      display: block;
+    }
 
-  :host([hidden]),
-  [hidden] {
-    display: none !important;
-  }
+    :host([hidden]),
+    [hidden] {
+      display: none !important;
+    }
 
-  :host([disabled]) {
-    pointer-events: none;
-  }
+    :host([disabled]) {
+      pointer-events: none;
+    }
 
-  [part='content'] {
-    display: flex;
-    align-items: center;
-  }
+    [part='content'] {
+      display: flex;
+      align-items: center;
+    }
 
-  [part='link'] {
-    flex: auto;
-    min-width: 0;
-    display: flex;
-    align-items: center;
-    text-decoration: none;
-    color: inherit;
-    font: inherit;
-  }
+    [part='link'] {
+      flex: auto;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      text-decoration: none;
+      color: inherit;
+      font: inherit;
+    }
 
-  button {
-    -webkit-appearance: none;
-    appearance: none;
-    flex: none;
-    position: relative;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    background: transparent;
-  }
+    button {
+      -webkit-appearance: none;
+      appearance: none;
+      flex: none;
+      position: relative;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      background: transparent;
+    }
 
-  [part='children'] {
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
-  }
+    [part='children'] {
+      padding: 0;
+      margin: 0;
+      list-style-type: none;
+    }
 
-  :host(:not([has-children])) button {
-    display: none !important;
-  }
+    :host(:not([has-children])) button {
+      display: none !important;
+    }
 
-  slot[name='prefix'],
-  slot[name='suffix'] {
-    flex: none;
-  }
+    slot[name='prefix'],
+    slot[name='suffix'] {
+      flex: none;
+    }
 
-  slot:not([name]) {
-    display: block;
-    flex: auto;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    slot:not([name]) {
+      display: block;
+      flex: auto;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 `;
 
 export const sideNavBaseStyles = css`
-  :host {
-    display: block;
-  }
+  @layer base {
+    :host {
+      display: block;
+    }
 
-  :host([hidden]) {
-    display: none !important;
-  }
+    :host([hidden]) {
+      display: none !important;
+    }
 
-  button {
-    display: flex;
-    align-items: center;
-    justify-content: inherit;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    background-color: initial;
-    color: inherit;
-    border: initial;
-    outline: none;
-    font: inherit;
-    text-align: inherit;
-  }
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: inherit;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      background-color: initial;
+      color: inherit;
+      border: initial;
+      outline: none;
+      font: inherit;
+      text-align: inherit;
+    }
 
-  [part='children'] {
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
+    [part='children'] {
+      padding: 0;
+      margin: 0;
+      list-style-type: none;
+    }
   }
 `;

--- a/packages/side-nav/src/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/vaadin-side-nav-base-styles.js
@@ -6,101 +6,97 @@
 import { css } from 'lit';
 
 export const sideNavItemBaseStyles = css`
-  @layer base {
-    :host {
-      display: block;
-    }
+  :host {
+    display: block;
+  }
 
-    :host([hidden]),
-    [hidden] {
-      display: none !important;
-    }
+  :host([hidden]),
+  [hidden] {
+    display: none !important;
+  }
 
-    :host([disabled]) {
-      pointer-events: none;
-    }
+  :host([disabled]) {
+    pointer-events: none;
+  }
 
-    [part='content'] {
-      display: flex;
-      align-items: center;
-    }
+  [part='content'] {
+    display: flex;
+    align-items: center;
+  }
 
-    [part='link'] {
-      flex: auto;
-      min-width: 0;
-      display: flex;
-      align-items: center;
-      text-decoration: none;
-      color: inherit;
-      font: inherit;
-    }
+  [part='link'] {
+    flex: auto;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    font: inherit;
+  }
 
-    button {
-      -webkit-appearance: none;
-      appearance: none;
-      flex: none;
-      position: relative;
-      margin: 0;
-      padding: 0;
-      border: 0;
-      background: transparent;
-    }
+  button {
+    -webkit-appearance: none;
+    appearance: none;
+    flex: none;
+    position: relative;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+  }
 
-    [part='children'] {
-      padding: 0;
-      margin: 0;
-      list-style-type: none;
-    }
+  [part='children'] {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
 
-    :host(:not([has-children])) button {
-      display: none !important;
-    }
+  :host(:not([has-children])) button {
+    display: none !important;
+  }
 
-    slot[name='prefix'],
-    slot[name='suffix'] {
-      flex: none;
-    }
+  slot[name='prefix'],
+  slot[name='suffix'] {
+    flex: none;
+  }
 
-    slot:not([name]) {
-      display: block;
-      flex: auto;
-      min-width: 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+  slot:not([name]) {
+    display: block;
+    flex: auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 `;
 
 export const sideNavBaseStyles = css`
-  @layer base {
-    :host {
-      display: block;
-    }
+  :host {
+    display: block;
+  }
 
-    :host([hidden]) {
-      display: none !important;
-    }
+  :host([hidden]) {
+    display: none !important;
+  }
 
-    button {
-      display: flex;
-      align-items: center;
-      justify-content: inherit;
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      background-color: initial;
-      color: inherit;
-      border: initial;
-      outline: none;
-      font: inherit;
-      text-align: inherit;
-    }
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: inherit;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    background-color: initial;
+    color: inherit;
+    border: initial;
+    outline: none;
+    font: inherit;
+    text-align: inherit;
+  }
 
-    [part='children'] {
-      padding: 0;
-      margin: 0;
-      list-style-type: none;
-    }
+  [part='children'] {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
   }
 `;


### PR DESCRIPTION
## Description

Ensures that all base styles are inside the `base` CSS layer to prevent them from overriding the Lumo styles in https://github.com/vaadin/web-components/pull/9206

## Type of change

- [x] Refactor
