### PR TITLE
chore: add missing a11y-base direct dependency to dashboard

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
+    "@vaadin/a11y-base": "25.0.0-alpha1",
     "@vaadin/button": "25.0.0-alpha1",
     "@vaadin/component-base": "25.0.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha1",


### PR DESCRIPTION
## Description

There is an import of `FocusTrapController` so it's better to have `@vaadin/a11y-base` as a direct dependency.

## Type of change

- Internal change