### PR TITLE
refactor: remove Polymer helper usage from ElementMixin

### DIFF
--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -33,12 +33,12 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
     "@vaadin/vaadin-usage-statistics": "^2.1.0",
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "25.0.0-alpha0",
     "@vaadin/test-runner-commands": "25.0.0-alpha0",
     "@vaadin/testing-helpers": "^1.1.0",

--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -3,17 +3,10 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { setCancelSyntheticClickEvents } from '@polymer/polymer/lib/utils/settings.js';
 import { usageStatistics } from '@vaadin/vaadin-usage-statistics/vaadin-usage-statistics.js';
 import { idlePeriod } from './async.js';
 import { Debouncer, enqueueDebouncer } from './debounce.js';
 import { DirMixin } from './dir-mixin.js';
-
-// This setting affects the legacy Polymer gestures which get activated
-// once you import any iron component e.g iron-icon.
-// It has to be explicitly disabled to prevent click issues in iOS + VoiceOver
-// for buttons that are based on `[role=button]` e.g vaadin-button.
-setCancelSyntheticClickEvents(false);
 
 if (!window.Vaadin) {
   window.Vaadin = {};

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -33,11 +33,6 @@ describe('ElementMixin', () => {
       expect(window.Vaadin.developmentModeCallback).to.be.instanceOf(Object);
       expect(window.Vaadin.developmentModeCallback['vaadin-usage-statistics']).to.be.instanceOf(Function);
     });
-
-    it('should set the Polymer cancelSyntheticClickEvents setting to false', async () => {
-      const { cancelSyntheticClickEvents } = await import('@polymer/polymer/lib/utils/settings.js');
-      expect(cancelSyntheticClickEvents).to.be.false;
-    });
   });
 
   describe('registrations', () => {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/6860

This essentially reverts https://github.com/vaadin/web-components/pull/3510 which was needed as a workaround for issues caused by using `<iron-icon>`. 

Also moved Polymer to devDependencies as it's only used in tests (will remove it later in a separate PR).

## Type of change

- Refactor