### PR TITLE
fix: save focus if target is set while popover is open

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement } from 'lit';
+import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -42,6 +43,21 @@ class PopoverOverlay extends PopoverOverlayMixin(
         <div part="content" id="content"><slot></slot></div>
       </div>
     `;
+  }
+
+  /** @protected */
+  updated(props) {
+    super.updated(props);
+
+    if (props.has('restoreFocusNode') && this.opened) {
+      // Save focus to be restored when target is set while opened
+      if (this.restoreFocusNode && isElementFocused(this.restoreFocusNode.focusElement || this.restoreFocusNode)) {
+        this.__focusRestorationController.saveFocus();
+      } else if (!this.restoreFocusNode) {
+        // Do not restore focus when target is cleared while opened
+        this.__focusRestorationController.focusNode = null;
+      }
+    }
   }
 
   /**

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -586,6 +586,11 @@ class Popover extends PopoverPositionMixin(
     target.addEventListener('mouseleave', this.__onTargetMouseLeave);
     target.addEventListener('focusin', this.__onTargetFocusIn);
     target.addEventListener('focusout', this.__onTargetFocusOut);
+
+    if (this.opened && this._overlayElement && isElementFocused(this.__getTargetFocusable())) {
+      this.__shouldRestoreFocus = true;
+      this._overlayElement.__focusRestorationController.saveFocus();
+    }
   }
 
   /**

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -588,7 +588,6 @@ class Popover extends PopoverPositionMixin(
     target.addEventListener('focusout', this.__onTargetFocusOut);
 
     if (this.opened && this._overlayElement && isElementFocused(this.__getTargetFocusable())) {
-      this.__shouldRestoreFocus = true;
       this._overlayElement.__focusRestorationController.saveFocus();
     }
   }

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -586,10 +586,6 @@ class Popover extends PopoverPositionMixin(
     target.addEventListener('mouseleave', this.__onTargetMouseLeave);
     target.addEventListener('focusin', this.__onTargetFocusIn);
     target.addEventListener('focusout', this.__onTargetFocusOut);
-
-    if (this.opened && this._overlayElement && isElementFocused(this.__getTargetFocusable())) {
-      this._overlayElement.__focusRestorationController.saveFocus();
-    }
   }
 
   /**

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -112,6 +112,37 @@ describe('popover', () => {
 
       expect(document.activeElement).to.equal(target);
     });
+
+    it('should not restore focus when target is cleared on already opened popover', async () => {
+      // Focus target before opening
+      target.focus();
+
+      // Open popover
+      popover.renderer = (root) => {
+        if (!root.firstChild) {
+          const input = document.createElement('input');
+          root.appendChild(input);
+        }
+      };
+      popover.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      // Set target
+      popover.target = target;
+      await nextUpdate(popover);
+
+      popover.querySelector('input').focus();
+
+      // Clear target
+      popover.target = null;
+      await nextUpdate(popover);
+
+      // Close popover
+      popover.opened = false;
+      await nextRender();
+
+      expect(document.activeElement).to.not.equal(target);
+    });
   });
 
   describe('for', () => {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -237,14 +237,37 @@ describe('popover', () => {
       expect(overlay.opened).to.be.true;
     });
 
-    it('should remove document click listener when popover is detached', async () => {
-      const spy = sinon.spy(document.documentElement, 'removeEventListener');
-      popover.remove();
-      await nextRender();
-      expect(spy).to.be.called;
-      expect(spy.firstCall.args[0]).to.equal('click');
-    });
+    it('should restore focus when target is set on already opened popover', async () => {
+      const target = fixtureSync('<button>Test Target</button>');
+      target.focus();
 
+      // Popover without target
+      const popover = document.createElement('vaadin-popover');
+      document.body.appendChild(popover);
+      popover.renderer = (root) => {
+        if (!root.firstChild) {
+          const input = document.createElement('input');
+          root.appendChild(input);
+        }
+      };
+
+      // Open popover
+      popover.opened = true;
+      await nextRender();
+      const overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      // Set target
+      popover.target = target;
+      await nextUpdate(popover);
+      popover.querySelector('input').focus();
+
+      // Close popover
+      popover.opened = false;
+      await nextRender();
+
+      expect(document.activeElement).to.equal(target);
+    });
     describe('Escape press', () => {
       beforeEach(async () => {
         target.click();


### PR DESCRIPTION
## Description

It is possible that the target is set after the popover is opened. One case is the popover being programmatically opened via the Flow component. In that case, the focus has already been saved and does not get updated. Therefore it is not restored when the popover is closed.

This PR saves focus when target is set. This allows returning the focus to the target in the initial open without a target.

Fixes #9555 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.