### PR TITLE
fix: add missing core styles to time-picker.css

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/time-picker.css
+++ b/packages/vaadin-lumo-styles/src/components/time-picker.css
@@ -8,15 +8,29 @@
     pointer-events: auto;
   }
 
+  [part~='toggle-button'] {
+    cursor: pointer;
+  }
+
   [part='toggle-button']::before {
     content: var(--lumo-icons-clock);
+  }
+
+  /* See https://github.com/vaadin/vaadin-time-picker/issues/145 */
+  :host([dir='rtl']) [part='input-field'] {
+    direction: ltr;
+  }
+
+  :host([dir='rtl']) [part='input-field'] ::slotted(input) {
+    --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
   }
 
   :host([dir='rtl']) [part='input-field'] ::slotted(input:placeholder-shown) {
     --_lumo-text-field-overflow-mask-image: none;
   }
 
-  :host([dir='rtl']) [part='input-field'] ::slotted(input) {
-    --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
+  :host([dir='rtl']) [part='input-field'] ::slotted(input)::placeholder {
+    direction: rtl;
+    text-align: left;
   }
 }

--- a/packages/vaadin-lumo-styles/src/mixins/base-layer-reset.css
+++ b/packages/vaadin-lumo-styles/src/mixins/base-layer-reset.css
@@ -12,6 +12,7 @@
     ::slotted(:is(*, #id))::before,
     ::slotted(:is(*, #id))::after {
       all: revert-layer;
+      direction: revert-layer;
       --vaadin-button-background: revert-layer;
       --vaadin-button-border-color: revert-layer;
       --vaadin-button-border: revert-layer;


### PR DESCRIPTION
## Description

The PR adds some missing core styles to `time-picker.css`. They were overlooked because `all: revert-layer` resets all properties except `direction`, which allowed some new base styles to leak through to Lumo and cause the visual tests to pass.

Finding from #9594 

## Type of change

- [x] Bugfix
