### PR TITLE
refactor: remove unused color transition

### DIFF
--- a/packages/form-layout/theme/lumo/vaadin-form-item-styles.js
+++ b/packages/form-layout/theme/lumo/vaadin-form-item-styles.js
@@ -16,7 +16,6 @@ registerStyles(
       margin-top: var(--lumo-space-m);
       margin-left: calc(var(--lumo-border-radius-m) / 4);
       margin-bottom: var(--lumo-space-xs);
-      transition: color 0.4s;
       line-height: 1.333;
     }
 


### PR DESCRIPTION
## Description

There is no rule that modifies `color` for the label part, so defining a color transition is pointless. It's apparently a leftover from an earlier implementation.

## Type of change

- [x] Refactor
