### PR TITLE
fix!: prevent focusout when closing select overlay on outside click

### DIFF
--- a/packages/select/src/vaadin-select-overlay-mixin.js
+++ b/packages/select/src/vaadin-select-overlay-mixin.js
@@ -38,6 +38,17 @@ export const SelectOverlayMixin = (superClass) =>
       return true;
     }
 
+    /**
+     * @protected
+     * @override
+     */
+    _mouseDownListener(event) {
+      super._mouseDownListener(event);
+
+      // Prevent global mousedown event to avoid losing focus on outside click
+      event.preventDefault();
+    }
+
     /** @protected */
     _getMenuElement() {
       return Array.from(this.children).find((el) => el.localName !== 'style');

--- a/packages/select/test/accessibility.test.js
+++ b/packages/select/test/accessibility.test.js
@@ -380,6 +380,15 @@ describe('accessibility', () => {
         expect(select.hasAttribute('focus-ring')).to.be.true;
       });
 
+      it('should restore focus-ring attribute on outside click if it was set before opening', async () => {
+        select.setAttribute('focus-ring', '');
+        select.opened = true;
+        await oneEvent(overlay, 'vaadin-overlay-open');
+        await sendMouse({ type: 'click', position: [100, 100] });
+        await nextRender();
+        expect(select.hasAttribute('focus-ring')).to.be.true;
+      });
+
       it('should not set focus-ring attribute on item click if it was not set before opening', async () => {
         select.opened = true;
         await oneEvent(overlay, 'vaadin-overlay-open');


### PR DESCRIPTION
## Description

Currently, the logic for restoring `focus-ring` attribute in `vaadin-select` works incorrectly when closed on outside click.

1. First, `focus-ring` is set in the `_openedChanged` observer based on `_openedWithFocusRing`,
2. Then focus moves to `<body>` and `FocusRestorationController` restores it after a timeout,
3. But then `_keyboardActive` flag is `false` due to click event, and `focus-ring` gets removed.

Added `preventDefault()` on `mousedown` event when opened to align with combo-box & date-picker behavior:

- #7846 
- #7855

As a result, the `FocusRestorationController` now resets focus synchronously and `_openedWithFocusRing` works.

## Type of change

- Refactor