### PR TITLE
chore: include Lumo CSS files in npm package

### DIFF
--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -26,11 +26,13 @@
     "*.d.ts",
     "*.js",
     "!gulpfile.js",
-    "auto-complete.css",
     "mixins/*.d.ts",
     "mixins/*.js",
     "presets/*.js",
-    "utilities/*.js"
+    "utilities/*.js",
+    "src",
+    "*.css",
+    "components/*.css"
   ],
   "keywords": [
     "vaadin",


### PR DESCRIPTION
## Description

This PR adds Lumo CSS files to the `files` field in `package.json` to include them in the npm package.

Part of #9082 

## Type of change

- [x] Internal
