### PR TITLE
refactor: remove obsolete @supports wrappers

### DIFF
--- a/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
+++ b/packages/side-nav/theme/lumo/vaadin-side-nav-item-styles.js
@@ -72,17 +72,15 @@ export const sideNavItemStyles = css`
     transform: none;
   }
 
-  @supports selector(:focus-visible) {
-    [part='link'],
-    [part='toggle-button'] {
-      outline: none;
-    }
+  [part='link'],
+  [part='toggle-button'] {
+    outline: none;
+  }
 
-    [part='link']:focus-visible,
-    [part='toggle-button']:focus-visible {
-      border-radius: var(--lumo-border-radius-m);
-      box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
-    }
+  [part='link']:focus-visible,
+  [part='toggle-button']:focus-visible {
+    border-radius: var(--lumo-border-radius-m);
+    box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
   }
 
   [part='link']:active {

--- a/packages/vaadin-lumo-styles/src/components/side-nav-item.css
+++ b/packages/vaadin-lumo-styles/src/components/side-nav-item.css
@@ -125,17 +125,15 @@ slot:not([name]) {
   transform: none;
 }
 
-@supports selector(:focus-visible) {
-  [part='link'],
-  [part='toggle-button'] {
-    outline: none;
-  }
+[part='link'],
+[part='toggle-button'] {
+  outline: none;
+}
 
-  [part='link']:focus-visible,
-  [part='toggle-button']:focus-visible {
-    border-radius: var(--lumo-border-radius-m);
-    box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
-  }
+[part='link']:focus-visible,
+[part='toggle-button']:focus-visible {
+  border-radius: var(--lumo-border-radius-m);
+  box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
 }
 
 [part='link']:active {


### PR DESCRIPTION
## Description

This PR removes `@supports` wrappers for properties that are now supported across all modern browsers.

## Type of change

- [x] Bugfix
