### PR TITLE
refactor: reflect overlay state attributes to owner

### DIFF
--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -185,6 +185,8 @@ snapshots["vaadin-avatar-group opened default"] =
 `<vaadin-avatar-group
   aria-label="Currently 4 active users"
   has-overflow=""
+  start-aligned=""
+  top-aligned=""
 >
   <vaadin-avatar
     abbr="AD"

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -11,7 +11,10 @@ snapshots["vaadin-avatar-group default"] =
     slot="overflow"
     tabindex="0"
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-0"
         role="tooltip"
@@ -34,7 +37,10 @@ snapshots["vaadin-avatar-group items"] =
     tabindex="0"
     with-tooltip=""
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-2"
         role="tooltip"
@@ -53,7 +59,10 @@ snapshots["vaadin-avatar-group items"] =
     tabindex="0"
     with-tooltip=""
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-3"
         role="tooltip"
@@ -74,7 +83,10 @@ snapshots["vaadin-avatar-group items"] =
     slot="overflow"
     tabindex="0"
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-1"
         role="tooltip"
@@ -103,7 +115,10 @@ snapshots["vaadin-avatar-group theme"] =
     theme="small"
     with-tooltip=""
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-5"
         role="tooltip"
@@ -123,7 +138,10 @@ snapshots["vaadin-avatar-group theme"] =
     theme="small"
     with-tooltip=""
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-6"
         role="tooltip"
@@ -145,7 +163,10 @@ snapshots["vaadin-avatar-group theme"] =
     tabindex="0"
     theme="small"
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-4"
         role="tooltip"
@@ -174,7 +195,10 @@ snapshots["vaadin-avatar-group opened default"] =
     tabindex="0"
     with-tooltip=""
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-8"
         role="tooltip"
@@ -193,7 +217,10 @@ snapshots["vaadin-avatar-group opened default"] =
     tabindex="0"
     with-tooltip=""
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-9"
         role="tooltip"
@@ -214,7 +241,10 @@ snapshots["vaadin-avatar-group opened default"] =
     slot="overflow"
     tabindex="0"
   >
-    <vaadin-tooltip slot="tooltip">
+    <vaadin-tooltip
+      modeless=""
+      slot="tooltip"
+    >
       <div
         id="vaadin-tooltip-7"
         role="tooltip"

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -319,6 +319,8 @@ snapshots["vaadin-combo-box host opened default"] =
 `<vaadin-combo-box
   focused=""
   opened=""
+  start-aligned=""
+  top-aligned=""
 >
   <label
     for="input-vaadin-combo-box-4"

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -51,7 +51,10 @@ snapshots["context-menu items"] =
       Menu Item 5
     </div>
   </vaadin-context-menu-list-box>
-  <vaadin-context-menu hidden="">
+  <vaadin-context-menu
+    hidden=""
+    modeless=""
+  >
   </vaadin-context-menu>
 </vaadin-context-menu-overlay>
 `;
@@ -89,7 +92,12 @@ snapshots["context-menu items nested"] =
       Menu Item 2-2
     </vaadin-context-menu-item>
   </vaadin-context-menu-list-box>
-  <vaadin-context-menu hidden="">
+  <vaadin-context-menu
+    hidden=""
+    modeless=""
+    start-aligned=""
+    top-aligned=""
+  >
   </vaadin-context-menu>
 </vaadin-context-menu-overlay>
 `;
@@ -148,7 +156,10 @@ snapshots["context-menu items overlay class"] =
       Menu Item 5
     </div>
   </vaadin-context-menu-list-box>
-  <vaadin-context-menu hidden="">
+  <vaadin-context-menu
+    hidden=""
+    modeless=""
+  >
   </vaadin-context-menu>
 </vaadin-context-menu-overlay>
 `;
@@ -187,7 +198,12 @@ snapshots["context-menu items overlay class nested"] =
       Menu Item 2-2
     </vaadin-context-menu-item>
   </vaadin-context-menu-list-box>
-  <vaadin-context-menu hidden="">
+  <vaadin-context-menu
+    hidden=""
+    modeless=""
+    start-aligned=""
+    top-aligned=""
+  >
   </vaadin-context-menu>
 </vaadin-context-menu-overlay>
 `;

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -231,6 +231,7 @@ snapshots["vaadin-crud shadow default"] =
   cancel-button-visible=""
   confirm-theme="primary"
   id="confirmCancel"
