### PR TITLE
fix: override button focus outline for native :focus-visible state

### DIFF
--- a/packages/button/src/styles/vaadin-button-base-styles.js
+++ b/packages/button/src/styles/vaadin-button-base-styles.js
@@ -51,7 +51,7 @@ export const buttonStyles = css`
       display: contents;
     }
 
-    :host([focus-ring]) {
+    :host(:is([focus-ring], :focus-visible)) {
       outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
       outline-offset: 1px;
     }


### PR DESCRIPTION
In some cases, focus is visible on the button but the `[focus-ring]` state is not set. Happens at least in Confirm Dialog in some cases when it is opened with the keyboard. This change overrides the focus outline for the `:focus-visible` state in addition to the custom `[focus-ring]` state.