### PR TITLE
fix: bump TypeScript to 5.9, remove autocorrect property override

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "stylelint": "^16.23.0",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-vaadin": "^1.0.0-alpha.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "resolutions": {
     "svg2ttf": "6.0.3",

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -48,15 +48,6 @@ export declare class InputFieldMixinClass {
   autocomplete: string | undefined;
 
   /**
-   * This is a property supported by Safari that is used to control whether
-   * autocorrection should be enabled when the user is entering/editing the text.
-   * Possible values are:
-   * on: Enable autocorrection.
-   * off: Disable autocorrection.
-   */
-  autocorrect: 'off' | 'on' | undefined;
-
-  /**
    * This is a property supported by Safari and Chrome that is used to control whether
    * autocapitalization should be enabled when the user is entering/editing the text.
    * Possible values are:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11189,10 +11189,10 @@ typescript-eslint@8.33.0:
     "@typescript-eslint/parser" "8.33.0"
     "@typescript-eslint/utils" "8.33.0"
 
-"typescript@>=3 < 6", typescript@^5.8.3:
-  version "5.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
-  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
+"typescript@>=3 < 6", typescript@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

This should fix the error discovered in React wrappers, see https://github.com/vaadin/react-components/pull/344.

```
The intersection 'ClearButtonMixinClass & DelegateFocusMixinClass & DelegateStateMixinClass & DisabledMixinClass & ... 15 more ... & HTMLElement' was reduced to 'never' because property 'autocorrect' has conflicting types in some constituents.
```

The reason is that `autocorrect` property was added in https://github.com/microsoft/TypeScript/pull/61647:

```
    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/autocorrect) */
    autocorrect: boolean;
```

## Type of change

- Bugfix