### PR TITLE
refactor: remove no longer needed check for adoptedStyleSheets

### DIFF
--- a/packages/component-base/src/browser-utils.js
+++ b/packages/component-base/src/browser-utils.js
@@ -33,6 +33,3 @@ export const isTouch = (() => {
     return false;
   }
 })();
-
-export const supportsAdoptingStyleSheets =
-  window.ShadowRoot && 'adoptedStyleSheets' in Document.prototype && 'replace' in CSSStyleSheet.prototype;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -5,15 +5,7 @@
  */
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
-import {
-  isAndroid,
-  isChrome,
-  isFirefox,
-  isIOS,
-  isSafari,
-  isTouch,
-  supportsAdoptingStyleSheets,
-} from '@vaadin/component-base/src/browser-utils.js';
+import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
@@ -929,15 +921,11 @@ export const GridMixin = (superClass) =>
 
       // The style is set to host instead of the scroller so that the value can be overridden by the user with "grid { min-height: 0 }"
       // Prefer setting style in adopted style sheet to avoid the need to add a confusing inline style on the host element
-      // If adopted style sheets are not supported, the style is set inline
-      if (!this.__minHeightStyleSheet && supportsAdoptingStyleSheets) {
+      if (!this.__minHeightStyleSheet) {
         this.__minHeightStyleSheet = new CSSStyleSheet();
-        this.shadowRoot.adoptedStyleSheets = [...this.shadowRoot.adoptedStyleSheets, this.__minHeightStyleSheet];
+        this.shadowRoot.adoptedStyleSheets.push(this.__minHeightStyleSheet);
       }
-      if (this.__minHeightStyleSheet) {
-        this.__minHeightStyleSheet.replaceSync(`:host { --_grid-min-height: ${minHeight}px; }`);
-      } else {
-        this.style.setProperty('--_grid-min-height', `${minHeight}px`);
-      }
+
+      this.__minHeightStyleSheet.replaceSync(`:host { --_grid-min-height: ${minHeight}px; }`);
     }
   };


### PR DESCRIPTION
## Description

In V25 we support Safari 17+ so the check for adoptedStyleSheets and the fallback can be removed.

## Type of change

- Refactor