### PR TITLE
fix: close date-picker overlay correctly on backdrop click

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1032,8 +1032,9 @@ export const DatePickerMixin = (subclass) =>
      * @private
      */
     _onClick(event) {
-      // Ignore click events bubbling from the overlay
-      if (event.composedPath().includes(this._overlayContent)) {
+      // Ignore click events bubbling from the overlay or backdrop
+      const path = event.composedPath();
+      if (path.includes(this._overlayContent) || path.includes(this._overlayElement)) {
         return;
       }
 

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -1032,9 +1032,8 @@ export const DatePickerMixin = (subclass) =>
      * @private
      */
     _onClick(event) {
-      // Ignore click events bubbling from the overlay or backdrop
-      const path = event.composedPath();
-      if (path.includes(this._overlayContent) || path.includes(this._overlayElement)) {
+      // Ignore click events bubbling from the overlay
+      if (event.composedPath().includes(this._overlayElement)) {
         return;
       }
 

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -271,7 +271,7 @@ class DatePicker extends DatePickerMixin(
   /** @private */
   _onVaadinOverlayClose(e) {
     // Prevent closing the overlay on label element click
-    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this)) {
+    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this._labelNode)) {
       e.preventDefault();
     }
   }

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -271,7 +271,8 @@ class DatePicker extends DatePickerMixin(
   /** @private */
   _onVaadinOverlayClose(e) {
     // Prevent closing the overlay on label element click
-    if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().includes(this._labelNode)) {
+    const event = e.detail.sourceEvent;
+    if (event && event.composedPath().includes(this) && !event.composedPath().includes(this._overlayElement)) {
       e.preventDefault();
     }
   }

--- a/packages/date-picker/test/dropdown.test.js
+++ b/packages/date-picker/test/dropdown.test.js
@@ -46,6 +46,16 @@ describe('dropdown', () => {
     expect(overlay.opened).to.be.false;
   });
 
+  it('should close overlay on backdrop element click', async () => {
+    await open(datePicker);
+
+    datePicker.setAttribute('fullscreen', '');
+    overlay.shadowRoot.querySelector('[part="backdrop"]').click();
+
+    expect(datePicker.opened).to.be.false;
+    expect(overlay.opened).to.be.false;
+  });
+
   describe('toggle button', () => {
     let toggleButton;
 


### PR DESCRIPTION
## Description

This fixes a regression from adding native popover to date-picker (which caused the grid-pro date-picker IT to fail).
Once this is merged, I will re-enable the following IT in the base styles PR where backdrop will be styled correctly:

https://github.com/vaadin/web-components/blob/d5ca0d94c0d16eacc65608d06000238f4e4b5eb5/test/integration/grid-pro-custom-editor.test.js#L221-L222

## Type of change

- Bugfix