### PR TITLE
docs: deprecate overlayRole property in dialog and popover

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
@@ -36,6 +36,7 @@ export declare class DialogBaseMixinClass {
    * The `role` attribute value to be set on the dialog. Defaults to "dialog".
    *
    * @attr {string} overlay-role
+   * @deprecated Use standard `role` attribute on the dialog instead
    */
   overlayRole: string;
 

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -80,6 +80,7 @@ export const DialogBaseMixin = (superClass) =>
          * The `role` attribute value to be set on the dialog. Defaults to "dialog".
          *
          * @attr {string} overlay-role
+         * @deprecated Use standard `role` attribute on the dialog instead
          */
         overlayRole: {
           type: String,

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -161,6 +161,7 @@ declare class Popover extends PopoverPositionMixin(
    * The `role` attribute value to be set on the overlay.
    *
    * @attr {string} overlay-role
+   * @deprecated Use standard `role` attribute on the popover instead
    */
   overlayRole: string;
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -327,6 +327,7 @@ class Popover extends PopoverPositionMixin(
        * The `role` attribute value to be set on the overlay.
        *
        * @attr {string} overlay-role
+       * @deprecated Use standard `role` attribute on the popover instead
        */
       overlayRole: {
         type: String,


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9824

## Type of change

- Docs / Deprecation