### PR TITLE
refactor!: remove deprecated custom-field internal-tab event

### DIFF
--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -220,11 +220,10 @@ export const CustomFieldMixin = (superClass) =>
           (inputs.indexOf(e.target) < inputs.length - 1 && !e.shiftKey) ||
           (inputs.indexOf(e.target) > 0 && e.shiftKey)
         ) {
-          this.dispatchEvent(new CustomEvent('internal-tab'));
-        } else {
-          // FIXME(yuriy): remove this workaround when value should not be updated before focusout
-          this.__setValue();
+          return;
         }
+        // FIXME(yuriy): remove this workaround when value should not be updated before focusout
+        this.__setValue();
       }
     }
 

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -31,20 +31,10 @@ export type CustomFieldValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type CustomFieldValidatedEvent = CustomEvent<{ valid: boolean }>;
 
-/**
- * Fired on Tab keydown triggered from the internal inputs, meaning focus will not leave the inputs.
- * @deprecated
- */
-export type CustomFieldInternalTabEvent = Event & {
-  target: CustomField;
-};
-
 export interface CustomFieldCustomEventMap {
   'invalid-changed': CustomFieldInvalidChangedEvent;
 
   'value-changed': CustomFieldValueChangedEvent;
-
-  'internal-tab': CustomFieldInternalTabEvent;
 
   validated: CustomFieldValidatedEvent;
 }

--- a/packages/custom-field/test/keyboard.test.js
+++ b/packages/custom-field/test/keyboard.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import '../src/vaadin-custom-field.js';
 
 describe('keyboard navigation', () => {
@@ -17,39 +16,6 @@ describe('keyboard navigation', () => {
         </vaadin-custom-field>
       `);
       await nextRender();
-    });
-
-    describe('internal-tab event', () => {
-      let spy;
-
-      beforeEach(() => {
-        spy = sinon.spy();
-        customField.addEventListener('internal-tab', spy);
-      });
-
-      it('should fire on Tab', () => {
-        for (let i = 0; i < 3; i++) {
-          tabKeyDown(customField.inputs[i]);
-        }
-        expect(spy.callCount).to.equal(3);
-      });
-
-      it('should not fire on Tab from the last input', () => {
-        tabKeyDown(customField.inputs[3]);
-        expect(spy.called).to.be.false;
-      });
-
-      it('should fire on Shift Tab', () => {
-        for (let i = 3; i > 0; i--) {
-          tabKeyDown(customField.inputs[i], ['shift']);
-        }
-        expect(spy.callCount).to.equal(3);
-      });
-
-      it('should not fire on Shift Tab from the first input', () => {
-        tabKeyDown(customField.inputs[0], ['shift']);
-        expect(spy.called).to.be.false;
-      });
     });
 
     describe('value change', () => {

--- a/packages/custom-field/test/typings/custom-field.types.ts
+++ b/packages/custom-field/test/typings/custom-field.types.ts
@@ -2,7 +2,6 @@ import '../../vaadin-custom-field.js';
 import type {
   CustomField,
   CustomFieldChangeEvent,
-  CustomFieldInternalTabEvent,
   CustomFieldInvalidChangedEvent,
   CustomFieldValidatedEvent,
   CustomFieldValueChangedEvent,
@@ -25,11 +24,6 @@ customField.addEventListener('invalid-changed', (event) => {
 customField.addEventListener('value-changed', (event) => {
   assertType<CustomFieldValueChangedEvent>(event);
   assertType<string>(event.detail.value);
-});
-
-customField.addEventListener('internal-tab', (event) => {
-  assertType<CustomFieldInternalTabEvent>(event);
-  assertType<CustomField>(event.target);
 });
 
 customField.addEventListener('validated', (event) => {


### PR DESCRIPTION
## Description

Removed the `internal-tab` event which is no longer used and deprecated, see these PRs:

- https://github.com/vaadin/web-components/pull/7870
- https://github.com/vaadin/web-components/pull/7889

## Type of change

- Breaking change