### PR TITLE
fix: reset base layer CSS properties in forced colors mode too

### DIFF
--- a/packages/vaadin-lumo-styles/src/props/base-layer-reset.css
+++ b/packages/vaadin-lumo-styles/src/props/base-layer-reset.css
@@ -1,5 +1,5 @@
 @layer vaadin.base {
-  html {
+  :is(html, #id) {
     --vaadin-focus-ring-color: revert-layer;
     --vaadin-focus-ring-width: revert-layer;
   }


### PR DESCRIPTION
## Description

This PR increases the specificity of the `html` selector in `base-layer-reset.css` to ensure that custom CSS properties are also reverted in forced colors mode.

Part of #9082 

## Type of change

- [x] Bugfix
