### PR TITLE
fix: bump TypeScript to 5.9, remove autocorrect property override (CP: 24.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rollup": "^4.4.0",
     "stylelint": "^16.10.0",
     "stylelint-config-vaadin": "^1.0.0-alpha.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.2"
   },
   "resolutions": {
     "playwright": "^1.50.1"

--- a/packages/field-base/src/input-field-mixin.d.ts
+++ b/packages/field-base/src/input-field-mixin.d.ts
@@ -50,15 +50,6 @@ export declare class InputFieldMixinClass {
   autocomplete: string | undefined;
 
   /**
-   * This is a property supported by Safari that is used to control whether
-   * autocorrection should be enabled when the user is entering/editing the text.
-   * Possible values are:
-   * on: Enable autocorrection.
-   * off: Disable autocorrection.
-   */
-  autocorrect: 'off' | 'on' | undefined;
-
-  /**
    * This is a property supported by Safari and Chrome that is used to control whether
    * autocapitalization should be enabled when the user is entering/editing the text.
    * Possible values are:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12397,10 +12397,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.7.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+typescript@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
+  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/web-components/pull/9870 to `24.7` branch.

## Type of change

- Cherry-pick