### PR TITLE
chore: update replace-in-file dev dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "postcss-lit": "^1.2.0",
     "prettier": "^3.6.0",
     "prettier-plugin-package": "^1.4.0",
-    "replace-in-file": "^6.3.5",
+    "replace-in-file": "^8.3.0",
     "rimraf": "^6.0.1",
     "rollup": "^4.4.0",
     "stylelint": "^16.21.0",

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from 'cross-spawn';
-import replace from 'replace-in-file';
+import { replaceInFile } from 'replace-in-file';
 import lerna from '../lerna.json' with { type: 'json' };
 
 const { version: oldVersion } = lerna;
@@ -45,7 +45,7 @@ if (!version) {
 async function main() {
   const fromRegex = new RegExp(`'${oldVersion.split('.').join('\\.')}'`, 'gu');
   const newVersion = `'${version.replace(/^v/u, '')}'`;
-  const results = await replace({
+  const results = await replaceInFile({
     files: ['packages/component-base/src/define.js'],
     from: fromRegex,
     to: newVersion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5732,7 +5732,7 @@ glob-watcher@^6.0.0:
     async-done "^2.0.0"
     chokidar "^3.5.3"
 
-glob@^10.0.0, glob@^10.2.2, glob@^10.3.10:
+glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.4.2:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
   integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
@@ -5756,7 +5756,7 @@ glob@^11.0.0, glob@^11.0.2:
     package-json-from-dist "^1.0.0"
     path-scurry "^2.0.0"
 
-glob@^7.1.3, glob@^7.2.0:
+glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -9640,14 +9640,14 @@ replace-homedir@^2.0.0:
   resolved "https://registry.yarnpkg.com/replace-homedir/-/replace-homedir-2.0.0.tgz#245bd9c909275e0beee75eae85bb40780cd61903"
   integrity sha512-bgEuQQ/BHW0XkkJtawzrfzHFSN70f/3cNOiHa2QsYxqrjaC30X1k74FJ6xswVBP0sr0SpGIdVFuPwfrYziVeyw==
 
-replace-in-file@^6.3.5:
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.5.tgz#ff956b0ab5bc96613207d603d197cd209400a654"
-  integrity sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==
+replace-in-file@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-8.3.0.tgz#53288f516fb8f3edc125c3af6b4b6adc2e5955bf"
+  integrity sha512-4VhddQiMCPIuypiwHDTM+XHjZoVu9h7ngBbSCnwGRcwdHwxltjt/m//Ep3GDwqaOx1fDSrKFQ+n7uo4uVcEz9Q==
   dependencies:
-    chalk "^4.1.2"
-    glob "^7.2.0"
-    yargs "^17.2.1"
+    chalk "^5.3.0"
+    glob "^10.4.2"
+    yargs "^17.7.2"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Description

As the project now uses ES modules for scripts, we can upgrade `replace-in-file` to v8.

## Type of change

- Internal change