### PR TITLE
chore: remove shadow CSS injection from accordion JSDoc

### DIFF
--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -56,15 +56,6 @@ export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
  * See the [`<vaadin-accordion-panel>`](#/elements/vaadin-accordion-panel)
  * documentation for the available state attributes and stylable shadow parts.
  *
- * **Note:** You can apply the theme to `<vaadin-accordion>` component itself,
- * especially by using the following CSS selector:
- *
- * ```
- * :host ::slotted(vaadin-accordion-panel) {
- *   margin-bottom: 5px;
- * }
- * ```
- *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -41,15 +41,6 @@ import { AccordionMixin } from './vaadin-accordion-mixin.js';
  * See the [`<vaadin-accordion-panel>`](#/elements/vaadin-accordion-panel)
  * documentation for the available state attributes and stylable shadow parts.
  *
- * **Note:** You can apply the theme to `<vaadin-accordion>` component itself,
- * especially by using the following CSS selector:
- *
- * ```
- * :host ::slotted(vaadin-accordion-panel) {
- *   margin-bottom: 5px;
- * }
- * ```
- *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.


### PR DESCRIPTION
## Description

These instructions in `vaadin-accordion` JSDoc are using the `:host` syntax that covers ThemableMixin based styling.
As we recommend using light DOM and part based CSS instead, let's remove these blocks from documentation.

## Type of change

- Documentation