### PR TITLE
fix: recalculate column widths on initial item load with same data provider

### DIFF
--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -59,9 +59,15 @@ export const ColumnAutoWidthMixin = (superClass) =>
     }
 
     /** @private */
-    __flatSizeChangedAutoWidth() {
+    __flatSizeChangedAutoWidth(flatSize) {
       // Flat size changed, recalculate column widths if pending (asynchronously, to allow grid to render row elements first)
-      requestAnimationFrame(() => this.__tryToRecalculateColumnWidthsIfPending());
+      requestAnimationFrame(() => {
+        if (!!flatSize && !this.__hasHadRenderedRowsForColumnWidthCalculation) {
+          this.recalculateColumnWidths();
+        } else {
+          this.__tryToRecalculateColumnWidthsIfPending();
+        }
+      });
     }
 
     /**

--- a/packages/grid/test/column-auto-width.test.js
+++ b/packages/grid/test/column-auto-width.test.js
@@ -354,6 +354,26 @@ describe('column auto-width', () => {
     expect(parseFloat(lastColumn.width)).not.to.be.lessThan(getCellIntrinsicWidth(frozenToEndHeaderCell));
   });
 
+  it('should recalculate column widths on initial item load without data provider change', async () => {
+    let items = [];
+    grid.dataProvider = (_, cb) => cb(items, items.length);
+    await nextFrame();
+
+    // Should recalculate once on initial load of items
+    spy.resetHistory();
+    items = [testItems[0], testItems[1]];
+    grid.size = items.length;
+    await nextFrame();
+    expect(spy.callCount).to.equal(1);
+
+    // Should not recalculate on further update of items
+    spy.resetHistory();
+    items = [...items, testItems[2]];
+    grid.size = items.length;
+    await nextFrame();
+    expect(spy.called).to.be.false;
+  });
+
   describe('focusButtonMode column', () => {
     beforeEach(async () => {
       const column = document.createElement('vaadin-grid-column');


### PR DESCRIPTION
## Description

When the initial items are loaded lazily without changing the data provider, the column widths are not recalculated. This is especially the case when the component is used via the Flow counterpart.

This PR recalculates the column widths when

- the column width hasn't been calculated with non-zero number of rows before
- the number of items change to a non-zero value

Fixes https://github.com/vaadin/flow-components/issues/7309

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.