### PR TITLE
chore: add missing open-wc dependency to horizontal-layout

### DIFF
--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -34,6 +34,7 @@
     "web-component"
   ],
   "dependencies": {
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/component-base": "25.0.0-alpha1",
     "@vaadin/vaadin-lumo-styles": "25.0.0-alpha1",
     "@vaadin/vaadin-themable-mixin": "25.0.0-alpha1",


### PR DESCRIPTION
## Description

This dependency is used in type definitions for the mixin, let's add it to package.json.

## Type of change

- Internal change