### PR TITLE
refactor!: rename updateItem to updateRow, mark it as private

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -544,16 +544,16 @@ export const InlineEditingMixin = (superClass) =>
     /**
      * @param {!HTMLElement} row
      * @param {GridItem} item
-     * @protected
+     * @private
      */
-    _updateItem(row, item) {
+    __updateRow(row, item = row._item) {
       if (this.__edited) {
         const { cell, model } = this.__edited;
         if (cell.parentNode === row && model.item !== item) {
           this._stopEdit();
         }
       }
-      super._updateItem(row, item);
+      super.__updateRow(row, item);
     }
 
     /**

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -588,7 +588,7 @@ export const InlineEditingMixin = (superClass) =>
       const isEditable = column.isCellEditable(model);
 
       // Cancel editing if the cell is currently edited one and becomes no longer editable
-      // TODO: should be moved to `_updateItem` when Grid connector is updated to use it.
+      // TODO: should be moved to `__updateRow` when Grid connector is updated to use it.
       if (this.__edited && this.__edited.cell === cell && !isEditable) {
         this._stopEdit(true, true);
       }

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -184,7 +184,7 @@ export const DataProviderMixin = (superClass) =>
 
     /**
      * @param {number} index
-     * @param {HTMLElement} el
+     * @param {HTMLElement} row
      * @protected
      */
     _getItem(index, row) {

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -187,18 +187,18 @@ export const DataProviderMixin = (superClass) =>
      * @param {HTMLElement} el
      * @protected
      */
-    _getItem(index, el) {
-      el.index = index;
+    _getItem(index, row) {
+      row.index = index;
 
       const { item } = this._dataProviderController.getFlatIndexContext(index);
       if (item) {
-        this.__updateLoading(el, false);
-        this._updateItem(el, item);
+        this.__updateLoading(row, false);
+        this.__updateRow(row, item);
         if (this._isExpanded(item)) {
           this._dataProviderController.ensureFlatIndexHierarchy(index);
         }
       } else {
-        this.__updateLoading(el, true);
+        this.__updateLoading(row, true);
         this._dataProviderController.ensureFlatIndexLoaded(index);
       }
     }

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -742,9 +742,9 @@ export const GridMixin = (superClass) =>
     /**
      * @param {!HTMLElement} row
      * @param {GridItem} item
-     * @protected
+     * @private
      */
-    _updateItem(row, item) {
+    __updateRow(row, item = row._item) {
       row._item = item;
       const model = this.__getRowModel(row);
 

--- a/packages/grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.js
@@ -140,7 +140,7 @@ export const RowDetailsMixin = (superClass) =>
       }
 
       // Assigns a renderer when the details cell is opened.
-      // The details cell content is rendered later in the `_updateItem` method.
+      // The details cell content is rendered later in the `__updateRow` method.
       if (this.rowDetailsRenderer) {
         cell._renderer = this.rowDetailsRenderer;
       }

--- a/packages/grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.js
@@ -98,13 +98,13 @@ export const RowDetailsMixin = (superClass) =>
       iterateChildren(this.$.items, (row) => {
         // Re-renders the row to possibly close the previously opened details.
         if (row.hasAttribute('details-opened')) {
-          this._updateItem(row, row._item);
+          this.__updateRow(row);
           return;
         }
 
         // Re-renders the row to open the details when a row details renderer is provided.
         if (rowDetailsRenderer && this._isDetailsOpened(row._item)) {
-          this._updateItem(row, row._item);
+          this.__updateRow(row);
         }
       });
     }

--- a/packages/grid/test/data-provider.test.js
+++ b/packages/grid/test/data-provider.test.js
@@ -323,7 +323,7 @@ describe('data provider', () => {
 
         grid.dataProvider.resetHistory();
         const renderSpy = sinon.spy(grid, '_flatSizeChanged');
-        const updateItemSpy = sinon.spy(grid, '_updateItem');
+        const updateItemSpy = sinon.spy(grid, '__updateRow');
         grid.clearCache();
 
         expect(grid.dataProvider.callCount).to.equal(2);
@@ -607,7 +607,7 @@ describe('data provider', () => {
 
     describe('rendering', () => {
       function getFirstRowUpdateCount() {
-        const callsForFirstIndex = grid._updateItem.getCalls().filter((call) => {
+        const callsForFirstIndex = grid.__updateRow.getCalls().filter((call) => {
           const item = call.args[1];
           return item.value === '0';
         });
@@ -626,14 +626,14 @@ describe('data provider', () => {
 
           cb(pageItems, 3);
         };
-        sinon.spy(grid, '_updateItem');
+        sinon.spy(grid, '__updateRow');
         await nextFrame();
       });
 
       it('should limit row updates', async () => {
         grid.expandedItems = [{ value: '0' }, { value: '1' }, { value: '1-0' }, { value: '2' }];
         await nextFrame();
-        // There are currently two _updateItem calls for a row. The extra one (a direct update request)
+        // There are currently two __updateRow calls for a row. The extra one (a direct update request)
         // is coming from _expandedItemsChanged.
         expect(getFirstRowUpdateCount()).to.equal(2);
       });


### PR DESCRIPTION
## Description

The PR renames `_updateItem` to `__updateRow`, marks it as private, and provides a default value for the second parameter `item`.

## Type of change

- [x] Refactor
