### PR TITLE
refactor: filter out irrelevant transition events

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-injector.js
+++ b/packages/vaadin-themable-mixin/src/css-injector.js
@@ -49,8 +49,8 @@ export class CSSInjector {
 
   constructor(root = document) {
     this.#root = root;
-    this.#cssPropertyObserver = new CSSPropertyObserver(this.#root, 'vaadin-css-injector', (event) => {
-      const tagName = event.propertyName.slice(2).replace('-css-inject', '');
+    this.#cssPropertyObserver = new CSSPropertyObserver(this.#root, 'vaadin-css-injector', (propertyName) => {
+      const tagName = propertyName.slice(2).replace('-css-inject', '');
       this.#updateComponentStyleSheet(tagName);
     });
   }

--- a/packages/vaadin-themable-mixin/src/css-property-observer.js
+++ b/packages/vaadin-themable-mixin/src/css-property-observer.js
@@ -12,11 +12,13 @@
 export class CSSPropertyObserver {
   #root;
   #name;
+  #callback;
   #properties = new Set();
 
   constructor(root, name, callback) {
     this.#root = root;
     this.#name = name;
+    this.#callback = callback;
 
     const styleSheet = new CSSStyleSheet();
     styleSheet.replaceSync(`
@@ -32,8 +34,15 @@ export class CSSPropertyObserver {
     `);
     this.#root.adoptedStyleSheets.unshift(styleSheet);
 
-    this.#rootHost.addEventListener('transitionstart', (event) => callback(event));
-    this.#rootHost.addEventListener('transitionend', (event) => callback(event));
+    this.#rootHost.addEventListener('transitionstart', (event) => this.#handleTransitionEvent(event));
+    this.#rootHost.addEventListener('transitionend', (event) => this.#handleTransitionEvent(event));
+  }
+
+  #handleTransitionEvent(event) {
+    const { propertyName } = event;
+    if (this.#properties.has(propertyName)) {
+      this.#callback(propertyName);
+    }
   }
 
   observe(property) {


### PR DESCRIPTION
## Description

Updated CSSPropertyObserver to filter out transition events triggered by CSS properties that aren't being observed.

## Type of change

- [x] Refactor