+  with-backdrop=""
 >
   <h3 slot="header">
     Discard changes
@@ -273,6 +274,7 @@ snapshots["vaadin-crud shadow default"] =
   cancel-button-visible=""
   confirm-theme="primary error"
   id="confirmDelete"
+  with-backdrop=""
 >
   <h3 slot="header">
     Delete item

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -89,7 +89,10 @@ snapshots["menu-bar overlay"] =
       Generate Report
     </vaadin-menu-bar-item>
   </vaadin-menu-bar-list-box>
-  <vaadin-menu-bar-submenu hidden="">
+  <vaadin-menu-bar-submenu
+    hidden=""
+    modeless=""
+  >
   </vaadin-menu-bar-submenu>
 </vaadin-menu-bar-overlay>
 `;
@@ -124,7 +127,10 @@ snapshots["menu-bar overlay class"] =
       Generate Report
     </vaadin-menu-bar-item>
   </vaadin-menu-bar-list-box>
-  <vaadin-menu-bar-submenu hidden="">
+  <vaadin-menu-bar-submenu
+    hidden=""
+    modeless=""
+  >
   </vaadin-menu-bar-submenu>
 </vaadin-menu-bar-overlay>
 `;

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -92,6 +92,7 @@ export const OverlayMixin = (superClass) =>
           type: Boolean,
           value: false,
           reflectToAttribute: true,
+          observer: '_withBackdropChanged',
           sync: true,
         },
       };
@@ -281,6 +282,11 @@ export const OverlayMixin = (superClass) =>
         this._exitModalState();
       }
       toggleOverlayStateAttribute(this, 'modeless', modeless === true);
+    }
+
+    /** @private */
+    _withBackdropChanged(withBackdrop) {
+      toggleOverlayStateAttribute(this, 'with-backdrop', withBackdrop === true);
     }
 
     /** @private */

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -6,7 +6,7 @@
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
-import { toggleOverlayStateAttribute } from './vaadin-overlay-utils.js';
+import { setOverlayStateAttribute } from './vaadin-overlay-utils.js';
 
 /**
  * @polymerMixin
@@ -281,12 +281,12 @@ export const OverlayMixin = (superClass) =>
         this._removeGlobalListeners();
         this._exitModalState();
       }
-      toggleOverlayStateAttribute(this, 'modeless', modeless === true);
+      setOverlayStateAttribute(this, 'modeless', modeless);
     }
 
     /** @private */
     _withBackdropChanged(withBackdrop) {
-      toggleOverlayStateAttribute(this, 'with-backdrop', withBackdrop === true);
+      setOverlayStateAttribute(this, 'with-backdrop', withBackdrop);
     }
 
     /** @private */
@@ -386,7 +386,7 @@ export const OverlayMixin = (superClass) =>
       if (!this.modeless) {
         this._enterModalState();
       }
