### PR TITLE
fix: prevent unwanted CSS transitions on Lumo injection

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -51,7 +51,7 @@ import { accordionHeading } from './styles/vaadin-accordion-heading-core-styles.
  * @mixes DirMixin
  * @mixes ThemableMixin
  */
-class AccordionHeading extends ActiveMixin(DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-accordion-heading';
   }

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -41,7 +41,7 @@ import { AccordionPanelMixin } from './vaadin-accordion-panel-mixin.js';
  * @mixes AccordionPanelMixin
  * @mixes ThemableMixin
  */
-class AccordionPanel extends AccordionPanelMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+class AccordionPanel extends AccordionPanelMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-accordion-panel';
   }

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -108,7 +108,7 @@ import { AppLayoutMixin } from './vaadin-app-layout-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class AppLayout extends AppLayoutMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class AppLayout extends AppLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-app-layout';
   }

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -29,7 +29,7 @@ import { drawerToggle } from './styles/vaadin-drawer-toggle-core-styles.js';
  * @mixes DirMixin
  * @mixes ThemableMixin
  */
-class DrawerToggle extends ButtonMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class DrawerToggle extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-drawer-toggle';
   }

--- a/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
@@ -22,7 +22,7 @@ import { avatarGroupMenuItemStyles } from './styles/vaadin-avatar-group-menu-ite
  * @mixes ThemableMixin
  * @protected
  */
-class AvatarGroupMenuItem extends ItemMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class AvatarGroupMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-avatar-group-menu-item';
   }

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.js
@@ -22,7 +22,7 @@ import { avatarGroupMenuStyles } from './styles/vaadin-avatar-group-menu-core-st
  * @mixes ThemableMixin
  * @protected
  */
-class AvatarGroupMenu extends ListMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class AvatarGroupMenu extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-avatar-group-menu';
   }

--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -25,7 +25,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @private
  */
 class AvatarGroupOverlay extends PositionMixin(
-  OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-avatar-group-overlay';

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -63,7 +63,7 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  * @mixes AvatarGroupMixin
  * @mixes ThemableMixin
  */
-class AvatarGroup extends AvatarGroupMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class AvatarGroup extends AvatarGroupMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-avatar-group';
   }

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -47,7 +47,7 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-avatar';
   }

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -47,7 +47,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Button extends ButtonMixin(ElementMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-button';
   }

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -52,7 +52,7 @@ import { cardStyles } from './styles/vaadin-card-core-styles.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Card extends ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-card';
   }

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -182,7 +182,7 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class Chart extends ChartMixin(ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Chart extends ChartMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-chart';
   }

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -63,7 +63,7 @@ import { CheckboxGroupMixin } from './vaadin-checkbox-group-mixin.js';
  * @mixes CheckboxGroupMixin
  */
 class CheckboxGroup extends CheckboxGroupMixin(
-  ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-checkbox-group';

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -60,7 +60,7 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-checkbox';
   }

--- a/packages/combo-box/src/vaadin-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-combo-box-item.js
@@ -40,7 +40,7 @@ import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
  * @private
  */
 export class ComboBoxItem extends ComboBoxItemMixin(
-  LumoInjectionMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-combo-box-item';

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -26,7 +26,7 @@ import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
  * @private
  */
 export class ComboBoxOverlay extends ComboBoxOverlayMixin(
-  OverlayMixin(DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-combo-box-overlay';

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -157,7 +157,7 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  */
 class ComboBox extends ComboBoxDataProviderMixin(
   ComboBoxMixin(
-    PatternMixin(InputControlMixin(LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))))),
+    PatternMixin(InputControlMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))))),
   ),
 ) {
   static get is() {

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -26,7 +26,7 @@ import { confirmDialogOverlayStyles } from './styles/vaadin-confirm-dialog-overl
  * @mixes ThemableMixin
  * @private
  */
-class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-confirm-dialog-overlay';
   }

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -22,7 +22,7 @@ import { contextMenuItemStyles } from './styles/vaadin-context-menu-item-core-st
  * @mixes ThemableMixin
  * @protected
  */
-class ContextMenuItem extends ItemMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class ContextMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-context-menu-item';
   }

--- a/packages/context-menu/src/vaadin-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.js
@@ -22,7 +22,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @mixes ThemableMixin
  * @protected
  */
