### PR TITLE
refactor: define Lumo injection properties on both :root and :host

### DIFF
--- a/packages/vaadin-lumo-styles/components/accordion-heading.css
+++ b/packages/vaadin-lumo-styles/components/accordion-heading.css
@@ -7,7 +7,7 @@
 @import '../src/components/accordion-heading.css';
 @import '../src/components/details-summary.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-accordion-heading-lumo-inject: 1;
   --vaadin-accordion-heading-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/accordion-panel.css
+++ b/packages/vaadin-lumo-styles/components/accordion-panel.css
@@ -8,7 +8,7 @@
 @import '../src/components/details.css';
 @import './accordion-heading.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-accordion-panel-lumo-inject: 1;
   --vaadin-accordion-panel-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/app-layout.css
+++ b/packages/vaadin-lumo-styles/components/app-layout.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/app-layout.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-app-layout-lumo-inject: 1;
   --vaadin-app-layout-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/avatar-group.css
+++ b/packages/vaadin-lumo-styles/components/avatar-group.css
@@ -12,7 +12,7 @@
 @import '../src/components/item.css';
 @import '../src/components/list-box.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-avatar-group-lumo-inject: 1;
   --vaadin-avatar-group-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/avatar.css
+++ b/packages/vaadin-lumo-styles/components/avatar.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/avatar.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-avatar-lumo-inject: 1;
   --vaadin-avatar-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/avatar.css
+++ b/packages/vaadin-lumo-styles/components/avatar.css
@@ -11,6 +11,9 @@
   --vaadin-avatar-lumo-inject-modules:
     lumo_mixins_base-layer-reset,
     lumo_components_avatar;
+}
+
+:is(:root, :host) {
   --vaadin-avatar-size: var(
     --lumo-size-m
   );

--- a/packages/vaadin-lumo-styles/components/button.css
+++ b/packages/vaadin-lumo-styles/components/button.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/button.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-button-lumo-inject: 1;
   --vaadin-button-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/card.css
+++ b/packages/vaadin-lumo-styles/components/card.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/card.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-card-lumo-inject: 1;
   --vaadin-card-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/card.css
+++ b/packages/vaadin-lumo-styles/components/card.css
@@ -11,6 +11,9 @@
   --vaadin-card-lumo-inject-modules:
     lumo_mixins_base-layer-reset,
     lumo_components_card;
+}
+
+:is(:root, :host) {
   --vaadin-card-background: var(
     --lumo-contrast-5pct
   );

--- a/packages/vaadin-lumo-styles/components/charts.css
+++ b/packages/vaadin-lumo-styles/components/charts.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/chart.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-chart-lumo-inject: 1;
   --vaadin-chart-lumo-inject-modules: lumo_components_chart;
 }

--- a/packages/vaadin-lumo-styles/components/checkbox-group.css
+++ b/packages/vaadin-lumo-styles/components/checkbox-group.css
@@ -12,7 +12,7 @@
 @import '../src/components/checkbox-group.css';
 @import './checkbox.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-checkbox-group-lumo-inject: 1;
   --vaadin-checkbox-group-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/components/checkbox.css
@@ -7,7 +7,7 @@
 @import '../src/mixins/checkable-field.css';
 @import '../src/components/checkbox.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-checkbox-lumo-inject: 1;
   --vaadin-checkbox-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/combo-box.css
+++ b/packages/vaadin-lumo-styles/components/combo-box.css
@@ -22,7 +22,7 @@
 @import '../src/components/item.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-combo-box-lumo-inject: 1;
   --vaadin-combo-box-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/confirm-dialog.css
+++ b/packages/vaadin-lumo-styles/components/confirm-dialog.css
@@ -9,7 +9,7 @@
 @import '../src/components/dialog-overlay.css';
 @import './button.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-confirm-dialog-overlay-lumo-inject: 1;
   --vaadin-confirm-dialog-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/context-menu.css
