### PR TITLE
refactor: remove unused opacity transition

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -65,7 +65,6 @@ const requiredField = css`
 
   :host([required]) [part='required-indicator']::after {
     content: var(--lumo-required-field-indicator, '\\2022');
-    transition: opacity 0.2s;
     color: var(--lumo-required-field-indicator-color, var(--lumo-primary-text-color));
     position: absolute;
     right: 0;


### PR DESCRIPTION
## Description

There is no rule that modifies `opacity` for the required indicator, so defining an opacity transition is useless.

## Type of change

- [x] Refactor