-class ContextMenuListBox extends ListMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class ContextMenuListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-context-menu-list-box';
   }

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -25,7 +25,7 @@ import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
  * @protected
  */
 export class ContextMenuOverlay extends MenuOverlayMixin(
-  OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-context-menu-overlay';

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -31,7 +31,7 @@ import { crudDialogOverlayStyles } from './styles/vaadin-crud-dialog-overlay-cor
  * @mixes ThemableMixin
  * @private
  */
-class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-crud-dialog-overlay';
   }

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -171,7 +171,7 @@ import { CrudMixin } from './vaadin-crud-mixin.js';
  * @mixes ThemableMixin
  * @mixes CrudMixin
  */
-class Crud extends CrudMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Crud extends CrudMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get styles() {
     return crudStyles;
   }

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -61,7 +61,7 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-custom-field';
   }

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -18,7 +18,7 @@ import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dashboardButtonStyles } from './styles/vaadin-dashboard-button-core-styles.js';
 
-class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-dashboard-button';
   }

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -58,7 +58,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * @mixes ThemableMixin
  */
 class DashboardLayout extends DashboardLayoutMixin(
-  ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-dashboard-layout';

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -71,7 +71,7 @@ import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
  * @mixes DashboardItemMixin
  */
 class DashboardSection extends DashboardItemMixin(
-  ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-dashboard-section';

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -105,7 +105,7 @@ import { DashboardSection } from './vaadin-dashboard-section.js';
  * @mixes DashboardItemMixin
  */
 class DashboardWidget extends DashboardItemMixin(
-  ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-dashboard-widget';

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -106,7 +106,7 @@ import { WidgetResizeController } from './widget-resize-controller.js';
  * @mixes ThemableMixin
  */
 class Dashboard extends DashboardLayoutMixin(
-  I18nMixin(getDefaultI18n(), ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  I18nMixin(getDefaultI18n(), ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-dashboard';

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -23,7 +23,7 @@ import { DatePickerOverlayContentMixin } from './vaadin-date-picker-overlay-cont
  * @private
  */
 class DatePickerOverlayContent extends DatePickerOverlayContentMixin(
-  LumoInjectionMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-date-picker-overlay-content';

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -24,7 +24,7 @@ import { DatePickerOverlayMixin } from './vaadin-date-picker-overlay-mixin.js';
  * @private
  */
 class DatePickerOverlay extends DatePickerOverlayMixin(
-  DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement)))),
+  DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-date-picker-overlay';

--- a/packages/date-picker/src/vaadin-date-picker-year.js
+++ b/packages/date-picker/src/vaadin-date-picker-year.js
@@ -19,7 +19,7 @@ import { datePickerYearStyles } from './styles/vaadin-date-picker-year-core-styl
  * @mixes DatePickerYearMixin
  * @private
  */
-export class DatePickerYear extends LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))) {
+export class DatePickerYear extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {
     return 'vaadin-date-picker-year';
   }

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -145,7 +145,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * @mixes DatePickerMixin
  */
 class DatePicker extends DatePickerMixin(
-  InputControlMixin(LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement))))),
+  InputControlMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-date-picker';

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -16,7 +16,7 @@ import { MonthCalendarMixin } from './vaadin-month-calendar-mixin.js';
  * @extends HTMLElement
  * @private
  */
-class MonthCalendar extends MonthCalendarMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement)))) {
+class MonthCalendar extends MonthCalendarMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-month-calendar';
   }

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -100,7 +100,7 @@ import { DateTimePickerMixin } from './vaadin-date-time-picker-mixin.js';
  * @mixes DateTimePickerMixin
  */
 class DateTimePicker extends DateTimePickerMixin(
-  ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-date-time-picker';

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -42,7 +42,7 @@ import { detailsSummary } from './styles/vaadin-details-summary-core-styles.js';
  * @mixes DirMixin
  * @mixes ThemableMixin
  */
-class DetailsSummary extends ButtonMixin(DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-details-summary';
   }

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -52,7 +52,7 @@ import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class Details extends DetailsBaseMixin(ElementMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class Details extends DetailsBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-details';
   }

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -23,7 +23,7 @@ import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
  * @private
  */
 export class DialogOverlay extends DialogOverlayMixin(
-  DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-dialog-overlay';

--- a/packages/field-highlighter/src/vaadin-field-outline.js
+++ b/packages/field-highlighter/src/vaadin-field-outline.js
@@ -19,7 +19,7 @@ import { fieldOutlineStyles } from './styles/vaadin-field-outline-core-styles.js
  * @mixes ThemableMixin
  * @private
  */
-export class FieldOutline extends ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+export class FieldOutline extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-field-outline';
   }

--- a/packages/field-highlighter/src/vaadin-user-tag.js
+++ b/packages/field-highlighter/src/vaadin-user-tag.js
@@ -20,7 +20,7 @@ import { userTagStyles } from './styles/vaadin-user-tag-core-styles.js';
  * @mixes ThemableMixin
  * @private
  */
-export class UserTag extends ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+export class UserTag extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-user-tag';
   }

