### PR TITLE
fix: allow popover to close while tooltip is open

### DIFF
--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -23,10 +23,14 @@ const getOverlayInstances = () => getAttachedInstances().filter((el) => el.$.ove
 /**
  * Returns true if the overlay is the last one in the opened overlays stack.
  * @param {HTMLElement} overlay
+ * @param {function(HTMLElement): boolean} filter
  * @return {boolean}
  * @protected
  */
-export const isLastOverlay = (overlay) => overlay === getOverlayInstances().pop();
+export const isLastOverlay = (overlay, filter = (_overlay) => true) => {
+  const filteredOverlays = getOverlayInstances().filter(filter);
+  return overlay === filteredOverlays.pop();
+};
 
 const overlayMap = new WeakMap();
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -155,9 +155,9 @@ class PopoverOpenedStateController {
  * @return {boolean}
  * @protected
  */
-export const isLastOverlay = (overlay) => {
+const isLastOverlay = (overlay) => {
   // Ignore tooltips, popovers should still close when a tooltip is present
-  const filter = (o) => o.constructor.is !== 'vaadin-tooltip-overlay';
+  const filter = (o) => o.localName !== 'vaadin-tooltip-overlay';
   return isLastOverlayBase(overlay, filter);
 };
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -17,7 +17,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
-import { isLastOverlay } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
+import { isLastOverlay as isLastOverlayBase } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import { PopoverPositionMixin } from './vaadin-popover-position-mixin.js';
@@ -148,6 +148,18 @@ class PopoverOpenedStateController {
     }, delay);
   }
 }
+
+/**
+ * Returns true if the popover overlay is the last one in the opened overlays stack, ignoring tooltips.
+ * @param {HTMLElement} overlay
+ * @return {boolean}
+ * @protected
+ */
+export const isLastOverlay = (overlay) => {
+  // Ignore tooltips, popovers should still close when a tooltip is present
+  const filter = (o) => o.constructor.is !== 'vaadin-tooltip-overlay';
+  return isLastOverlayBase(overlay, filter);
+};
 
 /**
  * `<vaadin-popover>` is a Web Component for creating overlays

--- a/test/integration/popover-tooltip.test.js
+++ b/test/integration/popover-tooltip.test.js
@@ -1,0 +1,53 @@
+import { expect } from '@vaadin/chai-plugins';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import './not-animated-styles.js';
+import '@vaadin/popover/src/vaadin-popover.js';
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
+import { mouseleave } from '@vaadin/popover/test/helpers';
+import { mouseenter } from '@vaadin/tooltip/test/helpers';
+
+describe('popover and tooltip', () => {
+  let target, popover, popoverOverlay, tooltip, tooltipOverlay;
+
+  beforeEach(async () => {
+    const wrapper = fixtureSync(`
+      <div>
+        <button id="target">Target</button>
+        <vaadin-popover></vaadin-popover>
+        <vaadin-tooltip text="Tooltip"></vaadin-popover>
+      </div>
+    `);
+    target = wrapper.querySelector('#target');
+    popover = wrapper.querySelector('vaadin-popover');
+    popoverOverlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+    tooltip = wrapper.querySelector('vaadin-tooltip');
+    tooltipOverlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+
+    popover.trigger = ['hover'];
+    popover.target = target;
+    popover.hoverDelay = 0;
+    popover.hideDelay = 0;
+
+    tooltip.target = target;
+    tooltip.hoverDelay = 1;
+    tooltip.hideDelay = 1;
+
+    await nextRender();
+  });
+
+  it('should close popover on mouse leave while tooltip is opened', async () => {
+    mouseenter(target);
+
+    await aTimeout(2);
+
+    expect(popoverOverlay.opened).to.be.true;
+    expect(tooltipOverlay.opened).to.be.true;
+
+    mouseleave(target);
+
+    await aTimeout(2);
+
+    expect(popoverOverlay.opened).to.be.false;
+    expect(tooltipOverlay.opened).to.be.false;
+  });
+});

--- a/test/integration/popover-tooltip.test.js
+++ b/test/integration/popover-tooltip.test.js
@@ -3,8 +3,7 @@ import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/popover/src/vaadin-popover.js';
 import '@vaadin/tooltip/src/vaadin-tooltip.js';
-import { mouseleave } from '@vaadin/popover/test/helpers';
-import { mouseenter } from '@vaadin/tooltip/test/helpers';
+import { mouseenter, mouseleave } from '@vaadin/popover/test/helpers';
 
 describe('popover and tooltip', () => {
   let target, popover, popoverOverlay, tooltip, tooltipOverlay;


### PR DESCRIPTION
## Description

Popovers are currently only allowed to close if they are the last overlay in the overlay stack. If the target element also has a tooltip that opens after the popover, then a popover can not close on `mouseleave` because the tooltip is the last overlay. This can easily happen on grids with a tooltip generator, as the tooltip overlay is always shown when hovering a cell, even if the generator doesn't return a text for that specific column / cell.

This changes the last overlay check to ignore tooltip overlays, so that a popover can still close even if a tooltip was opened afterwards.

Part of https://github.com/vaadin/flow-components/issues/7504

## Type of change

- Bugfix
