### PR TITLE
docs: remove mentions of overlays from components JSDoc

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -48,7 +48,6 @@ export { AvatarGroupI18n, AvatarGroupItem, AvatarI18n };
  * In addition to `<vaadin-avatar-group>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-avatar-group-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-avatar-group-menu>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  * - `<vaadin-avatar-group-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  */

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -55,7 +55,6 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  * In addition to `<vaadin-avatar-group>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-avatar-group-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-avatar-group-menu>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  * - `<vaadin-avatar-group-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  *

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -102,13 +102,11 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * In addition to `<vaadin-date-picker>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-date-picker-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-date-picker-overlay-content>`
  * - `<vaadin-date-picker-month-scroller>`
  * - `<vaadin-date-picker-year-scroller>`
  * - `<vaadin-date-picker-year>`
  * - `<vaadin-month-calendar>`
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the input.
  *
  * In order to style the overlay content, use `<vaadin-date-picker-overlay-content>` shadow DOM parts:
  *

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -66,13 +66,11 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * In addition to `<vaadin-date-picker>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-date-picker-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-date-picker-overlay-content>`
  * - `<vaadin-date-picker-month-scroller>`
  * - `<vaadin-date-picker-year-scroller>`
  * - `<vaadin-date-picker-year>`
  * - `<vaadin-month-calendar>`
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the input.
  *
  * In order to style the overlay content, use `<vaadin-date-picker-overlay-content>` shadow DOM parts:
  *

--- a/packages/popover/src/lit/renderer-directives.d.ts
+++ b/packages/popover/src/lit/renderer-directives.d.ts
@@ -27,7 +27,7 @@ export class PopoverRendererDirective extends LitRendererDirective<Popover, Popo
 }
 
 /**
- * A Lit directive for populating the content of the `<vaadin-popover-overlay>` element.
+ * A Lit directive for populating the content of the `<vaadin-popover>` element.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the popover
  * via the `renderer` property. The renderer is called once to populate the content when assigned

--- a/packages/popover/src/lit/renderer-directives.js
+++ b/packages/popover/src/lit/renderer-directives.js
@@ -32,7 +32,7 @@ export class PopoverRendererDirective extends LitRendererDirective {
 }
 
 /**
- * A Lit directive for populating the content of the `<vaadin-popover-overlay>` element.
+ * A Lit directive for populating the content of the `<vaadin-popover>` element.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the popover
  * via the `renderer` property. The renderer is called once to populate the content when assigned

--- a/packages/select/src/lit/renderer-directives.d.ts
+++ b/packages/select/src/lit/renderer-directives.d.ts
@@ -28,7 +28,7 @@ export class SelectRendererDirective extends LitRendererDirective<Select, Select
 }
 
 /**
- * A Lit directive for populating the content of the `<vaadin-select-overlay>` element.
+ * A Lit directive for populating the content of the `<vaadin-select>` element.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the select
  * via the `renderer` property. The renderer is called once to populate the content when assigned

--- a/packages/select/src/lit/renderer-directives.js
+++ b/packages/select/src/lit/renderer-directives.js
@@ -32,7 +32,7 @@ export class SelectRendererDirective extends LitRendererDirective {
 }
 
 /**
- * A Lit directive for populating the content of the `<vaadin-select-overlay>` element.
+ * A Lit directive for populating the content of the `<vaadin-select>` element.
  *
  * The directive accepts a renderer callback returning a Lit template and assigns it to the select
  * via the `renderer` property. The renderer is called once to populate the content when assigned

--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -64,8 +64,7 @@ export declare class SelectBaseMixinClass {
    * Custom function for rendering the content of the `<vaadin-select>`.
    * Receives two arguments:
    *
-   * - `root` The `<vaadin-select-overlay>` internal container
-   *   DOM element. Append your content to it.
+   * - `root` The internal container DOM element. Append your content to it.
    * - `select` The reference to the `<vaadin-select>` element.
    */
   renderer: SelectRenderer | undefined;

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -72,8 +72,7 @@ export const SelectBaseMixin = (superClass) =>
          * Custom function for rendering the content of the `<vaadin-select>`.
          * Receives two arguments:
          *
