### PR TITLE
refactor!: rename custom CSS property for transition duration

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -363,7 +363,7 @@ export const AppLayoutMixin = (superclass) =>
     /**
      * Returns a promise that resolves when the drawer opening/closing CSS transition ends.
      *
-     * The method relies on the `--vaadin-app-layout-transition` CSS variable to detect whether
+     * The method relies on the `--vaadin-app-layout-transition-duration` CSS variable to detect whether
      * the drawer has a CSS transition that needs to be awaited. If the CSS variable equals `none`,
      * the promise resolves immediately.
      *
@@ -372,7 +372,7 @@ export const AppLayoutMixin = (superclass) =>
      */
     __drawerTransitionComplete() {
       return new Promise((resolve) => {
-        if (this._getCustomPropertyValue('--vaadin-app-layout-transition') === 'none') {
+        if (this._getCustomPropertyValue('--vaadin-app-layout-transition-duration') === 'none') {
           resolve();
           return;
         }

--- a/packages/app-layout/src/vaadin-app-layout-styles.js
+++ b/packages/app-layout/src/vaadin-app-layout-styles.js
@@ -10,8 +10,8 @@ export const appLayoutStyles = css`
     display: block;
     box-sizing: border-box;
     height: 100%;
-    --vaadin-app-layout-transition: 200ms;
-    transition: padding var(--vaadin-app-layout-transition);
+    --vaadin-app-layout-transition-duration: 200ms;
+    transition: padding var(--vaadin-app-layout-transition-duration);
     --_vaadin-app-layout-drawer-width: var(--vaadin-app-layout-drawer-width, 16em);
     --vaadin-app-layout-touch-optimized: false;
     --vaadin-app-layout-navbar-offset-top: var(--_vaadin-app-layout-navbar-offset-size);
@@ -26,7 +26,7 @@ export const appLayoutStyles = css`
   }
 
   :host([no-anim]) {
-    --vaadin-app-layout-transition: none !important;
+    --vaadin-app-layout-transition-duration: none !important;
   }
 
   :host([drawer-opened]) {
@@ -58,7 +58,7 @@ export const appLayoutStyles = css`
     align-items: center;
     top: 0;
     inset-inline: 0;
-    transition: inset-inline-start var(--vaadin-app-layout-transition);
+    transition: inset-inline-start var(--vaadin-app-layout-transition-duration);
     padding-top: var(--safe-area-inset-top);
     padding-left: var(--safe-area-inset-left);
     padding-right: var(--safe-area-inset-right);
@@ -86,8 +86,8 @@ export const appLayoutStyles = css`
     bottom: var(--vaadin-app-layout-navbar-offset-bottom, var(--vaadin-viewport-offset-bottom, 0));
     inset-inline: var(--vaadin-app-layout-navbar-offset-left, 0) auto;
     transition:
-      transform var(--vaadin-app-layout-transition),
-      visibility var(--vaadin-app-layout-transition);
+      transform var(--vaadin-app-layout-transition-duration),
+      visibility var(--vaadin-app-layout-transition-duration);
     transform: translateX(-100%);
     max-width: 90%;
     width: var(--_vaadin-app-layout-drawer-width);
@@ -120,7 +120,7 @@ export const appLayoutStyles = css`
     position: fixed;
     inset: 0;
     pointer-events: none;
-    transition: opacity var(--vaadin-app-layout-transition);
+    transition: opacity var(--vaadin-app-layout-transition-duration);
     -webkit-tap-highlight-color: transparent;
   }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -165,7 +165,7 @@ describe('vaadin-app-layout', () => {
       const overlayMode = String(layoutMode === 'mobile');
 
       layout = fixtureSync(`
-        <vaadin-app-layout style="--vaadin-app-layout-drawer-overlay: ${overlayMode}; --vaadin-app-layout-transition: none;">
+        <vaadin-app-layout style="--vaadin-app-layout-drawer-overlay: ${overlayMode}; --vaadin-app-layout-transition-duration: none;">
           <vaadin-drawer-toggle id="toggle" slot="navbar"></vaadin-drawer-toggle>
           <section slot="drawer">
             <p>Item 1</p>
@@ -276,7 +276,7 @@ describe('vaadin-app-layout', () => {
         await nextResize(layout);
         await nextRender();
 
-        layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
+        layout.style.setProperty('--vaadin-app-layout-transition-duration', '100ms');
 
         const spy = sinon.spy(layout, '_updateOffsetSize');
         toggle.click();
@@ -376,7 +376,7 @@ describe('vaadin-app-layout', () => {
       });
 
       it('should move focus to the drawer after the opening animation completes', async () => {
-        layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
+        layout.style.setProperty('--vaadin-app-layout-transition-duration', '100ms');
         toggle.focus();
         layout.drawerOpened = true;
         await nextFrame();
@@ -443,7 +443,7 @@ describe('vaadin-app-layout', () => {
         });
 
         it('should move focus to the drawer toggle after the closing animation completes', async () => {
-          layout.style.setProperty('--vaadin-app-layout-transition', '100ms');
+          layout.style.setProperty('--vaadin-app-layout-transition-duration', '100ms');
           layout.drawerOpened = false;
           await nextFrame();
           expect(layout.shadowRoot.activeElement).to.equal(drawer);

--- a/packages/app-layout/test/keyboard-desktop.test.js
+++ b/packages/app-layout/test/keyboard-desktop.test.js
@@ -15,7 +15,7 @@ describe('desktop navigation', () => {
   beforeEach(async () => {
     const wrapper = fixtureSync(`
       <div>
-        <vaadin-app-layout style="--vaadin-app-layout-transition: none;">
+        <vaadin-app-layout style="--vaadin-app-layout-transition-duration: none;">
           <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
           <section slot="drawer">
             <input placeholder="Drawer input" />

--- a/packages/app-layout/test/keyboard-mobile.test.js
+++ b/packages/app-layout/test/keyboard-mobile.test.js
@@ -15,7 +15,7 @@ describe('mobile navigation', () => {
   beforeEach(async () => {
     const wrapper = fixtureSync(`
       <div>
-        <vaadin-app-layout style="--vaadin-app-layout-transition: none;">
+        <vaadin-app-layout style="--vaadin-app-layout-transition-duration: none;">
           <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
           <h1 slot="navbar">App title</h1>
           <section slot="drawer">


### PR DESCRIPTION
## Description

Extracted from #9269

This custom CSS property isn't listed in JSDoc or in the [public Styling docs](https://vaadin.com/docs/latest/components/app-layout/styling) so IMO we can just rename it.

## Type of change

- Breaking change