### PR TITLE
test: move imports in visual tests to prevent warnings

### DIFF
--- a/packages/confirm-dialog/test/visual/lumo/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/visual/lumo/confirm-dialog.test.js
@@ -3,8 +3,8 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/global.css';
 import '@vaadin/vaadin-lumo-styles/props.css';
 import '@vaadin/vaadin-lumo-styles/components/confirm-dialog.css';
-import '../../../vaadin-confirm-dialog.js';
 import '../../not-animated-styles.js';
+import '../../../vaadin-confirm-dialog.js';
 
 describe('confirm-dialog', () => {
   let div, element;

--- a/packages/field-highlighter/test/visual/lumo/field-highlighter.test.js
+++ b/packages/field-highlighter/test/visual/lumo/field-highlighter.test.js
@@ -11,6 +11,7 @@ import '@vaadin/vaadin-lumo-styles/components/item.css';
 import '@vaadin/vaadin-lumo-styles/components/radio-group.css';
 import '@vaadin/vaadin-lumo-styles/components/text-area.css';
 import '@vaadin/vaadin-lumo-styles/components/text-field.css';
+import '../common.js';
 import '@vaadin/checkbox';
 import '@vaadin/checkbox-group';
 import '@vaadin/date-time-picker';
@@ -19,7 +20,6 @@ import '@vaadin/list-box';
 import '@vaadin/radio-group';
 import '@vaadin/text-area';
 import '@vaadin/text-field';
-import '../common.js';
 import '../../../vaadin-field-highlighter.js';
 import { setUsers } from '../helpers.js';
 


### PR DESCRIPTION
## Description

This makes test styles imported before the components to avoid following warnings:

```
packages/confirm-dialog/test/visual/lumo/confirm-dialog.test.js:

 🚧 Browser logs:
      The custom element definition for "vaadin-confirm-dialog-overlay" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting "window.Vaadin.suppressPostFinalizeStylesWarning = true".

packages/field-highlighter/test/visual/lumo/field-highlighter.test.js:

 🚧 Browser logs:
      The custom element definition for "vaadin-text-field" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting "window.Vaadin.suppressPostFinalizeStylesWarning = true".
```

## Type of change

- Test