### PR TITLE
fix: set correct margin on the overlay content toolbar

### DIFF
--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -95,6 +95,7 @@ registerStyles(
 
     :host([fullscreen]) [part='toolbar'] {
       background-color: var(--lumo-base-color);
+      margin-inline-end: 57px;
     }
 
     :host([fullscreen]) [part='overlay-header'] {
@@ -129,9 +130,8 @@ registerStyles(
         background-image: none;
       }
 
-      [part='toolbar'],
-      ::slotted([slot='months']) {
-        margin-right: 0;
+      :host([fullscreen]) [part='toolbar'] {
+        margin-inline-end: 0;
       }
 
       /* TODO make date-picker adapt to the width of the years part */

--- a/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
@@ -119,6 +119,7 @@
 
 :host([fullscreen]) [part='toolbar'] {
   grid-area: header;
+  margin-inline-end: 57px;
 }
 
 [part='toolbar'] ::slotted(vaadin-button) {
@@ -181,9 +182,8 @@
     background-image: none;
   }
 
-  [part='toolbar'],
-  ::slotted([slot='months']) {
-    margin-right: 0;
+  :host([fullscreen]) [part='toolbar'] {
+    margin-inline-end: 0;
   }
 
   /* TODO make date-picker adapt to the width of the years part */


### PR DESCRIPTION
## Description

Fixed a margin to be set on the `toolbar` part so that it doesn't overlap year scroller both in LTR and RTL.

## Type of change

- Bugfix