### PR TITLE
fix: icon baseline alignment

### DIFF
--- a/packages/icon/src/styles/vaadin-icon-base-styles.js
+++ b/packages/icon/src/styles/vaadin-icon-base-styles.js
@@ -53,7 +53,7 @@ export const iconStyles = css`
   }
 
   .baseline::before {
-    content: '\\2003';
+    content: '\\2003' / '';
     display: inline-block;
     width: 0;
   }

--- a/packages/icon/src/styles/vaadin-icon-base-styles.js
+++ b/packages/icon/src/styles/vaadin-icon-base-styles.js
@@ -11,13 +11,11 @@ export const iconStyles = css`
     justify-content: center;
     align-items: center;
     box-sizing: border-box;
-    vertical-align: middle;
     width: var(--vaadin-icon-size, 1lh);
     height: var(--vaadin-icon-size, 1lh);
     flex: none;
     fill: var(--vaadin-icon-color, currentColor);
     container-type: size;
-    contain: layout;
   }
 
   :host::after,
@@ -47,5 +45,11 @@ export const iconStyles = css`
 
   :host([font-icon-content])::before {
     content: attr(font-icon-content);
+  }
+
+  .baseline::before {
+    content: '\\2003';
+    display: inline-block;
+    width: 0;
   }
 `;

--- a/packages/icon/src/styles/vaadin-icon-base-styles.js
+++ b/packages/icon/src/styles/vaadin-icon-base-styles.js
@@ -11,6 +11,7 @@ export const iconStyles = css`
     justify-content: center;
     align-items: center;
     box-sizing: border-box;
+    vertical-align: middle;
     width: var(--vaadin-icon-size, 1lh);
     height: var(--vaadin-icon-size, 1lh);
     flex: none;

--- a/packages/icon/src/styles/vaadin-icon-base-styles.js
+++ b/packages/icon/src/styles/vaadin-icon-base-styles.js
@@ -47,6 +47,10 @@ export const iconStyles = css`
     content: attr(font-icon-content);
   }
 
+  .baseline {
+    order: -1;
+  }
+
   .baseline::before {
     content: '\\2003';
     display: inline-block;

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -72,6 +72,7 @@ class Icon extends IconMixin(ElementMixin(LumoInjectionMixin(ThemableMixin(Polyl
   /** @protected */
   render() {
     return html`
+      <span class="baseline"></span>
       <svg
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -65,6 +65,12 @@ class Icon extends IconMixin(ElementMixin(LumoInjectionMixin(ThemableMixin(Polyl
     return 'vaadin-icon';
   }
 
+  static get lumoInjector() {
+    return {
+      includeBaseStyles: true,
+    };
+  }
+
   static get styles() {
     return iconStyles;
   }

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -65,14 +65,14 @@ class Icon extends IconMixin(ElementMixin(LumoInjectionMixin(ThemableMixin(Polyl
     return 'vaadin-icon';
   }
 
+  static get styles() {
+    return iconStyles;
+  }
+
   static get lumoInjector() {
     return {
       includeBaseStyles: true,
     };
-  }
-
-  static get styles() {
-    return iconStyles;
   }
 
   /** @protected */

--- a/packages/vaadin-lumo-styles/src/components/button.css
+++ b/packages/vaadin-lumo-styles/src/components/button.css
@@ -266,7 +266,6 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
   /* Icons */
 
   [part] ::slotted(vaadin-icon) {
-    display: inline-block;
     width: var(--lumo-icon-size-m);
     height: var(--lumo-icon-size-m);
   }

--- a/packages/vaadin-lumo-styles/src/components/icon.css
+++ b/packages/vaadin-lumo-styles/src/components/icon.css
@@ -5,43 +5,7 @@
  */
 @media lumo_components_icon {
   :host {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-    vertical-align: middle;
     width: var(--lumo-icon-size-m);
     height: var(--lumo-icon-size-m);
-    fill: currentColor;
-    container-type: size;
-  }
-
-  :host::after,
-  :host::before {
-    line-height: 1;
-    font-size: 100cqh;
-    -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
-    -moz-osx-font-smoothing: grayscale;
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-    /* prevent overflowing icon from clipping, see https://github.com/vaadin/flow-components/issues/5872 */
-    overflow: visible;
-  }
-
-  :host(:is([icon-class], [font-icon-content])) svg {
-    display: none;
-  }
-
-  :host([font-icon-content])::before {
-    content: attr(font-icon-content);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/menu-bar-item.css
+++ b/packages/vaadin-lumo-styles/src/components/menu-bar-item.css
@@ -12,7 +12,6 @@
   }
 
   [part='content'] ::slotted(vaadin-icon) {
-    display: inline-block;
     width: var(--lumo-icon-size-m);
     height: var(--lumo-icon-size-m);
   }


### PR DESCRIPTION
Add an explicit baseline alignment element to the shadow DOM, since both pseudo elements are already used.

Before:
![Screenshot 2025-07-08 at 15 17 44](https://github.com/user-attachments/assets/b53158d7-e810-470b-83b0-b0c9c54d71ab)

After:
![Screenshot 2025-07-08 at 15 17 30](https://github.com/user-attachments/assets/dfb66548-23e3-4f27-92ba-205c7318905e)