-      toggleOverlayStateAttribute(this, 'opening', true);
+      setOverlayStateAttribute(this, 'opening', true);
 
       if (this._shouldAnimate()) {
         this._enqueueAnimation('opening', () => {
@@ -406,7 +406,7 @@ export const OverlayMixin = (superClass) =>
 
     /** @private */
     _finishOpening() {
-      toggleOverlayStateAttribute(this, 'opening', false);
+      setOverlayStateAttribute(this, 'opening', false);
     }
 
     /** @private */
@@ -414,7 +414,7 @@ export const OverlayMixin = (superClass) =>
       this._detachOverlay();
       this._removeAttachedInstance();
       this.$.overlay.style.removeProperty('pointer-events');
-      toggleOverlayStateAttribute(this, 'closing', false);
+      setOverlayStateAttribute(this, 'closing', false);
       this.dispatchEvent(new CustomEvent('vaadin-overlay-closed'));
     }
 
@@ -425,7 +425,7 @@ export const OverlayMixin = (superClass) =>
       }
       if (this._isAttached) {
         this._exitModalState();
-        toggleOverlayStateAttribute(this, 'closing', true);
+        setOverlayStateAttribute(this, 'closing', true);
         this.dispatchEvent(new CustomEvent('vaadin-overlay-closing'));
 
         if (this._shouldAnimate()) {

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -6,6 +6,7 @@
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
+import { toggleOverlayStateAttribute } from './vaadin-overlay-utils.js';
 
 /**
  * @polymerMixin
@@ -378,7 +379,7 @@ export const OverlayMixin = (superClass) =>
       if (!this.modeless) {
         this._enterModalState();
       }
-      this.setAttribute('opening', '');
+      toggleOverlayStateAttribute(this, 'opening', true);
 
       if (this._shouldAnimate()) {
         this._enqueueAnimation('opening', () => {
@@ -398,7 +399,7 @@ export const OverlayMixin = (superClass) =>
 
     /** @private */
     _finishOpening() {
-      this.removeAttribute('opening');
+      toggleOverlayStateAttribute(this, 'opening', false);
     }
 
     /** @private */
@@ -406,7 +407,7 @@ export const OverlayMixin = (superClass) =>
       this._detachOverlay();
       this._removeAttachedInstance();
       this.$.overlay.style.removeProperty('pointer-events');
-      this.removeAttribute('closing');
+      toggleOverlayStateAttribute(this, 'closing', false);
       this.dispatchEvent(new CustomEvent('vaadin-overlay-closed'));
     }
 
@@ -417,7 +418,7 @@ export const OverlayMixin = (superClass) =>
       }
       if (this._isAttached) {
         this._exitModalState();
-        this.setAttribute('closing', '');
+        toggleOverlayStateAttribute(this, 'closing', true);
         this.dispatchEvent(new CustomEvent('vaadin-overlay-closing'));
 
         if (this._shouldAnimate()) {

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -280,6 +280,7 @@ export const OverlayMixin = (superClass) =>
         this._removeGlobalListeners();
         this._exitModalState();
       }
+      toggleOverlayStateAttribute(this, 'modeless', modeless === true);
     }
 
     /** @private */

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { getAncestorRootNodes } from '@vaadin/component-base/src/dom-utils.js';
-import { observeMove, toggleOverlayStateAttribute } from './vaadin-overlay-utils.js';
+import { observeMove, setOverlayStateAttribute } from './vaadin-overlay-utils.js';
 
 const PROP_NAMES_VERTICAL = {
   start: 'top',
@@ -271,11 +271,11 @@ export const PositionMixin = (superClass) =>
       // Apply the positioning properties to the overlay
       Object.assign(this.style, verticalProps, horizontalProps);
 
-      toggleOverlayStateAttribute(this, 'bottom-aligned', !shouldAlignStartVertically);
-      toggleOverlayStateAttribute(this, 'top-aligned', shouldAlignStartVertically);
+      setOverlayStateAttribute(this, 'bottom-aligned', !shouldAlignStartVertically);
+      setOverlayStateAttribute(this, 'top-aligned', shouldAlignStartVertically);
 
-      toggleOverlayStateAttribute(this, 'end-aligned', !flexStart);
-      toggleOverlayStateAttribute(this, 'start-aligned', flexStart);
+      setOverlayStateAttribute(this, 'end-aligned', !flexStart);
+      setOverlayStateAttribute(this, 'start-aligned', flexStart);
     }
 
     __shouldAlignStartHorizontally(targetRect, rtl) {

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { getAncestorRootNodes } from '@vaadin/component-base/src/dom-utils.js';
-import { observeMove } from './vaadin-overlay-utils.js';
+import { observeMove, toggleOverlayStateAttribute } from './vaadin-overlay-utils.js';
 
 const PROP_NAMES_VERTICAL = {
   start: 'top',
@@ -271,11 +271,11 @@ export const PositionMixin = (superClass) =>
       // Apply the positioning properties to the overlay
       Object.assign(this.style, verticalProps, horizontalProps);
 
-      this.__toggleOverlayStateAttribute('bottom-aligned', !shouldAlignStartVertically);
-      this.__toggleOverlayStateAttribute('top-aligned', shouldAlignStartVertically);
+      toggleOverlayStateAttribute(this, 'bottom-aligned', !shouldAlignStartVertically);
+      toggleOverlayStateAttribute(this, 'top-aligned', shouldAlignStartVertically);
 
-      this.__toggleOverlayStateAttribute('end-aligned', !flexStart);
-      this.__toggleOverlayStateAttribute('start-aligned', flexStart);
+      toggleOverlayStateAttribute(this, 'end-aligned', !flexStart);
+      toggleOverlayStateAttribute(this, 'start-aligned', flexStart);
     }
 
     __shouldAlignStartHorizontally(targetRect, rtl) {
@@ -396,20 +396,5 @@ export const PositionMixin = (superClass) =>
         [cssPropNameToSet]: valueToSet,
         [cssPropNameToClear]: '',
       };
-    }
-
-    /**
-     * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state
-     * attributes in the light DOM in case the overlay is in the shadow DOM of its owner.
-     * @param name {string} The name of the attribute to toggle.
-     * @param force {boolean} If true, the attribute will be set, if false, it will be removed. If not provided,
-     * the attribute will be toggled based on its current state.
-     * @private
-     */
-    __toggleOverlayStateAttribute(name, force) {
-      this.toggleAttribute(name, force);
-      if (this.owner) {
-        this.owner.toggleAttribute(name, force);
-      }
     }
   };

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -271,11 +271,11 @@ export const PositionMixin = (superClass) =>
       // Apply the positioning properties to the overlay
       Object.assign(this.style, verticalProps, horizontalProps);
 
