### PR TITLE
refactor!: update user-tags overlay to use native popover

### DIFF
--- a/packages/field-highlighter/src/styles/vaadin-user-tags-overlay-core-styles.js
+++ b/packages/field-highlighter/src/styles/vaadin-user-tags-overlay-core-styles.js
@@ -15,7 +15,7 @@ const userTagsOverlay = css`
     overflow: visible;
   }
 
-  ::slotted([part='tags']) {
+  [part='content'] {
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -45,6 +45,22 @@ class UserTagsOverlay extends PositionMixin(
       </div>
     `;
   }
+
+  /**
+   * @protected
+   * @override
+   */
+  _attachOverlay() {
+    this.showPopover();
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  _detachOverlay() {
+    this.hidePopover();
+  }
 }
 
 defineCustomElement(UserTagsOverlay);

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -140,6 +140,12 @@ export class UserTags extends PolylitMixin(LitElement) {
   }
 
   /** @protected */
+  get wrapper() {
+    // Used by Collaboration Kit util
+    return this;
+  }
+
+  /** @protected */
   connectedCallback() {
     super.connectedCallback();
 

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -20,8 +20,7 @@ describe('user-tags', () => {
   let wrapper;
 
   const getTags = () => {
-    const { overlay } = wrapper.$;
-    return overlay.querySelectorAll('vaadin-user-tag');
+    return wrapper.querySelectorAll('vaadin-user-tag');
   };
 
   const addUser = (user) => {
@@ -305,6 +304,34 @@ describe('user-tags', () => {
         await waitForIntersectionObserver();
 
         expect(spy.called).to.be.false;
+      });
+    });
+  });
+
+  describe('exportparts', () => {
+    let overlay;
+
+    beforeEach(() => {
+      field = fixtureSync(`<vaadin-text-field></vaadin-text-field>`);
+      FieldHighlighter.init(field);
+      wrapper = field.shadowRoot.querySelector('vaadin-user-tags');
+      overlay = wrapper.$.overlay;
+    });
+
+    it('should export all overlay parts for styling', () => {
+      const overlayParts = [...overlay.shadowRoot.querySelectorAll('[part]')].map((el) => el.getAttribute('part'));
+      const overlayExportParts = overlay.getAttribute('exportparts').split(', ');
+      const hostExportParts = wrapper.getAttribute('exportparts').split(', ');
+
+      overlayParts.forEach((part) => {
+        expect(overlayExportParts).to.include(`${part}:user-tags-${part}`);
+        expect(hostExportParts).to.include(`user-tags-${part}`);
+      });
+    });
+
+    it('should set part="user-tag" on the user tag elements', () => {
+      getTags().forEach((tag) => {
+        expect(tag.getAttribute('part')).to.equal('user-tag');
       });
     });
   });

--- a/packages/field-highlighter/test/user-tags.test.js
+++ b/packages/field-highlighter/test/user-tags.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './test-styles.test.js';
 import '@vaadin/text-field/src/vaadin-text-field.js';
@@ -59,10 +59,13 @@ describe('user-tags', () => {
     it('should replace user tags when replacing users', async () => {
       setUsers([user1, user2]);
       await wrapper.flashPromise;
+      expect(getTags()).to.have.lengthOf(2);
+
+      await nextRender();
+
       setUsers([user3]);
       await wrapper.flashPromise;
-      const tags = getTags();
-      expect(tags).to.have.lengthOf(1);
+      expect(getTags()).to.have.lengthOf(1);
     });
   });
 

--- a/packages/vaadin-lumo-styles/src/components/user-tags-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/user-tags-overlay.css
@@ -15,19 +15,16 @@
     will-change: opacity, transform;
   }
 
-  ::slotted([part='tags']) {
+  [part='content'] {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    padding: 0;
   }
 
   :host([dir='rtl']) [part='overlay'] {
     left: auto;
     right: -4px;
-  }
-
-  [part='content'] {
-    padding: 0;
   }
 
   :host([opening]),


### PR DESCRIPTION
## Description

Fixes

- Changed `vaadin-user-tags` to render `vaadin-user-tag` elements in the light DOM and set `part` attribute,
- Removed extra `<div part="tags">` wrapper and updated `part="content"` to be a flex container instead,
- Also added `exportparts` attribute to export the overlay stylable parts so that they can be used as follows:

```css
vaadin-checkbox-group::part(user-tags-overlay) {
  background-color: green;
}

vaadin-checkbox-group::part(user-tags-content) {
  border: solid 1px red;
}

vaadin-checkbox-group::part(user-tag) {
  border: solid 1px white;
}
```

## Type of change

- Breaking change