### PR TITLE
fix: use color-mix instead of relative color syntax

### DIFF
--- a/packages/component-base/src/loader-styles.js
+++ b/packages/component-base/src/loader-styles.js
@@ -26,8 +26,8 @@ export const loaderStyles = css`
         fade-in 0.3s 0.3s both;
       border: var(--vaadin-spinner-width, 2px) solid;
       --_spinner-color: var(--vaadin-spinner-color, var(--vaadin-color));
-      border-color: var(--_spinner-color) var(--_spinner-color) hsl(from var(--_spinner-color) h s l / 0.2)
-        hsl(from var(--_spinner-color) h s l / 0.2);
+      --_spinner-color2: color-mix(in srgb, var(--_spinner-color) 20%, transparent);
+      border-color: var(--_spinner-color) var(--_spinner-color) var(--_spinner-color2) var(--_spinner-color2);
       border-radius: 50%;
       box-sizing: border-box;
       height: var(--vaadin-spinner-size, 1lh);


### PR DESCRIPTION
Combining `light-dark()` with relative colors doesn't work in Safari 17 ([reference](https://github.com/w3c/csswg-drafts/issues/10572)), but combining with `color-mix()` does work.