### PR TITLE
fix: reset user-tags overlay part background and box-shadow

### DIFF
--- a/packages/field-highlighter/src/styles/vaadin-user-tags-overlay-core-styles.js
+++ b/packages/field-highlighter/src/styles/vaadin-user-tags-overlay-core-styles.js
@@ -7,14 +7,7 @@ import { css } from 'lit';
 import { overlayStyles } from '@vaadin/overlay/src/styles/vaadin-overlay-core-styles.js';
 
 const userTagsOverlay = css`
-  :host {
-    background: transparent;
-    box-shadow: none;
-  }
-
-  :scope [part='overlay'] {
-    box-shadow: none;
-    background: transparent;
+  [part='overlay'] {
     position: relative;
     left: -4px;
     padding: 4px;
@@ -31,10 +24,6 @@ const userTagsOverlay = css`
   :host([dir='rtl']) [part='overlay'] {
     left: auto;
     right: -4px;
-  }
-
-  :scope [part='content'] {
-    padding: 0;
   }
 
   :host([opening]),

--- a/packages/field-highlighter/theme/lumo/vaadin-user-tags-styles.js
+++ b/packages/field-highlighter/theme/lumo/vaadin-user-tags-styles.js
@@ -16,7 +16,13 @@ registerStyles(
     overlay,
     css`
       [part='overlay'] {
+        box-shadow: none;
+        background: transparent;
         will-change: opacity, transform;
+      }
+
+      [part='content'] {
+        padding: 0;
       }
 
       :host([opening]) [part='overlay'] {

--- a/packages/vaadin-lumo-styles/src/components/user-tags-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/user-tags-overlay.css
@@ -3,12 +3,7 @@
  * Copyright (c) 2000 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-:host {
-  background: transparent;
-  box-shadow: none;
-}
-
-:scope [part='overlay'] {
+[part='overlay'] {
   box-shadow: none;
   background: transparent;
   position: relative;
@@ -16,6 +11,7 @@
   padding: 4px;
   outline: none;
   overflow: visible;
+  will-change: opacity, transform;
 }
 
 ::slotted([part='tags']) {
@@ -29,7 +25,7 @@
   right: -4px;
 }
 
-:scope [part='content'] {
+[part='content'] {
   padding: 0;
 }
 
@@ -46,10 +42,6 @@
   100% {
     opacity: 1;
   }
-}
-
-[part='overlay'] {
-  will-change: opacity, transform;
 }
 
 :host([opening]) [part='overlay'] {


### PR DESCRIPTION
## Description

User-tags overlay is actually not supposed to have background and box-shadow but the CSS for it was overridden as a regression from https://github.com/vaadin/web-components/pull/8548. Originally, `src` styles were applied using `registerStyles` without setting `moduleId` and they were overriding Lumo as a side-effect.

Let's improve this by moving CSS for resetting background and box-shadow to Lumo itself.

BTW, the fact that existing visual tests didn't catch this is somewhat disturbing 😞  

## Type of change

- Bugfix