### PR TITLE
test: update component tooltip ITs to pass with base styles

### DIFF
--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -36,7 +36,13 @@ before(() => {
 [
   { tagName: Button.is },
   { tagName: Checkbox.is, ariaTargetSelector: 'input' },
-  { tagName: CheckboxGroup.is },
+  {
+    tagName: CheckboxGroup.is,
+    children: `
+      <vaadin-checkbox label="1" value="1"></vaadin-checkbox>
+      <vaadin-checkbox label="2" value="2"></vaadin-checkbox>
+    `,
+  },
   {
     tagName: ComboBox.is,
     position: 'top',
@@ -78,7 +84,13 @@ before(() => {
   },
   { tagName: NumberField.is, position: 'top', ariaTargetSelector: 'input' },
   { tagName: PasswordField.is, position: 'top', ariaTargetSelector: 'input' },
-  { tagName: RadioGroup.is },
+  {
+    tagName: RadioGroup.is,
+    children: `
+      <vaadin-radio-button label="1" value="1"></vaadin-radio-button>
+      <vaadin-radio-button label="2" value="2"></vaadin-radio-button>
+    `,
+  },
   { tagName: Select.is, position: 'top', ariaTargetSelector: 'vaadin-select-value-button' },
   { tagName: Tab.is },
   { tagName: TextArea.is, position: 'top', ariaTargetSelector: 'textarea' },


### PR DESCRIPTION
## Description

Fixes the following failures with tooltip not shown due to checkbox-group / radio-group zero height without items:

```
test/integration/component-tooltip.test.js:

 ❌ vaadin-checkbox-group with a slotted tooltip > should or should not show tooltip
      AssertionError: expected false to be true
      + expected - actual

      -false
      +true

      at n.<anonymous> (test/integration/component-tooltip.test.js:124:42)

 ❌ vaadin-radio-group with a slotted tooltip > should or should not show tooltip
      AssertionError: expected false to be true
      + expected - actual

      -false
      +true

      at n.<anonymous> (test/integration/component-tooltip.test.js:124:42)
```

## Type of change

- Test

## Note

Remaining IT failures with base styles are caused by dialog and will be covered by https://github.com/vaadin/web-components/pull/9531.