### PR TITLE
chore: create Stylelint rule to ensure files have license header

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,12 +1,16 @@
 {
   "extends": ["stylelint-config-vaadin"],
-  "plugins": ["./custom-rules/stylelint/no-shorthand-with-unresolved-longhand.js"],
+  "plugins": [
+    "./custom-rules/stylelint/no-shorthand-with-unresolved-longhand.js",
+    "./custom-rules/stylelint/license-header.js"
+  ],
   "overrides": [
     { "files": ["**/*.js"], "customSyntax": "postcss-lit" },
     {
-      "files": ["**/*.css"],
+      "files": ["packages/vaadin-lumo-styles/**/*.css"],
       "rules": {
-        "custom-rules/no-shorthand-with-unresolved-longhand": true
+        "custom-rules/no-shorthand-with-unresolved-longhand": true,
+        "custom-rules/license-header": true
       }
     }
   ],

--- a/custom-rules/stylelint/license-header.js
+++ b/custom-rules/stylelint/license-header.js
@@ -1,0 +1,62 @@
+import stylelint from 'stylelint';
+
+const licenseHeader = `
+/**
+ * @license
+ * Copyright (c) 2000 - ${new Date().getFullYear()} Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+`.trim();
+
+const {
+  createPlugin,
+  utils: { report },
+} = stylelint;
+
+const ruleName = 'custom-rules/license-header';
+
+const ruleFunction = () => {
+  return (root, result) => {
+    const firstNode = root.nodes[0];
+    if (firstNode.type !== 'comment' || !firstNode.text.includes('@license')) {
+      report({
+        result,
+        ruleName,
+        node: firstNode,
+        start: {
+          line: 1,
+          column: 1,
+        },
+        end: {
+          line: 1,
+          column: 1,
+        },
+        message: 'Missing license header',
+        fix: () => {
+          root.prepend(licenseHeader);
+          root.nodes[1].raws.before = '\n';
+        },
+      });
+      return;
+    }
+
+    if (!firstNode.text.includes('Vaadin Ltd')) {
+      return;
+    }
+
+    if (!firstNode.text.includes(`- ${new Date().getFullYear()}`)) {
+      report({
+        result,
+        ruleName,
+        node: firstNode,
+        message: 'License header year is not up to date',
+        fix: () => firstNode.replaceWith(licenseHeader),
+      });
+    }
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.meta = { fixable: true };
+
+export default createPlugin(ruleName, ruleFunction);

--- a/packages/vaadin-lumo-styles/components/select.css
+++ b/packages/vaadin-lumo-styles/components/select.css
@@ -1,3 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
 @import './input-container.css';
 
 @import '../src/mixins/base-layer-reset.css' vaadin-select;


### PR DESCRIPTION
## Description

Introduces a Stylelint rule that ensures all source files include a license header. The rule supports auto-fix.

## Type of change

- [x] Internal
