### PR TITLE
chore: move .cjs files to separate group in eslint.config.js

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -123,7 +123,18 @@ export default [
     },
   },
   {
-    files: ['scripts/**/*.js', '*.config.js', 'wtr-utils.js', 'packages/**/gulpfile.cjs'],
+    files: ['scripts/**/*.js', '*.config.js', 'wtr-utils.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
+    files: ['packages/**/gulpfile.cjs'],
     languageOptions: {
       globals: {
         ...globals.node,
@@ -131,7 +142,6 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
-      'no-console': 'off',
     },
   },
   {


### PR DESCRIPTION
## Description

The project is now fully converted to ESM and the only files where `require()` is allowed are `gulpfile.cjs`.

## Type of change

- Internal change