### PR TITLE
fix: add missing opened styles to ported combo-box CSS

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/combo-box.css
+++ b/packages/vaadin-lumo-styles/src/components/combo-box.css
@@ -3,6 +3,10 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+:host([opened]) {
+  pointer-events: auto;
+}
+
 [part='toggle-button']::before {
   content: var(--lumo-icons-dropdown);
 }


### PR DESCRIPTION
## Description

These [core styles](https://github.com/vaadin/web-components/blob/26205f4bf9eda1b60837953b22ed0d0ae9369b39/packages/combo-box/src/styles/vaadin-combo-box-core-styles.js#L9-L11) are missing from Lumo CSS, making it impossible to click clear button when opened.

## Type of change

- Bugfix