### PR TITLE
feat: add root heading level support to dashboard layout

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-helpers.js
+++ b/packages/dashboard/src/vaadin-dashboard-helpers.js
@@ -102,16 +102,10 @@ export function fireRemove(element) {
   element.dispatchEvent(new CustomEvent('item-remove', { bubbles: true }));
 }
 
-/**
- * Walks up the DOM tree starting from `node`, returning the first ancestor which is an instance of the given `baseClass`.
- *
- * @param {Node} node - starting node
- * @param {Function} baseClass - constructor, e.g. `Dashboard`
- * @returns {HTMLElement | null}
- */
-export function findAncestorInstance(node, baseClass) {
+/** @private */
+function __findFilteredAncestorInstance(node, elementFilter) {
   while (node) {
-    if (node instanceof baseClass) {
+    if (elementFilter(node)) {
       return node;
     }
     if (node instanceof ShadowRoot) {
@@ -128,4 +122,29 @@ export function findAncestorInstance(node, baseClass) {
     }
   }
   return null;
+}
+
+/**
+ * Walks up the DOM tree starting from `node`, returning the first ancestor which is an instance of the given `baseClass`.
+ *
+ * @param {Node} node - starting node
+ * @param {Function} baseClass - constructor, e.g. `Dashboard`
+ * @returns {HTMLElement | null}
+ */
+export function findAncestorInstance(node, baseClass) {
+  return __findFilteredAncestorInstance(node, (el) => {
+    return el instanceof baseClass;
+  });
+}
+
+/**
+ * Walks up the DOM tree starting from `node`, returning the first ancestor which extends 'DashboardLayoutMixin'.
+ *
+ * @param {Node} node - starting node
+ * @returns {HTMLElement | null}
+ */
+export function getParentLayout(node) {
+  return __findFilteredAncestorInstance(node, (el) => {
+    return el.constructor && el.constructor.toString().includes('DashboardLayoutMixin');
+  });
 }

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -13,7 +13,7 @@ import { html } from 'lit';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { KeyboardController } from './keyboard-controller.js';
-import { fireMove, fireRemove, fireResize } from './vaadin-dashboard-helpers.js';
+import { fireMove, fireRemove, fireResize, getParentLayout } from './vaadin-dashboard-helpers.js';
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-styles.js';
 
 const DEFAULT_I18N = {
@@ -56,6 +56,11 @@ export const DashboardItemMixin = (superClass) =>
         /** @protected */
         __i18n: {
           type: Object,
+        },
+
+        /** @protected */
+        _rootHeadingLevel: {
+          type: Number,
         },
 
         /** @private */
@@ -297,6 +302,19 @@ export const DashboardItemMixin = (superClass) =>
       this.addController(this.__focusTrapController);
     }
 
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      this.__updateRootHeadingLevel();
+      this.__setupHeadingLevelObserver();
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.__removeHeadingLevelObserver();
+    }
+
     /** @private */
     __selectedChanged(selected, oldSelected) {
       if (!!selected === !!oldSelected) {
@@ -376,5 +394,34 @@ export const DashboardItemMixin = (superClass) =>
         return;
       }
       this.dispatchEvent(new CustomEvent('item-resize-mode-changed', { bubbles: true, detail: { value: resizeMode } }));
+    }
+
+    /** @private */
+    __setupHeadingLevelObserver() {
+      this.__removeHeadingLevelObserver();
+      const parentLayout = getParentLayout(this);
+      if (parentLayout) {
+        this.__headingLevelObserver = new MutationObserver(() => this.__updateRootHeadingLevel());
+        this.__headingLevelObserver.observe(parentLayout, {
+          attributes: true,
+          attributeFilter: ['root-heading-level'],
+        });
+      }
+    }
+
+    /** @private */
+    __removeHeadingLevelObserver() {
+      if (this.__headingLevelObserver) {
+        this.__headingLevelObserver.disconnect();
+        this.__headingLevelObserver = null;
+      }
+    }
+
+    /** @private */
+    __updateRootHeadingLevel() {
+      const parentLayout = getParentLayout(this);
+      if (parentLayout) {
+        this._rootHeadingLevel = parentLayout.rootHeadingLevel;
+      }
     }
   };

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.d.ts
@@ -25,4 +25,14 @@ export declare class DashboardLayoutMixinClass {
    * @attr {boolean} dense-layout
    */
   denseLayout: boolean;
+
+  /**
+   * Root heading level for sections and widgets. Defaults to 2.
+   *
+   * If changed to e.g. 1:
+   * - sections will have the attribute `aria-level` with value 1
+   * - non-nested widgets will have the attribute `aria-level` with value 1
+   * - nested widgets will have the attribute `aria-level` with value 2
+   */
+  rootHeadingLevel: number | null | undefined;
 }

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -109,6 +109,21 @@ export const DashboardLayoutMixin = (superClass) =>
           value: false,
           reflectToAttribute: true,
         },
