### PR TITLE
refactor: extract popover core CSS to styles folder

### DIFF
--- a/packages/popover/src/styles/vaadin-popover-overlay-styles.d.ts
+++ b/packages/popover/src/styles/vaadin-popover-overlay-styles.d.ts
@@ -5,4 +5,6 @@
  */
 import type { CSSResult } from 'lit';
 
+export const popoverOverlay: CSSResult;
+
 export const popoverOverlayStyles: CSSResult;

--- a/packages/popover/src/styles/vaadin-popover-overlay-styles.d.ts
+++ b/packages/popover/src/styles/vaadin-popover-overlay-styles.d.ts
@@ -5,6 +5,4 @@
  */
 import type { CSSResult } from 'lit';
 
-export const popoverOverlay: CSSResult;
-
 export const popoverOverlayStyles: CSSResult;

--- a/packages/popover/src/styles/vaadin-popover-overlay-styles.js
+++ b/packages/popover/src/styles/vaadin-popover-overlay-styles.js
@@ -4,8 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 
-export const popoverOverlayStyles = css`
+export const popoverOverlay = css`
   :host {
     --_vaadin-popover-content-width: auto;
     --_vaadin-popover-content-height: auto;
@@ -70,3 +71,5 @@ export const popoverOverlayStyles = css`
     display: block;
   }
 `;
+
+export const popoverOverlayStyles = [overlayStyles, popoverOverlay];

--- a/packages/popover/src/styles/vaadin-popover-overlay-styles.js
+++ b/packages/popover/src/styles/vaadin-popover-overlay-styles.js
@@ -6,7 +6,7 @@
 import { css } from 'lit';
 import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 
-export const popoverOverlay = css`
+const popoverOverlay = css`
   :host {
     --_vaadin-popover-content-width: auto;
     --_vaadin-popover-content-height: auto;

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -7,7 +7,6 @@ import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { popoverOverlayStyles } from './styles/vaadin-popover-overlay-styles.js';
@@ -29,7 +28,7 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(CSSInjec
   }
 
   static get styles() {
-    return [overlayStyles, popoverOverlayStyles];
+    return popoverOverlayStyles;
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Extracted `popover` core styles into separate file in `styles` folder.

## Type of change

- Refactor