### PR TITLE
fix: add missing core styles to icon.css

### DIFF
--- a/packages/vaadin-lumo-styles/components/icon.css
+++ b/packages/vaadin-lumo-styles/components/icon.css
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+@import '../src/mixins/base-layer-reset.css' vaadin-icon;
 @import '../src/components/icon.css' vaadin-icon;
 
 html {

--- a/packages/vaadin-lumo-styles/src/components/icon.css
+++ b/packages/vaadin-lumo-styles/src/components/icon.css
@@ -4,6 +4,42 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 :host {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  vertical-align: middle;
   width: var(--lumo-icon-size-m);
   height: var(--lumo-icon-size-m);
+  fill: currentColor;
+  container-type: size;
+}
+
+:host::after,
+:host::before {
+  line-height: 1;
+  font-size: 100cqh;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+:host([hidden]) {
+  display: none !important;
+}
+
+svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  /* prevent overflowing icon from clipping, see https://github.com/vaadin/flow-components/issues/5872 */
+  overflow: visible;
+}
+
+:host(:is([icon-class], [font-icon-content])) svg {
+  display: none;
+}
+
+:host([font-icon-content])::before {
+  content: attr(font-icon-content);
 }


### PR DESCRIPTION
## Description

The PR adds missing core styles to `icon.css`.

Part of https://github.com/vaadin/web-components/issues/9082

## Type of change

- [x] Bugfix
