### PR TITLE
test: remove usage of Polymer helper from menu-bar tests

### DIFF
--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -19,10 +19,7 @@ import {
 import sinon from 'sinon';
 import './menu-bar-test-styles.js';
 import '../src/vaadin-menu-bar.js';
-import { setCancelSyntheticClickEvents } from '@polymer/polymer/lib/utils/settings.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-
-setCancelSyntheticClickEvents(false);
 
 const menuOpenEvent = isTouch ? 'click' : 'mouseover';
 


### PR DESCRIPTION
## Description

This was removed in https://github.com/vaadin/web-components/pull/9226, it shouldn't be needed in tests either.

## Type of change

- Test