### PR TITLE
refactor: simplify menu-bar observers to reduce update count

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -191,16 +191,6 @@ export const MenuBarMixin = (superClass) =>
           type: Boolean,
           sync: true,
         },
-
-        /**
-         * @type {boolean}
-         * @protected
-         */
-        _hasOverflow: {
-          type: Boolean,
-          value: false,
-          sync: true,
-        },
       };
     }
 
@@ -289,6 +279,17 @@ export const MenuBarMixin = (superClass) =>
       return this.shadowRoot.querySelector('vaadin-menu-bar-submenu');
     }
 
+    /** @private */
+    get _hasOverflow() {
+      return this._overflow && !this._overflow.hasAttribute('hidden');
+    }
+
+    set _hasOverflow(hasOverflow) {
+      if (this._overflow) {
+        this._overflow.toggleAttribute('hidden', !hasOverflow);
+      }
+    }
+
     /** @protected */
     ready() {
       super.ready();
@@ -355,10 +356,6 @@ export const MenuBarMixin = (superClass) =>
 
       if (props.has('__effectiveI18n')) {
         this.__i18nChanged(this.__effectiveI18n);
-      }
-
-      if (props.has('_hasOverflow')) {
-        this._overflow.toggleAttribute('hidden', !this._hasOverflow);
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -284,6 +284,7 @@ export const MenuBarMixin = (superClass) =>
       return this._overflow && !this._overflow.hasAttribute('hidden');
     }
 
+    /** @private */
     set _hasOverflow(hasOverflow) {
       if (this._overflow) {
         this._overflow.toggleAttribute('hidden', !hasOverflow);

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -201,29 +201,7 @@ export const MenuBarMixin = (superClass) =>
           value: false,
           sync: true,
         },
-
-        /** @protected */
-        _overflow: {
-          type: Object,
-        },
-
-        /** @protected */
-        _container: {
-          type: Object,
-          sync: true,
-        },
       };
-    }
-
-    static get observers() {
-      return [
-        '_themeChanged(_theme, _overflow, _container)',
-        '__hasOverflowChanged(_hasOverflow, _overflow)',
-        '__i18nChanged(__effectiveI18n, _overflow)',
-        '__updateButtons(items, disabled, _overflow, _container)',
-        '_reverseCollapseChanged(reverseCollapse, _overflow, _container)',
-        '_tabNavigationChanged(tabNavigation, _overflow, _container)',
-      ];
     }
 
     /**
@@ -344,10 +322,44 @@ export const MenuBarMixin = (superClass) =>
       const overlay = this._subMenu._overlayElement;
       overlay.addEventListener('keydown', this.__boundOnContextMenuKeydown);
 
-      const container = this.shadowRoot.querySelector('[part="container"]');
-      container.addEventListener('click', this.__onButtonClick.bind(this));
-      container.addEventListener('mouseover', (e) => this._onMouseOver(e));
-      this._container = container;
+      this._container = this.shadowRoot.querySelector('[part="container"]');
+    }
+
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('items') || props.has('_theme') || props.has('disabled')) {
+        this.__renderButtons(this.items);
+      }
+
+      if (props.has('items') || props.has('_theme') || props.has('reverseCollapse')) {
+        this.__scheduleOverflow();
+      }
+
+      if (props.has('items')) {
+        this.__updateSubMenu();
+      }
+
+      if (props.has('_theme')) {
+        this._themeChanged(this._theme);
+      }
+
+      if (props.has('disabled')) {
+        this._overflow.toggleAttribute('disabled', this.disabled);
+      }
+
+      if (props.has('tabNavigation')) {
+        this._tabNavigationChanged(this.tabNavigation);
+      }
+
+      if (props.has('__effectiveI18n')) {
+        this.__i18nChanged(this.__effectiveI18n);
+      }
+
+      if (props.has('_hasOverflow')) {
+        this._overflow.toggleAttribute('hidden', !this._hasOverflow);
+      }
     }
 
     /**
@@ -379,81 +391,34 @@ export const MenuBarMixin = (superClass) =>
       this.__scheduleOverflow();
     }
 
-    /**
-     * A callback for the `_theme` property observer.
-     * It propagates the host theme to the buttons and the sub menu.
-     *
-     * @param {string | null} theme
-     * @private
-     */
-    _themeChanged(theme, overflow, container) {
-      if (overflow && container) {
-        this.__renderButtons(this.items);
-        this.__scheduleOverflow();
-
-        if (theme) {
-          overflow.setAttribute('theme', theme);
-          this._subMenu.setAttribute('theme', theme);
-        } else {
-          overflow.removeAttribute('theme');
-          this._subMenu.removeAttribute('theme');
-        }
-      }
-    }
-
-    /**
-     * A callback for the 'reverseCollapse' property observer.
-     *
-     * @param {boolean | null} _reverseCollapse
-     * @private
-     */
-    _reverseCollapseChanged(_reverseCollapse, overflow, container) {
-      if (overflow && container) {
-        this.__scheduleOverflow();
+    /** @private */
+    _themeChanged(theme) {
+      if (theme) {
+        this._overflow.setAttribute('theme', theme);
+        this._subMenu.setAttribute('theme', theme);
+      } else {
+        this._overflow.removeAttribute('theme');
+        this._subMenu.removeAttribute('theme');
       }
     }
 
     /** @private */
-    _tabNavigationChanged(tabNavigation, overflow, container) {
-      if (overflow && container) {
-        const target = this.querySelector('[tabindex="0"]');
-        this._buttons.forEach((btn) => {
-          if (target) {
-            this._setTabindex(btn, btn === target);
-          } else {
-            this._setTabindex(btn, false);
-          }
-          btn.setAttribute('role', tabNavigation ? 'button' : 'menuitem');
-        });
-      }
+    _tabNavigationChanged(tabNavigation) {
+      const target = this.querySelector('[tabindex="0"]');
+      this._buttons.forEach((btn) => {
+        if (target) {
+          this._setTabindex(btn, btn === target);
+        } else {
+          this._setTabindex(btn, false);
+        }
+        btn.setAttribute('role', tabNavigation ? 'button' : 'menuitem');
+      });
+
       this.setAttribute('role', tabNavigation ? 'group' : 'menubar');
     }
 
     /** @private */
-    __hasOverflowChanged(hasOverflow, overflow) {
-      if (overflow) {
-        overflow.toggleAttribute('hidden', !hasOverflow);
-      }
-    }
-
-    /** @private */
-    __updateButtons(items, disabled, overflow, container) {
-      if (!overflow || !container) {
-        return;
-      }
-
-      if (items !== this._oldItems) {
-        this._oldItems = items;
-        this.__renderButtons(items);
-        this.__scheduleOverflow();
-      }
-
-      if (disabled !== this._oldDisabled) {
-        this._oldDisabled = disabled;
-        this.__renderButtons(items);
-        overflow.toggleAttribute('disabled', disabled);
-      }
-
+    __updateSubMenu() {
       const subMenu = this._subMenu;
       if (subMenu && subMenu.opened) {
         const button = subMenu._overlayElement.positionTarget;
@@ -467,12 +432,12 @@ export const MenuBarMixin = (superClass) =>
     }
 
     /** @private */
-    __i18nChanged(effectiveI18n, overflow) {
-      if (overflow && effectiveI18n && effectiveI18n.moreOptions !== undefined) {
+    __i18nChanged(effectiveI18n) {
+      if (effectiveI18n && effectiveI18n.moreOptions !== undefined) {
         if (effectiveI18n.moreOptions) {
-          overflow.setAttribute('aria-label', effectiveI18n.moreOptions);
+          this._overflow.setAttribute('aria-label', effectiveI18n.moreOptions);
         } else {
-          overflow.removeAttribute('aria-label');
+          this._overflow.removeAttribute('aria-label');
         }
       }
     }

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -89,7 +89,7 @@ class MenuBar extends MenuBarMixin(ElementMixin(ThemableMixin(LumoInjectionMixin
   /** @protected */
   render() {
     return html`
-      <div part="container">
+      <div part="container" @click="${this.__onButtonClick}" @mouseover="${this._onMouseOver}">
         <slot></slot>
         <slot name="overflow"></slot>
       </div>


### PR DESCRIPTION
## Description

Follow-up to #9618

Previously, we were setting `_container` after a microtask to delay running observers. This is no longer needed.

- Updated the menu-bar logic to use `updated()`, which runs after `ready()`, instead of individual observers that run before `ready()`. This way it runs after both `_container` and `_overflow` are set, which eliminates the need to define them in `static get properties()`. As a result we get one update less during an initial render of the component.
- Changed `_hasOverflow` to not be a reactive property either, otherwise setting it on resize (e.g. when inside of a split layout on the dev page) triggers update cycle for the component unnecessarily, whereas in fact we only need to set or remove the attribute.
- Moved two container event listeners to the Lit template instead of adding them manually in the `ready()` block.

## Type of change

- Refactor.