### PR TITLE
refactor: cleanup no longer needed usage of registerStyles

### DIFF
--- a/packages/rich-text-editor/gulpfile.cjs
+++ b/packages/rich-text-editor/gulpfile.cjs
@@ -43,7 +43,7 @@ gulp.task('icons', (done) => {
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from 'lit';
 
 const template = document.createElement('template');
 
@@ -90,9 +90,6 @@ export const iconsStyles = css\`\n`;
     content: var(--vaadin-rte-icons-redo);
   }`;
       output += `\n\`;\n`;
-      output += `
-// Register a module with ID for backwards compatibility.
-registerStyles('', iconsStyles, { moduleId: 'vaadin-rich-text-editor-icons' });\n`;
       fs.writeFile(`src/${fileName}.js`, output, (err) => {
         if (err) {
           return console.error(err);

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-content-styles.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-content-styles.js
@@ -8,7 +8,7 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from 'lit';
 
 export const contentStyles = css`
   [part='content'] {
@@ -113,6 +113,3 @@ export const contentStyles = css`
     text-align: right;
   }
 `;
-
-// Register a module with ID for backwards compatibility.
-registerStyles('', contentStyles, { moduleId: 'vaadin-rich-text-editor-content-styles' });

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-icons.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-icons.js
@@ -8,7 +8,7 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from 'lit';
 
 const template = document.createElement('template');
 
@@ -88,6 +88,3 @@ export const iconsStyles = css`
     content: var(--vaadin-rte-icons-redo);
   }
 `;
-
-// Register a module with ID for backwards compatibility.
-registerStyles('', iconsStyles, { moduleId: 'vaadin-rich-text-editor-icons' });

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-toolbar-styles.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-toolbar-styles.js
@@ -8,7 +8,7 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from 'lit';
 import { iconsStyles } from './vaadin-rich-text-editor-icons.js';
 
 export const buttonsStyles = css`
@@ -178,6 +178,3 @@ export const buttonsStyles = css`
 `;
 
 export const toolbarStyles = [iconsStyles, buttonsStyles];
-
-// Register a module with ID for backwards compatibility.
-registerStyles('', toolbarStyles, { moduleId: 'vaadin-rich-text-editor-toolbar-styles' });


### PR DESCRIPTION
## Description

This usage of `registerStyles()` is a leftover from V14 version and is no longer needed. Let's remove it.

## Type of change

- Refactor