-      this.toggleAttribute('bottom-aligned', !shouldAlignStartVertically);
-      this.toggleAttribute('top-aligned', shouldAlignStartVertically);
+      this.__toggleOverlayStateAttribute('bottom-aligned', !shouldAlignStartVertically);
+      this.__toggleOverlayStateAttribute('top-aligned', shouldAlignStartVertically);
 
-      this.toggleAttribute('end-aligned', !flexStart);
-      this.toggleAttribute('start-aligned', flexStart);
+      this.__toggleOverlayStateAttribute('end-aligned', !flexStart);
+      this.__toggleOverlayStateAttribute('start-aligned', flexStart);
     }
 
     __shouldAlignStartHorizontally(targetRect, rtl) {
@@ -396,5 +396,20 @@ export const PositionMixin = (superClass) =>
         [cssPropNameToSet]: valueToSet,
         [cssPropNameToClear]: '',
       };
+    }
+
+    /**
+     * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state
+     * attributes in the light DOM in case the overlay is in the shadow DOM of its owner.
+     * @param name {string} The name of the attribute to toggle.
+     * @param force {boolean} If true, the attribute will be set, if false, it will be removed. If not provided,
+     * the attribute will be toggled based on its current state.
+     * @private
+     */
+    __toggleOverlayStateAttribute(name, force) {
+      this.toggleAttribute(name, force);
+      if (this.owner) {
+        this.owner.toggleAttribute(name, force);
+      }
     }
   };

--- a/packages/overlay/src/vaadin-overlay-utils.d.ts
+++ b/packages/overlay/src/vaadin-overlay-utils.d.ts
@@ -11,3 +11,9 @@
  * https://github.com/floating-ui/floating-ui/blob/58ed169/packages/dom/src/autoUpdate.ts#L45
  */
 export function observeMove(element: HTMLElement, callback: () => void): () => void;
+
+/**
+ * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state attributes
+ * in the light DOM in case the overlay is in the shadow DOM of its owner.
+ */
+export function setOverlayStateAttribute(overlay: HTMLElement, name: string, value: string | boolean): void;

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -87,3 +87,18 @@ export function observeMove(element, callback) {
 
   return cleanup;
 }
+
+/**
+ * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state
+ * attributes in the light DOM in case the overlay is in the shadow DOM of its owner.
+ * @param {Element} overlay The overlay element on which to toggle the attribute.
+ * @param {string} name The name of the attribute to toggle.
+ * @param {boolean} [force] If true, the attribute will be set, if false, it will be removed. If not provided,
+ * the attribute will be toggled based on its current state.
+ */
+export function toggleOverlayStateAttribute(overlay, name, force) {
+  overlay.toggleAttribute(name, force);
+  if (overlay.owner) {
+    overlay.owner.toggleAttribute(name, force);
+  }
+}

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -89,16 +89,30 @@ export function observeMove(element, callback) {
 }
 
 /**
- * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state
- * attributes in the light DOM in case the overlay is in the shadow DOM of its owner.
+ * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state attributes
+ * in the light DOM in case the overlay is in the shadow DOM of its owner.
  * @param {Element} overlay The overlay element on which to toggle the attribute.
  * @param {string} name The name of the attribute to toggle.
- * @param {boolean} [force] If true, the attribute will be set, if false, it will be removed. If not provided,
- * the attribute will be toggled based on its current state.
+ * @param {string|boolean} value The value of the attribute. If a string is provided, it will be set as the attribute
+ * value. Otherwise, the attribute will be added or removed depending on whether `value` is truthy or falsy.
  */
