### PR TITLE
refactor!: update menu-bar to render root submenu in light DOM

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-submenu-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu-mixin.js
@@ -43,7 +43,7 @@ export const SubMenuMixin = (superClass) =>
 
       // Only handle 1st level submenu
       if (this.hasAttribute('is-root')) {
-        this.getRootNode().host._close();
+        this.parentElement._close();
       }
     }
 

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -93,7 +93,8 @@ class MenuBar extends MenuBarMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoI
         <slot></slot>
         <slot name="overflow"></slot>
       </div>
-      <vaadin-menu-bar-submenu is-root .overlayClass="${this.overlayClass}"></vaadin-menu-bar-submenu>
+
+      <slot name="submenu"></slot>
 
       <slot name="tooltip"></slot>
     `;

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -3,6 +3,11 @@ export const snapshots = {};
 
 snapshots["menu-bar basic"] = 
 `<vaadin-menu-bar role="menubar">
+  <vaadin-menu-bar-submenu
+    is-root=""
+    slot="submenu"
+  >
+  </vaadin-menu-bar-submenu>
   <vaadin-menu-bar-button
     class="home"
     first-visible=""


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9707

This is a pre-requisite for updating `vaadin-menu-bar-submenu` to use native popover.

## Type of change

- Breaking change