### PR TITLE
refactor: avoid updating CSS property on grid scroll

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -116,10 +116,7 @@ export const ScrollMixin = (superClass) =>
       super.ready();
 
       this.__horizontalScrollPositionStyleSheet = new CSSStyleSheet();
-      this.shadowRoot.adoptedStyleSheets = [
-        ...this.shadowRoot.adoptedStyleSheets,
-        this.__horizontalScrollPositionStyleSheet,
-      ];
+      this.shadowRoot.adoptedStyleSheets.push(this.__horizontalScrollPositionStyleSheet);
 
       this.scrollTarget = this.$.table;
 

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -115,6 +115,12 @@ export const ScrollMixin = (superClass) =>
     ready() {
       super.ready();
 
+      this.__horizontalScrollPositionStyleSheet = new CSSStyleSheet();
+      this.shadowRoot.adoptedStyleSheets = [
+        ...this.shadowRoot.adoptedStyleSheets,
+        this.__horizontalScrollPositionStyleSheet,
+      ];
+
       this.scrollTarget = this.$.table;
 
       this.$.items.addEventListener('focusin', (e) => {
@@ -511,11 +517,11 @@ export const ScrollMixin = (superClass) =>
         }
       });
 
-      // Only update the --_grid-horizontal-scroll-position custom property when navigating
-      // on row focus mode to avoid performance issues.
-      if (this.hasAttribute('navigating') && this.__rowFocusMode) {
-        this.$.table.style.setProperty('--_grid-horizontal-scroll-position', `${-x}px`);
-      }
+      this.__horizontalScrollPositionStyleSheet.replaceSync(`
+        :host([navigating]) [part~='row']:focus::before {
+          transform: translateX(${x}px);
+        }
+      `);
     }
 
     /** @private */

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -86,7 +86,6 @@ registerStyles(
     }
 
     :host([navigating]) [part~='row']:focus::before {
-      transform: translateX(calc(-1 * var(--_grid-horizontal-scroll-position)));
       z-index: 3;
     }
 


### PR DESCRIPTION
## Description

After some more investigation related to https://github.com/vaadin/web-components/pull/9342#discussion_r2125950679, we discovered that it's possible to unlock styling opportunities and improve current scrolling performance on row focus mode by updating an adopted style sheet with specific selectors, instead of updating a custom CSS property on grid scroll:

Before:

https://github.com/user-attachments/assets/da13418d-cffb-425f-88f8-e3409fd59af3

After:

https://github.com/user-attachments/assets/f62b3845-c1b7-4471-bff8-05c1cb3394a8

## Type of change

Refactor/performance enhancement