### PR TITLE
fix: scroll focus target into view when row is larger than viewport

### DIFF
--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -9,15 +9,15 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 
-function isRow(element) {
+export function isRow(element) {
   return element instanceof HTMLTableRowElement;
 }
 
-function isCell(element) {
+export function isCell(element) {
   return element instanceof HTMLTableCellElement;
 }
 
-function isDetailsCell(element) {
+export function isDetailsCell(element) {
   return element.matches('[part~="details-cell"]');
 }
 
@@ -280,7 +280,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       if (!targetRowInDom) {
         this._scrollToFlatIndex(index);
       } else {
-        this.__scrollIntoViewport(index);
+        this.__scrollIntoViewport(targetRowInDom);
       }
     }
 

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -9,15 +9,15 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 
-export function isRow(element) {
+function isRow(element) {
   return element instanceof HTMLTableRowElement;
 }
 
-export function isCell(element) {
+function isCell(element) {
   return element instanceof HTMLTableCellElement;
 }
 
-export function isDetailsCell(element) {
+function isDetailsCell(element) {
   return element.matches('[part~="details-cell"]');
 }
 

--- a/packages/grid/test/scroll-into-view.test.js
+++ b/packages/grid/test/scroll-into-view.test.js
@@ -112,25 +112,6 @@ describe('scroll into view', () => {
     });
   });
 
-  describe.skip('focusable elements in cells', () => {
-    it('should only scroll focusable element into view when it receives focus', async () => {
-      const secondCellInput = getCellContent(secondCell).querySelector('textarea');
-
-      verifyNotFullyVisible(secondRow);
-      verifyNotFullyVisible(secondCellInput);
-
-      // Enter navigation mode in first cell, Tab to textarea in second cell
-      firstCell.focus();
-      await sendKeys({ press: 'Enter' });
-      await sendKeys({ press: 'Tab' });
-
-      // Second input should be focused and fully visible, but second row should not be fully visible
-      expect(document.activeElement).to.equal(secondCellInput);
-      verifyFullyVisible(secondCellInput);
-      verifyNotFullyVisible(secondRow);
-    });
-  });
-
   describe('row is larger than viewport', () => {
     beforeEach(async () => {
       column.renderer = (root, _, model) => {


### PR DESCRIPTION
## Description

When the grid receives a focus event from either a row, cell, or element within a cell, it tries to scroll the related row into view. However, if the row is larger than the visible viewport of the grid and the focus event is from an element within a cell (e.g. an input), then that focused element can still end up outside of the viewport after scrolling.

This adds an additional check to see if the whole row fits into the viewport. If not it only tries to scroll the actual focused element into view.

Fixes https://github.com/vaadin/flow-components/issues/7554

## Type of change

- Bugfix
