### PR TITLE
test: add workaround to fix failing grid-pro custom-field test

### DIFF
--- a/test/integration/grid-pro-custom-editor.test.js
+++ b/test/integration/grid-pro-custom-editor.test.js
@@ -63,6 +63,8 @@ describe('grid-pro custom editor', () => {
             // NOTE: using `innerHTML` doesn't work due to the timing issue in custom-field
             // See https://github.com/vaadin/web-components/issues/7871
             const field = document.createElement('vaadin-custom-field');
+            // TODO: workaround sendMouse test failing locally in Chrome
+            field.style.lineHeight = '1.5';
             field.appendChild(document.createElement('vaadin-text-field'));
             field.appendChild(document.createElement('vaadin-text-field'));
             root.appendChild(field);

--- a/test/integration/grid-pro-custom-editor.test.js
+++ b/test/integration/grid-pro-custom-editor.test.js
@@ -22,6 +22,16 @@ describe('grid-pro custom editor', () => {
       </vaadin-gri-pro>
     `);
 
+    // FIXME: remove when switching to base styles.
+    // Ensure grid cells have some height.
+    fixtureSync(`
+      <style>
+        vaadin-grid-pro::part(cell) {
+          min-height: 36px;
+        }
+      </style>
+    `);
+
     const column = grid.querySelector(`[path="${path}"]`);
     switch (path) {
       case 'date':
@@ -63,8 +73,6 @@ describe('grid-pro custom editor', () => {
             // NOTE: using `innerHTML` doesn't work due to the timing issue in custom-field
             // See https://github.com/vaadin/web-components/issues/7871
             const field = document.createElement('vaadin-custom-field');
-            // TODO: workaround sendMouse test failing locally in Chrome
-            field.style.lineHeight = '1.5';
             field.appendChild(document.createElement('vaadin-text-field'));
             field.appendChild(document.createElement('vaadin-text-field'));
             root.appendChild(field);


### PR DESCRIPTION
## Description

The following test fails locally but for some reason passes in CI:

```
test/integration/grid-pro-custom-editor.test.js:

 ❌ grid-pro custom editor > custom-field > should not stop editing when switching between fields using mouse
      AssertionError: expected null to be truthy
        at n.<anonymous> (test/integration/grid-pro-custom-editor.test.js:305:71)

Chromium: |██████████████████████████████| 28/28 test files | 268 passed, 1 failed, 1 skipped
```

I wasn't able to figure out why it happens but it's somehow related to removal of Lumo from ITs.
After some debugging I figured out that test passes after adding `line-height` to the field.

## Type of change

- Test