### PR TITLE
refactor!: remove transform: translateZ(0) from split-layout

### DIFF
--- a/packages/split-layout/src/styles/vaadin-split-layout-core-styles.js
+++ b/packages/split-layout/src/styles/vaadin-split-layout-core-styles.js
@@ -9,7 +9,6 @@ export const splitLayoutStyles = css`
   :host {
     display: flex;
     overflow: hidden !important;
-    transform: translateZ(0);
   }
 
   :host([hidden]) {

--- a/packages/vaadin-lumo-styles/src/components/split-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/split-layout.css
@@ -7,7 +7,6 @@
   :host {
     display: flex;
     overflow: hidden !important;
-    transform: translateZ(0);
   }
 
   :host([hidden]) {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/537

While `overflow: hidden` should be preserved as I mentioned in https://github.com/vaadin/web-components/issues/537#issuecomment-3051502245, I couldn't reproduce the stacking issue mentioned in https://github.com/vaadin/vaadin-split-layout/pull/19#issuecomment-262521655, so let's remove `transform: translateZ(0)`. 

## Type of change

- Breaking change