### PR TITLE
docs: fix JSDoc for all-imports entrypoint to use .js

### DIFF
--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -102,7 +102,7 @@ export type GridDefaultItem = any;
  * - [`<vaadin-grid-tree-toggle>`](#/elements/vaadin-grid-tree-toggle)
  *
  * __Note that the helper elements must be explicitly imported.__
- * If you want to import everything at once you can use the `all-imports.html` bundle.
+ * If you want to import everything at once you can use the `all-imports.js` entrypoint.
  *
  * ### Lazy Loading with Function Data Provider
  *

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -102,7 +102,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
  * - [`<vaadin-grid-tree-toggle>`](#/elements/vaadin-grid-tree-toggle)
  *
  * __Note that the helper elements must be explicitly imported.__
- * If you want to import everything at once you can use the `all-imports.html` bundle.
+ * If you want to import everything at once you can use the `all-imports.js` entrypoint.
  *
  * ### Lazy Loading with Function Data Provider
  *


### PR DESCRIPTION
## Description

Usage of `.html` here is a leftover from V14 and HTML Imports, let's fix to use `.js` instead.

## Type of change

- Documentation