### PR TITLE
refactor: set owner property on the avatar-group overlay element

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -81,6 +81,7 @@ class AvatarGroup extends AvatarGroupMixin(ElementMixin(ThemableMixin(PolylitMix
       </div>
       <vaadin-avatar-group-overlay
         id="overlay"
+        .owner="${this}"
         .opened="${this._opened}"
         .positionTarget="${this._overflow}"
         .renderer="${this.__overlayRenderer}"

--- a/packages/avatar-group/test/avatar-group.test.js
+++ b/packages/avatar-group/test/avatar-group.test.js
@@ -283,6 +283,10 @@ describe('avatar-group', () => {
       overflow = group._overflow;
     });
 
+    it('should set owner property on the overlay', () => {
+      expect(overlay.owner).to.equal(group);
+    });
+
     it('should open overlay on overflow avatar click', () => {
       overflow.click();
       expect(overlay.opened).to.be.true;


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/9585

In the previous PR, `owner` was added to most of overlays except for avatar-group. This PR fixes that.

The change is relevant for Copilot which has some internal logic that relies on `owner` being set.

## Type of change

- Refactor