### PR TITLE
fix: defer scrollToIndex until grid is ready (#9223) (CP: 23.5)

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -500,8 +500,12 @@ export const DataProviderMixin = (superClass) =>
     }
 
     scrollToIndex(index) {
+      if (!this.__virtualizer || !this.clientHeight || !this._columnTree) {
+        this.__pendingScrollToIndex = index;
+        return;
+      }
       super.scrollToIndex(index);
-      if (!isNaN(index) && (this._cache.isLoading() || !this.clientHeight)) {
+      if (!isNaN(index) && this._cache.isLoading()) {
         this.__pendingScrollToIndex = index;
       }
     }

--- a/packages/grid/test/scroll-to-index.test.js
+++ b/packages/grid/test/scroll-to-index.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { fixtureSync, listenOnce, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/testing-helpers';
 import '@vaadin/polymer-legacy-adapter/template-renderer.js';
 import '../vaadin-grid.js';
 import '../vaadin-grid-tree-column.js';
@@ -279,6 +279,26 @@ describe('scroll to index', () => {
 
       grid.expandedItems = [parents[parents.length - 1]];
       grid.scrollToIndex(14);
+    });
+  });
+
+  describe('before grid is attached', () => {
+    let grid;
+
+    beforeEach(async () => {
+      const container = fixtureSync('<div></div>');
+      grid = document.createElement('vaadin-grid');
+      const column = document.createElement('vaadin-grid-column');
+      grid.appendChild(column);
+      grid.items = Array.from({ length: 100 }, (_, index) => `Item ${index}`);
+      grid.scrollToIndex(50);
+      container.appendChild(grid);
+      await oneEvent(grid, 'animationend');
+      await nextFrame();
+    });
+
+    it('should scroll to index after items are rendered', () => {
+      expect(getFirstVisibleItem(grid).index).to.equal(50);
     });
   });
 });


### PR DESCRIPTION
## Description

Back-port of https://github.com/vaadin/web-components/pull/9223 to v23.5.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.