### PR TITLE
fix: resize app layout drawer based on content

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -166,6 +166,7 @@ export const AppLayoutMixin = (superclass) =>
       });
       this._navbarSizeObserver.observe(this.$.navbarTop);
       this._navbarSizeObserver.observe(this.$.navbarBottom);
+      this._navbarSizeObserver.observe(this.$.drawer);
 
       window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
       window.addEventListener('keydown', this.__onDrawerKeyDown);

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -302,6 +302,23 @@ describe('vaadin-app-layout', () => {
 
         expect(width).to.be.equal(100);
       });
+
+      it('should update content offset when drawer width changes', async () => {
+        // Allow drawer size based on content
+        layout.style.setProperty('--vaadin-app-layout-drawer-width', 'auto');
+        const drawerContent = document.querySelector('section[slot="drawer"]');
+        drawerContent.style.width = '200px';
+        await nextResize(layout);
+        await nextRender();
+        const initialOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-inline-start'));
+        expect(initialOffset).to.equal(200);
+        // Decrease drawer content size and measure decrease
+        drawerContent.style.width = '100px';
+        await nextResize(layout);
+        await nextRender();
+        const updatedOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-inline-start'));
+        expect(updatedOffset).to.equal(100);
+      });
     });
 
     describe('mobile layout', () => {


### PR DESCRIPTION
## Description

Allow the layout to react to drawer content size changes when drawer width is auto.

### Before fix:

https://github.com/user-attachments/assets/e4f17718-61c3-4114-8320-6931ca17cc42

### After fix:


https://github.com/user-attachments/assets/a5897c41-7f42-4258-af74-dbafbf91f6a4



## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.