### PR TITLE
refactor: ensure Lumo global props and styles apply in Shadow DOM

### DIFF
--- a/packages/vaadin-lumo-styles/components/rich-text-editor.css
+++ b/packages/vaadin-lumo-styles/components/rich-text-editor.css
@@ -7,8 +7,6 @@
 @import '../src/mixins/overlay.css';
 @import '../src/components/rich-text-editor-popup-overlay.css';
 @import '../src/components/rich-text-editor.css';
-@import '../src/global/color.css'
-  lumo_global_color;
 @import '../src/global/typography.css'
   lumo_global_typography;
 @import './button.css';
@@ -20,7 +18,6 @@
   --vaadin-rich-text-editor-lumo-inject: 1;
   --vaadin-rich-text-editor-lumo-inject-modules:
     lumo_mixins_base-layer-reset,
-    lumo_global_color,
     lumo_global_typography,
     lumo_components_rich-text-editor;
 

--- a/packages/vaadin-lumo-styles/global.css
+++ b/packages/vaadin-lumo-styles/global.css
@@ -4,5 +4,20 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @import './src/global/badge.css';
-@import './src/global/color.css';
+@import './src/global/dark.css';
 @import './src/global/typography.css';
+
+:where(:root, :host) {
+  color: var(--lumo-body-text-color);
+  background-color: var(--lumo-base-color);
+  color-scheme: light;
+}
+
+:where(body, :host) {
+  font-family: var(--lumo-font-family);
+  font-size: var(--lumo-font-size-m);
+  line-height: var(--lumo-line-height-m);
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/packages/vaadin-lumo-styles/global.css
+++ b/packages/vaadin-lumo-styles/global.css
@@ -12,12 +12,3 @@
   background-color: var(--lumo-base-color);
   color-scheme: light;
 }
-
-:where(body, :host) {
-  font-family: var(--lumo-font-family);
-  font-size: var(--lumo-font-size-m);
-  line-height: var(--lumo-line-height-m);
-  -webkit-text-size-adjust: 100%;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}

--- a/packages/vaadin-lumo-styles/gulpfile.js
+++ b/packages/vaadin-lumo-styles/gulpfile.js
@@ -178,6 +178,7 @@ import { addLumoGlobalStyles } from './global.js';
 const fontIcons = css\`
 ${outputCSS
   .trim()
+  .replace(':where(:root, :host)', 'html')
   .replace(/\\/gu, '\\\\')
   .replace(/^(?!$)/gmu, '  ')}
 \`;

--- a/packages/vaadin-lumo-styles/gulpfile.js
+++ b/packages/vaadin-lumo-styles/gulpfile.js
@@ -159,7 +159,7 @@ Iconset.register('lumo', 1000, template);\n`;
   font-style: normal;
 }
 
