### PR TITLE
refactor!: update vaadin-overlay to use native popover by default

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -407,9 +407,7 @@ export const OverlayMixin = (superClass) =>
 
     /** @private */
     _attachOverlay() {
-      this._placeholder = document.createComment('vaadin-overlay-placeholder');
-      this.parentNode.insertBefore(this._placeholder, this);
-      document.body.appendChild(this);
+      this.showPopover();
     }
 
     /** @private */
@@ -448,8 +446,7 @@ export const OverlayMixin = (superClass) =>
 
     /** @private */
     _detachOverlay() {
-      this._placeholder.parentNode.insertBefore(this, this._placeholder);
-      this._placeholder.parentNode.removeChild(this._placeholder);
+      this.hidePopover();
     }
 
     /** @private */

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -98,6 +98,13 @@ class Overlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjec
     `;
   }
 
+  /** @protected */
+  firstUpdated() {
+    super.firstUpdated();
+
+    this.popover = 'manual';
+  }
+
   /**
    * @event vaadin-overlay-open
    * Fired after the overlay is opened.

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -143,25 +143,24 @@ describe('focus-trap', () => {
   });
 
   describe('aria-hidden', () => {
-    let outer, inner, overlay;
+    let wrapper, sibling, overlay;
 
     beforeEach(() => {
-      // Create outer element and pass it explicitly.
-      outer = document.createElement('main');
-
-      // Our `fixtureSync()` requires a single parent.
-      inner = fixtureSync(
-        `
+      wrapper = fixtureSync(`
         <div>
-          <button>Foo</button>
-          <vaadin-overlay focus-trap></vaadin-overlay>
-          <button>Bar</button>
+          <aside>
+            <button>Foo</button>
+          </aside>
+          <div>
+            <button>Foo</button>
+            <vaadin-overlay focus-trap></vaadin-overlay>
+            <button>Bar</button>
+          </div>
         </div>
-      `,
-        outer,
-      );
+      `);
 
-      overlay = inner.querySelector('vaadin-overlay');
+      overlay = wrapper.querySelector('vaadin-overlay');
+      sibling = wrapper.querySelector('aside');
       overlay.renderer = (root) => {
         root.innerHTML = '<input placeholder="Input">';
       };
@@ -175,7 +174,7 @@ describe('focus-trap', () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
 
-      expect(outer.getAttribute('aria-hidden')).to.equal('true');
+      expect(sibling.getAttribute('aria-hidden')).to.equal('true');
     });
 
     it('should remove aria-hidden from other elements on overlay close', async () => {
@@ -183,7 +182,7 @@ describe('focus-trap', () => {
       await oneEvent(overlay, 'vaadin-overlay-open');
 
       overlay.opened = false;
-      expect(outer.hasAttribute('aria-hidden')).to.be.false;
+      expect(sibling.hasAttribute('aria-hidden')).to.be.false;
     });
 
     it('should not set aria-hidden on other elements if focusTrap is set to false', async () => {
@@ -192,7 +191,7 @@ describe('focus-trap', () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
 
-      expect(outer.hasAttribute('aria-hidden')).to.be.false;
+      expect(sibling.hasAttribute('aria-hidden')).to.be.false;
     });
   });
 
@@ -235,27 +234,13 @@ describe('focus-trap', () => {
         get _modalRoot() {
           return this.owner;
         }
-
-        _attachOverlay() {
-          this.setAttribute('popover', 'manual');
-          this.showPopover();
-        }
-
-        _detachOverlay() {
-          this.hidePopover();
-        }
       },
     );
 
     let outer, inner, wrapper, overlay;
 
     beforeEach(() => {
-      // Create outer element and pass it explicitly.
-      outer = document.createElement('main');
-
-      // Our `fixtureSync()` requires a single parent.
-      inner = fixtureSync(
-        `
+      outer = fixtureSync(`
         <div>
           <aside>
             <button>Foo</button>
@@ -266,11 +251,10 @@ describe('focus-trap', () => {
             <button>Baz</button>
           </div>
         </div>
-      `,
-        outer,
-      );
+      `);
 
-      wrapper = inner.querySelector('custom-overlay-wrapper');
+      wrapper = outer.querySelector('custom-overlay-wrapper');
+      inner = outer.querySelector('div');
       overlay = wrapper.shadowRoot.querySelector('custom-overlay');
     });
 

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -264,6 +264,37 @@ describe('multiple overlays', () => {
       expect(modeless2.style.zIndex).to.be.empty;
     });
 
+    it('should not call showPopover on bringToFront if only nested overlay is open', () => {
+      modeless2.opened = true;
+      modeless2.opened = true;
+
+      // Mimic nested overlays case
+      modeless1.appendChild(modeless2);
+
+      const showSpy1 = sinon.spy(modeless1, 'showPopover');
+      const showSpy2 = sinon.spy(modeless2, 'showPopover');
+
+      modeless1.bringToFront();
+
+      expect(showSpy1).to.be.not.called;
+      expect(showSpy2).to.be.not.called;
+
+      expect(modeless2._last).to.be.true;
+    });
+
+    it('should not call showPopover on bringToFront for the last open overlay', () => {
+      modeless2.opened = true;
+      modeless2.opened = true;
+
+      const showSpy2 = sinon.spy(modeless2, 'showPopover');
+
+      modeless2.bringToFront();
+
+      expect(showSpy2).to.be.not.called;
+
+      expect(modeless2._last).to.be.true;
+    });
+
     it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', () => {
       const spy = sinon.spy();
       modeless1.addEventListener('vaadin-overlay-escape-press', spy);
@@ -315,63 +346,6 @@ describe('multiple overlays', () => {
 
       escKeyDown(input);
       expect(spy.called).to.be.false;
-    });
-
-    describe('native popovers', () => {
-      beforeEach(() => {
-        modeless1.popover = 'manual';
-        modeless2.popover = 'manual';
-      });
-
-      it('should update stacking order when using bringToFront', () => {
-        modeless1.opened = true;
-        modeless1.showPopover();
-        modeless2.opened = true;
-        modeless2.showPopover();
-
-        modeless1.bringToFront();
-
-        expect(modeless1._last).to.be.true;
-
-        // Check that the overlay is also visually the frontmost
-        const frontmost = getFrontmostOverlayFromScreenCenter();
-        expect(frontmost).to.equal(modeless1);
-      });
-
-      it('should not call showPopover on bringToFront if only nested overlay is open', () => {
-        modeless2.opened = true;
-        modeless1.showPopover();
-        modeless2.opened = true;
-        modeless2.showPopover();
-
-        // Mimic nested overlays case
-        modeless1.appendChild(modeless2);
-
-        const showSpy1 = sinon.spy(modeless1, 'showPopover');
-        const showSpy2 = sinon.spy(modeless2, 'showPopover');
-
-        modeless1.bringToFront();
-
-        expect(showSpy1).to.be.not.called;
-        expect(showSpy2).to.be.not.called;
-
-        expect(modeless2._last).to.be.true;
-      });
-
-      it('should not call showPopover on bringToFront for the last open overlay', () => {
-        modeless2.opened = true;
-        modeless1.showPopover();
-        modeless2.opened = true;
-        modeless2.showPopover();
-
-        const showSpy2 = sinon.spy(modeless2, 'showPopover');
-
-        modeless2.bringToFront();
-
-        expect(showSpy2).to.be.not.called;
-
-        expect(modeless2._last).to.be.true;
-      });
     });
   });
 });

--- a/packages/overlay/test/restore-focus.test.js
+++ b/packages/overlay/test/restore-focus.test.js
@@ -161,33 +161,13 @@ describe('restore focus', () => {
   });
 });
 
-// TODO: temporarily placed in a separate suite using native popover
-// DOM structure, where the content root is slotted into the overlay
+// Emulate dialog DOM structure, where the content root is slotted into the overlay
 describe('custom content root', () => {
   customElements.define(
     'custom-overlay',
     class extends Overlay {
       get _contentRoot() {
         return this.owner;
-      }
-
-      _attachOverlay() {
-        if (this.owner) {
-          this.setAttribute('popover', 'manual');
-          this.showPopover();
-          return;
-        }
-
-        super._attachOverlay();
-      }
-
-      _detachOverlay() {
-        if (this.owner) {
-          this.hidePopover();
-          return;
-        }
-
-        super._detachOverlay();
       }
     },
   );


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9822

## Type of change

- Breaking change