### PR TITLE
refactor: add native popover reset styles to Lumo overlay CSS

### DIFF
--- a/packages/vaadin-lumo-styles/src/mixins/overlay.css
+++ b/packages/vaadin-lumo-styles/src/mixins/overlay.css
@@ -18,6 +18,14 @@
     align-items: center;
     justify-content: center;
 
+    /* Override native [popover] user agent styles */
+    width: auto;
+    height: auto;
+    border: none;
+    padding: 0;
+    background-color: transparent;
+    overflow: visible;
+
     /* Allow centering when max-width/max-height applies. */
     margin: auto;
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/9739

I missed to add popover reset styles to Lumo CSS. This PR fixes that.

## Type of change

- Refactor