### PR TITLE
refactor: remove unnecessary adoptedStyleSheets fallback

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-utils.js
+++ b/packages/vaadin-themable-mixin/src/css-utils.js
@@ -33,10 +33,6 @@ function getEffectiveStyles(component) {
  * @param {HTMLElement} component
  */
 export function applyInstanceStyles(component) {
-  // The adoptStyles function may fall back to appending style elements to shadow root.
-  // Remove them first to avoid duplicates.
-  [...component.shadowRoot.querySelectorAll('style')].forEach((style) => style.remove());
-
   adoptStyles(component.shadowRoot, getEffectiveStyles(component));
 }
 


### PR DESCRIPTION
## Description

Since adoptedStyleSheets are supported in all modern browsers supported by Vaadin 25, Lit's adoptStyles helper isn't expected to fall back to injecting `<style>` elements.

Part of #9082 

## Type of change

- [x] Refactor
