### PR TITLE
chore: update custom-field dev page, fix console error

### DIFF
--- a/dev/custom-field.html
+++ b/dev/custom-field.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Custom Field</title>
+    <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
     <script type="module" src="./common.js"></script>
   </head>
 
@@ -17,7 +18,7 @@
     >
       <vaadin-select style="width: 6rem" value="+358" required></vaadin-select>
       <vaadin-text-field
-        allowed-char-pattern="[0-9]*"
+        allowed-char-pattern="[0-9]"
         pattern="[0-9]*"
         maxlength="4"
         style="width: 5rem"


### PR DESCRIPTION
## Description

Added missing Lumo CSS import and fixed the `allowedCharPattern` to prevent this error:

```
input-control-mixin.js:249 SyntaxError: Invalid regular expression: /^[0-9]**$/u: Nothing to repeat (at input-control-mixin.js:247:38)
    at new RegExp (<anonymous>)
    at TextField._allowedCharPatternChanged
````

## Type of change

- Internal change