### PR TITLE
refactor: make OverlayStackMixin work with native popovers

### DIFF
--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -317,6 +317,28 @@ describe('multiple overlays', () => {
       escKeyDown(input);
       expect(spy.called).to.be.false;
     });
+
+    describe('native popovers', () => {
+      beforeEach(() => {
+        modeless1.popover = 'manual';
+        modeless2.popover = 'manual';
+      });
+
+      it('should update stacking order when using bringToFront', () => {
+        modeless1.opened = true;
+        modeless1.showPopover();
+        modeless2.opened = true;
+        modeless2.showPopover();
+
+        modeless1.bringToFront();
+
+        expect(modeless1._last).to.be.true;
+
+        // Check that the overlay is also visually the frontmost
+        const frontmost = getFrontmostOverlayFromScreenCenter();
+        expect(frontmost).to.equal(modeless1);
+      });
+    });
   });
 
   describe('setNestedOverlay', () => {


### PR DESCRIPTION
## Description

Makes `OverlayStackMixin` work with overlays based on native popovers. This involves:
- Make `bringToFront` hide and show native popovers to make them the last in the stacking order, as the `z-index`style does not affect them
- Change the stacking order logic (e.g. for detecting the last / top-most overlay) to be based on the insert order of the attached instances instead of the z-index

After converting all overlay components to use native popovers, it should be possible to remove the logic for setting the `z-index` style prop.

Part of https://github.com/vaadin/platform/issues/7420

## Type of change

- Refactor