### PR TITLE
refactor: extract and unify dialog bounds handling logic

### DIFF
--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -93,10 +93,8 @@ export const DialogDraggableMixin = (superClass) =>
           window.addEventListener('touchend', this._stopDrag);
           window.addEventListener('mousemove', this._drag);
           window.addEventListener('touchmove', this._drag);
-          if (this.$.overlay.$.overlay.style.position !== 'absolute') {
-            const { top, left } = this._originalBounds;
-            this.$.overlay.setBounds({ top, left });
-          }
+          this.$.overlay.setBounds(this._originalBounds);
+          this.$.overlay.setAttribute('has-bounds-set', '');
         }
       }
     }

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -103,8 +103,9 @@ export const DialogDraggableMixin = (superClass) =>
       const event = getMouseOrFirstTouchEvent(e);
       if (eventInWindow(event)) {
         const { top, left } = this.__manager.bounds;
-        this.top = top + this.__manager.getEventY(event);
-        this.left = left + this.__manager.getEventX(event);
+        const { x, y } = this.__manager.getEventXY(event);
+        this.top = top + y;
+        this.left = left + x;
       }
     }
 

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -72,10 +72,7 @@ export const DialogResizableMixin = (superClass) =>
         window.addEventListener('touchmove', this._resizeListeners.resize[direction]);
         window.addEventListener('mouseup', this._resizeListeners.stop[direction]);
         window.addEventListener('touchend', this._resizeListeners.stop[direction]);
