### PR TITLE
refactor: update field components to set owner on the overlay

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -225,9 +225,6 @@ export const ComboBoxBaseMixin = (superClass) =>
     _initOverlay() {
       const overlay = this.$.overlay;
 
-      // Store instance for detecting "dir" attribute on opening
-      overlay._comboBox = this;
-
       overlay.addEventListener('touchend', this._boundOnOverlayTouchAction);
       overlay.addEventListener('touchmove', this._boundOnOverlayTouchAction);
 

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -34,7 +34,7 @@ export const ComboBoxOverlayMixin = (superClass) =>
 
     /** @protected */
     _getHostDir() {
-      return this._comboBox && this._comboBox.getAttribute('dir');
+      return this.owner && this.owner.getAttribute('dir');
     }
 
     /**
@@ -69,7 +69,7 @@ export const ComboBoxOverlayMixin = (superClass) =>
       const propPrefix = this.localName;
       this.style.setProperty(`--_${propPrefix}-default-width`, `${this.positionTarget.offsetWidth}px`);
 
-      const customWidth = getComputedStyle(this._comboBox).getPropertyValue(`--${propPrefix}-width`);
+      const customWidth = getComputedStyle(this.owner).getPropertyValue(`--${propPrefix}-width`);
 
       if (customWidth === '') {
         this.style.removeProperty(`--${propPrefix}-width`);

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -221,6 +221,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
 
       <vaadin-combo-box-overlay
         id="overlay"
+        .owner="${this}"
         .opened="${this._overlayOpened}"
         ?loading="${this.loading}"
         theme="${ifDefined(this._theme)}"

--- a/packages/combo-box/test/overlay-opening.test.js
+++ b/packages/combo-box/test/overlay-opening.test.js
@@ -19,6 +19,10 @@ describe('overlay opening', () => {
       expect(comboBox.opened).to.be.false;
     });
 
+    it('should set owner property on the overlay', () => {
+      expect(overlay.owner).to.equal(comboBox);
+    });
+
     it('should open by clicking label element', () => {
       comboBox.querySelector('[slot="label"]').click();
 

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -207,6 +207,7 @@ class DatePicker extends DatePickerMixin(
 
       <vaadin-date-picker-overlay
         id="overlay"
+        .owner="${this}"
         ?fullscreen="${this._fullscreen}"
         ?week-numbers="${this.showWeekNumbers}"
         theme="${ifDefined(this._theme)}"

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -20,6 +20,10 @@ describe('dropdown', () => {
     overlay = datePicker.$.overlay;
   });
 
+  it('should set owner property on the overlay', () => {
+    expect(overlay.owner).to.equal(datePicker);
+  });
+
   it('should update position of the overlay after changing opened property', async () => {
     const inputField = datePicker.shadowRoot.querySelector('[part="input-field"]');
     datePicker.opened = true;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal-mixin.js
@@ -93,6 +93,10 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
           sync: true,
         },
 
+        owner: {
+          type: Object,
+        },
+
         _target: {
           type: Object,
         },
@@ -177,7 +181,7 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
       if (items && items.length && this.topGroup && this.topGroup.length) {
         // Filter out items included to the top group.
         const filteredItems = items.filter(
-          (item) => this._comboBox._findIndex(item, this.topGroup, this.itemIdPath) === -1,
+          (item) => this.owner._findIndex(item, this.topGroup, this.itemIdPath) === -1,
         );
 
         super._setDropdownItems(this.topGroup.concat(filteredItems));
@@ -196,18 +200,11 @@ export const MultiSelectComboBoxInternalMixin = (superClass) =>
 
     /**
      * Override combo-box method to set correct owner for using by item renderers.
-     * This needs to be done before the scroller gets added to the DOM to ensure
-     * Lit directive works in case when combo-box is opened using attribute.
-     *
      * @protected
      * @override
      */
     _initScroller() {
-      const comboBox = this.getRootNode().host;
-
-      this._comboBox = comboBox;
-
-      super._initScroller(comboBox);
+      super._initScroller(this.owner);
     }
 
     /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-internal.js
@@ -45,6 +45,7 @@ class MultiSelectComboBoxInternal extends MultiSelectComboBoxInternalMixin(
 
       <vaadin-multi-select-combo-box-overlay
         id="overlay"
+        .owner="${this.owner}"
         .opened="${this._overlayOpened}"
         ?loading="${this.loading}"
         theme="${ifDefined(this._theme)}"

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -122,6 +122,7 @@ class MultiSelectComboBox extends MultiSelectComboBoxMixin(
 
         <vaadin-multi-select-combo-box-internal
           id="comboBox"
+          .owner="${this}"
           .filteredItems="${this.filteredItems}"
           .items="${this.items}"
           .itemIdPath="${this.itemIdPath}"

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -38,6 +38,11 @@ describe('basic', () => {
       expect(internal.inputElement).to.equal(comboBox.inputElement);
     });
 
+    it('should propagate owner property to combo-box', () => {
+      expect(internal.owner).to.equal(comboBox);
+      expect(internal.$.overlay.owner).to.equal(comboBox);
+    });
+
     it('should propagate opened property to input', () => {
       comboBox.opened = true;
       expect(internal.opened).to.be.true;

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -139,6 +139,7 @@ class TimePicker extends TimePickerMixin(CSSInjectionMixin(ThemableMixin(Element
 
       <vaadin-time-picker-overlay
         id="overlay"
+        .owner="${this}"
         .opened="${this._overlayOpened}"
         theme="${ifDefined(this._theme)}"
         .positionTarget="${this._inputContainer}"

--- a/packages/time-picker/test/overlay-opening.test.js
+++ b/packages/time-picker/test/overlay-opening.test.js
@@ -18,6 +18,10 @@ describe('overlay opening', () => {
       expect(timePicker.opened).to.be.false;
     });
 
+    it('should set owner property on the overlay', () => {
+      expect(overlay.owner).to.equal(timePicker);
+    });
+
     it('should open by clicking label element', () => {
       timePicker.querySelector('[slot="label"]').click();
 


### PR DESCRIPTION
## Description

Some components e.g. `vaadin-select`, `vaadin-popover` and `vaadin-tooltip` set `owner` on their overlays.
Other components e.g. `vaadin-combo-box`, `vaadin-date-picker` and `vaadin-time-picker` do not set it.

This PR aligns implementation to set `owner` property consistently so that it can be used e.g. in Copilot.

## Type of change

- Refactor