-export function toggleOverlayStateAttribute(overlay, name, force) {
-  overlay.toggleAttribute(name, force);
+export function setOverlayStateAttribute(overlay, name, value) {
+  const elements = [overlay];
   if (overlay.owner) {
-    overlay.owner.toggleAttribute(name, force);
+    elements.push(overlay.owner);
+  }
+
+  if (typeof value === 'string') {
+    elements.forEach((element) => {
+      element.setAttribute(name, value);
+    });
+  } else if (value) {
+    elements.forEach((element) => {
+      element.setAttribute(name, '');
+    });
+  } else {
+    elements.forEach((element) => {
+      element.removeAttribute(name);
+    });
   }
 }

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -91,7 +91,7 @@ export function observeMove(element, callback) {
 /**
  * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state attributes
  * in the light DOM in case the overlay is in the shadow DOM of its owner.
- * @param {Element} overlay The overlay element on which to toggle the attribute.
+ * @param {HTMLElement} overlay The overlay element on which to toggle the attribute.
  * @param {string} name The name of the attribute to toggle.
  * @param {string|boolean} value The value of the attribute. If a string is provided, it will be set as the attribute
  * value. Otherwise, the attribute will be added or removed depending on whether `value` is truthy or falsy.

--- a/packages/overlay/test/basic.test.js
+++ b/packages/overlay/test/basic.test.js
@@ -108,24 +108,23 @@ describe('vaadin-overlay', () => {
 
     it('should reflect modeless to owner', () => {
       overlay.modeless = true;
-      expect(overlay.hasAttribute('modeless')).to.be.true;
       expect(owner.hasAttribute('modeless')).to.be.true;
 
       overlay.modeless = false;
-      expect(overlay.hasAttribute('modeless')).to.be.false;
       expect(owner.hasAttribute('modeless')).to.be.false;
 
       overlay.modeless = undefined;
-      expect(overlay.hasAttribute('modeless')).to.be.false;
       expect(owner.hasAttribute('modeless')).to.be.false;
     });
   });
 
   describe('backdrop', () => {
-    let overlay, backdrop;
+    let overlay, backdrop, owner;
 
     beforeEach(async () => {
       overlay = createOverlay('overlay content');
+      owner = document.createElement('div');
+      overlay.owner = owner;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
       backdrop = overlay.$.backdrop;
@@ -151,6 +150,17 @@ describe('vaadin-overlay', () => {
     it('should reflect withBackdrop property to attribute', () => {
       overlay.withBackdrop = true;
       expect(overlay.hasAttribute('with-backdrop')).to.be.true;
+    });
+
+    it('should reflect withBackdrop to owner', () => {
+      overlay.withBackdrop = true;
+      expect(owner.hasAttribute('with-backdrop')).to.be.true;
+
+      overlay.withBackdrop = false;
+      expect(owner.hasAttribute('with-backdrop')).to.be.false;
+
+      overlay.withBackdrop = undefined;
+      expect(owner.hasAttribute('with-backdrop')).to.be.false;
     });
   });
 

--- a/packages/overlay/test/basic.test.js
+++ b/packages/overlay/test/basic.test.js
@@ -97,6 +97,30 @@ describe('vaadin-overlay', () => {
     });
   });
 
+  describe('modeless', () => {
+    let overlay, owner;
+
+    beforeEach(() => {
+      overlay = createOverlay('overlay content');
+      owner = document.createElement('div');
+      overlay.owner = owner;
+    });
+
+    it('should reflect modeless to owner', () => {
+      overlay.modeless = true;
+      expect(overlay.hasAttribute('modeless')).to.be.true;
+      expect(owner.hasAttribute('modeless')).to.be.true;
+
+      overlay.modeless = false;
+      expect(overlay.hasAttribute('modeless')).to.be.false;
+      expect(owner.hasAttribute('modeless')).to.be.false;
+
+      overlay.modeless = undefined;
+      expect(overlay.hasAttribute('modeless')).to.be.false;
+      expect(owner.hasAttribute('modeless')).to.be.false;
+    });
+  });
+
   describe('backdrop', () => {
     let overlay, backdrop;
 

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -12,7 +12,7 @@ describe('position mixin', () => {
   const LEFT = 'left';
   const RIGHT = 'right';
 
-  let target, overlay, overlayContent;
+  let parent, target, overlay, overlayContent;
   let margin;
 
   // Top or left coordinates for position target
@@ -30,7 +30,7 @@ describe('position mixin', () => {
   }
 
   beforeEach(async () => {
-    const parent = fixtureSync(`
+    parent = fixtureSync(`
       <div id="parent">
         <div id="target" style="position: fixed; top: 100px; left: 100px; width: 20px; height: 20px; border: 1px solid">
           target
@@ -40,6 +40,7 @@ describe('position mixin', () => {
     `);
     target = parent.querySelector('#target');
     overlay = parent.querySelector('#overlay');
+    overlay.owner = parent;
     overlay.renderer = (root) => {
       if (!root.firstChild) {
         const div = document.createElement('div');
@@ -120,6 +121,8 @@ describe('position mixin', () => {
     it('should set top-aligned attribute', () => {
       expect(overlay.hasAttribute('top-aligned')).to.be.true;
       expect(overlay.hasAttribute('bottom-aligned')).to.be.false;
+      expect(parent.hasAttribute('top-aligned')).to.be.true;
+      expect(parent.hasAttribute('bottom-aligned')).to.be.false;
     });
 
     it('should align top edges when overlay part is animated', async () => {
@@ -139,6 +142,8 @@ describe('position mixin', () => {
       updatePosition();
       expect(overlay.hasAttribute('top-aligned')).to.be.false;
       expect(overlay.hasAttribute('bottom-aligned')).to.be.true;
+      expect(parent.hasAttribute('top-aligned')).to.be.false;
+      expect(parent.hasAttribute('bottom-aligned')).to.be.true;
     });
 
     it('should flip when out of space and squeezed smaller than current available space', () => {
@@ -182,11 +187,13 @@ describe('position mixin', () => {
       updatePosition();
       expectEdgesAligned(TOP, TOP);
       expect(overlay.hasAttribute('top-aligned')).to.be.true;
+      expect(parent.hasAttribute('top-aligned')).to.be.true;
 
       target.style.top = `${targetPositionForCentering + 3}px`;
       updatePosition();
       expectEdgesAligned(BOTTOM, BOTTOM);
       expect(overlay.hasAttribute('bottom-aligned')).to.be.true;
+      expect(parent.hasAttribute('bottom-aligned')).to.be.true;
     });
 
     describe('no overlap', () => {
@@ -373,6 +380,8 @@ describe('position mixin', () => {
     it('should set start-aligned attribute', () => {
       expect(overlay.hasAttribute('start-aligned')).to.be.true;
       expect(overlay.hasAttribute('end-aligned')).to.be.false;
+      expect(parent.hasAttribute('start-aligned')).to.be.true;
+      expect(parent.hasAttribute('end-aligned')).to.be.false;
     });
 
     it('should align right edges with right-to-left', async () => {
@@ -386,6 +395,16 @@ describe('position mixin', () => {
       target.style.left = `${targetPositionToFlipOverlay + 3}px`;
       updatePosition();
       expectEdgesAligned(RIGHT, RIGHT);
+    });
+
+    it('should set end-aligned attribute when out of space', () => {
+      target.style.left = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+
+      expect(overlay.hasAttribute('start-aligned')).to.be.false;
+      expect(overlay.hasAttribute('end-aligned')).to.be.true;
+      expect(parent.hasAttribute('start-aligned')).to.be.false;
+      expect(parent.hasAttribute('end-aligned')).to.be.true;
     });
 
     it('should flip when out of space and squeezed smaller than current available space', () => {
@@ -413,11 +432,13 @@ describe('position mixin', () => {
       updatePosition();
       expectEdgesAligned(LEFT, LEFT);
       expect(overlay.hasAttribute('start-aligned')).to.be.true;
+      expect(parent.hasAttribute('start-aligned')).to.be.true;
 
       target.style.left = `${targetPositionForCentering + 3}px`;
       updatePosition();
       expectEdgesAligned(RIGHT, RIGHT);
       expect(overlay.hasAttribute('end-aligned')).to.be.true;
+      expect(parent.hasAttribute('end-aligned')).to.be.true;
     });
 
     describe('no overlap', () => {
@@ -478,6 +499,8 @@ describe('position mixin', () => {
     it('should set end-aligned attribute', () => {
       expect(overlay.hasAttribute('end-aligned')).to.be.true;
       expect(overlay.hasAttribute('start-aligned')).to.be.false;
+      expect(parent.hasAttribute('end-aligned')).to.be.true;
+      expect(parent.hasAttribute('start-aligned')).to.be.false;
     });
 
     it('should align left edges with right-to-left', async () => {
@@ -600,7 +623,7 @@ describe('opened before attach', () => {
 
   it('should not throw when adding pre-opened overlay to the DOM', async () => {
     overlay = document.createElement('vaadin-positioned-overlay');
-
+    overlay.owner = parent;
     overlay.positionTarget = target;
     overlay.opened = true;
 
@@ -608,5 +631,6 @@ describe('opened before attach', () => {
     await oneEvent(overlay, 'vaadin-overlay-open');
 
     expect(overlay.hasAttribute('start-aligned')).to.be.true;
+    expect(parent.hasAttribute('start-aligned')).to.be.true;
   });
 });

--- a/packages/overlay/test/renderer.test.js
+++ b/packages/overlay/test/renderer.test.js
@@ -25,7 +25,7 @@ describe('renderer', () => {
     });
 
     it('should receive empty root, model and owner when they are defined', () => {
-      const overlayOwner = {};
+      const overlayOwner = document.createElement('div');
       const overlayModel = {};
 
       overlay.owner = overlayOwner;
@@ -59,7 +59,7 @@ describe('renderer', () => {
       overlay.opened = true;
       expect(overlay.textContent.trim()).to.equal('renderer-content');
 
-      const overlayOwner = {};
+      const overlayOwner = document.createElement('div');
       const overlayModel = {};
 
       overlay.owner = overlayOwner;
@@ -69,7 +69,7 @@ describe('renderer', () => {
     });
 
     it('should pass owner as this to the renderer', () => {
-      const owner = {};
+      const owner = document.createElement('div');
       overlay.owner = owner;
 
       const renderer = sinon.spy();
@@ -99,7 +99,7 @@ describe('renderer', () => {
       overlay.renderer = renderer;
 
       renderer.resetHistory();
-      overlay.owner = {};
+      overlay.owner = document.createElement('div');
 
       expect(renderer.calledOnce).to.be.true;
     });

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -275,7 +275,11 @@ snapshots["vaadin-select host error"] =
 /* end snapshot vaadin-select host error */
 
 snapshots["vaadin-select host opened default"] = 
-`<vaadin-select opened="">
+`<vaadin-select
+  opened=""
+  start-aligned=""
+  top-aligned=""
+>
   <label
     id="label-vaadin-select-0"
     slot="label"

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -320,6 +320,8 @@ snapshots["vaadin-time-picker host opened default"] =
 `<vaadin-time-picker
   focused=""
   opened=""
+  start-aligned=""
+  top-aligned=""
 >
   <label
     for="search-input-vaadin-time-picker-4"

--- a/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
+++ b/packages/tooltip/test/dom/__snapshots__/tooltip.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-tooltip host"] = 
-`<vaadin-tooltip>
+`<vaadin-tooltip modeless="">
   <div
     id="vaadin-tooltip-0"
     role="tooltip"


### PR DESCRIPTION
## Description

With moving overlay elements into the shadow root of their owner element, state attributes need to be exposed on the owner element so that they can be still used for targeting styles through the light DOM. This reflects the following common state attributes of overlay elements to their owner:
- `top-aligned`, `bottom-aligned`, `start-aligned`, `end-aligned`
- `opening`
- `closing`
- `modeless`
- `with-backdrop`

State attributes specific to individual components (dialog, popover, ...) will be covered in respective PRs for those components.

Fixes https://github.com/vaadin/web-components/issues/9704

## Type of change

- Refactor