### PR TITLE
chore: lint and format CSS files in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
     "*.{js,ts}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "*.css": [
+      "stylelint --fix",
+      "prettier --write"
     ]
   },
   "workspaces": [


### PR DESCRIPTION
## Description

Configures pre-commit hook to run stylelint and prettier for CSS files.

Part of https://github.com/vaadin/web-components/issues/9082

## Type of change

- [x] Internal
