### PR TITLE
refactor!: update multi-select-combo-box to use native popover

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -499,6 +499,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       // Do not commit focused item on not blur / outside click
       if (this._ignoreCommitValue) {
         this._inputElementValue = '';
+        this._focusedIndex = -1;
         this._ignoreCommitValue = false;
       } else {
         this.__commitUserInput();

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -419,6 +419,18 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /**
+     * Override method from `ComboBoxBaseMixin` to render scroller in the slot.
+     * @protected
+     * @override
+     */
+    _renderScroller(scroller) {
+      scroller.setAttribute('slot', 'overlay');
+      // Prevent focusing scroller on input Tab
+      scroller.setAttribute('tabindex', '-1');
+      this.appendChild(scroller);
+    }
+
+    /**
      * Override method from `ComboBoxBaseMixin` to implement clearing logic.
      * @protected
      * @override

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -45,6 +45,22 @@ class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(
       </div>
     `;
   }
+
+  /**
+   * @protected
+   * @override
+   */
+  _attachOverlay() {
+    this.showPopover();
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  _detachOverlay() {
+    this.hidePopover();
+  }
 }
 
 defineCustomElement(MultiSelectComboBoxOverlay);

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -144,12 +144,8 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * In addition to `<vaadin-multi-select-combo-box>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-multi-select-combo-box-overlay>` - has the same API as `<vaadin-overlay>`.
+ * - `<vaadin-multi-select-combo-box-chip>`
  * - `<vaadin-multi-select-combo-box-item>` - has the same API as `<vaadin-item>`.
- * - `<vaadin-multi-select-combo-box-container>` - has the same API as `<vaadin-input-container>`.
- *
- * Note: the `theme` attribute value set on `<vaadin-multi-select-combo-box>` is
- * propagated to these components.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.d.ts
@@ -110,6 +110,9 @@ export interface MultiSelectComboBoxEventMap<TItem> extends HTMLElementEventMap 
  * `helper-text`          | The helper text element wrapper
  * `required-indicator`   | The `required` state indicator element
  * `toggle-button`        | The toggle button
+ * `overlay`              | The overlay container
+ * `content`              | The overlay content
+ * `loader`               | The loading indicator shown while loading items
  *
  * The following state attributes are available for styling:
  *

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -47,6 +47,9 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  * `helper-text`          | The helper text element wrapper
  * `required-indicator`   | The `required` state indicator element
  * `toggle-button`        | The toggle button
+ * `overlay`              | The overlay container
+ * `content`              | The overlay content
+ * `loader`               | The loading indicator shown while loading items
  *
  * The following state attributes are available for styling:
  *
@@ -149,13 +152,17 @@ class MultiSelectComboBox extends MultiSelectComboBoxMixin(
 
       <vaadin-multi-select-combo-box-overlay
         id="overlay"
+        popover="manual"
+        exportparts="overlay, content, loader"
         .owner="${this}"
         .opened="${this._overlayOpened}"
         ?loading="${this.loading}"
         theme="${ifDefined(this._theme)}"
         .positionTarget="${this._inputField}"
         no-vertical-overlap
-      ></vaadin-multi-select-combo-box-overlay>
+      >
+        <slot name="overlay"></slot>
+      </vaadin-multi-select-combo-box-overlay>
 
       <slot name="tooltip"></slot>
     `;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -81,12 +81,8 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  * In addition to `<vaadin-multi-select-combo-box>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-multi-select-combo-box-overlay>` - has the same API as `<vaadin-overlay>`.
+ * - `<vaadin-multi-select-combo-box-chip>`
  * - `<vaadin-multi-select-combo-box-item>` - has the same API as `<vaadin-item>`.
- * - `<vaadin-multi-select-combo-box-container>` - has the same API as `<vaadin-input-container>`.
- *
- * Note: the `theme` attribute value set on `<vaadin-multi-select-combo-box>` is
- * propagated to these components.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -407,4 +407,23 @@ describe('basic', () => {
       expect(item.textContent).to.equal('');
     });
   });
+
+  describe('exportparts', () => {
+    let overlay;
+
+    beforeEach(() => {
+      overlay = comboBox.$.overlay;
+    });
+
+    it('should export overlay parts for styling', () => {
+      const parts = [...overlay.shadowRoot.querySelectorAll('[part]')]
+        .map((el) => el.getAttribute('part'))
+        .filter((part) => part !== 'backdrop');
+      const exportParts = overlay.getAttribute('exportparts').split(', ');
+
+      parts.forEach((part) => {
+        expect(exportParts).to.include(part);
+      });
+    });
+  });
 });

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -556,7 +556,7 @@ describe('chips', () => {
     it('should adapt overlay width to the input field width while opened', async () => {
       comboBox.opened = true;
 
-      const overlay = document.querySelector('vaadin-multi-select-combo-box-overlay');
+      const overlay = comboBox.$.overlay;
       const overlayPart = overlay.$.overlay;
       const width = overlayPart.offsetWidth;
       expect(width).to.equal(comboBox.clientWidth);

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -3,6 +3,14 @@ export const snapshots = {};
 
 snapshots["vaadin-multi-select-combo-box host default"] = 
 `<vaadin-multi-select-combo-box>
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -39,6 +47,14 @@ snapshots["vaadin-multi-select-combo-box host default"] =
 
 snapshots["vaadin-multi-select-combo-box host label"] = 
 `<vaadin-multi-select-combo-box has-label="">
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -77,6 +93,14 @@ snapshots["vaadin-multi-select-combo-box host label"] =
 
 snapshots["vaadin-multi-select-combo-box host helper"] = 
 `<vaadin-multi-select-combo-box has-helper="">
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -123,6 +147,14 @@ snapshots["vaadin-multi-select-combo-box host error"] =
   has-error-message=""
   invalid=""
 >
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -162,6 +194,14 @@ snapshots["vaadin-multi-select-combo-box host error"] =
 
 snapshots["vaadin-multi-select-combo-box host required"] = 
 `<vaadin-multi-select-combo-box required="">
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -202,6 +242,14 @@ snapshots["vaadin-multi-select-combo-box host disabled"] =
   aria-disabled="true"
   disabled=""
 >
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -241,6 +289,14 @@ snapshots["vaadin-multi-select-combo-box host disabled"] =
 
 snapshots["vaadin-multi-select-combo-box host readonly"] = 
 `<vaadin-multi-select-combo-box readonly="">
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -279,6 +335,14 @@ snapshots["vaadin-multi-select-combo-box host readonly"] =
 
 snapshots["vaadin-multi-select-combo-box host placeholder"] = 
 `<vaadin-multi-select-combo-box placeholder="Placeholder">
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -319,6 +383,14 @@ snapshots["vaadin-multi-select-combo-box host opened default"] =
   focused=""
   opened=""
 >
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
   <label
     for="input-vaadin-multi-select-combo-box-4"
     id="label-vaadin-multi-select-combo-box-0"
@@ -356,15 +428,13 @@ snapshots["vaadin-multi-select-combo-box host opened default"] =
 
 snapshots["vaadin-multi-select-combo-box host opened overlay"] = 
 `<vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-multi-select-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-multi-select-combo-box-overlay>
 `;
 /* end snapshot vaadin-multi-select-combo-box host opened overlay */
@@ -372,15 +442,13 @@ snapshots["vaadin-multi-select-combo-box host opened overlay"] =
 snapshots["vaadin-multi-select-combo-box host opened overlay class"] = 
 `<vaadin-multi-select-combo-box-overlay
   class="custom multi-select-combo-box-overlay"
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-multi-select-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-multi-select-combo-box-overlay>
 `;
 /* end snapshot vaadin-multi-select-combo-box host opened overlay class */
@@ -437,15 +505,13 @@ snapshots["vaadin-multi-select-combo-box shadow default"] =
   </div>
 </div>
 <vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-multi-select-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-multi-select-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -507,15 +573,13 @@ snapshots["vaadin-multi-select-combo-box shadow disabled"] =
   </div>
 </div>
 <vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-multi-select-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-multi-select-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -577,15 +641,13 @@ snapshots["vaadin-multi-select-combo-box shadow readonly"] =
   </div>
 </div>
 <vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-multi-select-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-multi-select-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -647,15 +709,13 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
   </div>
 </div>
 <vaadin-multi-select-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-multi-select-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-multi-select-combo-box-overlay>
 <slot name="tooltip">
 </slot>

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
-import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, keyboardEventFor, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
@@ -157,11 +157,16 @@ describe('selecting items', () => {
 
     it('should reset the item focused state when closing on outside click', async () => {
       await sendKeys({ press: 'ArrowDown' });
+      await oneEvent(comboBox, 'vaadin-overlay-open');
+
       await sendKeys({ press: 'ArrowDown' });
+
       await sendMouseToElement({ type: 'click', element: document.body });
       await resetMouse();
 
       await sendKeys({ press: 'ArrowDown' });
+      await oneEvent(comboBox, 'vaadin-overlay-open');
+
       const item = getFirstItem(comboBox);
       expect(item.hasAttribute('focused')).to.be.false;
     });

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
@@ -153,6 +153,32 @@ describe('selecting items', () => {
       await sendMouse({ type: 'click', position: [200, 200] });
       await resetMouse();
       expect(comboBox.selectedItems).to.deep.equal([]);
+    });
+
+    it('should reset the item focused state when closing on outside click', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      await sendKeys({ press: 'ArrowDown' });
+      await sendMouseToElement({ type: 'click', element: document.body });
+      await resetMouse();
+
+      await sendKeys({ press: 'ArrowDown' });
+      const item = getFirstItem(comboBox);
+      expect(item.hasAttribute('focused')).to.be.false;
+    });
+
+    it('should reset the item focused state when closing on blur', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      await sendKeys({ press: 'ArrowDown' });
+
+      // Blur the combo-box
+      await sendKeys({ press: 'Shift+Tab' });
+
+      // Focus and re-open
+      await sendKeys({ press: 'Tab' });
+
+      await sendKeys({ press: 'ArrowDown' });
+      const item = getFirstItem(comboBox);
+      expect(item.hasAttribute('focused')).to.be.false;
     });
 
     it('should not select an item on blur when it is focused', async () => {

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
 import { fixtureSync, keyboardEventFor, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
@@ -26,6 +26,10 @@ describe('selecting items', () => {
   describe('basic', () => {
     beforeEach(() => {
       comboBox.items = ['apple', 'banana', 'lemon', 'orange'];
+    });
+
+    afterEach(async () => {
+      await resetMouse();
     });
 
     it('should update selectedItems when selecting an item on Enter', async () => {
@@ -122,7 +126,6 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'Enter' });
       await sendMouse({ type: 'click', position: [200, 200] });
-      await resetMouse();
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 
@@ -132,7 +135,6 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'Enter' });
       await sendMouse({ type: 'click', position: [200, 200] });
-      await resetMouse();
       await sendKeys({ down: 'Tab' });
       expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
@@ -151,18 +153,14 @@ describe('selecting items', () => {
       await sendKeys({ down: 'ArrowDown' });
       await sendKeys({ down: 'ArrowDown' });
       await sendMouse({ type: 'click', position: [200, 200] });
-      await resetMouse();
       expect(comboBox.selectedItems).to.deep.equal([]);
     });
 
     it('should reset the item focused state when closing on outside click', async () => {
       await sendKeys({ press: 'ArrowDown' });
-      await oneEvent(comboBox, 'vaadin-overlay-open');
-
       await sendKeys({ press: 'ArrowDown' });
 
-      await sendMouseToElement({ type: 'click', element: document.body });
-      await resetMouse();
+      await sendMouse({ type: 'click', position: [400, 400] });
 
       await sendKeys({ press: 'ArrowDown' });
       await oneEvent(comboBox, 'vaadin-overlay-open');


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9723

Depends on https://github.com/vaadin/web-components/pull/9804

Similar to the time-picker change https://github.com/vaadin/web-components/pull/9755 but for `vaadin-multi-select-combo-box`.

## Type of change

- Breaking change

## Note

Flow components branch: https://github.com/vaadin/flow-components/compare/proto/mscb-native-popover