### PR TITLE
chore: use different names for failed screenshot artifacts

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: screenshots
+          name: base-screenshots
           path: |
             packages/*/test/visual/base/screenshots/*/failed/*.png
   lumo:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: screenshots
+          name: lumo-screenshots
           path: |
             packages/*/test/visual/lumo/screenshots/*/failed/*.png
             packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: screenshots
+          name: lumo-css-screenshots
           path: |
             packages/*/test/visual/lumo/screenshots/*/failed/*.png
             packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png


### PR DESCRIPTION
## Description

Currently, when both Base and Lumo visual test jobs fail, only the first one that failed upload artifacts.
The other one fails with the following error as we use the same "screenshots" artifact name:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

Updated to add prefix so that we can handle these cases and get screenshots uploaded for all jobs.

## Type of change

- Internal change