### PR TITLE
feat: fire closed event after closing animation has finished

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -649,4 +649,10 @@ export const ContextMenuMixin = (superClass) =>
         this.close();
       }
     }
+
+    /**
+     * Fired when the context menu is closed.
+     *
+     * @event closed
+     */
   };

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -209,6 +209,14 @@ export const ContextMenuMixin = (superClass) =>
       this.__forwardFocus();
     }
 
+    /**
+     * Runs after overlay's closing animation is finished
+     * @private
+     */
+    _onVaadinOverlayClosed() {
+      this.dispatchEvent(new CustomEvent('closed'));
+    }
+
     /** @private */
     _targetOrOpenOnChanged(listenOn, openOn) {
       if (this._oldListenOn && this._oldOpenOn) {

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -35,7 +35,7 @@ export type ContextMenuItemSelectedEvent<TItem extends ContextMenuItem = Context
 }>;
 
 /**
- * Fired when the overlay is closed.
+ * Fired when the context menu is closed.
  */
 export type ContextMenuClosedEvent = CustomEvent;
 
@@ -244,7 +244,7 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenu
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
- * @fires {CustomEvent} closed - Fired when the overlay is closed.
+ * @fires {CustomEvent} closed - Fired when the context menu is closed.
  */
 declare class ContextMenu<TItem extends ContextMenuItem = ContextMenuItem> extends HTMLElement {
   addEventListener<K extends keyof ContextMenuEventMap>(

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -34,6 +34,11 @@ export type ContextMenuItemSelectedEvent<TItem extends ContextMenuItem = Context
   value: TItem;
 }>;
 
+/**
+ * Fired when the overlay is closed.
+ */
+export type ContextMenuClosedEvent = CustomEvent;
+
 export interface ContextMenuCustomEventMap<TItem extends ContextMenuItem = ContextMenuItem> {
   'opened-changed': ContextMenuOpenedChangedEvent;
 
@@ -42,6 +47,8 @@ export interface ContextMenuCustomEventMap<TItem extends ContextMenuItem = Conte
   'close-all-menus': Event;
 
   'items-outside-click': Event;
+
+  closed: ContextMenuClosedEvent;
 }
 
 export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenuItem>
@@ -237,6 +244,7 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenu
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
+ * @fires {CustomEvent} closed - Fired when the overlay is closed.
  */
 declare class ContextMenu<TItem extends ContextMenuItem = ContextMenuItem> extends HTMLElement {
   addEventListener<K extends keyof ContextMenuEventMap>(

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -205,7 +205,7 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
- * @fires {CustomEvent} closed - Fired when the overlay is closed.
+ * @fires {CustomEvent} closed - Fired when the context menu is closed.
  *
  * @customElement
  * @extends HTMLElement

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -205,6 +205,7 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
+ * @fires {CustomEvent} closed - Fired when the overlay is closed.
  *
  * @customElement
  * @extends HTMLElement
@@ -249,6 +250,7 @@ class ContextMenu extends ContextMenuMixin(
         exportparts="backdrop, overlay, content"
         @opened-changed="${this._onOverlayOpened}"
         @vaadin-overlay-open="${this._onVaadinOverlayOpen}"
+        @vaadin-overlay-closed="${this._onVaadinOverlayClosed}"
       >
         <slot name="overlay"></slot>
         <slot name="submenu" slot="submenu"></slot>

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -394,6 +394,14 @@ describe('overlay', () => {
       expect(menu.opened).to.eql(true);
     });
 
+    it('should dispatch closed event when the overlay is closed', async () => {
+      const closedSpy = sinon.spy();
+      menu.addEventListener('closed', closedSpy);
+      fire(document.body, 'click');
+      await nextRender();
+      expect(closedSpy.calledOnce).to.be.true;
+    });
+
     describe('with shift key', () => {
       it('should not close on menu contextmenu', () => {
         const e = contextmenu(0, 0, true, overlay);

--- a/packages/context-menu/test/typings/context-menu.types.ts
+++ b/packages/context-menu/test/typings/context-menu.types.ts
@@ -7,6 +7,7 @@ import type { ContextMenuItem } from '../../src/vaadin-context-menu-item.js';
 import type { ContextMenuListBox } from '../../src/vaadin-context-menu-list-box.js';
 import type {
   ContextMenu,
+  ContextMenuClosedEvent,
   ContextMenuItem as MenuItem,
   ContextMenuItemSelectedEvent,
   ContextMenuOpenedChangedEvent,
@@ -34,6 +35,10 @@ menu.addEventListener('opened-changed', (event) => {
 menu.addEventListener('item-selected', (event) => {
   assertType<ContextMenuItemSelectedEvent>(event);
   assertType<MenuItem>(event.detail.value);
+});
+
+menu.addEventListener('closed', (event) => {
+  assertType<ContextMenuClosedEvent>(event);
 });
 
 const renderer: ContextMenuRenderer = (root, contextMenu, context) => {


### PR DESCRIPTION
## Description

Adds a `closed` event to `vaadin-context-menu` that fires after the overlay's closing animation has finished.

## Type of change

- Feature
