### PR TITLE
test: disable CSS transitions on checkbox and radio

### DIFF
--- a/packages/checkbox-group/test/visual/common.js
+++ b/packages/checkbox-group/test/visual/common.js
@@ -7,7 +7,6 @@ registerStyles(
     /* Disable animation */
     [part='label'],
     [part='helper-text'],
-    [part='input-field'],
     [part='error-message'],
     [part='required-indicator'] {
       &,

--- a/packages/checkbox-group/test/visual/common.js
+++ b/packages/checkbox-group/test/visual/common.js
@@ -1,3 +1,4 @@
+import '@vaadin/checkbox/test/visual/common.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 registerStyles(
@@ -5,12 +6,10 @@ registerStyles(
   css`
     /* Disable animation */
     [part='label'],
-    [part$='button'],
     [part='helper-text'],
     [part='input-field'],
     [part='error-message'],
-    [part='required-indicator'],
-    ::slotted(:is(input, textarea):placeholder-shown) {
+    [part='required-indicator'] {
       &,
       &::before,
       &::after {

--- a/packages/checkbox/test/visual/common.js
+++ b/packages/checkbox/test/visual/common.js
@@ -7,7 +7,6 @@ registerStyles(
     [part='label'],
     [part='checkbox'],
     [part='helper-text'],
-    [part='input-field'],
     [part='error-message'],
     [part='required-indicator'] {
       &,

--- a/packages/checkbox/test/visual/common.js
+++ b/packages/checkbox/test/visual/common.js
@@ -5,12 +5,11 @@ registerStyles(
   css`
     /* Disable animation */
     [part='label'],
-    [part$='button'],
+    [part='checkbox'],
     [part='helper-text'],
     [part='input-field'],
     [part='error-message'],
-    [part='required-indicator'],
-    ::slotted(:is(input, textarea):placeholder-shown) {
+    [part='required-indicator'] {
       &,
       &::before,
       &::after {

--- a/packages/radio-group/test/visual/common.js
+++ b/packages/radio-group/test/visual/common.js
@@ -6,7 +6,6 @@ registerStyles(
     /* Disable animation */
     [part='label'],
     [part='helper-text'],
-    [part='input-field'],
     [part='error-message'],
     [part='required-indicator'] {
       &,

--- a/packages/radio-group/test/visual/common.js
+++ b/packages/radio-group/test/visual/common.js
@@ -5,12 +5,25 @@ registerStyles(
   css`
     /* Disable animation */
     [part='label'],
-    [part$='button'],
     [part='helper-text'],
     [part='input-field'],
     [part='error-message'],
-    [part='required-indicator'],
-    ::slotted(:is(input, textarea):placeholder-shown) {
+    [part='required-indicator'] {
+      &,
+      &::before,
+      &::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    }
+  `,
+);
+
+registerStyles(
+  'vaadin-radio-button',
+  css`
+    /* Disable animation */
+    [part='radio'] {
       &,
       &::before,
       &::after {


### PR DESCRIPTION
## Description

To improve the stability of visual tests, the PR disables the CSS transitions applied to `vaadin-radio-button` and `vaadin-checkbox`.

Part of #9082 

## Type of change

- [x] Internal
