### PR TITLE
test: update multi-line text-area tests to pass with base styles

### DIFF
--- a/packages/text-area/test/text-area.test.js
+++ b/packages/text-area/test/text-area.test.js
@@ -265,7 +265,7 @@ describe('text-area', () => {
     });
 
     describe('min / max rows', () => {
-      let lineHeight;
+      let lineHeight, padding, border;
       let consoleWarn;
 
       beforeEach(async () => {
@@ -286,6 +286,8 @@ describe('text-area', () => {
         textArea = fixture.querySelector('vaadin-text-area');
         await nextUpdate(textArea);
         native = textArea.querySelector('textarea');
+        padding = parseInt(getComputedStyle(inputField).paddingTop) * 2;
+        border = parseInt(getComputedStyle(inputField).borderTopWidth) * 2;
 
         consoleWarn = sinon.stub(console, 'warn');
       });
@@ -295,21 +297,21 @@ describe('text-area', () => {
       });
 
       it('should use min-height of two rows by default', () => {
-        expect(textArea.clientHeight).to.equal(lineHeight * 2);
+        expect(textArea.clientHeight).to.equal(lineHeight * 2 + padding + border);
       });
 
       it('should use min-height based on minimum rows', async () => {
         textArea.minRows = 4;
         await nextUpdate(textArea);
 
-        expect(textArea.clientHeight).to.equal(lineHeight * 4);
+        expect(textArea.clientHeight).to.equal(lineHeight * 4 + padding + border);
       });
 
       it('should be possible to set min-height to a single row', async () => {
         textArea.minRows = 1;
         await nextUpdate(textArea);
 
-        expect(textArea.clientHeight).to.closeTo(lineHeight, 1);
+        expect(textArea.clientHeight).to.closeTo(lineHeight + padding + border, 1);
       });
 
       it('should log warning when setting minRows to less than one row', async () => {
@@ -342,7 +344,7 @@ describe('text-area', () => {
         await nextUpdate(textArea);
 
         expect(custom.rows).to.equal(1);
-        expect(textArea.clientHeight).to.closeTo(lineHeight, 1);
+        expect(textArea.clientHeight).to.closeTo(lineHeight + padding + border, 1);
       });
 
       it('should grow beyond the min-height defined by minimum rows', async () => {
@@ -352,7 +354,7 @@ describe('text-area', () => {
         textArea.value = Array(400).join('400');
         await nextUpdate(textArea);
 
-        expect(textArea.clientHeight).to.be.above(80);
+        expect(textArea.clientHeight).to.be.above(lineHeight * 4 + padding + border);
       });
 
       it('should use max-height based on maximum rows', async () => {
@@ -360,7 +362,7 @@ describe('text-area', () => {
         textArea.value = Array(400).join('400');
         await nextUpdate(textArea);
 
-        expect(textArea.clientHeight).to.equal(lineHeight * 4);
+        expect(textArea.clientHeight).to.equal(lineHeight * 4 + padding + border);
       });
 
       it('should include margins, paddings and borders when calculating max-height', async () => {
@@ -387,7 +389,7 @@ describe('text-area', () => {
         textArea.value = 'value';
         await nextUpdate(textArea);
 
-        expect(textArea.clientHeight).to.be.below(lineHeight * 4);
+        expect(textArea.clientHeight).to.be.below(lineHeight * 4 + padding);
       });
 
       it('should update max-height when component is resized', async () => {
@@ -402,7 +404,7 @@ describe('text-area', () => {
         // Trigger a resize event
         textArea._onResize();
 
-        expect(textArea.clientHeight).to.equal(lineHeight * 4);
+        expect(textArea.clientHeight).to.equal(lineHeight * 4 + padding + border);
       });
 
       it('should update max-height when value changes', async () => {
@@ -417,7 +419,7 @@ describe('text-area', () => {
         // Trigger a value change
         textArea.value += 'change';
 
-        expect(textArea.clientHeight).to.equal(lineHeight * 4);
+        expect(textArea.clientHeight).to.equal(lineHeight * 4 + padding + border);
       });
     });
 


### PR DESCRIPTION
## Description

Based on #8987

Adapted `vaadin-text-area` unit tests to pass with base styles. 
Can be tested with `yarn test --group text-area --theme=base`

## Type of change

- Test