### PR TITLE
refactor: drop legacy -webkit-scrolling-overflow property

### DIFF
--- a/packages/combo-box/src/styles/vaadin-combo-box-scroller-core-styles.js
+++ b/packages/combo-box/src/styles/vaadin-combo-box-scroller-core-styles.js
@@ -14,9 +14,6 @@ export const comboBoxScrollerStyles = css`
     /* Fixes item background from getting on top of scrollbars on Safari */
     transform: translate3d(0, 0, 0);
 
-    /* Enable momentum scrolling on iOS */
-    -webkit-overflow-scrolling: touch;
-
     /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
     box-shadow: 0 0 0 white;
   }

--- a/packages/list-box/src/styles/vaadin-list-box-core-styles.js
+++ b/packages/list-box/src/styles/vaadin-list-box-core-styles.js
@@ -18,6 +18,5 @@ export const listBoxStyles = css`
     height: 100%;
     width: 100%;
     overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
   }
 `;

--- a/packages/login/theme/lumo/vaadin-login-overlay-styles.js
+++ b/packages/login/theme/lumo/vaadin-login-overlay-styles.js
@@ -130,7 +130,6 @@ const loginOverlayWrapper = css`
     [part='form'] {
       height: 100%;
       overflow: auto;
-      -webkit-overflow-scrolling: touch;
     }
   }
 
@@ -175,7 +174,6 @@ const loginFormWrapper = css`
   @media only screen and (max-height: 600px) and (min-width: 600px) and (orientation: landscape) {
     :host([theme~='with-overlay']) [part='form'] {
       height: 100%;
-      -webkit-overflow-scrolling: touch;
       flex: 1;
       padding: 2px;
     }

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-scroller-core-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-scroller-core-styles.js
@@ -14,9 +14,6 @@ export const multiSelectComboBoxScrollerStyles = css`
     /* Fixes item background from getting on top of scrollbars on Safari */
     transform: translate3d(0, 0, 0);
 
-    /* Enable momentum scrolling on iOS */
-    -webkit-overflow-scrolling: touch;
-
     /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
     box-shadow: 0 0 0 white;
   }

