### PR TITLE
chore: add postcss-lit comment to disable Stylelint warning

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -6,6 +6,7 @@
 import '@vaadin/component-base/src/style-props.js';
 import { css, unsafeCSS } from 'lit';
 
+// postcss-lit-disable-next-line
 export const checkable = (part, propName = part) => css`
   :host {
     align-items: center;


### PR DESCRIPTION
## Description

Added a comment to disable the Stylelint warning caused by `unsafeCSS` syntax it fails to handle:

```
$ yarn lint:css
yarn run v1.22.22
$ stylelint --ignore-path .gitignore "packages/**/src/**/*.js" "packages/**/theme/**/*-styles.js" "packages/**/*.css" "dev/**/*.html"
[postcss-lit] Skipping template (/Users/serhii/vaadin/web-components/packages/field-base/src/styles/checkable-base-styles.js:9) as it included either invalid syntax or complex expressions the plugin could not interpret. Consider using a "// postcss-lit-disable-next-line" comment to disable this message
✨  Done in 7.15s
```

## Type of change

- Internal change