### PR TITLE
refactor: remove Polymer helpers usage from date-picker

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures.js';
@@ -937,8 +936,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
         await new Promise((resolve) => {
           requestAnimationFrame(() => {
             setTimeout(() => {
-              // Force dom-repeat elements to render
-              flush();
               resolve();
             });
           });

--- a/packages/date-picker/src/vaadin-infinite-scroller.js
+++ b/packages/date-picker/src/vaadin-infinite-scroller.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
@@ -220,8 +219,6 @@ export class InfiniteScroller extends HTMLElement {
       this._updateClones();
       this._debouncerUpdateClones.cancel();
     }
-
-    flush();
   }
 
   /**

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -1,13 +1,11 @@
 import { fire, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
-import { flush } from '@polymer/polymer/lib/utils/flush.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 export function activateScroller(scroller) {
   scroller.active = true;
-  // Setting `active` triggers `_finishInit` using afterNextRender
+  // Setting `active` triggers `_finishInit` using requestAnimationFrame
   return new Promise((resolve) => {
-    afterNextRender(scroller, () => {
+    requestAnimationFrame(() => {
       scroller._debouncerUpdateClones.flush();
       resolve();
     });
@@ -76,9 +74,6 @@ export async function untilOverlayRendered(datePicker) {
 
   // Then wait for scrollers to fully render
   await nextRender(datePicker);
-
-  // Force dom-repeat to render table elements
-  flush();
 
   await untilOverlayScrolled(datePicker);
 }


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/6860

Lit based version doesn't use `dom-repeat` so the usage of `flush()` can be removed.

## Type of change

- Refactor