### PR TITLE
test: import components without Lumo styles from src

### DIFF
--- a/packages/board/test/visual/lumo/board.test.js
+++ b/packages/board/test/visual/lumo/board.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/lumo/vaadin-board.js';
+import '../../../vaadin-board.js';
 
 describe('board', () => {
   let element;

--- a/packages/cookie-consent/test/visual/lumo/cookie-consent.test.js
+++ b/packages/cookie-consent/test/visual/lumo/cookie-consent.test.js
@@ -1,6 +1,6 @@
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../../theme/lumo/vaadin-cookie-consent.js';
+import '../../../vaadin-cookie-consent.js';
 
 describe('cookie-consent', () => {
   let element;


### PR DESCRIPTION
## Description

Board and CookieConsent don't have any Lumo styles, but their visual tests should still be updated to import these components from `src/`, as `theme/lumo` will be removed eventually.

Part of #9082 

## Type of change

- [x] Internal