+++ b/packages/vaadin-lumo-styles/components/context-menu.css
@@ -13,7 +13,7 @@
 @import '../src/components/item.css';
 @import '../src/components/list-box.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-context-menu-overlay-lumo-inject: 1;
   --vaadin-context-menu-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/crud.css
+++ b/packages/vaadin-lumo-styles/components/crud.css
@@ -18,7 +18,7 @@
 @import './grid-sorter.css';
 @import './text-field.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-crud-lumo-inject: 1;
   --vaadin-crud-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/custom-field.css
+++ b/packages/vaadin-lumo-styles/components/custom-field.css
@@ -10,7 +10,7 @@
 @import '../src/mixins/field-required.css';
 @import '../src/components/custom-field.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-custom-field-lumo-inject: 1;
   --vaadin-custom-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/dashboard.css
+++ b/packages/vaadin-lumo-styles/components/dashboard.css
@@ -11,7 +11,7 @@
 @import '../src/components/dashboard-widget.css';
 @import '../src/components/dashboard.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-dashboard-lumo-inject: 1;
   --vaadin-dashboard-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/date-picker.css
+++ b/packages/vaadin-lumo-styles/components/date-picker.css
@@ -21,7 +21,7 @@
 @import './button.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-date-picker-lumo-inject: 1;
   --vaadin-date-picker-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/date-time-picker.css
+++ b/packages/vaadin-lumo-styles/components/date-time-picker.css
@@ -15,7 +15,7 @@
 @import './date-picker.css';
 @import './time-picker.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-date-time-picker-lumo-inject: 1;
   --vaadin-date-time-picker-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/details-summary.css
+++ b/packages/vaadin-lumo-styles/components/details-summary.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/details-summary.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-details-summary-lumo-inject: 1;
   --vaadin-details-summary-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/details.css
+++ b/packages/vaadin-lumo-styles/components/details.css
@@ -6,7 +6,7 @@
 @import '../src/components/details.css';
 @import './details-summary.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-details-lumo-inject: 1;
   --vaadin-details-lumo-inject-modules: lumo_components_details;
 }

--- a/packages/vaadin-lumo-styles/components/dialog.css
+++ b/packages/vaadin-lumo-styles/components/dialog.css
@@ -8,7 +8,7 @@
 @import '../src/mixins/resizable-overlay.css';
 @import '../src/components/dialog-overlay.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-dialog-overlay-lumo-inject: 1;
   --vaadin-dialog-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/drawer-toggle.css
+++ b/packages/vaadin-lumo-styles/components/drawer-toggle.css
@@ -7,7 +7,7 @@
 @import '../src/components/button.css';
 @import '../src/components/drawer-toggle.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-drawer-toggle-lumo-inject: 1;
   --vaadin-drawer-toggle-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/email-field.css
+++ b/packages/vaadin-lumo-styles/components/email-field.css
@@ -13,7 +13,7 @@
 @import '../src/components/email-field.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-email-field-lumo-inject: 1;
   --vaadin-email-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/field-highlighter.css
+++ b/packages/vaadin-lumo-styles/components/field-highlighter.css
@@ -9,7 +9,7 @@
 @import '../src/components/user-tag.css';
 @import '../src/components/user-tags-overlay.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-user-tags-overlay-lumo-inject: 1;
   --vaadin-user-tags-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/form-item.css
+++ b/packages/vaadin-lumo-styles/components/form-item.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/form-item.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-form-item-lumo-inject: 1;
   --vaadin-form-item-lumo-inject-modules: lumo_components_form-item;
 }

--- a/packages/vaadin-lumo-styles/components/form-layout.css
+++ b/packages/vaadin-lumo-styles/components/form-layout.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/form-layout.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-form-layout-lumo-inject: 1;
   --vaadin-form-layout-lumo-inject-modules: lumo_components_form-layout;
 }

