### PR TITLE
refactor: cleanup waiting for updateComplete in select

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -644,13 +644,7 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     /** @private */
-    async __dispatchChange() {
-      // Wait for the update complete to guarantee that value-changed is fired
-      // before validated and change events when using the Lit version of the component.
-      if (this.updateComplete) {
-        await this.updateComplete;
-      }
-
+    __dispatchChange() {
       this._requestValidation();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
       this.__dispatchChangePending = false;


### PR DESCRIPTION
## Description

This logic was added in https://github.com/vaadin/web-components/pull/6256 - back then, the component was not using `sync: true` for `value`. It was added much later in https://github.com/vaadin/web-components/pull/8223. So `value-changed` fires synchronously now and there is no more need to wait for `updateComplete`.

## Type of change

- Refactor