### PR TITLE
refactor: move multi-select-combo-box CSS to styles folder

### DIFF
--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-styles.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const multiSelectComboBoxChipStyles = css`
+  :host {
+    display: inline-flex;
+    align-items: center;
+    align-self: center;
+    white-space: nowrap;
+    box-sizing: border-box;
+  }
+
+  [part='label'] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  :host([hidden]),
+  :host(:is([readonly], [disabled], [slot='overflow'])) [part='remove-button'] {
+    display: none !important;
+  }
+
+  @media (forced-colors: active) {
+    :host {
+      outline: 1px solid;
+      outline-offset: -1px;
+    }
+  }
+`;

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-overlay-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-overlay-styles.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const multiSelectComboBoxOverlayStyles = css`
+  #overlay {
+    width: var(
+      --vaadin-multi-select-combo-box-overlay-width,
+      var(--_vaadin-multi-select-combo-box-overlay-default-width, auto)
+    );
+  }
+
+  [part='content'] {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+`;

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-scroller-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-scroller-styles.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const multiSelectComboBoxScrollerStyles = css`
+  :host {
+    display: block;
+    min-height: 1px;
+    overflow: auto;
+
+    /* Fixes item background from getting on top of scrollbars on Safari */
+    transform: translate3d(0, 0, 0);
+
+    /* Enable momentum scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+
+    /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
+    box-shadow: 0 0 0 white;
+  }
+
+  #selector {
+    border-width: var(--_vaadin-multi-select-combo-box-items-container-border-width);
+    border-style: var(--_vaadin-multi-select-combo-box-items-container-border-style);
+    border-color: var(--_vaadin-multi-select-combo-box-items-container-border-color, transparent);
+    position: relative;
+  }
+`;

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-styles.d.ts
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-styles.d.ts
@@ -5,6 +5,4 @@
  */
 import type { CSSResult } from 'lit';
 
-export const multiSelectComboBox: CSSResult;
-
-export const multiSelectComboBoxChip: CSSResult;
+export const multiSelectComboBoxStyles: CSSResult;

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-styles.js
@@ -3,9 +3,9 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from 'lit';
 
-export const multiSelectComboBox = css`
+export const multiSelectComboBoxStyles = css`
   :host {
     max-width: 100%;
     --input-min-width: var(--vaadin-multi-select-combo-box-input-min-width, 4em);
@@ -43,32 +43,5 @@ export const multiSelectComboBox = css`
 
   :host([auto-expand-horizontally]) [class$='container'] {
     width: auto;
-  }
-`;
-
-export const multiSelectComboBoxChip = css`
-  :host {
-    display: inline-flex;
-    align-items: center;
-    align-self: center;
-    white-space: nowrap;
-    box-sizing: border-box;
-  }
-
-  [part='label'] {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  :host([hidden]),
-  :host(:is([readonly], [disabled], [slot='overflow'])) [part='remove-button'] {
-    display: none !important;
-  }
-
-  @media (forced-colors: active) {
-    :host {
-      outline: 1px solid;
-      outline-offset: -1px;
-    }
   }
 `;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
@@ -8,7 +8,7 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import { multiSelectComboBoxChip } from './vaadin-multi-select-combo-box-styles.js';
+import { multiSelectComboBoxChipStyles } from './styles/vaadin-multi-select-combo-box-chip-styles.js';
 
 /**
  * An element used by `<vaadin-multi-select-combo-box>` to display selected items.
@@ -34,7 +34,7 @@ class MultiSelectComboBoxChip extends CSSInjectionMixin(ThemableMixin(PolylitMix
   }
 
   static get styles() {
-    return multiSelectComboBoxChip;
+    return multiSelectComboBoxChipStyles;
   }
 
   static get properties() {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
@@ -3,11 +3,12 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { ComboBoxItemMixin } from '@vaadin/combo-box/src/vaadin-combo-box-item-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { itemStyles } from '@vaadin/item/src/styles/vaadin-item-core-styles.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
@@ -46,15 +47,7 @@ export class MultiSelectComboBoxItem extends ComboBoxItemMixin(
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: block;
-      }
-
-      :host([hidden]) {
-        display: none !important;
-      }
-    `;
+    return itemStyles;
   }
 
   /** @protected */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { ComboBoxOverlayMixin } from '@vaadin/combo-box/src/vaadin-combo-box-overlay-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
@@ -12,21 +12,7 @@ import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-
-const multiSelectComboBoxOverlayStyles = css`
-  #overlay {
-    width: var(
-      --vaadin-multi-select-combo-box-overlay-width,
-      var(--_vaadin-multi-select-combo-box-overlay-default-width, auto)
-    );
-  }
-
-  [part='content'] {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
-`;
+import { multiSelectComboBoxOverlayStyles } from './styles/vaadin-multi-select-combo-box-overlay-styles.js';
 
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -3,12 +3,13 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
 import { ComboBoxScrollerMixin } from '@vaadin/combo-box/src/vaadin-combo-box-scroller-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
+import { multiSelectComboBoxScrollerStyles } from './styles/vaadin-multi-select-combo-box-scroller-styles.js';
 
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
@@ -24,29 +25,7 @@ export class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(CSSInject
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: block;
-        min-height: 1px;
-        overflow: auto;
-
-        /* Fixes item background from getting on top of scrollbars on Safari */
-        transform: translate3d(0, 0, 0);
-
-        /* Enable momentum scrolling on iOS */
-        -webkit-overflow-scrolling: touch;
-
-        /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
-        box-shadow: 0 0 0 white;
-      }
-
-      #selector {
-        border-width: var(--_vaadin-multi-select-combo-box-items-container-border-width);
-        border-style: var(--_vaadin-multi-select-combo-box-items-container-border-style);
-        border-color: var(--_vaadin-multi-select-combo-box-items-container-border-color, transparent);
-        position: relative;
-      }
-    `;
+    return multiSelectComboBoxScrollerStyles;
   }
 
   /** @protected */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -14,8 +14,8 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { inputFieldShared } from '@vaadin/field-base/src/styles/input-field-shared-styles.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { multiSelectComboBoxStyles } from './styles/vaadin-multi-select-combo-box-styles.js';
 import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.js';
-import { multiSelectComboBox } from './vaadin-multi-select-combo-box-styles.js';
 
 /**
  * `<vaadin-multi-select-combo-box>` is a web component that wraps `<vaadin-combo-box>` and extends
@@ -108,7 +108,7 @@ class MultiSelectComboBox extends MultiSelectComboBoxMixin(
   }
 
   static get styles() {
-    return [inputFieldShared, multiSelectComboBox];
+    return [inputFieldShared, multiSelectComboBoxStyles];
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Moved `vaadin-multi-select-combo-box` core CSS to `styles` folder. Also changed to use shared item styles.

## Type of change

- Refactor