### PR TITLE
refactor: drop legacy -webkit-mask fallback

### DIFF
--- a/packages/avatar-group/src/styles/vaadin-avatar-group-core-styles.js
+++ b/packages/avatar-group/src/styles/vaadin-avatar-group-core-styles.js
@@ -26,25 +26,17 @@ export const avatarGroupStyles = css`
   }
 
   ::slotted(vaadin-avatar:not(:first-child)) {
-    -webkit-mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
     mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
-    -webkit-mask-size: calc(
-      300% + var(--vaadin-avatar-group-overlap-border) * 6 - var(--vaadin-avatar-outline-width) * 6
-    );
     mask-size: calc(300% + var(--vaadin-avatar-group-overlap-border) * 6 - var(--vaadin-avatar-outline-width) * 6);
   }
 
   ::slotted(vaadin-avatar:not([dir='rtl']):not(:first-child)) {
     margin-left: calc(var(--vaadin-avatar-group-overlap) * -1 - var(--vaadin-avatar-outline-width));
-    -webkit-mask-position: calc(50% - var(--vaadin-avatar-size) + var(--vaadin-avatar-group-overlap));
     mask-position: calc(50% - var(--vaadin-avatar-size) + var(--vaadin-avatar-group-overlap));
   }
 
   ::slotted(vaadin-avatar[dir='rtl']:not(:first-child)) {
     margin-right: calc(var(--vaadin-avatar-group-overlap) * -1);
-    -webkit-mask-position: calc(
-      50% + var(--vaadin-avatar-size) - var(--vaadin-avatar-group-overlap) + var(--vaadin-avatar-outline-width)
-    );
     mask-position: calc(
       50% + var(--vaadin-avatar-size) - var(--vaadin-avatar-group-overlap) + var(--vaadin-avatar-outline-width)
     );

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-content-styles.js
@@ -40,7 +40,6 @@ registerStyles(
             + var(--lumo-space-s)
           );
       --vaadin-infinite-scroller-buffer-offset: 10%;
-      -webkit-mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
       mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
       position: relative;
     }
@@ -51,7 +50,6 @@ registerStyles(
       width: 57px;
       font-size: var(--lumo-font-size-s);
       box-shadow: inset 2px 0 4px 0 var(--lumo-shade-5pct);
-      -webkit-mask-image: linear-gradient(transparent, #000 35%, #000 65%, transparent);
       mask-image: linear-gradient(transparent, #000 35%, #000 65%, transparent);
       cursor: var(--lumo-clickable-cursor);
     }

--- a/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
+++ b/packages/date-picker/theme/lumo/vaadin-date-picker-overlay-styles.js
@@ -29,7 +29,6 @@ const datePickerOverlay = css`
     padding: 0;
     height: 100%;
     overflow: hidden;
-    -webkit-mask-image: none;
     mask-image: none;
   }
 

--- a/packages/field-highlighter/theme/lumo/vaadin-field-outline-styles.js
+++ b/packages/field-highlighter/theme/lumo/vaadin-field-outline-styles.js
@@ -12,7 +12,6 @@ registerStyles(
   css`
     :host {
       transition: opacity 0.3s;
-      -webkit-mask-image: none !important;
       mask-image: none !important;
     }
 

--- a/packages/input-container/theme/lumo/vaadin-input-container-styles.js
+++ b/packages/input-container/theme/lumo/vaadin-input-container-styles.js
@@ -65,7 +65,6 @@ registerStyles(
       min-height: var(--vaadin-input-field-height, var(--_input-height));
       padding: 0 0.25em;
       --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
-      -webkit-mask-image: var(--_lumo-text-field-overflow-mask-image);
       mask-image: var(--_lumo-text-field-overflow-mask-image);
     }
 

--- a/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
+++ b/packages/multi-select-combo-box/theme/lumo/vaadin-multi-select-combo-box-styles.js
@@ -77,7 +77,6 @@ const multiSelectComboBox = css`
     min-height: auto;
     padding: 0.3125em calc(0.5em + var(--lumo-border-radius-s) / 4);
     color: var(--lumo-body-text-color);
-    -webkit-mask-image: none;
     mask-image: none;
   }
 

