### PR TITLE
chore: update visual tests workflow to only test Lumo CSS

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -70,44 +70,12 @@ jobs:
           timeout_minutes: 20
           retry_wait_seconds: 60
           max_attempts: 3
-          command: yarn test:lumo
+          command: yarn test:lumo --ported
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: lumo-screenshots
-          path: |
-            packages/*/test/visual/lumo/screenshots/*/failed/*.png
-            packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png
-  lumo-ported:
-    name: Lumo (CSS files)
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'yarn'
-
-      - name: Install Dependencies
-        run: yarn --frozen-lockfile --no-progress --non-interactive
-
-      - name: Visual tests
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: yarn test:lumo --ported
-
-      - uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
-        with:
-          name: lumo-css-screenshots
           path: |
             packages/*/test/visual/lumo/screenshots/*/failed/*.png
             packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png


### PR DESCRIPTION
## Description

Removed GitHub Actions job that runs visual tests for legacy Lumo in preparation for removing it.

## Type of change

- Internal change