### PR TITLE
test: add CSS to make combo-box tests pass locally in Firefox

### DIFF
--- a/packages/combo-box/test/data-provider-styles.js
+++ b/packages/combo-box/test/data-provider-styles.js
@@ -1,6 +1,15 @@
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
+  'vaadin-combo-box-item',
+  css`
+    :host {
+      min-height: 36px;
+    }
+  `,
+);
+
+registerStyles(
   'vaadin-combo-box*',
   css`
     :host {

--- a/packages/combo-box/test/overlay-position-styles.js
+++ b/packages/combo-box/test/overlay-position-styles.js
@@ -1,0 +1,15 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-combo-box-overlay',
+  css`
+    :host {
+      inset: 16px;
+    }
+
+    [part='overlay'] {
+      /* Reset overlay offset to simplify calculation */
+      margin: 0 !important;
+    }
+  `,
+);

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import './overlay-position-styles.js';
 import '../src/vaadin-combo-box.js';
 import { makeItems, setInputValue } from './helpers.js';
 
@@ -20,14 +21,6 @@ describe('overlay position', () => {
   }
 
   beforeEach(async () => {
-    fixtureSync(`
-      <style>
-        vaadin-combo-box-overlay::part(overlay) {
-          margin: 0 !important;
-        }
-      </style>
-    `);
-
     comboBox = fixtureSync(`<vaadin-combo-box label='comboBox' style='width: 300px;' items='[1]'></vaadin-combo-box>`);
     await nextRender();
     const comboBoxRect = comboBox.getBoundingClientRect();


### PR DESCRIPTION
## Description

Some combo-box tests pass in CI but fail locally. This PR adds styles to make them pass consistently.

## Type of change

- Test