### PR TITLE
refactor!: update context-menu to use native popover

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -201,8 +201,8 @@ export const ContextMenuMixin = (superClass) =>
       overlay.append(overlaySlot);
 
       const subMenuSlot = document.createElement('slot');
-      subMenuSlot.name = 'sub-menu';
-      subMenuSlot.slot = 'sub-menu';
+      subMenuSlot.name = 'submenu';
+      subMenuSlot.slot = 'submenu';
       overlay.append(subMenuSlot);
 
       this._overlayElement = overlay;

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -185,6 +185,7 @@ export const ContextMenuMixin = (superClass) =>
       // Create an overlay in the constructor to use in observers before `ready()`
       const overlay = document.createElement(`${this._tagNamePrefix}-overlay`);
       overlay.owner = this;
+      overlay.setAttribute('exportparts', 'backdrop, overlay, content');
 
       overlay.addEventListener('opened-changed', (e) => {
         this._onOverlayOpened(e);

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -31,6 +31,7 @@ export const ContextMenuMixin = (superClass) =>
          */
         opened: {
           type: Boolean,
+          reflectToAttribute: true,
           value: false,
           notify: true,
           readOnly: true,

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -194,6 +194,15 @@ export const ContextMenuMixin = (superClass) =>
         this._onVaadinOverlayOpen(e);
       });
 
+      const overlaySlot = document.createElement('slot');
+      overlaySlot.name = 'overlay';
+      overlay.append(overlaySlot);
+
+      const subMenuSlot = document.createElement('slot');
+      subMenuSlot.name = 'sub-menu';
+      subMenuSlot.slot = 'sub-menu';
+      overlay.append(subMenuSlot);
+
       this._overlayElement = overlay;
     }
 
@@ -201,8 +210,13 @@ export const ContextMenuMixin = (superClass) =>
      * Runs before overlay is fully rendered
      * @private
      */
