### PR TITLE
chore: remove Polymer dependency from all packages

### DIFF
--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "lit": "^3.0.0"
   },

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -35,12 +35,10 @@
     "Vaadin",
     "vaadin-accordion",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/details": "25.0.0-alpha0",

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-app-layout",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -32,12 +32,10 @@
     "vaadin-avatar-group",
     "avatar-group",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/avatar": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -32,12 +32,10 @@
     "Avatar",
     "vaadin-avatar",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/tooltip": "25.0.0-alpha0",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "description": "Polymer element to create flexible responsive layouts and build nice looking dashboard.",
+  "description": "Web component to create flexible responsive layouts and build nice looking dashboard.",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -34,12 +34,10 @@
     "responsive",
     "layout",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "lit": "^3.0.0"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-charts",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "checkbox",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/checkbox": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "checkbox",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -32,12 +32,10 @@
     "Vaadin",
     "combo-box",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -38,7 +38,6 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "25.0.0-alpha0",
     "@vaadin/test-runner-commands": "25.0.0-alpha0",
     "@vaadin/testing-helpers": "^1.1.0",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-confirm-dialog",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/dialog": "25.0.0-alpha0",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "context menu",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/item": "25.0.0-alpha0",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-cookie-consent",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "cookieconsent": "^3.0.6",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-crud",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.2.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-date-time-picker",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/custom-field": "25.0.0-alpha0",

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "vaadin-details",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "vaadin-dialog",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/lit-renderer": "25.0.0-alpha0",
     "@vaadin/overlay": "25.0.0-alpha0",

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -34,7 +34,6 @@
     "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/text-field": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -33,7 +33,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "lit": "^3.0.0"

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -33,7 +33,6 @@
     "field"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/overlay": "25.0.0-alpha0",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "form-layout",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "vaadin-grid-pro",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/checkbox": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/grid": "25.0.0-alpha0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -45,7 +45,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/checkbox": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -31,11 +31,9 @@
     "Vaadin",
     "vaadin-horizontal-layout",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -31,11 +31,9 @@
     "Vaadin",
     "icons",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/icon": "25.0.0-alpha0"
   },
   "devDependencies": {

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -32,7 +32,6 @@
     "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -34,7 +34,6 @@
     "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/number-field": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0"

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "vaadin-item",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "vaadin-list-box",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/item": "25.0.0-alpha0",

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-login",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/overlay": "25.0.0-alpha0",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-map",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-menu-bar",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "message-input",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/text-area": "25.0.0-alpha0",

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -33,12 +33,10 @@
     "vaadin-message",
     "vaadin-message-list",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/avatar": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "multi-select-combo-box",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/combo-box": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -33,12 +33,10 @@
     "Vaadin",
     "vaadin-notification",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/lit-renderer": "25.0.0-alpha0",
     "@vaadin/overlay": "25.0.0-alpha0",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -32,12 +32,10 @@
     "vaadin-overlay",
     "overlay",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -32,12 +32,10 @@
     "vaadin-progress",
     "vaadin-progress-bar",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -33,12 +33,10 @@
     "vaadin-radio-button",
     "web-components",
     "web-component",
-    "radio button",
-    "polymer"
+    "radio button"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -35,12 +35,10 @@
     "Vaadin",
     "vaadin-rich-text-editor",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/confirm-dialog": "25.0.0-alpha0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-scroller",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -35,12 +35,10 @@
     "Vaadin",
     "vaadin-select",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.2.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "split layout",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-tabs",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/item": "25.0.0-alpha0",

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-tabsheet",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/scroller": "25.0.0-alpha0",
     "@vaadin/tabs": "25.0.0-alpha0",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "vaadin-time-picker",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/combo-box": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/field-base": "25.0.0-alpha0",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/overlay": "25.0.0-alpha0",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -31,12 +31,10 @@
     "Vaadin",
     "upload",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/a11y-base": "25.0.0-alpha0",
     "@vaadin/button": "25.0.0-alpha0",
     "@vaadin/component-base": "25.0.0-alpha0",

--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -36,11 +36,9 @@
     "lumo",
     "design-system",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/icon": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0"

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -28,8 +28,7 @@
   "keywords": [
     "Vaadin",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -31,11 +31,9 @@
     "Vaadin",
     "vaadin-vertical-layout",
     "web-components",
-    "web-component",
-    "polymer"
+    "web-component"
   ],
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha0",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -38,7 +38,6 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@polymer/polymer": "^3.0.0",
     "@vaadin/component-base": "25.0.0-alpha0",
     "@vaadin/lit-renderer": "25.0.0-alpha0",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,7 +1297,7 @@
     "@polymer/iron-overlay-behavior" "^3.0.0-pre.27"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/polymer@^3.0.0", "@polymer/polymer@^3.2.0", "@polymer/polymer@^3.5.1":
+"@polymer/polymer@^3.0.0", "@polymer/polymer@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.5.1.tgz#4b5234e43b8876441022bcb91313ab3c4a29f0c8"
   integrity sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==


### PR DESCRIPTION
## Description

Removed `@polymer/polymer` dependency from all npm packages. Also removed `polymer` from keywords.

The only package where we keep Polymer as a dev dependency for now is `@vaadin/vaadin-themable-mixin`.
As discussed internally, we can keep it there for to make migrating addons using `ThemableMixin` easier.

## Type of change

- Internal change