### PR TITLE
refactor: move all color scheme styles to one dedicated file

### DIFF
--- a/packages/vaadin-lumo-styles/global.css
+++ b/packages/vaadin-lumo-styles/global.css
@@ -4,11 +4,5 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @import './src/global/badge.css';
-@import './src/global/dark.css';
+@import './src/global/color-scheme.css';
 @import './src/global/typography.css';
-
-:where(:root, :host) {
-  color: var(--lumo-body-text-color);
-  background-color: var(--lumo-base-color);
-  color-scheme: light;
-}

--- a/packages/vaadin-lumo-styles/src/global/color-scheme.css
+++ b/packages/vaadin-lumo-styles/src/global/color-scheme.css
@@ -1,8 +1,14 @@
 /**
  * @license
- * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * Copyright (c) 2000 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+:where(:root, :host) {
+  color: var(--lumo-body-text-color);
+  background-color: var(--lumo-base-color);
+  color-scheme: light;
+}
+
 [theme~='dark'] {
   /* Base (background) */
   --lumo-base-color: hsl(214, 35%, 21%);


### PR DESCRIPTION
## Description

The PR consolidates all color scheme styles into a `color-scheme.css` file. Before, they were partially defined in `global.css`, which made it impossible to import them separately from other global styles. This created unnecessary inconsistency with the JS-based Lumo version where it was possible by using `color.js`.

Part of #9082 

## Type of change

- [x] Refactor