--- a/packages/vaadin-lumo-styles/components/grid-filter.css
+++ b/packages/vaadin-lumo-styles/components/grid-filter.css
@@ -7,7 +7,7 @@
 @import '../src/components/grid-filter.css';
 @import './text-field.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-grid-filter-lumo-inject: 1;
   --vaadin-grid-filter-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/grid-pro-edit-column.css
+++ b/packages/vaadin-lumo-styles/components/grid-pro-edit-column.css
@@ -19,7 +19,7 @@
 @import './select.css';
 @import './text-field.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-grid-pro-edit-text-field-lumo-inject: 1;
   --vaadin-grid-pro-edit-text-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/grid-pro.css
+++ b/packages/vaadin-lumo-styles/components/grid-pro.css
@@ -7,7 +7,7 @@
 @import '../src/components/grid-pro.css';
 @import '../src/components/grid.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-grid-pro-lumo-inject: 1;
   --vaadin-grid-pro-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/grid-sorter.css
+++ b/packages/vaadin-lumo-styles/components/grid-sorter.css
@@ -14,7 +14,7 @@
   font-style: normal;
 }
 
-html {
+:is(:root, :host)::before {
   --vaadin-grid-sorter-lumo-inject: 1;
   --vaadin-grid-sorter-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/grid-tree-toggle.css
+++ b/packages/vaadin-lumo-styles/components/grid-tree-toggle.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/grid-tree-toggle.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-grid-tree-toggle-lumo-inject: 1;
   --vaadin-grid-tree-toggle-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/grid.css
+++ b/packages/vaadin-lumo-styles/components/grid.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/grid.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-grid-lumo-inject: 1;
   --vaadin-grid-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/horizontal-layout.css
+++ b/packages/vaadin-lumo-styles/components/horizontal-layout.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/horizontal-layout.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-horizontal-layout-lumo-inject: 1;
   --vaadin-horizontal-layout-lumo-inject-modules: lumo_components_horizontal-layout;
 }

--- a/packages/vaadin-lumo-styles/components/icon.css
+++ b/packages/vaadin-lumo-styles/components/icon.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/icon.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-icon-lumo-inject: 1;
   --vaadin-icon-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/input-container.css
+++ b/packages/vaadin-lumo-styles/components/input-container.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-input-container-lumo-inject: 1;
   --vaadin-input-container-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/integer-field.css
+++ b/packages/vaadin-lumo-styles/components/integer-field.css
@@ -13,7 +13,7 @@
 @import '../src/components/number-field.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-integer-field-lumo-inject: 1;
   --vaadin-integer-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/item.css
+++ b/packages/vaadin-lumo-styles/components/item.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/item.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-item-lumo-inject: 1;
   --vaadin-item-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/list-box.css
+++ b/packages/vaadin-lumo-styles/components/list-box.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/list-box.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-list-box-lumo-inject: 1;
   --vaadin-list-box-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/login-form.css
+++ b/packages/vaadin-lumo-styles/components/login-form.css
@@ -9,7 +9,7 @@
 @import './password-field.css';
 @import './text-field.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-login-form-wrapper-lumo-inject: 1;
   --vaadin-login-form-wrapper-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/login.css
+++ b/packages/vaadin-lumo-styles/components/login.css
@@ -8,7 +8,7 @@
 @import '../src/components/login-overlay-wrapper.css';
 @import './login-form.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-login-overlay-wrapper-lumo-inject: 1;
   --vaadin-login-overlay-wrapper-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/map.css
+++ b/packages/vaadin-lumo-styles/components/map.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/map.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-map-lumo-inject: 1;
   --vaadin-map-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/master-detail-layout.css
+++ b/packages/vaadin-lumo-styles/components/master-detail-layout.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/master-detail-layout.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-master-detail-layout-lumo-inject: 1;
   --vaadin-master-detail-layout-lumo-inject-modules: lumo_components_master-detail-layout;
 }

