### PR TITLE
chore: remove 24.6 branch from the check-releases script

### DIFF
--- a/scripts/check-releases.js
+++ b/scripts/check-releases.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 const REPO_OWNER = 'vaadin';
 const REPO_NAME = 'web-components';
-const BRANCHES = ['main', '24.8', '24.7', '24.6', '23.6'];
+const BRANCHES = ['main', '24.8', '24.7', '23.6'];
 const GITHUB_TOKEN = process.env.GITHUB_API_TOKEN; // Set this in your .env file
 
 if (!GITHUB_TOKEN) {


### PR DESCRIPTION
## Description

Vaadin 24.6 is EOL tomorrow, let's remove it from the script.

## Type of change

- Internal change