### PR TITLE
feat: add draggable attribute to vaadin-dialog-overlay

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -114,6 +114,7 @@ class Dialog extends DialogDraggableMixin(
         modeless="[[modeless]]"
         with-backdrop="[[!modeless]]"
         resizable$="[[resizable]]"
+        draggable$="[[draggable]]"
         restore-focus-on-close
         focus-trap
       ></vaadin-dialog-overlay>

--- a/packages/dialog/src/vaadin-lit-dialog.js
+++ b/packages/dialog/src/vaadin-lit-dialog.js
@@ -87,6 +87,7 @@ class Dialog extends DialogDraggableMixin(
         .modeless="${this.modeless}"
         .withBackdrop="${!this.modeless}"
         ?resizable="${this.resizable}"
+        ?draggable="${this.draggable}"
         restore-focus-on-close
         focus-trap
       ></vaadin-dialog-overlay>

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -623,8 +623,12 @@ describe('draggable', () => {
     expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('100%');
   });
 
-  it('should add [draggable] attribute on vaadin-dialog-overlay if vaadin-dialog is draggable', () => {
-    expect(dialog.$.overlay.hasAttribute('draggable')).to.be.ok;
+  it('should toggle draggable attribute on the overlay based on the property', async () => {
+    expect(dialog.$.overlay.hasAttribute('draggable')).to.be.true;
+
+    dialog.draggable = false;
+    await nextUpdate(dialog);
+    expect(dialog.$.overlay.hasAttribute('draggable')).to.be.false;
   });
 });
 

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -623,7 +623,7 @@ describe('draggable', () => {
     expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('100%');
   });
 
-  it('should add [draggable] attribute on vaadin-dialog-overlay if vaadin-dialog is draggable', async () => {    
+  it('should add [draggable] attribute on vaadin-dialog-overlay if vaadin-dialog is draggable', () => {
     expect(dialog.$.overlay.hasAttribute('draggable')).to.be.ok;
   });
 });

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -622,6 +622,10 @@ describe('draggable', () => {
     await nextRender();
     expect(getComputedStyle(dialog.$.overlay.$.overlay).maxWidth).to.equal('100%');
   });
+
+  it('should add [draggable] attribute on vaadin-dialog-overlay if vaadin-dialog is draggable', async () => {    
+    expect(dialog.$.overlay.hasAttribute('draggable')).to.be.ok;
+  });
 });
 
 describe('touch', () => {


### PR DESCRIPTION
## Description

Adds draggable attribute to vaadin-dialog-overlay such that it can be styled as currently it can be done with resizable like 
```
vaadin-dialog-overlay[draggable]::part(overlay){
}
```

Fixes # [9377](https://github.com/vaadin/web-components/issues/9377)


