### PR TITLE
fix: adjust row and col count base on Grid state

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -53,7 +53,7 @@ export const A11yMixin = (superClass) =>
       const bodyColumns = _columnTree[_columnTree.length - 1];
       // If no header and footer rows while the empty state is active, count as one column
       // Otherwise, use the number of body columns, if present
-      const columnsCount = emptyState && rowsCount === 1 ? 1 : (rowsCount && bodyColumns && bodyColumns.length) || 0;
+      const columnsCount = emptyState ? 1 : (rowsCount && bodyColumns && bodyColumns.length) || 0;
       this.$.table.setAttribute('aria-colcount', columnsCount);
 
       this._a11yUpdateHeaderRows();

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -38,14 +38,14 @@ export const A11yMixin = (superClass) =>
     }
 
     /** @private */
-    _a11yUpdateGridSize(size, _columnTree, __emptyState) {
+    _a11yUpdateGridSize(size, _columnTree, emptyState) {
       if (size === undefined || _columnTree === undefined) {
         return;
       }
 
       const headerRowsCount = this._a11yGetHeaderRowCount(_columnTree);
       const footerRowsCount = this._a11yGetFooterRowCount(_columnTree);
-      const bodyRowsCount = __emptyState ? 1 : size;
+      const bodyRowsCount = emptyState ? 1 : size;
       const rowsCount = bodyRowsCount + headerRowsCount + footerRowsCount;
 
       this.$.table.setAttribute('aria-rowcount', rowsCount);
@@ -53,7 +53,7 @@ export const A11yMixin = (superClass) =>
       const bodyColumns = _columnTree[_columnTree.length - 1];
       // If no header and footer rows while the empty state is active, count as one column
       // Otherwise, use the number of body columns, if present
-      const columnsCount = __emptyState && rowsCount === 1 ? 1 : (rowsCount && bodyColumns && bodyColumns.length) || 0;
+      const columnsCount = emptyState && rowsCount === 1 ? 1 : (rowsCount && bodyColumns && bodyColumns.length) || 0;
       this.$.table.setAttribute('aria-colcount', columnsCount);
 
       this._a11yUpdateHeaderRows();

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -53,7 +53,6 @@ export const A11yMixin = (superClass) =>
       const bodyColumns = _columnTree[_columnTree.length - 1];
       // If no header and footer rows while the empty state is active, count as one column
       // Otherwise, use the number of body columns, if present
-      // console.log('rowsCount', rowsCount);
       const columnsCount = __emptyState && rowsCount === 1 ? 1 : (rowsCount && bodyColumns && bodyColumns.length) || 0;
       this.$.table.setAttribute('aria-colcount', columnsCount);
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -630,6 +630,7 @@ export const GridMixin = (superClass) =>
 
       // Make sure the section has a tabbable element
       this._resetKeyboardNavigation();
+      this._a11yUpdateGridSize(this.size, this._columnTree, this.__emptyState);
     }
 
     /** @private */

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -240,6 +240,19 @@ describe('accessibility', () => {
         await nextFrame();
         expect(grid.$.table.getAttribute('aria-colcount')).to.equal('4');
       });
+
+      it('should update aria-colcount when grid is empty with empty-state and no header/footer rendered', async () => {
+        const emptyStateText = document.createElement('span');
+        emptyStateText.setAttribute('slot', 'empty-state');
+        grid.appendChild(emptyStateText);
+        grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
+          col.headerRenderer = null;
+          col.footerRenderer = null;
+        });
+        grid.items = [];
+        await nextFrame();
+        expect(grid.$.table.getAttribute('aria-colcount')).to.equal('1');
+      });
     });
 
     describe('row details in use', () => {
@@ -313,6 +326,26 @@ describe('accessibility', () => {
 
       // 10 item rows + header row + footer row = 12 in total
       expect(grid.$.table.getAttribute('aria-rowcount')).to.equal('12');
+    });
+
+    it('should count the footer rows correctly as part of the aria-rowcount', async () => {
+      // Remove the header renderers
+      grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
+        col.headerRenderer = null;
+      });
+
+      await nextFrame();
+      expect(grid.$.table.getAttribute('aria-rowcount')).to.equal('3');
+    });
+
+    it('should count the header rows correctly as part of the aria-rowcount', async () => {
+      // Remove the footer renderers
+      grid.querySelectorAll('vaadin-grid-column').forEach((col) => {
+        col.footerRenderer = null;
+      });
+
+      await nextFrame();
+      expect(grid.$.table.getAttribute('aria-rowcount')).to.equal('3');
     });
   });
 


### PR DESCRIPTION
## Description

Apply some adjustments to how the `aria-rowcount`/`aria-colcount` values are measured. The changes in this PR are:
- Fix the wrong usage of `headerRenderer` at the method responsible of counting the number of footer rows
- Add a call to `_a11yUpdateGridSize` in the `__updateHeaderFooterRowVisibility` method to recalculate the number of rows/cols when the renderers change
- If empty-state is used and it's active, it is counted as a row
- If the grid has no items and no header/footer is rendered, then the number of columns is adjusted accordingly

Below is a table with the possible states and how the amount of `aria-rowcount` and `aria-colcount` are reflected:

_B: is the number of body rows, H of header rows, and F of footer rows_

| Body Rows | Header | Footer | Empty State | `aria-rowcount`   | `aria-colcount`    |
|-----------|--------|--------|-------------|-------------------|--------------------|
| ✅        | ✅     | ✅     | ❌          | B + H + F         | # of cols in body  |
| ✅        | ❌     | ✅     | ❌          | B + F             | # of cols in body  |
| ✅        | ✅     | ❌     | ❌          | B + H             | # of cols in body  |
| ❌        | ✅     | ✅     | ❌          | H + F             | # of cols in body  |
| ❌        | ❌     | ✅     | ❌          | F                 | # of cols in body  |
| ❌        | ✅     | ❌     | ❌          | H                 | # of cols in body  |
| ❌        | ❌     | ❌     | ❌          | 0                 | 0                  |
| ❌        | ✅     | ✅     | ✅          | 1 + H + F         | # of cols in body  |
| ❌        | ❌     | ✅     | ✅          | 1 + F             | # of cols in body  |
| ❌        | ✅     | ❌     | ✅          | 1 + H             | # of cols in body  |
| ❌        | ✅     | ❌     | ✅          | 1                 | 1                  |


Fixes #9081

## Type of change

- Bugfix