### PR TITLE
fix: sync top group if necessary even when dropdown is opened (#9095) (CP: 23.5)

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -934,9 +934,24 @@ class MultiSelectComboBox extends ResizeMixin(InputControlMixin(ThemableMixin(El
   __updateTopGroup(selectedItemsOnTop, selectedItems, opened) {
     if (!selectedItemsOnTop) {
       this._topGroup = [];
-    } else if (!opened) {
+    } else if (!opened || this.__needToSyncTopGroup()) {
       this._topGroup = [...selectedItems];
     }
+  }
+
+  /** @private */
+  __needToSyncTopGroup() {
+    // Only sync for object items
+    if (!this.itemIdPath) {
+      return false;
+    }
+    return (
+      this._topGroup &&
+      this._topGroup.some((item) => {
+        const selectedItem = this.selectedItems[this._findIndex(item, this.selectedItems, this.itemIdPath)];
+        return selectedItem && item !== selectedItem;
+      })
+    );
   }
 
   /** @private */

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -227,12 +227,21 @@ describe('selecting items', () => {
       beforeEach(() => {
         comboBox.itemIdPath = 'id';
         comboBox.items = items;
-        comboBox.selectedItems = items.slice(1, 3);
       });
 
       it('should show selected items at the top of the overlay', () => {
+        comboBox.selectedItems = items.slice(1, 3);
         comboBox.opened = true;
         expectItems(['banana', 'lemon', 'apple', 'orange', 'pear']);
+      });
+
+      it('should synchronize selected item state when overlay is opened', async () => {
+        comboBox.selectedItems = [{ id: '1', label: 'banana' }];
+        comboBox.opened = true;
+        const itemReference = getFirstItem(comboBox).item;
+        comboBox.selectedItems = [{ id: '1', label: 'banana' }];
+        await nextRender();
+        expect(getFirstItem(comboBox).item).to.not.equal(itemReference);
       });
     });
 


### PR DESCRIPTION
## Description

Back-port of https://github.com/vaadin/web-components/pull/9095 to v23.5

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.