### PR TITLE
docs: improve code snippets in JSDoc comments, add language tags

### DIFF
--- a/packages/accordion/src/vaadin-accordion.d.ts
+++ b/packages/accordion/src/vaadin-accordion.d.ts
@@ -38,7 +38,7 @@ export type AccordionEventMap = AccordionCustomEventMap & HTMLElementEventMap;
  * Only one panel can be opened at a time, opening a new one forces
  * previous panel to close and hide its content.
  *
- * ```
+ * ```html
  * <vaadin-accordion>
  *   <vaadin-accordion-panel>
  *     <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -23,7 +23,7 @@ import { AccordionMixin } from './vaadin-accordion-mixin.js';
  * Only one panel can be opened at a time, opening a new one forces
  * previous panel to close and hide its content.
  *
- * ```
+ * ```html
  * <vaadin-accordion>
  *   <vaadin-accordion-panel>
  *     <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>

--- a/packages/app-layout/src/vaadin-app-layout.d.ts
+++ b/packages/app-layout/src/vaadin-app-layout.d.ts
@@ -37,7 +37,7 @@ export type AppLayoutEventMap = AppLayoutCustomEventMap & HTMLElementEventMap;
 /**
  * `<vaadin-app-layout>` is a Web Component providing a quick and easy way to get a common application layout structure done.
  *
- * ```
+ * ```html
  * <vaadin-app-layout primary-section="navbar|drawer">
  *  <vaadin-drawer-toggle slot="navbar [touch-optimized]"></vaadin-drawer-toggle>
  *  <h3 slot="navbar [touch-optimized]">Company Name</h3>

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -17,7 +17,7 @@ import { AppLayoutMixin } from './vaadin-app-layout-mixin.js';
 /**
  * `<vaadin-app-layout>` is a Web Component providing a quick and easy way to get a common application layout structure done.
  *
- * ```
+ * ```html
  * <vaadin-app-layout primary-section="navbar|drawer">
  *  <vaadin-drawer-toggle slot="navbar [touch-optimized]"></vaadin-drawer-toggle>
  *  <h3 slot="navbar [touch-optimized]">Company Name</h3>

--- a/packages/app-layout/src/vaadin-drawer-toggle.d.ts
+++ b/packages/app-layout/src/vaadin-drawer-toggle.d.ts
@@ -10,7 +10,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * The Drawer Toggle component controls the drawer in App Layout component.
  *
- * ```
+ * ```html
  * <vaadin-app-layout>
  *   <vaadin-drawer-toggle slot="navbar">Toggle drawer</vaadin-drawer-toggle>
  * </vaadin-app-layout>

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -17,7 +17,7 @@ import { drawerToggle } from './styles/vaadin-drawer-toggle-core-styles.js';
 /**
  * The Drawer Toggle component controls the drawer in App Layout component.
  *
- * ```
+ * ```html
  * <vaadin-app-layout>
  *   <vaadin-drawer-toggle slot="navbar">Toggle drawer</vaadin-drawer-toggle>
  * </vaadin-app-layout>

--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -15,13 +15,13 @@ export { AvatarGroupI18n, AvatarGroupItem, AvatarI18n };
  *
  * To create the avatar group, first add the component to the page:
  *
- * ```
+ * ```html
  * <vaadin-avatar-group></vaadin-avatar-group>
  * ```
  *
  * And then use [`items`](#/elements/vaadin-avatar-group#property-items) property to initialize the structure:
  *
- * ```
+ * ```js
  * document.querySelector('vaadin-avatar-group').items = [
  *   {name: 'John Doe'},
  *   {abbr: 'AB'}

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -22,13 +22,13 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  *
  * To create the avatar group, first add the component to the page:
  *
- * ```
+ * ```html
  * <vaadin-avatar-group></vaadin-avatar-group>
  * ```
  *
  * And then use [`items`](#/elements/vaadin-avatar-group#property-items) property to initialize the structure:
  *
- * ```
+ * ```js
  * document.querySelector('vaadin-avatar-group').items = [
  *   {name: 'John Doe'},
  *   {abbr: 'AB'}

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -12,7 +12,7 @@ export * from './vaadin-confirm-dialog-mixin.js';
 /**
  * `<vaadin-confirm-dialog>` is a Web Component for showing alerts and asking for user confirmation.
  *
- * ```
+ * ```html
  * <vaadin-confirm-dialog cancel-button-visible>
  *   There are unsaved changes. Do you really want to leave?
  * </vaadin-confirm-dialog>

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -16,7 +16,7 @@ import { ConfirmDialogMixin } from './vaadin-confirm-dialog-mixin.js';
 /**
  * `<vaadin-confirm-dialog>` is a Web Component for showing alerts and asking for user confirmation.
  *
- * ```
+ * ```html
  * <vaadin-confirm-dialog cancel-button-visible>
  *   There are unsaved changes. Do you really want to leave?
  * </vaadin-confirm-dialog>

--- a/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -19,7 +19,7 @@ import { CookieConsentMixin } from './vaadin-cookie-consent-mixin.js';
  * predefined text, a link to https://cookiesandyou.com/ describing cookies and a consent button.
  *
  * The texts, link and position can be configured using attributes/properties, e.g.
- * ```
+ * ```html
  * <vaadin-cookie-consent learn-more-link="https://mysite.com/cookies.html"></vaadin-cookie-consent>
  * ```
  *

--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -22,7 +22,7 @@ import { CookieConsentMixin } from './vaadin-cookie-consent-mixin.js';
  * predefined text, a link to https://cookiesandyou.com/ describing cookies and a consent button.
  *
  * The texts, link and position can be configured using attributes/properties, e.g.
- * ```
+ * ```html
  * <vaadin-cookie-consent learn-more-link="https://mysite.com/cookies.html"></vaadin-cookie-consent>
  * ```
  *

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -46,7 +46,7 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
 /**
  * `<vaadin-custom-field>` is a web component for wrapping multiple components as a single field.
  *
- * ```
+ * ```html
  * <vaadin-custom-field label="Appointment time">
  *   <vaadin-date-picker></vaadin-date-picker>
  *   <vaadin-time-picker></vaadin-time-picker>

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -15,7 +15,7 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
 /**
  * `<vaadin-custom-field>` is a web component for wrapping multiple components as a single field.
  *
- * ```
+ * ```html
  * <vaadin-custom-field label="Appointment time">
  *   <vaadin-date-picker></vaadin-date-picker>
  *   <vaadin-time-picker></vaadin-time-picker>

--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -22,7 +22,7 @@ export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
  * `<vaadin-details>` is a Web Component which the creates an
  * expandable panel similar to `<details>` HTML element.
  *
- * ```
+ * ```html
  * <vaadin-details>
  *   <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
  *   <div>

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -16,7 +16,7 @@ import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
  * `<vaadin-details>` is a Web Component which the creates an
  * expandable panel similar to `<details>` HTML element.
  *
- * ```
+ * ```html
  * <vaadin-details>
  *   <vaadin-details-summary slot="summary">Expandable Details</vaadin-details-summary>
  *   <div>

--- a/packages/grid-pro/src/vaadin-grid-pro.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro.d.ts
@@ -49,7 +49,7 @@ export interface GridProEventMap<TItem>
  *
  * See [`<vaadin-grid>`](#/elements/vaadin-grid) documentation for details.
  *
- * ```
+ * ```html
  * <vaadin-grid-pro></vaadin-grid-pro>
  * ```
  *

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -19,7 +19,7 @@ import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
  *
  * See [`<vaadin-grid>`](#/elements/vaadin-grid) documentation for details.
  *
- * ```
+ * ```html
  * <vaadin-grid-pro></vaadin-grid-pro>
  * ```
  *

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.d.ts
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.d.ts
@@ -10,7 +10,7 @@ import { HorizontalLayoutMixin } from './vaadin-horizontal-layout-mixin.js';
 /**
  * `<vaadin-horizontal-layout>` provides a simple way to horizontally align your HTML elements.
  *
- * ```
+ * ```html
  * <vaadin-horizontal-layout>
  *   <div>Item 1</div>
  *   <div>Item 2</div>

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -15,7 +15,7 @@ import { HorizontalLayoutMixin } from './vaadin-horizontal-layout-mixin.js';
 /**
  * `<vaadin-horizontal-layout>` provides a simple way to horizontally align your HTML elements.
  *
- * ```
+ * ```html
  * <vaadin-horizontal-layout>
  *   <div>Item 1</div>
  *   <div>Item 2</div>

--- a/packages/item/src/vaadin-item.d.ts
+++ b/packages/item/src/vaadin-item.d.ts
@@ -10,10 +10,8 @@ import { ItemMixin } from './vaadin-item-mixin.js';
 /**
  * `<vaadin-item>` is a Web Component providing layout for items in tabs and menus.
  *
- * ```
- *   <vaadin-item>
- *     Item content
- *   </vaadin-item>
+ * ```html
+ * <vaadin-item>Item content</vaadin-item>
  * ```
  *
  * ### Selectable

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -15,10 +15,8 @@ import { ItemMixin } from './vaadin-item-mixin.js';
 /**
  * `<vaadin-item>` is a Web Component providing layout for items in tabs and menus.
  *
- * ```
- *   <vaadin-item>
- *     Item content
- *   </vaadin-item>
+ * ```html
+ * <vaadin-item>Item content</vaadin-item>
  * ```
  *
  * ### Selectable

--- a/packages/list-box/src/vaadin-list-box.d.ts
+++ b/packages/list-box/src/vaadin-list-box.d.ts
@@ -35,13 +35,13 @@ export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxCustomEvent
 /**
  * `<vaadin-list-box>` is a Web Component for creating menus.
  *
- * ```
- *   <vaadin-list-box selected="2">
- *     <vaadin-item>Item 1</vaadin-item>
- *     <vaadin-item>Item 2</vaadin-item>
- *     <vaadin-item>Item 3</vaadin-item>
- *     <vaadin-item>Item 4</vaadin-item>
- *   </vaadin-list-box>
+ * ```html
+ * <vaadin-list-box selected="2">
+ *   <vaadin-item>Item 1</vaadin-item>
+ *   <vaadin-item>Item 2</vaadin-item>
+ *   <vaadin-item>Item 3</vaadin-item>
+ *   <vaadin-item>Item 4</vaadin-item>
+ * </vaadin-list-box>
  * ```
  *
  * ### Styling

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -16,13 +16,13 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
 /**
  * `<vaadin-list-box>` is a Web Component for creating menus.
  *
- * ```
- *   <vaadin-list-box selected="2">
- *     <vaadin-item>Item 1</vaadin-item>
- *     <vaadin-item>Item 2</vaadin-item>
- *     <vaadin-item>Item 3</vaadin-item>
- *     <vaadin-item>Item 4</vaadin-item>
- *   </vaadin-list-box>
+ * ```html
+ * <vaadin-list-box selected="2">
+ *   <vaadin-item>Item 1</vaadin-item>
+ *   <vaadin-item>Item 2</vaadin-item>
+ *   <vaadin-item>Item 3</vaadin-item>
+ *   <vaadin-item>Item 4</vaadin-item>
+ * </vaadin-list-box>
  * ```
  *
  * ### Styling

--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -39,7 +39,7 @@ export interface LoginFormEventMap extends HTMLElementEventMap, LoginFormCustomE
  * `<vaadin-login-form>` is a Web Component providing an easy way to require users
  * to log in into an application. Note that component has no shadowRoot.
  *
- * ```
+ * ```html
  * <vaadin-login-form></vaadin-login-form>
  * ```
  *

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -19,7 +19,7 @@ import { LoginFormMixin } from './vaadin-login-form-mixin.js';
  * `<vaadin-login-form>` is a Web Component providing an easy way to require users
  * to log in into an application. Note that component has no shadowRoot.
  *
- * ```
+ * ```html
  * <vaadin-login-form></vaadin-login-form>
  * ```
  *

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -52,7 +52,7 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * having an additional `brand` part for application title and description. Using `<vaadin-login-overlay>` allows
  * password managers to work with login form.
  *
- * ```
+ * ```html
  * <vaadin-login-overlay opened></vaadin-login-overlay>
  * ```
  *

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -18,7 +18,7 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  * having an additional `brand` part for application title and description. Using `<vaadin-login-overlay>` allows
  * password managers to work with login form.
  *
- * ```
+ * ```html
  * <vaadin-login-overlay opened></vaadin-login-overlay>
  * ```
  *

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -30,13 +30,13 @@ export interface MenuBarEventMap<TItem extends MenuBarItem = MenuBarItem>
  *
  * To create the menu bar, first add the component to the page:
  *
- * ```
+ * ```html
  * <vaadin-menu-bar></vaadin-menu-bar>
  * ```
  *
  * And then use [`items`](#/elements/vaadin-menu-bar#property-items) property to initialize the structure:
  *
- * ```
+ * ```js
  * document.querySelector('vaadin-menu-bar').items = [{text: 'File'}, {text: 'Edit'}];
  * ```
  *

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -22,13 +22,13 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  *
  * To create the menu bar, first add the component to the page:
  *
- * ```
+ * ```html
  * <vaadin-menu-bar></vaadin-menu-bar>
  * ```
  *
  * And then use [`items`](#/elements/vaadin-menu-bar#property-items) property to initialize the structure:
  *
- * ```
+ * ```js
  * document.querySelector('vaadin-menu-bar').items = [{text: 'File'}, {text: 'Edit'}];
  * ```
  *

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.d.ts
@@ -29,7 +29,7 @@ export interface RichTextEditorEventMap extends HTMLElementEventMap, RichTextEdi
  * It provides a set of toolbar controls to apply formatting on the content,
  * which is stored and can be accessed as HTML5 or JSON string.
  *
- * ```
+ * ```html
  * <vaadin-rich-text-editor></vaadin-rich-text-editor>
  * ```
  *

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -27,7 +27,7 @@ import { RichTextEditorMixin } from './vaadin-rich-text-editor-mixin.js';
  * It provides a set of toolbar controls to apply formatting on the content,
  * which is stored and can be accessed as HTML5 or JSON string.
  *
- * ```
+ * ```html
  * <vaadin-rich-text-editor></vaadin-rich-text-editor>
  * ```
  *

--- a/packages/scroller/src/vaadin-scroller.d.ts
+++ b/packages/scroller/src/vaadin-scroller.d.ts
@@ -10,7 +10,7 @@ import { ScrollerMixin } from './vaadin-scroller-mixin.js';
 /**
  * `<vaadin-scroller>` provides a simple way to enable scrolling when its content is overflowing.
  *
- * ```
+ * ```html
  * <vaadin-scroller>
  *   <div>Content</div>
  * </vaadin-scroller>

--- a/packages/scroller/src/vaadin-scroller.js
+++ b/packages/scroller/src/vaadin-scroller.js
@@ -16,7 +16,7 @@ import { ScrollerMixin } from './vaadin-scroller-mixin.js';
 /**
  * `<vaadin-scroller>` provides a simple way to enable scrolling when its content is overflowing.
  *
- * ```
+ * ```html
  * <vaadin-scroller>
  *   <div>Content</div>
  * </vaadin-scroller>

--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -10,10 +10,8 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * `<vaadin-tab>` is a Web Component providing an accessible and customizable tab.
  *
- * ```
- *   <vaadin-tab>
- *     Tab 1
- *   </vaadin-tab>
+ * ```html
+ * <vaadin-tab>Tab 1</vaadin-tab>
  * ```
  *
  * The following state attributes are available for styling:

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -16,10 +16,8 @@ import { tabStyles } from './styles/vaadin-tab-core-styles.js';
 /**
  * `<vaadin-tab>` is a Web Component providing an accessible and customizable tab.
  *
- * ```
- *   <vaadin-tab>
- *     Tab 1
- *   </vaadin-tab>
+ * ```html
+ * <vaadin-tab>Tab 1</vaadin-tab>
  * ```
  *
  * The following state attributes are available for styling:

--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -30,13 +30,13 @@ export interface TabsEventMap extends HTMLElementEventMap, TabsCustomEventMap {}
 /**
  * `<vaadin-tabs>` is a Web Component for organizing and grouping content into sections.
  *
- * ```
- *   <vaadin-tabs selected="4">
- *     <vaadin-tab>Page 1</vaadin-tab>
- *     <vaadin-tab>Page 2</vaadin-tab>
- *     <vaadin-tab>Page 3</vaadin-tab>
- *     <vaadin-tab>Page 4</vaadin-tab>
- *   </vaadin-tabs>
+ * ```html
+ * <vaadin-tabs selected="4">
+ *   <vaadin-tab>Page 1</vaadin-tab>
+ *   <vaadin-tab>Page 2</vaadin-tab>
+ *   <vaadin-tab>Page 3</vaadin-tab>
+ *   <vaadin-tab>Page 4</vaadin-tab>
+ * </vaadin-tabs>
  * ```
  *
  * ### Styling

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -16,13 +16,13 @@ import { TabsMixin } from './vaadin-tabs-mixin.js';
 /**
  * `<vaadin-tabs>` is a Web Component for organizing and grouping content into sections.
  *
- * ```
- *   <vaadin-tabs selected="4">
- *     <vaadin-tab>Page 1</vaadin-tab>
- *     <vaadin-tab>Page 2</vaadin-tab>
- *     <vaadin-tab>Page 3</vaadin-tab>
- *     <vaadin-tab>Page 4</vaadin-tab>
- *   </vaadin-tabs>
+ * ```html
+ * <vaadin-tabs selected="4">
+ *   <vaadin-tab>Page 1</vaadin-tab>
+ *   <vaadin-tab>Page 2</vaadin-tab>
+ *   <vaadin-tab>Page 3</vaadin-tab>
+ *   <vaadin-tab>Page 4</vaadin-tab>
+ * </vaadin-tabs>
  * ```
  *
  * ### Styling

--- a/packages/tabsheet/src/vaadin-tabsheet.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet.d.ts
@@ -30,21 +30,21 @@ export interface TabSheetEventMap extends HTMLElementEventMap, TabSheetCustomEve
  * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
  * into scrollable panels. The panels can be switched between by using tabs.
  *
- * ```
- *  <vaadin-tabsheet>
- *    <div slot="prefix">Prefix</div>
- *    <div slot="suffix">Suffix</div>
+ * ```html
+ * <vaadin-tabsheet>
+ *   <div slot="prefix">Prefix</div>
+ *   <div slot="suffix">Suffix</div>
  *
- *    <vaadin-tabs slot="tabs">
- *      <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
- *      <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
- *      <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
- *    </vaadin-tabs>
+ *   <vaadin-tabs slot="tabs">
+ *     <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+ *     <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+ *     <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+ *   </vaadin-tabs>
  *
- *    <div tab="tab-1">Panel 1</div>
- *    <div tab="tab-2">Panel 2</div>
- *    <div tab="tab-3">Panel 3</div>
- *  </vaadin-tabsheet>
+ *   <div tab="tab-1">Panel 1</div>
+ *   <div tab="tab-2">Panel 2</div>
+ *   <div tab="tab-3">Panel 3</div>
+ * </vaadin-tabsheet>
  * ```
  *
  * ### Styling

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -18,21 +18,21 @@ import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
  * `<vaadin-tabsheet>` is a Web Component for organizing and grouping content
  * into scrollable panels. The panels can be switched between by using tabs.
  *
- * ```
- *  <vaadin-tabsheet>
- *    <div slot="prefix">Prefix</div>
- *    <div slot="suffix">Suffix</div>
+ * ```html
+ * <vaadin-tabsheet>
+ *   <div slot="prefix">Prefix</div>
+ *   <div slot="suffix">Suffix</div>
  *
- *    <vaadin-tabs slot="tabs">
- *      <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
- *      <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
- *      <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
- *    </vaadin-tabs>
+ *   <vaadin-tabs slot="tabs">
+ *     <vaadin-tab id="tab-1">Tab 1</vaadin-tab>
+ *     <vaadin-tab id="tab-2">Tab 2</vaadin-tab>
+ *     <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
+ *   </vaadin-tabs>
  *
- *    <div tab="tab-1">Panel 1</div>
- *    <div tab="tab-2">Panel 2</div>
- *    <div tab="tab-3">Panel 3</div>
- *  </vaadin-tabsheet>
+ *   <div tab="tab-1">Panel 1</div>
+ *   <div tab="tab-2">Panel 2</div>
+ *   <div tab="tab-3">Panel 3</div>
+ * </vaadin-tabsheet>
  * ```
  *
  * ### Styling

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -118,7 +118,7 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  *
  * Example:
  *
- * ```
+ * ```html
  * <vaadin-upload></vaadin-upload>
  * ```
  *

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -22,7 +22,7 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  *
  * Example:
  *
- * ```
+ * ```html
  * <vaadin-upload></vaadin-upload>
  * ```
  *

--- a/packages/vertical-layout/src/vaadin-vertical-layout.d.ts
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.d.ts
@@ -9,7 +9,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * `<vaadin-vertical-layout>` provides a simple way to vertically align your HTML elements.
  *
- * ```
+ * ```html
  * <vaadin-vertical-layout>
  *   <div>Item 1</div>
  *   <div>Item 2</div>

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -14,7 +14,7 @@ import { verticalLayoutStyles } from './styles/vaadin-vertical-layout-core-style
 /**
  * `<vaadin-vertical-layout>` provides a simple way to vertically align your HTML elements.
  *
- * ```
+ * ```html
  * <vaadin-vertical-layout>
  *   <div>Item 1</div>
  *   <div>Item 2</div>


### PR DESCRIPTION
## Description

Added missing `html` and `js` tags to code formatting. Also fixed indentation in a few places.

This will make code snippets look nicer when using the Astro based API docs viewer prototype.

## Type of change

- Documentation