### PR TITLE
docs: remove mentions of using Polymer API from charts JSDoc

### DIFF
--- a/packages/charts/src/vaadin-chart-series-mixin.d.ts
+++ b/packages/charts/src/vaadin-chart-series-mixin.d.ts
@@ -48,10 +48,6 @@ export declare class ChartSeriesMixinClass {
    *   - An array of objects, each one describing one point `[ {x: x0, y: y0, name: 'Point0', color: '#FF0000'}, {...}, ...]`
    *
    *  See more in [API Site](https://api.highcharts.com/highcharts/series)
-   *
-   * Note that you should always use [Polymer API](https://www.polymer-project.org/2.0/docs/devguide/model-data#array-mutation)
-   * to mutate the values array in order to make the component aware of the
-   * change and be able to synchronize it.
    */
   values: ChartSeriesValues | null;
 

--- a/packages/charts/src/vaadin-chart-series-mixin.js
+++ b/packages/charts/src/vaadin-chart-series-mixin.js
@@ -26,9 +26,6 @@ export const ChartSeriesMixin = (superClass) =>
          *
          *  See more in [API Site](https://api.highcharts.com/highcharts/series)
          *
-         * Note that you should always use [Polymer API](https://www.polymer-project.org/2.0/docs/devguide/model-data#array-mutation)
-         * to mutate the values array in order to make the component aware of the
-         * change and be able to synchronize it.
          * @type {ChartSeriesValues}
          */
         values: {


### PR DESCRIPTION
## Description

Missed to remove these references when switching to Lit.

## Type of change

- Docs