### PR TITLE
fix: add missing JSDoc annotation to TimePickerMixin

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -23,6 +23,7 @@ const MAX_ALLOWED_TIME = '23:59:59.999';
  * A mixin providing common time-picker functionality.
  *
  * @polymerMixin
+ * @mixes ComboBoxBaseMixin
  * @mixes InputControlMixin
  * @mixes PatternMixin
  */


### PR DESCRIPTION
## Description

This fixes a problem introduced in https://github.com/vaadin/web-components/pull/9354 which causes mixin properties to be missing from docs and as a result, not having `onOpenedChanged` in React wrappers:

```
[types]   Property 'onOpenedChanged' does not exist on type 'IntrinsicAttributes & Partial<ThemedWebComponentProps<TimePicker, Readonly<{ onValidated: EventName<TimePickerValidatedEvent>; onChange: EventName<...>; onInput: EventName<...>; onInvalidChanged: EventName<...>; onValueChanged: EventName<...>; }>>> & RefAttributes<...>'.
```

## Type of change

- Bugfix