### PR TITLE
refactor: move context-menu and menu-bar overlay to the template

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -8,6 +8,7 @@ import './vaadin-context-menu-item.js';
 import './vaadin-context-menu-list-box.js';
 import './vaadin-context-menu-overlay.js';
 import { css, html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
@@ -233,17 +234,26 @@ class ContextMenu extends ContextMenuMixin(
 
   /** @protected */
   render() {
-    return html`<slot id="slot"></slot>`;
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  createRenderRoot() {
-    const root = super.createRenderRoot();
-    root.appendChild(this._overlayElement);
-    return root;
+    return html`
+      <slot id="slot"></slot>
+      <vaadin-context-menu-overlay
+        id="overlay"
+        .owner="${this}"
+        .opened="${this.opened}"
+        .model="${this._context}"
+        .modeless="${this._modeless}"
+        .renderer="${this.items ? this.__itemsRenderer : this.renderer}"
+        .withBackdrop="${this._phone}"
+        ?phone="${this._phone}"
+        theme="${ifDefined(this._theme)}"
+        exportparts="backdrop, overlay, content"
+        @opened-changed="${this._onOverlayOpened}"
+        @vaadin-overlay-open="${this._onVaadinOverlayOpen}"
+      >
+        <slot name="overlay"></slot>
+        <slot name="submenu" slot="submenu"></slot>
+      </vaadin-context-menu-overlay>
+    `;
   }
 
   /**

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -1,6 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
-snapshots["context-menu items"] =
+
+snapshots["context-menu items"] = 
 `<vaadin-context-menu opened="">
   <div>
     Target
@@ -64,7 +65,7 @@ snapshots["context-menu items"] =
 `;
 /* end snapshot context-menu items */
 
-snapshots["context-menu items nested"] =
+snapshots["context-menu items nested"] = 
 `<vaadin-context-menu
   modeless=""
   opened=""
@@ -153,10 +154,11 @@ snapshots["context-menu items nested"] =
 `;
 /* end snapshot context-menu items nested */
 
-snapshots["context-menu overlay class"] =
+snapshots["context-menu overlay class"] = 
 `<vaadin-context-menu-overlay
   class="context-menu-overlay custom"
   exportparts="backdrop, overlay, content"
+  id="overlay"
   opened=""
   popover="manual"
 >
@@ -171,10 +173,11 @@ snapshots["context-menu overlay class"] =
 `;
 /* end snapshot context-menu overlay class */
 
-snapshots["context-menu overlay class nested"] =
+snapshots["context-menu overlay class nested"] = 
 `<vaadin-context-menu-overlay
   class="context-menu-overlay custom"
   exportparts="backdrop, overlay, content"
+  id="overlay"
   modeless=""
   opened=""
   popover="manual"
@@ -191,3 +194,4 @@ snapshots["context-menu overlay class nested"] =
 </vaadin-context-menu-overlay>
 `;
 /* end snapshot context-menu overlay class nested */
+

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu-mixin.js
@@ -31,8 +31,8 @@ export const SubMenuMixin = (superClass) =>
     /**
      * Overriding the observer to not add global "contextmenu" listener.
      */
-    _openedChanged(opened) {
-      this._overlayElement.opened = opened;
+    _openedChanged() {
+      // Do nothing
     }
 
     /**

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -7,6 +7,7 @@ import './vaadin-menu-bar-item.js';
 import './vaadin-menu-bar-list-box.js';
 import './vaadin-menu-bar-overlay.js';
 import { css, html, LitElement } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
@@ -40,17 +41,25 @@ class MenuBarSubmenu extends SubMenuMixin(ThemePropertyMixin(PolylitMixin(LitEle
 
   /** @protected */
   render() {
-    return html`<slot id="slot"></slot>`;
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  createRenderRoot() {
-    const root = super.createRenderRoot();
-    root.appendChild(this._overlayElement);
-    return root;
+    return html`
+      <vaadin-menu-bar-overlay
+        id="overlay"
+        .owner="${this}"
+        .opened="${this.opened}"
+        .model="${this._context}"
+        .modeless="${this._modeless}"
+        .renderer="${this.__itemsRenderer}"
+        .withBackdrop="${this._phone}"
+        ?phone="${this._phone}"
+        theme="${ifDefined(this._theme)}"
+        exportparts="backdrop, overlay, content"
+        @opened-changed="${this._onOverlayOpened}"
+        @vaadin-overlay-open="${this._onVaadinOverlayOpen}"
+      >
+        <slot name="overlay"></slot>
+        <slot name="submenu" slot="submenu"></slot>
+      </vaadin-menu-bar-overlay>
+    `;
   }
 }
 

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -1,6 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
-snapshots["menu-bar basic"] =
+
+snapshots["menu-bar basic"] = 
 `<vaadin-menu-bar role="menubar">
   <vaadin-menu-bar-submenu
     is-root=""
@@ -65,7 +66,7 @@ snapshots["menu-bar basic"] =
 `;
 /* end snapshot menu-bar basic */
 
-snapshots["menu-bar opened"] =
+snapshots["menu-bar opened"] = 
 `<vaadin-menu-bar
   role="menubar"
   style="pointer-events: auto;"
@@ -165,9 +166,10 @@ snapshots["menu-bar opened"] =
 `;
 /* end snapshot menu-bar opened */
 
-snapshots["menu-bar overlay"] =
+snapshots["menu-bar overlay"] = 
 `<vaadin-menu-bar-overlay
   exportparts="backdrop, overlay, content"
+  id="overlay"
   opened=""
   popover="manual"
   start-aligned=""
@@ -184,10 +186,11 @@ snapshots["menu-bar overlay"] =
 `;
 /* end snapshot menu-bar overlay */
 
-snapshots["menu-bar overlay class"] =
+snapshots["menu-bar overlay class"] = 
 `<vaadin-menu-bar-overlay
   class="custom menu-bar-overlay"
   exportparts="backdrop, overlay, content"
+  id="overlay"
   opened=""
   popover="manual"
   start-aligned=""
@@ -203,3 +206,4 @@ snapshots["menu-bar overlay class"] =
 </vaadin-menu-bar-overlay>
 `;
 /* end snapshot menu-bar overlay class */
+


### PR DESCRIPTION
## Description

Moved `vaadin-context-menu-overlay` and `vaadin-menu-bar-overlay` back to the template.

This essentially reverts https://github.com/vaadin/web-components/pull/6870 which is no longer relevant after switching to native `popover`.

## Type of change

- Refactor