### PR TITLE
Dev page base styles

### DIFF
--- a/dev/common.js
+++ b/dev/common.js
@@ -4,6 +4,10 @@ import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-sty
 addGlobalThemeStyles(
   'dev-common',
   css`
+    html {
+      color-scheme: light dark;
+    }
+
     body {
       font-family: system-ui, sans-serif;
       line-height: 1.25;

--- a/dev/common.js
+++ b/dev/common.js
@@ -23,6 +23,7 @@ addGlobalThemeStyles(
       flex-wrap: wrap;
       gap: 1lh 1.5lh;
       margin: 2lh 0;
+      align-items: baseline;
     }
 
     .section > :is(.heading, p) {


### PR DESCRIPTION
A couple of minor updates to dev page base styles.

Baseline alignment allows to see alignment issues more easily, and it doesn't stretch components unnecessarily, for example, in the “Min & Max Rows” text area examples.

OS-level dark mode support to easily test that the colors work on both modes.