### PR TITLE
feat: customizable input field autofill styles

### DIFF
--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -103,12 +103,24 @@ export const InputControlMixin = (superclass) =>
 
     /** @protected */
     get slotStyles() {
-      // Needed for Safari, where ::slotted(...)::placeholder does not work
       return [
         `
+          /* Needed for Safari, where ::slotted(...)::placeholder does not work */
           :is(input[slot='input'], textarea[slot='textarea'])::placeholder {
             font: inherit;
             color: inherit;
+          }
+
+          /* Override built-in autofill styles */
+          input[slot='input']:autofill {
+            -webkit-text-fill-color: var(--vaadin-input-field-autofill-color, black);
+            transition: background-color 9999s step-end;
+          }
+
+          :has(> input[slot='input']:autofill) {
+            --vaadin-input-field-background: var(--vaadin-input-field-autofill-background, lightyellow);
+            --vaadin-input-field-value-color: var(--vaadin-input-field-autofill-color, black);
+            --vaadin-input-field-button-color: var(--vaadin-input-field-autofill-color, black);
           }
         `,
       ];

--- a/packages/field-base/src/styles/button-base-styles.js
+++ b/packages/field-base/src/styles/button-base-styles.js
@@ -9,7 +9,7 @@ import { css } from 'lit';
 export const button = css`
   @layer base {
     [part$='button'] {
-      color: var(--_vaadin-color);
+      color: var(--vaadin-input-field-button-color, var(--_vaadin-color));
       cursor: var(--vaadin-clickable-cursor);
       touch-action: manipulation;
       -webkit-tap-highlight-color: transparent;

--- a/packages/input-container/src/styles/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-base-styles.js
@@ -66,6 +66,7 @@ export const inputContainerStyles = css`
       color: inherit;
       background: transparent;
       cursor: inherit;
+      caret-color: var(--vaadin-input-field-value-color);
     }
 
     ::slotted(*) {

--- a/packages/password-field/src/styles/vaadin-password-field-button-base-styles.js
+++ b/packages/password-field/src/styles/vaadin-password-field-button-base-styles.js
@@ -13,7 +13,7 @@ const passwordFieldBase = css`
       --vaadin-button-background: transparent;
       --vaadin-button-border: none;
       --vaadin-button-padding: 0;
-      color: inherit;
+      color: var(--vaadin-input-field-button-color, inherit);
       display: block;
       cursor: var(--vaadin-clickable-cursor);
     }


### PR DESCRIPTION
Add new custom properties that allows you to override the background and text color of input fields that have been autofilled by the browser. Add a new custom property to control the input field button color at the same time.

| Property | Description |
| --- | --- |
| `--vaadin-input-field-autofill-background` | Overrides the `--vaadin-input-field-background` property when the field is autofilled. |
| `--vaadin-input-field-autofill-color` | Overrides the `--vaadin-input-field-value-color` property when the field is autofilled. |
| `--vaadin-input-field-button-color` | The color of icon buttons that are inside input fields. |