### PR TITLE
test: disable animation on input-container

### DIFF
--- a/packages/input-container/test/visual/common.js
+++ b/packages/input-container/test/visual/common.js
@@ -1,0 +1,16 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-input-container',
+  css`
+    /* Disable animation */
+    :host {
+      &,
+      &::before,
+      &::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    }
+  `,
+);

--- a/packages/input-container/test/visual/lumo/input-container.test.js
+++ b/packages/input-container/test/visual/lumo/input-container.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../common.js';
 import '@vaadin/icon/vaadin-icon.js';
 import '@vaadin/vaadin-lumo-styles/test/autoload.js';
 import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';


### PR DESCRIPTION
## Description

To improve the stability of visual tests, the PR disables the [animation](https://github.com/vaadin/web-components/blob/404ad730c30f48c779b363462bbf2d961e9b1775/packages/input-container/theme/lumo/vaadin-input-container-styles.js#L57-L59) applied to `vaadin-input-container::before`.

Part of #9082 

## Type of change

- [x] Internal
