### PR TITLE
test: refactor exporting tests to use better selectors

### DIFF
--- a/packages/charts/test/exporting.test.js
+++ b/packages/charts/test/exporting.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { click, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './exporting-styles.js';
 import '../src/vaadin-chart.js';
@@ -8,6 +8,11 @@ import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
 
 describe('vaadin-chart exporting', () => {
   let chart, chartContainer, fireEventSpy;
+
+  function clickExportingButton() {
+    const exportingButton = chartContainer.querySelector('.highcharts-exporting-group > .highcharts-no-tooltip');
+    click(exportingButton);
+  }
 
   before(() => {
     // Prevent form submit
@@ -49,11 +54,12 @@ describe('vaadin-chart exporting', () => {
     observer.observe(document.body, { childList: true });
 
     // Reveal exporting menu items
-    chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+    // chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+    clickExportingButton();
 
     // Simulate a PNG export
     const pngExportButton = chartContainer.querySelectorAll('.highcharts-menu-item')[2];
-    pngExportButton.onclick();
+    click(pngExportButton);
 
     expect(fireEventSpy.firstCall.args[1]).to.be.equal('beforeExport');
     await nextRender();
@@ -77,7 +83,7 @@ describe('vaadin-chart exporting', () => {
     observer.observe(document.body, { childList: true });
 
     // Reveal exporting menu items
-    chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+    clickExportingButton();
 
     // Simulate a PNG export
     const pngExportButton = chartContainer.querySelectorAll('.highcharts-menu-item')[2];
@@ -108,7 +114,7 @@ describe('vaadin-chart exporting', () => {
     observer.observe(targetNode, config);
 
     // Reveal exporting menu items
-    chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+    clickExportingButton();
 
     // Simulate a PNG export
     const pngExportButton = chartContainer.querySelectorAll('.highcharts-menu-item')[2];
@@ -140,7 +146,7 @@ describe('vaadin-chart exporting', () => {
     observer.observe(targetNode, config);
 
     // Reveal exporting menu items
-    chartContainer.querySelector('button.highcharts-a11y-proxy-button.highcharts-no-tooltip').click();
+    clickExportingButton();
 
     // Simulate a PNG export
     const pngExportButton = chartContainer.querySelectorAll('.highcharts-menu-item')[2];


### PR DESCRIPTION
## Description

Highcharts V12 doesn't use a `button` in the exporting anymore, and the CSS classes have changed. Update the selector and use the `click` helper method to make it work both in the current version and in V12.

Part of #9908
