### PR TITLE
refactor!: update rich-text-editor to render tooltip in light DOM 

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -425,6 +425,7 @@ export const RichTextEditorMixin = (superClass) =>
         });
       });
 
+      // Set up tooltip to show when hovering or focusing toolbar buttons
       this._tooltip = document.createElement('vaadin-tooltip');
       // Create dummy aria target, as toolbar buttons already have aria-label, and also cannot be linked with the
       // tooltip being in the light DOM
@@ -444,7 +445,7 @@ export const RichTextEditorMixin = (superClass) =>
     __showTooltip(event) {
       const target = event.target;
       this._tooltip.target = target;
-      this._tooltip.text = target.getAttribute('aria-label');
+      this._tooltip.text = target.ariaLabel;
       this._tooltip._stateController.open({
         focus: event.type === 'focusin',
         hover: event.type === 'mouseenter',

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -436,8 +436,6 @@ export const RichTextEditorMixin = (superClass) =>
       buttons.forEach((button) => {
         button.addEventListener('mouseenter', this.__showTooltip.bind(this));
         button.addEventListener('focusin', this.__showTooltip.bind(this));
-        button.addEventListener('mouseleave', this.__hideTooltip.bind(this));
-        button.addEventListener('focusout', this.__hideTooltip.bind(this));
       });
     }
 
@@ -450,11 +448,6 @@ export const RichTextEditorMixin = (superClass) =>
         focus: event.type === 'focusin',
         hover: event.type === 'mouseenter',
       });
-    }
-
-    /** @private */
-    __hideTooltip() {
-      this._tooltip._stateController.close();
     }
 
     /** @private */

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -424,6 +424,36 @@ export const RichTextEditorMixin = (superClass) =>
           this.$.linkUrl.focus();
         });
       });
+
+      this._tooltip = document.createElement('vaadin-tooltip');
+      // Create dummy aria target, as toolbar buttons already have aria-label, and also cannot be linked with the
+      // tooltip being in the light DOM
+      this._tooltip.ariaTarget = document.createElement('div');
+      this.append(this._tooltip);
+
+      const buttons = this.shadowRoot.querySelectorAll('[part~="toolbar-button"]');
+      buttons.forEach((button) => {
+        button.addEventListener('mouseenter', this.__showTooltip.bind(this));
+        button.addEventListener('focusin', this.__showTooltip.bind(this));
+        button.addEventListener('mouseleave', this.__hideTooltip.bind(this));
+        button.addEventListener('focusout', this.__hideTooltip.bind(this));
+      });
+    }
+
+    /** @private */
+    __showTooltip(event) {
+      const target = event.target;
+      this._tooltip.target = target;
+      this._tooltip.text = target.getAttribute('aria-label');
+      this._tooltip._stateController.open({
+        focus: event.type === 'focusin',
+        hover: event.type === 'mouseenter',
+      });
+    }
+
+    /** @private */
+    __hideTooltip() {
+      this._tooltip._stateController.close();
     }
 
     /** @private */
@@ -799,10 +829,7 @@ export const RichTextEditorMixin = (superClass) =>
         timeOut.after(timeout),
         () => {
           const formatting = Array.from(this.shadowRoot.querySelectorAll('[part="toolbar"] .ql-active'))
-            .map((button) => {
-              const tooltip = this.shadowRoot.querySelector(`[for="${button.id}"]`);
-              return tooltip.text;
-            })
+            .map((button) => button.getAttribute('aria-label'))
             .join(', ');
           announcer.textContent = formatting;
         },

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -427,6 +427,7 @@ export const RichTextEditorMixin = (superClass) =>
 
       // Set up tooltip to show when hovering or focusing toolbar buttons
       this._tooltip = document.createElement('vaadin-tooltip');
