### PR TITLE
refactor: simplify icon rendering logic, inline some methods

### DIFF
--- a/packages/icon/src/vaadin-icon-mixin.js
+++ b/packages/icon/src/vaadin-icon-mixin.js
@@ -5,7 +5,7 @@
  */
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
-import { ensureSvgLiteral, renderSvg, unsafeSvgLiteral } from './vaadin-icon-svg.js';
+import { unsafeSvgLiteral } from './vaadin-icon-svg.js';
 
 const srcCache = new Map();
 
@@ -133,19 +133,10 @@ export const IconMixin = (superClass) =>
         },
 
         /** @private */
-        __defaultPAR: {
-          type: String,
-          value: 'xMidYMid meet',
-        },
-
-        /** @private */
         __preserveAspectRatio: String,
 
         /** @private */
-        __useRef: Object,
-
-        /** @private */
-        __svgElement: String,
+        __useRef: String,
 
         /** @private */
         __viewBox: String,
@@ -168,11 +159,7 @@ export const IconMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '__svgChanged(svg, __svgElement)',
-        '__fontChanged(iconClass, char, ligature)',
-        '__srcChanged(src, symbol)',
-      ];
+      return ['__fontChanged(iconClass, char, ligature)', '__srcChanged(src, symbol)'];
     }
 
     static get observedAttributes() {
@@ -206,7 +193,6 @@ export const IconMixin = (superClass) =>
     /** @protected */
     ready() {
       super.ready();
-      this.__svgElement = this.shadowRoot.querySelector('#svg-group');
       this._tooltipController = new TooltipController(this);
       this.addController(this._tooltipController);
     }
@@ -243,7 +229,7 @@ export const IconMixin = (superClass) =>
       if (icon) {
         this._applyIcon();
       } else {
-        this.svg = ensureSvgLiteral(null);
+        this.svg = null;
       }
     }
 
@@ -299,29 +285,6 @@ export const IconMixin = (superClass) =>
           this.svg = null;
         }
       }
-    }
-
-    /** @private */
-    __svgChanged(svg, svgElement) {
-      if (!svgElement) {
-        return;
-      }
-      renderSvg(svg, svgElement);
-    }
-
-    /** @private */
-    __computePAR(defaultPAR, preserveAspectRatio) {
-      return preserveAspectRatio || defaultPAR;
-    }
-
-    /** @private */
-    __computeVisibility(__useRef) {
-      return __useRef ? 'visible' : 'hidden';
-    }
-
-    /** @private */
-    __computeViewBox(size, viewBox) {
-      return viewBox || `0 0 ${size} ${size}`;
     }
 
     /** @private */

--- a/packages/icon/src/vaadin-icon-svg.d.ts
+++ b/packages/icon/src/vaadin-icon-svg.d.ts
@@ -23,11 +23,6 @@ export function isValidSvg(source: unknown): source is IconSvgLiteral;
 export function ensureSvgLiteral(source: unknown): IconSvgLiteral;
 
 /**
- * Render a given SVG literal to the container.
- */
-export function renderSvg(source: unknown, container: SVGElement): void;
-
-/**
  * Create an SVG literal from source string.
  */
 export function unsafeSvgLiteral(source: string): IconSvgLiteral;

--- a/packages/icon/src/vaadin-icon-svg.js
+++ b/packages/icon/src/vaadin-icon-svg.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { nothing, render, svg } from 'lit';
+import { nothing, svg } from 'lit';
 import { isTemplateResult, TemplateResultType } from 'lit/directive-helpers.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 
@@ -46,17 +46,6 @@ export function ensureSvgLiteral(source) {
   }
 
   return result;
-}
-
-/**
- * Render a given SVG literal to the container.
- *
- * @param {unknown} source
- * @param {SVGElement} container
- */
-export function renderSvg(source, container) {
-  const result = ensureSvgLiteral(source);
-  render(result, container);
 }
 
 /**

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -13,6 +13,7 @@ import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-m
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { iconStyles } from './styles/vaadin-icon-core-styles.js';
 import { IconMixin } from './vaadin-icon-mixin.js';
+import { ensureSvgLiteral } from './vaadin-icon-svg.js';
 
 /**
  * `<vaadin-icon>` is a Web Component for displaying SVG icons.
@@ -75,8 +76,8 @@ class Icon extends IconMixin(ElementMixin(CSSInjectionMixin(ThemableMixin(Polyli
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
         xmlns:xlink="http://www.w3.org/1999/xlink"
-        viewBox="${this.__computeViewBox(this.size, this.__viewBox)}"
-        preserveAspectRatio="${this.__computePAR(this.__defaultPAR, this.__preserveAspectRatio)}"
+        viewBox="${this.__viewBox || `0 0 ${this.size} ${this.size}`}"
+        preserveAspectRatio="${this.__preserveAspectRatio || 'xMidYMid meet'}"
         fill="${ifDefined(this.__fill)}"
         stroke="${ifDefined(this.__stroke)}"
         stroke-width="${ifDefined(this.__strokeWidth)}"
@@ -84,8 +85,8 @@ class Icon extends IconMixin(ElementMixin(CSSInjectionMixin(ThemableMixin(Polyli
         stroke-linejoin="${ifDefined(this.__strokeLinejoin)}"
         aria-hidden="true"
       >
-        <g id="svg-group"></g>
-        <g id="use-group" visibility="${this.__computeVisibility(this.__useRef, this.svg)}">
+        <g id="svg-group">${ensureSvgLiteral(this.svg)}</g>
+        <g id="use-group" visibility="${this.__useRef ? 'visible' : 'hidden'}">
           <use href="${this.__useRef}" />
         </g>
       </svg>

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -404,6 +404,11 @@ describe('vaadin-icon', () => {
         expect(child.getAttribute('fill')).to.equal('red');
       });
 
+      it('should set default preserveAspectRatio attribute when not set on the icon', () => {
+        icon.icon = 'vaadin:angle-down';
+        expect(svgElement.getAttribute('preserveAspectRatio')).to.equal('xMidYMid meet');
+      });
+
       it('should preserve the preserveAspectRatio attribute set on the icon', () => {
         icon.icon = 'vaadin:angle-right';
         expect(svgElement.getAttribute('preserveAspectRatio')).to.equal('xMidYMin slice');


### PR DESCRIPTION
## Description

Updated `vaadin-icon` to pass `svg` directly to the `render()` method without storing a reference to the `<g>` element - this was only needed with Polymer. Also inlined methods that were extracted due to Polymer into the `render()`.

## Type of change

- Refactor