### PR TITLE
chore: add Stylelint plugin to ensure base styles are inside base CSS layer

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,10 +2,17 @@
   "extends": ["stylelint-config-vaadin"],
   "plugins": [
     "./custom-rules/stylelint/no-shorthand-with-unresolved-longhand.js",
-    "./custom-rules/stylelint/license-header.js"
+    "./custom-rules/stylelint/license-header.js",
+    "./custom-rules/stylelint/use-layers.js"
   ],
   "overrides": [
     { "files": ["**/*.js"], "customSyntax": "postcss-lit" },
+    {
+      "files": ["**/*-base-styles.js"],
+      "rules": {
+        "custom-rules/use-layers": ["^(vaadin\\.)?base$"]
+      }
+    },
     {
       "files": ["packages/vaadin-lumo-styles/**/*.css"],
       "rules": {

--- a/custom-rules/stylelint/use-layers.js
+++ b/custom-rules/stylelint/use-layers.js
@@ -1,0 +1,54 @@
+import stylelint from 'stylelint';
+
+const {
+  createPlugin,
+  utils: { report },
+} = stylelint;
+
+const ruleName = 'custom-rules/use-layers';
+
+const messages = {
+  missingLayer: 'Expected rule to be within a layer',
+  layerNameMismatch: (name, pattern) => `Expected layer name '${name}' to match pattern '${pattern}'.`,
+};
+
+function getParentLayerName(rule) {
+  let parent = rule.parent;
+  while (parent) {
+    if (parent.type === 'atrule' && parent.name === 'layer') {
+      return parent.params.trim();
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+const ruleFunction = (layerNamePattern) => {
+  return (root, result) => {
+    root.walkRules((rule) => {
+      const parentLayerName = getParentLayerName(rule);
+      if (parentLayerName === null) {
+        return report({
+          ruleName,
+          result,
+          node: rule,
+          message: messages.missingLayer,
+        });
+      }
+
+      if (layerNamePattern && !new RegExp(layerNamePattern, 'u').test(parentLayerName)) {
+        return report({
+          ruleName,
+          result,
+          node: rule,
+          message: messages.layerNameMismatch(parentLayerName, layerNamePattern),
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+
+export default createPlugin(ruleName, ruleFunction);

--- a/packages/icon/src/styles/vaadin-icon-base-styles.js
+++ b/packages/icon/src/styles/vaadin-icon-base-styles.js
@@ -6,45 +6,47 @@
 import { css } from 'lit';
 
 export const iconStyles = css`
-  :host {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-    vertical-align: middle;
-    width: var(--vaadin-icon-size, 1lh);
-    height: var(--vaadin-icon-size, 1lh);
-    fill: var(--vaadin-icon-color, currentColor);
-    container-type: size;
-    contain: layout;
-  }
+  @layer base {
+    :host {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      box-sizing: border-box;
+      vertical-align: middle;
+      width: var(--vaadin-icon-size, 1lh);
+      height: var(--vaadin-icon-size, 1lh);
+      fill: var(--vaadin-icon-color, currentColor);
+      container-type: size;
+      contain: layout;
+    }
 
-  :host::after,
-  :host::before {
-    line-height: 1;
-    font-size: 100cqh;
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    -moz-osx-font-smoothing: grayscale;
-  }
+    :host::after,
+    :host::before {
+      line-height: 1;
+      font-size: 100cqh;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+      -moz-osx-font-smoothing: grayscale;
+    }
 
-  :host([hidden]) {
-    display: none !important;
-  }
+    :host([hidden]) {
+      display: none !important;
+    }
 
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-    /* prevent overflowing icon from clipping, see https://github.com/vaadin/flow-components/issues/5872 */
-    overflow: visible;
-  }
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+      /* prevent overflowing icon from clipping, see https://github.com/vaadin/flow-components/issues/5872 */
+      overflow: visible;
+    }
 
-  :host(:is([icon-class], [font-icon-content])) svg {
-    display: none;
-  }
+    :host(:is([icon-class], [font-icon-content])) svg {
+      display: none;
+    }
 
-  :host([font-icon-content])::before {
-    content: attr(font-icon-content);
+    :host([font-icon-content])::before {
+      content: attr(font-icon-content);
+    }
   }
 `;


### PR DESCRIPTION
## Description

The PR introduces a custom Stylelint plugin to ensure all base styles are defined inside base CSS layer.

## Type of change

- [x] Internal
