### PR TITLE
fix: make checkbox render correctly in column flex on Safari 17

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -13,6 +13,12 @@ export const checkable = (part, propName = part) => css`
       display: inline-grid;
       gap: var(--vaadin-${unsafeCSS(propName)}-gap, 0.25lh var(--_vaadin-gap-container-inline));
       grid-template-columns: auto 1fr;
+      /*
+        Using minmax(auto, max-content) works around a Safari 17 issue where placing a checkbox
+        inside a flex container with flex-direction: column causes the container to unexpectedly
+        grow to the max available height.
+      */
+      grid-template-rows: minmax(auto, max-content);
       -webkit-tap-highlight-color: transparent;
     }
 

--- a/packages/field-base/src/styles/group-base-styles.js
+++ b/packages/field-base/src/styles/group-base-styles.js
@@ -10,17 +10,20 @@ export const group = (name = 'checkbox') => css`
   @layer base {
     :host {
       width: fit-content;
-      display: grid;
-      gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--_vaadin-gap-container-block));
     }
 
     .vaadin-group-field-container {
       display: contents;
     }
 
+    :host,
     [part='group-field'] {
       display: flex;
       flex-direction: column;
+      gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--_vaadin-gap-container-block));
+    }
+
+    [part='group-field'] {
       gap: 0.5lh 1.5em;
     }
 

--- a/packages/field-base/src/styles/group-base-styles.js
+++ b/packages/field-base/src/styles/group-base-styles.js
@@ -16,14 +16,14 @@ export const group = (name = 'checkbox') => css`
       display: contents;
     }
 
-    :host,
-    [part='group-field'] {
-      display: flex;
-      flex-direction: column;
+    :host {
+      display: grid;
       gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--_vaadin-gap-container-block));
     }
 
     [part='group-field'] {
+      display: flex;
+      flex-direction: column;
       gap: 0.5lh 1.5em;
     }
 

--- a/packages/field-base/src/styles/group-base-styles.js
+++ b/packages/field-base/src/styles/group-base-styles.js
@@ -10,15 +10,12 @@ export const group = (name = 'checkbox') => css`
   @layer base {
     :host {
       width: fit-content;
+      display: grid;
+      gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--_vaadin-gap-container-block));
     }
 
     .vaadin-group-field-container {
       display: contents;
-    }
-
-    :host {
-      display: grid;
-      gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--_vaadin-gap-container-block));
     }
 
     [part='group-field'] {


### PR DESCRIPTION
Some combination of nested flex containers causes a weird rendering issue in Safari 17 (tested on iOS 17.5 simulator).

Test case:
```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Checkbox Group</title>
    <script type="module" src="./common.js"></script>

    <script type="module">
      import '@vaadin/checkbox-group';
    </script>
  </head>

  <body>
      <vaadin-checkbox-group label="Options">
        <vaadin-checkbox value="1" label="Option One" checked></vaadin-checkbox>
        <vaadin-checkbox value="2" label="Option Two"></vaadin-checkbox>
        <vaadin-checkbox value="3" label="Option Three"></vaadin-checkbox>
      </vaadin-checkbox-group>
  </body>
</html>
```

Before:
<img width="379" alt="Screenshot 2025-06-18 at 9 48 39" src="https://github.com/user-attachments/assets/e1a97d8f-7345-4a0d-bdfe-29af2b6d9665" />

After:
<img width="377" alt="Screenshot 2025-06-18 at 9 49 04" src="https://github.com/user-attachments/assets/44166474-43c7-41bd-933d-8bd44a5ea864" />

