### PR TITLE
test: add missing Lumo CSS imports

### DIFF
--- a/packages/vaadin-lumo-styles/test/visual/badge.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/badge.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../badge-global.js';
+import '../../props.css';
+import '../../global.css';
 
 describe('badge', () => {
   it('flex-shrink', async () => {

--- a/packages/vaadin-lumo-styles/test/visual/font-icons.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/font-icons.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../font-icons.js';
+import '../../props.css';
+import '../../global.css';
 
 describe('font-icons', () => {
   let wrapper;

--- a/packages/vaadin-lumo-styles/test/visual/font-size.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/font-size.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../../typography-global.js';
+import '../../props.css';
+import '../../global.css';
 
 describe('font-size', () => {
   let wrapper;

--- a/packages/vaadin-lumo-styles/test/visual/headings.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/headings.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
-import '../autoload.js';
+import '../../props.css';
+import '../../global.css';
 
 describe('headings', () => {
   it('default', async () => {
@@ -28,27 +29,27 @@ describe('headings', () => {
         h6 {
           margin-top: 1.25em;
         }
-        
+
         h1 {
           margin-bottom: 0.75em;
         }
-        
+
         h2 {
           margin-bottom: 0.5em;
         }
-        
+
         h3 {
           margin-bottom: 0.5em;
         }
-        
+
         h4 {
           margin-bottom: 0.5em;
         }
-        
+
         h5 {
           margin-bottom: 0.25em;
         }
-        
+
         h6 {
           margin-bottom: 0;
         }

--- a/packages/vaadin-lumo-styles/test/visual/vaadin-iconset.test.js
+++ b/packages/vaadin-lumo-styles/test/visual/vaadin-iconset.test.js
@@ -1,5 +1,7 @@
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../props.css';
+import '../../components/icon.css';
 import '@vaadin/icon/vaadin-icon.js';
 import '../../vaadin-iconset.js';
 

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -52,11 +52,12 @@ export function enforceThemePlugin(theme) {
 
         // For visual tests: replace import of CSS file with JS autoload script
         body = body.replace('vaadin-lumo-styles/global.css', 'vaadin-lumo-styles/test/autoload.js');
+        body = body.replace('../../global.css', '../autoload.js');
       }
 
       if (['base', 'legacy-lumo'].includes(theme) && context.response.is('html', 'js')) {
         // Remove all not transformed CSS imports
-        body = body.replaceAll(/^.+vaadin-lumo-styles\/.+\.css.+$/gmu, '');
+        body = body.replaceAll(/^.+(vaadin-lumo-styles|\.\.)\/.+\.css.+$/gmu, '');
       }
 
       return body;


### PR DESCRIPTION
## Description

Adds missing Lumo CSS imports to visual tests in the Lumo package to make them work with both JS-based and CSS-based Lumo.

Part of #9082 

## Type of change

- [x] Internal
