### PR TITLE
fix: move CRUD children back to light DOM and keep their order

### DIFF
--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -484,7 +484,7 @@ export const CrudMixin = (superClass) =>
         } else {
           this.$.editor.removeAttribute('tabindex');
         }
-      } else if (oldOpened && this.__shouldOpenDialog(this._fullscreen, this.editorPosition)) {
+      } else if (oldOpened) {
         // Teleport form and buttons back to light DOM when closing overlay
         this.__moveChildNodes(this);
       }

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -384,6 +384,13 @@ export const CrudMixin = (superClass) =>
       this.$.dialog.$.overlay.addEventListener('vaadin-overlay-outside-click', this.__cancel);
       this.$.dialog.$.overlay.addEventListener('vaadin-overlay-escape-press', this.__cancel);
 
+      this._gridController = new GridSlotController(this);
+      this.addController(this._gridController);
+
+      // Init button controllers in `ready()` (not constructor) so that Flow can set `_noDefaultButtons`
+      this._newButtonController = new ButtonSlotController(this, 'new', 'primary', this._noDefaultButtons);
+      this.addController(this._newButtonController);
+
       this._headerController = new SlotController(this, 'header', 'h3', {
         initializer: (node) => {
           this._defaultHeader = node;
@@ -391,18 +398,11 @@ export const CrudMixin = (superClass) =>
       });
       this.addController(this._headerController);
 
-      this._gridController = new GridSlotController(this);
-      this.addController(this._gridController);
-
       this.addController(new FormSlotController(this));
 
-      // Init controllers in `ready()` (not constructor) so that Flow can set `_noDefaultButtons`
-      this._newButtonController = new ButtonSlotController(this, 'new', 'primary', this._noDefaultButtons);
       this._saveButtonController = new ButtonSlotController(this, 'save', 'primary', this._noDefaultButtons);
       this._cancelButtonController = new ButtonSlotController(this, 'cancel', 'tertiary', this._noDefaultButtons);
       this._deleteButtonController = new ButtonSlotController(this, 'delete', 'tertiary error', this._noDefaultButtons);
-
-      this.addController(this._newButtonController);
 
       // NOTE: order in which buttons are added should match the order of slots in template
       this.addController(this._saveButtonController);
@@ -484,6 +484,9 @@ export const CrudMixin = (superClass) =>
         } else {
           this.$.editor.removeAttribute('tabindex');
         }
+      } else if (oldOpened && this.__shouldOpenDialog(this._fullscreen, this.editorPosition)) {
+        // Teleport form and buttons back to light DOM when closing overlay
+        this.__moveChildNodes(this);
       }
 
       this.__toggleToolbar();
@@ -522,7 +525,10 @@ export const CrudMixin = (superClass) =>
       // Teleport header node, form, and the buttons to corresponding slots.
       // NOTE: order in which buttons are moved matches the order of slots.
       [...nodes, ...buttons].forEach((node) => {
-        target.appendChild(node);
+        // Do not move nodes if the editor position has not changed
+        if (node.parentNode !== target) {
+          target.appendChild(node);
+        }
       });
 
       // Wait to set label until slotted element has been moved.

--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -86,6 +86,13 @@ describe('crud editor', () => {
         expect(form.parentElement).to.equal(overlay);
       });
 
+      it(`should move ${type} form to crud after dialog closing with default editorPosition`, async () => {
+        crud._grid.activeItem = crud.items[0];
+        await nextRender();
+        btnCancel.click();
+        expect(form.parentElement).to.equal(crud);
+      });
+
       it(`should move ${type} form to crud when editorPosition set to bottom`, async () => {
         crud.editorPosition = 'bottom';
         crud._grid.activeItem = crud.items[0];

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -3,9 +3,6 @@ export const snapshots = {};
 
 snapshots["vaadin-crud host default"] = 
 `<vaadin-crud editor-position="">
-  <h3 slot="header">
-    Edit item
-  </h3>
   <vaadin-crud-grid
     slot="grid"
     style="touch-action: none;"
@@ -135,8 +132,6 @@ snapshots["vaadin-crud host default"] =
       </vaadin-crud-edit>
     </vaadin-grid-cell-content>
   </vaadin-crud-grid>
-  <vaadin-crud-form slot="form">
-  </vaadin-crud-form>
   <vaadin-button
     role="button"
     slot="new-button"
@@ -145,6 +140,11 @@ snapshots["vaadin-crud host default"] =
   >
     New item
   </vaadin-button>
+  <h3 slot="header">
+    Edit item
+  </h3>
+  <vaadin-crud-form slot="form">
+  </vaadin-crud-form>
   <vaadin-button
     aria-disabled="true"
     disabled=""


### PR DESCRIPTION
## Description

Currently, when closing `vaadin-crud-dialog`, teleported elements (header, form and buttons) are not returned and end up in `vaadin-crud` shadow DOM. This PR fixes that by calling `__moveChildNodes()` on closing the editor.

Also updated the order in which controllers are added to match the list of slots in the template, and added a check to avoid moving nodes in the DOM unnecessarily when using default / aside editor position.

## Type of change

- Bugfix / refactor