-        if (this.$.overlay.$.overlay.style.position !== 'absolute' || this.width || this.height) {
-          this.$.overlay.setBounds(this._originalBounds);
-        }
-
+        this.$.overlay.setBounds(this._originalBounds);
         this.$.overlay.setAttribute('has-bounds-set', '');
       }
     }

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -87,8 +87,7 @@ export const DialogResizableMixin = (superClass) =>
       if (eventInWindow(event)) {
         const minimumSize = 40;
         const { height: boundsHeight, width: boundsWidth, top: boundsTop, left: boundsLeft } = this.__manager.bounds;
-        const eventX = this.__manager.getEventX(event);
-        const eventY = this.__manager.getEventY(event);
+        const { x: eventX, y: eventY } = this.__manager.getEventXY(event);
 
         resizer.split('').forEach((direction) => {
           switch (direction) {

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -73,7 +73,7 @@ export const DialogResizableMixin = (superClass) =>
         window.addEventListener('mouseup', this._resizeListeners.stop[direction]);
         window.addEventListener('touchend', this._resizeListeners.stop[direction]);
 
-        this.__manager.handleEvent(e);
+        this.__manager.handleEvent(e, true);
       }
     }
 

--- a/packages/dialog/src/vaadin-dialog-utils.d.ts
+++ b/packages/dialog/src/vaadin-dialog-utils.d.ts
@@ -27,7 +27,7 @@ export declare class DialogManager {
 
   readonly bounds: { top: number; left: number; width: number; height: number };
 
-  handleEvent(event: MouseEvent | Touch): void;
+  handleEvent(event: MouseEvent | Touch, setBounds?: boolean): void;
 
   getEventXY(event: MouseEvent | Touch): { x: number; y: number };
 }

--- a/packages/dialog/src/vaadin-dialog-utils.d.ts
+++ b/packages/dialog/src/vaadin-dialog-utils.d.ts
@@ -29,7 +29,5 @@ export declare class DialogManager {
 
   handleEvent(event: MouseEvent | Touch): void;
 
-  getEventX(event: MouseEvent | Touch): number;
-
-  getEventY(event: MouseEvent | Touch): number;
+  getEventXY(event: MouseEvent | Touch): { x: number; y: number };
 }

--- a/packages/dialog/src/vaadin-dialog-utils.d.ts
+++ b/packages/dialog/src/vaadin-dialog-utils.d.ts
@@ -18,3 +18,18 @@ export { getMouseOrFirstTouchEvent };
 declare function eventInWindow(e: MouseEvent | TouchEvent): boolean;
 
 export { eventInWindow };
+
+/**
+ * Internal class handling dialog bounds and coordinates.
+ */
+export declare class DialogManager {
+  static create(dialog: HTMLElement): DialogManager;
+
+  readonly bounds: { top: number; left: number; width: number; height: number };
+
+  handleEvent(event: MouseEvent | Touch): void;
+
+  getEventX(event: MouseEvent | Touch): number;
+
+  getEventY(event: MouseEvent | Touch): number;
+}

--- a/packages/dialog/src/vaadin-dialog-utils.js
+++ b/packages/dialog/src/vaadin-dialog-utils.js
@@ -24,3 +24,47 @@ export function getMouseOrFirstTouchEvent(e) {
 export function eventInWindow(e) {
   return e.clientX >= 0 && e.clientX <= window.innerWidth && e.clientY >= 0 && e.clientY <= window.innerHeight;
 }
+
+const instancesMap = new WeakMap();
+
+/**
+ * Internal class handling dialog bounds and coordinates.
+ */
+export class DialogManager {
+  static create(dialog) {
+    if (instancesMap.has(dialog)) {
+      return instancesMap.get(dialog);
+    }
+
+    const instance = new DialogManager(dialog);
+    instancesMap.set(dialog, instance);
+    return instance;
+  }
+
+  constructor(dialog) {
+    this.host = dialog;
+    this.overlay = dialog.$.overlay;
+    this._originalBounds = {};
+    this._originalMouseCoords = {};
+  }
+
+  handleEvent(e) {
+    const event = getMouseOrFirstTouchEvent(e);
+    this._originalBounds = this.overlay.getBounds();
+    this._originalMouseCoords = { top: event.pageY, left: event.pageX };
+    this.overlay.setBounds(this._originalBounds);
+    this.overlay.setAttribute('has-bounds-set', '');
+  }
+
+  get bounds() {
+    return this._originalBounds;
+  }
+
+  getEventX(event) {
+    return event.pageX - this._originalMouseCoords.left;
+  }
+
+  getEventY(event) {
+    return event.pageY - this._originalMouseCoords.top;
+  }
+}

--- a/packages/dialog/src/vaadin-dialog-utils.js
+++ b/packages/dialog/src/vaadin-dialog-utils.js
@@ -42,7 +42,6 @@ export class DialogManager {
   }
 
   constructor(dialog) {
-    this.host = dialog;
     this.overlay = dialog.$.overlay;
     this._originalBounds = {};
     this._originalMouseCoords = {};

--- a/packages/dialog/src/vaadin-dialog-utils.js
+++ b/packages/dialog/src/vaadin-dialog-utils.js
@@ -60,11 +60,10 @@ export class DialogManager {
     return this._originalBounds;
   }
 
-  getEventX(event) {
-    return event.pageX - this._originalMouseCoords.left;
-  }
-
-  getEventY(event) {
-    return event.pageY - this._originalMouseCoords.top;
+  getEventXY(event) {
+    return {
+      x: event.pageX - this._originalMouseCoords.left,
+      y: event.pageY - this._originalMouseCoords.top,
+    };
   }
 }

--- a/packages/dialog/src/vaadin-dialog-utils.js
+++ b/packages/dialog/src/vaadin-dialog-utils.js
@@ -47,12 +47,20 @@ export class DialogManager {
     this._originalMouseCoords = {};
   }
 
-  handleEvent(e) {
+  handleEvent(e, setBounds = false) {
     const event = getMouseOrFirstTouchEvent(e);
     this._originalBounds = this.overlay.getBounds();
     this._originalMouseCoords = { top: event.pageY, left: event.pageX };
-    this.overlay.setBounds(this._originalBounds);
-    this.overlay.setAttribute('has-bounds-set', '');
+
+    if (setBounds) {
+      // On resize, we should set width and height
+      this.overlay.setBounds(this._originalBounds);
+      this.overlay.setAttribute('has-bounds-set', '');
+    } else {
+      // On drag, we should only set top and left
+      const { top, left } = this._originalBounds;
+      this.overlay.setBounds({ top, left });
+    }
   }
 
   get bounds() {

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -305,14 +305,6 @@ describe('resizable', () => {
     expect(Math.floor(resizedBounds.width)).to.be.eql(Math.floor(bounds.width + dx));
   });
 
-  it('should not set bounds again after position is set to absolute', () => {
-    const spy = sinon.spy(dialog.$.overlay, 'setBounds');
-    dispatchMouseEvent(overlayPart.querySelector('.n'), 'mousedown');
-    dialog.$.overlay.$.overlay.style.position = 'absolute';
-    dispatchMouseEvent(overlayPart.querySelector('.n'), 'mousedown');
-    expect(spy.calledOnce).to.be.true;
-  });
-
   it('should dispatch resize event with correct details', () => {
     const onResize = sinon.spy();
     dialog.addEventListener('resize', onResize);
@@ -428,14 +420,17 @@ describe('draggable', () => {
     expect(Math.floor(draggedBounds.left)).to.be.eql(Math.floor(bounds.left + dx));
   });
 
-  it('should only change "position", "top", and "left" values on drag', () => {
+  it('should set bounds on drag', () => {
     drag(content);
     const overlay = dialog.$.overlay.$.overlay;
     const style = overlay.style;
-    expect(style.length).to.be.eql(3);
+    expect(style.length).to.be.eql(5);
     expect(style.position).to.be.ok;
     expect(style.top).to.be.ok;
     expect(style.left).to.be.ok;
+    expect(style.width).to.be.ok;
+    expect(style.height).to.be.ok;
+    expect(dialog.$.overlay.hasAttribute('has-bounds-set')).to.be.true;
   });
 
   it('should drag and move dialog if mousedown on element with [class="draggable"] in another shadow root', async () => {
@@ -566,14 +561,6 @@ describe('draggable', () => {
     expect(Math.floor(draggedBounds.height)).to.be.eql(Math.floor(bounds.height));
   });
 
-  it('should not update overlay bounds with position: absolute', () => {
-    const spy = sinon.spy(dialog.$.overlay, 'setBounds');
-    dispatchMouseEvent(content, 'mousedown');
-    dialog.$.overlay.$.overlay.style.position = 'absolute';
-    dispatchMouseEvent(content, 'mousedown');
-    expect(spy.calledOnce).to.be.true;
-  });
-
   it('should not reset scroll position on dragstart', async () => {
     dialog.modeless = true;
     button.style.marginBottom = '200px';
@@ -603,12 +590,6 @@ describe('draggable', () => {
     const { detail } = onDragged.args[0][0];
     expect(detail.top).to.be.equal(dialog.top);
     expect(detail.left).to.be.equal(dialog.left);
-  });
-
-  it('should not set overlay max-width to none on drag', async () => {
-    drag(container);
-    await nextRender();
-    expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('100%');
   });
 });
 

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -420,17 +420,14 @@ describe('draggable', () => {
     expect(Math.floor(draggedBounds.left)).to.be.eql(Math.floor(bounds.left + dx));
   });
 
-  it('should set bounds on drag', () => {
+  it('should only change "position", "top", and "left" values on drag', () => {
     drag(content);
     const overlay = dialog.$.overlay.$.overlay;
     const style = overlay.style;
-    expect(style.length).to.be.eql(5);
+    expect(style.length).to.be.eql(3);
     expect(style.position).to.be.ok;
     expect(style.top).to.be.ok;
     expect(style.left).to.be.ok;
-    expect(style.width).to.be.ok;
-    expect(style.height).to.be.ok;
-    expect(dialog.$.overlay.hasAttribute('has-bounds-set')).to.be.true;
   });
 
   it('should drag and move dialog if mousedown on element with [class="draggable"] in another shadow root', async () => {
@@ -590,6 +587,12 @@ describe('draggable', () => {
     const { detail } = onDragged.args[0][0];
     expect(detail.top).to.be.equal(dialog.top);
     expect(detail.left).to.be.equal(dialog.left);
+  });
+
+  it('should not set overlay max-width to none on drag', async () => {
+    drag(container);
+    await nextRender();
+    expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('100%');
   });
 });
 


### PR DESCRIPTION
## Description

Extracted from #9438, see https://github.com/vaadin/web-components/pull/9438#issuecomment-2975751041 and https://github.com/vaadin/web-components/pull/9438#issuecomment-2977514658.

Currently, we have `_originalBounds` and `_originalMouseCoords` mostly duplicated in two mixins due to how dialog is structured. Refactored most of the logic to be placed in separate helper class (could be also a controller but it doesn't really have to do anything with connected / disconnected / updated callbacks, so I just used a plain class).

Note: original change (first commit in this PR) also reverted https://github.com/vaadin/web-components/pull/7970 and https://github.com/vaadin/web-components/pull/8830 which would re-introduce https://github.com/vaadin/web-components/issues/436 and https://github.com/vaadin/web-components/issues/8790 respectively. In the last commit, I reverted that behavior and restored corresponding tests.

## Type of change

- Refactor