### PR TITLE
refactor: extract tabsheet core CSS to styles folder

### DIFF
--- a/packages/tabsheet/src/styles/vaadin-tabsheet-styles.d.ts
+++ b/packages/tabsheet/src/styles/vaadin-tabsheet-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2022 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const tabSheetStyles: CSSResult;

--- a/packages/tabsheet/src/styles/vaadin-tabsheet-styles.js
+++ b/packages/tabsheet/src/styles/vaadin-tabsheet-styles.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2022 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css } from 'lit';
+
+export const tabSheetStyles = css`
+  :host {
+    display: flex;
+    flex-direction: column;
+  }
+
+  :host([hidden]) {
+    display: none !important;
+  }
+
+  [part='tabs-container'] {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  ::slotted([slot='tabs']) {
+    flex: 1;
+    align-self: stretch;
+    min-width: 8em;
+  }
+
+  [part='content'] {
+    position: relative;
+    flex: 1;
+    box-sizing: border-box;
+  }
+`;

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -5,11 +5,12 @@
  */
 import '@vaadin/tabs/src/vaadin-tabs.js';
 import './vaadin-tabsheet-scroller.js';
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { tabSheetStyles } from './styles/vaadin-tabsheet-styles.js';
 import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
 
 /**
@@ -66,34 +67,7 @@ class TabSheet extends TabSheetMixin(ThemableMixin(ElementMixin(PolylitMixin(Lit
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: flex;
-        flex-direction: column;
-      }
-
-      :host([hidden]) {
-        display: none !important;
-      }
-
-      [part='tabs-container'] {
-        position: relative;
-        display: flex;
-        align-items: center;
-      }
-
-      ::slotted([slot='tabs']) {
-        flex: 1;
-        align-self: stretch;
-        min-width: 8em;
-      }
-
-      [part='content'] {
-        position: relative;
-        flex: 1;
-        box-sizing: border-box;
-      }
-    `;
+    return tabSheetStyles;
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Extracted `vaadin-tabsheet` core styles into separate file in `styles` folder.

## Type of change

- Refactor