--- a/packages/vaadin-lumo-styles/components/menu-bar.css
+++ b/packages/vaadin-lumo-styles/components/menu-bar.css
@@ -18,7 +18,7 @@
 @import '../src/components/menu-bar-overlay.css';
 @import '../src/components/menu-bar.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-menu-bar-lumo-inject: 1;
   --vaadin-menu-bar-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/message-input.css
+++ b/packages/vaadin-lumo-styles/components/message-input.css
@@ -8,7 +8,7 @@
 @import './button.css';
 @import './text-area.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-message-input-lumo-inject: 1;
   --vaadin-message-input-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/message.css
+++ b/packages/vaadin-lumo-styles/components/message.css
@@ -7,7 +7,7 @@
 @import '../src/components/message.css';
 @import './avatar.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-message-lumo-inject: 1;
   --vaadin-message-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/components/multi-select-combo-box.css
@@ -25,7 +25,7 @@
 @import '../src/components/multi-select-combo-box-scroller.css';
 @import '../src/components/multi-select-combo-box.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-multi-select-combo-box-container-lumo-inject: 1;
   --vaadin-multi-select-combo-box-container-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/notification.css
+++ b/packages/vaadin-lumo-styles/components/notification.css
@@ -7,7 +7,7 @@
 @import '../src/components/notification-card.css';
 @import '../src/components/notification-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-notification-container-lumo-inject: 1;
   --vaadin-notification-container-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/number-field.css
+++ b/packages/vaadin-lumo-styles/components/number-field.css
@@ -13,7 +13,7 @@
 @import '../src/components/number-field.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-number-field-lumo-inject: 1;
   --vaadin-number-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/overlay.css
+++ b/packages/vaadin-lumo-styles/components/overlay.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/mixins/overlay.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-overlay-lumo-inject: 1;
   --vaadin-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/password-field.css
+++ b/packages/vaadin-lumo-styles/components/password-field.css
@@ -15,7 +15,7 @@
 @import '../src/components/password-field.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-password-field-lumo-inject: 1;
   --vaadin-password-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/popover.css
+++ b/packages/vaadin-lumo-styles/components/popover.css
@@ -7,7 +7,7 @@
 @import '../src/mixins/overlay.css';
 @import '../src/components/popover-overlay.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-popover-overlay-lumo-inject: 1;
   --vaadin-popover-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/progress-bar.css
+++ b/packages/vaadin-lumo-styles/components/progress-bar.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/progress-bar.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-progress-bar-lumo-inject: 1;
   --vaadin-progress-bar-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/radio-button.css
+++ b/packages/vaadin-lumo-styles/components/radio-button.css
@@ -7,7 +7,7 @@
 @import '../src/mixins/checkable-field.css';
 @import '../src/components/radio-button.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-radio-button-lumo-inject: 1;
   --vaadin-radio-button-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/radio-group.css
+++ b/packages/vaadin-lumo-styles/components/radio-group.css
@@ -12,7 +12,7 @@
 @import '../src/components/radio-group.css';
 @import './radio-button.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-radio-group-lumo-inject: 1;
   --vaadin-radio-group-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/rich-text-editor.css
+++ b/packages/vaadin-lumo-styles/components/rich-text-editor.css
@@ -16,7 +16,7 @@
 @import './text-field.css';
 @import './tooltip.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-rich-text-editor-lumo-inject: 1;
   --vaadin-rich-text-editor-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/scroller.css
+++ b/packages/vaadin-lumo-styles/components/scroller.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/scroller.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-scroller-lumo-inject: 1;
   --vaadin-scroller-lumo-inject-modules: lumo_components_scroller;
 }

--- a/packages/vaadin-lumo-styles/components/select.css
+++ b/packages/vaadin-lumo-styles/components/select.css
@@ -20,7 +20,7 @@
 @import '../src/components/select.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-select-lumo-inject: 1;
   --vaadin-select-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/side-nav-item.css
