### PR TITLE
fix: do not reopen manual tooltips on overlay mouseenter

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -617,6 +617,9 @@ export const TooltipMixin = (superClass) =>
 
     /** @protected */
     __onOverlayMouseEnter() {
+      if (this.manual) {
+        return;
+      }
       // Retain opened state when moving pointer over the overlay.
       // Closing can start due to an offset between the target and
       // the overlay itself. If that's the case, re-open overlay.

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
+  aTimeout,
   escKeyDown,
   fixtureSync,
   focusin,
@@ -805,6 +806,27 @@ describe('vaadin-tooltip', () => {
       tooltip.opened = true;
       mousedown(target);
       expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close overlay on overlay mouseleave', () => {
+      tooltip.opened = true;
+      mouseleave(overlay);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not re-open overlay on overlay mouseenter', async () => {
+      // Open tooltip
+      tooltip.opened = true;
+      expect(overlay.opened).to.be.true;
+
+      // Hide tooltip with a delay, while simulating pointer moving into the overlay
+      tooltip.hideDelay = 1;
+      tooltip._stateController.close(false);
+      mouseenter(overlay);
+      await aTimeout(2);
+
+      // Should still close the overlay, as it was closed manually
+      expect(overlay.opened).to.be.false;
     });
 
     it('should close overlay when opened is set to false', () => {


### PR DESCRIPTION
## Description

`vaadin-grid` uses a manually controlled tooltip that is shown when the pointer enters a cell, and hidden when it leaves a cell. However, when moving the pointer from the cell to the tooltip overlay, the tooltip stays open and then never closes if the pointer moves out of the grid after that as there is no mouseleave event from a cell. The issue is that the tooltip overlay allows the tooltip to stay open on mouseenter, whereas for mouseleave there is a specific condition to ignore that when the tooltip is controlled manually.

This adds the same condition to the tooltip overlay mouseenter, so that if the tooltip was closed manually, it does not reopen. I assume this should be fine:
- The tooltip overlay mouseenter / mouseleave logic allows to move the pointer into the tooltip without closing it, which can be useful to copy text for example.
- For manually controlled tooltips that use an application controlled trigger that doesn't seem relevant, as the tooltip wouldn't necessarily close when leaving the target element.
- For Grid specifically, it is already very challenging to move the pointer into the tooltip overlay, as moving the pointer will first result in hovering a different cell, thus moving the tooltip overlay away from the pointer. So the copy text use-case is not really supported here anyway.

Part of https://github.com/vaadin/flow-components/issues/7504

## Type of change

- Bugfix
