### PR TITLE
chore: prevent FOUC in dev pages with ported Lumo styles

### DIFF
--- a/dev/accordion.html
+++ b/dev/accordion.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Accordion</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/accordion';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/app-layout.html
+++ b/dev/app-layout.html
@@ -9,6 +9,8 @@
     <!-- possible content values: default, black or black-translucent -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>App Layout</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <style>
@@ -79,8 +81,6 @@
       import '@vaadin/button';
       import '@vaadin/icon';
       import '@vaadin/icons';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       document.querySelector('vaadin-button').addEventListener('click', () => {
         document.querySelector('vaadin-app-layout').classList.toggle('small-drawer');

--- a/dev/avatar-group.html
+++ b/dev/avatar-group.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Avatar Group</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/avatar-group';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const groups = document.querySelectorAll('vaadin-avatar-group');
       groups.forEach((group) => (group.items = [{ name: 'AA' }, { name: 'BB' }, { name: 'CC' }, { name: 'DD' }]));

--- a/dev/avatar.html
+++ b/dev/avatar.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Avatar</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/avatar';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/button.html
+++ b/dev/button.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Button</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
@@ -17,8 +19,6 @@
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/card.html
+++ b/dev/card.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Card</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
@@ -17,8 +19,6 @@
       import '@vaadin/icons';
       import '@vaadin/select';
       import '@vaadin/scroller';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/icons.js';
 
       const playground = document.querySelector('.playground');

--- a/dev/charts/lumo/area.html
+++ b/dev/charts/lumo/area.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | area</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/arearange.html
+++ b/dev/charts/lumo/arearange.html
@@ -12,11 +12,11 @@
           series.values = data;
         });
     </script>
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/areaspline.html
+++ b/dev/charts/lumo/areaspline.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | area spline</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/areasplinerange.html
+++ b/dev/charts/lumo/areasplinerange.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | area spline range</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <script defer>

--- a/dev/charts/lumo/bar.html
+++ b/dev/charts/lumo/bar.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | bar</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/boxplot.html
+++ b/dev/charts/lumo/boxplot.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | box plot</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/bubble.html
+++ b/dev/charts/lumo/bubble.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | bubble</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/bullet.html
+++ b/dev/charts/lumo/bullet.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | bullet</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/candlestick.html
+++ b/dev/charts/lumo/candlestick.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | candle stick</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <script defer>

--- a/dev/charts/lumo/column.html
+++ b/dev/charts/lumo/column.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | column</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/columnrange.html
+++ b/dev/charts/lumo/columnrange.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | column range</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <script defer>

--- a/dev/charts/lumo/errorbar.html
+++ b/dev/charts/lumo/errorbar.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | error bar</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/funnel.html
+++ b/dev/charts/lumo/funnel.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | funnel</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/gantt.html
+++ b/dev/charts/lumo/gantt.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | gantt</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <style>

--- a/dev/charts/lumo/gauge.html
+++ b/dev/charts/lumo/gauge.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | gauge</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/gaugedual.html
+++ b/dev/charts/lumo/gaugedual.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | gauge with dual axes</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/heatmap.html
+++ b/dev/charts/lumo/heatmap.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | heatmap</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/line.html
+++ b/dev/charts/lumo/line.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | line</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/ohlc.html
+++ b/dev/charts/lumo/ohlc.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | ohlc</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <script defer>

--- a/dev/charts/lumo/organization.html
+++ b/dev/charts/lumo/organization.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | organization</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/pie.html
+++ b/dev/charts/lumo/pie.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | pie</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/polar.html
+++ b/dev/charts/lumo/polar.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | polar</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/polygon.html
+++ b/dev/charts/lumo/polygon.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | polygon</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <script defer>

--- a/dev/charts/lumo/pyramid.html
+++ b/dev/charts/lumo/pyramid.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | pyramid</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/scatter.html
+++ b/dev/charts/lumo/scatter.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | scatter</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
     <script defer>

--- a/dev/charts/lumo/solidgauge.html
+++ b/dev/charts/lumo/solidgauge.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | solid gauge</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/spiderweb.html
+++ b/dev/charts/lumo/spiderweb.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | spiderweb</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/timeline.html
+++ b/dev/charts/lumo/timeline.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | timeline</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/treemap.html
+++ b/dev/charts/lumo/treemap.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | treemap</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/charts/lumo/waterfall.html
+++ b/dev/charts/lumo/waterfall.html
@@ -4,11 +4,11 @@
     <title>Vaadin charts | treemap</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../../../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="../../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '../theme-switcher.js';
     </script>
   </head>

--- a/dev/checkbox-group.html
+++ b/dev/checkbox-group.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Checkbox Group</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/checkbox-group';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
 
     <style>

