### PR TITLE
refactor: remove unused ID attributes

### DIFF
--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -65,11 +65,10 @@ class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElem
         @error="${this.__onImageLoadError}"
         draggable="false"
       />
-      <div part="icon" ?hidden="${!this.__iconVisible}" id="avatar-icon" aria-hidden="true"></div>
+      <div part="icon" ?hidden="${!this.__iconVisible}" aria-hidden="true"></div>
       <svg
         part="abbr"
         ?hidden="${!this.__abbrVisible}"
-        id="avatar-abbr"
         viewBox="-50 -50 100 100"
         preserveAspectRatio="xMidYMid meet"
         aria-hidden="true"

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -31,8 +31,8 @@ describe('vaadin-avatar', () => {
   describe('properties', () => {
     beforeEach(() => {
       imgElement = avatar.shadowRoot.querySelector('img');
-      iconElement = avatar.shadowRoot.querySelector('#avatar-icon');
-      abbrElement = avatar.shadowRoot.querySelector('#avatar-abbr');
+      iconElement = avatar.shadowRoot.querySelector('[part=icon]');
+      abbrElement = avatar.shadowRoot.querySelector('[part=abbr]');
     });
 
     const validImageSrc =
@@ -376,12 +376,12 @@ describe('vaadin-avatar', () => {
     });
 
     it('should set aria-hidden="true" on the icon element', () => {
-      const iconElement = avatar.shadowRoot.querySelector('#avatar-icon');
+      const iconElement = avatar.shadowRoot.querySelector('[part=icon]');
       expect(iconElement.getAttribute('aria-hidden')).to.equal('true');
     });
 
     it('should set aria-hidden="true" on the abbr element', () => {
-      const abbrElement = avatar.shadowRoot.querySelector('#avatar-abbr');
+      const abbrElement = avatar.shadowRoot.querySelector('[part=abbr]');
       expect(abbrElement.getAttribute('aria-hidden')).to.equal('true');
     });
 

--- a/packages/avatar/test/dom/__snapshots__/avatar.test.snap.js
+++ b/packages/avatar/test/dom/__snapshots__/avatar.test.snap.js
@@ -10,7 +10,6 @@ snapshots["vaadin-avatar default"] =
 <div
   aria-hidden="true"
   hidden=""
-  id="avatar-icon"
   part="icon"
 >
 </div>
@@ -28,7 +27,6 @@ snapshots["vaadin-avatar img"] =
 <div
   aria-hidden="true"
   hidden=""
-  id="avatar-icon"
   part="icon"
 >
 </div>


### PR DESCRIPTION
## Description

Removes the ID attributes `avatar-icon` and `avatar-abbr`  from the `vaadin-avatar` component, as they were only used in unit tests.

Follow-up to #9316 

## Type of change

- [x] Refactor
