### PR TITLE
chore: remove `color-scheme` property from body

### DIFF
--- a/dev/common.js
+++ b/dev/common.js
@@ -4,10 +4,6 @@ import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-sty
 addGlobalThemeStyles(
   'dev-common',
   css`
-    html {
-      color-scheme: light dark;
-    }
-
     body {
       font-family: system-ui, sans-serif;
       line-height: 1.25;


### PR DESCRIPTION
## Description

With this property, the style in the dev pages look off when running the server with the Lumo styles.

![image](https://github.com/user-attachments/assets/2aa697c9-c5f1-4068-9e92-b72c88bc6096)

Removing it for now. Can be reintroduced later when base styles become the default.