### PR TITLE
refactor: simplify combo-box scroller initialization and update logic

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -54,17 +54,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
           observer: '_dataProviderChanged',
           sync: true,
         },
-
-        /** @private */
-        __dataProviderInitialized: {
-          type: Boolean,
-          value: false,
-        },
-
-        /** @private */
-        __previousDataProviderFilter: {
-          type: String,
-        },
       };
     }
 
@@ -78,6 +67,22 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
     constructor() {
       super();
+
+      /**
+       * Flag indicating that data provider has been initialized.
+       * Do not define in `properties` to avoid triggering updates.
+       * @type {boolean}
+       * @protected
+       */
+      this.__dataProviderInitialized = false;
+
+      /**
+       * Used to store the previous value of the data provider filter.
+       * Do not define in `properties` to avoid triggering updates.
+       * @type {string}
+       * @protected
+       */
+      this.__previousDataProviderFilter;
 
       /**
        * @type {DataProviderController}


### PR DESCRIPTION
## Description

Currently, `vaadin-combo-box` triggers way too many updates on initial render. This PR attempts to reduce the count by changing how scroller is initialized - it's now moved to `firstUpdated()` callback. This callback is executed before all observers are run so we no longer need `_scroller` available as a reactive property for `_updateScroller` observer.

Also modified a few other internal flags to not be defined in `static get properties()` as these are not used in observers.

## Type of change

- Refactor

## Comparison

### Before

12 updates:

```
vaadin-combo-box-mixin.js:425 Map(1) {'_overlayOpened' => undefined}
vaadin-combo-box-mixin.js:425 Map(3) {'__previousDataProviderFilter' => undefined, '_overlayElement' => undefined, '_scroller' => undefined}
vaadin-combo-box-mixin.js:425 Map(3) {'_lastCommittedValue' => undefined, '__dataProviderInitialized' => false, 'inputElement' => undefined}
vaadin-combo-box-mixin.js:425 Map(1) {'focusElement' => undefined}
vaadin-combo-box-mixin.js:425 Map(18) {'dir' => undefined, 'value' => undefined, 'clearButtonVisible' => undefined, 'invalid' => undefined, 'manualValidation' => undefined, …}
vaadin-combo-box-mixin.js:425 Map(4) {'stateTarget' => undefined, 'ariaTarget' => undefined, '_positionTarget' => undefined, '_toggleElement' => undefined}
vaadin-combo-box-mixin.js:425 Map(1) {'_dropdownItems' => undefined}
vaadin-combo-box-mixin.js:425 Map(1) {'filteredItems' => undefined}
vaadin-combo-box-mixin.js:425 Map(1) {'dataProvider' => undefined}
vaadin-combo-box-mixin.js:425 Map(1) {'selectedItem' => undefined}
vaadin-combo-box-mixin.js:425 Map(1) {'_lastCommittedValue' => ''}
```

### After

10 updates:

```
vaadin-combo-box-mixin.js:444 Map(1) {'_overlayOpened' => undefined}
vaadin-combo-box-mixin.js:444 Map(2) {'_overlayElement' => undefined, 'inputElement' => undefined}
vaadin-combo-box-mixin.js:444 Map(1) {'focusElement' => undefined}
vaadin-combo-box-mixin.js:444 Map(17) {'dir' => undefined, 'value' => undefined, 'clearButtonVisible' => undefined, 'invalid' => undefined, 'manualValidation' => undefined, …}
vaadin-combo-box-mixin.js:444 Map(4) {'stateTarget' => undefined, 'ariaTarget' => undefined, '_positionTarget' => undefined, '_toggleElement' => undefined}
vaadin-combo-box-mixin.js:444 Map(1) {'_dropdownItems' => undefined}
vaadin-combo-box-mixin.js:444 Map(1) {'filteredItems' => undefined}
vaadin-combo-box-mixin.js:444 Map(1) {'dataProvider' => undefined}
vaadin-combo-box-mixin.js:444 Map(1) {'value' => ''}
vaadin-combo-box-mixin.js:444 Map(1) {'selectedItem' => undefined}
```