### PR TITLE
fix: overlay shadow color (support Safari 17)

### DIFF
--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -50,7 +50,7 @@ export const overlayStyles = css`
       background: var(--vaadin-overlay-background, var(--_vaadin-background));
       border: var(--vaadin-overlay-border, 1px solid var(--_vaadin-border-color));
       border-radius: var(--vaadin-overlay-border-radius, var(--_vaadin-radius-m));
-      box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px hsl(0 0 0 / 0.3));
+      box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3));
       box-sizing: border-box;
       max-width: 100%;
       overflow: auto;


### PR DESCRIPTION
Use an older color syntax to support Safari 17.