### PR TITLE
chore: fix Prettier formatting in card dev page and button CSS

### DIFF
--- a/dev/card.html
+++ b/dev/card.html
@@ -344,8 +344,11 @@
       <vaadin-checkbox-group class="theme-variant" theme="horizontal" label="Theme Variant">
         <vaadin-checkbox label="Outlined" value="outlined"></vaadin-checkbox>
         <vaadin-checkbox label="Elevated" value="elevated">
-          <vaadin-tooltip slot="tooltip" text="Also sets the background color of the page to make the elevated style more apparent"></vaadin-tooltip>
-          <label slot="label">Elevated <vaadin-icon icon="lumo:error" style="scale: -1;"></vaadin-icon></label>
+          <vaadin-tooltip
+            slot="tooltip"
+            text="Also sets the background color of the page to make the elevated style more apparent"
+          ></vaadin-tooltip>
+          <label slot="label">Elevated <vaadin-icon icon="lumo:error" style="scale: -1"></vaadin-icon></label>
         </vaadin-checkbox>
         <vaadin-checkbox label="Dark" value="dark"></vaadin-checkbox>
         <vaadin-checkbox label="Horizontal" value="horizontal"></vaadin-checkbox>

--- a/packages/vaadin-lumo-styles/components/button.css
+++ b/packages/vaadin-lumo-styles/components/button.css
@@ -7,6 +7,5 @@
 
 :is(:root, :host)::before {
   --vaadin-button-lumo-inject: 1;
-  --vaadin-button-lumo-inject-modules:
-    lumo_components_button;
+  --vaadin-button-lumo-inject-modules: lumo_components_button;
 }


### PR DESCRIPTION
## Description

Fixed Prettier formatting for some HTML / CSS that we missed to update (we only get ESLint errors for Prettier in JS).

## Type of change

- Internal change