### PR TITLE
refactor: update dashboard styles, fix unit tests to use src version

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-button-core-styles.d.ts
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-core-styles.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import type { CSSResult } from 'lit';
+
+export const dashboardButtonStyles: CSSResult;

--- a/packages/dashboard/src/styles/vaadin-dashboard-button-core-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-core-styles.js
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { css } from 'lit';
+import { buttonStyles } from '@vaadin/button/src/styles/vaadin-button-core-styles.js';
+
+const dashboardButton = css`
+  :host {
+    min-width: 1rem;
+  }
+`;
+
+export const dashboardButtonStyles = [buttonStyles, dashboardButton];

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-core-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-core-styles.js
@@ -28,10 +28,6 @@ const widgetStyles = css`
     display: none;
   }
 
-  vaadin-dashboard-button {
-    min-width: 1rem;
-  }
-
   [part~='content'] {
     flex: 1;
     overflow: hidden;

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-core-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-core-styles.js
@@ -28,9 +28,14 @@ const widgetStyles = css`
     display: none;
   }
 
+  vaadin-dashboard-button {
+    min-width: 1rem;
+  }
+
   [part~='content'] {
     flex: 1;
     overflow: hidden;
+    min-height: 1rem;
   }
 
   [part~='resize-button'] {

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -9,7 +9,6 @@
  * license.
  */
 import { html, LitElement } from 'lit';
-import { buttonStyles } from '@vaadin/button/src/styles/vaadin-button-core-styles.js';
 import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -17,6 +16,7 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { CSSInjectionMixin } from '@vaadin/vaadin-themable-mixin/css-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { dashboardButtonStyles } from './styles/vaadin-dashboard-button-core-styles.js';
 
 class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(CSSInjectionMixin(PolylitMixin(LitElement))))) {
   static get is() {
@@ -24,7 +24,7 @@ class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(CSSInjectio
   }
 
   static get styles() {
-    return buttonStyles;
+    return dashboardButtonStyles;
   }
 
   /** @protected */

--- a/packages/dashboard/test/dashboard-keyboard.test.ts
+++ b/packages/dashboard/test/dashboard-keyboard.test.ts
@@ -2,8 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, isChrome, isFirefox, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dashboard.js';
-import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
+import '../src/vaadin-dashboard.js';
+import type { Dashboard, DashboardItem } from '../src/vaadin-dashboard.js';
 import {
   describeBidirectional,
   getDraggable,

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -1,10 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
-import '../vaadin-dashboard-layout.js';
-import '../vaadin-dashboard-section.js';
-import '@vaadin/vaadin-lumo-styles/spacing.js';
-import type { DashboardLayout } from '../vaadin-dashboard-layout.js';
-import type { DashboardSection } from '../vaadin-dashboard-section.js';
+import '../src/vaadin-dashboard-layout.js';
+import '../src/vaadin-dashboard-section.js';
+import type { DashboardLayout } from '../src/vaadin-dashboard-layout.js';
+import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import {
   expectLayout,
   getColumnWidths,
@@ -25,7 +24,7 @@ const [defaultSpacing, defaultMinimumColumnWidth] = (() => {
   document.body.appendChild(div);
   div.style.width = '1rem';
   const minColWidth = div.offsetWidth * 25;
-  div.style.width = 'var(--lumo-space-m)';
+  div.style.width = '1rem'; // var(--lumo-space-m)
   const spacing = div.offsetWidth;
   div.remove();
   return [spacing, minColWidth];
@@ -360,9 +359,9 @@ describe('dashboard layout', () => {
       await nextResize(dashboard);
 
       const { left: itemLeft } = childElements[0].getBoundingClientRect();
-      const { left: dashbboardLeft } = dashboard.getBoundingClientRect();
-      // Expect the dashbaord to have default padding of 1rem
-      expect(itemLeft - dashbboardLeft).to.eql(defaultSpacing);
+      const { left: dashboardLeft } = dashboard.getBoundingClientRect();
+      // Expect the dashboard to have default padding of 1rem
+      expect(itemLeft - dashboardLeft).to.eql(defaultSpacing);
     });
 
     it('should have custom gap between items horizontally', async () => {
@@ -371,9 +370,9 @@ describe('dashboard layout', () => {
       await nextResize(dashboard);
 
       const { left: itemLeft } = childElements[0].getBoundingClientRect();
-      const { left: dashbboardLeft } = dashboard.getBoundingClientRect();
+      const { left: dashboardLeft } = dashboard.getBoundingClientRect();
       // Expect the items to have a gap of 10px
-      expect(itemLeft - dashbboardLeft).to.eql(customSpacing);
+      expect(itemLeft - dashboardLeft).to.eql(customSpacing);
     });
   });
 

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-dashboard-section.js';
-import type { DashboardSection } from '../vaadin-dashboard-section.js';
+import '../src/vaadin-dashboard-section.js';
+import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import {
   getDraggable,
   getMoveApplyButton,

--- a/packages/dashboard/test/dashboard-widget-reordering.test.ts
+++ b/packages/dashboard/test/dashboard-widget-reordering.test.ts
@@ -2,8 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, isFirefox, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dashboard.js';
-import type { Dashboard, DashboardItem, DashboardSectionItem } from '../vaadin-dashboard.js';
+import '../src/vaadin-dashboard.js';
+import type { Dashboard, DashboardItem, DashboardSectionItem } from '../src/vaadin-dashboard.js';
 import {
   createDragEvent,
   expectLayout,

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -1,9 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dashboard.js';
+import '../src/vaadin-dashboard.js';
 import { isSafari } from '@vaadin/component-base/src/browser-utils.js';
-import type { Dashboard, DashboardItem } from '../vaadin-dashboard.js';
+import type { Dashboard, DashboardItem } from '../src/vaadin-dashboard.js';
 import {
   describeBidirectional,
   expectLayout,

--- a/packages/dashboard/test/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dashboard-widget.test.ts
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-import '../vaadin-dashboard-widget.js';
-import { DashboardSection } from '../vaadin-dashboard-section.js';
-import { DashboardWidget } from '../vaadin-dashboard-widget.js';
+import '../src/vaadin-dashboard-widget.js';
+import { DashboardSection } from '../src/vaadin-dashboard-section.js';
+import { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
 import {
   getDraggable,
   getMoveApplyButton,

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../vaadin-dashboard.js';
+import '../src/vaadin-dashboard.js';
 import type { CustomElementType } from '@vaadin/component-base/src/define.js';
 import type { DashboardSection } from '../src/vaadin-dashboard-section.js';
 import type { DashboardWidget } from '../src/vaadin-dashboard-widget.js';
@@ -591,7 +591,7 @@ describe('dashboard', () => {
 
     it('should scroll the focused item outside dashboard viewport back into view', async () => {
       // Limit the dashboard height to force scrolling
-      dashboard.style.height = '300px';
+      dashboard.style.height = '150px';
       await nextResize(dashboard);
       // Focus the first item
       getElementFromCell(dashboard, 0, 0)!.focus();
@@ -609,7 +609,7 @@ describe('dashboard', () => {
 
     it('should not scroll the focused item into view if it is partially visible', async () => {
       // Limit the dashboard height to force scrolling
-      dashboard.style.height = '300px';
+      dashboard.style.height = '150px';
       await nextResize(dashboard);
       // Focus the first item
       getElementFromCell(dashboard, 0, 0)!.focus();


### PR DESCRIPTION
## Description

Updated dashboard tests to use `src` version instead of Lumo, which fixes errors noticeable with `--theme=base`:

1. Added `min-height` to the content part as otherwise it has 0 height
2. Added `min-width` to dashboard button as otherwise it has 0 width
3. Limited height in some tests to smaller value to ensure scrollbar

## Type of change

- Test