### PR TITLE
fix: allow setting null explicitly to reset width and height

### DIFF
--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.js
@@ -207,7 +207,8 @@ export const DialogOverlayMixin = (superClass) =>
       }
 
       Object.keys(parsedBounds).forEach((arg) => {
-        if (!isNaN(parsedBounds[arg])) {
+        // Allow setting width or height to `null`
+        if (parsedBounds[arg] !== null && !isNaN(parsedBounds[arg])) {
           parsedBounds[arg] = `${parsedBounds[arg]}px`;
         }
       });

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -342,5 +342,35 @@ describe('vaadin-dialog', () => {
       expect(getComputedStyle(overlay.$.overlay).position).to.equal('relative');
       expect(getComputedStyle(overlay.$.overlay).maxWidth).to.equal('100%');
     });
+
+    it('should reset overlay width when set to null', async () => {
+      dialog.opened = true;
+      await nextRender();
+
+      const originalWidth = getComputedStyle(overlay.$.overlay).width;
+
+      dialog.width = 300;
+      await nextRender();
+
+      dialog.width = null;
+      await nextRender();
+
+      expect(getComputedStyle(overlay.$.overlay).width).to.equal(originalWidth);
+    });
+
+    it('should reset overlay height when set to null', async () => {
+      dialog.opened = true;
+      await nextRender();
+
+      const originalHeight = getComputedStyle(overlay.$.overlay).height;
+
+      dialog.height = 400;
+      await nextRender();
+
+      dialog.height = null;
+      await nextRender();
+
+      expect(getComputedStyle(overlay.$.overlay).height).to.equal(originalHeight);
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixed a finding from https://github.com/vaadin/web-components/pull/9453 also for `vaadin-dialog`.

Currently setting `width` or `height` to `null` explicitly doesn't restore the original width or height.
This can end up with an overlay in unexpected state. This PR fixes that by adding `null` check.

## Type of change

- Bugfix