### PR TITLE
refactor: extract confirm-dialog core CSS to styles folder

### DIFF
--- a/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-styles.d.ts
+++ b/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-styles.d.ts
@@ -5,4 +5,4 @@
  */
 import type { CSSResult } from 'lit';
 
-export const confirmDialogOverlay: CSSResult;
+export declare const confirmDialogOverlayStyles: CSSResult;

--- a/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-styles.js
+++ b/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-styles.js
@@ -4,8 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';
+import { dialogOverlay } from '@vaadin/dialog/src/vaadin-dialog-styles.js';
+import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 
-export const confirmDialogOverlay = css`
+const confirmDialogOverlay = css`
   :host {
     --_vaadin-confirm-dialog-content-width: auto;
     --_vaadin-confirm-dialog-content-height: auto;
@@ -29,3 +31,4 @@ export const confirmDialogOverlay = css`
     pointer-events: all;
   }
 `;
+export const confirmDialogOverlayStyles = [overlayStyles, dialogOverlay, confirmDialogOverlay];

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -10,14 +10,12 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DialogBaseMixin } from '@vaadin/dialog/src/vaadin-dialog-base-mixin.js';
-import { dialogOverlay } from '@vaadin/dialog/src/vaadin-dialog-styles.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
-import { overlayStyles } from '@vaadin/overlay/src/vaadin-overlay-styles.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
+import { confirmDialogOverlayStyles } from './styles/vaadin-confirm-dialog-overlay-styles.js';
 import { ConfirmDialogBaseMixin } from './vaadin-confirm-dialog-base-mixin.js';
-import { confirmDialogOverlay } from './vaadin-confirm-dialog-overlay-styles.js';
 
 /**
  * An element used internally by `<vaadin-confirm-dialog>`. Not intended to be used separately.
@@ -35,7 +33,7 @@ class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(CSSInject
   }
 
   static get styles() {
-    return [overlayStyles, dialogOverlay, confirmDialogOverlay];
+    return confirmDialogOverlayStyles;
   }
 
   /** @protected */


### PR DESCRIPTION
## Description

Extracted `confirm-dialog` core styles into separate file in `styles` folder.

## Type of change

- Refactor