### PR TITLE
chore: update testing-helpers dev dependency to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/mocha": "^10.0.7",
     "@types/sinon": "^17.0.3",
     "@ungap/structured-clone": "^1.3.0",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "@web/dev-server": "^0.4.6",
     "@web/dev-server-esbuild": "^1.0.4",
     "@web/rollup-plugin-html": "^2.0.0",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-board",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -47,7 +47,7 @@
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/icon": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-chart",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -47,7 +47,7 @@
     "@vaadin/a11y-base": "25.0.0-alpha1",
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "cvdlName": "vaadin-cookie-consent",
   "web-types": [

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-crud",

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -52,7 +52,7 @@
     "@vaadin/password-field": "25.0.0-alpha1",
     "@vaadin/select": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/text-area": "25.0.0-alpha1",
     "@vaadin/text-field": "25.0.0-alpha1",
     "@vaadin/time-picker": "25.0.0-alpha1",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "cvdlName": "vaadin-dashboard",
   "web-types": [

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -48,7 +48,7 @@
     "@vaadin/a11y-base": "25.0.0-alpha1",
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -52,7 +52,7 @@
     "@vaadin/radio-group": "25.0.0-alpha1",
     "@vaadin/select": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/text-area": "25.0.0-alpha1",
     "@vaadin/text-field": "25.0.0-alpha1",
     "@vaadin/time-picker": "25.0.0-alpha1",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -45,7 +45,7 @@
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/custom-field": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/text-field": "25.0.0-alpha1",
     "sinon": "^18.0.0"
   },

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-grid-pro",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -42,7 +42,7 @@
     "@vaadin/icon": "25.0.0-alpha1",
     "@vaadin/icons": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/lit-renderer/package.json
+++ b/packages/lit-renderer/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -48,7 +48,7 @@
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/checkbox": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "cvdlName": "vaadin-map",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/master-detail-layout/package.json
+++ b/packages/master-detail-layout/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -50,7 +50,7 @@
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/icon": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -48,7 +48,7 @@
     "@vaadin/button": "25.0.0-alpha1",
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -53,7 +53,7 @@
     "@vaadin/a11y-base": "25.0.0-alpha1",
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "gulp": "^5.0.0",
     "gulp-cli": "^3.0.0",
     "gulp-iconfont": "^11.0.0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "lit": "^3.0.0",
     "sinon": "^18.0.0"
   },

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/packages/vaadin-themable-mixin/package.json
+++ b/packages/vaadin-themable-mixin/package.json
@@ -39,7 +39,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   }
 }

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0"
+    "@vaadin/testing-helpers": "^2.0.0"
   },
   "web-types": [
     "web-types.json",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^18.0.0"
   },
   "web-types": [

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -39,7 +39,7 @@
     "@vaadin/select": "25.0.0-alpha1",
     "@vaadin/tabs": "25.0.0-alpha1",
     "@vaadin/test-runner-commands": "25.0.0-alpha1",
-    "@vaadin/testing-helpers": "^1.1.0",
+    "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/text-area": "25.0.0-alpha1",
     "@vaadin/text-field": "25.0.0-alpha1",
     "@vaadin/time-picker": "25.0.0-alpha1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,7 +1297,7 @@
     "@polymer/iron-overlay-behavior" "^3.0.0-pre.27"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/polymer@^3.0.0", "@polymer/polymer@^3.5.1":
+"@polymer/polymer@^3.0.0":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.5.1.tgz#4b5234e43b8876441022bcb91313ab3c4a29f0c8"
   integrity sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==
@@ -1968,12 +1968,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@vaadin/testing-helpers@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-1.1.0.tgz#8eeac00443cf7d4c130fc136fc7d2c9abee1dbfc"
-  integrity sha512-fbBIsla857GlzQDDd/NPNQxTcV76F0SzFm4U2WaDhH+RouCVta2z1IhAeIIOXz+dc2Ni0VLwlF77QEr9hSzLIQ==
+"@vaadin/testing-helpers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@vaadin/testing-helpers/-/testing-helpers-2.0.0.tgz#e53e3443a27e7be3f06dd4e1562a7405dc352043"
+  integrity sha512-/aU11ft4V6HuOKIFoKixHQm8lC9OH/pNed2cWtUrpyb7q27nkHF9eLb6DON+ixCzd/IqJ8sOdRczGSECKYZ1xA==
   dependencies:
-    "@polymer/polymer" "^3.5.1"
     lit "^3.0.0"
 
 "@vaadin/vaadin-development-mode-detector@^2.0.0":


### PR DESCRIPTION
## Description

Updated to new version of `@vaadin/testing-helpers` without Polymer dependency.

## Type of change

- Internal change