### PR TITLE
refactor: remove no longer used private getter from confirm-dialog

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -220,10 +220,6 @@ export const ConfirmDialogMixin = (superClass) =>
       this.__reject = this.__reject.bind(this);
     }
 
-    get __slottedNodes() {
-      return [this._headerNode, ...this._messageNodes, this._cancelButton, this._confirmButton, this._rejectButton];
-    }
-
     /** @protected */
     connectedCallback() {
       super.connectedCallback();


### PR DESCRIPTION
## Description

This getter was used for teleporting content, it's no longer used since https://github.com/vaadin/web-components/pull/9776.

## Type of change

- Refactor