### PR TITLE
test: update tabsheet loading tests to pass with base styles

### DIFF
--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '@vaadin/tabs/src/vaadin-tabs.js';
 import '../src/vaadin-tabsheet.js';
 
 describe('tabsheet', () => {
@@ -19,9 +18,9 @@ describe('tabsheet', () => {
           <vaadin-tab id="tab-3">Tab 3</vaadin-tab>
         </vaadin-tabs>
 
-        <div tab="tab-1">Panel 1</div>
-        <div tab="tab-2">Panel 2</div>
-        <div tab="tab-3">Panel 3</div>
+        <p tab="tab-1">Panel 1</p>
+        <p tab="tab-2">Panel 2</p>
+        <p tab="tab-3">Panel 3</p>
       </vaadin-tabsheet>
     `);
     tabs = tabsheet.querySelector('vaadin-tabs');
@@ -283,8 +282,8 @@ describe('tabsheet', () => {
       await nextFrame();
 
       // Add two panels
-      tabsheet.appendChild(fixtureSync(`<div tab="new-tab-1">New Panel 1</div>`));
-      tabsheet.appendChild(fixtureSync(`<div tab="new-tab-2">New Panel 2</div>`));
+      tabsheet.appendChild(fixtureSync(`<p tab="new-tab-1">New Panel 1</p>`));
+      tabsheet.appendChild(fixtureSync(`<p tab="new-tab-2">New Panel 2</p>`));
 
       await nextFrame();
       expect(tabsheet.offsetHeight).to.be.below(height);


### PR DESCRIPTION
## Description

In `vaadin-tabsheet` there is some logic for setting / removing `minHeight` of the content added in https://github.com/vaadin/web-components/pull/4391. This includes tests that check content height. The problem with base styles is that default panel height and loader height is the same.

Updated test to use `<p>` instead of `<div>` which mimics the Lumo version where `vaadin-tabsheet` with a visible panel has bigger height than the `vaadin-tabsheet` without panels in a `loading` state.

## Type of change

- Test