### PR TITLE
fix: do not throw when cssRules property is inaccessible

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-rules.js
+++ b/packages/vaadin-themable-mixin/src/css-rules.js
@@ -30,9 +30,16 @@ function isTagScopedMedia(media) {
  * @return {Array<CSSMediaRule | CSSImportRule>}
  */
 function extractMediaRulesFromStyleSheet(styleSheet, predicate) {
-  const result = [];
+  let cssRules;
+  try {
+    cssRules = styleSheet.cssRules;
+  } catch {
+    // External stylesheets may not be accessible due to CORS security restrictions.
+    cssRules = [];
+  }
 
-  for (const rule of styleSheet.cssRules) {
+  const result = [];
+  for (const rule of cssRules) {
     const ruleType = rule.constructor.name;
 
     if (ruleType === 'CSSImportRule') {
@@ -49,7 +56,6 @@ function extractMediaRulesFromStyleSheet(styleSheet, predicate) {
       }
     }
   }
-
   return result;
 }
 

--- a/packages/vaadin-themable-mixin/test/css-rules-extraction.test.js
+++ b/packages/vaadin-themable-mixin/test/css-rules-extraction.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { extractTagScopedCSSRules } from '../src/css-rules.js';
 
 const BASE_PATH = import.meta.url.split('/').slice(0, -1).join('/');
@@ -136,6 +137,18 @@ describe('CSS rules extraction', () => {
       expect(rules).to.have.lengthOf(2);
       expect(rules[0].cssText).to.equal(':host { color: black; }');
       expect(rules[1].cssText).to.equal(':host { color: red; }');
+    });
+
+    it('should not throw when stylesheet rules are not accessible', () => {
+      const style = new CSSStyleSheet();
+
+      sinon.stub(style, 'cssRules').get(() => {
+        throw new DOMException('Failed to read the "cssRules" property from "CSSStyleSheet"', 'SecurityError');
+      });
+
+      document.adoptedStyleSheets = [style];
+
+      expect(() => extractTagScopedCSSRules(document, 'test-button')).to.not.throw();
     });
 
     it('should put adoptedStyleSheet rules after other rules', () => {


### PR DESCRIPTION
## Description

CSS rules from external stylesheets may be inaccessible due to CORS security restrictions. This PR updates CSSInjector to gracefully ignore such stylesheets without throwing exceptions.

Related to #9082 

## Type of change

- [x] Bugfix