--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -25,7 +25,7 @@ import { userTagsOverlayStyles } from './styles/vaadin-user-tags-overlay-core-st
  * @private
  */
 class UserTagsOverlay extends PositionMixin(
-  OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-user-tags-overlay';

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -103,7 +103,7 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  * @mixes FormItemMixin
  * @mixes ThemableMixin
  */
-class FormItem extends FormItemMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class FormItem extends FormItemMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-form-item';
   }

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -206,7 +206,7 @@ import { FormLayoutMixin } from './vaadin-form-layout-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class FormLayout extends FormLayoutMixin(ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class FormLayout extends FormLayoutMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-form-layout';
   }

--- a/packages/grid/src/vaadin-grid-filter.js
+++ b/packages/grid/src/vaadin-grid-filter.js
@@ -41,7 +41,7 @@ import { GridFilterElementMixin } from './vaadin-grid-filter-element-mixin.js';
  * @extends HTMLElement
  * @mixes GridFilterElementMixin
  */
-class GridFilter extends GridFilterElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class GridFilter extends GridFilterElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-grid-filter';
   }

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -57,7 +57,7 @@ import { GridSorterMixin } from './vaadin-grid-sorter-mixin.js';
  * @mixes ThemableMixin
  * @mixes DirMixin
  */
-class GridSorter extends GridSorterMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class GridSorter extends GridSorterMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-grid-sorter';
   }

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -67,7 +67,7 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  * @mixes GridTreeToggleMixin
  */
 class GridTreeToggle extends GridTreeToggleMixin(
-  ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-grid-tree-toggle';

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -262,7 +262,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
  * @mixes GridMixin
  * @mixes ThemableMixin
  */
-class Grid extends GridMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Grid extends GridMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-grid';
   }

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -50,7 +50,7 @@ import { HorizontalLayoutMixin } from './vaadin-horizontal-layout-mixin.js';
  * @mixes HorizontalLayoutMixin
  */
 class HorizontalLayout extends HorizontalLayoutMixin(
-  ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-horizontal-layout';

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -60,7 +60,7 @@ import { ensureSvgLiteral } from './vaadin-icon-svg.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class Icon extends IconMixin(ElementMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class Icon extends IconMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-icon';
   }

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -17,7 +17,7 @@ import { inputContainerStyles } from './styles/vaadin-input-container-core-style
  * @mixes ThemableMixin
  * @mixes DirMixin
  */
-export class InputContainer extends LumoInjectionMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))) {
+export class InputContainer extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-input-container';
   }

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -56,7 +56,7 @@ import { ItemMixin } from './vaadin-item-mixin.js';
  * @mixes ThemableMixin
  * @mixes DirMixin
  */
-class Item extends ItemMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Item extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-item';
   }

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -45,7 +45,7 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-list-box';
   }

--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -17,7 +17,7 @@ import { loginFormWrapperStyles } from './styles/vaadin-login-form-wrapper-core-
  * @mixes ThemableMixin
  * @private
  */
