### PR TITLE
test: update MSCB tests to use shared helpers for items

### DIFF
--- a/packages/multi-select-combo-box/test/accessibility.test.js
+++ b/packages/multi-select-combo-box/test/accessibility.test.js
@@ -3,6 +3,7 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
+import { getAllItems, getFirstItem } from './helpers.js';
 
 describe('accessibility', () => {
   let comboBox, inputElement;
@@ -102,7 +103,7 @@ describe('accessibility', () => {
         comboBox.selectedItems = ['Apple', 'Lemon'];
         comboBox.inputElement.click();
         scroller = comboBox.$.comboBox._scroller;
-        items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+        items = getAllItems(comboBox);
       });
 
       it('should set aria-multiselectable attribute on the scroller', () => {
@@ -157,7 +158,7 @@ describe('accessibility', () => {
     it('should announce when selecting an item', () => {
       inputElement.click();
 
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       item.click();
 
       clock.tick(150);
@@ -169,7 +170,7 @@ describe('accessibility', () => {
       comboBox.selectedItems = [apple, banana, lemon];
       inputElement.click();
 
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       item.click();
 
       clock.tick(150);

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import './multi-select-combo-box-test-styles.js';
 import '../src/vaadin-multi-select-combo-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { getFirstItem } from './helpers.js';
 
 describe('basic', () => {
   let comboBox, internal, inputElement;
@@ -328,7 +329,7 @@ describe('basic', () => {
 
     it('should clear input element value after clicking matching value', async () => {
       await sendKeys({ type: 'ora' });
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       item.click();
       expect(internal.value).to.equal('');
       expect(inputElement.value).to.equal('');
@@ -336,7 +337,7 @@ describe('basic', () => {
 
     it('should clear filter property after clicking matching value', async () => {
       await sendKeys({ type: 'ora' });
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       item.click();
       expect(comboBox.filter).to.equal('');
     });
@@ -442,7 +443,7 @@ describe('basic', () => {
       };
       comboBox.opened = true;
 
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       expect(item.textContent.trim()).to.equal('apple 0');
     });
 
@@ -475,7 +476,7 @@ describe('basic', () => {
       };
       comboBox.opened = true;
 
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       expect(item.textContent).to.equal('APPLE');
 
       comboBox.renderer = null;
@@ -486,7 +487,7 @@ describe('basic', () => {
     it('should clear the old content after assigning a new renderer', () => {
       comboBox.opened = true;
       comboBox.renderer = () => {};
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       expect(item.textContent).to.equal('');
     });
   });

--- a/packages/multi-select-combo-box/test/lit-renderer-directives.test.js
+++ b/packages/multi-select-combo-box/test/lit-renderer-directives.test.js
@@ -5,6 +5,7 @@ import '../src/vaadin-multi-select-combo-box.js';
 import { html, render } from 'lit';
 import { flushComboBox } from '@vaadin/combo-box/test/helpers.js';
 import { multiSelectComboBoxRenderer } from '../lit.js';
+import { getFirstItem } from './helpers.js';
 
 async function renderComboBox(container, { items }) {
   render(
@@ -44,15 +45,15 @@ describe('lit renderer directives', () => {
 
       it('should render items with the renderer when the combo-box is opened', () => {
         comboBox.opened = true;
-        const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
-        expect(items[0].textContent).to.equal('Item');
+        const item = getFirstItem(comboBox);
+        expect(item.textContent).to.equal('Item');
       });
 
       it('should re-render items when the combo-box is opened and a renderer dependency changes', async () => {
         comboBox.opened = true;
         await renderComboBox(container, { items: ['New Item'] });
-        const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
-        expect(items[0].textContent).to.equal('New Item');
+        const item = getFirstItem(comboBox);
+        expect(item.textContent).to.equal('New Item');
       });
     });
 

--- a/packages/multi-select-combo-box/test/readonly.test.js
+++ b/packages/multi-select-combo-box/test/readonly.test.js
@@ -3,7 +3,7 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
-import { getAsyncDataProvider } from './helpers.js';
+import { getAllItems, getAsyncDataProvider, getFirstItem } from './helpers.js';
 
 describe('readonly', () => {
   let comboBox, inputElement, internal;
@@ -78,20 +78,20 @@ describe('readonly', () => {
     it('should not set item focus-ring attribute on Arrow Down', async () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'ArrowDown' });
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
-      expect(items[0].hasAttribute('focus-ring')).to.be.false;
+      const item = getFirstItem(comboBox);
+      expect(item.hasAttribute('focus-ring')).to.be.false;
     });
 
     it('should not set item focus-ring attribute on Arrow Up', async () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'ArrowDown' });
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items[1].hasAttribute('focus-ring')).to.be.false;
     });
 
     it('should only render selected items in the dropdown when readonly', () => {
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('orange');
@@ -100,7 +100,7 @@ describe('readonly', () => {
     it('should render regular items in the dropdown when readonly is off', () => {
       comboBox.readonly = false;
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(4);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('banana');
@@ -112,28 +112,28 @@ describe('readonly', () => {
       comboBox.selectedItems = [];
       comboBox.selectedItems = ['lemon'];
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(1);
       expect(items[0].textContent).to.equal('lemon');
     });
 
     it('should not set selected attribute on the dropdown items', () => {
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items[0].hasAttribute('selected')).to.be.false;
       expect(items[1].hasAttribute('selected')).to.be.false;
     });
 
     it('should set readonly attribute on the dropdown items', () => {
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items[0].hasAttribute('readonly')).to.be.true;
       expect(items[1].hasAttribute('readonly')).to.be.true;
     });
 
     it('should not un-select item on click when readonly', () => {
       inputElement.click();
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       item.click();
       expect(comboBox.selectedItems.length).to.equal(2);
     });
@@ -180,7 +180,7 @@ describe('readonly', () => {
       inputElement.click();
       // Wait for the async data provider timeout
       await aTimeout(0);
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('orange');
@@ -191,7 +191,7 @@ describe('readonly', () => {
       inputElement.click();
       // Wait for the async data provider timeout
       await aTimeout(0);
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(4);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('banana');
@@ -204,7 +204,7 @@ describe('readonly', () => {
       // Wait for the async data provider timeout
       await aTimeout(0);
       comboBox.size = 4;
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('orange');
@@ -224,7 +224,7 @@ describe('readonly', () => {
       inputElement.click();
       // Wait for the async data provider timeout
       await aTimeout(0);
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('orange');
@@ -250,7 +250,7 @@ describe('readonly', () => {
       comboBox.inputElement.click();
       // Wait for the async data provider timeout
       await aTimeout(0);
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('new item 1');
       expect(items[1].textContent).to.equal('new item 2');
@@ -270,7 +270,7 @@ describe('readonly', () => {
 
     it('should only render selected items in the dropdown when readonly', () => {
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(2);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('orange');
@@ -279,7 +279,7 @@ describe('readonly', () => {
     it('should render regular items in the dropdown when readonly is off', () => {
       comboBox.readonly = false;
       inputElement.click();
-      const items = document.querySelectorAll('vaadin-multi-select-combo-box-item');
+      const items = getAllItems(comboBox);
       expect(items.length).to.equal(4);
       expect(items[0].textContent).to.equal('apple');
       expect(items[1].textContent).to.equal('banana');

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -45,7 +45,7 @@ describe('selecting items', () => {
 
     it('should update selectedItems when selecting an item on click', async () => {
       await sendKeys({ down: 'ArrowDown' });
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       item.click();
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
@@ -108,7 +108,7 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'Enter' });
-      const item = document.querySelector('vaadin-multi-select-combo-box-item');
+      const item = getFirstItem(comboBox);
       expect(item.hasAttribute('focused')).to.be.true;
     });
 
@@ -116,7 +116,7 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ type: 'banana' });
       await sendKeys({ down: 'Enter' });
-      const item = document.querySelectorAll('vaadin-multi-select-combo-box-item')[1];
+      const item = getAllItems(comboBox)[1];
       expect(item.hasAttribute('focused')).to.be.true;
     });
 


### PR DESCRIPTION
## Description

Updated tests to use `getFirstItem()` and `getAllItems()` helpers for consistency.

## Type of change

- Test