### PR TITLE
fix: defer scrollToIndex until grid is ready

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -483,6 +483,10 @@ export const DataProviderMixin = (superClass) =>
      * @param indexes {...number} Row indexes to scroll to
      */
     scrollToIndex(...indexes) {
+      if (!this.__virtualizer) {
+        this.__pendingScrollToIndexes = indexes;
+        return;
+      }
       // Synchronous data provider may cause changes to the cache on scroll without
       // ending up in a loading state. Try scrolling to the index until the target
       // index stabilizes.

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -495,7 +495,7 @@ export const DataProviderMixin = (superClass) =>
         this._scrollToFlatIndex(targetIndex);
       }
 
-      if (this._dataProviderController.isLoading() || !this.clientHeight || !this._columnTree) {
+      if (this._dataProviderController.isLoading()) {
         this.__pendingScrollToIndexes = indexes;
       }
     }

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -483,7 +483,7 @@ export const DataProviderMixin = (superClass) =>
      * @param indexes {...number} Row indexes to scroll to
      */
     scrollToIndex(...indexes) {
-      if (!this.__virtualizer) {
+      if (!this.__virtualizer || !this.clientHeight || !this._columnTree) {
         this.__pendingScrollToIndexes = indexes;
         return;
       }

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -577,4 +577,24 @@ describe('scroll to index', () => {
       expect(getFirstVisibleItem(grid).index).to.equal(50);
     });
   });
+
+  describe('before grid is attached', () => {
+    let grid;
+
+    beforeEach(async () => {
+      const container = fixtureSync('<div></div>');
+      grid = document.createElement('vaadin-grid');
+      const column = document.createElement('vaadin-grid-column');
+      grid.appendChild(column);
+      grid.items = Array.from({ length: 100 }, (_, index) => `Item ${index}`);
+      grid.scrollToIndex(50);
+      container.appendChild(grid);
+      await oneEvent(grid, 'animationend');
+      await nextFrame();
+    });
+
+    it('should scroll to index after items are rendered', () => {
+      expect(getFirstVisibleItem(grid).index).to.equal(50);
+    });
+  });
 });


### PR DESCRIPTION
## Description

In some cases (like calling from the Flow component on `afterNavigation` when using Spring Boot), it is possible that the component is not fully ready yet when `scrollToIndex` is called.

This PR defers `scrollToIndex` calls until the component is ready.

Fixes [#7375](https://github.com/vaadin/flow-components/issues/7375)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.