### PR TITLE
docs: remove dialog ariaLabel property override from typings

### DIFF
--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -126,13 +126,6 @@ declare class Dialog extends DialogSizeMixin(
     ),
   ),
 ) {
-  /**
-   * Set the `aria-label` attribute for assistive technologies like
-   * screen readers. An empty string value for this property (the
-   * default) means that the `aria-label` attribute is not present.
-   */
-  ariaLabel: string;
-
   addEventListener<K extends keyof DialogEventMap>(
     type: K,
     listener: (this: Dialog, ev: DialogEventMap[K]) => void,


### PR DESCRIPTION
## Description

This property was removed in https://github.com/vaadin/web-components/pull/9807 but is still present in typings. This PR fixes that.

## Type of change

- Documentation