### PR TITLE
fix: avoid shifting center regions on hover

### DIFF
--- a/packages/notification/src/styles/vaadin-notification-container-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-container-base-styles.js
@@ -79,8 +79,12 @@ export const notificationContainerStyles = css`
     padding: var(--_paint-area);
   }
 
+  [region]:not([region='middle'], [region$='center']):where(:hover, :focus-within) {
+    margin-inline: calc(var(--_paint-area) * -1);
+  }
+
   [region]:not([region='middle']):where(:hover, :focus-within) {
-    margin: calc(var(--_paint-area) * -1);
+    margin-block: calc(var(--_paint-area) * -1);
   }
 
   [region-group='top'] > [region] {


### PR DESCRIPTION
Before fix:

https://github.com/user-attachments/assets/0bc73a03-2d0b-4da1-bb49-7d5f58deb807

