### PR TITLE
refactor: prevent unnecessary avatar-group-overlay renders

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -481,11 +481,6 @@ export const AvatarGroupMixin = (superClass) =>
     }
 
     /** @private */
-    _updateOverlay() {
-      this.$.overlay.requestContentUpdate();
-    }
-
-    /** @private */
     __overflowItemsChanged(items, oldItems) {
       // Prevent renderer from being called unnecessarily on initialization
       if (items && items.length === 0 && (!oldItems || oldItems.length === 0)) {
@@ -493,7 +488,7 @@ export const AvatarGroupMixin = (superClass) =>
       }
 
       if (items || oldItems) {
-        this._updateOverlay();
+        this.$.overlay.requestContentUpdate();
       }
     }
 

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -167,6 +167,12 @@ export const AvatarGroupMixin = (superClass) =>
       super.i18n = value;
     }
 
+    constructor() {
+      super();
+
+      this.__overlayRenderer = this.__overlayRenderer.bind(this);
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -189,9 +195,7 @@ export const AvatarGroupMixin = (superClass) =>
       });
       this.addController(this._overflowController);
 
-      const overlay = this.$.overlay;
-      overlay.renderer = this.__overlayRenderer.bind(this);
-      this._overlayElement = overlay;
+      this._overlayElement = this.$.overlay;
     }
 
     /** @protected */
@@ -477,9 +481,19 @@ export const AvatarGroupMixin = (superClass) =>
     }
 
     /** @private */
+    _updateOverlay() {
+      this.$.overlay.requestContentUpdate();
+    }
+
+    /** @private */
     __overflowItemsChanged(items, oldItems) {
+      // Prevent renderer from being called unnecessarily on initialization
+      if (items && items.length === 0 && (!oldItems || oldItems.length === 0)) {
+        return;
+      }
+
       if (items || oldItems) {
-        this.$.overlay.requestContentUpdate();
+        this._updateOverlay();
       }
     }
 

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -82,6 +82,7 @@ class AvatarGroup extends AvatarGroupMixin(ElementMixin(ThemableMixin(PolylitMix
         id="overlay"
         .opened="${this._opened}"
         .positionTarget="${this._overflow}"
+        .renderer="${this.__overlayRenderer}"
         no-vertical-overlap
         @vaadin-overlay-close="${this._onVaadinOverlayClose}"
         @vaadin-overlay-open="${this._onVaadinOverlayOpen}"

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -650,3 +650,30 @@ describe('avatar group in column flex', () => {
     expect(group._overflow.hasAttribute('hidden')).to.be.true;
   });
 });
+
+describe('initial render', () => {
+  let group, spy;
+
+  beforeEach(() => {
+    group = document.createElement('vaadin-avatar-group');
+    spy = sinon.spy(group, '_updateOverlay');
+  });
+
+  afterEach(() => {
+    group.remove();
+  });
+
+  it('should not request content update on initial render without overflow items', async () => {
+    document.body.appendChild(group);
+    await nextRender();
+    expect(spy.called).to.be.false;
+  });
+
+  it('should only request content update once on initial render with overflow items', async () => {
+    group.items = [{ abbr: 'A' }, { abbr: 'B' }, { abbr: 'C' }];
+    group.maxItemsVisible = 2;
+    document.body.appendChild(group);
+    await nextRender();
+    expect(spy).to.be.calledOnce;
+  });
+});

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -656,7 +656,7 @@ describe('initial render', () => {
 
   beforeEach(() => {
     group = document.createElement('vaadin-avatar-group');
-    spy = sinon.spy(group, '_updateOverlay');
+    spy = sinon.spy(group, '__overlayRenderer');
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Description

Currently, by default there is a situation where `requestContentUpdate()` is called unnecessarily on initialization, especially due to the fact that in the `__overflowItemsChanged` observer both `items` and `oldItems` are set to `[]`.

This improves the logic to only render if we actually have valid overflow items. Also moved `renderer` setting to the template, it feels unnecessary to set it via property (especially now that we only have Lit version of the component). 

## Type of change

- Refactor