### PR TITLE
refactor: open date picker overlay on element focus in fullscreen

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -470,6 +470,18 @@ export const DatePickerMixin = (subclass) =>
     }
 
     /**
+     * @protected
+     * @override
+     * */
+    focus(options) {
+      if (this._noInput && !isKeyboardActive()) {
+        this.open();
+      } else {
+        super.focus(options);
+      }
+    }
+
+    /**
      * Opens the dropdown.
      */
     open() {

--- a/packages/date-picker/test/fullscreen.test.js
+++ b/packages/date-picker/test/fullscreen.test.js
@@ -59,10 +59,33 @@ describe('fullscreen mode', () => {
         expect(document.activeElement).to.not.equal(input);
       });
 
+      it('should not focus input element when focusing the date picker', () => {
+        const spy = sinon.spy(input, 'focus');
+        datePicker.focus();
+        expect(spy.called).to.be.false;
+        expect(document.activeElement).to.not.equal(input);
+      });
+
+      it('should focus date element when focusing the date picker', async () => {
+        datePicker.focus();
+        await untilOverlayRendered(datePicker);
+        const cell = getFocusableCell(datePicker);
+        expect(cell).to.be.instanceOf(HTMLTableCellElement);
+        expect(cell.getAttribute('part')).to.include('today');
+      });
+
       it('should not blur input element when focusing it with keyboard', () => {
         const spy = sinon.spy(input, 'blur');
         tabKeyDown(input);
         input.focus();
+        expect(spy.called).to.be.false;
+        expect(document.activeElement).to.equal(input);
+      });
+
+      it('should not blur input element when focusing date picker with keyboard', () => {
+        const spy = sinon.spy(input, 'blur');
+        tabKeyDown(input);
+        datePicker.focus();
         expect(spy.called).to.be.false;
         expect(document.activeElement).to.equal(input);
       });


### PR DESCRIPTION
## Description

This change overrides the `focus` method to change how focus is handled when the element is in fullscreen mode and it's focused. This is needed to avoid the element being immediately removed by the Grid Pro when the user is on a device with small viewport. The element receives focus, but the `_onFocus` listener has a similar detection, which removes the focus from the input element, which causes the component to be removed from the cell when used as a custom editor.

Part of #9158

## Type of change

Refactor