### PR TITLE
refactor: remove vendor prefixes from appearance CSS property

### DIFF
--- a/packages/field-base/src/styles/checkable-core-styles.js
+++ b/packages/field-base/src/styles/checkable-core-styles.js
@@ -57,7 +57,7 @@ export const checkable = (part, propName = part) => css`
     cursor: inherit;
     margin: 0;
     align-self: stretch;
-    -webkit-appearance: none;
+    appearance: none;
     width: initial;
     height: initial;
   }

--- a/packages/input-container/src/styles/vaadin-input-container-core-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-core-styles.js
@@ -38,8 +38,7 @@ export const inputContainerStyles = css`
 
   /* Reset the native input styles */
   ::slotted(input) {
-    -webkit-appearance: none;
-    -moz-appearance: none;
+    appearance: none;
     flex: auto;
     white-space: nowrap;
     overflow: hidden;

--- a/packages/map/src/styles/vaadin-map-core-styles.js
+++ b/packages/map/src/styles/vaadin-map-core-styles.js
@@ -169,7 +169,7 @@ export const mapStyles = css`
   }
 
   .ol-control button {
-    -webkit-appearance: none;
+    appearance: none;
     border: 0;
     margin: 0;
     padding: 0;

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -87,12 +87,12 @@ export const NumberFieldMixin = (superClass) =>
         `
           ${tag} input[type="number"]::-webkit-outer-spin-button,
           ${tag} input[type="number"]::-webkit-inner-spin-button {
-            -webkit-appearance: none;
+            appearance: none;
             margin: 0;
           }
 
           ${tag} input[type="number"] {
-            -moz-appearance: textfield;
+            appearance: textfield;
           }
 
           ${tag}[dir='rtl'] input[type="number"]::placeholder {

--- a/packages/side-nav/src/styles/vaadin-side-nav-item-core-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-core-styles.js
@@ -35,7 +35,6 @@ export const sideNavItemStyles = css`
   }
 
   button {
-    -webkit-appearance: none;
     appearance: none;
     flex: none;
     position: relative;

--- a/packages/text-area/src/styles/vaadin-text-area-core-styles.js
+++ b/packages/text-area/src/styles/vaadin-text-area-core-styles.js
@@ -24,8 +24,7 @@ export const textAreaStyles = css`
   }
 
   ::slotted(textarea) {
-    -webkit-appearance: none;
-    -moz-appearance: none;
+    appearance: none;
     flex: auto;
     overflow: hidden;
     width: 100%;

--- a/packages/vaadin-lumo-styles/src/components/input-container.css
+++ b/packages/vaadin-lumo-styles/src/components/input-container.css
@@ -70,8 +70,7 @@
 
 /* Reset the native input styles */
 ::slotted(input) {
-  -webkit-appearance: none;
-  -moz-appearance: none;
+  appearance: none;
   flex: auto;
   white-space: nowrap;
   overflow: hidden;

--- a/packages/vaadin-lumo-styles/src/components/map.css
+++ b/packages/vaadin-lumo-styles/src/components/map.css
@@ -311,7 +311,7 @@
 }
 
 .ol-control button {
-  -webkit-appearance: none;
+  appearance: none;
   border: 0;
   margin: 0;
   padding: 0;

--- a/packages/vaadin-lumo-styles/src/components/side-nav-item.css
+++ b/packages/vaadin-lumo-styles/src/components/side-nav-item.css
@@ -44,7 +44,6 @@
 }
 
 button {
-  -webkit-appearance: none;
   appearance: none;
   flex: none;
   position: relative;

--- a/packages/vaadin-lumo-styles/src/components/text-area.css
+++ b/packages/vaadin-lumo-styles/src/components/text-area.css
@@ -15,8 +15,7 @@
 }
 
 ::slotted(textarea) {
-  -webkit-appearance: none;
-  -moz-appearance: none;
+  appearance: none;
   flex: auto;
   overflow: hidden;
   width: 100%;

--- a/packages/vaadin-lumo-styles/src/mixins/checkable-field.css
+++ b/packages/vaadin-lumo-styles/src/mixins/checkable-field.css
@@ -59,7 +59,7 @@
   cursor: inherit;
   margin: 0;
   align-self: stretch;
-  -webkit-appearance: none;
+  appearance: none;
   width: initial;
   height: initial;
 }


### PR DESCRIPTION
## Description

The `appearance` CSS property is supported without vendor prefixes in all modern browsers.

![image](https://github.com/user-attachments/assets/fef016d3-bcb7-423b-a8c2-74148536eeae)

## Type of change

- [x] Refactor
