### PR TITLE
refactor: remove no longer used setNestedOverlay logic and tests

### DIFF
--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -53,23 +53,6 @@ export const isLastOverlay = (overlay, filter = (_overlay) => true) => {
   return overlay === filteredOverlays.pop();
 };
 
-const overlayMap = new WeakMap();
-
-/**
- * Stores the reference to the nested overlay for given parent,
- * or removes it when the nested overlay is null.
- * @param {HTMLElement} parent
- * @param {HTMLElement} nested
- * @protected
- */
-export const setNestedOverlay = (parent, nested) => {
-  if (nested != null) {
-    overlayMap.set(parent, nested);
-  } else {
-    overlayMap.delete(parent);
-  }
-};
-
 /**
  * @polymerMixin
  */
@@ -133,11 +116,6 @@ export const OverlayStackMixin = (superClass) =>
       // Update order of attached instances
       this._removeAttachedInstance();
       this._appendAttachedInstance();
-
-      // If there is a nested overlay, call `bringToFront()` for it as well.
-      if (overlayMap.has(this)) {
-        overlayMap.get(this).bringToFront();
-      }
     }
 
     /** @protected */

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -2,7 +2,6 @@ import { expect } from '@vaadin/chai-plugins';
 import { click, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-overlay.js';
-import { setNestedOverlay } from '../src/vaadin-overlay-stack-mixin.js';
 import { createOverlay } from './helpers.js';
 
 describe('multiple overlays', () => {
@@ -373,64 +372,6 @@ describe('multiple overlays', () => {
 
         expect(modeless2._last).to.be.true;
       });
-    });
-  });
-
-  describe('setNestedOverlay', () => {
-    let overlays;
-
-    beforeEach(() => {
-      overlays = Array.from(
-        fixtureSync(`
-        <div id="parent">
-          <vaadin-overlay modeless></vaadin-overlay>
-          <vaadin-overlay modeless></vaadin-overlay>
-          <vaadin-overlay modeless></vaadin-overlay>
-        </div>
-      `).children,
-      );
-      overlays.forEach((el, idx) => {
-        el.renderer = (root) => {
-          if (!root.firstChild) {
-            const btn = document.createElement('button');
-            btn.textContent = `Overlay ${idx}`;
-            root.appendChild(btn);
-          }
-        };
-        el.opened = true;
-      });
-    });
-
-    afterEach(() => {
-      overlays.forEach((el) => {
-        el.opened = false;
-      });
-    });
-
-    it('should bring nested overlays to front recursively', () => {
-      setNestedOverlay(overlays[0], overlays[1]);
-      setNestedOverlay(overlays[1], overlays[2]);
-
-      const bringToFrontSpy1 = sinon.spy(overlays[1], 'bringToFront');
-      const bringToFrontSpy2 = sinon.spy(overlays[2], 'bringToFront');
-
-      overlays[0].bringToFront();
-
-      expect(bringToFrontSpy1).to.be.calledOnce;
-      expect(bringToFrontSpy2).to.be.calledOnce;
-      expect(bringToFrontSpy2).to.be.calledAfter(bringToFrontSpy1);
-    });
-
-    it('should not bring nested overlay to front when resetting', () => {
-      setNestedOverlay(overlays[0], overlays[1]);
-
-      setNestedOverlay(overlays[0], null);
-
-      const bringToFrontSpy = sinon.spy(overlays[1], 'bringToFront');
-
-      overlays[0].bringToFront();
-
-      expect(bringToFrontSpy).to.be.not.called;
     });
   });
 });


### PR DESCRIPTION
## Description

This logic is no longer used anywhere after upgrading `vaadin-popover` to use native popover in https://github.com/vaadin/web-components/pull/9785.

I tested the modeless dialog & popover combinations and it seems we don't need to call `bringToFront()` for nested overlays, especially because popover always closes on outside click since https://github.com/vaadin/web-components/pull/8409. All other overlay components e.g. `vaadin-date-picker` use modal overlays so they also close on outside click, and were not affected by https://github.com/vaadin/web-components/issues/8521.

## Type of change

- Refactor