### PR TITLE
refactor!: remove no longer needed wrapper around scrollers slots

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-styles.js
@@ -52,10 +52,6 @@ export const overlayContentStyles = css`
     display: flex;
   }
 
-  #scrollers {
-    display: contents;
-  }
-
   ::slotted([slot='years']) {
     visibility: hidden;
   }

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -46,10 +46,8 @@ class DatePickerOverlayContent extends DatePickerOverlayContentMixin(
         </div>
       </div>
 
-      <div id="scrollers">
-        <slot name="months"></slot>
-        <slot name="years"></slot>
-      </div>
+      <slot name="months"></slot>
+      <slot name="years"></slot>
 
       <div @touchend="${this._preventDefault}" role="toolbar" part="toolbar">
         <slot name="today-button"></slot>

--- a/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
@@ -84,11 +84,6 @@
   --_lumo-date-picker-year-opacity: 1;
 }
 
-/* TODO unsupported selector */
-#scrollers {
-  display: contents;
-}
-
 :host([desktop]) ::slotted([slot='years']),
 :host([years-visible]) ::slotted([slot='years']) {
   visibility: visible;


### PR DESCRIPTION
## Description

Follow-up to #9360 and #9362

The `<div id="scrollers">` was previously used for adding listeners, but that's no longer the case.
Instead of setting `display: contents` on it, let's just remove it altogether.

## Type of change

- Breaking change