-class LoginFormWrapper extends ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))) {
+class LoginFormWrapper extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {
     return 'vaadin-login-form-wrapper';
   }

--- a/packages/login/src/vaadin-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-login-overlay-wrapper.js
@@ -20,7 +20,7 @@ import { LoginOverlayWrapperMixin } from './vaadin-login-overlay-wrapper-mixin.j
  * @private
  */
 class LoginOverlayWrapper extends LoginOverlayWrapperMixin(
-  ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))),
+  ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))),
 ) {
   static get is() {
     return 'vaadin-login-overlay-wrapper';

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -57,7 +57,7 @@ import { MapMixin } from './vaadin-map-mixin.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class Map extends MapMixin(ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Map extends MapMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-map';
   }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -53,7 +53,7 @@ import { masterDetailLayoutTransitionStyles } from './styles/vaadin-master-detai
  * @mixes SlotStylesMixin
  */
 class MasterDetailLayout extends SlotStylesMixin(
-  ResizeMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  ResizeMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-master-detail-layout';

--- a/packages/menu-bar/src/vaadin-menu-bar-item.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.js
@@ -22,7 +22,7 @@ import { menuBarItemStyles } from './styles/vaadin-menu-bar-item-core-styles.js'
  * @mixes ThemableMixin
  * @protected
  */
-class MenuBarItem extends ItemMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class MenuBarItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-menu-bar-item';
   }

--- a/packages/menu-bar/src/vaadin-menu-bar-list-box.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-list-box.js
@@ -22,7 +22,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @mixes ThemableMixin
  * @protected
  */
-class MenuBarListBox extends ListMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class MenuBarListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-menu-bar-list-box';
   }

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -25,7 +25,7 @@ import { menuBarOverlayStyles } from './styles/vaadin-menu-bar-overlay-core-styl
  * @protected
  */
 export class MenuBarOverlay extends MenuOverlayMixin(
-  OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-menu-bar-overlay';

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -77,7 +77,7 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  * @mixes MenuBarMixin
  * @mixes ThemableMixin
  */
-class MenuBar extends MenuBarMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class MenuBar extends MenuBarMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-menu-bar';
   }

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -33,7 +33,7 @@ import { MessageInputMixin } from './vaadin-message-input-mixin.js';
  * @mixes ElementMixin
  */
 class MessageInput extends MessageInputMixin(
-  ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-message-input';

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -48,7 +48,7 @@ import { MessageMixin } from './vaadin-message-mixin.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class Message extends MessageMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Message extends MessageMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-message';
   }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
@@ -28,7 +28,7 @@ import { multiSelectComboBoxChipStyles } from './styles/vaadin-multi-select-comb
  * @extends HTMLElement
  * @private
  */
-class MultiSelectComboBoxChip extends LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))) {
+class MultiSelectComboBoxChip extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {
     return 'vaadin-multi-select-combo-box-chip';
   }

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
@@ -40,7 +40,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @private
  */
 export class MultiSelectComboBoxItem extends ComboBoxItemMixin(
-  LumoInjectionMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-multi-select-combo-box-item';

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -26,7 +26,7 @@ import { multiSelectComboBoxOverlayStyles } from './styles/vaadin-multi-select-c
  * @private
  */
 class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(
-  OverlayMixin(DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-multi-select-combo-box-overlay';

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -100,7 +100,7 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  * @mixes MultiSelectComboBoxMixin
  */
 class MultiSelectComboBox extends MultiSelectComboBoxMixin(
-  LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-multi-select-combo-box';

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -25,7 +25,7 @@ import { NotificationContainerMixin, NotificationMixin } from './vaadin-notifica
  * @private
  */
 class NotificationContainer extends NotificationContainerMixin(
-  ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-notification-container';
@@ -63,7 +63,7 @@ class NotificationContainer extends NotificationContainerMixin(
  * @mixes ThemableMixin
  * @private
  */
-class NotificationCard extends ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))) {
+class NotificationCard extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {
     return 'vaadin-notification-card';
   }

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -70,7 +70,7 @@ import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class NumberField extends NumberFieldMixin(LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement))))) {
+class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-number-field';
   }

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -77,7 +77,7 @@ import { OverlayMixin } from './vaadin-overlay-mixin.js';
  * @mixes DirMixin
  * @mixes OverlayMixin
  */
-class Overlay extends OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Overlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-overlay';
   }

--- a/packages/password-field/src/vaadin-password-field-button.js
+++ b/packages/password-field/src/vaadin-password-field-button.js
@@ -22,7 +22,7 @@ import { passwordFieldButton } from './styles/vaadin-password-field-button-core-
  * @mixes ThemableMixin
  * @private
  */
-class PasswordFieldButton extends ButtonMixin(DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))) {
+class PasswordFieldButton extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-password-field-button';
   }

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -23,7 +23,7 @@ import { PopoverOverlayMixin } from './vaadin-popover-overlay-mixin.js';
  * @private
  */
 class PopoverOverlay extends PopoverOverlayMixin(
-  DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-popover-overlay';

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -49,7 +49,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class ProgressBar extends ProgressMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class ProgressBar extends ProgressMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-progress-bar';
   }

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -53,7 +53,7 @@ import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
  * @mixes ElementMixin
  * @mixes RadioButtonMixin
  */
