### PR TITLE
refactor!: update combo-box overlay to use native popover

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -258,21 +258,14 @@ export const ComboBoxBaseMixin = (superClass) =>
 
     /**
      * Render the scroller element to the overlay.
-     * Override to provide custom logic (e.g. setting "slot").
      *
-     * @protected
+     * @private
      */
     _renderScroller(scroller) {
-      const overlay = this.$.overlay;
-
-      overlay.renderer = (root) => {
-        if (!root.innerHTML) {
-          root.appendChild(scroller);
-        }
-      };
-
-      // Ensure the scroller is rendered
-      overlay.requestContentUpdate();
+      scroller.setAttribute('slot', 'overlay');
+      // Prevent focusing scroller on input Tab
+      scroller.setAttribute('tabindex', '-1');
+      this.appendChild(scroller);
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -184,15 +184,6 @@ export const ComboBoxBaseMixin = (superClass) =>
         this.clearElement.addEventListener('mousedown', this._boundOnClearButtonMouseDown);
       }
 
-      const bringToFrontListener = () => {
-        requestAnimationFrame(() => {
-          this._overlayElement.bringToFront();
-        });
-      };
-
-      this.addEventListener('mousedown', bringToFrontListener);
-      this.addEventListener('touchstart', bringToFrontListener);
-
       this.addController(new VirtualKeyboardController(this));
     }
 

--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.js
@@ -92,7 +92,7 @@ export const ComboBoxItemMixin = (superClass) =>
 
     /** @protected */
     _getHostDir() {
-      return this._owner && this._owner.getAttribute('dir');
+      return this._owner && this._owner.$.overlay.getAttribute('dir');
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -22,21 +22,6 @@ export const ComboBoxOverlayMixin = (superClass) =>
       this.requiredVerticalSpace = 200;
     }
 
