### PR TITLE
test: update custom dialog CSS in Lumo no-padding visual test

### DIFF
--- a/packages/dialog/test/visual/lumo/dialog.test.js
+++ b/packages/dialog/test/visual/lumo/dialog.test.js
@@ -80,7 +80,7 @@ describe('dialog', () => {
   it('should not contain padding with no-padding theme', async () => {
     element.setAttribute('theme', 'no-padding');
     const contentStyles = new CSSStyleSheet();
-    contentStyles.insertRule('vaadin-dialog-overlay::part(content) { padding: 20px; }');
+    contentStyles.insertRule('vaadin-dialog::part(content) { padding: 20px; }');
     document.adoptedStyleSheets = [contentStyles];
     await nextUpdate(element);
     await visualDiff(div, 'content-no-padding-theme');


### PR DESCRIPTION
## Description

Updated the CSS used in visual test added in https://github.com/vaadin/web-components/pull/6689 to work with native `popover`.

## Type of change

- Test