### PR TITLE
refactor!: make default overlay width custom CSS property private

### DIFF
--- a/packages/select/src/styles/vaadin-select-overlay-base-styles.js
+++ b/packages/select/src/styles/vaadin-select-overlay-base-styles.js
@@ -13,7 +13,7 @@ export const selectOverlayStyles = css`
     }
 
     :host(:not([phone])) [part='overlay'] {
-      min-width: var(--vaadin-select-overlay-width, var(--vaadin-select-text-field-width));
+      min-width: var(--vaadin-select-overlay-width, var(--_vaadin-select-overlay-default-width));
     }
 
     [part='content'] {

--- a/packages/select/src/styles/vaadin-select-overlay-core-styles.js
+++ b/packages/select/src/styles/vaadin-select-overlay-core-styles.js
@@ -12,7 +12,7 @@ export const selectOverlayStyles = css`
   }
 
   :host(:not([phone])) [part='overlay'] {
-    min-width: var(--vaadin-select-overlay-width, var(--vaadin-select-text-field-width));
+    min-width: var(--vaadin-select-overlay-width, var(--_vaadin-select-overlay-default-width));
   }
 
   @media (forced-colors: active) {

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -63,6 +63,7 @@ export const SelectBaseMixin = (superClass) =>
           type: Boolean,
           value: false,
           notify: true,
+          observer: '_openedChanged',
           reflectToAttribute: true,
           sync: true,
         },
@@ -160,11 +161,7 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '_updateAriaExpanded(opened, focusElement)',
-        '_updateSelectedItem(value, _items, placeholder)',
-        '_openedChanged(opened, _overlayElement)',
-      ];
+      return ['_updateAriaExpanded(opened, focusElement)', '_updateSelectedItem(value, _items, placeholder)'];
     }
 
     constructor() {
@@ -364,11 +361,7 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _openedChanged(opened, overlayElement) {
-      if (!overlayElement) {
-        return;
-      }
-
+    _openedChanged(opened, oldOpened) {
       if (opened) {
         if (this.disabled || this.readonly) {
           // Disallow programmatic opening when disabled or readonly
@@ -379,8 +372,6 @@ export const SelectBaseMixin = (superClass) =>
         // Avoid multiple announcements when a value gets selected from the dropdown
         this._updateAriaLive(false);
 
-        overlayElement.style.setProperty('--vaadin-select-text-field-width', `${this._inputContainer.offsetWidth}px`);
-
         // Preserve focus-ring to restore it later
         const hasFocusRing = this.hasAttribute('focus-ring');
         this._openedWithFocusRing = hasFocusRing;
@@ -389,7 +380,7 @@ export const SelectBaseMixin = (superClass) =>
         if (hasFocusRing) {
           this.removeAttribute('focus-ring');
         }
-      } else if (this.__oldOpened) {
+      } else if (oldOpened) {
         if (this._openedWithFocusRing) {
           this.setAttribute('focus-ring', '');
         }
@@ -401,8 +392,6 @@ export const SelectBaseMixin = (superClass) =>
           this._requestValidation();
         }
       }
-
-      this.__oldOpened = opened;
     }
 
     /** @private */

--- a/packages/select/src/vaadin-select-overlay-mixin.js
+++ b/packages/select/src/vaadin-select-overlay-mixin.js
@@ -16,7 +16,7 @@ import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin
 export const SelectOverlayMixin = (superClass) =>
   class SelectOverlayMixin extends PositionMixin(OverlayMixin(DirMixin(superClass))) {
     static get observers() {
-      return ['_updateOverlayWidth(opened, owner)'];
+      return ['_updateOverlayWidth(opened, positionTarget)'];
     }
 
     /** @protected */
@@ -44,10 +44,12 @@ export const SelectOverlayMixin = (superClass) =>
     }
 
     /** @private */
-    _updateOverlayWidth(opened, owner) {
-      if (opened && owner) {
+    _updateOverlayWidth(opened, positionTarget) {
+      if (opened && positionTarget) {
+        this.style.setProperty('--_vaadin-select-overlay-default-width', `${positionTarget.offsetWidth}px`);
+
         const widthProperty = '--vaadin-select-overlay-width';
-        const customWidth = getComputedStyle(owner).getPropertyValue(widthProperty);
+        const customWidth = getComputedStyle(this.owner).getPropertyValue(widthProperty);
 
         if (customWidth === '') {
           this.style.removeProperty(widthProperty);

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -127,9 +127,8 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * The following custom properties are available for styling:
  *
  * Custom property                    | Description                  | Target element          | Default
- * -----------------------------------|------------------------------|----------------------------------
+ * -----------------------------------|------------------------------|-------------------------|--------
  * `--vaadin-field-default-width`     | Default width of the field   | :host                   | `12em`
- * `--vaadin-select-text-field-width` | Effective width of the field | `vaadin-select-overlay` |
  * `--vaadin-select-overlay-width`    | Width of the overlay         | `vaadin-select-overlay` |
  *
  * `<vaadin-select>` provides mostly the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -81,9 +81,8 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * The following custom properties are available for styling:
  *
  * Custom property                    | Description                  | Target element          | Default
- * -----------------------------------|------------------------------|----------------------------------
+ * -----------------------------------|------------------------------|-------------------------|--------
  * `--vaadin-field-default-width`     | Default width of the field   | :host                   | `12em`
- * `--vaadin-select-text-field-width` | Effective width of the field | `vaadin-select-overlay` |
  * `--vaadin-select-overlay-width`    | Width of the overlay         | `vaadin-select-overlay` |
  *
  * `<vaadin-select>` provides mostly the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -716,7 +716,7 @@ describe('vaadin-select', () => {
         select.style.width = '200px';
         select.opened = true;
         await oneEvent(overlay, 'vaadin-overlay-open');
-        const prop = '--vaadin-select-text-field-width';
+        const prop = '--_vaadin-select-overlay-default-width';
         const inputRect = select._inputContainer.getBoundingClientRect();
         const value = getComputedStyle(overlay).getPropertyValue(prop);
         expect(value).to.be.equal(`${inputRect.width}px`);

--- a/packages/vaadin-lumo-styles/src/components/select-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/select-overlay.css
@@ -22,7 +22,7 @@
 }
 
 :host(:not([phone])) [part='overlay'] {
-  min-width: var(--vaadin-select-overlay-width, var(--vaadin-select-text-field-width));
+  min-width: var(--vaadin-select-overlay-width, var(--_vaadin-select-overlay-default-width));
 }
 
 :host([no-vertical-overlap][top-aligned]) [part='overlay'] {


### PR DESCRIPTION
## Description

Currently, `vaadin-select` sets custom CSS property called `--vaadin-select-text-field` on the overlay. This property shouldn't be configured by the user and there is no need to keep it marked as public. This PR aligns the property name with `vaadin-combo-box` where we use `--_vaadin-combo-box-overlay-default-width` private CSS custom property.

Also moved the logic for setting custom property to the overlay and simplified `_openedChanged` observer a bit.

## Type of change

- Breaking change