### PR TITLE
test: remove target arg from `nextRender` calls

### DIFF
--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -40,7 +40,7 @@ describe('avatar-group', () => {
   describe('items property', () => {
     beforeEach(async () => {
       group.items = [{ abbr: 'PM' }, { name: 'Yuriy Yevstihnyeyev' }, { abbr: 'SK' }, { name: 'Jens Jansson' }];
-      await nextRender(group);
+      await nextRender();
     });
 
     it('should render avatar for each item, plus overflow avatar', () => {
@@ -84,7 +84,7 @@ describe('avatar-group', () => {
     beforeEach(async () => {
       group.items = [{ abbr: 'PM' }, { name: 'Yuriy Yevstihnyeyev' }, { name: 'Serhii Kulykov' }, { abbr: 'JJ' }, {}];
       group.maxItemsVisible = 3;
-      await nextRender(group);
+      await nextRender();
     });
 
     it('should render avatar based on maxItemsVisible, including overflow avatar', () => {
@@ -112,14 +112,14 @@ describe('avatar-group', () => {
 
     it('should show at least two avatars if maxItemsVisible is below 2', async () => {
       group.maxItemsVisible = 1;
-      await nextRender(group);
+      await nextRender();
       const items = group.querySelectorAll('vaadin-avatar');
       expect(items.length).to.equal(2);
     });
 
     it('should set abbr property correctly if maxItemsVisible is below 2', async () => {
       group.maxItemsVisible = 1;
-      await nextRender(group);
+      await nextRender();
       const overflow = group._overflow;
       expect(overflow.abbr).to.equal('+4');
     });
@@ -127,28 +127,28 @@ describe('avatar-group', () => {
     it('should show two avatars if maxItemsVisible is below 2', async () => {
       group.items = group.items.slice(0, 2);
       group.maxItemsVisible = 1;
-      await nextRender(group);
+      await nextRender();
       const items = group.querySelectorAll('vaadin-avatar:not([hidden])');
       expect(items.length).to.equal(2);
     });
 
     it('should hide overflow avatar when maxItemsVisible property is set to null', async () => {
       group.maxItemsVisible = null;
-      await nextRender(group);
+      await nextRender();
       expect(group._overflow.hasAttribute('hidden')).to.be.true;
     });
 
     it('should hide overflow avatar when maxItemsVisible property is set to undefined', async () => {
       group.maxItemsVisible = undefined;
-      await nextRender(group);
+      await nextRender();
       expect(group._overflow.hasAttribute('hidden')).to.be.true;
     });
 
     it('should hide overflow avatar when items property is changed', async () => {
       group.maxItemsVisible = 2;
-      await nextRender(group);
+      await nextRender();
       group.items = group.items.slice(0, 2);
-      await nextRender(group);
+      await nextRender();
       expect(group._overflow.hasAttribute('hidden')).to.be.true;
     });
 
@@ -156,11 +156,11 @@ describe('avatar-group', () => {
     it('should show only maxItemsVisible when setting items after being empty', async () => {
       const maxItemsVisible = 3;
       group.maxItemsVisible = maxItemsVisible;
-      await nextRender(group);
+      await nextRender();
       const items = group.items;
       group.items = [];
       group.items = items;
-      await nextRender(group);
+      await nextRender();
       const renderedElements = group.querySelectorAll('vaadin-avatar');
       expect(renderedElements.length).to.equal(maxItemsVisible);
     });
@@ -168,7 +168,7 @@ describe('avatar-group', () => {
     describe('width is set', () => {
       beforeEach(async () => {
         group.maxItemsVisible = 4;
-        await nextRender(group);
+        await nextRender();
       });
 
       it('should consider element width when maxItemsVisible is set', async () => {
@@ -194,7 +194,7 @@ describe('avatar-group', () => {
 
     beforeEach(async () => {
       group.items = [{ abbr: '01' }, { abbr: '02' }, { abbr: '03' }, { abbr: '04' }, { abbr: '05' }];
-      await nextRender(group);
+      await nextRender();
       overlay = group.$.overlay;
       overflow = group._overflow;
     });
@@ -278,7 +278,7 @@ describe('avatar-group', () => {
         { name: 'Jens Jansson' },
       ];
       group.maxItemsVisible = 2;
-      await nextRender(group);
+      await nextRender();
       overlay = group.$.overlay;
       overflow = group._overflow;
     });
@@ -405,7 +405,7 @@ describe('avatar-group', () => {
         { name: 'Yuriy Yevstihnyeyev', colorIndex: 1 },
         { name: 'Serhii Kulykov', colorIndex: 2 },
       ];
-      await nextRender(group);
+      await nextRender();
       overlay = group.$.overlay;
       overflow = group._overflow;
     });
@@ -438,7 +438,7 @@ describe('avatar-group', () => {
         { name: 'Yuriy Yevstihnyeyev', className: 'bar' },
         { name: 'Serhii Kulykov', className: 'baz' },
       ];
-      await nextRender(group);
+      await nextRender();
       overlay = group.$.overlay;
       overflow = group._overflow;
     });
@@ -475,7 +475,7 @@ describe('avatar-group', () => {
 
     beforeEach(async () => {
       group.items = [{ abbr: 'PM' }, { name: 'Yuriy Yevstihnyeyev' }, { name: 'Serhii Kulykov' }];
-      await nextRender(group);
+      await nextRender();
       overlay = group.$.overlay;
       overflow = group._overflow;
     });
@@ -535,7 +535,7 @@ describe('avatar-group', () => {
         { name: 'Jens Jansson' },
       ];
       group.maxItemsVisible = 2;
-      await nextRender(group);
+      await nextRender();
       overlay = group.$.overlay;
       overflow = group._overflow;
     });
@@ -563,7 +563,7 @@ describe('avatar-group', () => {
 
     beforeEach(async () => {
       group.items = [{ name: 'AA' }, { name: 'BB' }, { name: 'CC' }];
-      await nextRender(group);
+      await nextRender();
       clock = sinon.useFakeTimers();
     });
 
@@ -639,7 +639,7 @@ describe('avatar group in column flex', () => {
       { abbr: 'LA' },
       { name: 'Jens Jansson' },
     ];
-    await nextRender(group);
+    await nextRender();
   });
 
   it('should have width of the parent', () => {

--- a/packages/avatar-group/test/visual/lumo/avatar-group.test.js
+++ b/packages/avatar-group/test/visual/lumo/avatar-group.test.js
@@ -65,9 +65,9 @@ describe('avatar-group', () => {
     document.body.style.width = '220px';
     element.maxItemsVisible = 3;
     element.items = [{ name: 'Abc Def' }, { name: 'Ghi Jkl' }, { name: 'Mno Pqr' }, { name: 'Stu Vwx' }];
-    await nextRender(element);
+    await nextRender();
     element._overflow.click();
-    await nextRender(element);
+    await nextRender();
     await visualDiff(document.body, 'opened');
   });
 

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -29,7 +29,7 @@ describe('vaadin-button', () => {
     describe('default', () => {
       beforeEach(async () => {
         button = fixtureSync('<vaadin-button>Press me</vaadin-button>');
-        await nextRender(button);
+        await nextRender();
       });
 
       it('should set role attribute to button by default', () => {
@@ -40,7 +40,7 @@ describe('vaadin-button', () => {
     describe('custom', () => {
       beforeEach(async () => {
         button = fixtureSync('<vaadin-button role="menuitem">Press me</vaadin-button>');
-        await nextRender(button);
+        await nextRender();
       });
 
       it('should not override custom role attribute', () => {
@@ -52,7 +52,7 @@ describe('vaadin-button', () => {
   describe('keyboard', () => {
     beforeEach(async () => {
       button = fixtureSync('<vaadin-button>Press me</vaadin-button>');
-      await nextRender(button);
+      await nextRender();
       button.focus();
     });
 
@@ -129,7 +129,7 @@ describe('vaadin-button', () => {
           <input id="last-global-focusable" />
         </div>`,
       ).children as unknown as [Button, HTMLInputElement];
-      await nextRender(button);
+      await nextRender();
     });
 
     afterEach(async () => {
@@ -181,7 +181,7 @@ describe('vaadin-button', () => {
           <input id="last-global-focusable" />
         </div>`,
       ).children as unknown as [Button, HTMLInputElement];
-      await nextRender(button);
+      await nextRender();
     });
 
     afterEach(async () => {

--- a/packages/card/test/accessibility.test.js
+++ b/packages/card/test/accessibility.test.js
@@ -10,7 +10,7 @@ describe('accessibility', () => {
 
   beforeEach(async () => {
     card = fixtureSync('<vaadin-card></vaadin-card>');
-    await nextRender(card);
+    await nextRender();
   });
 
   describe('ARIA roles', () => {
@@ -35,7 +35,7 @@ describe('accessibility', () => {
       await nextUpdate(card);
       const customTitleElement = fixtureSync('<span slot="title">Custom title element</span>');
       card.appendChild(customTitleElement);
-      await nextRender(card);
+      await nextRender();
       expect(card.hasAttribute('aria-labelledby')).to.be.false;
     });
   });

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -43,7 +43,7 @@ describe('vaadin-card', () => {
     it('should create title element with default aria-level when title property is set', async () => {
       const stringTitle = 'Some title';
       card.cardTitle = stringTitle;
-      await nextRender(card);
+      await nextRender();
       const stringTitleElement = getStringTitleElement();
       expect(stringTitleElement).to.exist;
       expect(stringTitleElement.getAttribute('aria-level')).to.equal('2');
@@ -53,7 +53,7 @@ describe('vaadin-card', () => {
     it('should update aria-level when heading level changes', async () => {
       card.cardTitle = 'Some title';
       card.titleHeadingLevel = 3;
-      await nextRender(card);
+      await nextRender();
       const stringTitleElement = getStringTitleElement();
       expect(stringTitleElement.getAttribute('aria-level')).to.equal('3');
     });
@@ -62,43 +62,43 @@ describe('vaadin-card', () => {
       card.titleHeadingLevel = 3;
       card.cardTitle = 'Some title';
       card.titleHeadingLevel = null;
-      await nextRender(card);
+      await nextRender();
       expect(getStringTitleElement().getAttribute('aria-level')).to.equal('2');
     });
 
     it('should clear string title when custom title element is used', async () => {
       card.cardTitle = 'Some title';
-      await nextRender(card);
+      await nextRender();
       const customTitleElement = fixtureSync('<span slot="title">Custom title element</span>');
       card.appendChild(customTitleElement);
-      await nextRender(card);
+      await nextRender();
       expect(card.cardTitle).to.be.not.ok;
       expect(getStringTitleElement()).to.not.exist;
     });
 
     it('should clear string title when empty string title is set', async () => {
       card.cardTitle = 'Some title';
-      await nextRender(card);
+      await nextRender();
       card.cardTitle = '';
-      await nextRender(card);
+      await nextRender();
       expect(getStringTitleElement()).to.not.exist;
     });
 
     it('should clear custom title element when string title is set', async () => {
       const customTitleElement = fixtureSync('<span slot="title">Custom title element</span>');
       card.appendChild(customTitleElement);
-      await nextRender(card);
+      await nextRender();
       card.cardTitle = 'Some title';
-      await nextRender(card);
+      await nextRender();
       expect(getCustomTitleElement()).to.not.exist;
     });
 
     it('should not clear custom title element when empty string title is set', async () => {
       const customTitleElement = fixtureSync('<span slot="title">Custom title element</span>');
       card.appendChild(customTitleElement);
-      await nextRender(card);
+      await nextRender();
       card.cardTitle = '';
-      await nextRender(card);
+      await nextRender();
       expect(getCustomTitleElement()).to.exist;
     });
   });

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -96,33 +96,33 @@ describe('vaadin-chart-series', () => {
 
       it('should have markers by default for widespread data', async () => {
         series.values = [10, 20, 10, 30, 50];
-        await nextRender(chart);
+        await nextRender();
         expect(markersVisible(chartContainer)).to.be.true;
       });
 
       it('should not have markers by default for dense data', async () => {
         series.values = new Array(400).fill(10);
-        await nextRender(chart);
+        await nextRender();
         expect(markersVisible(chartContainer)).to.be.false;
       });
 
       it('should have markers when set to shown', async () => {
         series.markers = 'shown';
         series.values = new Array(400).fill(10);
-        await nextRender(chart);
+        await nextRender();
         expect(markersVisible(chartContainer)).to.be.true;
       });
 
       it('should not have markers when set to hidden', async () => {
         series.markers = 'hidden';
         series.values = [10, 20, 10, 30, 50];
-        await nextRender(chart);
+        await nextRender();
         expect(markersVisible(chartContainer)).to.be.false;
       });
 
       it('should not have markers when options are set', async () => {
         series.values = [10, 20, 10, 30, 50];
-        await nextRender(chart);
+        await nextRender();
         chart.additionalOptions = { plotOptions: { series: { marker: { enabled: false } } } };
         await aTimeout(50);
         expect(markersVisible(chartContainer)).to.be.false;

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -57,7 +57,7 @@ describe('vaadin-chart exporting', () => {
     pngExportButton.onclick();
 
     expect(fireEventSpy.firstCall.args[1]).to.be.equal('beforeExport');
-    await nextRender(chart);
+    await nextRender();
     expect(styleCopiedToBody).to.be.true;
     expect(styleContent).to.include('.highcharts-color-0');
   });
@@ -85,7 +85,7 @@ describe('vaadin-chart exporting', () => {
     pngExportButton.onclick();
 
     expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
-    await nextRender(chart);
+    await nextRender();
     expect(styleRemovedFromBody).to.be.true;
   });
 
@@ -116,7 +116,7 @@ describe('vaadin-chart exporting', () => {
     pngExportButton.onclick();
 
     expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
-    await nextRender(chart);
+    await nextRender();
     expect(styledModeAddedToBody).to.be.true;
     expect(document.body.hasAttribute(attributeName)).to.be.false;
   });
@@ -148,7 +148,7 @@ describe('vaadin-chart exporting', () => {
     pngExportButton.onclick();
 
     expect(fireEventSpy.lastCall.args[1]).to.be.equal('afterExport');
-    await nextRender(chart);
+    await nextRender();
     expect(styledModeAddedToBody).to.be.false;
     expect(document.body.hasAttribute(attributeName)).to.be.false;
   });

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -129,7 +129,7 @@ describe('items', () => {
 
   (isTouch ? it.skip : it)('should open the subMenu on the left if root menu is end-aligned', async () => {
     subMenu.close();
-    await nextRender(subMenu);
+    await nextRender();
     const rootItem = getMenuItems(rootMenu)[0];
     const rootItemRect = rootItem.getBoundingClientRect();
     rootOverlay.style.removeProperty('left');
@@ -147,7 +147,7 @@ describe('items', () => {
   it.skip('should open the second subMenu on the right again if not enough space', async () => {
     let padding;
     subMenu.close();
-    await nextRender(subMenu);
+    await nextRender();
     rootMenu.items[0].children[2].text = 'foo-0-2-longer';
 
     const rootItem = getMenuItems(rootMenu)[0];
@@ -381,7 +381,7 @@ describe('items', () => {
     rootOverlay.focus();
     await openMenu(getMenuItems(rootMenu)[0]);
     expect(subMenu.opened).to.be.true;
-    await nextRender(subMenu);
+    await nextRender();
     expect(getMenuItems(subMenu)[0].hasAttribute('focused')).to.be.false;
   });
 
@@ -565,7 +565,7 @@ describe('items', () => {
       const subBRCTop2 = subOverlay2.getBoundingClientRect().top;
 
       scrollElm.scrollTop = scrollDistance;
-      await nextRender(rootMenu);
+      await nextRender();
       expect(rootOverlay.getBoundingClientRect().top).to.be.closeTo(rootBRCTop - scrollDistance, 1);
       expect(subOverlay1.getBoundingClientRect().top).to.be.closeTo(subBRCTop1 - scrollDistance, 1);
       expect(subOverlay2.getBoundingClientRect().top).to.be.closeTo(subBRCTop2 - scrollDistance, 1);
@@ -580,7 +580,7 @@ describe('items', () => {
       const subBRCLeft2 = subOverlay2.getBoundingClientRect().left;
 
       scrollElm.scrollLeft = scrollDistance;
-      await nextRender(rootMenu);
+      await nextRender();
       expect(rootOverlay.getBoundingClientRect().left).to.be.closeTo(rootBRCLeft - scrollDistance, 1);
       expect(subOverlay1.getBoundingClientRect().left).to.be.closeTo(subBRCLeft1 - scrollDistance, 1);
       expect(subOverlay2.getBoundingClientRect().left).to.be.closeTo(subBRCLeft2 - scrollDistance, 1);

--- a/packages/context-menu/test/selection.test.js
+++ b/packages/context-menu/test/selection.test.js
@@ -26,7 +26,7 @@ describe('selection', () => {
   it('should close on item click', async () => {
     menu._setOpened(true);
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextRender(overlay);
+    await nextRender();
 
     const listBox = overlay.querySelector('#menu');
     click(listBox.items[0]);
@@ -36,7 +36,7 @@ describe('selection', () => {
   it('should close on keyboard selection', async () => {
     menu._setOpened(true);
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextRender(overlay);
+    await nextRender();
 
     const spy = sinon.spy();
     menu.addEventListener('opened-changed', spy);
@@ -50,7 +50,7 @@ describe('selection', () => {
   it('should focus the child element', async () => {
     menu._setOpened(true);
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextRender(overlay);
+    await nextRender();
 
     const item = overlay.querySelector('#menu vaadin-item');
     expect(document.activeElement).to.eql(item);
@@ -59,7 +59,7 @@ describe('selection', () => {
   (isIOS ? it.skip : it)('should focus the child element on `contextmenu` event', async () => {
     fire(menu, 'contextmenu');
     await oneEvent(overlay, 'vaadin-overlay-open');
-    await nextRender(overlay);
+    await nextRender();
 
     const item = overlay.querySelector('#menu vaadin-item');
     expect(document.activeElement).to.eql(item);

--- a/packages/context-menu/test/visual/lumo/context-menu.test.js
+++ b/packages/context-menu/test/visual/lumo/context-menu.test.js
@@ -52,7 +52,7 @@ describe('context-menu', () => {
 
         it('basic', async () => {
           contextmenu(element);
-          await nextRender(element);
+          await nextRender();
           await visualDiff(document.body, `${dir}-basic`);
         });
       });
@@ -79,7 +79,7 @@ describe('context-menu', () => {
 
         it('basic', async () => {
           contextmenu(element);
-          await nextRender(element);
+          await nextRender();
           await visualDiff(document.body, `${dir}-long`);
         });
 
@@ -88,7 +88,7 @@ describe('context-menu', () => {
           element.style.bottom = '50px';
           element.style.right = '50px';
           contextmenu(element);
-          await nextRender(element);
+          await nextRender();
           await visualDiff(document.body, `${dir}-long-bottom`);
         });
       });
@@ -126,7 +126,7 @@ describe('context-menu', () => {
           ];
           contextmenu(element);
           await openSubMenus(element);
-          await nextRender(element);
+          await nextRender();
           await visualDiff(document.body, `${dir}-items`);
         });
       });

--- a/packages/crud/test/crud-buttons.test.js
+++ b/packages/crud/test/crud-buttons.test.js
@@ -33,7 +33,7 @@ describe('crud buttons', () => {
           `);
         }
         crud.items = [{ foo: 'bar' }];
-        await nextRender(crud._grid);
+        await nextRender();
         saveButton = crud.querySelector('[slot=save-button]');
         cancelButton = crud.querySelector('[slot=cancel-button]');
         deleteButton = crud.querySelector('[slot=delete-button]');
@@ -376,7 +376,7 @@ describe('crud buttons', () => {
           crud.editedItem = crud.items[0];
           await nextRender();
           cancelButton.click();
-          await nextRender(crud);
+          await nextRender();
           expect(crud.__isNew).not.to.be.true;
         });
 
@@ -418,7 +418,7 @@ describe('crud buttons', () => {
             crud.editOnClick = true;
             confirmCancelDialog = crud.$.confirmCancel;
             confirmCancelOverlay = confirmCancelDialog.$.dialog.$.overlay;
-            await nextRender(crud);
+            await nextRender();
             flushGrid(crud._grid);
             crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
           });
@@ -973,20 +973,20 @@ describe('crud buttons', () => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
       items = [{ foo: 'bar' }];
       crud.dataProvider = (_, callback) => callback(items, items.length);
-      await nextRender(crud._grid);
+      await nextRender();
       saveButton = crud.querySelector('[slot=save-button]');
       deleteButton = crud.querySelector('[slot=delete-button]');
     });
 
     it('should hide delete button on new', async () => {
       crud._newButton.click();
-      await nextRender(crud.$.dialog.$.overlay);
+      await nextRender();
       expect(deleteButton.hasAttribute('hidden')).to.be.true;
     });
 
     it('should show delete button and disable save button on edit', async () => {
       edit(items[0]);
-      await nextRender(crud.$.dialog.$.overlay);
+      await nextRender();
       expect(saveButton.hasAttribute('disabled')).to.be.true;
       expect(deleteButton.hasAttribute('hidden')).not.to.be.true;
     });

--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -28,7 +28,7 @@ describe('crud editor', () => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
       crud.items = [{ foo: 'bar' }];
       header = crud.querySelector('[slot=header]');
-      await nextRender(crud._grid);
+      await nextRender();
     });
 
     it('should have new item title', async () => {
@@ -69,11 +69,11 @@ describe('crud editor', () => {
           `);
         }
         crud.editOnClick = true;
-        await nextRender(crud);
+        await nextRender();
         flushGrid(crud._grid);
 
         crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
-        await nextRender(crud);
+        await nextRender();
         dialog = crud.$.dialog;
         overlay = dialog.$.overlay;
         form = crud.querySelector('[slot=form]');
@@ -106,7 +106,7 @@ describe('crud editor', () => {
         btnCancel.click();
 
         crud.editorPosition = 'bottom';
-        await nextRender(crud);
+        await nextRender();
 
         crud._grid.activeItem = crud.items[1];
         await nextRender();
@@ -115,14 +115,14 @@ describe('crud editor', () => {
 
       it(`should move ${type} form when editorPosition changes from bottom to default`, async () => {
         crud.editorPosition = 'bottom';
-        await nextRender(crud);
+        await nextRender();
 
         crud._grid.activeItem = crud.items[0];
         await nextRender();
         btnCancel.click();
 
         crud.editorPosition = '';
-        await nextRender(crud);
+        await nextRender();
 
         crud._grid.activeItem = crud.items[1];
         await nextRender();
@@ -138,7 +138,7 @@ describe('crud editor', () => {
 
         crud._grid.activeItem = crud.items[0];
         crud.appendChild(newForm);
-        await nextRender(crud);
+        await nextRender();
 
         expect(form.parentElement).to.be.null;
         expect(newForm.parentElement).to.equal(overlay);

--- a/packages/crud/test/crud-form.test.js
+++ b/packages/crud/test/crud-form.test.js
@@ -87,7 +87,7 @@ describe('crud form', () => {
 
     beforeEach(async () => {
       crudForm.item = item;
-      await nextRender(crudForm);
+      await nextRender();
     });
 
     it('should automatically generate fields when item is set', () => {

--- a/packages/crud/test/crud-grid.test.js
+++ b/packages/crud/test/crud-grid.test.js
@@ -61,7 +61,7 @@ describe('crud grid', () => {
         },
       ];
       flushGrid(grid);
-      await nextRender(grid);
+      await nextRender();
 
       // First column
       expect(getHeaderCellContent(grid, 2, 0).textContent.trim()).to.be.equal('Foo');
@@ -81,7 +81,7 @@ describe('crud grid', () => {
       it('should configure include fields in the provided order', async () => {
         grid.include = 'role,password,name.first,name.last';
         flushGrid(grid);
-        await nextRender(grid);
+        await nextRender();
         expect(getHeaderCellContent(grid, 0, 2).textContent.trim()).to.be.equal('Name');
         expect(getHeaderCellContent(grid, 1, 0).textContent.trim()).to.be.equal('Role');
         expect(getHeaderCellContent(grid, 1, 1).textContent.trim()).to.be.equal('Password');
@@ -92,7 +92,7 @@ describe('crud grid', () => {
       it('should convert camelCase fields label into sentence field label', async () => {
         grid.include = 'passwordField,name.firstName';
         flushGrid(grid);
-        await nextRender(grid);
+        await nextRender();
         expect(getHeaderCellContent(grid, 1, 0).textContent.trim()).to.be.equal('Password field');
         expect(getHeaderCellContent(grid, 1, 1).textContent.trim()).to.be.equal('First name');
       });
@@ -101,7 +101,7 @@ describe('crud grid', () => {
         grid.include = 'a, b, c';
         grid.items = [{ d: 1 }];
         flushGrid(grid);
-        await nextRender(grid);
+        await nextRender();
 
         expect(grid.querySelectorAll('vaadin-grid-column').length).to.be.equal(3);
         expect(getHeaderCellContent(grid, 0, 0).textContent.trim()).to.be.equal('A');
@@ -120,7 +120,7 @@ describe('crud grid', () => {
           },
         ];
         flushGrid(grid);
-        await nextRender(grid);
+        await nextRender();
 
         // The filter column should end up with only one parent group (the sorter group column)
         // which in turn should be a direct child of the grid
@@ -141,7 +141,7 @@ describe('crud grid', () => {
             };
           }
           flushGrid(grid);
-          await nextRender(grid);
+          await nextRender();
         });
 
         it('should ignore excluded fields', () => {
@@ -193,7 +193,7 @@ describe('crud grid', () => {
 
         it('should only render one control in a cell', async () => {
           grid.requestContentUpdate();
-          await nextRender(grid);
+          await nextRender();
           expect(getHeaderCellContent(grid, 1, 0).childElementCount).to.equal(1);
           expect(getHeaderCellContent(grid, 2, 0).childElementCount).to.equal(1);
         });
@@ -210,7 +210,7 @@ describe('crud grid', () => {
       `);
       grid.items = items;
       flushGrid(grid);
-      await nextRender(grid);
+      await nextRender();
     });
 
     it('should theme edit icon element', () => {

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -39,7 +39,7 @@ describe('crud', () => {
       crud = fixtureSync(`
         <vaadin-crud style="width: 300px;" items='[{"foo": "bar"}]' edited-item="{}"></vaadin-crud>
       `);
-      await nextRender(crud);
+      await nextRender();
       flushGrid(crud._grid);
     });
 
@@ -65,7 +65,7 @@ describe('crud', () => {
     it('should be able to internationalize via `i18n` property', async () => {
       expect(crud._newButton.textContent).to.be.equal('New item');
       crud.i18n = { newItem: 'Nueva entidad', editLabel: 'Editar entidad' };
-      await nextRender(crud._grid);
+      await nextRender();
       expect(crud._newButton.textContent).to.be.equal('Nueva entidad');
       expect(crud._grid.querySelector('vaadin-crud-edit-column').ariaLabel).to.be.equal('Editar entidad');
       expect(crud._grid.querySelector('vaadin-crud-edit').getAttribute('aria-label')).to.be.equal('Editar entidad');
@@ -127,7 +127,7 @@ describe('crud', () => {
 
     it('should have an empty form if no item is present', async () => {
       crud.dataProvider = (_, callback) => callback([], 0);
-      await nextRender(crud);
+      await nextRender();
       crud._newButton.click();
       await nextRender();
       expect(crud._form._fields).to.be.not.ok;
@@ -160,7 +160,7 @@ describe('crud', () => {
         // This should initialize the grid and pass the data provider
         document.body.appendChild(crud);
         // Verify item from data provider is rendered
-        await nextRender(crud);
+        await nextRender();
         flushGrid(crud._grid);
         expect(getBodyCellContent(crud._grid, 0, 0).textContent).to.be.equal('bar');
       });
@@ -172,7 +172,7 @@ describe('crud', () => {
         document.body.appendChild(crud);
 
         // Verify item from data provider is rendered
-        await nextRender(crud);
+        await nextRender();
         flushGrid(customGrid);
         expect(getBodyCellContent(customGrid, 0, 0).textContent).to.be.equal('bar');
       });
@@ -184,7 +184,7 @@ describe('crud', () => {
         // Replace default grid with custom one after setting the data provider
         crud.appendChild(customGrid);
         // Verify item from data provider is rendered
-        await nextRender(crud);
+        await nextRender();
         flushGrid(customGrid);
         expect(getBodyCellContent(customGrid, 0, 0).textContent).to.be.equal('bar');
       });
@@ -270,7 +270,7 @@ describe('crud', () => {
       grid.querySelector('vaadin-grid-column').renderer = (root, _, model) => {
         root.textContent = model.item;
       };
-      await nextRender(grid);
+      await nextRender();
     });
 
     afterEach(async () => {
@@ -282,7 +282,7 @@ describe('crud', () => {
       crud.appendChild(grid);
       await nextRender();
       crud.items = [1, 2];
-      await nextRender(crud);
+      await nextRender();
       flushGrid(grid);
       expect(crud._grid).not.to.be.equal(grid);
     });
@@ -292,7 +292,7 @@ describe('crud', () => {
       crud.appendChild(grid);
       await nextRender();
       crud.items = [1, 2];
-      await nextRender(crud);
+      await nextRender();
       flushGrid(grid);
       expect(crud._grid).to.be.equal(grid);
       expect(getBodyCellContent(crud._grid, 0, 0).textContent).to.be.equal('1');
@@ -303,9 +303,9 @@ describe('crud', () => {
       crud.appendChild(form);
       await nextRender();
       crud.items = [{ foo: 1 }];
-      await nextRender(crud);
+      await nextRender();
       edit(crud.items[0]);
-      await nextRender(crud.$.dialog);
+      await nextRender();
       expect(crud._form).not.to.be.equal(form);
     });
 
@@ -357,7 +357,7 @@ describe('crud', () => {
     it('should not propagate theme attribute to a custom grid', async () => {
       crud.setAttribute('theme', 'foo');
       crud.appendChild(grid);
-      await nextRender(crud);
+      await nextRender();
       expect(grid.hasAttribute('theme')).to.be.false;
     });
   });
@@ -378,7 +378,7 @@ describe('crud', () => {
       crud.appendChild(form);
       await nextRender();
       crud.items = [{ foo: 1, bar: 2 }];
-      await nextRender(crud);
+      await nextRender();
     });
 
     afterEach(() => {
@@ -507,7 +507,7 @@ describe('crud', () => {
       crud.editorPosition = 'bottom';
       crud.editOnClick = true;
       crud.items = [{ foo: 'bar' }, { foo: 'baz' }];
-      await nextRender(crud);
+      await nextRender();
       flushGrid(crud._grid);
       confirmCancelDialog = crud.$.confirmCancel;
       confirmCancelOverlay = confirmCancelDialog.$.dialog.$.overlay;

--- a/packages/crud/test/visual/lumo/crud.test.js
+++ b/packages/crud/test/visual/lumo/crud.test.js
@@ -11,7 +11,7 @@ describe('crud', () => {
     div.style.height = '100%';
     element = fixtureSync('<vaadin-crud style="height: calc(100vh - 16px)"></vaadin-crud>', div);
     element.items = [{ name: { first: 'Susan', last: 'Smith' } }];
-    await nextRender(element);
+    await nextRender();
   });
 
   it('basic', async () => {
@@ -48,7 +48,7 @@ describe('crud', () => {
       div.style.height = 'auto';
       element.style.height = '400px';
       element.editorPosition = 'aside';
-      await nextRender(element);
+      await nextRender();
     });
 
     it('row', async () => {
@@ -80,11 +80,11 @@ describe('crud', () => {
               case 'aside':
               case 'bottom':
                 element.editorPosition = position;
-                await nextRender(element);
+                await nextRender();
                 break;
               case 'fullscreen':
                 element._fullscreen = true;
-                await nextRender(element);
+                await nextRender();
                 break;
               default:
               // Do nothing

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -56,7 +56,7 @@ export async function untilOverlayScrolled(datePickerOrOverlayContent) {
     await overlayContent._revealPromise;
   }
 
-  await nextRender(overlayContent);
+  await nextRender();
 
   // Flush the ignoreTaps debouncer to make sure taps are not ignored.
   overlayContent._debouncer?.flush();
@@ -70,10 +70,10 @@ export async function untilOverlayScrolled(datePickerOrOverlayContent) {
  */
 export async function untilOverlayRendered(datePicker) {
   // First, wait for vaadin-overlay-open event
-  await nextRender(datePicker);
+  await nextRender();
 
   // Then wait for scrollers to fully render
-  await nextRender(datePicker);
+  await nextRender();
 
   await untilOverlayScrolled(datePicker);
 }

--- a/packages/date-picker/test/keyboard-input.test.js
+++ b/packages/date-picker/test/keyboard-input.test.js
@@ -43,7 +43,7 @@ describe('keyboard', () => {
       // Move focus to the calendar
       await sendKeys({ press: 'Tab' });
 
-      await nextRender(datePicker);
+      await nextRender();
 
       await sendKeys({ press: 'ArrowDown' });
       expect(input.value).to.equal('1/8/2000');
@@ -319,7 +319,7 @@ describe('keyboard', () => {
       it('should close the overlay when calendar has focus', async () => {
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datePicker);
+        await nextRender();
 
         await sendKeys({ press: 'Escape' });
         expect(datePicker.opened).to.be.false;
@@ -328,7 +328,7 @@ describe('keyboard', () => {
       it('should move focus from the calendar back to input', async () => {
         // Move focus to the calendar
         await sendKeys({ press: 'ArrowDown' });
-        await nextRender(datePicker);
+        await nextRender();
         expect(document.activeElement).to.not.equal(input);
 
         await sendKeys({ press: 'Escape' });

--- a/packages/date-picker/test/keyboard-navigation.test.js
+++ b/packages/date-picker/test/keyboard-navigation.test.js
@@ -460,7 +460,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with pageup when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
       await sendKeys({ press: 'PageUp' });
       await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
@@ -470,7 +470,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with pagedown when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
       await sendKeys({ press: 'PageDown' });
       await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
@@ -480,7 +480,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with shift pageup when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
 
       await sendKeys({ press: 'Shift+PageUp' });
 
@@ -492,7 +492,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with shift pagedown when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.maxDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
 
       await sendKeys({ press: 'Shift+PageDown' });
 
@@ -522,7 +522,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with arrow up when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
       await sendKeys({ press: 'ArrowUp' });
       await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
@@ -532,7 +532,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with arrow down when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
       await sendKeys({ press: 'ArrowDown' });
       await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
@@ -542,7 +542,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with arrow left when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
       await sendKeys({ press: 'ArrowLeft' });
       await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);
@@ -552,7 +552,7 @@ describe('keyboard navigation', () => {
     it('should focus the closest allowed date with arrow right when selected date is disabled', async () => {
       overlay.focusedDate = new Date(1999, 5, 10);
       overlay.minDate = new Date(1999, 11, 25);
-      await nextRender(overlay);
+      await nextRender();
       await sendKeys({ press: 'ArrowRight' });
       await untilOverlayScrolled(overlay);
       const cell = getFocusedCell(overlay);

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -22,7 +22,7 @@ describe('WAI-ARIA', () => {
 
     it('should set aria-hidden on all calendars except focusable one', async () => {
       await open(datePicker);
-      await nextRender(datePicker);
+      await nextRender();
       const calendars = datePicker._overlayContent.querySelectorAll('vaadin-month-calendar');
       calendars.forEach((calendar) => {
         const focusable = calendar.shadowRoot.querySelector('[tabindex="0"]');

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -570,7 +570,7 @@ describe('form layout', () => {
       layout = container.firstElementChild;
       layout.responsiveSteps = [{ columns: 2 }];
       items = [...layout.querySelectorAll('vaadin-form-item')];
-      await nextRender(container);
+      await nextRender();
     });
 
     function estimateEffectiveColspan(el) {
@@ -581,7 +581,7 @@ describe('form layout', () => {
       expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(1, 0.1);
 
       layout.children[0].setAttribute('colspan', 2);
-      await nextRender(container);
+      await nextRender();
       expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(2, 0.1);
     });
 
@@ -589,14 +589,14 @@ describe('form layout', () => {
       expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(1, 0.1);
 
       layout.children[0].setAttribute('data-colspan', 2);
-      await nextRender(container);
+      await nextRender();
       expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(2, 0.1);
     });
 
     it('should prefer colspan attribute over data-colspan when both are set', async () => {
       layout.children[0].setAttribute('colspan', 2);
       layout.children[0].setAttribute('data-colspan', 1);
-      await nextRender(container);
+      await nextRender();
       expect(estimateEffectiveColspan(layout.children[0])).to.be.closeTo(2, 0.1);
     });
 
@@ -607,11 +607,11 @@ describe('form layout', () => {
       const newFormItem = document.createElement('vaadin-form-item');
       newFormItem.hidden = true;
       layout.appendChild(newFormItem);
-      await nextRender(container);
+      await nextRender();
       expect(newFormItem.getBoundingClientRect().width).to.equal(0);
 
       newFormItem.hidden = false;
-      await nextRender(container);
+      await nextRender();
       const unhiddenItemWidth = newFormItem.getBoundingClientRect().width;
       expect(unhiddenItemWidth).to.equal(itemWidth);
     });
@@ -620,7 +620,7 @@ describe('form layout', () => {
       const newFormItem = document.createElement('vaadin-form-item');
       newFormItem.innerHTML = '<label slot="label">Field</label><input />';
       layout.insertBefore(newFormItem, items[0]);
-      await nextRender(container);
+      await nextRender();
       expect(getComputedStyle(newFormItem).marginLeft).to.be.equal('0px');
     });
 
@@ -628,12 +628,12 @@ describe('form layout', () => {
       const newFormItem = document.createElement('vaadin-form-item');
       newFormItem.innerHTML = '<label slot="label">Field</label><input />';
       layout.insertBefore(newFormItem, items[0]);
-      await nextRender(container);
+      await nextRender();
 
       expect(getComputedStyle(items[0]).marginLeft).to.not.be.equal('0px');
 
       newFormItem.remove();
-      await nextRender(container);
+      await nextRender();
       expect(getComputedStyle(items[0]).marginLeft).to.be.equal('0px');
     });
 

--- a/packages/grid-pro/test/edit-column-type.test.js
+++ b/packages/grid-pro/test/edit-column-type.test.js
@@ -179,7 +179,7 @@ describe('edit column editor type', () => {
         focusout(editor);
         focusin(editor._overlayElement.querySelector('vaadin-select-item'));
         grid._flushStopEdit();
-        await nextRender(editor._menuElement);
+        await nextRender();
         expect(editor.opened).to.equal(true);
       });
 
@@ -192,7 +192,7 @@ describe('edit column editor type', () => {
         editor.opened = false;
         await nextFrame();
         space(editor.focusElement);
-        await nextRender(editor._menuElement);
+        await nextRender();
         expect(editor.opened).to.equal(true);
       });
 
@@ -200,7 +200,7 @@ describe('edit column editor type', () => {
         editor.opened = false;
         await nextFrame();
         arrowDown(editor.focusElement);
-        await nextRender(editor._menuElement);
+        await nextRender();
         expect(editor.opened).to.equal(true);
       });
 
@@ -208,7 +208,7 @@ describe('edit column editor type', () => {
         editor.opened = false;
         await nextFrame();
         arrowUp(editor.focusElement);
-        await nextRender(editor._menuElement);
+        await nextRender();
         expect(editor.opened).to.equal(true);
       });
 
@@ -258,7 +258,7 @@ describe('edit column editor type', () => {
         cell = getContainerCell(grid.$.items, 0, 1);
         enter(cell._content);
         editor = getCellEditor(cell);
-        await nextRender(editor);
+        await nextRender();
 
         sinon.stub(console, 'warn');
       });

--- a/packages/grid-pro/test/visual/lumo/grid-pro.test.js
+++ b/packages/grid-pro/test/visual/lumo/grid-pro.test.js
@@ -28,7 +28,7 @@ describe('grid-pro', () => {
         div,
       );
       element.items = users;
-      await nextRender(element);
+      await nextRender();
       div.style.width = '300px';
       element.focus();
     });
@@ -91,7 +91,7 @@ describe('grid-pro', () => {
         div,
       );
       element.items = users;
-      await nextRender(element);
+      await nextRender();
     });
 
     it('text', async () => {
@@ -112,7 +112,7 @@ describe('grid-pro', () => {
         div,
       );
       element.items = users;
-      await nextRender(element);
+      await nextRender();
     });
 
     it('checkbox', async () => {
@@ -135,7 +135,7 @@ describe('grid-pro', () => {
       element.items = users;
       const column = element.querySelector('vaadin-grid-pro-edit-column');
       column.editorOptions = ['mr', 'mrs', 'ms'];
-      await nextRender(element);
+      await nextRender();
     });
 
     it('select', async () => {

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -54,7 +54,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
       document.documentElement.setAttribute('dir', direction);
 
       flushGrid(grid);
-      await nextRender(grid);
+      await nextRender();
     });
 
     after(() => document.documentElement.removeAttribute('dir'));
@@ -194,7 +194,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
       document.documentElement.setAttribute('dir', direction);
 
       flushGrid(grid);
-      await nextRender(grid);
+      await nextRender();
     });
 
     it('should have first frozen to end only when there are frozen columns', () => {

--- a/packages/grid/test/keyboard-interaction-mode.test.js
+++ b/packages/grid/test/keyboard-interaction-mode.test.js
@@ -532,7 +532,7 @@ describe('keyboard interaction mode', () => {
 
     async function rendered() {
       await nextFrame();
-      await nextRender(grid);
+      await nextRender();
       await nextFrame();
     }
 

--- a/packages/grid/test/keyboard-navigation-row-focus.test.js
+++ b/packages/grid/test/keyboard-navigation-row-focus.test.js
@@ -135,13 +135,13 @@ describe('keyboard navigation - row focus', () => {
     body = grid.$.items;
     footer = grid.$.footer;
 
-    await nextRender(grid);
+    await nextRender();
 
     // Make the grid enter row focus mode initially
     focusFirstHeaderCell();
     left();
 
-    await nextRender(grid);
+    await nextRender();
   });
 
   describe('scrolling and navigating', () => {
@@ -234,12 +234,12 @@ describe('keyboard navigation - row focus', () => {
     describe(`interacting with keys - ${direction}`, () => {
       beforeEach(async () => {
         document.dir = direction;
-        await nextRender(grid);
+        await nextRender();
       });
 
       afterEach(async () => {
         document.dir = undefined;
-        await nextRender(grid);
+        await nextRender();
       });
 
       it('should remain in row focus mode on backwards', () => {
@@ -431,13 +431,13 @@ describe('keyboard navigation on column groups - row focus', () => {
     };
     flushGrid(grid);
 
-    await nextRender(grid);
+    await nextRender();
 
     // Make the grid enter row focus mode initially
     focusFirstHeaderCell();
     left();
 
-    await nextRender(grid);
+    await nextRender();
   });
 
   describe('updating tabbable rows', () => {

--- a/packages/grid/test/visual/grid.common.js
+++ b/packages/grid/test/visual/grid.common.js
@@ -37,7 +37,7 @@ describe('grid', () => {
 
           element.items = users;
           flushGrid(element);
-          await nextRender(element);
+          await nextRender();
         });
 
         it('header footer', async () => {
@@ -70,7 +70,7 @@ describe('grid', () => {
           };
 
           flushGrid(element);
-          await nextRender(element);
+          await nextRender();
         });
 
         it('column groups', async () => {
@@ -127,7 +127,7 @@ describe('grid', () => {
           };
 
           flushGrid(element);
-          await nextRender(element);
+          await nextRender();
         });
 
         it('row details', async () => {
@@ -154,7 +154,7 @@ describe('grid', () => {
           };
 
           flushGrid(element);
-          await nextRender(element);
+          await nextRender();
           const sorters = [...document.querySelectorAll('vaadin-grid-sorter')];
           firstSorter = sorters.find((sorter) => sorter.textContent === 'First name');
           secondSorter = sorters.find((sorter) => sorter.textContent === 'Last name');
@@ -203,7 +203,7 @@ describe('grid', () => {
             `);
             element.items = users;
             flushGrid(element);
-            await nextRender(element);
+            await nextRender();
             selectionColumn = element.querySelector('vaadin-grid-selection-column');
           });
 
@@ -229,7 +229,7 @@ describe('grid', () => {
             `);
             element.items = users;
             flushGrid(element);
-            await nextRender(element);
+            await nextRender();
             selectionColumn = element.querySelector('vaadin-grid-selection-column');
           });
 
@@ -268,7 +268,7 @@ describe('grid', () => {
           // Tab to body row
           await sendKeys({ press: 'Tab' });
 
-          await nextRender(element);
+          await nextRender();
         });
 
         it('row focus', async () => {
@@ -330,7 +330,7 @@ describe('grid', () => {
       };
       element.items = users;
       flushGrid(element);
-      await nextRender(element);
+      await nextRender();
     });
 
     it('dragover', async () => {
@@ -389,7 +389,7 @@ describe('grid', () => {
       `);
       element.items = users;
       flushGrid(element);
-      await nextRender(element);
+      await nextRender();
     });
 
     it('disabled', async () => {
@@ -422,7 +422,7 @@ describe('grid', () => {
         cb(pageItems, levelSize);
       };
       flushGrid(element);
-      await nextRender(element);
+      await nextRender();
     });
 
     it('default', async () => {
@@ -456,7 +456,7 @@ describe('grid', () => {
       });
 
       flushGrid(element);
-      await nextRender(element);
+      await nextRender();
     });
 
     it('default', async () => {

--- a/packages/grid/test/visual/lumo/grid.test.js
+++ b/packages/grid/test/visual/lumo/grid.test.js
@@ -23,7 +23,7 @@ describe('theme', () => {
       `);
     element.items = users;
     flushGrid(element);
-    await nextRender(element);
+    await nextRender();
   });
 
   it('column-borders', async () => {

--- a/packages/markdown/test/dom-sync.test.js
+++ b/packages/markdown/test/dom-sync.test.js
@@ -7,7 +7,7 @@ describe('vaadin-markdown DOM synchronization', () => {
 
   beforeEach(async () => {
     element = fixtureSync('<vaadin-markdown></vaadin-markdown>');
-    await nextRender(element);
+    await nextRender();
   });
 
   it('should not recreate the entire DOM on content updates', async () => {

--- a/packages/markdown/test/rendering.test.js
+++ b/packages/markdown/test/rendering.test.js
@@ -7,7 +7,7 @@ describe('vaadin-markdown content rendering', () => {
 
   beforeEach(async () => {
     element = fixtureSync('<vaadin-markdown></vaadin-markdown>');
-    await nextRender(element);
+    await nextRender();
   });
 
   it('should render all basic markdown elements correctly', async () => {

--- a/packages/menu-bar/test/a11y.test.js
+++ b/packages/menu-bar/test/a11y.test.js
@@ -20,7 +20,7 @@ describe('a11y', () => {
           children: [{ text: 'Menu Item 3 1' }, { text: 'Menu Item 3 2' }],
         },
       ];
-      await nextRender(menu);
+      await nextRender();
       subMenu = menu._subMenu;
       buttons = menu._buttons;
       overflow = menu._overflow;

--- a/packages/menu-bar/test/accessible-disabled-buttons.test.js
+++ b/packages/menu-bar/test/accessible-disabled-buttons.test.js
@@ -22,7 +22,7 @@ describe('accessible disabled buttons', () => {
       { text: 'Item 1', disabled: true, children: [{ text: 'SubItem 0' }] },
       { text: 'Item 2' },
     ];
-    await nextRender(menuBar);
+    await nextRender();
     buttons = menuBar._buttons;
   });
 

--- a/packages/menu-bar/test/item-components.test.js
+++ b/packages/menu-bar/test/item-components.test.js
@@ -22,7 +22,7 @@ describe('item components', () => {
         { text: 'Item 3', component: document.createElement('vaadin-menu-bar-item') },
         { text: 'Item 4' },
       ];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
     });
 
@@ -56,14 +56,14 @@ describe('item components', () => {
 
     it('should update buttons when replacing item component with text', async () => {
       menu.items = [{ text: 'Item 0' }, ...menu.items.slice(1)];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       expect(buttons[0].textContent).to.equal('Item 0');
     });
 
     it('should update buttons when replacing item text with component', async () => {
       menu.items = [...menu.items.slice(0, 3), { component: makeComponent('4') }];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       expect(buttons[3].firstElementChild).to.equal(buttons[3].item.component);
       expect(buttons[3].firstElementChild.textContent).to.equal('Item 4');
@@ -71,14 +71,14 @@ describe('item components', () => {
 
     it('should update buttons when replacing item component with empty object', async () => {
       menu.items = [{}, ...menu.items.slice(1)];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       expect(buttons[0].textContent).to.equal('');
     });
 
     it('should update buttons when replacing item text with empty object', async () => {
       menu.items = [...menu.items.slice(0, 3), {}];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       expect(buttons[3].textContent).to.equal('');
     });

--- a/packages/menu-bar/test/keyboard-navigation.test.js
+++ b/packages/menu-bar/test/keyboard-navigation.test.js
@@ -26,7 +26,7 @@ describe('keyboard navigation', () => {
   describe('root level buttons', () => {
     beforeEach(async () => {
       menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3', disabled: true }, { text: 'Item 4' }];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
     });
 
@@ -331,7 +331,7 @@ describe('keyboard navigation', () => {
 
         // Tab to next button with submenu
         await sendKeys({ press: 'Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.true;
         expect(subMenu.listenOn).to.equal(buttons[3]);
@@ -347,7 +347,7 @@ describe('keyboard navigation', () => {
 
         // Shift Tab to previous button with submenu
         await sendKeys({ press: 'Shift+Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.true;
         expect(subMenu.listenOn).to.equal(buttons[2]);
@@ -363,7 +363,7 @@ describe('keyboard navigation', () => {
 
         // Tab to next button without submenu
         await sendKeys({ press: 'Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.false;
         expect(document.activeElement).to.equal(buttons[1]);
@@ -379,7 +379,7 @@ describe('keyboard navigation', () => {
 
         // Tab to next button without submenu
         await sendKeys({ press: 'Shift+Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.false;
         expect(document.activeElement).to.equal(buttons[1]);
@@ -395,7 +395,7 @@ describe('keyboard navigation', () => {
 
         // Tab outside the menu bar
         await sendKeys({ press: 'Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.false;
         expect(document.activeElement).to.equal(lastGlobalFocusable);
@@ -411,7 +411,7 @@ describe('keyboard navigation', () => {
 
         // Shift + Tab outside the menu bar
         await sendKeys({ press: 'Shift+Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.false;
         expect(document.activeElement).to.equal(firstGlobalFocusable);
@@ -429,7 +429,7 @@ describe('keyboard navigation', () => {
 
         // Tab outside the menu bar (since next button is disabled)
         await sendKeys({ press: 'Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.false;
         expect(document.activeElement).to.equal(lastGlobalFocusable);
@@ -448,7 +448,7 @@ describe('keyboard navigation', () => {
 
         // Tab outside the menu bar (since previous buttons are disabled)
         await sendKeys({ press: 'Shift+Tab' });
-        await nextRender(subMenu);
+        await nextRender();
 
         expect(subMenu.opened).to.be.false;
         expect(document.activeElement).to.equal(firstGlobalFocusable);

--- a/packages/menu-bar/test/menu-bar.test.js
+++ b/packages/menu-bar/test/menu-bar.test.js
@@ -30,7 +30,7 @@ describe('root menu layout', () => {
   beforeEach(async () => {
     menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
     menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3', disabled: true }, { text: 'Item 4' }];
-    await nextRender(menu);
+    await nextRender();
     buttons = menu._buttons;
   });
 

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -29,7 +29,7 @@ describe('overflow', () => {
         </div>
       `);
       menu = wrapper.querySelector('vaadin-menu-bar');
-      await nextRender(menu);
+      await nextRender();
       menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }, { text: 'Item 5' }];
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
@@ -211,7 +211,7 @@ describe('overflow', () => {
     beforeEach(async () => {
       menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
       menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
     });
@@ -284,7 +284,7 @@ describe('overflow', () => {
       container.style.width = '250px';
 
       menu.items = [{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }, { text: 'Item 4' }, { text: 'Item 5' }];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
     });
@@ -395,7 +395,7 @@ describe('overflow', () => {
         { text: 'Item 5', component: document.createElement('vaadin-menu-bar-item') },
         { component: makeComponent('6'), children: [{ text: 'SubItem6.1' }, { text: 'SubItem6.2' }] },
       ];
-      await nextRender(menu);
+      await nextRender();
       buttons = menu._buttons;
       overflow = buttons[buttons.length - 1];
       subMenu = menu._subMenu;
@@ -406,7 +406,7 @@ describe('overflow', () => {
 
     it('should close the overflow sub-menu on menu-bar resize', async () => {
       overflow.click();
-      await nextRender(subMenu);
+      await nextRender();
       menu.style.width = 'auto';
       await nextResize(menu);
       expect(subMenu.opened).to.be.false;
@@ -414,7 +414,7 @@ describe('overflow', () => {
 
     it('should close the overflow sub-menu programmatically', async () => {
       overflow.click();
-      await nextRender(subMenu);
+      await nextRender();
       expect(subMenu.opened).to.be.true;
 
       menu.close();
@@ -423,7 +423,7 @@ describe('overflow', () => {
 
     it('should teleport the same component to overflow sub-menu and back', async () => {
       overflow.click();
-      await nextRender(subMenu);
+      await nextRender();
       const listBox = subMenu._overlayElement.querySelector('vaadin-menu-bar-list-box');
       expect(listBox.items[0]).to.equal(buttons[2].item.component);
       expect(listBox.items[0].firstChild).to.equal(menu.items[2].component);
@@ -441,7 +441,7 @@ describe('overflow', () => {
       const item = buttons[5].firstElementChild;
       const itemAttributes = item.getAttributeNames();
       overflow.click();
-      await nextRender(subMenu);
+      await nextRender();
       subMenu.close();
       await nextUpdate(menu);
       menu.style.width = 'auto';
@@ -454,7 +454,7 @@ describe('overflow', () => {
       const item = buttons[5].firstElementChild;
       item.classList.add('test-class-1');
       overflow.click();
-      await nextRender(subMenu);
+      await nextRender();
       subMenu.close();
       await nextUpdate(menu);
       menu.style.width = 'auto';

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -61,7 +61,7 @@ describe('sub-menu', () => {
         ],
       },
     ];
-    await nextRender(menu);
+    await nextRender();
     subMenu = menu._subMenu;
     subMenuOverlay = subMenu._overlayElement;
     buttons = menu._buttons;
@@ -69,23 +69,23 @@ describe('sub-menu', () => {
 
   it('should open sub-menu when button with nested items clicked', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
   });
 
   it('should not open sub-menu when button without nested items clicked', async () => {
     buttons[1].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
   it('should reopen sub-menu when different button with nested items clicked', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.listenOn).to.equal(buttons[0]);
     const spy = sinon.spy(subMenu, 'close');
     buttons[2].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
     expect(subMenu.listenOn).to.equal(buttons[2]);
     expect(spy.calledOnce).to.be.true;
@@ -93,16 +93,16 @@ describe('sub-menu', () => {
 
   it('should set pointer events to `auto` when opened on click', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(menu.style.pointerEvents).to.equal('auto');
   });
 
   it('should reset pointer events after closing on click', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
 
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(menu.style.pointerEvents).to.be.empty;
   });
 
@@ -110,7 +110,7 @@ describe('sub-menu', () => {
     const event = new CustomEvent('click', { bubbles: true });
     const spy = sinon.spy(event, 'stopPropagation');
     buttons[0].dispatchEvent(event);
-    await nextRender(subMenu);
+    await nextRender();
     expect(spy.called).to.be.false;
   });
 
@@ -125,7 +125,7 @@ describe('sub-menu', () => {
 
   it('should focus the first item on overlay arrow down after open on click', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     const overlay = subMenuOverlay.$.overlay;
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     const spy = sinon.spy(item, 'focus');
@@ -135,7 +135,7 @@ describe('sub-menu', () => {
 
   it('should focus the last item on overlay arrow up after open on click', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     const overlay = subMenuOverlay.$.overlay;
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
@@ -148,7 +148,7 @@ describe('sub-menu', () => {
     const spy = sinon.spy();
     menu._container.addEventListener('keydown', spy);
     arrowDown(buttons[0]);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
     expect(spy.firstCall.args[0].defaultPrevented).to.be.true;
   });
@@ -224,9 +224,9 @@ describe('sub-menu', () => {
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     expect(item).to.be.ok;
-    await nextRender(subMenu);
+    await nextRender();
     arrowUp(item);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
@@ -235,9 +235,9 @@ describe('sub-menu', () => {
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
     let item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
-    await nextRender(subMenu);
+    await nextRender();
     arrowLeft(item);
-    await nextRender(subMenu);
+    await nextRender();
     item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     const spy = sinon.spy(item, 'focus');
     arrowDown(buttons[2]);
@@ -249,9 +249,9 @@ describe('sub-menu', () => {
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
-    await nextRender(subMenu);
+    await nextRender();
     arrowLeft(item);
-    await nextRender(subMenu);
+    await nextRender();
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     const spy = sinon.spy(last, 'focus');
@@ -263,34 +263,34 @@ describe('sub-menu', () => {
     arrowDown(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
-    await nextRender(subMenu);
+    await nextRender();
     const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     arrowLeft(item);
-    await nextRender(subMenu);
+    await nextRender();
     esc(buttons[2]);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
     expect(buttons[2].hasAttribute('focused')).to.be.true;
   });
 
   it('should close sub-menu on outside click', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
 
     document.body.click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
   it('should close and dispatch item-selected event on select', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
 
     const spy = sinon.spy();
     menu.addEventListener('item-selected', spy);
     item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     item.click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
     expect(spy.calledOnce).to.be.true;
     expect(spy.firstCall.args[0].detail.value).to.deep.equal({ text: 'Menu Item 1 1' });
@@ -298,7 +298,7 @@ describe('sub-menu', () => {
 
   it('should close sub-menu programmatically', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
 
     menu.close();
@@ -307,10 +307,10 @@ describe('sub-menu', () => {
 
   it('should not close submenu on item contextmenu event', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
     item.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true, composed: true }));
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
   });
 
@@ -319,9 +319,9 @@ describe('sub-menu', () => {
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
-    await nextRender(subMenu);
+    await nextRender();
     last.click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
   });
 
@@ -406,35 +406,35 @@ describe('sub-menu', () => {
 
   it('should not close sub-menu on items change if item has not changed', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
 
     menu.items = [...menu.items, { text: 'Menu Item 1' }];
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
   });
 
   it('should close sub-menu on items change if item no longer has children', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
 
     menu.items = [{ text: 'Menu Item 0' }, ...menu.items];
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
   it('should close sub-menu on items change if item has empty children', async () => {
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
 
     menu.items = [{ text: 'Menu Item 0', children: [] }, ...menu.items];
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
   describe('expanded attribute', () => {
     it('should toggle expanded attribute on button with nested items clicked', async () => {
       buttons[0].click();
-      await nextRender(subMenu);
+      await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.true;
 
       buttons[0].click();
@@ -443,32 +443,32 @@ describe('sub-menu', () => {
 
     it('should toggle expanded attribute on button with nested items toggled with the keyboard', async () => {
       arrowDown(buttons[0]);
-      await nextRender(subMenu);
+      await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.true;
 
       item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
       arrowUp(item);
-      await nextRender(subMenu);
+      await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.false;
     });
 
     it('should remove expanded attribute and restore focus when sub-menu closed on Esc', async () => {
       arrowDown(buttons[0]);
-      await nextRender(subMenu);
+      await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.true;
 
       esc(subMenuOverlay);
-      await nextRender(subMenu);
+      await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.false;
       expect(buttons[0].hasAttribute('focus-ring')).to.be.true;
     });
 
     it('should remove expanded attribute when submenu closed on overlay backdrop click', async () => {
       buttons[0].click();
-      await nextRender(subMenu);
+      await nextRender();
 
       subMenuOverlay.$.backdrop.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
-      await nextRender(subMenu);
+      await nextRender();
       expect(subMenu.opened).to.be.false;
       expect(buttons[0].hasAttribute('expanded')).to.be.false;
     });
@@ -494,7 +494,7 @@ describe('open on hover', () => {
       },
     ];
     menu.openOnHover = true;
-    await nextRender(menu);
+    await nextRender();
     subMenu = menu._subMenu;
     buttons = menu._buttons;
   });
@@ -503,30 +503,30 @@ describe('open on hover', () => {
     expect(menu.style.pointerEvents).to.be.empty;
 
     fire(buttons[0], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     expect(menu.style.pointerEvents).to.equal('auto');
 
     fire(buttons[2], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     expect(menu.style.pointerEvents).to.equal('auto');
 
     document.body.click();
-    await nextRender(subMenu);
+    await nextRender();
     expect(menu.style.pointerEvents).to.be.empty;
   });
 
   it('should open sub-menu on mouseover on button with nested items', async () => {
     fire(buttons[0], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
     expect(subMenu.listenOn).to.equal(buttons[0]);
   });
 
   it('should close open sub-menu on mouseover on button without nested items', async () => {
     fire(buttons[0], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     fire(buttons[1], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.false;
   });
 
@@ -534,9 +534,9 @@ describe('open on hover', () => {
     menu.openOnHover = false;
     await nextUpdate(menu);
     buttons[0].click();
-    await nextRender(subMenu);
+    await nextRender();
     fire(buttons[2], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
     expect(subMenu.listenOn).to.equal(buttons[2]);
   });
@@ -550,9 +550,9 @@ describe('open on hover', () => {
 
   it('should not close sub-menu on expanded button mouseover', async () => {
     fire(buttons[0], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     fire(buttons[0], openOnHoverEvent);
-    await nextRender(subMenu);
+    await nextRender();
     expect(subMenu.opened).to.be.true;
   });
 });
@@ -575,7 +575,7 @@ describe('theme attribute', () => {
       { text: 'Menu Item 2' },
       { text: 'Menu Item 3' },
     ];
-    await nextRender(menu);
+    await nextRender();
     subMenu = menu._subMenu;
     subMenuOverlay = subMenu._overlayElement;
     buttons = menu._buttons;
@@ -583,7 +583,7 @@ describe('theme attribute', () => {
     // Open submenu
     menu.openOnHover = true;
     buttons[0].dispatchEvent(new CustomEvent(menuOpenEvent, { bubbles: true, composed: true }));
-    await nextRender(subMenu);
+    await nextRender();
   });
 
   it('should propagate theme attribute to the submenu', () => {
@@ -609,7 +609,7 @@ describe('theme attribute', () => {
     await nextUpdate(menu);
 
     buttons[0].dispatchEvent(new CustomEvent(menuOpenEvent, { bubbles: true, composed: true }));
-    await nextRender(subMenu);
+    await nextRender();
 
     items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
 
@@ -653,7 +653,7 @@ describe('touch', () => {
         children: [{ text: 'Menu Item 3 1' }, { text: 'Menu Item 3 2' }],
       },
     ];
-    await nextRender(menu);
+    await nextRender();
     subMenu = menu._subMenu;
     subMenuOverlay = subMenu._overlayElement;
     buttons = menu._buttons;
@@ -666,13 +666,13 @@ describe('touch', () => {
     items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
     open(item);
-    await nextRender(subMenu2);
+    await nextRender();
     items = subMenu2._overlayElement.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
     touchstart(item);
     touchend(item);
     click(item);
-    await nextRender(subMenu2);
+    await nextRender();
     expect(subMenu2.opened).to.be.false;
   });
 
@@ -683,12 +683,12 @@ describe('touch', () => {
     items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
     open(item);
-    await nextRender(subMenu2);
+    await nextRender();
     const subMenu3 = subMenu2._overlayElement.querySelector('vaadin-menu-bar-submenu');
     item = subMenu2._overlayElement.querySelector('vaadin-menu-bar-item');
     expect(item).to.be.ok;
     open(item);
-    await nextRender(subMenu3);
+    await nextRender();
     expect(subMenu3.opened).to.be.true;
     subMenu3.dispatchEvent(new CustomEvent('close-all-menus'));
   });

--- a/packages/menu-bar/test/visual/lumo/menu-bar.test.js
+++ b/packages/menu-bar/test/visual/lumo/menu-bar.test.js
@@ -45,7 +45,7 @@ describe('menu-bar', () => {
         it('opened', async () => {
           div.style.height = '150px';
           element._buttons[1].click();
-          await nextRender(element);
+          await nextRender();
           await visualDiff(div, `${dir}-opened`);
         });
 
@@ -54,7 +54,7 @@ describe('menu-bar', () => {
           div.style.width = '350px';
           div.style.height = '150px';
           element.reverseCollapse = true;
-          await nextRender(element);
+          await nextRender();
           element._buttons[4].click();
           const overlay = element._subMenu._overlayElement;
           await oneEvent(overlay, 'vaadin-overlay-open');

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -85,7 +85,7 @@ describe('message-list', () => {
   describe('items property', () => {
     beforeEach(async () => {
       messageList.items = messages;
-      await nextRender(messageList);
+      await nextRender();
     });
 
     it('should render vaadin-message element for each item', () => {
@@ -173,7 +173,7 @@ describe('message-list', () => {
             userColorIndex: 2,
           },
         ];
-        await nextRender(messageList);
+        await nextRender();
         expect(messageList.scrollTop).to.be.at.least(scrollTopBeforeMessage + 1);
       });
 
@@ -189,7 +189,7 @@ describe('message-list', () => {
             userColorIndex: 2,
           },
         ];
-        await nextRender(messageList);
+        await nextRender();
         expect(messageList.scrollTop).to.be.equal(0);
       });
     });
@@ -221,7 +221,7 @@ describe('message-list', () => {
             userColorIndex: 2,
           },
         ];
-        await nextRender(messageList);
+        await nextRender();
         const firstMessage = messages[0];
         // Verify that the first item got the new tabIndex=0.
         expect(firstMessage.tabIndex).to.be.equal(0);
@@ -241,7 +241,7 @@ describe('message-list', () => {
             userColorIndex: 2,
           },
         ];
-        await nextRender(messageList);
+        await nextRender();
         const messages = messageList.querySelectorAll('vaadin-message');
         messages.forEach((msg, idx) => {
           expect(msg.tabIndex).to.equal(idx === 1 ? 0 : -1);
@@ -271,7 +271,7 @@ describe('message-list', () => {
           },
         ];
 
-        await nextRender(messageList);
+        await nextRender();
         const messages = messageList.querySelectorAll('vaadin-message');
         // Verify that the second item got the new tabIndex=0.
         expect(messages[0].tabIndex).to.be.equal(-1);
@@ -285,7 +285,7 @@ describe('message-list', () => {
 
     beforeEach(async () => {
       messageList.items = messages;
-      await nextRender(messageList);
+      await nextRender();
       messageElements = messageList.querySelectorAll('vaadin-message');
       message = messageElements[1];
     });
@@ -333,7 +333,7 @@ describe('message-list', () => {
 
     beforeEach(async () => {
       messageList.items = messages;
-      await nextRender(messageList);
+      await nextRender();
       messageElements = messageList.querySelectorAll('vaadin-message');
     });
 

--- a/packages/message-list/test/visual/lumo/message-list.test.js
+++ b/packages/message-list/test/visual/lumo/message-list.test.js
@@ -47,7 +47,7 @@ describe('message-list', () => {
               userColorIndex: 3,
             },
           ];
-          await nextRender(element);
+          await nextRender();
         });
 
         it('basic', async () => {

--- a/packages/notification/test/visual/lumo/notification.test.js
+++ b/packages/notification/test/visual/lumo/notification.test.js
@@ -33,7 +33,7 @@ describe('notification', () => {
     it(position, async () => {
       element.position = position;
       element.opened = true;
-      await nextRender(element);
+      await nextRender();
       await visualDiff(document.body, `${position}`);
     });
   });

--- a/packages/rich-text-editor/test/toolbar.test.js
+++ b/packages/rich-text-editor/test/toolbar.test.js
@@ -32,7 +32,7 @@ describe('toolbar controls', () => {
       editor.focus();
       editor.insertText(0, 'Foo', 'user');
       editor.setSelection(0, 3);
-      await nextRender(rte);
+      await nextRender();
     });
 
     ['bold', 'italic', 'underline', 'strike', 'blockquote', 'code-block'].forEach((fmt) => {

--- a/packages/side-nav/test/accessibility.test.js
+++ b/packages/side-nav/test/accessibility.test.js
@@ -10,7 +10,7 @@ describe('accessibility', () => {
 
     beforeEach(async () => {
       sideNav = fixtureSync('<vaadin-side-nav></vaadin-side-nav>');
-      await nextRender(sideNav);
+      await nextRender();
     });
 
     it('should set "navigation" role by default on side-nav', () => {
@@ -19,7 +19,7 @@ describe('accessibility', () => {
 
     it('should have custom role effective', async () => {
       const sideNavWithCustomRole = fixtureSync('<vaadin-side-nav role="custom role"></vaadin-side-nav>');
-      await nextRender(sideNavWithCustomRole);
+      await nextRender();
       expect(sideNavWithCustomRole.getAttribute('role')).to.equal('custom role');
     });
   });

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -38,25 +38,25 @@ describe('vaadin-side-nav-item', () => {
 
     it('expanded', async () => {
       sideNavItem.expanded = true;
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).dom.to.equalSnapshot();
     });
 
     it('disabled', async () => {
       sideNavItem.disabled = true;
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).dom.to.equalSnapshot();
     });
 
     it('current', async () => {
       sideNavItem.path = '';
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).dom.to.equalSnapshot();
     });
 
     it('path', async () => {
       sideNavItem.path = 'path';
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).dom.to.equalSnapshot();
     });
   });
@@ -68,25 +68,25 @@ describe('vaadin-side-nav-item', () => {
 
     it('expanded', async () => {
       sideNavItem.expanded = true;
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).shadowDom.to.equalSnapshot();
     });
 
     it('current', async () => {
       sideNavItem.path = '';
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).shadowDom.to.equalSnapshot();
     });
 
     it('path', async () => {
       sideNavItem.path = 'path';
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).shadowDom.to.equalSnapshot();
     });
 
     it('null path', async () => {
       sideNavItem.path = null;
-      await nextRender(sideNavItem);
+      await nextRender();
       await expect(sideNavItem).shadowDom.to.equalSnapshot();
     });
 

--- a/packages/side-nav/test/dom/side-nav.test.js
+++ b/packages/side-nav/test/dom/side-nav.test.js
@@ -25,14 +25,14 @@ describe('vaadin-side-nav', () => {
 
     it('collapsible', async () => {
       sideNav.collapsible = true;
-      await nextRender(sideNav);
+      await nextRender();
       await expect(sideNav).dom.to.equalSnapshot();
     });
 
     it('collapsed', async () => {
       sideNav.collapsible = true;
       sideNav.collapsed = true;
-      await nextRender(sideNav);
+      await nextRender();
       await expect(sideNav).dom.to.equalSnapshot();
     });
   });
@@ -44,14 +44,14 @@ describe('vaadin-side-nav', () => {
 
     it('collapsible', async () => {
       sideNav.collapsible = true;
-      await nextRender(sideNav);
+      await nextRender();
       await expect(sideNav).shadowDom.to.equalSnapshot();
     });
 
     it('collapsed', async () => {
       sideNav.collapsible = true;
       sideNav.collapsed = true;
-      await nextRender(sideNav);
+      await nextRender();
       await expect(sideNav).shadowDom.to.equalSnapshot();
     });
   });

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -50,7 +50,7 @@ describe('file list', () => {
     it('should not overflow content', async () => {
       upload.style.width = '180px';
       upload._addFile(createFiles(1)[0]);
-      await nextRender(upload);
+      await nextRender();
       const fileListItem = getFileListItems(upload)[0];
       expect(fileListItem.scrollWidth - fileListItem.offsetWidth).to.equal(0);
     });

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -400,7 +400,7 @@ describe('upload', () => {
 
     it('should be in held status', async () => {
       upload._addFile(file);
-      await nextRender(upload);
+      await nextRender();
       expect(file.uploaded).not.to.be.ok;
       expect(file.held).to.be.true;
       expect(file.status).to.be.equal(upload.i18n.uploading.status.held);

--- a/test/integration/grid-combo-box.test.js
+++ b/test/integration/grid-combo-box.test.js
@@ -29,7 +29,7 @@ describe('combo-box in grid', () => {
       }
     };
     flushGrid(grid);
-    await nextRender(grid);
+    await nextRender();
   });
 
   it('should not activate item on combo-box toggle button click', () => {

--- a/test/integration/grid-select.test.js
+++ b/test/integration/grid-select.test.js
@@ -29,7 +29,7 @@ describe('select in grid', () => {
       }
     };
     flushGrid(grid);
-    await nextRender(grid);
+    await nextRender();
   });
 
   it('should not activate item on select toggle button click', () => {


### PR DESCRIPTION
## Description

As part of the Polymer removal, we removed the [`target` argument in the `nextRender` testing function](https://github.com/vaadin/testing-helpers/pull/16). The argument itself wasn't used for anything meaningful, so it should be ok to remove it now. 