### PR TITLE
refactor: remove obsolete \@supports CSS block

### DIFF
--- a/packages/map/theme/lumo/vaadin-map-styles.js
+++ b/packages/map/theme/lumo/vaadin-map-styles.js
@@ -107,13 +107,6 @@ registerStyles(
       background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
     }
 
-    @supports not selector(:focus-visible) {
-      .ol-control button:focus {
-        outline: none;
-        box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
-      }
-    }
-
     .ol-control button:focus-visible {
       outline: none;
       box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);


### PR DESCRIPTION
## Description

Removes `@supports not selector(:focus-visible)`, as all modern browsers support `:focus-visible`, see https://github.com/vaadin/web-components/pull/9501#discussion_r2154931665.

## Type of change

- [x] Refactor
