### PR TITLE
fix: replace hsl(0 0 0) syntax not supported in Safari 17

### DIFF
--- a/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
+++ b/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
@@ -146,7 +146,7 @@ export const appLayoutStyles = css`
     :host([overlay]) [part='drawer'] {
       top: 0;
       bottom: 0;
-      box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px hsl(0 0 0 / 0.3));
+      box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3));
     }
 
     :host([overlay]) [part='drawer'],

--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -35,7 +35,7 @@ export const dialogOverlayBase = css`
       border: 0;
       box-shadow:
         0 0 0 var(--vaadin-dialog-border-width, 1px) var(--vaadin-dialog-border-color, rgba(0, 0, 0, 0.1)),
-        var(--vaadin-dialog-box-shadow, 0 8px 24px -4px hsl(0 0 0 / 0.3));
+        var(--vaadin-dialog-box-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3));
       border-radius: var(--vaadin-dialog-border-radius, var(--vaadin-radius-l));
       width: max-content;
       min-width: min(var(--vaadin-dialog-min-width, 4em), 100%);


### PR DESCRIPTION
## Description

Inspired by following PRs:

- https://github.com/vaadin/web-components/pull/9492
- https://github.com/vaadin/web-components/pull/9340

## Type of change

- Bugfix