### PR TITLE
refactor: move dataProvider value warning logic to combo-box

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -58,11 +58,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '_dataProviderFilterChanged(filter)',
-        '_warnDataProviderValue(dataProvider, value)',
-        '_ensureFirstPage(opened)',
-      ];
+      return ['_dataProviderFilterChanged(filter)', '_ensureFirstPage(opened)'];
     }
 
     constructor() {
@@ -281,22 +277,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       if (this.items !== undefined && this.dataProvider !== undefined) {
         restoreOldValueCallback();
         throw new Error('Using `items` and `dataProvider` together is not supported');
-      }
-    }
-
-    /** @private */
-    _warnDataProviderValue(dataProvider, value) {
-      if (dataProvider && value !== '' && (this.selectedItem === undefined || this.selectedItem === null)) {
-        const valueIndex = this.__getItemIndexByValue(this.filteredItems, value);
-        if (valueIndex < 0 || !this._getItemLabel(this.filteredItems[valueIndex])) {
-          console.warn(
-            'Warning: unable to determine the label for the provided `value`. ' +
-              'Nothing to display in the text field. This usually happens when ' +
-              'setting an initial `value` before any items are returned from ' +
-              'the `dataProvider` callback. Consider setting `selectedItem` ' +
-              'instead of `value`',
-          );
-        }
       }
     }
   };

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -257,6 +257,15 @@ class ComboBox extends ComboBoxDataProviderMixin(
     this._toggleElement = this.$.toggleButton;
   }
 
+  /** @protected */
+  updated(props) {
+    super.updated(props);
+
+    if (props.has('dataProvider') || props.has('value')) {
+      this._warnDataProviderValue(this.dataProvider, this.value);
+    }
+  }
+
   /**
    * Override the method from `InputControlMixin`
    * to stop event propagation to prevent `ComboBoxMixin`
@@ -281,6 +290,22 @@ class ComboBox extends ComboBoxDataProviderMixin(
     // Open dropdown only when clicking on the label or input field
     if (path.includes(this._labelNode) || path.includes(this._positionTarget)) {
       super._onHostClick(event);
+    }
+  }
+
+  /** @private */
+  _warnDataProviderValue(dataProvider, value) {
+    if (dataProvider && value !== '' && (this.selectedItem === undefined || this.selectedItem === null)) {
+      const valueIndex = this.__getItemIndexByValue(this.filteredItems, value);
+      if (valueIndex < 0 || !this._getItemLabel(this.filteredItems[valueIndex])) {
+        console.warn(
+          'Warning: unable to determine the label for the provided `value`. ' +
+            'Nothing to display in the text field. This usually happens when ' +
+            'setting an initial `value` before any items are returned from ' +
+            'the `dataProvider` callback. Consider setting `selectedItem` ' +
+            'instead of `value`',
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

The warning was added in https://github.com/vaadin/vaadin-combo-box/pull/725/commits/7f3a57d7b97706f5ca1ef197d7f04db74319f46f to handle a case where an object item isn't loaded yet but a `value` property is set. This is not relevant for `vaadin-multi-select-combo-box` which is going to use `DataProviderMixin` as in MSCB we don't use `value` property at all (it's excluded from typings). Moved the warning to the combo-box itself.

## Type of change

- Refactor