-         * - `root` The `<vaadin-select-overlay>` internal container
-         *   DOM element. Append your content to it.
+         * - `root` The internal container DOM element. Append your content to it.
          * - `select` The reference to the `<vaadin-select>` element.
          * @type {!SelectRenderer | undefined}
          */

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -26,8 +26,7 @@ export type SelectChangeEvent = Event & {
  * Function for rendering the content of the `<vaadin-select>`.
  * Receives two arguments:
  *
- * - `root` The `<vaadin-select-overlay>` internal container
- *   DOM element. Append your content to it.
+ * - `root` The internal container DOM element. Append your content to it.
  * - `select` The reference to the `<vaadin-select>` element.
  */
 export type SelectRenderer = (root: HTMLElement, select: Select) => void;
@@ -160,12 +159,9 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * In addition to `<vaadin-select>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-select-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-select-value-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the button.
- *
- * Note: the `theme` attribute value set on `<vaadin-select>` is
- * propagated to the internal components listed above.
+ * - `<vaadin-select-list-box>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-list-box).
+ * - `<vaadin-select-item>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-item).
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -114,12 +114,9 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * In addition to `<vaadin-select>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-select-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-select-value-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the button.
- *
- * Note: the `theme` attribute value set on `<vaadin-select>` is
- * propagated to the internal components listed above.
+ * - `<vaadin-select-list-box>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-list-box).
+ * - `<vaadin-select-item>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-item).
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -95,12 +95,7 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * In addition to `<vaadin-time-picker>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-time-picker-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-time-picker-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the input.
- *
- * Note: the `theme` attribute value set on `<vaadin-time-picker>` is
- * propagated to the internal components listed above.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -62,12 +62,7 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  * In addition to `<vaadin-time-picker>` itself, the following internal
  * components are themable:
  *
- * - `<vaadin-time-picker-overlay>` - has the same API as [`<vaadin-overlay>`](#/elements/vaadin-overlay).
  * - `<vaadin-time-picker-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
- * - [`<vaadin-input-container>`](#/elements/vaadin-input-container) - an internal element wrapping the input.
- *
- * Note: the `theme` attribute value set on `<vaadin-time-picker>` is
- * propagated to the internal components listed above.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -32,9 +32,6 @@ export { TooltipPosition } from './vaadin-tooltip-mixin.js';
  * -----------------|----------------------------------------
  * `position`       | Reflects the `position` property value.
  *
- * Note: the `theme` attribute value set on `<vaadin-tooltip>` is
- * propagated to the internal `<vaadin-tooltip-overlay>` component.
- *
  * ### Custom CSS Properties
  *
  * The following custom CSS properties are available on the `<vaadin-tooltip>` element:

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -35,9 +35,6 @@ import { TooltipMixin } from './vaadin-tooltip-mixin.js';
  * -----------------|----------------------------------------
  * `position`       | Reflects the `position` property value.
  *
- * Note: the `theme` attribute value set on `<vaadin-tooltip>` is
- * propagated to the internal `<vaadin-tooltip-overlay>` component.
- *
  * ### Custom CSS Properties
  *
  * The following custom CSS properties are available on the `<vaadin-tooltip>` element:


### PR DESCRIPTION
## Description

- Removed mentions of overlays as these are no longer globally stylable and `::part(overlay)` should be used instead
- Removed mentions of the input container for the same reason - it's already stylable via `::part(input-field)`
- Removed mentions of the `theme` propagation which is only relevant for the shadow DOM injection styling
- Added missing `<vaadin-select-list-box>` and `<vaadin-select-item>` elements to align with e.g. `context-menu`

## Type of change

- Documentation