### PR TITLE
test: update popover content test to pass with base styles

### DIFF
--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -493,20 +493,24 @@ describe('popover', () => {
   });
 
   describe('content overflow', () => {
+    let overlayHeight;
+
     beforeEach(async () => {
       popover.renderer = (root) => {
         root.textContent = new Array(2000).fill('foo').join(' ');
       };
       popover.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
+      overlayHeight = overlay.getBoundingClientRect().height;
     });
 
     it('should limit overlay height if content overflows the viewport', () => {
-      expect(overlay.$.overlay.getBoundingClientRect().height).to.equal(overlay.getBoundingClientRect().height);
+      expect(overlay.$.overlay.getBoundingClientRect().height).to.equal(overlayHeight);
     });
 
     it('should limit content height if content overflows the viewport', () => {
-      expect(overlay.$.content.getBoundingClientRect().height).to.equal(overlay.getBoundingClientRect().height);
+      const border = parseInt(getComputedStyle(overlay.$.overlay).borderTopWidth);
+      expect(overlay.$.content.getBoundingClientRect().height).to.equal(overlayHeight - border * 2);
     });
   });
 


### PR DESCRIPTION
## Description

Updated a test to pass with base styles where `border` is set on the `[part='overlay']`.
Can be verified by using `yarn test --group popover --theme=base`.

## Type of change

- Test