### PR TITLE
refactor: add !important to ::before styles in CSS property observer

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-property-observer.js
+++ b/packages/vaadin-themable-mixin/src/css-property-observer.js
@@ -23,13 +23,13 @@ export class CSSPropertyObserver {
     const styleSheet = new CSSStyleSheet();
     styleSheet.replaceSync(`
       :is(:root, :host)::before {
-        content: '';
-        position: absolute;
-        top: -9999px;
-        left: -9999px;
-        visibility: hidden;
-        transition: 1ms allow-discrete step-end;
-        transition-property: var(--${this.#name}-props);
+        content: '' !important;
+        position: absolute !important;
+        top: -9999px !important;
+        left: -9999px !important;
+        visibility: hidden !important;
+        transition: 1ms allow-discrete step-end !important;
+        transition-property: var(--${this.#name}-props) !important;
       }
     `);
     this.#root.adoptedStyleSheets.unshift(styleSheet);


### PR DESCRIPTION
## Description

This PR adds `!important` to the CSS declarations set by the CSS property observer to track custom property changes. This helps reduce the risk of those declarations being unintentionally overridden by user-defined styles.

Part of #9082 

## Type of change

- [x] Refactor
