### PR TITLE
chore: decrease body selector specificity in dev pages

### DIFF
--- a/dev/common.js
+++ b/dev/common.js
@@ -4,7 +4,7 @@ import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-sty
 addGlobalThemeStyles(
   'dev-common',
   css`
-    body {
+    :where(body) {
       font-family: system-ui, sans-serif;
       line-height: 1.25;
       margin: 2rem;


### PR DESCRIPTION
## Description

This aligns the `body` selector specificity with the change from https://github.com/vaadin/web-components/pull/9626 so that with ported Lumo, dev page styles do not take precedence over Lumo typography `body` styles.

## Type of change

- Internal change