-    _onOverlayOpened(e) {
-      const opened = e.detail.value;
+    _onOverlayOpened(event) {
+      // Ignore events from submenus
+      if (event.target !== this._overlayElement) {
+        return;
+      }
+
+      const opened = event.detail.value;
       this._setOpened(opened);
       if (opened) {
         this.__alignOverlayPosition();
@@ -213,7 +227,12 @@ export const ContextMenuMixin = (superClass) =>
      * Runs after overlay is fully rendered
      * @private
      */
-    _onVaadinOverlayOpen() {
+    _onVaadinOverlayOpen(event) {
+      // Ignore events from submenus
+      if (event.target !== this._overlayElement) {
+        return;
+      }
+
       this.__alignOverlayPosition();
       this._overlayElement.style.visibility = '';
       this.__forwardFocus();
@@ -393,6 +412,11 @@ export const ContextMenuMixin = (superClass) =>
      * @param {!Event | undefined} e used as the context for the menu. Overlay coordinates are taken from this event.
      */
     open(e) {
+      // Ignore events from the overlay
+      if (this._overlayElement && e.composedPath().includes(this._overlayElement)) {
+        return;
+      }
+
       if (e && !this.opened) {
         this._context = {
           detail: e.detail,

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -697,7 +697,11 @@ export const ContextMenuMixin = (superClass) =>
           // Dispatch another contextmenu at the same coordinates after the overlay is closed
           this._overlayElement.addEventListener(
             'vaadin-overlay-closed',
-            () => this.__contextMenuAt(e.clientX, e.clientY),
+            (closeEvent) => {
+              if (closeEvent.target === this._overlayElement) {
+                this.__contextMenuAt(e.clientX, e.clientY);
+              }
+            },
             {
               once: true,
             },

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -42,7 +42,7 @@ export class ContextMenuOverlay extends MenuOverlayMixin(
       <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">
           <slot></slot>
-          <slot name="sub-menu"></slot>
+          <slot name="submenu"></slot>
         </div>
       </div>
     `;

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -42,6 +42,7 @@ export class ContextMenuOverlay extends MenuOverlayMixin(
       <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">
           <slot></slot>
+          <slot name="sub-menu"></slot>
         </div>
       </div>
     `;

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -208,18 +208,19 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenu
  *
  * ### Styling
  *
- * `<vaadin-context-menu>` uses `<vaadin-context-menu-overlay>` internal
- * themable component as the actual visible context menu overlay.
+ * The following shadow DOM parts are available for styling:
  *
- * See [`<vaadin-overlay>`](#/elements/vaadin-overlay)
- * documentation for `<vaadin-context-menu-overlay>` stylable parts.
+ * Part name        | Description
+ * -----------------|-------------------------------------------
+ * `backdrop`       | Backdrop of the overlay
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Internal components
  *
- * When using `items` API, in addition `<vaadin-context-menu-overlay>`, the following
- * internal components are themable:
+ * When using `items` API the following internal components are themable:
  *
  * - `<vaadin-context-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-context-menu-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -175,18 +175,19 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * ### Styling
  *
- * `<vaadin-context-menu>` uses `<vaadin-context-menu-overlay>` internal
- * themable component as the actual visible context menu overlay.
+ * The following shadow DOM parts are available for styling:
  *
- * See [`<vaadin-overlay>`](#/elements/vaadin-overlay)
- * documentation for `<vaadin-context-menu-overlay>` stylable parts.
+ * Part name        | Description
+ * -----------------|-------------------------------------------
+ * `backdrop`       | Backdrop of the overlay
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Internal components
  *
- * When using `items` API, in addition `<vaadin-context-menu-overlay>`, the following
- * internal components are themable:
+ * When using `items` API the following internal components are themable:
  *
  * - `<vaadin-context-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-context-menu-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -297,7 +297,6 @@ export const ItemsMixin = (superClass) =>
 
       subMenu._modeless = true;
       subMenu.openOn = 'opensubmenu';
-      subMenu.slot = 'sub-menu';
 
       // Close sub-menu when the parent menu closes.
       this.addEventListener('opened-changed', (event) => {
@@ -448,7 +447,7 @@ export const ItemsMixin = (superClass) =>
     }
 
     /** @private */
-    __initMenu(root, menu) {
+    __initMenu(root, _menu) {
       // NOTE: in this method, `menu` and `this` reference the same element,
       // so we can use either of those. Original implementation used `menu`.
       if (!root.firstElementChild) {
@@ -459,8 +458,9 @@ export const ItemsMixin = (superClass) =>
         root.appendChild(listBox);
 
         const subMenu = this.__initSubMenu();
+        subMenu.slot = 'sub-menu';
         this._subMenu = subMenu;
-        menu.appendChild(subMenu);
+        this.appendChild(subMenu);
 
         requestAnimationFrame(() => {
           this.__openListenerActive = true;

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -458,7 +458,7 @@ export const ItemsMixin = (superClass) =>
         root.appendChild(listBox);
 
         const subMenu = this.__initSubMenu();
-        subMenu.slot = 'sub-menu';
+        subMenu.slot = 'submenu';
         this._subMenu = subMenu;
         this.appendChild(subMenu);
 

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -116,10 +116,10 @@ export const ItemsMixin = (superClass) =>
     /** @protected */
     __forwardFocus() {
       const overlay = this._overlayElement;
-      const child = overlay.getFirstChild();
+      const child = overlay._contentRoot.firstElementChild;
       // If parent item is not focused, do not focus submenu
       if (overlay.parentOverlay) {
-        const parent = overlay.parentOverlay.querySelector('[expanded]');
+        const parent = overlay.parentOverlay._contentRoot.querySelector('[expanded]');
         if (parent && parent.hasAttribute('focused') && child) {
           child.focus();
         } else {
@@ -253,10 +253,20 @@ export const ItemsMixin = (superClass) =>
       // Open a submenu on click event when a touch device is used.
       // On desktop, a submenu opens on hover.
       overlay.addEventListener(isTouch ? 'click' : 'mouseover', (event) => {
+        // Ignore events from the submenus
+        if (event.composedPath().includes(this._subMenu)) {
+          return;
+        }
+
         this.__showSubMenu(event);
       });
 
       overlay.addEventListener('keydown', (event) => {
+        // Ignore events from the submenus
+        if (event.composedPath().includes(this._subMenu)) {
+          return;
+        }
+
         const { key } = event;
         const isRTL = this.__isRTL;
 
@@ -287,10 +297,7 @@ export const ItemsMixin = (superClass) =>
 
       subMenu._modeless = true;
       subMenu.openOn = 'opensubmenu';
-
-      // Sub-menu doesn't have a target to wrap,
-      // so there is no need to keep it visible.
-      subMenu.setAttribute('hidden', '');
+      subMenu.slot = 'sub-menu';
 
       // Close sub-menu when the parent menu closes.
       this.addEventListener('opened-changed', (event) => {
@@ -366,7 +373,7 @@ export const ItemsMixin = (superClass) =>
         const { children } = item._item;
 
         // Check if the sub-menu was focused before closing it.
-        const child = subMenu._overlayElement.getFirstChild();
+        const child = subMenu._overlayElement._contentRoot.firstElementChild;
         const isSubmenuFocused = child && child.focused;
 
         if (subMenu.items !== children) {
@@ -394,7 +401,7 @@ export const ItemsMixin = (superClass) =>
 
     /** @protected */
     __getListBox() {
-      return this._overlayElement.querySelector(`${this._tagNamePrefix}-list-box`);
+      return this._overlayElement._contentRoot.querySelector(`${this._tagNamePrefix}-list-box`);
     }
 
     /**
@@ -406,15 +413,12 @@ export const ItemsMixin = (superClass) =>
     __itemsRenderer(root, menu) {
       this.__initMenu(root, menu);
 
-      const subMenu = root.querySelector(this.constructor.is);
-      subMenu.closeOn = menu.closeOn;
-
-      const listBox = this.__getListBox();
-      listBox.innerHTML = '';
+      this._subMenu.closeOn = menu.closeOn;
+      this._listBox.innerHTML = '';
 
       menu.items.forEach((item) => {
         const component = this.__createComponent(item);
-        listBox.appendChild(component);
+        this._listBox.appendChild(component);
       });
     }
 
@@ -444,7 +448,7 @@ export const ItemsMixin = (superClass) =>
     }
 
     /** @private */
-    __initMenu(root, _menu) {
+    __initMenu(root, menu) {
       // NOTE: in this method, `menu` and `this` reference the same element,
       // so we can use either of those. Original implementation used `menu`.
       if (!root.firstElementChild) {
@@ -456,7 +460,7 @@ export const ItemsMixin = (superClass) =>
 
         const subMenu = this.__initSubMenu();
         this._subMenu = subMenu;
-        root.appendChild(subMenu);
+        menu.appendChild(subMenu);
 
         requestAnimationFrame(() => {
           this.__openListenerActive = true;

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.d.ts
@@ -18,9 +18,4 @@ export declare class MenuOverlayMixinClass {
    * Returns the adjusted boundaries of the overlay.
    */
   getBoundaries(): { xMax: number; xMin: number; yMax: number };
-
-  /**
-   * Returns the first element in the overlay content.
-   */
-  getFirstChild(): HTMLElement;
 }

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { OverlayFocusMixin } from '@vaadin/overlay/src/vaadin-overlay-focus-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
@@ -37,15 +36,33 @@ export const MenuOverlayMixin = (superClass) =>
       return ['_themeChanged(_theme)'];
     }
 
+    /**
+     * Override method from OverlayFocusMixin to use slotted div as the content root.
+     * @protected
+     * @override
+     */
+    get _contentRoot() {
+      if (!this.__savedRoot) {
+        const root = document.createElement('div');
+        root.setAttribute('slot', 'overlay');
+        root.style.display = 'contents';
+        this.owner.appendChild(root);
+        this.__savedRoot = root;
+      }
+
+      return this.__savedRoot;
+    }
+
     /** @protected */
     ready() {
       super.ready();
 
+      this.popover = 'manual';
       this.restoreFocusOnClose = true;
 
       this.addEventListener('keydown', (e) => {
         if (!e.defaultPrevented && e.composedPath()[0] === this.$.overlay && [38, 40].indexOf(e.keyCode) > -1) {
-          const child = this.getFirstChild();
+          const child = this._contentRoot.firstElementChild;
           if (child && Array.isArray(child.items) && child.items.length) {
             e.preventDefault();
             if (e.keyCode === 38) {
@@ -56,15 +73,6 @@ export const MenuOverlayMixin = (superClass) =>
           }
         }
       });
-    }
-
-    /**
-     * Returns the first element in the overlay content.
-     *
-     * @returns {HTMLElement}
-     */
-    getFirstChild() {
-      return this.querySelector(':not(style):not(slot)');
     }
 
     /** @private */
@@ -149,9 +157,9 @@ export const MenuOverlayMixin = (superClass) =>
     }
 
     /**
-     * Override method inherited from `OverlayFocusMixin` to return
-     * true if the overlay contains the given node, including
-     * those within descendant menu overlays.
+     * Override method inherited from `OverlayFocusMixin` to check if the
+     * node is contained within the overlay's owner element (the menu),
+     * where all content (overlay content, sub-menus, etc.) is slotted.
      *
      * @protected
      * @override
@@ -159,18 +167,22 @@ export const MenuOverlayMixin = (superClass) =>
      * @return {boolean}
      */
     _deepContains(node) {
-      // Find the closest menu overlay for the given node.
-      let overlay = getClosestElement(this.localName, node);
-      while (overlay) {
-        if (overlay === this) {
-          // The node is inside a descendant menu overlay.
-          return true;
-        }
+      return this.owner.contains(node);
+    }
 
-        // Traverse the overlay hierarchy to check parent overlays.
-        overlay = overlay.parentOverlay;
-      }
+    /**
+     * @protected
+     * @override
+     */
+    _attachOverlay() {
+      this.showPopover();
+    }
 
-      return false;
+    /**
+     * @protected
+     * @override
+     */
+    _detachOverlay() {
+      this.hidePopover();
     }
   };

--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -20,7 +20,7 @@ class XFoo extends HTMLElement {
 customElements.define('x-foo', XFoo);
 
 describe('context', () => {
-  let menu, foo, fooContent, target, another;
+  let menu, overlayContent, foo, fooContent, target, another;
 
   beforeEach(async () => {
     menu = fixtureSync(`
@@ -40,6 +40,7 @@ describe('context', () => {
       `;
     };
     await nextRender();
+    overlayContent = menu._overlayElement._contentRoot;
     foo = document.querySelector('x-foo');
     fooContent = foo.shadowRoot.querySelector('#content');
     target = document.querySelector('#target');
@@ -51,7 +52,7 @@ describe('context', () => {
     await nextRender();
 
     expect(menu._context.target).to.eql(target);
-    expect(menu._overlayElement.textContent).to.contain(target.textContent);
+    expect(overlayContent.textContent).to.contain(target.textContent);
 
     menu.close();
 
@@ -59,7 +60,7 @@ describe('context', () => {
     await nextRender();
 
     expect(menu._context.target).to.eql(another);
-    expect(menu._overlayElement.textContent).to.contain(another.textContent);
+    expect(overlayContent.textContent).to.contain(another.textContent);
   });
 
   it('should use details as context details', () => {

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -1,211 +1,192 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["context-menu items"] = 
-`<vaadin-context-menu-overlay opened="">
-  <vaadin-context-menu-list-box
-    aria-orientation="vertical"
-    role="menu"
-  >
-    <vaadin-context-menu-item
-      aria-haspopup="false"
-      aria-selected="false"
-      class="first"
-      focus-ring=""
-      focused=""
-      role="menuitem"
-      tabindex="0"
+snapshots["context-menu items"] =
+`<vaadin-context-menu>
+  <div>
+    Target
+  </div>
+  <div slot="overlay">
+    <vaadin-context-menu-list-box
+      aria-orientation="vertical"
+      role="menu"
     >
-      Menu Item 1
-    </vaadin-context-menu-item>
-    <hr role="separator">
-    <vaadin-context-menu-item
-      aria-expanded="false"
-      aria-haspopup="true"
-      aria-selected="false"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Menu Item 2
-    </vaadin-context-menu-item>
-    <vaadin-context-menu-item
-      aria-disabled="true"
-      aria-haspopup="false"
-      aria-selected="false"
-      disabled=""
-      role="menuitem"
-      tabindex="-1"
-    >
-      Menu Item 3
-    </vaadin-context-menu-item>
-    <div
-      aria-haspopup="false"
-      class="custom"
-    >
-      Menu Item 4
-    </div>
-    <div
-      aria-haspopup="false"
-      class="last"
-    >
-      Menu Item 5
-    </div>
-  </vaadin-context-menu-list-box>
+      <vaadin-context-menu-item
+        aria-haspopup="false"
+        aria-selected="false"
+        class="first"
+        focus-ring=""
+        focused=""
+        role="menuitem"
+        tabindex="0"
+      >
+        Menu Item 1
+      </vaadin-context-menu-item>
+      <hr role="separator">
+      <vaadin-context-menu-item
+        aria-expanded="false"
+        aria-haspopup="true"
+        aria-selected="false"
+        role="menuitem"
+        tabindex="-1"
+      >
+        Menu Item 2
+      </vaadin-context-menu-item>
+      <vaadin-context-menu-item
+        aria-disabled="true"
+        aria-haspopup="false"
+        aria-selected="false"
+        disabled=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        Menu Item 3
+      </vaadin-context-menu-item>
+      <div
+        aria-haspopup="false"
+        class="custom"
+      >
+        Menu Item 4
+      </div>
+      <div
+        aria-haspopup="false"
+        class="last"
+      >
+        Menu Item 5
+      </div>
+    </vaadin-context-menu-list-box>
+  </div>
   <vaadin-context-menu
-    hidden=""
     modeless=""
+    slot="sub-menu"
   >
   </vaadin-context-menu>
-</vaadin-context-menu-overlay>
+</vaadin-context-menu>
 `;
 /* end snapshot context-menu items */
 
-snapshots["context-menu items nested"] = 
-`<vaadin-context-menu-overlay
+snapshots["context-menu items nested"] =
+`<vaadin-context-menu
   modeless=""
-  opened=""
+  slot="sub-menu"
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-context-menu-list-box
-    aria-orientation="vertical"
-    role="menu"
-  >
-    <vaadin-context-menu-item
-      aria-haspopup="false"
-      aria-selected="false"
-      class="first"
-      role="menuitem"
-      tabindex="0"
+  <div slot="overlay">
+    <vaadin-context-menu-list-box
+      aria-orientation="vertical"
+      role="menu"
     >
-      Menu Item 2-1
-    </vaadin-context-menu-item>
-    <vaadin-context-menu-item
-      aria-expanded="true"
-      aria-haspopup="true"
-      aria-selected="false"
-      class="last"
-      expanded=""
-      role="menuitem"
-      tabindex="-1"
-    >
-      Menu Item 2-2
-    </vaadin-context-menu-item>
-  </vaadin-context-menu-list-box>
+      <vaadin-context-menu-item
+        aria-haspopup="false"
+        aria-selected="false"
+        class="first"
+        role="menuitem"
+        tabindex="0"
+      >
+        Menu Item 2-1
+      </vaadin-context-menu-item>
+      <vaadin-context-menu-item
+        aria-expanded="true"
+        aria-haspopup="true"
+        aria-selected="false"
+        class="last"
+        expanded=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        Menu Item 2-2
+      </vaadin-context-menu-item>
+    </vaadin-context-menu-list-box>
+  </div>
   <vaadin-context-menu
-    hidden=""
     modeless=""
+    slot="sub-menu"
     start-aligned=""
     top-aligned=""
   >
+    <div slot="overlay">
+      <vaadin-context-menu-list-box
+        aria-orientation="vertical"
+        role="menu"
+      >
+        <vaadin-context-menu-item
+          aria-haspopup="false"
+          aria-selected="false"
+          class="first"
+          menu-item-checked=""
+          role="menuitem"
+          tabindex="0"
+        >
+          Menu Item 2-2-1
+        </vaadin-context-menu-item>
+        <vaadin-context-menu-item
+          aria-disabled="true"
+          aria-haspopup="false"
+          aria-selected="false"
+          disabled=""
+          role="menuitem"
+          tabindex="-1"
+        >
+          Menu Item 2-2-2
+        </vaadin-context-menu-item>
+        <hr role="separator">
+        <vaadin-context-menu-item
+          aria-haspopup="false"
+          aria-selected="false"
+          class="last"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Menu Item 2-2-3
+        </vaadin-context-menu-item>
+      </vaadin-context-menu-list-box>
+    </div>
+    <vaadin-context-menu
+      modeless=""
+      slot="sub-menu"
+    >
+    </vaadin-context-menu>
   </vaadin-context-menu>
-</vaadin-context-menu-overlay>
+</vaadin-context-menu>
 `;
 /* end snapshot context-menu items nested */
 
-snapshots["context-menu items overlay class"] = 
+snapshots["context-menu overlay class"] =
 `<vaadin-context-menu-overlay
   class="context-menu-overlay custom"
+  exportparts="backdrop, overlay, content"
   opened=""
+  popover="manual"
 >
-  <vaadin-context-menu-list-box
-    aria-orientation="vertical"
-    role="menu"
+  <slot name="overlay">
+  </slot>
+  <slot
+    name="sub-menu"
+    slot="sub-menu"
   >
-    <vaadin-context-menu-item
-      aria-haspopup="false"
-      aria-selected="false"
-      class="first"
-      focus-ring=""
-      focused=""
-      role="menuitem"
-      tabindex="0"
-    >
-      Menu Item 1
-    </vaadin-context-menu-item>
-    <hr role="separator">
-    <vaadin-context-menu-item
-      aria-expanded="false"
-      aria-haspopup="true"
-      aria-selected="false"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Menu Item 2
-    </vaadin-context-menu-item>
-    <vaadin-context-menu-item
-      aria-disabled="true"
-      aria-haspopup="false"
-      aria-selected="false"
-      disabled=""
-      role="menuitem"
-      tabindex="-1"
-    >
-      Menu Item 3
-    </vaadin-context-menu-item>
-    <div
-      aria-haspopup="false"
-      class="custom"
-    >
-      Menu Item 4
-    </div>
-    <div
-      aria-haspopup="false"
-      class="last"
-    >
-      Menu Item 5
-    </div>
-  </vaadin-context-menu-list-box>
-  <vaadin-context-menu
-    hidden=""
-    modeless=""
-  >
-  </vaadin-context-menu>
+  </slot>
 </vaadin-context-menu-overlay>
 `;
-/* end snapshot context-menu items overlay class */
+/* end snapshot context-menu overlay class */
 
-snapshots["context-menu items overlay class nested"] = 
+snapshots["context-menu overlay class nested"] =
 `<vaadin-context-menu-overlay
   class="context-menu-overlay custom"
+  exportparts="backdrop, overlay, content"
   modeless=""
   opened=""
+  popover="manual"
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-context-menu-list-box
-    aria-orientation="vertical"
-    role="menu"
+  <slot name="overlay">
+  </slot>
+  <slot
+    name="sub-menu"
+    slot="sub-menu"
   >
-    <vaadin-context-menu-item
-      aria-haspopup="false"
-      aria-selected="false"
-      class="first"
-      role="menuitem"
-      tabindex="0"
-    >
-      Menu Item 2-1
-    </vaadin-context-menu-item>
-    <vaadin-context-menu-item
-      aria-expanded="true"
-      aria-haspopup="true"
-      aria-selected="false"
-      class="last"
-      expanded=""
-      role="menuitem"
-      tabindex="-1"
-    >
-      Menu Item 2-2
-    </vaadin-context-menu-item>
-  </vaadin-context-menu-list-box>
-  <vaadin-context-menu
-    hidden=""
-    modeless=""
-    start-aligned=""
-    top-aligned=""
-  >
-  </vaadin-context-menu>
+  </slot>
 </vaadin-context-menu-overlay>
 `;
-/* end snapshot context-menu items overlay class nested */
-
+/* end snapshot context-menu overlay class nested */

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -1,7 +1,6 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
-
-snapshots["context-menu items"] = 
+snapshots["context-menu items"] =
 `<vaadin-context-menu opened="">
   <div>
     Target
@@ -58,18 +57,18 @@ snapshots["context-menu items"] =
   </div>
   <vaadin-context-menu
     modeless=""
-    slot="sub-menu"
+    slot="submenu"
   >
   </vaadin-context-menu>
 </vaadin-context-menu>
 `;
 /* end snapshot context-menu items */
 
-snapshots["context-menu items nested"] = 
+snapshots["context-menu items nested"] =
 `<vaadin-context-menu
   modeless=""
   opened=""
-  slot="sub-menu"
+  slot="submenu"
   start-aligned=""
   top-aligned=""
 >
@@ -103,7 +102,7 @@ snapshots["context-menu items nested"] =
   <vaadin-context-menu
     modeless=""
     opened=""
-    slot="sub-menu"
+    slot="submenu"
     start-aligned=""
     top-aligned=""
   >
@@ -146,7 +145,7 @@ snapshots["context-menu items nested"] =
     </div>
     <vaadin-context-menu
       modeless=""
-      slot="sub-menu"
+      slot="submenu"
     >
     </vaadin-context-menu>
   </vaadin-context-menu>
@@ -164,8 +163,8 @@ snapshots["context-menu overlay class"] =
   <slot name="overlay">
   </slot>
   <slot
-    name="sub-menu"
-    slot="sub-menu"
+    name="submenu"
+    slot="submenu"
   >
   </slot>
 </vaadin-context-menu-overlay>
@@ -185,8 +184,8 @@ snapshots["context-menu overlay class nested"] =
   <slot name="overlay">
   </slot>
   <slot
-    name="sub-menu"
-    slot="sub-menu"
+    name="submenu"
+    slot="submenu"
   >
   </slot>
 </vaadin-context-menu-overlay>

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -1,8 +1,8 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["context-menu items"] =
-`<vaadin-context-menu>
+snapshots["context-menu items"] = 
+`<vaadin-context-menu opened="">
   <div>
     Target
   </div>
@@ -65,9 +65,10 @@ snapshots["context-menu items"] =
 `;
 /* end snapshot context-menu items */
 
-snapshots["context-menu items nested"] =
+snapshots["context-menu items nested"] = 
 `<vaadin-context-menu
   modeless=""
+  opened=""
   slot="sub-menu"
   start-aligned=""
   top-aligned=""
@@ -101,6 +102,7 @@ snapshots["context-menu items nested"] =
   </div>
   <vaadin-context-menu
     modeless=""
+    opened=""
     slot="sub-menu"
     start-aligned=""
     top-aligned=""

--- a/packages/context-menu/test/dom/context-menu.test.js
+++ b/packages/context-menu/test/dom/context-menu.test.js
@@ -12,7 +12,7 @@ function createComponent(textContent, { className }) {
 }
 
 describe('context-menu', () => {
-  let menu, overlay;
+  let menu;
 
   const SNAPSHOT_CONFIG = {
     // Some inline CSS styles related to the overlay's position
@@ -64,7 +64,6 @@ describe('context-menu', () => {
       </vaadin-context-menu>
     `);
     await nextRender();
-    overlay = menu._overlayElement;
   });
 
   it('items', async () => {
@@ -74,7 +73,7 @@ describe('context-menu', () => {
     await nextUpdate(menu);
     await nextRender();
 
-    await expect(overlay).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    await expect(menu).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 
   it('items nested', async () => {
@@ -84,11 +83,11 @@ describe('context-menu', () => {
     await openSubMenus(menu);
     await nextRender();
 
-    const subMenu = overlay.querySelector('vaadin-context-menu');
-    await expect(subMenu._overlayElement).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    const subMenu = menu.querySelector('vaadin-context-menu');
+    await expect(subMenu).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 
-  it('items overlay class', async () => {
+  it('overlay class', async () => {
     menu.overlayClass = 'context-menu-overlay custom';
     menu.items = ITEMS;
 
@@ -99,7 +98,7 @@ describe('context-menu', () => {
     await expect(menu._overlayElement).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 
-  it('items overlay class nested', async () => {
+  it('overlay class nested', async () => {
     menu.overlayClass = 'context-menu-overlay custom';
     menu.items = ITEMS;
 
@@ -107,7 +106,7 @@ describe('context-menu', () => {
     await openSubMenus(menu);
     await nextRender();
 
-    const subMenu = overlay.querySelector('vaadin-context-menu');
+    const subMenu = menu.querySelector('vaadin-context-menu');
     await expect(subMenu._overlayElement).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
 });

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -7,12 +7,7 @@ export function activateItem(target, event = isTouch ? 'click' : 'mouseover') {
 }
 
 export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') {
-  let menu = target.closest('vaadin-context-menu');
-  if (!menu) {
-    // If the target is a menu item, get reference to the submenu.
-    const overlay = target.closest('vaadin-context-menu-overlay');
-    menu = overlay.querySelector('vaadin-context-menu');
-  }
+  const menu = target.closest('vaadin-context-menu');
   // Disable logic that delays opening submenu
   menu.__openListenerActive = true;
   activateItem(target, event);
@@ -20,16 +15,16 @@ export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') 
 }
 
 export function getMenuItems(menu) {
-  return [...menu._overlayElement.querySelectorAll('[role="menu"] > :not([role="separator]"')];
+  return [...menu.querySelectorAll(':scope > [slot="overlay"] [role="menu"] > :not([role="separator]"')];
 }
 
 export function getSubMenu(menu) {
-  return menu._overlayElement.querySelector('vaadin-context-menu');
+  return menu.querySelector(':scope > vaadin-context-menu[slot="sub-menu"]');
 }
 
 export async function openSubMenus(menu) {
   await oneEvent(menu._overlayElement, 'vaadin-overlay-open');
-  const itemElement = menu._overlayElement.querySelector('[aria-haspopup="true"]');
+  const itemElement = menu.querySelector(':scope > [slot="overlay"] [aria-haspopup="true"]');
   if (itemElement) {
     itemElement.dispatchEvent(new CustomEvent('mouseover', { bubbles: true, composed: true }));
     const subMenu = getSubMenu(menu);

--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -19,7 +19,7 @@ export function getMenuItems(menu) {
 }
 
 export function getSubMenu(menu) {
-  return menu.querySelector(':scope > vaadin-context-menu[slot="sub-menu"]');
+  return menu.querySelector(':scope > vaadin-context-menu[slot="submenu"]');
 }
 
 export async function openSubMenus(menu) {

--- a/packages/context-menu/test/items-theme.test.js
+++ b/packages/context-menu/test/items-theme.test.js
@@ -57,7 +57,7 @@ describe('items theme', () => {
   it('should propagate host theme attribute to the nested elements', () => {
     [rootMenu, subMenu, subMenu2].forEach((subMenu) => {
       const overlay = subMenu._overlayElement;
-      const listBox = overlay.querySelector('vaadin-context-menu-list-box');
+      const listBox = overlay._contentRoot.querySelector('vaadin-context-menu-list-box');
       const items = Array.from(listBox.querySelectorAll('vaadin-context-menu-item'));
 
       expect(overlay.getAttribute('theme')).to.equal('foo');
@@ -87,7 +87,7 @@ describe('items theme', () => {
 
     [rootMenu, subMenu, subMenu2].forEach((subMenu) => {
       const overlay = subMenu._overlayElement;
-      const listBox = overlay.querySelector('vaadin-context-menu-list-box');
+      const listBox = overlay._contentRoot.querySelector('vaadin-context-menu-list-box');
       const items = Array.from(listBox.querySelectorAll('vaadin-context-menu-item'));
 
       expect(overlay.hasAttribute('theme')).to.be.false;

--- a/packages/context-menu/test/lit-renderer-directives.test.js
+++ b/packages/context-menu/test/lit-renderer-directives.test.js
@@ -19,7 +19,7 @@ async function renderContextMenu(container, { content }) {
 }
 
 describe('lit renderer directives', () => {
-  let container, contextMenu, target, overlay;
+  let container, contextMenu, overlayContent, target;
 
   beforeEach(() => {
     container = fixtureSync('<div></div>');
@@ -29,8 +29,8 @@ describe('lit renderer directives', () => {
     describe('basic', () => {
       beforeEach(async () => {
         contextMenu = await renderContextMenu(container, { content: 'Content' });
+        overlayContent = contextMenu._overlayElement._contentRoot;
         target = contextMenu.querySelector('button');
-        overlay = contextMenu._overlayElement;
       });
 
       it('should set `renderer` property when the directive is attached', () => {
@@ -45,13 +45,13 @@ describe('lit renderer directives', () => {
       it('should render the content with the renderer when the menu is opened', async () => {
         target.click();
         await nextRender();
-        expect(overlay.textContent).to.equal('Content');
+        expect(overlayContent.textContent).to.equal('Content');
       });
 
       it('should re-render the content when the menu is opened and a renderer dependency changes', async () => {
         target.click();
         await renderContextMenu(container, { content: 'New Content' });
-        expect(overlay.textContent).to.equal('New Content');
+        expect(overlayContent.textContent).to.equal('New Content');
       });
     });
 

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -527,4 +527,15 @@ describe('overlay', () => {
       expect(contextmenuSpy.calledOnce).to.be.true;
     });
   });
+
+  describe('exportparts', () => {
+    it('should export all overlay parts for styling', () => {
+      const parts = [...overlay.shadowRoot.querySelectorAll('[part]')].map((el) => el.getAttribute('part'));
+      const exportParts = overlay.getAttribute('exportparts').split(', ');
+
+      parts.forEach((part) => {
+        expect(exportParts).to.include(part);
+      });
+    });
+  });
 });

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -360,7 +360,7 @@ describe('overlay', () => {
     it('should close on menu contextmenu', () => {
       // Dispatch a contextmenu event on the overlay content
       const { left, top } = content.getBoundingClientRect();
-      const e = contextmenu(left, top, false, overlay);
+      const e = contextmenu(left, top, false, overlay._contentRoot);
       expect(e.defaultPrevented).to.be.true;
       expect(menu.opened).to.be.false;
     });

--- a/packages/context-menu/test/renderer.test.js
+++ b/packages/context-menu/test/renderer.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import '../src/vaadin-context-menu.js';
 
 describe('renderer', () => {
-  let menu, target, overlay;
+  let menu, target, overlayContent;
 
   beforeEach(async () => {
     menu = fixtureSync(`
@@ -22,7 +22,7 @@ describe('renderer', () => {
     });
     await nextRender();
     target = menu.querySelector('#target');
-    overlay = menu._overlayElement;
+    overlayContent = menu._overlayElement._contentRoot;
   });
 
   afterEach(() => {
@@ -36,21 +36,21 @@ describe('renderer', () => {
     await nextRender();
 
     expect(menu.renderer.callCount).to.equal(1);
-    expect(overlay.textContent).to.contain('Renderer');
+    expect(overlayContent.textContent).to.contain('Renderer');
   });
 
   it('should have target in context', async () => {
     fire(target, 'vaadin-contextmenu');
     await nextRender();
 
-    expect(overlay.textContent).to.contain('target');
+    expect(overlayContent.textContent).to.contain('target');
   });
 
   it('should have detail in context', async () => {
     fire(target, 'vaadin-contextmenu', { foo: 'bar' });
     await nextRender();
 
-    expect(overlay.textContent).to.contain('bar');
+    expect(overlayContent.textContent).to.contain('bar');
   });
 
   it('should have contextMenu owner argument', async () => {
@@ -122,12 +122,12 @@ describe('renderer', () => {
     fire(target, 'vaadin-contextmenu');
     await nextRender();
 
-    expect(overlay.textContent.trim()).to.equal('foo');
+    expect(overlayContent.textContent.trim()).to.equal('foo');
 
     menu.renderer = null;
     await nextRender();
 
-    expect(overlay.textContent.trim()).to.equal('');
+    expect(overlayContent.textContent.trim()).to.equal('');
   });
 
   it('should not throw if requestContentUpdate() called before adding to DOM', () => {

--- a/packages/context-menu/test/selection.test.js
+++ b/packages/context-menu/test/selection.test.js
@@ -28,7 +28,7 @@ describe('selection', () => {
     await oneEvent(overlay, 'vaadin-overlay-open');
     await nextRender();
 
-    const listBox = overlay.querySelector('#menu');
+    const listBox = menu.querySelector('#menu');
     click(listBox.items[0]);
     expect(menu.opened).to.eql(false);
   });
@@ -41,7 +41,7 @@ describe('selection', () => {
     const spy = sinon.spy();
     menu.addEventListener('opened-changed', spy);
 
-    const item = overlay.querySelector('#menu vaadin-item');
+    const item = menu.querySelector('#menu vaadin-item');
     enter(item);
     await nextRender();
     expect(spy.calledOnce).to.be.true;
@@ -52,7 +52,7 @@ describe('selection', () => {
     await oneEvent(overlay, 'vaadin-overlay-open');
     await nextRender();
 
-    const item = overlay.querySelector('#menu vaadin-item');
+    const item = menu.querySelector('#menu vaadin-item');
     expect(document.activeElement).to.eql(item);
   });
 
@@ -61,7 +61,7 @@ describe('selection', () => {
     await oneEvent(overlay, 'vaadin-overlay-open');
     await nextRender();
 
-    const item = overlay.querySelector('#menu vaadin-item');
+    const item = menu.querySelector('#menu vaadin-item');
     expect(document.activeElement).to.eql(item);
   });
 });

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -42,7 +42,7 @@ export class MenuBarOverlay extends MenuOverlayMixin(
       <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">
           <slot></slot>
-          <slot name="sub-menu"></slot>
+          <slot name="submenu"></slot>
         </div>
       </div>
     `;

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -42,6 +42,7 @@ export class MenuBarOverlay extends MenuOverlayMixin(
       <div part="overlay" id="overlay" tabindex="0">
         <div part="content" id="content">
           <slot></slot>
+          <slot name="sub-menu"></slot>
         </div>
       </div>
     `;

--- a/packages/menu-bar/src/vaadin-menu-bar.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar.d.ts
@@ -65,7 +65,7 @@ export interface MenuBarEventMap<TItem extends MenuBarItem = MenuBarItem>
  * - `<vaadin-menu-bar-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
  * - `<vaadin-menu-bar-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-menu-bar-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
- * - `<vaadin-menu-bar-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
+ * - `<vaadin-menu-bar-submenu>` - has the same API as [`<vaadin-context-menu>`](#/elements/vaadin-context-menu).
  *
  * The `<vaadin-menu-bar-item>` sub-menu elements have the following additional state attributes
  * on top of the built-in `<vaadin-item>` state attributes:
@@ -73,9 +73,6 @@ export interface MenuBarEventMap<TItem extends MenuBarItem = MenuBarItem>
  * Attribute  | Description
  * ---------- |-------------
  * `expanded` | Expanded parent item.
- *
- * Note: the `theme` attribute value set on `<vaadin-menu-bar>` is
- * propagated to the internal components listed above.
  *
  * @fires {CustomEvent} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  */

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -57,7 +57,7 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  * - `<vaadin-menu-bar-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
  * - `<vaadin-menu-bar-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  * - `<vaadin-menu-bar-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
- * - `<vaadin-menu-bar-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
+ * - `<vaadin-menu-bar-submenu>` - has the same API as [`<vaadin-context-menu>`](#/elements/vaadin-context-menu).
  *
  * The `<vaadin-menu-bar-item>` sub-menu elements have the following additional state attributes
  * on top of the built-in `<vaadin-item>` state attributes:
@@ -65,9 +65,6 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  * Attribute  | Description
  * ---------- |-------------
  * `expanded` | Expanded parent item.
- *
- * Note: the `theme` attribute value set on `<vaadin-menu-bar>` is
- * propagated to the internal components listed above.
  *
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *

--- a/packages/menu-bar/test/a11y.test.js
+++ b/packages/menu-bar/test/a11y.test.js
@@ -93,7 +93,7 @@ describe('a11y', () => {
   });
 
   describe('focus restoration', () => {
-    let menuBar, overlay, buttons;
+    let menuBar, subMenu, overlay, buttons;
 
     beforeEach(async () => {
       menuBar = fixtureSync(`<vaadin-menu-bar></vaadin-menu-bar>`);
@@ -110,7 +110,8 @@ describe('a11y', () => {
         },
       ];
       await nextRender();
-      overlay = menuBar._subMenu._overlayElement;
+      subMenu = menuBar._subMenu;
+      overlay = subMenu._overlayElement;
       buttons = menuBar.querySelectorAll('vaadin-menu-bar-button');
       buttons[0].focus();
     });
@@ -163,7 +164,7 @@ describe('a11y', () => {
       await nextRender();
       // Open Item 0/1
       arrowRight(getDeepActiveElement());
-      const nestedSubMenu = overlay.querySelector('vaadin-menu-bar-submenu');
+      const nestedSubMenu = subMenu.querySelector('vaadin-menu-bar-submenu');
       await oneEvent(nestedSubMenu._overlayElement, 'vaadin-overlay-open');
       // Select Item 0/1/0
       enter(getDeepActiveElement());

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -1,12 +1,17 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["menu-bar basic"] = 
+snapshots["menu-bar basic"] =
 `<vaadin-menu-bar role="menubar">
   <vaadin-menu-bar-submenu
     is-root=""
     slot="submenu"
   >
+    <div
+      slot="overlay"
+      style="display: contents;"
+    >
+    </div>
   </vaadin-menu-bar-submenu>
   <vaadin-menu-bar-button
     class="home"
@@ -61,78 +66,141 @@ snapshots["menu-bar basic"] =
 `;
 /* end snapshot menu-bar basic */
 
-snapshots["menu-bar overlay"] = 
+snapshots["menu-bar opened"] =
+`<vaadin-menu-bar
+  role="menubar"
+  style="pointer-events: auto;"
+>
+  <vaadin-menu-bar-submenu
+    is-root=""
+    opened=""
+    slot="submenu"
+    start-aligned=""
+    top-aligned=""
+  >
+    <div
+      slot="overlay"
+      style="display: contents;"
+    >
+      <vaadin-menu-bar-list-box
+        aria-orientation="vertical"
+        role="menu"
+      >
+        <vaadin-menu-bar-item
+          aria-haspopup="false"
+          aria-selected="false"
+          role="menuitem"
+          tabindex="0"
+        >
+          View Reports
+        </vaadin-menu-bar-item>
+        <vaadin-menu-bar-item
+          aria-haspopup="false"
+          aria-selected="false"
+          class="generate reports"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Generate Report
+        </vaadin-menu-bar-item>
+      </vaadin-menu-bar-list-box>
+    </div>
+    <vaadin-menu-bar-submenu
+      modeless=""
+      slot="sub-menu"
+    >
+    </vaadin-menu-bar-submenu>
+  </vaadin-menu-bar-submenu>
+  <vaadin-menu-bar-button
+    class="home"
+    first-visible=""
+    role="menuitem"
+    tabindex="0"
+  >
+    Home
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    active=""
+    aria-expanded="true"
+    aria-haspopup="true"
+    expanded=""
+    role="menuitem"
+    tabindex="0"
+  >
+    Reports
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    aria-disabled="true"
+    disabled=""
+    role="menuitem"
+    tabindex="-1"
+  >
+    Dashboard
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    class="help"
+    last-visible=""
+    role="menuitem"
+    tabindex="0"
+  >
+    <vaadin-menu-bar-item aria-selected="false">
+      <strong>
+        Help
+      </strong>
+    </vaadin-menu-bar-item>
+  </vaadin-menu-bar-button>
+  <vaadin-menu-bar-button
+    aria-expanded="false"
+    aria-haspopup="true"
+    aria-label="More options"
+    hidden=""
+    role="menuitem"
+    slot="overflow"
+    tabindex="0"
+  >
+    <div aria-hidden="true">
+      ···
+    </div>
+  </vaadin-menu-bar-button>
+</vaadin-menu-bar>
+`;
+/* end snapshot menu-bar opened */
+
+snapshots["menu-bar overlay"] =
 `<vaadin-menu-bar-overlay
+  exportparts="backdrop, overlay, content"
   opened=""
+  popover="manual"
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-menu-bar-list-box
-    aria-orientation="vertical"
-    role="menu"
+  <slot name="overlay">
+  </slot>
+  <slot
+    name="sub-menu"
+    slot="sub-menu"
   >
-    <vaadin-menu-bar-item
-      aria-haspopup="false"
-      aria-selected="false"
-      role="menuitem"
-      tabindex="0"
-    >
-      View Reports
-    </vaadin-menu-bar-item>
-    <vaadin-menu-bar-item
-      aria-haspopup="false"
-      aria-selected="false"
-      class="generate reports"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Generate Report
-    </vaadin-menu-bar-item>
-  </vaadin-menu-bar-list-box>
-  <vaadin-menu-bar-submenu
-    hidden=""
-    modeless=""
-  >
-  </vaadin-menu-bar-submenu>
+  </slot>
 </vaadin-menu-bar-overlay>
 `;
 /* end snapshot menu-bar overlay */
 
-snapshots["menu-bar overlay class"] = 
+snapshots["menu-bar overlay class"] =
 `<vaadin-menu-bar-overlay
   class="custom menu-bar-overlay"
+  exportparts="backdrop, overlay, content"
   opened=""
+  popover="manual"
   start-aligned=""
   top-aligned=""
 >
-  <vaadin-menu-bar-list-box
-    aria-orientation="vertical"
-    role="menu"
+  <slot name="overlay">
+  </slot>
+  <slot
+    name="sub-menu"
+    slot="sub-menu"
   >
-    <vaadin-menu-bar-item
-      aria-haspopup="false"
-      aria-selected="false"
-      role="menuitem"
-      tabindex="0"
-    >
-      View Reports
-    </vaadin-menu-bar-item>
-    <vaadin-menu-bar-item
-      aria-haspopup="false"
-      aria-selected="false"
-      class="generate reports"
-      role="menuitem"
-      tabindex="-1"
-    >
-      Generate Report
-    </vaadin-menu-bar-item>
-  </vaadin-menu-bar-list-box>
-  <vaadin-menu-bar-submenu
-    hidden=""
-    modeless=""
-  >
-  </vaadin-menu-bar-submenu>
+  </slot>
 </vaadin-menu-bar-overlay>
 `;
 /* end snapshot menu-bar overlay class */
-

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -1,6 +1,5 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
-
 snapshots["menu-bar basic"] =
 `<vaadin-menu-bar role="menubar">
   <vaadin-menu-bar-submenu
@@ -107,7 +106,7 @@ snapshots["menu-bar opened"] =
     </div>
     <vaadin-menu-bar-submenu
       modeless=""
-      slot="sub-menu"
+      slot="submenu"
     >
     </vaadin-menu-bar-submenu>
   </vaadin-menu-bar-submenu>
@@ -177,8 +176,8 @@ snapshots["menu-bar overlay"] =
   <slot name="overlay">
   </slot>
   <slot
-    name="sub-menu"
-    slot="sub-menu"
+    name="submenu"
+    slot="submenu"
   >
   </slot>
 </vaadin-menu-bar-overlay>
@@ -197,8 +196,8 @@ snapshots["menu-bar overlay class"] =
   <slot name="overlay">
   </slot>
   <slot
-    name="sub-menu"
-    slot="sub-menu"
+    name="submenu"
+    slot="submenu"
   >
   </slot>
 </vaadin-menu-bar-overlay>

--- a/packages/menu-bar/test/dom/menu-bar.test.js
+++ b/packages/menu-bar/test/dom/menu-bar.test.js
@@ -39,6 +39,12 @@ describe('menu-bar', () => {
     await expect(menu).dom.to.equalSnapshot();
   });
 
+  it('opened', async () => {
+    menu._buttons[1].click();
+    await nextRender();
+    await expect(menu).dom.to.equalSnapshot();
+  });
+
   it('overlay', async () => {
     menu._buttons[1].click();
     await nextRender();

--- a/packages/menu-bar/test/keyboard-navigation.test.js
+++ b/packages/menu-bar/test/keyboard-navigation.test.js
@@ -193,7 +193,7 @@ describe('keyboard navigation', () => {
   });
 
   describe('submenu items', () => {
-    let subMenu, overlay;
+    let subMenu;
 
     beforeEach(async () => {
       menu.items = [
@@ -211,7 +211,6 @@ describe('keyboard navigation', () => {
       await nextUpdate(menu);
       buttons = menu._buttons;
       subMenu = menu._subMenu;
-      overlay = subMenu._overlayElement;
     });
 
     describe('default mode', () => {
@@ -221,7 +220,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Move to previous button with submenu
         await sendKeys({ press: 'ArrowLeft' });
@@ -237,7 +236,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Move to previous button without submenu
         await sendKeys({ press: 'ArrowLeft' });
@@ -253,7 +252,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Move to next button with submenu
         await sendKeys({ press: 'ArrowRight' });
@@ -269,7 +268,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Move to next button without submenu
         await sendKeys({ press: 'ArrowRight' });
@@ -285,7 +284,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         await sendKeys({ press: 'ArrowLeft' });
         await nextRender();
@@ -303,7 +302,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         await sendKeys({ press: 'ArrowRight' });
         await nextRender();
@@ -327,7 +326,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Tab to next button with submenu
         await sendKeys({ press: 'Tab' });
@@ -343,7 +342,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Shift Tab to previous button with submenu
         await sendKeys({ press: 'Shift+Tab' });
@@ -359,7 +358,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Tab to next button without submenu
         await sendKeys({ press: 'Tab' });
@@ -375,7 +374,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Tab to next button without submenu
         await sendKeys({ press: 'Shift+Tab' });
@@ -391,7 +390,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Tab outside the menu bar
         await sendKeys({ press: 'Tab' });
@@ -407,7 +406,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Shift + Tab outside the menu bar
         await sendKeys({ press: 'Shift+Tab' });
@@ -425,7 +424,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Tab outside the menu bar (since next button is disabled)
         await sendKeys({ press: 'Tab' });
@@ -444,7 +443,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowDown' });
         await nextRender();
         expect(subMenu.opened).to.be.true;
-        expect(document.activeElement).to.equal(overlay.querySelector('vaadin-menu-bar-item'));
+        expect(document.activeElement).to.equal(subMenu.querySelector('vaadin-menu-bar-item'));
 
         // Tab outside the menu bar (since previous buttons are disabled)
         await sendKeys({ press: 'Shift+Tab' });

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -432,7 +432,7 @@ describe('overflow', () => {
     it('should teleport the same component to overflow sub-menu and back', async () => {
       overflow.click();
       await nextRender();
-      const listBox = subMenu._overlayElement.querySelector('vaadin-menu-bar-list-box');
+      const listBox = subMenu._overlayElement._contentRoot.querySelector('vaadin-menu-bar-list-box');
       expect(listBox.items[0]).to.equal(buttons[2].item.component);
       expect(listBox.items[0].firstChild).to.equal(menu.items[2].component);
       expect(listBox.items[0].firstChild.localName).to.equal('div');

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -692,4 +692,15 @@ describe('touch', () => {
     expect(subMenu3.opened).to.be.true;
     subMenu3.dispatchEvent(new CustomEvent('close-all-menus'));
   });
+
+  describe('exportparts', () => {
+    it('should export all overlay parts for styling', () => {
+      const parts = [...subMenuOverlay.shadowRoot.querySelectorAll('[part]')].map((el) => el.getAttribute('part'));
+      const exportParts = subMenuOverlay.getAttribute('exportparts').split(', ');
+
+      parts.forEach((part) => {
+        expect(exportParts).to.include(part);
+      });
+    });
+  });
 });

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -119,7 +119,7 @@ describe('sub-menu', () => {
     buttons[0].click();
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(spy.calledOnce).to.be.true;
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     expect(item.hasAttribute('focused')).to.be.false;
   });
 
@@ -127,7 +127,7 @@ describe('sub-menu', () => {
     buttons[0].click();
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const overlay = subMenuOverlay.$.overlay;
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     const spy = sinon.spy(item, 'focus');
     arrowDown(overlay);
     expect(spy.calledOnce).to.be.true;
@@ -137,7 +137,7 @@ describe('sub-menu', () => {
     buttons[0].click();
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     const overlay = subMenuOverlay.$.overlay;
-    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     const spy = sinon.spy(last, 'focus');
     arrowUp(overlay);
@@ -156,7 +156,7 @@ describe('sub-menu', () => {
   it('should focus first sub-menu item when opened on arrow down', async () => {
     arrowDown(buttons[0]);
     await nextUpdate(subMenu);
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     const spy = sinon.spy(item, 'focus');
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(spy.calledOnce).to.be.true;
@@ -165,21 +165,21 @@ describe('sub-menu', () => {
   it('should focus the first item on button space', async () => {
     space(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     expect(item.hasAttribute('focused')).to.be.true;
   });
 
   it('should focus the first item on button enter', async () => {
     enter(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     expect(item.hasAttribute('focused')).to.be.true;
   });
 
   it('should open sub-menu and focus last item on arrow up', async () => {
     arrowUp(buttons[0]);
     await nextUpdate(subMenu);
-    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     const spy = sinon.spy(last, 'focus');
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
@@ -190,7 +190,7 @@ describe('sub-menu', () => {
     arrowDown(buttons[2]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
-    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     arrowDown(items[0]);
     expect(items[1].hasAttribute('focus-ring')).to.be.true;
 
@@ -208,7 +208,7 @@ describe('sub-menu', () => {
     arrowDown(buttons[2]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
 
-    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     expect(items[1].hasAttribute('focus-ring')).to.be.true;
 
     // Close and re-open
@@ -222,7 +222,7 @@ describe('sub-menu', () => {
   it('should close sub-menu on first item arrow up', async () => {
     arrowDown(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     expect(item).to.be.ok;
     await nextRender();
     arrowUp(item);
@@ -234,11 +234,11 @@ describe('sub-menu', () => {
     arrowDown(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
-    let item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    let item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     await nextRender();
     arrowLeft(item);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     const spy = sinon.spy(item, 'focus');
     arrowDown(buttons[2]);
     expect(spy.calledOnce).to.be.true;
@@ -248,11 +248,11 @@ describe('sub-menu', () => {
     arrowDown(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     await nextRender();
     arrowLeft(item);
     await nextRender();
-    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     const spy = sinon.spy(last, 'focus');
     arrowUp(buttons[2]);
@@ -264,7 +264,7 @@ describe('sub-menu', () => {
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
     expect(subMenu.opened).to.be.true;
     await nextRender();
-    const item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    const item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     arrowLeft(item);
     await nextRender();
     esc(buttons[2]);
@@ -288,7 +288,7 @@ describe('sub-menu', () => {
 
     const spy = sinon.spy();
     menu.addEventListener('item-selected', spy);
-    item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     item.click();
     await nextRender();
     expect(subMenu.opened).to.be.false;
@@ -308,7 +308,7 @@ describe('sub-menu', () => {
   it('should not close submenu on item contextmenu event', async () => {
     buttons[0].click();
     await nextRender();
-    item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+    item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
     item.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true, composed: true }));
     await nextRender();
     expect(subMenu.opened).to.be.true;
@@ -317,7 +317,7 @@ describe('sub-menu', () => {
   it('should not close on parent item click', async () => {
     arrowUp(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    const items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     const last = items[items.length - 1];
     await nextRender();
     last.click();
@@ -446,7 +446,7 @@ describe('sub-menu', () => {
       await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.true;
 
-      item = subMenuOverlay.querySelector('vaadin-menu-bar-item');
+      item = subMenuOverlay._contentRoot.querySelector('vaadin-menu-bar-item');
       arrowUp(item);
       await nextRender();
       expect(buttons[0].hasAttribute('expanded')).to.be.false;
@@ -597,7 +597,7 @@ describe('theme attribute', () => {
   });
 
   it('should override the component theme attribute with the item.theme property', async () => {
-    let items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    let items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
 
     expect(items[0].getAttribute('theme')).to.equal('sub-item-theme');
     expect(items[1].getAttribute('theme')).to.equal('foo');
@@ -611,7 +611,7 @@ describe('theme attribute', () => {
     buttons[0].dispatchEvent(new CustomEvent(menuOpenEvent, { bubbles: true, composed: true }));
     await nextRender();
 
-    items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
 
     expect(items[0].getAttribute('theme')).to.equal('sub-item-theme');
     expect(items[1].hasAttribute('theme')).to.be.false;
@@ -662,12 +662,12 @@ describe('touch', () => {
   (isSafari ? it.skip : it)('should close submenu on mobile when selecting an item in the nested one', async () => {
     arrowDown(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    const subMenu2 = subMenuOverlay.querySelector('vaadin-menu-bar-submenu');
-    items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const subMenu2 = subMenu.querySelector('vaadin-menu-bar-submenu');
+    items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
     open(item);
     await nextRender();
-    items = subMenu2._overlayElement.querySelectorAll('vaadin-menu-bar-item');
+    items = subMenu2._overlayElement._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
     touchstart(item);
     touchend(item);
@@ -679,13 +679,13 @@ describe('touch', () => {
   it('should not close submenu on mobile when opening the nested submenu', async () => {
     arrowDown(buttons[0]);
     await oneEvent(subMenuOverlay, 'vaadin-overlay-open');
-    const subMenu2 = subMenuOverlay.querySelector('vaadin-menu-bar-submenu');
-    items = subMenuOverlay.querySelectorAll('vaadin-menu-bar-item');
+    const subMenu2 = subMenu.querySelector('vaadin-menu-bar-submenu');
+    items = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item');
     item = items[items.length - 1];
     open(item);
     await nextRender();
-    const subMenu3 = subMenu2._overlayElement.querySelector('vaadin-menu-bar-submenu');
-    item = subMenu2._overlayElement.querySelector('vaadin-menu-bar-item');
+    const subMenu3 = subMenu2.querySelector('vaadin-menu-bar-submenu');
+    item = subMenu2._overlayElement._contentRoot.querySelector('vaadin-menu-bar-item');
     expect(item).to.be.ok;
     open(item);
     await nextRender();


### PR DESCRIPTION
## Description

Updates `vaadin-context-menu` to use native popovers for its overlay. As part of that overlay content is rendered into a slotted div in the light DOM. Likewise, the submenu is slotted from the light DOM. Also updates `vaadin-menu-bar` to use the new structure for `vaadin-menu-bar-submenu`.

Fixes https://github.com/vaadin/web-components/issues/9714
Fixes https://github.com/vaadin/web-components/issues/9715

## Type of change

- Breaking change