### PR TITLE
refactor: defer computing styles until opened

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay-mixin.js
+++ b/packages/popover/src/vaadin-popover-overlay-mixin.js
@@ -57,21 +57,6 @@ export const PopoverOverlayMixin = (superClass) =>
       return 'vaadin-popover';
     }
 
-    requestContentUpdate() {
-      super.requestContentUpdate();
-
-      // Copy custom properties from the owner
-      if (this.positionTarget && this.owner) {
-        const style = getComputedStyle(this.owner);
-        ['top', 'bottom', 'start', 'end'].forEach((prop) => {
-          this.style.setProperty(
-            `--${this._tagNamePrefix}-offset-${prop}`,
-            style.getPropertyValue(`--${this._tagNamePrefix}-offset-${prop}`),
-          );
-        });
-      }
-    }
-
     /**
      * @protected
      * @override
@@ -81,6 +66,15 @@ export const PopoverOverlayMixin = (superClass) =>
 
       if (!this.positionTarget || !this.opened) {
         return;
+      }
+
+      // Copy custom properties from the owner
+      if (this.owner) {
+        const style = getComputedStyle(this.owner);
+        ['top', 'bottom', 'start', 'end'].forEach((prop) => {
+          const propertyName = `--${this._tagNamePrefix}-offset-${prop}`;
+          this.style.setProperty(propertyName, style.getPropertyValue(propertyName));
+        });
       }
 
       this.removeAttribute('arrow-centered');


### PR DESCRIPTION
## Description

Currently tooltip overlays copy custom CSS variables from their tooltip element immediately in `connectedCallback`, which causes a style recalculation for each tooltip that is added to the DOM. That can slow down the page significantly when adding hundreds of tooltips.

This change defers copying of the styles to when the tooltip is actually opened, thus not causing a style recalculation from just adding tooltips to the DOM.

Fixes https://github.com/vaadin/flow-components/issues/7595

## Type of change

- Performance enhancement