### PR TITLE
feat: notification order property

### DIFF
--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -362,9 +362,9 @@ export const NotificationMixin = (superClass) =>
 
       this._card.slot = this.position;
       if (this._container.firstElementChild && this.position.startsWith('top')) {
-        this._container.insertBefore(this._card, this._container.firstElementChild);
+        this._container.prepend(this._card);
       } else {
-        this._container.appendChild(this._card);
+        this._container.append(this._card);
       }
 
       this._updateCardOrder(this.position);

--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -361,11 +361,13 @@ export const NotificationMixin = (superClass) =>
       this._container.bringToFront();
 
       this._card.slot = this.position;
-      if (this._container.firstElementChild && /top/u.test(this.position)) {
+      if (this._container.firstElementChild && this.position.startsWith('top')) {
         this._container.insertBefore(this._card, this._container.firstElementChild);
       } else {
         this._container.appendChild(this._card);
       }
+
+      this._updateCardOrder(this.position);
     }
 
     /** @private */
@@ -376,6 +378,7 @@ export const NotificationMixin = (superClass) =>
 
       if (this._card.parentNode) {
         this._card.parentNode.removeChild(this._card);
+        this._updateCardOrder(this._card.slot);
       }
       this._card.removeAttribute('closing');
       this._container.opened = Boolean(this._container.firstElementChild);
@@ -422,6 +425,13 @@ export const NotificationMixin = (superClass) =>
           this._durationTimeoutId = setTimeout(() => this.close(), duration);
         }
       }
+    }
+
+    /** @private */
+    _updateCardOrder(position) {
+      this._container.querySelectorAll(`[slot="${position}"]`).forEach((card, i, cards) => {
+        card.style.setProperty('--order', this.position.startsWith('top') ? i + 1 : cards.length - i);
+      });
     }
 
     /**

--- a/packages/notification/test/dom/__snapshots__/notification.test.snap.js
+++ b/packages/notification/test/dom/__snapshots__/notification.test.snap.js
@@ -1,22 +1,24 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-notification card"] = 
+snapshots["vaadin-notification card"] =
 `<vaadin-notification-card
   aria-live="polite"
   role="alert"
   slot="bottom-start"
+  style="--order: 1;"
 >
   content
 </vaadin-notification-card>
 `;
 /* end snapshot vaadin-notification card */
 
-snapshots["vaadin-notification card theme"] = 
+snapshots["vaadin-notification card theme"] =
 `<vaadin-notification-card
   aria-live="polite"
   role="alert"
   slot="bottom-start"
+  style="--order: 1;"
   theme="custom"
 >
   content
@@ -24,26 +26,27 @@ snapshots["vaadin-notification card theme"] =
 `;
 /* end snapshot vaadin-notification card theme */
 
-snapshots["vaadin-notification card class"] = 
+snapshots["vaadin-notification card class"] =
 `<vaadin-notification-card
   aria-live="polite"
   class="custom"
   role="alert"
   slot="bottom-start"
+  style="--order: 1;"
 >
   content
 </vaadin-notification-card>
 `;
 /* end snapshot vaadin-notification card class */
 
-snapshots["vaadin-notification assertive"] = 
+snapshots["vaadin-notification assertive"] =
 `<vaadin-notification-card
   aria-live="assertive"
   role="alert"
   slot="bottom-start"
+  style="--order: 1;"
 >
   content
 </vaadin-notification-card>
 `;
 /* end snapshot vaadin-notification assertive */
-


### PR DESCRIPTION
Add an `--order` property to notification cards based on the slot/position they are in, to help style the cards based on their position in the stack.

Update: I’m not sure this is absolutely needed for #9540, as we might be able to use `:nth-child(1 of [slot="..."]) instead.