### PR TITLE
chore: fix context menu selector in tests

### DIFF
--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -24,7 +24,7 @@ export async function openMenu(target, event = isTouch ? 'click' : 'mouseover') 
 }
 
 export function getMenuItems(menu) {
-  return [...menu.querySelectorAll(':scope > [slot="overlay"] [role="menu"] > :not([role="separator]"')];
+  return [...menu.querySelectorAll(':scope > [slot="overlay"] [role="menu"] > *')];
 }
 
 export function getSubMenu(menu) {


### PR DESCRIPTION
## Description

The selector was intended to ignore separators, but due to an invalid syntax it still returned separators. All tests are written so that they deal with that, so I just removed the selector.

## Type of change

- Internal