+      this._tooltip.slot = 'tooltip';
       // Create dummy aria target, as toolbar buttons already have aria-label, and also cannot be linked with the
       // tooltip being in the light DOM
       this._tooltip.ariaTarget = document.createElement('div');

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -395,6 +395,8 @@ class RichTextEditor extends RichTextEditorMixin(
         @color-selected="${this.__onBackgroundSelected}"
         @opened-changed="${this.__onBackgroundEditingChanged}"
       ></vaadin-rich-text-editor-popup>
+
+      <slot name="tooltip"></slot>
     `;
   }
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -127,35 +127,51 @@ class RichTextEditor extends RichTextEditorMixin(
               id="btn-undo"
               type="button"
               part="toolbar-button toolbar-button-undo"
+              aria-label="${this.__effectiveI18n.undo}"
               @click="${this._undo}"
             ></button>
-            <vaadin-tooltip for="btn-undo" .text="${this.__effectiveI18n.undo}"></vaadin-tooltip>
 
             <button
               id="btn-redo"
               type="button"
               part="toolbar-button toolbar-button-redo"
+              aria-label="${this.__effectiveI18n.redo}"
               @click="${this._redo}"
             ></button>
-            <vaadin-tooltip for="btn-redo" .text="${this.__effectiveI18n.redo}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-emphasis">
             <!-- Bold -->
-            <button id="btn-bold" class="ql-bold" part="toolbar-button toolbar-button-bold"></button>
-            <vaadin-tooltip for="btn-bold" .text="${this.__effectiveI18n.bold}"></vaadin-tooltip>
+            <button
+              id="btn-bold"
+              class="ql-bold"
+              part="toolbar-button toolbar-button-bold"
+              aria-label="${this.__effectiveI18n.bold}"
+            ></button>
 
             <!-- Italic -->
-            <button id="btn-italic" class="ql-italic" part="toolbar-button toolbar-button-italic"></button>
-            <vaadin-tooltip for="btn-italic" .text="${this.__effectiveI18n.italic}"></vaadin-tooltip>
+            <button
+              id="btn-italic"
+              class="ql-italic"
+              part="toolbar-button toolbar-button-italic"
+              aria-label="${this.__effectiveI18n.italic}"
+            ></button>
 
             <!-- Underline -->
-            <button id="btn-underline" class="ql-underline" part="toolbar-button toolbar-button-underline"></button>
-            <vaadin-tooltip for="btn-underline" .text="${this.__effectiveI18n.underline}"></vaadin-tooltip>
+            <button
+              id="btn-underline"
+              class="ql-underline"
+              part="toolbar-button toolbar-button-underline"
+              aria-label="${this.__effectiveI18n.underline}"
+            ></button>
 
             <!-- Strike -->
-            <button id="btn-strike" class="ql-strike" part="toolbar-button toolbar-button-strike"></button>
-            <vaadin-tooltip for="btn-strike" .text="${this.__effectiveI18n.strike}"></vaadin-tooltip>
+            <button
+              id="btn-strike"
+              class="ql-strike"
+              part="toolbar-button toolbar-button-strike"
+              aria-label="${this.__effectiveI18n.strike}"
+            ></button>
           </span>
 
           <span part="toolbar-group toolbar-group-style">
@@ -164,17 +180,17 @@ class RichTextEditor extends RichTextEditorMixin(
               id="btn-color"
               type="button"
               part="toolbar-button toolbar-button-color"
+              aria-label="${this.__effectiveI18n.color}"
               @click="${this.__onColorClick}"
             ></button>
-            <vaadin-tooltip for="btn-color" .text="${this.__effectiveI18n.color}"></vaadin-tooltip>
             <!-- Background -->
             <button
               id="btn-background"
               type="button"
               part="toolbar-button toolbar-button-background"
+              aria-label="${this.__effectiveI18n.background}"
               @click="${this.__onBackgroundClick}"
             ></button>
-            <vaadin-tooltip for="btn-background" .text="${this.__effectiveI18n.background}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-heading">
@@ -185,24 +201,24 @@ class RichTextEditor extends RichTextEditorMixin(
               class="ql-header"
               value="1"
               part="toolbar-button toolbar-button-h1"
+              aria-label="${this.__effectiveI18n.h1}"
             ></button>
-            <vaadin-tooltip for="btn-h1" .text="${this.__effectiveI18n.h1}"></vaadin-tooltip>
             <button
               id="btn-h2"
               type="button"
               class="ql-header"
               value="2"
               part="toolbar-button toolbar-button-h2"
+              aria-label="${this.__effectiveI18n.h2}"
             ></button>
-            <vaadin-tooltip for="btn-h2" .text="${this.__effectiveI18n.h2}"></vaadin-tooltip>
             <button
               id="btn-h3"
               type="button"
               class="ql-header"
               value="3"
               part="toolbar-button toolbar-button-h3"
+              aria-label="${this.__effectiveI18n.h3}"
             ></button>
-            <vaadin-tooltip for="btn-h3" .text="${this.__effectiveI18n.h3}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-glyph-transformation">
@@ -212,15 +228,15 @@ class RichTextEditor extends RichTextEditorMixin(
               class="ql-script"
               value="sub"
               part="toolbar-button toolbar-button-subscript"
+              aria-label="${this.__effectiveI18n.subscript}"
             ></button>
-            <vaadin-tooltip for="btn-subscript" .text="${this.__effectiveI18n.subscript}"></vaadin-tooltip>
             <button
               id="btn-superscript"
               class="ql-script"
               value="super"
               part="toolbar-button toolbar-button-superscript"
+              aria-label="${this.__effectiveI18n.superscript}"
             ></button>
-            <vaadin-tooltip for="btn-superscript" text="${this.__effectiveI18n.superscript}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-list">
@@ -231,16 +247,16 @@ class RichTextEditor extends RichTextEditorMixin(
               class="ql-list"
               value="ordered"
               part="toolbar-button toolbar-button-list-ordered"
+              aria-label="${this.__effectiveI18n.listOrdered}"
             ></button>
-            <vaadin-tooltip for="btn-ol" text="${this.__effectiveI18n.listOrdered}"></vaadin-tooltip>
             <button
               id="btn-ul"
               type="button"
               class="ql-list"
               value="bullet"
               part="toolbar-button toolbar-button-list-bullet"
+              aria-label="${this.__effectiveI18n.listBullet}"
             ></button>
-            <vaadin-tooltip for="btn-ul" text="${this.__effectiveI18n.listBullet}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-alignment">
@@ -251,24 +267,24 @@ class RichTextEditor extends RichTextEditorMixin(
               class="ql-align"
               value=""
               part="toolbar-button toolbar-button-align-left"
+              aria-label="${this.__effectiveI18n.alignLeft}"
             ></button>
-            <vaadin-tooltip for="btn-left" .text="${this.__effectiveI18n.alignLeft}"></vaadin-tooltip>
             <button
               id="btn-center"
               type="button"
               class="ql-align"
               value="center"
               part="toolbar-button toolbar-button-align-center"
+              aria-label="${this.__effectiveI18n.alignCenter}"
             ></button>
-            <vaadin-tooltip for="btn-center" .text="${this.__effectiveI18n.alignCenter}"></vaadin-tooltip>
             <button
               id="btn-right"
               type="button"
               class="ql-align"
               value="right"
               part="toolbar-button toolbar-button-align-right"
+              aria-label="${this.__effectiveI18n.alignRight}"
             ></button>
-            <vaadin-tooltip for="btn-right" .text="${this.__effectiveI18n.alignRight}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-rich-text">
@@ -277,18 +293,18 @@ class RichTextEditor extends RichTextEditorMixin(
               id="btn-image"
               type="button"
               part="toolbar-button toolbar-button-image"
+              aria-label="${this.__effectiveI18n.image}"
               @touchend="${this._onImageTouchEnd}"
               @click="${this._onImageClick}"
             ></button>
-            <vaadin-tooltip for="btn-image" .text="${this.__effectiveI18n.image}"></vaadin-tooltip>
             <!-- Link -->
             <button
               id="btn-link"
               type="button"
               part="toolbar-button toolbar-button-link"
+              aria-label="${this.__effectiveI18n.link}"
               @click="${this._onLinkClick}"
             ></button>
-            <vaadin-tooltip for="btn-link" .text="${this.__effectiveI18n.link}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-block">
@@ -298,22 +314,27 @@ class RichTextEditor extends RichTextEditorMixin(
               type="button"
               class="ql-blockquote"
               part="toolbar-button toolbar-button-blockquote"
+              aria-label="${this.__effectiveI18n.blockquote}"
             ></button>
-            <vaadin-tooltip for="btn-blockquote" .text="${this.__effectiveI18n.blockquote}"></vaadin-tooltip>
             <!-- Code block -->
             <button
               id="btn-code"
               type="button"
               class="ql-code-block"
               part="toolbar-button toolbar-button-code-block"
+              aria-label="${this.__effectiveI18n.codeBlock}"
             ></button>
-            <vaadin-tooltip for="btn-code" .text="${this.__effectiveI18n.codeBlock}"></vaadin-tooltip>
           </span>
 
           <span part="toolbar-group toolbar-group-format">
             <!-- Clean -->
-            <button id="btn-clean" type="button" class="ql-clean" part="toolbar-button toolbar-button-clean"></button>
-            <vaadin-tooltip for="btn-clean" .text="${this.__effectiveI18n.clean}"></vaadin-tooltip>
+            <button
+              id="btn-clean"
+              type="button"
+              class="ql-clean"
+              part="toolbar-button toolbar-button-clean"
+              aria-label="${this.__effectiveI18n.clean}"
+            ></button>
           </span>
 
           <input

--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -24,15 +24,14 @@ describe('accessibility', () => {
       announcer = rte.shadowRoot.querySelector('[aria-live=polite]');
     });
 
-    it('should have default tooltips for the buttons', () => {
+    it('should have aria-label for the buttons', () => {
       buttons.forEach((button, index) => {
         const expectedLabel = rte.i18n[Object.keys(rte.i18n)[index]];
-        const tooltip = rte.shadowRoot.querySelector(`[for="${button.id}"]`);
-        expect(tooltip.text).to.equal(expectedLabel);
+        expect(button.ariaLabel).to.equal(expectedLabel);
       });
     });
 
-    it('should localize tooltips for the buttons', async () => {
+    it('should localize aria-label for the buttons', async () => {
       const defaultI18n = rte.i18n;
 
       const localized = {};
@@ -44,8 +43,7 @@ describe('accessibility', () => {
 
       buttons.forEach((button, index) => {
         const expectedLabel = `${defaultI18n[Object.keys(defaultI18n)[index]]} localized`;
-        const tooltip = rte.shadowRoot.querySelector(`[for="${button.id}"]`);
-        expect(tooltip.text).to.equal(expectedLabel);
+        expect(button.ariaLabel).to.equal(expectedLabel);
       });
     });
 

--- a/packages/rich-text-editor/test/toolbar.test.js
+++ b/packages/rich-text-editor/test/toolbar.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
   esc,
+  fire,
   fixtureSync,
   focusout,
   isDesktopSafari,
@@ -560,6 +561,91 @@ describe('toolbar controls', () => {
       btn = getButton('redo');
       btn.click();
       expect(editor.getText()).to.equal('Foo\n');
+    });
+  });
+
+  describe('tooltip', () => {
+    const Tooltip = customElements.get('vaadin-tooltip');
+    let tooltip, overlay;
+
+    before(() => {
+      Tooltip.setDefaultFocusDelay(0);
+      Tooltip.setDefaultHoverDelay(0);
+      Tooltip.setDefaultHideDelay(0);
+    });
+
+    beforeEach(() => {
+      tooltip = rte.querySelector('vaadin-tooltip');
+      overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+    });
+
+    it('should open tooltip when hovering toolbar button', () => {
+      const undo = getButton('undo');
+      fire(undo, 'mouseenter');
+
+      expect(tooltip.target).to.equal(undo);
+      expect(tooltip.text).to.equal(undo.ariaLabel);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should move tooltip when hovering other toolbar button', () => {
+      const undo = getButton('undo');
+      fire(undo, 'mouseenter');
+
+      const redo = getButton('redo');
+      fire(redo, 'mouseenter');
+
+      expect(tooltip.target).to.equal(redo);
+      expect(tooltip.text).to.equal(redo.ariaLabel);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close tooltip when mouse leaves toolbar button', () => {
+      const undo = getButton('undo');
+      fire(undo, 'mouseenter');
+
+      expect(overlay.opened).to.be.true;
+
+      fire(undo, 'mouseleave');
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should open tooltip when focusing toolbar button', () => {
+      const undo = getButton('undo');
+      undo.focus();
+
+      expect(tooltip.target).to.equal(undo);
+      expect(tooltip.text).to.equal(undo.ariaLabel);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should move tooltip when focusing other toolbar button', () => {
+      const undo = getButton('undo');
+      undo.focus();
+
+      const redo = getButton('redo');
+      redo.focus();
+
+      expect(tooltip.target).to.equal(redo);
+      expect(tooltip.text).to.equal(redo.ariaLabel);
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should close tooltip when focus is moved away from toolbar button', () => {
+      const undo = getButton('undo');
+      undo.focus();
+
+      expect(overlay.opened).to.be.true;
+
+      focusout(undo);
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should not set aria-describedby on toolbar button', () => {
+      const undo = getButton('undo');
+      undo.focus();
+
+      expect(undo.hasAttribute('aria-describedby')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

Replaces the existing tooltips in the shadow DOM with a single tooltip in the light DOM that is dynamically assigned to individual toolbar buttons when those are hovered or focused.

Fixes https://github.com/vaadin/web-components/issues/9711

## Type of change

- Breaking change