### PR TITLE
fix: add missing .js extension to SlotStylesMixin import

### DIFF
--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -6,7 +6,7 @@
 import { html, render } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
-import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin';
+import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 
 /**
  * @polymerMixin


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9588

## Type of change

- Bugfix