### PR TITLE
refactor: do not use resizable dialog styles in CRUD dialog overlay

### DIFF
--- a/packages/crud/src/styles/vaadin-crud-dialog-overlay-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-dialog-overlay-styles.js
@@ -20,6 +20,8 @@ const crudDialogOverlay = css`
   }
 
   .resizer-container {
+    display: flex;
+    flex-direction: column;
     flex-grow: 1;
   }
 


### PR DESCRIPTION
## Description

Updated `crudDialogOverlayStyles` to only use CSS it actually needs (to expand to 100% height in fullscreen mode)

## Type of change

- Refactor