### PR TITLE
test: disable combo box overlay animation

### DIFF
--- a/packages/combo-box/test/visual/common.js
+++ b/packages/combo-box/test/visual/common.js
@@ -35,5 +35,13 @@ registerStyles(
       animation: none;
       opacity: 1;
     }
+
+    :host([opening]),
+    :host([closing]),
+    :host([opening]) [part='overlay'],
+    :host([closing]) [part='overlay'] {
+      transition: none !important;
+      animation: none !important;
+    }
   `,
 );

--- a/packages/multi-select-combo-box/test/visual/common.js
+++ b/packages/multi-select-combo-box/test/visual/common.js
@@ -26,3 +26,22 @@ registerStyles(
     }
   `,
 );
+
+/* Stop loader animation */
+registerStyles(
+  'vaadin-multi-select-combo-box-overlay',
+  css`
+    :host([loading]) [part='loader'] {
+      animation: none;
+      opacity: 1;
+    }
+
+    :host([opening]),
+    :host([closing]),
+    :host([opening]) [part='overlay'],
+    :host([closing]) [part='overlay'] {
+      transition: none !important;
+      animation: none !important;
+    }
+  `,
+);

--- a/packages/time-picker/test/visual/common.js
+++ b/packages/time-picker/test/visual/common.js
@@ -26,3 +26,16 @@ registerStyles(
     }
   `,
 );
+
+registerStyles(
+  'vaadin-time-picker-overlay',
+  css`
+    :host([opening]),
+    :host([closing]),
+    :host([opening]) [part='overlay'],
+    :host([closing]) [part='overlay'] {
+      transition: none !important;
+      animation: none !important;
+    }
+  `,
+);


### PR DESCRIPTION
## Description

The combo-box overlay animation should be disabled in visual tests to prevent flakiness.

Related to #9594 

## Type of change

- [x] Internal