--- a/packages/tabs/theme/lumo/vaadin-tabs-styles.js
+++ b/packages/tabs/theme/lumo/vaadin-tabs-styles.js
@@ -73,7 +73,6 @@ registerStyles(
 
     [part='tabs'] {
       --_lumo-tabs-overflow-mask-image: none;
-      -webkit-mask-image: var(--_lumo-tabs-overflow-mask-image);
       mask-image: var(--_lumo-tabs-overflow-mask-image);
     }
 

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -38,7 +38,6 @@ const inputField = css`
   }
 
   :host([focused]) [part='input-field'] ::slotted(:is(input, textarea)) {
-    -webkit-mask-image: none;
     mask-image: none;
   }
 
@@ -73,7 +72,7 @@ const inputField = css`
      the ring is only visible / has a width when the respective CSS property is
      "enabled" using a value of 1 */
   :host([focused]) [part='input-field'] {
-    /* Borders are implemented using box-shadows as well. To avoid overriding 
+    /* Borders are implemented using box-shadows as well. To avoid overriding
        the border on focus, even if the pointer focus-ring is disabled, we need to:
        - Duplicate the border box shadow for this rule
        - Remove the border (by using width of 0) when the focus-ring is visible,

--- a/packages/vaadin-lumo-styles/mixins/menu-overlay.js
+++ b/packages/vaadin-lumo-styles/mixins/menu-overlay.js
@@ -69,7 +69,6 @@ const menuOverlayExt = css`
       box-sizing: border-box;
       -webkit-overflow-scrolling: touch;
       overflow: auto;
-      -webkit-mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
       mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
     }
 

--- a/packages/vaadin-lumo-styles/src/components/avatar-group.css
+++ b/packages/vaadin-lumo-styles/src/components/avatar-group.css
@@ -24,25 +24,17 @@
 }
 
 ::slotted(vaadin-avatar:not(:first-child)) {
-  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
   mask-image: url('data:image/svg+xml;utf8,<svg viewBox=%220 0 300 300%22 fill=%22none%22 xmlns=%22http://www.w3.org/2000/svg%22><path fill-rule=%22evenodd%22 clip-rule=%22evenodd%22 d=%22M300 0H0V300H300V0ZM150 200C177.614 200 200 177.614 200 150C200 122.386 177.614 100 150 100C122.386 100 100 122.386 100 150C100 177.614 122.386 200 150 200Z%22 fill=%22black%22/></svg>');
-  -webkit-mask-size: calc(
-    300% + var(--vaadin-avatar-group-overlap-border) * 6 - var(--vaadin-avatar-outline-width) * 6
-  );
   mask-size: calc(300% + var(--vaadin-avatar-group-overlap-border) * 6 - var(--vaadin-avatar-outline-width) * 6);
 }
 
 ::slotted(vaadin-avatar:not([dir='rtl']):not(:first-child)) {
   margin-left: calc(var(--vaadin-avatar-group-overlap) * -1 - var(--vaadin-avatar-outline-width));
-  -webkit-mask-position: calc(50% - var(--vaadin-avatar-size) + var(--vaadin-avatar-group-overlap));
   mask-position: calc(50% - var(--vaadin-avatar-size) + var(--vaadin-avatar-group-overlap));
 }
 
 ::slotted(vaadin-avatar[dir='rtl']:not(:first-child)) {
   margin-right: calc(var(--vaadin-avatar-group-overlap) * -1);
-  -webkit-mask-position: calc(
-    50% + var(--vaadin-avatar-size) - var(--vaadin-avatar-group-overlap) + var(--vaadin-avatar-outline-width)
-  );
   mask-position: calc(
     50% + var(--vaadin-avatar-size) - var(--vaadin-avatar-group-overlap) + var(--vaadin-avatar-outline-width)
   );

--- a/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-overlay-content.css
@@ -53,7 +53,6 @@
         + var(--lumo-space-s)
       );
   --vaadin-infinite-scroller-buffer-offset: 10%;
-  -webkit-mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
   mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
   position: relative;
 }
@@ -67,7 +66,6 @@
   bottom: 0;
   font-size: var(--lumo-font-size-s);
   box-shadow: inset 2px 0 4px 0 var(--lumo-shade-5pct);
-  -webkit-mask-image: linear-gradient(transparent, #000 35%, #000 65%, transparent);
   mask-image: linear-gradient(transparent, #000 35%, #000 65%, transparent);
   cursor: var(--lumo-clickable-cursor);
 }

--- a/packages/vaadin-lumo-styles/src/components/date-picker-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/date-picker-overlay.css
@@ -32,7 +32,6 @@
   padding: 0;
   height: 100%;
   overflow: hidden;
-  -webkit-mask-image: none;
   mask-image: none;
 }
 

--- a/packages/vaadin-lumo-styles/src/components/field-outline.css
+++ b/packages/vaadin-lumo-styles/src/components/field-outline.css
@@ -15,7 +15,6 @@
   opacity: 0;
   --_active-user-color: transparent;
   transition: opacity 0.3s;
-  -webkit-mask-image: none !important;
   mask-image: none !important;
 }
 

--- a/packages/vaadin-lumo-styles/src/components/input-container.css
+++ b/packages/vaadin-lumo-styles/src/components/input-container.css
@@ -109,7 +109,6 @@
   min-height: var(--vaadin-input-field-height, var(--_input-height));
   padding: 0 0.25em;
   --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
-  -webkit-mask-image: var(--_lumo-text-field-overflow-mask-image);
   mask-image: var(--_lumo-text-field-overflow-mask-image);
 }
 

--- a/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
@@ -60,7 +60,6 @@
   min-height: auto;
   padding: 0.3125em calc(0.5em + var(--lumo-border-radius-s) / 4);
   color: var(--lumo-body-text-color);
-  -webkit-mask-image: none;
   mask-image: none;
 }
 

--- a/packages/vaadin-lumo-styles/src/components/tabs.css
+++ b/packages/vaadin-lumo-styles/src/components/tabs.css
@@ -107,7 +107,6 @@
 
 [part='tabs'] {
   --_lumo-tabs-overflow-mask-image: none;
-  -webkit-mask-image: var(--_lumo-tabs-overflow-mask-image);
   mask-image: var(--_lumo-tabs-overflow-mask-image);
 }
 

--- a/packages/vaadin-lumo-styles/src/mixins/field-base.css
+++ b/packages/vaadin-lumo-styles/src/mixins/field-base.css
@@ -44,7 +44,6 @@
 }
 
 :host([focused]) [part='input-field'] ::slotted(:is(input, textarea)) {
-  -webkit-mask-image: none;
   mask-image: none;
 }
 

--- a/packages/vaadin-lumo-styles/src/mixins/menu-overlay-ext.css
+++ b/packages/vaadin-lumo-styles/src/mixins/menu-overlay-ext.css
@@ -26,7 +26,6 @@
     box-sizing: border-box;
     -webkit-overflow-scrolling: touch;
     overflow: auto;
-    -webkit-mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
     mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
   }
 


### PR DESCRIPTION
## Description

The `mask` property is widely supported in all modern browsers and no longer requires vendor prefixes.

## Type of change

- [x] Refactor