-class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-radio-button';
   }

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -61,7 +61,7 @@ import { RadioGroupMixin } from './vaadin-radio-group-mixin.js';
  * @mixes ElementMixin
  * @mixes RadioGroupMixin
  */
-class RadioGroup extends RadioGroupMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class RadioGroup extends RadioGroupMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-radio-group';
   }

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
@@ -137,7 +137,7 @@ export { RichTextEditorPopup };
  * @private
  */
 class RichTextEditorPopupOverlay extends PositionMixin(
-  OverlayMixin(DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-rich-text-editor-popup-overlay';

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -101,7 +101,7 @@ import { RichTextEditorMixin } from './vaadin-rich-text-editor-mixin.js';
  * @mixes ThemableMixin
  */
 class RichTextEditor extends RichTextEditorMixin(
-  ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-rich-text-editor';

--- a/packages/scroller/src/vaadin-scroller.js
+++ b/packages/scroller/src/vaadin-scroller.js
@@ -35,7 +35,7 @@ import { ScrollerMixin } from './vaadin-scroller-mixin.js';
  * @mixes ElementMixin
  * @mixes ScrollerMixin
  */
-class Scroller extends ScrollerMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Scroller extends ScrollerMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-scroller';
   }

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -22,7 +22,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @mixes ThemableMixin
  * @protected
  */
-class SelectItem extends ItemMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-select-item';
   }

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -22,7 +22,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @mixes ThemableMixin
  * @protected
  */
-class SelectListBox extends ListMixin(ThemableMixin(DirMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class SelectListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-select-list-box';
   }

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -21,7 +21,7 @@ import { SelectOverlayMixin } from './vaadin-select-overlay-mixin.js';
  * @mixes ThemableMixin
  * @private
  */
-export class SelectOverlay extends SelectOverlayMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+export class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-select-overlay';
   }

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -20,7 +20,7 @@ import { valueButton } from './styles/vaadin-select-value-button-core-styles.js'
  * @mixes ThemableMixin
  * @protected
  */
-class SelectValueButton extends ButtonMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class SelectValueButton extends ButtonMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-select-value-button';
   }

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -131,7 +131,7 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * @mixes SelectBaseMixin
  * @mixes ThemableMixin
  */
-class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-select';
   }

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -82,7 +82,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * @mixes SideNavChildrenMixin
  */
 class SideNavItem extends SideNavChildrenMixin(
-  DisabledMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))),
+  DisabledMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-side-nav-item';

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -74,7 +74,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * @mixes SideNavChildrenMixin
  */
 class SideNav extends SideNavChildrenMixin(
-  SlotStylesMixin(FocusMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))))),
+  SlotStylesMixin(FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))))),
 ) {
   static get is() {
     return 'vaadin-side-nav';

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -156,7 +156,7 @@ import { SplitLayoutMixin } from './vaadin-split-layout-mixin.js';
  * @mixes SplitLayoutMixin
  * @mixes ThemableMixin
  */
-class SplitLayout extends SplitLayoutMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class SplitLayout extends SplitLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-split-layout';
   }

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -41,7 +41,7 @@ import { tabStyles } from './styles/vaadin-tab-core-styles.js';
  * @mixes ItemMixin
  * @mixes ThemableMixin
  */
-class Tab extends ItemMixin(ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Tab extends ItemMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-tab';
   }

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -53,7 +53,7 @@ import { TabsMixin } from './vaadin-tabs-mixin.js';
  * @mixes TabsMixin
  * @mixes ThemableMixin
  */
-class Tabs extends TabsMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Tabs extends TabsMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-tabs';
   }

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -62,7 +62,7 @@ import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
  * @mixes ElementMixin
  * @mixes ThemableMixin
  */
-class TabSheet extends TabSheetMixin(ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class TabSheet extends TabSheetMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-tabsheet';
   }

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -62,7 +62,7 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  * @mixes TextAreaMixin
  * @mixes ThemableMixin
  */
