### PR TITLE
refactor: drop legacy -webkit-sticky fallback

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-core-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-core-styles.js
@@ -76,7 +76,6 @@ export const gridStyles = css`
   #header,
   #footer {
     display: block;
-    position: -webkit-sticky;
     position: sticky;
     left: 0;
     overflow: visible;
@@ -105,7 +104,6 @@ export const gridStyles = css`
     flex-grow: 1;
     flex-shrink: 0;
     display: block;
-    position: -webkit-sticky;
     position: sticky;
     width: 100%;
     left: 0;


### PR DESCRIPTION
## Description

The `position: sticky` is widely supported in all modern browsers without vendor prefixes.

Related to #9520 

## Type of change

- [x] Refactor