-    /** @protected */
-    connectedCallback() {
-      super.connectedCallback();
-
-      const hostDir = this._getHostDir();
-      if (hostDir) {
-        this.setAttribute('dir', hostDir);
-      }
-    }
-
-    /** @protected */
-    _getHostDir() {
-      return this.owner && this.owner.getAttribute('dir');
-    }
-
     /**
      * Override method inherited from `Overlay`
      * to not close on position target click.

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -66,16 +66,7 @@ export const ComboBoxOverlayMixin = (superClass) =>
 
     /** @protected */
     _updateOverlayWidth() {
-      const propPrefix = this.localName;
-      this.style.setProperty(`--_${propPrefix}-default-width`, `${this.positionTarget.offsetWidth}px`);
-
-      const customWidth = getComputedStyle(this.owner).getPropertyValue(`--${propPrefix}-width`);
-
-      if (customWidth === '') {
-        this.style.removeProperty(`--${propPrefix}-width`);
-      } else {
-        this.style.setProperty(`--${propPrefix}-width`, customWidth);
-      }
+      this.style.setProperty(`--_${this.localName}-default-width`, `${this.positionTarget.offsetWidth}px`);
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -45,6 +45,22 @@ export class ComboBoxOverlay extends ComboBoxOverlayMixin(
       </div>
     `;
   }
+
+  /**
+   * @protected
+   * @override
+   */
+  _attachOverlay() {
+    this.showPopover();
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  _detachOverlay() {
+    this.hidePopover();
+  }
 }
 
 defineCustomElement(ComboBoxOverlay);

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -200,12 +200,7 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * In addition to `<vaadin-combo-box>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-combo-box-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-combo-box-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the input.
- *
- * Note: the `theme` attribute value set on `<vaadin-combo-box>` is
- * propagated to the internal components listed above.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -181,9 +181,12 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  *
  * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
+ * Part name        | Description
+ * -----------------|------------------
+ * `toggle-button`  | The toggle button
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
+ * `loader`         | The loading indicator shown while loading items
  *
  * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
  *

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -227,6 +227,7 @@ class ComboBox extends ComboBoxDataProviderMixin(
         popover="manual"
         exportparts="overlay, content, loader"
         .owner="${this}"
+        .dir="${this.dir}"
         .opened="${this._overlayOpened}"
         ?loading="${this.loading}"
         theme="${ifDefined(this._theme)}"

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -112,9 +112,12 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  *
  * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
+ * Part name        | Description
+ * -----------------|------------------
+ * `toggle-button`  | The toggle button
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
+ * `loader`         | The loading indicator shown while loading items
  *
  * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
  *
@@ -221,13 +224,17 @@ class ComboBox extends ComboBoxDataProviderMixin(
 
       <vaadin-combo-box-overlay
         id="overlay"
+        popover="manual"
+        exportparts="overlay, content, loader"
         .owner="${this}"
         .opened="${this._overlayOpened}"
         ?loading="${this.loading}"
         theme="${ifDefined(this._theme)}"
         .positionTarget="${this._positionTarget}"
         no-vertical-overlap
-      ></vaadin-combo-box-overlay>
+      >
+        <slot name="overlay"></slot>
+      </vaadin-combo-box-overlay>
 
       <slot name="tooltip"></slot>
     `;

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -131,12 +131,7 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * In addition to `<vaadin-combo-box>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-combo-box-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-combo-box-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the input.
- *
- * Note: the `theme` attribute value set on `<vaadin-combo-box>` is
- * propagated to the internal components listed above.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -264,7 +264,7 @@ describe('pre-opened', () => {
         style="--vaadin-combo-box-overlay-max-height: 200px"
       ></vaadin-combo-box>`);
     await nextRender();
-    const scroller = comboBox.$.overlay.querySelector('vaadin-combo-box-scroller');
+    const scroller = comboBox.querySelector('vaadin-combo-box-scroller');
     expect(scroller.style.maxHeight).to.equal('200px');
   });
 });

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -3,6 +3,13 @@ export const snapshots = {};
 
 snapshots["vaadin-combo-box host default"] = 
 `<vaadin-combo-box>
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -35,6 +42,13 @@ snapshots["vaadin-combo-box host disabled"] =
   aria-disabled="true"
   disabled=""
 >
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -66,6 +80,13 @@ snapshots["vaadin-combo-box host disabled"] =
 
 snapshots["vaadin-combo-box host placeholder"] = 
 `<vaadin-combo-box placeholder="Placeholder">
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -96,6 +117,13 @@ snapshots["vaadin-combo-box host placeholder"] =
 
 snapshots["vaadin-combo-box host readonly"] = 
 `<vaadin-combo-box readonly="">
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -126,6 +154,13 @@ snapshots["vaadin-combo-box host readonly"] =
 
 snapshots["vaadin-combo-box host required"] = 
 `<vaadin-combo-box required="">
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -156,6 +191,13 @@ snapshots["vaadin-combo-box host required"] =
 
 snapshots["vaadin-combo-box host pattern"] = 
 `<vaadin-combo-box>
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -186,6 +228,13 @@ snapshots["vaadin-combo-box host pattern"] =
 
 snapshots["vaadin-combo-box host label"] = 
 `<vaadin-combo-box has-label="">
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -217,6 +266,13 @@ snapshots["vaadin-combo-box host label"] =
 
 snapshots["vaadin-combo-box host helper"] = 
 `<vaadin-combo-box has-helper="">
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -256,6 +312,13 @@ snapshots["vaadin-combo-box host error"] =
   has-error-message=""
   invalid=""
 >
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -288,6 +351,13 @@ snapshots["vaadin-combo-box host error"] =
 
 snapshots["vaadin-combo-box host value"] = 
 `<vaadin-combo-box has-value="">
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -322,6 +392,33 @@ snapshots["vaadin-combo-box host opened default"] =
   start-aligned=""
   top-aligned=""
 >
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+    <vaadin-combo-box-item
+      aria-posinset="1"
+      aria-selected="false"
+      aria-setsize="2"
+      id="vaadin-combo-box-item-0"
+      role="option"
+      tabindex="-1"
+    >
+      Item 1
+    </vaadin-combo-box-item>
+    <vaadin-combo-box-item
+      aria-posinset="2"
+      aria-selected="false"
+      aria-setsize="2"
+      id="vaadin-combo-box-item-1"
+      role="option"
+      tabindex="-1"
+    >
+      Item 2
+    </vaadin-combo-box-item>
+  </vaadin-combo-box-scroller>
   <label
     for="input-vaadin-combo-box-4"
     id="label-vaadin-combo-box-0"
@@ -352,37 +449,16 @@ snapshots["vaadin-combo-box host opened default"] =
 
 snapshots["vaadin-combo-box host opened overlay"] = 
 `<vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
   opened=""
+  popover="manual"
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-    <vaadin-combo-box-item
-      aria-posinset="1"
-      aria-selected="false"
-      aria-setsize="2"
-      id="vaadin-combo-box-item-0"
-      role="option"
-      tabindex="-1"
-    >
-      Item 1
-    </vaadin-combo-box-item>
-    <vaadin-combo-box-item
-      aria-posinset="2"
-      aria-selected="false"
-      aria-setsize="2"
-      id="vaadin-combo-box-item-1"
-      role="option"
-      tabindex="-1"
-    >
-      Item 2
-    </vaadin-combo-box-item>
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 `;
 /* end snapshot vaadin-combo-box host opened overlay */
@@ -408,75 +484,33 @@ snapshots["vaadin-combo-box host opened overlay shadow"] =
 snapshots["vaadin-combo-box host opened overlay class"] = 
 `<vaadin-combo-box-overlay
   class="combo-box-overlay custom"
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
   opened=""
+  popover="manual"
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-    <vaadin-combo-box-item
-      aria-posinset="1"
-      aria-selected="false"
-      aria-setsize="2"
-      id="vaadin-combo-box-item-0"
-      role="option"
-      tabindex="-1"
-    >
-      Item 1
-    </vaadin-combo-box-item>
-    <vaadin-combo-box-item
-      aria-posinset="2"
-      aria-selected="false"
-      aria-setsize="2"
-      id="vaadin-combo-box-item-1"
-      role="option"
-      tabindex="-1"
-    >
-      Item 2
-    </vaadin-combo-box-item>
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 `;
 /* end snapshot vaadin-combo-box host opened overlay class */
 
 snapshots["vaadin-combo-box host opened theme overlay"] = 
 `<vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
   opened=""
+  popover="manual"
   start-aligned=""
   theme="align-right"
   top-aligned=""
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-    <vaadin-combo-box-item
-      aria-posinset="1"
-      aria-selected="false"
-      aria-setsize="2"
-      id="vaadin-combo-box-item-0"
-      role="option"
-      tabindex="-1"
-    >
-      Item 1
-    </vaadin-combo-box-item>
-    <vaadin-combo-box-item
-      aria-posinset="2"
-      aria-selected="false"
-      aria-setsize="2"
-      id="vaadin-combo-box-item-1"
-      role="option"
-      tabindex="-1"
-    >
-      Item 2
-    </vaadin-combo-box-item>
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 `;
 /* end snapshot vaadin-combo-box host opened theme overlay */
@@ -525,14 +559,13 @@ snapshots["vaadin-combo-box shadow default"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -586,14 +619,13 @@ snapshots["vaadin-combo-box shadow disabled"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -647,14 +679,13 @@ snapshots["vaadin-combo-box shadow readonly"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -708,14 +739,13 @@ snapshots["vaadin-combo-box shadow invalid"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 <slot name="tooltip">
 </slot>
@@ -769,15 +799,14 @@ snapshots["vaadin-combo-box shadow theme"] =
   </div>
 </div>
 <vaadin-combo-box-overlay
+  exportparts="overlay, content, loader"
   id="overlay"
   no-vertical-overlap=""
+  popover="manual"
   theme="align-right"
 >
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-  >
-  </vaadin-combo-box-scroller>
+  <slot name="overlay">
+  </slot>
 </vaadin-combo-box-overlay>
 <slot name="tooltip">
 </slot>

--- a/packages/combo-box/test/overlay-opening.test.js
+++ b/packages/combo-box/test/overlay-opening.test.js
@@ -203,4 +203,17 @@ describe('overlay opening', () => {
       expect(overlay.opened).to.be.false;
     });
   });
+
+  describe('exportparts', () => {
+    it('should export overlay parts for styling', () => {
+      const parts = [...overlay.shadowRoot.querySelectorAll('[part]')]
+        .map((el) => el.getAttribute('part'))
+        .filter((part) => part !== 'backdrop');
+      const exportParts = overlay.getAttribute('exportparts').split(', ');
+
+      parts.forEach((part) => {
+        expect(exportParts).to.include(part);
+      });
+    });
+  });
 });

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -419,18 +419,6 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /**
-     * Override method from `ComboBoxBaseMixin` to render scroller in the slot.
-     * @protected
-     * @override
-     */
-    _renderScroller(scroller) {
-      scroller.setAttribute('slot', 'overlay');
-      // Prevent focusing scroller on input Tab
-      scroller.setAttribute('tabindex', '-1');
-      this.appendChild(scroller);
-    }
-
-    /**
      * Override method from `ComboBoxBaseMixin` to implement clearing logic.
      * @protected
      * @override

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -151,6 +151,7 @@ class MultiSelectComboBox extends MultiSelectComboBoxMixin(
         popover="manual"
         exportparts="overlay, content, loader"
         .owner="${this}"
+        .dir="${this.dir}"
         .opened="${this._overlayOpened}"
         ?loading="${this.loading}"
         theme="${ifDefined(this._theme)}"

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -59,17 +59,6 @@ export class TimePickerItem extends ComboBoxItemMixin(
       </div>
     `;
   }
-
-  /**
-   * Override method from `ComboBoxItemMixin` to enforce
-   * `dir` attribute to be set to `ltr` on the item.
-   * @protected
-   * @override
-   */
-  _getHostDir() {
-    // See https://github.com/vaadin/vaadin-time-picker/issues/145
-    return 'ltr';
-  }
 }
 
 defineCustomElement(TimePickerItem);

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -259,18 +259,6 @@ export const TimePickerMixin = (superClass) =>
       return item ? item.label : '';
     }
 
-    /**
-     * Override method from `ComboBoxBaseMixin` to render scroller in the slot.
-     * @protected
-     * @override
-     */
-    _renderScroller(scroller) {
-      scroller.setAttribute('slot', 'overlay');
-      // Prevent focusing scroller on input Tab
-      scroller.setAttribute('tabindex', '-1');
-      this.appendChild(scroller);
-    }
-
     /** @private */
     _updateScroller(opened, items, focusedIndex, theme) {
       if (opened) {

--- a/packages/time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.js
@@ -61,17 +61,6 @@ export class TimePickerOverlay extends ComboBoxOverlayMixin(
   _detachOverlay() {
     this.hidePopover();
   }
-
-  /**
-   * Override method from `ComboBoxOverlayMixin` to enforce
-   * `dir` attribute to be set to `ltr` on the overlay.
-   * @protected
-   * @override
-   */
-  _getHostDir() {
-    // See https://github.com/vaadin/vaadin-time-picker/issues/145
-    return 'ltr';
-  }
 }
 
 defineCustomElement(TimePickerOverlay);

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -142,6 +142,7 @@ class TimePicker extends TimePickerMixin(ThemableMixin(ElementMixin(PolylitMixin
       <vaadin-time-picker-overlay
         id="overlay"
         popover="manual"
+        dir="ltr"
         .owner="${this}"
         .opened="${this._overlayOpened}"
         theme="${ifDefined(this._theme)}"

--- a/test/integration/dialog-combo-box.test.js
+++ b/test/integration/dialog-combo-box.test.js
@@ -1,14 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import {
-  fixtureSync,
-  mousedown,
-  nextFrame,
-  nextUpdate,
-  oneEvent,
-  outsideClick,
-  touchstart,
-} from '@vaadin/testing-helpers';
+import { fixtureSync, nextUpdate, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/combo-box';
 import '@vaadin/dialog';
@@ -76,28 +68,6 @@ describe('combo-box in dialog', () => {
       await sendKeys({ press: 'Escape' });
 
       expect(dialog.opened).to.be.false;
-    });
-  });
-
-  describe('modeless', () => {
-    beforeEach(async () => {
-      dialog.modeless = true;
-      comboBox.open();
-      await nextFrame();
-    });
-
-    it('should not end up behind the dialog overlay on mousedown', async () => {
-      mousedown(comboBox);
-      await nextFrame();
-      expect(comboBox.$.overlay._last).to.be.true;
-    });
-
-    it('should not end up behind the dialog overlay on touchstart', async () => {
-      const { left: x, top: y } = comboBox.getBoundingClientRect();
-      touchstart(comboBox, { x, y });
-
-      await nextFrame();
-      expect(comboBox.$.overlay._last).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9721

Depends on https://github.com/vaadin/web-components/pull/9814

Updated `vaadin-combo-box` to use native `popover` for the overlay.

Also removed no longer needed `bringToFront()` workaround (same change was done for `vaadin-date-picker`).

## Type of change

- Breaking change

## Note

Flow components branch: https://github.com/vaadin/flow-components/compare/proto/combo-native-popover