-export class TextArea extends TextAreaMixin(LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement))))) {
+export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-text-area';
   }

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -85,7 +85,7 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  * @mixes TextFieldMixin
  */
 export class TextField extends TextFieldMixin(
-  LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-text-field';

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -40,7 +40,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @private
  */
 export class TimePickerItem extends ComboBoxItemMixin(
-  LumoInjectionMixin(ThemableMixin(DirMixin(PolylitMixin(LitElement)))),
+  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-time-picker-item';

--- a/packages/time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.js
@@ -25,7 +25,7 @@ import { timePickerOverlayStyles } from './styles/vaadin-time-picker-overlay-cor
  * @private
  */
 export class TimePickerOverlay extends ComboBoxOverlayMixin(
-  OverlayMixin(DirMixin(LumoInjectionMixin(ThemableMixin(PolylitMixin(LitElement))))),
+  OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-time-picker-overlay';

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -97,7 +97,7 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  * @mixes ThemableMixin
  * @mixes TimePickerMixin
  */
-class TimePicker extends TimePickerMixin(LumoInjectionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement))))) {
+class TimePicker extends TimePickerMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-time-picker';
   }

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -24,7 +24,7 @@ import { tooltipOverlayStyles } from './styles/vaadin-tooltip-overlay-core-style
  * @private
  */
 class TooltipOverlay extends PopoverOverlayMixin(
-  DirMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))),
+  DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
     return 'vaadin-tooltip-overlay';

--- a/packages/upload/src/vaadin-upload-file-list.js
+++ b/packages/upload/src/vaadin-upload-file-list.js
@@ -21,7 +21,7 @@ import { UploadFileListMixin } from './vaadin-upload-file-list-mixin.js';
  * @mixes UploadFileListMixin
  * @private
  */
-class UploadFileList extends UploadFileListMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class UploadFileList extends UploadFileListMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-upload-file-list';
   }

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -54,7 +54,7 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
  * @mixes UploadFileMixin
  * @mixes ThemableMixin
  */
-class UploadFile extends UploadFileMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class UploadFile extends UploadFileMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-upload-file';
   }

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -66,7 +66,7 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  * @mixes ElementMixin
  * @mixes UploadMixin
  */
-class Upload extends UploadMixin(ElementMixin(ThemableMixin(LumoInjectionMixin(PolylitMixin(LitElement))))) {
+class Upload extends UploadMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-upload';
   }

--- a/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { LumoInjectionMixin } from '../lumo-injection-mixin.js';
 import { registerStyles, ThemableMixin } from '../vaadin-themable-mixin.js';
 
-class TestFoo extends ThemableMixin(LumoInjectionMixin(LitElement)) {
+class TestFoo extends LumoInjectionMixin(ThemableMixin(LitElement)) {
   static get is() {
     return 'test-foo';
   }

--- a/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
@@ -4,7 +4,7 @@ import { css, html, LitElement } from 'lit';
 import { LumoInjectionMixin } from '../lumo-injection-mixin.js';
 import { registerStyles, ThemableMixin } from '../vaadin-themable-mixin.js';
 
-class TestFoo extends LumoInjectionMixin(ThemableMixin(LitElement)) {
+class TestFoo extends ThemableMixin(LumoInjectionMixin(LitElement)) {
   static get is() {
     return 'test-foo';
   }

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -37,7 +37,7 @@ import { verticalLayoutStyles } from './styles/vaadin-vertical-layout-core-style
  * @mixes ThemableMixin
  * @mixes ElementMixin
  */
-class VerticalLayout extends ThemableMixin(ElementMixin(LumoInjectionMixin(PolylitMixin(LitElement)))) {
+class VerticalLayout extends ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-vertical-layout';
   }


### PR DESCRIPTION
## Description

The PR moves `LumoInjectionMixin` before `PolylitMixin` in the extension order to ensure that Lumo styles are injected before `PolylitMixin` triggers the initial synchronous rendering. This prevents unwanted CSS transitions on child elements that would otherwise be triggered if the styles are applied after rendering:

| Before | After |
|--------|------|
| ![Screenshot 2025-07-14 at 12 17 57](https://github.com/user-attachments/assets/04930095-f2b5-4dec-9b1e-9d1d6766e6ca) | ![Screenshot 2025-07-14 at 12 18 53](https://github.com/user-attachments/assets/6aab5bef-f1a1-48aa-a774-65af33b389a0) |

Part of #9082 

## How to test

1. `git switch vite-css-bundle`
2. `yarn install`
3. `npx vite build`
4. `npx vite preview`
5. Open http://localhost:4173/dev/rich-text-editor.html
6. Observe multiple CSS transitions in the Performance panel

## Type of change

- [x] Bugfix
