### PR TITLE
fix: allow vaadin-overlay-open event to bubble to the document

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -306,7 +306,7 @@ export const OverlayMixin = (superClass) =>
           setTimeout(() => {
             this._trapFocus();
 
-            this.dispatchEvent(new CustomEvent('vaadin-overlay-open', { bubbles: true }));
+            this.dispatchEvent(new CustomEvent('vaadin-overlay-open', { bubbles: true, composed: true }));
           });
         });
 


### PR DESCRIPTION
## Description

This fixes an IT test that started to fail after #9751 and #9170 were merged:

```
test/integration/component-tooltip.test.js:

 ❌ vaadin-select overlay with slotted tooltip > should close tooltip when opening vaadin-select overlay
      AssertionError: expected true to be false
      + expected - actual

      -true
      +false

      at n.<anonymous> (test/integration/component-tooltip.test.js:214:42)
```

Tooltip relies on global `vaadin-overlay-open` event listeners since https://github.com/vaadin/web-components/pull/4852 so we need to add `composed: true`.

## Type of change

- Bugfix