+++ b/packages/vaadin-lumo-styles/components/side-nav-item.css
@@ -7,7 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/components/side-nav-item.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-side-nav-item-lumo-inject: 1;
   --vaadin-side-nav-item-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/side-nav.css
+++ b/packages/vaadin-lumo-styles/components/side-nav.css
@@ -7,7 +7,7 @@
 @import '../src/components/side-nav.css';
 @import './side-nav-item.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-side-nav-lumo-inject: 1;
   --vaadin-side-nav-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/split-layout.css
+++ b/packages/vaadin-lumo-styles/components/split-layout.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/split-layout.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-split-layout-lumo-inject: 1;
   --vaadin-split-layout-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/tab.css
+++ b/packages/vaadin-lumo-styles/components/tab.css
@@ -6,7 +6,7 @@
 @import '../src/mixins/base-layer-reset.css';
 @import '../src/components/tab.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-tab-lumo-inject: 1;
   --vaadin-tab-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/tabs.css
+++ b/packages/vaadin-lumo-styles/components/tabs.css
@@ -7,7 +7,7 @@
 @import '../src/components/tabs.css';
 @import './tab.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-tabs-lumo-inject: 1;
   --vaadin-tabs-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/tabsheet.css
+++ b/packages/vaadin-lumo-styles/components/tabsheet.css
@@ -9,7 +9,7 @@
 @import './scroller.css';
 @import './tabs.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-tabsheet-lumo-inject: 1;
   --vaadin-tabsheet-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/text-area.css
+++ b/packages/vaadin-lumo-styles/components/text-area.css
@@ -13,7 +13,7 @@
 @import '../src/components/text-area.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-text-area-lumo-inject: 1;
   --vaadin-text-area-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/text-field.css
+++ b/packages/vaadin-lumo-styles/components/text-field.css
@@ -12,7 +12,7 @@
 @import '../src/mixins/field-required.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-text-field-lumo-inject: 1;
   --vaadin-text-field-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/time-picker.css
+++ b/packages/vaadin-lumo-styles/components/time-picker.css
@@ -20,7 +20,7 @@
 @import '../src/components/time-picker.css';
 @import './input-container.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-time-picker-lumo-inject: 1;
   --vaadin-time-picker-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/tooltip.css
+++ b/packages/vaadin-lumo-styles/components/tooltip.css
@@ -7,7 +7,7 @@
 @import '../src/mixins/overlay.css';
 @import '../src/components/tooltip-overlay.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-tooltip-overlay-lumo-inject: 1;
   --vaadin-tooltip-overlay-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/upload.css
+++ b/packages/vaadin-lumo-styles/components/upload.css
@@ -12,7 +12,7 @@
 @import './button.css';
 @import './progress-bar.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-upload-lumo-inject: 1;
   --vaadin-upload-lumo-inject-modules:
     lumo_mixins_base-layer-reset,

--- a/packages/vaadin-lumo-styles/components/vertical-layout.css
+++ b/packages/vaadin-lumo-styles/components/vertical-layout.css
@@ -5,7 +5,7 @@
  */
 @import '../src/components/vertical-layout.css';
 
-html {
+:is(:root, :host)::before {
   --vaadin-vertical-layout-lumo-inject: 1;
   --vaadin-vertical-layout-lumo-inject-modules: lumo_components_vertical-layout;
 }


### PR DESCRIPTION
## Description

Lumo injection properties should be defined on both `:root` and `:host`, depending on which one is available in the current cascade context to support loading Lumo in Flow embedded web components. 

I've also updated these properties to be defined on the `::before` pseudo-element instead of directly on `html`. This helps prevent them from cluttering the DevTools inspector when inspecting other elements:

| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/b35df6a0-1c38-49a6-94e9-d73fe2582799) | ![image](https://github.com/user-attachments/assets/b7822781-24f3-44f3-9f6e-ad07ca4b3b53) |


Part of #9082 

## Type of change

- [x] Bugfix
