### PR TITLE
chore: remove usages of ControllerMixin from test suites

### DIFF
--- a/packages/a11y-base/test/active-mixin.test.js
+++ b/packages/a11y-base/test/active-mixin.test.js
@@ -1,20 +1,11 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import {
-  defineLit,
-  definePolymer,
-  fixtureSync,
-  mousedown,
-  mouseup,
-  touchend,
-  touchstart,
-} from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync, mousedown, mouseup, touchend, touchstart } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ActiveMixin } from '../src/active-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('active-mixin', '<slot></slot>', (Base) => class extends ActiveMixin(baseMixin(Base)) {});
+describe('ActiveMixin', () => {
+  const tag = defineLit('active-mixin', '<slot></slot>', (Base) => class extends ActiveMixin(PolylitMixin(Base)) {});
 
   let element;
 
@@ -121,12 +112,4 @@ const runTests = (defineHelper, baseMixin) => {
     element.parentNode.removeChild(element);
     expect(element.hasAttribute('active')).to.be.false;
   });
-};
-
-describe('ActiveMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ActiveMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/aria-modal-controller.test.js
+++ b/packages/a11y-base/test/aria-modal-controller.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { AriaModalController } from '../src/aria-modal-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('AriaModalController', () => {
   let wrapper, elements, modal, controller;
 
-  const tag = defineHelper('aria-modal', '<slot></slot>', (Base) => class extends baseMixin(Base) {});
+  const tag = defineLit('aria-modal', '<slot></slot>', (Base) => class extends PolylitMixin(Base) {});
 
   beforeEach(async () => {
     wrapper = fixtureSync(`
@@ -82,12 +81,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('AriaModalController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('AriaModalController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/delegate-focus-mixin.test.js
+++ b/packages/a11y-base/test/delegate-focus-mixin.test.js
@@ -1,21 +1,20 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, focusin, focusout, nextFrame } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, focusin, focusout, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DelegateFocusMixin } from '../src/delegate-focus-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('DelegateFocusMixin', () => {
   let setFocusedSpy;
 
-  const tag = defineHelper(
+  const tag = defineLit(
     'delegate-focus-mixin',
     `
       <slot name="input"></slot>
       <slot name="suffix"></slot>
     `,
     (Base) =>
-      class extends DelegateFocusMixin(baseMixin(Base)) {
+      class extends DelegateFocusMixin(PolylitMixin(Base)) {
         ready() {
           super.ready();
           const input = this.querySelector('input');
@@ -306,12 +305,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('DelegateFocusMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('DelegateFocusMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/disabled-mixin.test.js
+++ b/packages/a11y-base/test/disabled-mixin.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DisabledMixin } from '../src/disabled-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('DisabledMixin', () => {
+  const tag = defineLit(
     'disabled-mixin',
     '<slot></slot>',
-    (Base) => class extends DisabledMixin(baseMixin(Base)) {},
+    (Base) => class extends DisabledMixin(PolylitMixin(Base)) {},
   );
 
   let element;
@@ -46,12 +45,4 @@ const runTests = (defineHelper, baseMixin) => {
     element.click();
     expect(spy.called).to.be.false;
   });
-};
-
-describe('DisabledMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('DisabledMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -1,11 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FieldAriaController } from '../src/field-aria-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('field-aria', '<slot></slot>', (Base) => class extends baseMixin(Base) {});
+describe('FieldAriaController', () => {
+  const tag = defineLit('field-aria', '<slot></slot>', (Base) => class extends PolylitMixin(Base) {});
 
   let element, input, controller;
 
@@ -216,12 +215,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('FieldAriaController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FieldAriaController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/focus-mixin.test.js
+++ b/packages/a11y-base/test/focus-mixin.test.js
@@ -1,23 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import {
-  defineLit,
-  definePolymer,
-  fixtureSync,
-  focusin,
-  focusout,
-  keyDownOn,
-  mousedown,
-} from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync, focusin, focusout, keyDownOn, mousedown } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FocusMixin } from '../src/focus-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('FocusMixin', () => {
+  const tag = defineLit(
     'focus-mixin',
     '<slot></slot>',
     (Base) =>
-      class extends FocusMixin(baseMixin(Base)) {
+      class extends FocusMixin(PolylitMixin(Base)) {
         ready() {
           super.ready();
           const input = document.createElement('input');
@@ -65,12 +56,4 @@ const runTests = (defineHelper, baseMixin) => {
     focusin(input);
     expect(element.hasAttribute('focus-ring')).to.be.false;
   });
-};
-
-describe('FocusMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FocusMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -1,8 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FocusTrapController } from '../src/focus-trap-controller.js';
 
@@ -16,12 +15,12 @@ async function shiftTab() {
   return document.activeElement;
 }
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('FocusTrapController', () => {
+  const tag = defineLit(
     'focus-trap',
     '<slot></slot>',
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends PolylitMixin(Base) {
         ready() {
           super.ready();
           this.innerHTML = `
@@ -43,11 +42,11 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  const wrapperTag = defineHelper(
+  const wrapperTag = defineLit(
     'focus-trap-wrapper',
     '<slot></slot>',
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends PolylitMixin(Base) {
         ready() {
           super.ready();
           this.innerHTML = `
@@ -352,12 +351,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(document.activeElement).to.equal(trapInput1);
     });
   });
-};
-
-describe('FocusTrapController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FocusTrapController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/keyboard-direction-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-direction-mixin.test.js
@@ -5,19 +5,17 @@ import {
   arrowRightKeyDown,
   arrowUpKeyDown,
   defineLit,
-  definePolymer,
   endKeyDown,
   fixtureSync,
   homeKeyDown,
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { KeyboardDirectionMixin } from '../src/keyboard-direction-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('KeyboardDirectionMixin', () => {
+  const tag = defineLit(
     'keyboard-direction-mixin',
     `
       <style>
@@ -32,7 +30,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot></slot>
     `,
     (Base) =>
-      class extends KeyboardDirectionMixin(baseMixin(Base)) {
+      class extends KeyboardDirectionMixin(PolylitMixin(Base)) {
         get _vertical() {
           return this.hasAttribute('vertical');
         }
@@ -246,12 +244,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.focused).to.not.equal(items[0]);
     });
   });
-};
-
-describe('KeyboardDirectionMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('KeyboardDirectionMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/keyboard-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-mixin.test.js
@@ -1,19 +1,18 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { KeyboardMixin } from '../src/keyboard-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('KeyboardMixin', () => {
   let element, enterSpy, escapeSpy, keyDownSpy, keyUpSpy;
 
-  const tag = defineHelper(
+  const tag = defineLit(
     'keyboard-mixin',
     '<slot></slot>',
     (Base) =>
-      class extends KeyboardMixin(baseMixin(Base)) {
+      class extends KeyboardMixin(PolylitMixin(Base)) {
         _onKeyDown(event) {
           super._onKeyDown(event);
 
@@ -83,12 +82,4 @@ const runTests = (defineHelper, baseMixin) => {
     expect(enterSpy.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
     expect(enterSpy.args[0][0].type).to.equal('keydown');
   });
-};
-
-describe('KeyboardMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('KeyboardMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -5,7 +5,6 @@ import {
   arrowRight,
   arrowUp,
   defineLit,
-  definePolymer,
   end,
   fixtureSync,
   home,
@@ -15,14 +14,13 @@ import {
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ListMixin } from '../src/list-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('ListMixin', () => {
   let list;
 
-  const listTag = defineHelper(
+  const listTag = defineLit(
     'list',
     `
       <style>
@@ -45,14 +43,14 @@ const runTests = (defineHelper, baseMixin) => {
       </div>
     `,
     (Base) =>
-      class extends ListMixin(baseMixin(Base)) {
+      class extends ListMixin(PolylitMixin(Base)) {
         get _scrollerElement() {
           return this.$.scroll;
         }
       },
   );
 
-  const itemTag = defineHelper(
+  const itemTag = defineLit(
     'item',
     `
       <style>
@@ -71,7 +69,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot></slot>
     `,
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends PolylitMixin(Base) {
         static get properties() {
           return {
             disabled: {
@@ -857,18 +855,10 @@ const runTests = (defineHelper, baseMixin) => {
     });
 
     it('should warn when creating an element without focusElement', () => {
-      const tag = defineHelper('no-scroller', '<slot></slot>', (Base) => class extends ListMixin(baseMixin(Base)) {});
+      const tag = defineLit('no-scroller', '<slot></slot>', (Base) => class extends ListMixin(PolylitMixin(Base)) {});
       const instance = document.createElement(tag);
       expect(instance._scrollerElement).to.equal(instance);
       expect(console.warn.calledOnce).to.be.true;
     });
   });
-};
-
-describe('ListMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ListMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/tabindex-mixin.test.js
+++ b/packages/a11y-base/test/tabindex-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { TabindexMixin } from '../src/tabindex-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('TabindexMixin', () => {
+  const tag = defineLit(
     'tabindex-mixin',
     '<slot></slot>',
-    (Base) => class extends TabindexMixin(baseMixin(Base)) {},
+    (Base) => class extends TabindexMixin(PolylitMixin(Base)) {},
   );
 
   let element;
@@ -89,12 +88,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.tabindex).to.equal(1);
     });
   });
-};
-
-describe('TabindexMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('TabindexMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/controller-mixin.test.js
+++ b/packages/component-base/test/controller-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer } from '@vaadin/testing-helpers';
+import { defineLit } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { LitElement } from 'lit';
 import { ControllerMixin } from '../src/controller-mixin.js';
@@ -18,8 +18,8 @@ class SpyController {
   }
 }
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('controller-mixin', 'Content', (Base) => class extends baseMixin(Base) {});
+describe('ControllerMixin + Lit', () => {
+  const tag = defineLit('controller-mixin', 'Content', (Base) => class extends ControllerMixin(Base) {});
 
   let element, controller;
 
@@ -71,14 +71,6 @@ const runTests = (defineHelper, baseMixin) => {
       expect(controller.hostConnected.calledTwice).to.be.true;
     });
   });
-};
-
-describe('ControllerMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ControllerMixin + Lit', () => {
-  runTests(defineLit, ControllerMixin);
 
   it('should not apply ControllerMixin to LitElement-based classes', () => {
     class TestElement extends LitElement {}

--- a/packages/component-base/test/delegate-state-mixin.test.js
+++ b/packages/component-base/test/delegate-state-mixin.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '../src/controller-mixin.js';
+import { defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { DelegateStateMixin } from '../src/delegate-state-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('DelegateStateMixin + Lit', () => {
+  const tag = defineLit(
     'delegate-state-mixin',
     '<input id="input">',
     (Base) =>
-      class extends DelegateStateMixin(baseMixin(Base)) {
+      class extends DelegateStateMixin(PolylitMixin(Base)) {
         static get properties() {
           return {
             title: {
@@ -146,12 +145,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(target.indeterminate).to.be.false;
     });
   });
-};
-
-describe('DelegateStateMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('DelegateStateMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/dir-mixin.test.js
+++ b/packages/component-base/test/dir-mixin.test.js
@@ -1,18 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { LitElement } from 'lit';
 import { DirMixin } from '../src/dir-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
-
-class DirMixinPolymerElement extends DirMixin(PolymerElement) {
-  static get is() {
-    return 'dir-mixin-polymer-element';
-  }
-}
-
-customElements.define(DirMixinPolymerElement.is, DirMixinPolymerElement);
 
 class DirMixinLitElement extends DirMixin(PolylitMixin(LitElement)) {
   static get is() {
@@ -22,8 +13,8 @@ class DirMixinLitElement extends DirMixin(PolylitMixin(LitElement)) {
 
 customElements.define(DirMixinLitElement.is, DirMixinLitElement);
 
-const runTests = (baseClass) => {
-  const tag = `dir-mixin-${baseClass}-element`;
+describe('DirMixin', () => {
+  const tag = `dir-mixin-lit-element`;
 
   describe('Native HTMLElement.dir API', () => {
     let element;
@@ -231,12 +222,4 @@ const runTests = (baseClass) => {
       expect(element.getAttribute('dir')).to.eql('ltr');
     });
   });
-};
-
-describe('DirMixin + Polymer', () => {
-  runTests('polymer');
-});
-
-describe('DirMixin + Lit', () => {
-  runTests('lit');
 });

--- a/packages/component-base/test/element-mixin.test.js
+++ b/packages/component-base/test/element-mixin.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import sinon from 'sinon';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { LitElement } from 'lit';
 import { flush } from '../src/debounce.js';
 import { ElementMixin } from '../src/element-mixin.js';
 
@@ -8,7 +8,7 @@ describe('ElementMixin', () => {
   const defineCE = (tagName) => {
     customElements.define(
       tagName,
-      class extends ElementMixin(PolymerElement) {
+      class extends ElementMixin(LitElement) {
         static get is() {
           return tagName;
         }
@@ -32,11 +32,6 @@ describe('ElementMixin', () => {
     it('should collect usage statistics', () => {
       expect(window.Vaadin.developmentModeCallback).to.be.instanceOf(Object);
       expect(window.Vaadin.developmentModeCallback['vaadin-usage-statistics']).to.be.instanceOf(Function);
-    });
-
-    it('should set the Polymer cancelSyntheticClickEvents setting to false', async () => {
-      const { cancelSyntheticClickEvents } = await import('@polymer/polymer/lib/utils/settings.js');
-      expect(cancelSyntheticClickEvents).to.be.false;
     });
   });
 
@@ -108,7 +103,7 @@ describe('ElementMixin', () => {
     });
 
     it('should warn about missing doctype', () => {
-      class ElementQux extends ElementMixin(PolymerElement) {
+      class ElementQux extends ElementMixin(LitElement) {
         static get is() {
           return 'element-qux';
         }

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { nextRender } from '@vaadin/testing-helpers';
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { LitElement } from 'lit';
 import { I18nMixin } from '../src/i18n-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
@@ -13,14 +12,6 @@ const DEFAULT_I18N = {
   qux: ['q', 'u', 'x'],
 };
 
-class I18nMixinPolymerElement extends I18nMixin(DEFAULT_I18N, PolymerElement) {
-  static get is() {
-    return 'i18n-mixin-polymer-element';
-  }
-}
-
-customElements.define(I18nMixinPolymerElement.is, I18nMixinPolymerElement);
-
 class I18nMixinLitElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElement)) {
   static get is() {
     return 'i18n-mixin-lit-element';
@@ -29,11 +20,11 @@ class I18nMixinLitElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElemen
 
 customElements.define(I18nMixinLitElement.is, I18nMixinLitElement);
 
-const runTests = (baseClass) => {
+describe('I18nMixin', () => {
   let element;
 
   beforeEach(async () => {
-    element = document.createElement(baseClass.is);
+    element = document.createElement(I18nMixinLitElement.is);
     document.body.appendChild(element);
     await nextRender();
   });
@@ -88,12 +79,4 @@ const runTests = (baseClass) => {
 
     expect(element.__effectiveI18n).to.equal(effectiveI18n);
   });
-};
-
-describe('I18nMixin + Polymer', () => {
-  runTests(I18nMixinPolymerElement);
-});
-
-describe('I18nMixin + Lit', () => {
-  runTests(I18nMixinLitElement);
 });

--- a/packages/component-base/test/media-query-controller.test.js
+++ b/packages/component-base/test/media-query-controller.test.js
@@ -1,12 +1,11 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '../src/controller-mixin.js';
 import { MediaQueryController } from '../src/media-query-controller.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('media-query-controller', `<slot></slot>`, (Base) => class extends baseMixin(Base) {});
+describe('MediaQueryController', () => {
+  const tag = defineLit('media-query-controller', `<slot></slot>`, (Base) => class extends PolylitMixin(Base) {});
 
   let element, controller;
 
@@ -41,12 +40,4 @@ const runTests = (defineHelper, baseMixin) => {
 
     expect(stub.calledTwice).to.be.true;
   });
-};
-
-describe('MediaQueryController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('MediaQueryController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/overflow-controller.test.js
+++ b/packages/component-base/test/overflow-controller.test.js
@@ -1,11 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '../src/controller-mixin.js';
+import { defineLit, fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import { OverflowController } from '../src/overflow-controller.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('OverflowController', () => {
+  const tag = defineLit(
     'overflow',
     `
       <style>
@@ -25,10 +24,10 @@ const runTests = (defineHelper, baseMixin) => {
       </style>
       <slot></slot>
     `,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends PolylitMixin(Base) {},
   );
 
-  const wrapperTag = defineHelper(
+  const wrapperTag = defineLit(
     'overflow-wrapper',
     `
       <style>
@@ -55,7 +54,7 @@ const runTests = (defineHelper, baseMixin) => {
         <slot></slot>
       </div>
     `,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends PolylitMixin(Base) {},
   );
 
   describe('default', () => {
@@ -283,12 +282,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('OverflowController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('OverflowController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '../src/controller-mixin.js';
+import { defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { OverlayClassMixin } from '../src/overlay-class-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('OverlayClassMixin', () => {
+  const tag = defineLit(
     'overlay-class-mixin',
     '<slot name="overlay">',
     (Base) =>
-      class extends OverlayClassMixin(baseMixin(Base)) {
+      class extends OverlayClassMixin(PolylitMixin(Base)) {
         ready() {
           super.ready();
 
@@ -169,12 +168,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(overlay.classList.contains('xyz')).to.be.true;
     });
   });
-};
-
-describe('OverlayClassMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('OverlayClassMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/resize-mixin.test.js
+++ b/packages/component-base/test/resize-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, defineLit, definePolymer, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, defineLit, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '../src/controller-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 import { ResizeMixin } from '../src/resize-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('ResizeMixin', () => {
   let observeParent;
 
-  const tag = defineHelper(
+  const tag = defineLit(
     'resize-mixin',
     `
       <style>
@@ -19,7 +18,7 @@ const runTests = (defineHelper, baseMixin) => {
       <div></div>
     `,
     (Base) =>
-      class extends ResizeMixin(baseMixin(Base)) {
+      class extends ResizeMixin(PolylitMixin(Base)) {
         get _observeParent() {
           return observeParent;
         }
@@ -119,12 +118,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('ResizeMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ResizeMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineCE, defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineCE, defineLit, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '../src/controller-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 import { SlotController } from '../src/slot-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('SlotController', () => {
+  const tag = defineLit(
     'slot-controller',
     `<slot name="foo"></slot><slot></slot>`,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends PolylitMixin(Base) {},
   );
 
   let element, child, controller;
@@ -122,11 +121,11 @@ const runTests = (defineHelper, baseMixin) => {
 
       const initializeSpy = sinon.spy();
 
-      const innerTag = defineHelper(
+      const innerTag = defineLit(
         'slot-controller-inner',
         `<slot></slot>`,
         (Base) =>
-          class extends baseMixin(Base) {
+          class extends PolylitMixin(Base) {
             ready() {
               super.ready();
 
@@ -484,12 +483,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('SlotController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('SlotController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/slot-styles-mixin.test.js
+++ b/packages/component-base/test/slot-styles-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '../src/controller-mixin.js';
+import { defineLit, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 import { SlotController } from '../src/slot-controller.js';
 import { SlotStylesMixin } from '../src/slot-styles-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('SlotStylesMixin', () => {
   const COLOR = 'rgb(0, 100, 0)';
 
-  const tag = defineHelper(
+  const tag = defineLit(
     'slot-styles-mixin',
     `
       <style>
@@ -19,7 +18,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="button"></slot>
       `,
     (Base) =>
-      class extends SlotStylesMixin(baseMixin(Base)) {
+      class extends SlotStylesMixin(PolylitMixin(Base)) {
         get slotStyles() {
           return [
             `
@@ -85,12 +84,4 @@ const runTests = (defineHelper, baseMixin) => {
     wrapper.appendChild(element);
     expect(getComputedStyle(button).color).to.equal(COLOR);
   });
-};
-
-describe('SlotStylesMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('SlotStylesMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -1,16 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '../src/controller-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
 import { TooltipController } from '../src/tooltip-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('TooltipController', () => {
+  const tag = defineLit(
     'tooltip-host',
     `<slot></slot><slot name="tooltip"></slot>
     `,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends PolylitMixin(Base) {},
   );
 
   let host, tooltip, controller;
@@ -186,12 +185,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy).to.be.calledTwice;
     });
   });
-};
-
-describe('TooltipController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('TooltipController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { DelegateFocusMixin } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('CheckedMixin', () => {
+  const tag = defineLit(
     'checked-mixin',
     `
       <div>
@@ -16,7 +15,7 @@ const runTests = (defineHelper, baseMixin) => {
       </div>
     `,
     (Base) =>
-      class extends CheckedMixin(DelegateFocusMixin(baseMixin(Base))) {
+      class extends CheckedMixin(DelegateFocusMixin(PolylitMixin(Base))) {
         constructor() {
           super();
 
@@ -113,12 +112,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('CheckedMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('CheckedMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
   defineLit,
-  definePolymer,
   escKeyDown,
   fixtureSync,
   keyboardEventFor,
@@ -11,20 +10,19 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ClearButtonMixin } from '../src/clear-button-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('ClearButtonMixin', () => {
+  const tag = defineLit(
     'clear-button-mixin',
     `
       <slot name="input"></slot>
       <button id="clearButton">Clear</button>
     `,
     (Base) =>
-      class extends ClearButtonMixin(baseMixin(Base)) {
+      class extends ClearButtonMixin(PolylitMixin(Base)) {
         get clearElement() {
           return this.$.clearButton;
         }
@@ -183,12 +181,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.called).to.be.false;
     });
   });
-};
-
-describe('ClearButtonMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ClearButtonMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { aTimeout, defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FieldMixin } from '../src/field-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('FieldMixin', () => {
+  const tag = defineLit(
     'field-mixin',
     `
       <style>
@@ -36,7 +35,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends FieldMixin(InputMixin(baseMixin(Base))) {
+      class extends FieldMixin(InputMixin(PolylitMixin(Base))) {
         ready() {
           super.ready();
 
@@ -51,7 +50,7 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  const groupTag = defineHelper(
+  const groupTag = defineLit(
     'field-mixin-group',
     `
       <slot name="label"></slot>
@@ -59,7 +58,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends FieldMixin(baseMixin(Base)) {
+      class extends FieldMixin(PolylitMixin(Base)) {
         ready() {
           super.ready();
 
@@ -476,7 +475,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     describe('slotted custom element', () => {
       beforeEach(async () => {
-        const helperTag = defineHelper('custom-helper', '<div>Helper</div>', (Base) => Base);
+        const helperTag = defineLit('custom-helper', '<div>Helper</div>', (Base) => Base);
         element = fixtureSync(`
           <${tag}>
             <${helperTag} slot="helper"></${helperTag}>
@@ -1010,12 +1009,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.getAttribute('aria-describedby')).to.include(helper.id);
     });
   });
-};
-
-describe('FieldMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FieldMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,17 +1,16 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { defineLit, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputConstraintsMixin } from '../src/input-constraints-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputConstraintsMixin', () => {
+  const tag = defineLit(
     'input-constraints-mixin',
     '<slot name="input"></slot>',
     (Base) =>
-      class extends InputConstraintsMixin(baseMixin(Base)) {
+      class extends InputConstraintsMixin(PolylitMixin(Base)) {
         static get properties() {
           return {
             minlength: {
@@ -310,12 +309,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(field.checkValidity()).to.be.false;
     });
   });
-};
-
-describe('InputConstraintsMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputConstraintsMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import {
   defineLit,
-  definePolymer,
   escKeyDown,
   fixtureSync,
   keyboardEventFor,
@@ -13,13 +12,12 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputControlMixin } from '../src/input-control-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputControlMixin', () => {
+  const tag = defineLit(
     'input-control-mixin',
     `
       <div part="label">
@@ -33,7 +31,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends InputControlMixin(baseMixin(Base)) {
+      class extends InputControlMixin(PolylitMixin(Base)) {
         get clearElement() {
           return this.$.clearButton;
         }
@@ -487,12 +485,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('InputControlMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputControlMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -1,17 +1,16 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputController', () => {
+  const tag = defineLit(
     'input-mixin',
     `<slot name="input"></slot>`,
-    (Base) => class extends InputMixin(baseMixin(Base)) {},
+    (Base) => class extends InputMixin(PolylitMixin(Base)) {},
   );
 
   describe('default', () => {
@@ -127,12 +126,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input1.id).to.not.equal(input2.id);
     });
   });
-};
-
-describe('InputController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputFieldMixin } from '../src/input-field-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputFieldMixin', () => {
+  const tag = defineLit(
     'input-field-mixin',
     `
       <div part="label">
@@ -22,7 +21,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends InputFieldMixin(baseMixin(Base)) {
+      class extends InputFieldMixin(PolylitMixin(Base)) {
         get clearElement() {
           return this.$.clearButton;
         }
@@ -247,12 +246,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(console.warn.called).to.be.false;
     });
   });
-};
-
-describe('InputFieldMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputFieldMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputMixin', () => {
+  const tag = defineLit(
     'input-mixin',
     '<slot name="input"></slot>',
-    (Base) => class extends InputMixin(baseMixin(Base)) {},
+    (Base) => class extends InputMixin(PolylitMixin(Base)) {},
   );
 
   let element, input;
@@ -133,11 +132,11 @@ const runTests = (defineHelper, baseMixin) => {
       inputSpy = sinon.spy();
       changeSpy = sinon.spy();
 
-      eventsTag = defineHelper(
+      eventsTag = defineLit(
         'input-mixin-events',
         '<slot name="input"></slot>',
         (Base) =>
-          class extends InputMixin(baseMixin(Base)) {
+          class extends InputMixin(PolylitMixin(Base)) {
             _onInput() {
               inputSpy();
             }
@@ -189,12 +188,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(changeSpy.called).to.be.false;
     });
   });
-};
-
-describe('InputMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('LabelMixin', () => {
+  const tag = defineLit(
     'label-mixin',
     '<slot name="label"></slot>',
-    (Base) => class extends LabelMixin(baseMixin(Base)) {},
+    (Base) => class extends LabelMixin(PolylitMixin(Base)) {},
   );
 
   let element, label;
@@ -331,12 +330,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('LabelMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('LabelMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/labelled-input-controller.test.js
+++ b/packages/field-base/test/labelled-input-controller.test.js
@@ -1,23 +1,22 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
 import { LabelledInputController } from '../src/labelled-input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const inputTag = defineHelper(
+describe('LabelledInputController', () => {
+  const inputTag = defineLit(
     'input',
     `<slot name="label"></slot><slot name="input"></slot>`,
-    (Base) => class extends InputMixin(LabelMixin(baseMixin(Base))) {},
+    (Base) => class extends InputMixin(LabelMixin(PolylitMixin(Base))) {},
   );
 
-  const textareaTag = defineHelper(
+  const textareaTag = defineLit(
     'textarea',
     `<slot name="label"></slot><slot name="textarea"></slot>`,
-    (Base) => class extends InputMixin(LabelMixin(baseMixin(Base))) {},
+    (Base) => class extends InputMixin(LabelMixin(PolylitMixin(Base))) {},
   );
 
   let element, target, label;
@@ -69,12 +68,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('LabelledInputController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('LabelledInputController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,18 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { defineLit, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { PatternMixin } from '../src/pattern-mixin.js';
 import { TextAreaController } from '../src/text-area-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('PatternMixin', () => {
+  const tag = defineLit(
     'pattern-mixin',
     '<slot name="input"></slot>',
     (Base) =>
-      class extends PatternMixin(baseMixin(Base)) {
+      class extends PatternMixin(PolylitMixin(Base)) {
         ready() {
           super.ready();
 
@@ -26,11 +25,11 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  const textareaTag = defineHelper(
+  const textareaTag = defineLit(
     'pattern-mixin-textarea',
     '<slot name="textarea"></slot>',
     (Base) =>
-      class extends PatternMixin(baseMixin(Base)) {
+      class extends PatternMixin(PolylitMixin(Base)) {
         ready() {
           super.ready();
 
@@ -186,12 +185,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.checkValidity()).to.be.true;
     });
   });
-};
-
-describe('PatternMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('PatternMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/text-area-controller.test.js
+++ b/packages/field-base/test/text-area-controller.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 import { TextAreaController } from '../src/text-area-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('TextAreaController', () => {
+  const tag = defineLit(
     'input-mixin',
     `<slot name="textarea"></slot>`,
-    (Base) => class extends InputMixin(baseMixin(Base)) {},
+    (Base) => class extends InputMixin(PolylitMixin(Base)) {},
   );
 
   describe('default', () => {
@@ -94,12 +93,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(textarea1.id).to.not.equal(textarea2.id);
     });
   });
-};
-
-describe('TextAreaController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('TextAreaController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,12 +1,11 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ValidateMixin } from '../src/validate-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('validate-mixin', '<input>', (Base) => class extends ValidateMixin(baseMixin(Base)) {});
+describe('ValidateMixin', () => {
+  const tag = defineLit('validate-mixin', '<input>', (Base) => class extends ValidateMixin(PolylitMixin(Base)) {});
 
   let element;
 
@@ -165,11 +164,11 @@ const runTests = (defineHelper, baseMixin) => {
   });
 
   describe('invalid cannot be set to false', () => {
-    const tagWithShouldSetInvalid = defineHelper(
+    const tagWithShouldSetInvalid = defineLit(
       'validate-mixin-with-should-set-invalid',
       '<input>',
       (Base) =>
-        class extends ValidateMixin(baseMixin(Base)) {
+        class extends ValidateMixin(PolylitMixin(Base)) {
           _shouldSetInvalid(invalid) {
             return invalid;
           }
@@ -190,12 +189,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.invalid).to.be.true;
     });
   });
-};
-
-describe('ValidateMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ValidateMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -1,16 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync, touchstart } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
+import { defineLit, fixtureSync, touchstart } from '@vaadin/testing-helpers';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { VirtualKeyboardController } from '../src/virtual-keyboard-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('VirtualKeyboardController', () => {
+  const tag = defineLit(
     'virtual-keyboard-controller',
     `<slot></slot>`,
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends PolylitMixin(Base) {
         constructor() {
           super();
           this.inputElement = document.createElement('input');
@@ -65,12 +64,4 @@ const runTests = (defineHelper, baseMixin) => {
     await sendKeys({ press: 'Tab' });
     expect(input.inputMode).to.equal('');
   });
-};
-
-describe('VirtualKeyboardController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('VirtualKeyboardController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/item/test/item-mixin.test.js
+++ b/packages/item/test/item-mixin.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
   defineLit,
-  definePolymer,
   enterKeyDown,
   fixtureSync,
   focusin,
@@ -16,12 +15,11 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ItemMixin } from '../src/vaadin-item-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('item-mixin', '<slot></slot>', (Base) => class extends ItemMixin(baseMixin(Base)) {});
+describe('ItemMixin', () => {
+  const tag = defineLit('item-mixin', '<slot></slot>', (Base) => class extends ItemMixin(PolylitMixin(Base)) {});
 
   let item;
 
@@ -258,12 +256,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.called).to.be.false;
     });
   });
-};
-
-describe('ItemMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ItemMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -1,12 +1,11 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { MultiSelectListMixin } from '../src/vaadin-multi-select-list-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const listTag = defineHelper(
+describe('MultiSelectListMixin', () => {
+  const listTag = defineLit(
     'multi-select-list-element',
     `
       <style>
@@ -29,14 +28,14 @@ const runTests = (defineHelper, baseMixin) => {
       </div>
     `,
     (Base) =>
-      class extends MultiSelectListMixin(baseMixin(Base)) {
+      class extends MultiSelectListMixin(PolylitMixin(Base)) {
         get _scrollerElement() {
           return this.$.scroll;
         }
       },
   );
 
-  const itemTag = defineHelper(
+  const itemTag = defineLit(
     'item-element',
     `
       <style>
@@ -47,7 +46,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot></slot>
     `,
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends PolylitMixin(Base) {
         static get properties() {
           return {
             _hasVaadinItemMixin: {
@@ -221,12 +220,4 @@ const runTests = (defineHelper, baseMixin) => {
     await nextUpdate(list);
     expect(list.items[2].selected).to.be.true;
   });
-};
-
-describe('MultiSelectListMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('MultiSelectListMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });


### PR DESCRIPTION
## Description

Removes usages of `ControllerMixin` from test suites, together with the Polymer specific test suites that use it. Also updated/removed some other test suites that were Polymer specific. 

There are probably some Polymer specific tests left, notably the ThemeableMixin test which I wasn't sure about. For now the main goal here is to get rid of `ControllerMixin` usages.

Part of https://github.com/vaadin/web-components/issues/9145

## Type of change

- Internal