### PR TITLE
fix: import dashboard base styles from the correct files

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-base-styles.js
@@ -9,7 +9,7 @@
  * license.
  */
 import { css } from 'lit';
-import { dashboardLayoutStyles } from './vaadin-dashboard-layout-core-styles.js';
+import { dashboardLayoutStyles } from './vaadin-dashboard-layout-base-styles.js';
 
 const dashboard = css`
   #grid[item-resizing] {

--- a/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
@@ -9,7 +9,7 @@
  * license.
  */
 import { css } from 'lit';
-import { buttonStyles } from '@vaadin/button/src/styles/vaadin-button-core-styles.js';
+import { buttonStyles } from '@vaadin/button/src/styles/vaadin-button-base-styles.js';
 
 const dashboardButton = css`
   :host {

--- a/packages/dashboard/src/styles/vaadin-dashboard-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-section-base-styles.js
@@ -10,7 +10,7 @@
  */
 import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
-import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-widget-section-core-styles.js';
+import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-widget-section-base-styles.js';
 
 const sectionStyles = css`
   :host {

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -10,7 +10,7 @@
  */
 import '@vaadin/component-base/src/style-props.js';
 import { css } from 'lit';
-import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-widget-section-core-styles.js';
+import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-widget-section-base-styles.js';
 
 const widgetStyles = css`
   :host {


### PR DESCRIPTION
## Description

Base styles should be imported from correct files, currently these used `-core` (it was still rewritten to `-base` in tests).

## Type of change

- Bugfix