### PR TITLE
test: add missing Lumo props.css import

### DIFF
--- a/packages/icons/test/visual/lumo/vaadin-iconset.test.js
+++ b/packages/icons/test/visual/lumo/vaadin-iconset.test.js
@@ -1,3 +1,4 @@
+import '@vaadin/vaadin-lumo-styles/props.css';
 import '@vaadin/vaadin-lumo-styles/components/icon.css';
 import '@vaadin/icon';
 import '../../../vaadin-iconset.js';


### PR DESCRIPTION
## Description

Adds a missing `@vaadin/vaadin-lumo-styles/props.css` import to iconset visual tests.

## Type of change

- [x] Internal
