### PR TITLE
fix: reset user-tags overlay part background and box-shadow (#9574) (CP: 24.8)

### DIFF
--- a/packages/field-highlighter/src/vaadin-field-highlighter-styles.js
+++ b/packages/field-highlighter/src/vaadin-field-highlighter-styles.js
@@ -60,14 +60,7 @@ export const userTagStyles = css`
 `;
 
 export const userTagsOverlayStyles = css`
-  :host {
-    background: transparent;
-    box-shadow: none;
-  }
-
-  :scope [part='overlay'] {
-    box-shadow: none;
-    background: transparent;
+  [part='overlay'] {
     position: relative;
     left: -4px;
     padding: 4px;
@@ -84,10 +77,6 @@ export const userTagsOverlayStyles = css`
   :host([dir='rtl']) [part='overlay'] {
     left: auto;
     right: -4px;
-  }
-
-  :scope [part='content'] {
-    padding: 0;
   }
 
   :host([opening]),

--- a/packages/field-highlighter/theme/lumo/vaadin-user-tags-styles.js
+++ b/packages/field-highlighter/theme/lumo/vaadin-user-tags-styles.js
@@ -16,7 +16,13 @@ registerStyles(
     overlay,
     css`
       [part='overlay'] {
+        box-shadow: none;
+        background: transparent;
         will-change: opacity, transform;
+      }
+
+      [part='content'] {
+        padding: 0;
       }
 
       :host([opening]) [part='overlay'] {

--- a/packages/field-highlighter/theme/material/vaadin-user-tags-styles.js
+++ b/packages/field-highlighter/theme/material/vaadin-user-tags-styles.js
@@ -9,9 +9,25 @@ import '@vaadin/vaadin-material-styles/typography.js';
 import { overlay } from '@vaadin/vaadin-material-styles/mixins/overlay.js';
 import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
-registerStyles('vaadin-user-tags-overlay', [overlay], {
-  moduleId: 'material-user-tags-overlay',
-});
+registerStyles(
+  'vaadin-user-tags-overlay',
+  [
+    overlay,
+    css`
+      [part='overlay'] {
+        box-shadow: none;
+        background: transparent;
+      }
+
+      [part='content'] {
+        padding: 0;
+      }
+    `,
+  ],
+  {
+    moduleId: 'material-user-tags-overlay',
+  },
+);
 
 registerStyles(
   'vaadin-user-tag',


### PR DESCRIPTION
## Description

Manual cherry-pick of #9574 to `24.8` - also added reset styles for Material theme.

## Type of change

- Cherry-pick