### PR TITLE
refactor!: remove contentWidth and contentHeight from resize event

### DIFF
--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -147,17 +147,8 @@ export const DialogResizableMixin = (superClass) =>
      * @protected
      */
     _getResizeDimensions() {
-      const scrollPosition = this.$.overlay.$.resizerContainer.scrollTop;
       const { width, height, top, left } = getComputedStyle(this.$.overlay.$.overlay);
-      const content = this.$.overlay.$.content;
-      content.setAttribute(
-        'style',
-        'position: absolute; top: 0; right: 0; bottom: 0; left: 0; box-sizing: content-box; height: auto;',
-      );
-      const { width: contentWidth, height: contentHeight } = getComputedStyle(content);
-      content.removeAttribute('style');
-      this.$.overlay.$.resizerContainer.scrollTop = scrollPosition;
-      return { width, height, contentWidth, contentHeight, top, left };
+      return { width, height, top, left };
     }
 
     /**

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -20,8 +20,6 @@ export type DialogResizableDirection = 'e' | 'n' | 'ne' | 'nw' | 's' | 'se' | 's
 export type DialogResizeDimensions = {
   width: string;
   height: string;
-  contentWidth: string;
-  contentHeight: string;
   top: string;
   left: string;
 };

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -315,30 +315,18 @@ describe('resizable', () => {
 
   it('should dispatch resize event with correct details', () => {
     const onResize = sinon.spy();
-    const content = dialog.$.overlay.$.content;
-    let detail = {};
     dialog.addEventListener('resize', onResize);
-    dialog.addEventListener('resize', (e) => {
-      detail = e.detail;
-    });
+
     resize(overlayPart.querySelector('.w'), -dx, 0);
 
+    const { detail } = onResize.firstCall.args[0];
     const resizedBounds = overlayPart.getBoundingClientRect();
-    const contentStyles = getComputedStyle(content);
-    const verticalPadding =
-      parseInt(contentStyles.paddingTop) +
-      parseInt(contentStyles.paddingBottom) +
-      parseInt(contentStyles.borderTopWidth) +
-      parseInt(contentStyles.borderBottomWidth);
-    content.style.boxSizing = 'content-box';
 
     expect(onResize.calledOnce).to.be.true;
     expect(Math.floor(resizedBounds.width)).to.be.eql(parseInt(detail.width));
     expect(Math.floor(resizedBounds.height)).to.be.eql(parseInt(detail.height));
     expect(Math.floor(resizedBounds.left)).to.be.eql(parseInt(detail.left));
     expect(Math.floor(resizedBounds.top)).to.be.eql(parseInt(detail.top));
-    expect(parseInt(detail.contentWidth)).to.be.eql(parseInt(contentStyles.width));
-    expect(parseInt(detail.contentHeight)).to.be.eql(parseInt(contentStyles.height) - verticalPadding);
   });
 
   it('should update "width" and "height" properties on resize', async () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9414

## Type of change

- Breaking change