### PR TITLE
fix: do not set use href attribute if icon src is not defined

### DIFF
--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -87,7 +87,7 @@ class Icon extends IconMixin(ElementMixin(CSSInjectionMixin(ThemableMixin(Polyli
       >
         <g id="svg-group">${ensureSvgLiteral(this.svg)}</g>
         <g id="use-group" visibility="${this.__useRef ? 'visible' : 'hidden'}">
-          <use href="${this.__useRef}" />
+          <use href="${ifDefined(this.__useRef)}" />
         </g>
       </svg>
 

--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -113,6 +113,11 @@ describe('vaadin-icon', () => {
       svgElement = icon.shadowRoot.querySelector('svg');
     });
 
+    it('should not set href attribute on the use element by default', () => {
+      const use = svgElement.querySelector('use');
+      expect(use.hasAttribute('href')).to.be.false;
+    });
+
     it('should render svg when path is provided', async () => {
       const svgSrc = `<svg>${ANGLE_DOWN}</svg>`;
       sinon.stub(icon, '__fetch').resolves({ ok: true, text: () => Promise.resolve(svgSrc) });


### PR DESCRIPTION
## Description

With Polymer version binding to attribute didn't set value with falsy value, but with Lit we need `ifDefined()` for that.

## Type of change

- Bugfix