--- a/packages/overlay/src/styles/vaadin-overlay-core-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-core-styles.js
@@ -45,7 +45,6 @@ export const overlayStyles = css`
   }
 
   [part='overlay'] {
-    -webkit-overflow-scrolling: touch;
     overflow: auto;
     pointer-events: auto;
 

--- a/packages/split-layout/src/styles/vaadin-split-layout-core-styles.js
+++ b/packages/split-layout/src/styles/vaadin-split-layout-core-styles.js
@@ -23,7 +23,6 @@ export const splitLayoutStyles = css`
   :host ::slotted(*) {
     flex: 1 1 auto;
     overflow: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   [part='splitter'] {

--- a/packages/tabs/src/styles/vaadin-tabs-core-styles.js
+++ b/packages/tabs/src/styles/vaadin-tabs-core-styles.js
@@ -24,7 +24,6 @@ export const tabsStyles = css`
     display: flex;
     align-self: stretch;
     overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   /* This seems more future-proof than \`overflow: -moz-scrollbars-none\` which is marked obsolete
@@ -43,7 +42,6 @@ export const tabsStyles = css`
   :host([orientation='vertical']) [part='tabs'] {
     height: 100%;
     overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   [part='back-button'],

--- a/packages/text-area/src/styles/vaadin-text-area-core-styles.js
+++ b/packages/text-area/src/styles/vaadin-text-area-core-styles.js
@@ -20,7 +20,6 @@ export const textAreaStyles = css`
   [part='input-field'] {
     flex: auto;
     overflow: auto;
-    -webkit-overflow-scrolling: touch;
   }
 
   ::slotted(textarea) {

--- a/packages/time-picker/src/styles/vaadin-time-picker-scroller-core-styles.js
+++ b/packages/time-picker/src/styles/vaadin-time-picker-scroller-core-styles.js
@@ -14,9 +14,6 @@ export const timePickerScrollerStyles = css`
     /* Fixes item background from getting on top of scrollbars on Safari */
     transform: translate3d(0, 0, 0);
 
-    /* Enable momentum scrolling on iOS */
-    -webkit-overflow-scrolling: touch;
-
     /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
     box-shadow: 0 0 0 white;
   }

--- a/packages/vaadin-lumo-styles/mixins/menu-overlay.js
+++ b/packages/vaadin-lumo-styles/mixins/menu-overlay.js
@@ -67,7 +67,6 @@ const menuOverlayExt = css`
       padding: 30px var(--lumo-space-m);
       max-height: inherit;
       box-sizing: border-box;
-      -webkit-overflow-scrolling: touch;
       overflow: auto;
       mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
     }

--- a/packages/vaadin-lumo-styles/src/components/combo-box-scroller.css
+++ b/packages/vaadin-lumo-styles/src/components/combo-box-scroller.css
@@ -11,9 +11,6 @@
   /* Fixes item background from getting on top of scrollbars on Safari */
   transform: translate3d(0, 0, 0);
 
-  /* Enable momentum scrolling on iOS */
-  -webkit-overflow-scrolling: touch;
-
   /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
   box-shadow: 0 0 0 white;
 }

--- a/packages/vaadin-lumo-styles/src/components/list-box.css
+++ b/packages/vaadin-lumo-styles/src/components/list-box.css
@@ -17,7 +17,6 @@
   height: 100%;
   width: 100%;
   overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 /* Dividers */

--- a/packages/vaadin-lumo-styles/src/components/login-form-wrapper.css
+++ b/packages/vaadin-lumo-styles/src/components/login-form-wrapper.css
@@ -116,7 +116,6 @@
 @media only screen and (max-height: 600px) and (min-width: 600px) and (orientation: landscape) {
   :host([theme~='with-overlay']) [part='form'] {
     height: 100%;
-    -webkit-overflow-scrolling: touch;
     flex: 1;
     padding: 2px;
   }

--- a/packages/vaadin-lumo-styles/src/components/login-overlay-wrapper.css
+++ b/packages/vaadin-lumo-styles/src/components/login-overlay-wrapper.css
@@ -149,7 +149,6 @@
   [part='form'] {
     height: 100%;
     overflow: auto;
-    -webkit-overflow-scrolling: touch;
   }
 }
 

--- a/packages/vaadin-lumo-styles/src/components/multi-select-combo-box-scroller.css
+++ b/packages/vaadin-lumo-styles/src/components/multi-select-combo-box-scroller.css
@@ -11,9 +11,6 @@
   /* Fixes item background from getting on top of scrollbars on Safari */
   transform: translate3d(0, 0, 0);
 
-  /* Enable momentum scrolling on iOS */
-  -webkit-overflow-scrolling: touch;
-
   /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
   box-shadow: 0 0 0 white;
 }

--- a/packages/vaadin-lumo-styles/src/components/split-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/split-layout.css
@@ -20,7 +20,6 @@
 :host ::slotted(*) {
   flex: 1 1 auto;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 [part='splitter'] {

--- a/packages/vaadin-lumo-styles/src/components/tabs.css
+++ b/packages/vaadin-lumo-styles/src/components/tabs.css
@@ -21,7 +21,6 @@
 :host([orientation='vertical']) [part='tabs'] {
   height: 100%;
   overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
   width: 100%;
   margin: 0.5rem 0;
 }
@@ -37,7 +36,6 @@
   display: flex;
   align-self: stretch;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
   margin: 0 0.75rem;
 }
 

--- a/packages/vaadin-lumo-styles/src/components/text-area.css
+++ b/packages/vaadin-lumo-styles/src/components/text-area.css
@@ -63,7 +63,6 @@
 [part='input-field'] {
   flex: auto;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
   /* Equal to the implicit padding in vaadin-text-field */
   padding-top: calc((var(--lumo-text-field-size) - 1em * var(--lumo-line-height-s)) / 2);
   padding-bottom: calc((var(--lumo-text-field-size) - 1em * var(--lumo-line-height-s)) / 2);

--- a/packages/vaadin-lumo-styles/src/components/time-picker-scroller.css
+++ b/packages/vaadin-lumo-styles/src/components/time-picker-scroller.css
@@ -11,9 +11,6 @@
   /* Fixes item background from getting on top of scrollbars on Safari */
   transform: translate3d(0, 0, 0);
 
-  /* Enable momentum scrolling on iOS */
-  -webkit-overflow-scrolling: touch;
-
   /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
   box-shadow: 0 0 0 white;
 }

--- a/packages/vaadin-lumo-styles/src/mixins/menu-overlay-ext.css
+++ b/packages/vaadin-lumo-styles/src/mixins/menu-overlay-ext.css
@@ -24,7 +24,6 @@
     padding: 30px var(--lumo-space-m);
     max-height: inherit;
     box-sizing: border-box;
-    -webkit-overflow-scrolling: touch;
     overflow: auto;
     mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
   }

--- a/packages/vaadin-lumo-styles/src/mixins/overlay.css
+++ b/packages/vaadin-lumo-styles/src/mixins/overlay.css
@@ -42,7 +42,6 @@
 }
 
 [part='overlay'] {
-  -webkit-overflow-scrolling: touch;
   overflow: auto;
   pointer-events: auto;
 


### PR DESCRIPTION
## Description

As of Safari 13, momentum scrolling is always enabled by default, making the use of `-webkit-overflow-scrolling: touch` unnecessary.

## Type of change

- [x] Refactor
