### PR TITLE
test: update grid-pro test to fix post-finalize style warning

### DIFF
--- a/packages/grid-pro/test/visual/lumo/grid-pro.test.js
+++ b/packages/grid-pro/test/visual/lumo/grid-pro.test.js
@@ -4,9 +4,9 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/props.css';
 import '@vaadin/vaadin-lumo-styles/components/grid-pro.css';
 import '@vaadin/vaadin-lumo-styles/components/grid-pro-edit-column.css';
+import '../../not-animated-styles.js';
 import '../../../vaadin-grid-pro.js';
 import '../../../vaadin-grid-pro-edit-column.js';
-import '../../not-animated-styles.js';
 import { getContainerCell } from '../../helpers.js';
 import { users } from '../users.js';
 


### PR DESCRIPTION
## Description

This fixes the last remaining warning in visual tests:

```
packages/grid-pro/test/visual/lumo/grid-pro.test.js:
 🚧 Browser logs:
      The custom element definition for "vaadin-select-overlay" was finalized before a style module was registered. Ideally, import component specific style modules before importing the corresponding custom element. This warning can be suppressed by setting "window.Vaadin.suppressPostFinalizeStylesWarning = true".
```

## Type of change

- Test