### PR TITLE
test: update combo-box unit tests to pass with base styles

### DIFF
--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -252,7 +252,7 @@ describe('pre-opened', () => {
     const comboBox = fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`);
     await nextRender();
     const expectedOverlayWidth = comboBox.clientWidth;
-    const actualOverlayWidth = comboBox.$.overlay.$.content.clientWidth;
+    const actualOverlayWidth = comboBox.$.overlay.$.overlay.offsetWidth;
     expect(actualOverlayWidth).to.eq(expectedOverlayWidth);
   });
 

--- a/packages/combo-box/test/helpers.js
+++ b/packages/combo-box/test/helpers.js
@@ -43,8 +43,11 @@ export const getAllItems = (comboBox) => {
 export const getViewportItems = (comboBox) => {
   const overlayRect = comboBox.$.overlay.$.content.getBoundingClientRect();
 
+  // Take the default 4px border width into account
+  const scrollerTop = parseInt(getComputedStyle(comboBox._scroller.$.selector).borderTopWidth);
+
   // Firefox can produce values like 19.199996948242188
-  const top = Math.round(overlayRect.top);
+  const top = Math.round(overlayRect.top) + scrollerTop;
   const bottom = Math.round(overlayRect.bottom);
 
   return getAllItems(comboBox).filter((item) => {

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -461,6 +461,13 @@ describe('keyboard', () => {
 
   describe('scrolling items', () => {
     beforeEach(async () => {
+      fixtureSync(`
+        <style>
+          vaadin-combo-box-item {
+            min-height: 36px;
+          }
+        </style>
+      `);
       comboBox.open();
       comboBox.items = new Array(100).fill().map((_, idx) => `${idx}`);
       await aTimeout(1);


### PR DESCRIPTION
## Description

Ported some test fixes from the `base-styles` branch, including item `min-height` needed to avoid browser-specific differences causing certain scrolling items tests to behave unexpectedly and fail in Firefox with base styles.

Can be verified with `yarn test:firefox --group combo-box --theme=base`.

## Type of change

- Test