### PR TITLE
chore: update Lerna savePrefix patch to use correct file

### DIFF
--- a/patches/lerna+8.2.2.patch
+++ b/patches/lerna+8.2.2.patch
@@ -1,8 +1,8 @@
-diff --git a/node_modules/lerna/dist/commands/version/command.js b/node_modules/lerna/dist/commands/version/command.js
-index b8a30b5..80e4579 100644
---- a/node_modules/lerna/dist/commands/version/command.js
-+++ b/node_modules/lerna/dist/commands/version/command.js
-@@ -6209,7 +6209,7 @@ var require_src = __commonJS({
+diff --git a/node_modules/lerna/dist/index.js b/node_modules/lerna/dist/index.js
+index 69bd218..1ba6346 100644
+--- a/node_modules/lerna/dist/index.js
++++ b/node_modules/lerna/dist/index.js
+@@ -9450,7 +9450,7 @@ var require_src2 = __commonJS({
            forceGitTag,
            overrideMessage
          };


### PR DESCRIPTION
## Description

In Lerna 8, the version command is bundled so the patch needs to be applied to `index.js` file in order to work.

Can be tested locally by picking this commit to `24.8` branch and running the following command:

```sh
npx lerna version 24.8.1 --no-push --no-git-tag-version --force-publish --yes
```

Outcome should look like this:

```diff
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@polymer/polymer": "^3.0.0",
-    "@vaadin/component-base": "^24.8.0",
+    "@vaadin/component-base": "~24.8.1",
```

## Type of change

- Internal change