+
+        /**
+         * Root heading level for sections and widgets. Defaults to 2.
+         *
+         * If changed to e.g. 1:
+         * - sections will have the attribute `aria-level` with value 1
+         * - non-nested widgets will have the attribute `aria-level` with value 1
+         * - nested widgets will have the attribute `aria-level` with value 2
+         */
+        rootHeadingLevel: {
+          type: Number,
+          value: 2,
+          sync: true,
+          reflectToAttribute: true,
+        },
       };
     }
 

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -159,11 +159,6 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
         value: '',
       },
 
-      /* @private */
-      __rootHeadingLevel: {
-        type: Number,
-      },
-
       /** @private */
       __childCount: {
         type: Number,
@@ -182,7 +177,7 @@ class DashboardSection extends DashboardItemMixin(ElementMixin(ThemableMixin(Pol
 
         <header part="header">
           ${this.__renderDragHandle()}
-          <div id="title" role="heading" aria-level=${this.__rootHeadingLevel || 2} part="title"
+          <div id="title" role="heading" aria-level=${this._rootHeadingLevel || 2} part="title"
             >${this.sectionTitle}</div
           >
           ${this.__renderRemoveButton()}

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -204,11 +204,6 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
       },
 
       /* @private */
-      __rootHeadingLevel: {
-        type: Number,
-      },
-
-      /* @private */
       __isNestedWidget: {
         type: Boolean,
         value: false,
@@ -249,7 +244,6 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
         this.toggleAttribute(attr, !!wrapper[attr]);
       });
       this.__i18n = wrapper.i18n;
-      this.__rootHeadingLevel = wrapper.__rootHeadingLevel;
     }
 
     this.__updateNestedState();
@@ -271,7 +265,7 @@ class DashboardWidget extends DashboardItemMixin(ElementMixin(ThemableMixin(Poly
 
   /** @private */
   __renderWidgetTitle() {
-    let effectiveHeadingLevel = this.__rootHeadingLevel;
+    let effectiveHeadingLevel = this._rootHeadingLevel;
     // Default to 2 if not defined
     if (effectiveHeadingLevel == null) {
       effectiveHeadingLevel = 2;

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -244,16 +244,6 @@ declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends Das
   editable: boolean;
 
   /**
-   * Root heading level for sections and widgets. Defaults to 2.
-   *
-   * If changed to e.g. 1:
-   * - sections will have the attribute `aria-level` with value 1
-   * - non-nested widgets will have the attribute `aria-level` with value 1
-   * - nested widgets will have the attribute `aria-level` with value 2
-   */
-  rootHeadingLevel: number | null | undefined;
-
-  /**
    * The object used to localize this component. To change the default
    * localization, replace this with an object that provides all properties, or
    * just the individual properties you want to change.

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -166,20 +166,6 @@ class Dashboard extends DashboardLayoutMixin(
         type: Boolean,
       },
 
-      /**
-       * Root heading level for sections and widgets. Defaults to 2.
-       *
-       * If changed to e.g. 1:
-       * - sections will have the attribute `aria-level` with value 1
-       * - non-nested widgets will have the attribute `aria-level` with value 1
-       * - nested widgets will have the attribute `aria-level` with value 2
-       */
-      rootHeadingLevel: {
-        type: Number,
-        value: 2,
-        sync: true,
-      },
-
       /** @private */
       __childCount: {
         type: Number,
@@ -189,7 +175,7 @@ class Dashboard extends DashboardLayoutMixin(
   }
 
   static get observers() {
-    return ['__itemsOrRendererChanged(items, renderer, editable, __effectiveI18n, rootHeadingLevel)'];
+    return ['__itemsOrRendererChanged(items, renderer, editable, __effectiveI18n)'];
   }
 
   /**
@@ -275,7 +261,6 @@ class Dashboard extends DashboardLayoutMixin(
           wrapper.firstElementChild.toggleAttribute(attr, !!wrapper[attr]);
         });
         wrapper.firstElementChild.__i18n = this.__effectiveI18n;
-        wrapper.firstElementChild.__rootHeadingLevel = this.rootHeadingLevel;
       }
     });
   }
@@ -319,7 +304,6 @@ class Dashboard extends DashboardLayoutMixin(
 
         SYNCHRONIZED_ATTRIBUTES.forEach((attr) => section.toggleAttribute(attr, !!wrapper[attr]));
         section.__i18n = this.__effectiveI18n;
-        section.__rootHeadingLevel = this.rootHeadingLevel;
 
         // Render the subitems
         section.__childCount = item.items.length;
@@ -444,7 +428,6 @@ class Dashboard extends DashboardLayoutMixin(
     wrapper['first-child'] = item === getItemsArrayOfItem(item, this.items)[0];
     wrapper['last-child'] = item === getItemsArrayOfItem(item, this.items).slice(-1)[0];
     wrapper.i18n = this.__effectiveI18n;
-    wrapper.__rootHeadingLevel = this.rootHeadingLevel;
   }
 
   /** @private */

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -2,10 +2,13 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import '../vaadin-dashboard-layout.js';
 import '../vaadin-dashboard-section.js';
+import '../vaadin-dashboard-widget.js';
 import '@vaadin/vaadin-lumo-styles/spacing.js';
 import type { DashboardLayout } from '../vaadin-dashboard-layout.js';
 import type { DashboardSection } from '../vaadin-dashboard-section.js';
+import type { DashboardWidget } from '../vaadin-dashboard-widget.js';
 import {
+  assertHeadingLevel,
   expectLayout,
   getColumnWidths,
   getRowHeights,
@@ -611,5 +614,75 @@ describe('dashboard layout', () => {
         [2],
       ]);
     });
+  });
+});
+
+describe('root heading level', () => {
+  let dashboard: DashboardLayout;
+  let section: DashboardSection;
+  let widget: DashboardWidget;
+  let nestedWidget: DashboardWidget;
+
+  beforeEach(async () => {
+    dashboard = fixtureSync(`
+      <vaadin-dashboard-layout>
+        <vaadin-dashboard-widget widget-title="Widget"></vaadin-dashboard-widget>
+        <vaadin-dashboard-section section-title="Section">
+          <vaadin-dashboard-widget widget-title="Nested Widget"></vaadin-dashboard-widget>
+        </vaadin-dashboard-section>
+      </vaadin-dashboard-layout>
+    `);
+    await nextFrame();
+    await nextResize(dashboard);
+    widget = dashboard.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+    section = dashboard.querySelector('vaadin-dashboard-section') as DashboardSection;
+    nestedWidget = section.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+  });
+
+  function assertHeadingLevels(expectedHeadingLevel: number) {
+    assertHeadingLevel(widget, expectedHeadingLevel);
+    assertHeadingLevel(section, expectedHeadingLevel);
+    assertHeadingLevel(nestedWidget, expectedHeadingLevel + 1);
+  }
+
+  it('should use default title heading level (2) when not explicitly set', () => {
+    assertHeadingLevels(2);
+  });
+
+  it('should use custom title heading level when set on dashboard layout', async () => {
+    dashboard.rootHeadingLevel = 4;
+    await nextFrame();
+    assertHeadingLevels(4);
+  });
+
+  it('should update title heading level when changed on dashboard layout', async () => {
+    dashboard.rootHeadingLevel = 3;
+    await nextFrame();
+    dashboard.rootHeadingLevel = 1;
+    await nextFrame();
+    assertHeadingLevels(1);
+  });
+
+  it('should revert to default title heading level (2) when set to null', async () => {
+    dashboard.rootHeadingLevel = 4;
+    await nextFrame();
+    dashboard.rootHeadingLevel = null;
+    await nextFrame();
+    assertHeadingLevels(2);
+  });
+
+  it('should update heading levels for newly added components', async () => {
+    dashboard.rootHeadingLevel = 3;
+    await nextFrame();
+    const newWidget = document.createElement('vaadin-dashboard-widget');
+    dashboard.appendChild(newWidget);
+    const newSection = document.createElement('vaadin-dashboard-section');
+    const nestedInNewSection = document.createElement('vaadin-dashboard-widget');
+    newSection.appendChild(nestedInNewSection);
+    dashboard.appendChild(newSection);
+    await nextFrame();
+    assertHeadingLevel(newWidget, 3);
+    assertHeadingLevel(newSection, 3);
+    assertHeadingLevel(nestedInNewSection, 4);
   });
 });

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -1,8 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '../vaadin-dashboard-layout.js';
 import '../vaadin-dashboard-section.js';
-import type { DashboardSection } from '../vaadin-dashboard-section.js';
+import '../vaadin-dashboard-widget.js';
+import type { DashboardLayout } from '../vaadin-dashboard-layout.js';
+import { DashboardSection } from '../vaadin-dashboard-section.js';
+import type { DashboardWidget } from '../vaadin-dashboard-widget.js';
 import {
+  assertHeadingLevel,
   getDraggable,
   getMoveApplyButton,
   getMoveBackwardButton,
@@ -110,6 +115,99 @@ describe('dashboard section', () => {
       expect(getMoveApplyButton(section)?.getAttribute('title')).to.eql('foo');
       expect(getMoveForwardButton(section)?.getAttribute('title')).to.eql('bar');
       expect(getMoveBackwardButton(section)?.getAttribute('title')).to.eql('baz');
+    });
+  });
+
+  describe('title heading level', () => {
+    describe('with dashboard layout parent', () => {
+      let layout: DashboardLayout;
+      let section: DashboardSection;
+      let nestedWidget: DashboardWidget;
+
+      beforeEach(async () => {
+        layout = fixtureSync(`
+        <vaadin-dashboard-layout>
+          <vaadin-dashboard-section section-title="Section">
+            <vaadin-dashboard-widget widget-title="Nested Widget"></vaadin-dashboard-widget>
+          </vaadin-dashboard-section>
+        </vaadin-dashboard-layout>
+      `);
+        section = layout.querySelector('vaadin-dashboard-section') as DashboardSection;
+        nestedWidget = section.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+        await nextFrame();
+      });
+
+      it('should have title heading level (2) by default', () => {
+        assertHeadingLevel(section, 2);
+      });
+
+      it('should update heading level when parent dashboard layout changes', async () => {
+        layout.rootHeadingLevel = 4;
+        await nextFrame();
+        assertHeadingLevel(section, 4);
+        assertHeadingLevel(nestedWidget, 5);
+      });
+    });
+
+    describe('moving between parents', () => {
+      let newLayout: DashboardLayout;
+      let section: DashboardSection;
+      let nestedWidget: DashboardWidget;
+
+      beforeEach(async () => {
+        const container = fixtureSync(`
+        <div>
+          <vaadin-dashboard-layout id="layout1" root-heading-level="1">
+            <vaadin-dashboard-section section-title="Section">
+              <vaadin-dashboard-widget widget-title="Nested Widget"></vaadin-dashboard-widget>
+            </vaadin-dashboard-section>
+          </vaadin-dashboard-layout>
+          <vaadin-dashboard-layout id="layout2" root-heading-level="3"></vaadin-dashboard-layout>
+        </div>
+      `);
+        const initialLayout = container.querySelector('#layout1') as DashboardLayout;
+        newLayout = container.querySelector('#layout2') as DashboardLayout;
+        section = initialLayout.querySelector('vaadin-dashboard-section') as DashboardSection;
+        nestedWidget = section.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+        await nextFrame();
+      });
+
+      it('should update heading level when moved to another dashboard layout', async () => {
+        newLayout.appendChild(section);
+        await nextFrame();
+        assertHeadingLevel(section, 3);
+        assertHeadingLevel(nestedWidget, 4);
+      });
+
+      it('should update heading level when a new widget is added', async () => {
+        const newWidget = document.createElement('vaadin-dashboard-widget');
+        newWidget.widgetTitle = 'New Widget';
+        section.appendChild(newWidget);
+        await nextFrame();
+        assertHeadingLevel(newWidget, 2);
+        newLayout.appendChild(section);
+        await nextFrame();
+        assertHeadingLevel(newWidget, 4);
+      });
+    });
+
+    describe('custom section', () => {
+      it('should update heading level when a custom section is used', async () => {
+        class CustomSection extends DashboardSection {}
+        customElements.define('custom-dashboard-section', CustomSection);
+        const layout = fixtureSync(`
+        <vaadin-dashboard-layout root-heading-level="5">
+          <custom-dashboard-section section-title="Custom Section">
+            <vaadin-dashboard-widget widget-title="Widget in Custom"></vaadin-dashboard-widget>
+          </custom-dashboard-section>
+        </vaadin-dashboard-layout>
+      `) as DashboardLayout;
+        await nextFrame();
+        const customSection = layout.querySelector('custom-dashboard-section') as DashboardSection;
+        const widget = customSection.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+        assertHeadingLevel(customSection, 5);
+        assertHeadingLevel(widget, 6);
+      });
     });
   });
 });

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -4,6 +4,7 @@ import '../vaadin-dashboard-widget.js';
 import { DashboardSection } from '../vaadin-dashboard-section.js';
 import { DashboardWidget } from '../vaadin-dashboard-widget.js';
 import {
+  assertHeadingLevel,
   getDraggable,
   getMoveApplyButton,
   getMoveBackwardButton,
@@ -156,16 +157,14 @@ describe('widget title level', () => {
     const widget = fixtureSync(`<vaadin-dashboard-widget widget-title="foo"></vaadin-dashboard-widget>`);
     await nextFrame();
 
-    const title = getTitleElement(widget as DashboardWidget);
-    expect(title?.getAttribute('aria-level')).to.equal('2');
+    assertHeadingLevel(widget as DashboardWidget, 2);
   });
 
   it('should have title heading level 2 by default on the section', async () => {
     const section = fixtureSync(`<vaadin-dashboard-section section-title="foo"></vaadin-dashboard-section>`);
     await nextFrame();
 
-    const title = getTitleElement(section as DashboardSection);
-    expect(title?.getAttribute('aria-level')).to.equal('2');
+    assertHeadingLevel(section as DashboardSection, 2);
   });
 
   it('should have title heading level 3 when rendered inside a section', async () => {
@@ -176,8 +175,7 @@ describe('widget title level', () => {
     `).querySelector('vaadin-dashboard-widget')!;
     await nextFrame();
 
-    const title = getTitleElement(widget);
-    expect(title?.getAttribute('aria-level')).to.equal('3');
+    assertHeadingLevel(widget, 3);
   });
 
   it('should have title heading level 2 after moving out of a section', async () => {
@@ -194,8 +192,7 @@ describe('widget title level', () => {
     wrapper.appendChild(widget);
     await nextFrame();
 
-    const title = getTitleElement(widget);
-    expect(title?.getAttribute('aria-level')).to.equal('2');
+    assertHeadingLevel(widget, 2);
   });
 
   it('should have title heading level 3 after moving into a section', async () => {
@@ -211,8 +208,7 @@ describe('widget title level', () => {
     section.appendChild(widget);
     await nextFrame();
 
-    const title = getTitleElement(widget);
-    expect(title?.getAttribute('aria-level')).to.equal('3');
+    assertHeadingLevel(widget, 3);
   });
 
   it('should have title heading level 3 after defining parent section', async () => {
@@ -227,8 +223,7 @@ describe('widget title level', () => {
     customElements.define('my-custom-section', MyCustomSection);
     await nextFrame();
 
-    const title = getTitleElement(widget);
-    expect(title?.getAttribute('aria-level')).to.equal('3');
+    assertHeadingLevel(widget, 3);
   });
 
   it('should have title heading level 3 after defining the widget', async () => {
@@ -243,8 +238,7 @@ describe('widget title level', () => {
     customElements.define('my-custom-widget', MyCustomWidget);
     await nextFrame();
 
-    const title = getTitleElement(widget as DashboardWidget);
-    expect(title?.getAttribute('aria-level')).to.equal('3');
+    assertHeadingLevel(widget as DashboardWidget, 3);
   });
 
   it('should have title heading level 3 after moving a wrapped widget into a section', async () => {
@@ -263,7 +257,6 @@ describe('widget title level', () => {
     section.appendChild(wrapper);
     await nextFrame();
 
-    const title = getTitleElement(widget);
-    expect(title?.getAttribute('aria-level')).to.equal('3');
+    assertHeadingLevel(widget, 3);
   });
 });

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -7,6 +7,7 @@ import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
 import type { Dashboard, DashboardI18n, DashboardItem, DashboardSectionItem } from '../vaadin-dashboard.js';
 import {
+  assertHeadingLevel,
   expectLayout,
   getColumnWidths,
   getDraggable,
@@ -15,7 +16,6 @@ import {
   getRemoveButton,
   getResizeHandle,
   getScrollingContainer,
-  getTitleElement,
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
@@ -775,17 +775,13 @@ describe('dashboard', () => {
 
     function assertHeadingLevels(expectedRootHeadingLevel: number) {
       const nonNestedWidget = getElementFromCell(dashboard, 0, 0) as DashboardWidget;
-      expect(getTitleElement(nonNestedWidget)?.getAttribute('aria-level')).to.equal(
-        expectedRootHeadingLevel.toString(),
-      );
+      assertHeadingLevel(nonNestedWidget, expectedRootHeadingLevel);
 
       const nestedWidget = getElementFromCell(dashboard, 1, 0) as DashboardWidget;
-      expect(getTitleElement(nestedWidget)?.getAttribute('aria-level')).to.equal(
-        (expectedRootHeadingLevel + 1).toString(),
-      );
+      assertHeadingLevel(nestedWidget, expectedRootHeadingLevel + 1);
 
       const section = nestedWidget?.closest('vaadin-dashboard-section') as DashboardSection;
-      expect(getTitleElement(section)?.getAttribute('aria-level')).to.equal(expectedRootHeadingLevel.toString());
+      assertHeadingLevel(section, expectedRootHeadingLevel);
     }
 
     it('should use custom title heading level when set on dashboard', () => {

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -372,3 +372,7 @@ export async function updateComplete(dashboard: HTMLElement): Promise<void> {
   await nextFrame();
   await aTimeout(0);
 }
+
+export function assertHeadingLevel(item: DashboardWidget | DashboardSection, expectedHeadingLevel: number): void {
+  expect(getTitleElement(item).getAttribute('aria-level')).to.equal(expectedHeadingLevel.toString());
+}


### PR DESCRIPTION
## Description

This PR adds root heading level support to `DashboardLayout`. It was previously [added for Dashboard](https://github.com/vaadin/web-components/pull/8885). This PR also refactors the heading level logic in `Dashboard`, `DashboardWidget`, and `DashboardSection`; centralizing them in `DashboardLayoutMixin` and `DashboardItemMixin`.

Fixes #8924 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.