### PR TITLE
refactor: remove no longer needed Polymer workaround

### DIFF
--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -56,15 +56,6 @@ export const InputFieldMixin = (superclass) =>
       return [...super.delegateAttrs, 'autocapitalize', 'autocomplete', 'autocorrect'];
     }
 
-    // Workaround for https://github.com/Polymer/polymer/issues/5259
-    get __data() {
-      return this.__dataValue || {};
-    }
-
-    set __data(value) {
-      this.__dataValue = value;
-    }
-
     /**
      * @param {HTMLElement} input
      * @protected

--- a/packages/integer-field/test/integer-field.test.js
+++ b/packages/integer-field/test/integer-field.test.js
@@ -287,17 +287,3 @@ describe('integer-field', () => {
     });
   });
 });
-
-describe('mixed', () => {
-  it('should not break when used with text-field and number-field', () => {
-    expect(() =>
-      fixtureSync(`
-        <div>
-          <vaadin-integer-field label="integer fld"></vaadin-integer-field>
-          <vaadin-text-field label="text fld"></vaadin-text-field>
-          <vaadin-number-field label="number fld"></vaadin-number-field>
-        </div>
-      `),
-    ).to.not.throw(Error);
-  });
-});


### PR DESCRIPTION
## Description

Removed no longer needed workaround added in https://github.com/vaadin/vaadin-text-field/pull/484

## Type of change

- Refactor