### PR TITLE
refactor: revert flex-wrap and --vaadin-card-border to avoid breaking change

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/card.css
+++ b/packages/vaadin-lumo-styles/src/components/card.css
@@ -7,10 +7,14 @@
   :host::before {
     inset: var(--_card-border-inset, 0);
     border-radius: var(--_card-border-pseudo-radius, inherit);
+    border: var(--vaadin-card-border, var(--vaadin-card-border-width) solid var(--vaadin-card-border-color));
+  }
+
+  :host([_f]) [part='footer'] {
+    flex-wrap: revert;
   }
 
   :host([theme~='outlined']) {
-    --vaadin-card-border-width: 1px;
     --vaadin-card-background: var(--lumo-base-color);
   }
 


### PR DESCRIPTION
## Description

Reverts the value of `flex-wrap` and restores `--vaadin-card-border` to allow the use of the shorthand in Lumo. This PR is mainly created to discuss if we really want to bring these properties back into Lumo.

Part of #9082 

## Type of change

- [x] Refactor
