### PR TITLE
docs: deprecate accessibleName and accessibleNameRef in popover

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -93,6 +93,7 @@ declare class Popover extends PopoverPositionMixin(
    * String used to label the popover to screen reader users.
    *
    * @attr {string} accessible-name
+   * @deprecated Use `aria-label` attribute on the popover instead
    */
   accessibleName: string | null | undefined;
 
@@ -100,6 +101,7 @@ declare class Popover extends PopoverPositionMixin(
    * Id of the element used as label of the popover to screen reader users.
    *
    * @attr {string} accessible-name-ref
+   * @deprecated Use `aria-labelledby` attribute on the popover instead
    */
   accessibleNameRef: string | null | undefined;
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -229,6 +229,7 @@ class Popover extends PopoverPositionMixin(
        * String used to label the popover to screen reader users.
        *
        * @attr {string} accessible-name
+       * @deprecated Use `aria-label` attribute on the popover instead
        */
       accessibleName: {
         type: String,
@@ -238,6 +239,7 @@ class Popover extends PopoverPositionMixin(
        * Id of the element used as label of the popover to screen reader users.
        *
        * @attr {string} accessible-name-ref
+       * @deprecated Use `aria-labelledby` attribute on the popover instead
        */
       accessibleNameRef: {
         type: String,


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9863

## Type of change

- Docs / Deprecation