### PR TITLE
refactor: restore vaadin prefix to style-props base layer

### DIFF
--- a/packages/component-base/src/style-props.js
+++ b/packages/component-base/src/style-props.js
@@ -10,7 +10,7 @@ import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-sty
 addGlobalThemeStyles(
   'vaadin-base',
   css`
-    @layer base {
+    @layer vaadin.base {
       :where(html) {
         /* Background color */
         --vaadin-background-color: light-dark(#fff, #222);


### PR DESCRIPTION
## Description

Follow-up to #9675

The original layer was using `vaadin.base` - let's use that again.

## Type of change

- Refactor