--- a/dev/checkbox.html
+++ b/dev/checkbox.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Checkbox</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/checkbox';
       import '@vaadin/icon';
       import '@vaadin/icons';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/combo-box.html
+++ b/dev/combo-box.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Combo Box</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/combo-box';
       import '@vaadin/icon';
       import '@vaadin/icons';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/confirm-dialog.html
+++ b/dev/confirm-dialog.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Confirm dialog</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/confirm-dialog';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
   <body>

--- a/dev/context-menu.html
+++ b/dev/context-menu.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Context Menu</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/context-menu';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const menu = document.querySelector('vaadin-context-menu');
       menu.items = [

--- a/dev/dashboard-layout.html
+++ b/dev/dashboard-layout.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard layout</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/dashboard/vaadin-dashboard-layout.js';
       import '@vaadin/dashboard/vaadin-dashboard-widget.js';
       import '@vaadin/dashboard/vaadin-dashboard-section.js';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
 
     <style>

--- a/dev/dashboard.html
+++ b/dev/dashboard.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <style>
@@ -33,8 +35,6 @@
 
     <script type="module">
       import '@vaadin/dashboard';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const dashboard = document.querySelector('vaadin-dashboard');
 

--- a/dev/date-picker.html
+++ b/dev/date-picker.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Date Picker</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/date-picker';
       import '@vaadin/icon';
       import '@vaadin/icons';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 
       const isDateDisabled = (date) => {

--- a/dev/date-time-picker.html
+++ b/dev/date-time-picker.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Date Time picker</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
     <script type="module">
       import '@vaadin/date-time-picker';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
   <body>

--- a/dev/details.html
+++ b/dev/details.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Details</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/details';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/dialog.html
+++ b/dev/dialog.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dialog</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
@@ -14,8 +16,6 @@
       import '@vaadin/dialog';
       import '@vaadin/icon';
       import '@vaadin/icons';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
 
     <style>

--- a/dev/email-field.html
+++ b/dev/email-field.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Email field</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/email-field';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/field-highlighter.html
+++ b/dev/field-highlighter.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Field highlighter</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
   </head>
 
@@ -23,8 +25,6 @@
 
     <script type="module">
       import '@vaadin/checkbox-group';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       // import '@vaadin/date-time-picker';
       // import '@vaadin/text-area';
       import { FieldHighlighter } from '@vaadin/field-highlighter';

--- a/dev/form-layout-auto-responsive.html
+++ b/dev/form-layout-auto-responsive.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" />
     <title>Form Layout</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <style>
@@ -33,8 +35,6 @@
       import '@vaadin/tabsheet';
       import '@vaadin/text-area';
       import '@vaadin/text-field';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import { html, LitElement, render } from 'lit';
       import { dialogRenderer } from '@vaadin/dialog/lit.js';
 

--- a/dev/form-layout.html
+++ b/dev/form-layout.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Form Layout</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
@@ -12,8 +14,6 @@
       import '@vaadin/form-layout/vaadin-form-item.js';
       import '@vaadin/text-field';
       import '@vaadin/password-field';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
 
     <style>

--- a/dev/horizontal-layout.html
+++ b/dev/horizontal-layout.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Horizontal layout</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/horizontal-layout';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/icon.html
+++ b/dev/icon.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Icon</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons/vaadin-iconset.js';
       import '@vaadin/vaadin-lumo-styles/font-icons.js';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/tooltip';
       import { Iconset } from '@vaadin/icon/vaadin-iconset.js';
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,10 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dev pages</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/props.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
     <script type="module" src="./dev/common.js"></script>
-    <script type="module">
-      import '@vaadin/vaadin-lumo-styles/global.css';
-    </script>
   </head>
   <body>
     <h1>Web Component development pages</h1>

--- a/dev/integer-field.html
+++ b/dev/integer-field.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Integer field</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/integer-field';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/list-box.html
+++ b/dev/list-box.html
@@ -6,14 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>List box</title>
     <script type="module" src="./common.js"></script>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
   </head>
   <body>
     <script type="module">
       import '@vaadin/list-box';
       import '@vaadin/item';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
 
     <vaadin-list-box multiple selected-values="[0]" style="width: 200px">

--- a/dev/login-form.html
+++ b/dev/login-form.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login form</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/login/vaadin-login-form.js';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/login-overlay.html
+++ b/dev/login-overlay.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login overlay</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/login/vaadin-login-overlay.js';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const login = document.querySelector('vaadin-login-overlay');
       login.addEventListener('login', () => {

--- a/dev/map.html
+++ b/dev/map.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Map</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
   </head>
   <body>
     <script type="module">
       import '@vaadin/map';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import TileLayer from 'ol/layer/Tile';
       import OSM from 'ol/source/OSM';
       import View from 'ol/View';

--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Menu bar</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/menu-bar';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const menuBar = document.querySelector('vaadin-menu-bar');
       menuBar.items = [

--- a/dev/messages.html
+++ b/dev/messages.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Messages</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/message-input';
       import '@vaadin/message-list';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const list = document.querySelector('vaadin-message-list');
       list.items = [

--- a/dev/multi-select-combo-box.html
+++ b/dev/multi-select-combo-box.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Multi Select Combo box</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/multi-select-combo-box';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
   <body>

--- a/dev/notification.html
+++ b/dev/notification.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Notification</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
   </head>
 
@@ -14,8 +16,6 @@
     <script type="module">
       import '@vaadin/button';
       import '@vaadin/notification';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const notification = document.querySelector('vaadin-notification');
       notification.renderer = (root) => {

--- a/dev/number-field.html
+++ b/dev/number-field.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Number field</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/number-field';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/password-field.html
+++ b/dev/password-field.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Password Field</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/password-field';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/popover.html
+++ b/dev/popover.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Popover</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
@@ -12,8 +14,6 @@
       import '@vaadin/horizontal-layout';
       import '@vaadin/popover';
       import '@vaadin/text-field';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/progress-bar.html
+++ b/dev/progress-bar.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Progress Bar</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
     <script type="module">
       import '@vaadin/progress-bar';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
   <body>

--- a/dev/radio-group.html
+++ b/dev/radio-group.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Radio Group</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/radio-group';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
 
     <style>

--- a/dev/rich-text-editor.html
+++ b/dev/rich-text-editor.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RTE</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/rich-text-editor';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/scroller.html
+++ b/dev/scroller.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Scroller</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
     <script type="module">
       import '@vaadin/scroller';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       document.querySelectorAll('.content').forEach((content) => {
         content.textContent = new Array(1000).fill('content').join(' ');

--- a/dev/select.html
+++ b/dev/select.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Select</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/select';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/side-nav.html
+++ b/dev/side-nav.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Side nav</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/side-nav';
       import '@vaadin/radio-group';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       const icons = [
         'vaadin:home',

--- a/dev/split-layout.html
+++ b/dev/split-layout.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Split Layout</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/split-layout';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
 
       document.querySelectorAll('.first').forEach((el) => {
         el.textContent = new Array(1000).fill('a').join(' ');

--- a/dev/tabs.html
+++ b/dev/tabs.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tabs</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/tabs';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
 

--- a/dev/text-area.html
+++ b/dev/text-area.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Text Area</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/text-area';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/text-field.html
+++ b/dev/text-field.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Text Field</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/text-field';
       import '@vaadin/icon';
       import '@vaadin/icons';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/time-picker.html
+++ b/dev/time-picker.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Time Picker</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/time-picker';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
     </script>
   </head>

--- a/dev/tooltip.html
+++ b/dev/tooltip.html
@@ -5,12 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tooltip</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
     <script type="module">
       import '@vaadin/radio-group';
       import '@vaadin/tooltip';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
     </script>
   </head>
   <body>

--- a/dev/upload.html
+++ b/dev/upload.html
@@ -5,13 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Upload</title>
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">
+    <link rel="stylesheet" href="../packages/vaadin-lumo-styles/lumo.css">
     <script type="module" src="./common.js"></script>
 
     <script type="module">
       import '@vaadin/radio-group';
       import '@vaadin/upload';
-      import '@vaadin/vaadin-lumo-styles/global.css';
-      import '@vaadin/vaadin-lumo-styles/lumo.css';
       import { createFiles, xhrCreator } from '@vaadin/upload/test/helpers.js';
 
       const nextUpload = document.querySelector('#next-upload');

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -44,7 +44,10 @@ export function enforceThemePlugin(theme) {
       let { body } = context;
 
       if (theme === 'legacy-lumo' && context.response.is('html', 'js')) {
-        body = body.replace('vaadin-lumo-styles/global.css', 'vaadin-lumo-styles/test/autoload.js');
+        body = body.replace(
+          '<link rel="stylesheet" href="../packages/vaadin-lumo-styles/global.css">',
+          '<script type="module" src="../packages/vaadin-lumo-styles/test/autoload.js"></script>',
+        );
       }
 
       if (['base', 'legacy-lumo'].includes(theme) && context.response.is('html', 'js')) {


### PR DESCRIPTION
## Description

Prevents flashing of unstyled or base styles components by moving the Lumo CSS imports into `<link>` tags. `web-dev-server.config.js` was updated to replace the link for the global CSS with a script to include the legacy auto load script when not using ported Lumo styles.

## Type of change

- Internal
