### PR TITLE
refactor: move chart base theme CSS to src styles folder

### DIFF
--- a/packages/charts/src/styles/vaadin-chart-styles.d.ts
+++ b/packages/charts/src/styles/vaadin-chart-styles.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import type { CSSResult } from 'lit';
+
+export const chartStyles: CSSResult;

--- a/packages/charts/src/styles/vaadin-chart-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-styles.js
@@ -16,17 +16,24 @@
  *
  * License: www.highcharts.com/license
  */
-import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { css } from 'lit';
 
 /* When updating this file do not override vaadin-charts custom properties section */
 
-const chartBaseTheme = css`
+export const chartStyles = css`
   :host {
+    display: block;
+    width: 100%;
+    overflow: hidden;
     font-family:
       -apple-system, BlinkMacSystemFont, 'Roboto', 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
       'Segoe UI Emoji', 'Segoe UI Symbol';
     font-size: 12px;
     line-height: normal;
+  }
+
+  :host([hidden]) {
+    display: none !important;
   }
 
   .highcharts-container {
@@ -126,7 +133,7 @@ const chartBaseTheme = css`
   }
 
   :where([styled-mode]) .highcharts-xaxis-grid .highcharts-grid-line {
-    stroke-width: var(--vaadin-charts-xaxis-line-width, 0px);
+    stroke-width: var(--vaadin-charts-xaxis-line-width, 0);
   }
 
   :where([styled-mode]) .highcharts-tick {
@@ -172,9 +179,6 @@ const chartBaseTheme = css`
     pointer-events: none;
     white-space: nowrap;
     transition: stroke 150ms;
-  }
-
-  :where([styled-mode]) .highcharts-tooltip {
     filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.05)) !important;
   }
 
@@ -445,7 +449,7 @@ const chartBaseTheme = css`
   }
 
   :where([styled-mode]) .highcharts-treemap-series .highcharts-point-hover {
-    stroke-width: 0px;
+    stroke-width: 0;
     stroke: var(--vaadin-charts-background, #fff);
     fill-opacity: 0.75;
     transition:
@@ -509,7 +513,7 @@ const chartBaseTheme = css`
   }
 
   :where([styled-mode]) .highcharts-legend-item > .highcharts-point {
-    stroke-width: 0px;
+    stroke-width: 0;
   }
 
   :where([styled-mode]) .highcharts-legend-item:hover text {
@@ -754,7 +758,7 @@ const chartBaseTheme = css`
   :where([styled-mode]) .highcharts-button-hover {
     transition: fill 0ms;
     fill: var(--vaadin-charts-button-hover-background, hsla(214, 90%, 52%, 0.1));
-    stroke-width: 0px;
+    stroke-width: 0;
   }
 
   :where([styled-mode]) .highcharts-button-hover text {
@@ -904,7 +908,7 @@ const chartBaseTheme = css`
 
   :where([styled-mode]) .highcharts-coloraxis-marker {
     fill: var(--vaadin-charts-axis-label, hsla(214, 42%, 18%, 0.72));
-    stroke-width: 0px;
+    stroke-width: 0;
   }
 
   :where([styled-mode]) .highcharts-null-point {
@@ -1054,10 +1058,6 @@ const chartBaseTheme = css`
   /* https://github.com/highcharts/highcharts/issues/16282 */
   /* without this the resize callback always calls __reflow */
   ul[aria-hidden='false'] {
-    margin: 0px;
+    margin: 0;
   }
 `;
-
-registerStyles('vaadin-chart', chartBaseTheme, { moduleId: 'vaadin-chart-base-theme' });
-
-export { chartBaseTheme };

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -9,11 +9,12 @@
  * license.
  */
 import './vaadin-chart-series.js';
-import { css, html, LitElement } from 'lit';
+import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { chartStyles } from './styles/vaadin-chart-styles.js';
 import { ChartMixin } from './vaadin-chart-mixin.js';
 
 /**
@@ -190,17 +191,7 @@ class Chart extends ChartMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElemen
   }
 
   static get styles() {
-    return css`
-      :host {
-        display: block;
-        width: 100%;
-        overflow: hidden;
-      }
-
-      :host([hidden]) {
-        display: none !important;
-      }
-    `;
+    return chartStyles;
   }
 
   /** @protected */

--- a/packages/charts/test/chart-element.test.js
+++ b/packages/charts/test/chart-element.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, nextRender, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/vaadin-chart-base-theme.js';
 import '../src/vaadin-chart.js';
 
 describe('vaadin-chart', () => {

--- a/packages/charts/test/chart-properties.test.js
+++ b/packages/charts/test/chart-properties.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/vaadin-chart-base-theme.js';
 import '../src/vaadin-chart.js';
 import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 

--- a/packages/charts/test/chart-series.test.js
+++ b/packages/charts/test/chart-series.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/vaadin-chart-base-theme.js';
 import '../src/vaadin-chart.js';
 
 describe('vaadin-chart-series', () => {

--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/vaadin-chart-base-theme.js';
 import './exporting-styles.js';
 import '../src/vaadin-chart.js';
 import HttpUtilities from 'highcharts/es-modules/Core/HttpUtilities.js';

--- a/packages/charts/test/styling.test.js
+++ b/packages/charts/test/styling.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
-import '../theme/vaadin-chart-base-theme.js';
 import './theme-styles.js';
 import '../src/vaadin-chart.js';
 

--- a/packages/charts/test/turbo-mode.test.js
+++ b/packages/charts/test/turbo-mode.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../theme/vaadin-chart-base-theme.js';
 import '../src/vaadin-chart.js';
 
 describe('turbo-mode', () => {

--- a/packages/charts/theme/lumo/vaadin-chart-styles.js
+++ b/packages/charts/theme/lumo/vaadin-chart-styles.js
@@ -1,4 +1,3 @@
-import '../vaadin-chart-base-theme.js';
 import '@vaadin/vaadin-lumo-styles/color.js';
 import '@vaadin/vaadin-lumo-styles/typography.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';


### PR DESCRIPTION
## Description

Moved `vaadin-chart-base-theme` from the `theme` folder to `src/styles` as these are essentially core styles.

## Type of change

- Refactor