### PR TITLE
fix: limit resizer-container max-width with base styles

### DIFF
--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -144,6 +144,7 @@ const dialogResizableOverlay = css`
       flex-direction: column;
       flex-grow: 1;
       border-radius: inherit;
+      max-width: 100%;
     }
 
     :host(:not([resizable])) .resizer {

--- a/test/integration/dialog-menu-bar.test.js
+++ b/test/integration/dialog-menu-bar.test.js
@@ -12,13 +12,19 @@ describe('menu-bar in dialog', () => {
   let dialog, overlay, menuBar;
 
   beforeEach(async () => {
-    dialog = fixtureSync(`<vaadin-dialog theme="no-padding"></vaadin-dialog>`);
+    fixtureSync(`
+      <style>
+        vaadin-dialog-overlay::part(content) {
+          padding: 0;
+        }
+      </style>
+    `);
+    dialog = fixtureSync(`<vaadin-dialog width="700px"></vaadin-dialog>`);
     dialog.renderer = (root) => {
       if (!root.firstChild) {
-        root.$.overlay.style.width = '700px';
         root.innerHTML = `
           <vaadin-vertical-layout theme="padding spacing" style="width: 100%; align-items: stretch;">
-            <vaadin-menu-bar style="min-width: var(--lumo-size-m);"></vaadin-menu-bar>
+            <vaadin-menu-bar style="min-width: 2.25rem;"></vaadin-menu-bar>
           </vaadin-vertical-layout>
         `;
         const menu = root.querySelector('vaadin-menu-bar');


### PR DESCRIPTION
## Description

This fixes integration test failures with base styles for menu-bar and form-layout tests.

### Before

<img width="741" alt="Screenshot 2025-06-24 at 13 00 10" src="https://github.com/user-attachments/assets/e089a5ee-a837-4c4c-8bfa-3b579024684d" />

### After

<img width="736" alt="Screenshot 2025-06-24 at 13 00 29" src="https://github.com/user-attachments/assets/1c1425c7-3109-4166-96fb-9b4887147122" />

## Type of change

- Bugfix