-html {
+:where(:root, :host) {
   ${glyphCSSProperties.join('\n  ')}
 }
 `;

--- a/packages/vaadin-lumo-styles/src/global/color.css
+++ b/packages/vaadin-lumo-styles/src/global/color.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   color: var(--lumo-body-text-color);
   background-color: var(--lumo-base-color);
   color-scheme: light;

--- a/packages/vaadin-lumo-styles/src/global/dark.css
+++ b/packages/vaadin-lumo-styles/src/global/dark.css
@@ -3,12 +3,6 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-:where(:root, :host) {
-  color: var(--lumo-body-text-color);
-  background-color: var(--lumo-base-color);
-  color-scheme: light;
-}
-
 [theme~='dark'] {
   /* Base (background) */
   --lumo-base-color: hsl(214, 35%, 21%);
@@ -96,35 +90,4 @@
   color: var(--lumo-body-text-color);
   background-color: var(--lumo-base-color);
   color-scheme: dark;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  color: var(--lumo-header-text-color);
-}
-
-a:where(:any-link) {
-  color: var(--lumo-primary-text-color);
-}
-
-a:not(:any-link) {
-  color: var(--lumo-disabled-text-color);
-}
-
-blockquote {
-  color: var(--lumo-secondary-text-color);
-}
-
-code,
-pre {
-  background-color: var(--lumo-contrast-10pct);
-  border-radius: var(--lumo-border-radius-m);
-}
-
-pre code {
-  background: transparent;
 }

--- a/packages/vaadin-lumo-styles/src/global/style.css
+++ b/packages/vaadin-lumo-styles/src/global/style.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   /* Button */
   --vaadin-button-background: var(--lumo-contrast-5pct);
   --vaadin-button-border: none;

--- a/packages/vaadin-lumo-styles/src/global/typography.css
+++ b/packages/vaadin-lumo-styles/src/global/typography.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-body {
+:where(body, :host) {
   font-family: var(--lumo-font-family);
   font-size: var(--lumo-font-size-m);
   line-height: var(--lumo-line-height-m);

--- a/packages/vaadin-lumo-styles/src/global/typography.css
+++ b/packages/vaadin-lumo-styles/src/global/typography.css
@@ -3,15 +3,6 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-:where(body, :host) {
-  font-family: var(--lumo-font-family);
-  font-size: var(--lumo-font-size-m);
-  line-height: var(--lumo-line-height-m);
-  -webkit-text-size-adjust: 100%;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 small,
 [theme~='font-size-s'] {
   font-size: var(--lumo-font-size-s);
@@ -26,6 +17,7 @@ small,
 :where(h1, h2, h3, h4, h5, h6) {
   font-weight: 600;
   line-height: var(--lumo-line-height-xs);
+  color: var(--lumo-header-text-color);
   margin-block: 0;
 }
 
@@ -65,8 +57,16 @@ a {
   text-decoration: none;
 }
 
+a:where(:any-link) {
+  color: var(--lumo-primary-text-color);
+}
+
 a:where(:any-link):hover {
   text-decoration: underline;
+}
+
+a:not(:any-link) {
+  color: var(--lumo-disabled-text-color);
 }
 
 hr {
@@ -79,16 +79,25 @@ hr {
   background-color: var(--lumo-contrast-10pct);
 }
 
-blockquote {
-  border-left: 2px solid var(--lumo-contrast-30pct);
-}
-
 b,
 strong {
   font-weight: 600;
 }
 
-/* RTL specific styles */
+code,
+pre {
+  border-radius: var(--lumo-border-radius-m);
+}
+
+pre code {
+  background: transparent;
+}
+
+blockquote {
+  border-left: 2px solid var(--lumo-contrast-30pct);
+  color: var(--lumo-secondary-text-color);
+}
+
 blockquote[dir='rtl'] {
   border-left: none;
   border-right: 2px solid var(--lumo-contrast-30pct);

--- a/packages/vaadin-lumo-styles/src/global/typography.css
+++ b/packages/vaadin-lumo-styles/src/global/typography.css
@@ -3,6 +3,15 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+:where(body, :host) {
+  font-family: var(--lumo-font-family);
+  font-size: var(--lumo-font-size-m);
+  line-height: var(--lumo-line-height-m);
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 small,
 [theme~='font-size-s'] {
   font-size: var(--lumo-font-size-s);

--- a/packages/vaadin-lumo-styles/src/props/color.css
+++ b/packages/vaadin-lumo-styles/src/props/color.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   /* Base (background) */
   --lumo-base-color: #fff;
 
@@ -92,7 +92,7 @@ html {
 
 /* forced-colors mode adjustments */
 @media (forced-colors: active) {
-  html {
+  :where(:root, :host) {
     --lumo-disabled-text-color: GrayText;
   }
 }

--- a/packages/vaadin-lumo-styles/src/props/icons.css
+++ b/packages/vaadin-lumo-styles/src/props/icons.css
@@ -11,7 +11,7 @@
   font-style: normal;
 }
 
-html {
+:where(:root, :host) {
   --lumo-icons-align-center: '\ea01';
   --lumo-icons-align-left: '\ea02';
   --lumo-icons-align-right: '\ea03';

--- a/packages/vaadin-lumo-styles/src/props/sizing.css
+++ b/packages/vaadin-lumo-styles/src/props/sizing.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   --lumo-size-xs: 1.625rem;
   --lumo-size-s: 1.875rem;
   --lumo-size-m: 2.25rem;

--- a/packages/vaadin-lumo-styles/src/props/spacing.css
+++ b/packages/vaadin-lumo-styles/src/props/spacing.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   /* Square */
   --lumo-space-xs: 0.25rem;
   --lumo-space-s: 0.5rem;

--- a/packages/vaadin-lumo-styles/src/props/style.css
+++ b/packages/vaadin-lumo-styles/src/props/style.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   /* Border radius */
   --lumo-border-radius-s: 0.25em; /* Checkbox, badge, date-picker year indicator, etc */
   --lumo-border-radius-m: var(--lumo-border-radius, 0.25em); /* Button, text field, menu overlay, etc */

--- a/packages/vaadin-lumo-styles/src/props/typography.css
+++ b/packages/vaadin-lumo-styles/src/props/typography.css
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-html {
+:where(:root, :host) {
   /* prettier-ignore */
   --lumo-font-family: -apple-system, BlinkMacSystemFont, 'Roboto', 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 


### PR DESCRIPTION
## Description

This PR replaces the `html` selector with `:where(:root, :host)` to ensure Lumo global properties and styles apply when Lumo is loaded in Shadow DOM.

Part of #9082 

## Type of change

- [x] Refactor