### PR TITLE
refactor: remove no longer needed contained theme from buttons

### DIFF
--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -116,12 +116,7 @@ class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(L
           </vaadin-password-field>
         </form>
 
-        <vaadin-button
-          slot="submit"
-          theme="primary contained submit"
-          @click="${this.submit}"
-          .disabled="${this.disabled}"
-        >
+        <vaadin-button slot="submit" theme="primary submit" @click="${this.submit}" .disabled="${this.disabled}">
           ${this.__effectiveI18n.form.submit}
         </vaadin-button>
 

--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -95,7 +95,7 @@ snapshots["vaadin-login-form host default"] =
       role="button"
       slot="submit"
       tabindex="0"
-      theme="primary contained submit"
+      theme="primary submit"
     >
       Log in
     </vaadin-button>
@@ -214,7 +214,7 @@ snapshots["vaadin-login-form host required"] =
       role="button"
       slot="submit"
       tabindex="0"
-      theme="primary contained submit"
+      theme="primary submit"
     >
       Log in
     </vaadin-button>
@@ -325,7 +325,7 @@ snapshots["vaadin-login-form host i18n"] =
       role="button"
       slot="submit"
       tabindex="0"
-      theme="primary contained submit"
+      theme="primary submit"
     >
       Kirjaudu sisään
     </vaadin-button>
@@ -436,7 +436,7 @@ snapshots["vaadin-login-form host i18n-partial"] =
       role="button"
       slot="submit"
       tabindex="0"
-      theme="primary contained submit"
+      theme="primary submit"
     >
       Log in
     </vaadin-button>
@@ -555,7 +555,7 @@ snapshots["vaadin-login-form host i18n-required"] =
       role="button"
       slot="submit"
       tabindex="0"
-      theme="primary contained submit"
+      theme="primary submit"
     >
       Kirjaudu sisään
     </vaadin-button>
@@ -666,7 +666,7 @@ snapshots["vaadin-login-form host noForgotPassword"] =
       role="button"
       slot="submit"
       tabindex="0"
-      theme="primary contained submit"
+      theme="primary submit"
     >
       Log in
     </vaadin-button>

--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -109,7 +109,7 @@ snapshots["vaadin-login-overlay host default"] =
         role="button"
         slot="submit"
         tabindex="0"
-        theme="primary contained submit"
+        theme="primary submit"
       >
         Log in
       </vaadin-button>
@@ -235,7 +235,7 @@ snapshots["vaadin-login-overlay host i18n"] =
         role="button"
         slot="submit"
         tabindex="0"
-        theme="primary contained submit"
+        theme="primary submit"
       >
         Kirjaudu sisään
       </vaadin-button>
@@ -361,7 +361,7 @@ snapshots["vaadin-login-overlay host i18n-partial"] =
         role="button"
         slot="submit"
         tabindex="0"
-        theme="primary contained submit"
+        theme="primary submit"
       >
         Log in
       </vaadin-button>
@@ -488,7 +488,7 @@ snapshots["vaadin-login-overlay host overlay class"] =
         role="button"
         slot="submit"
         tabindex="0"
-        theme="primary contained submit"
+        theme="primary submit"
       >
         Log in
       </vaadin-button>

--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -92,7 +92,7 @@ export const MessageInputMixin = (superClass) =>
 
       this._buttonController = new SlotController(this, 'button', 'vaadin-button', {
         initializer: (btn) => {
-          btn.setAttribute('theme', 'primary contained');
+          btn.setAttribute('theme', 'primary');
 
           btn.addEventListener('click', () => {
             this.__submit();

--- a/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
+++ b/packages/message-input/test/dom/__snapshots__/message-input.test.snap.js
@@ -7,7 +7,7 @@ snapshots["vaadin-message-input default"] =
     role="button"
     slot="button"
     tabindex="0"
-    theme="primary contained"
+    theme="primary"
   >
     Send
   </vaadin-button>
@@ -48,7 +48,7 @@ snapshots["vaadin-message-input disabled"] =
     role="button"
     slot="button"
     tabindex="-1"
-    theme="primary contained"
+    theme="primary"
   >
     Send
   </vaadin-button>


### PR DESCRIPTION
## Description

Removed "contained" theme variant usage - it is a leftover from Material theme (Lumo doesn't have it).

## Type of change

- Refactor