### PR TITLE
refactor: remove tabindex from avatar-group overlay part

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -38,7 +38,7 @@ class AvatarGroupOverlay extends PositionMixin(
   /** @protected */
   render() {
     return html`
-      <div part="overlay" id="overlay" tabindex="0">
+      <div part="overlay" id="overlay">
         <div part="content" id="content">
           <slot></slot>
         </div>

--- a/packages/vaadin-lumo-styles/src/components/avatar-group-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/avatar-group-overlay.css
@@ -8,8 +8,4 @@
     --_lumo-list-box-item-selected-icon-display: none;
     --_lumo-list-box-item-padding-left: calc(var(--lumo-space-m) + var(--lumo-border-radius-m) / 4);
   }
-
-  [part='overlay'] {
-    outline: none;
-  }
 }


### PR DESCRIPTION
## Description

The `tabindex="0"` shouldn't be needed in avatar-group as we always focus the list-box.
It was likely copied from `vaadin-select-overlay` where we removed it in https://github.com/vaadin/web-components/pull/9751.

## Type of change

- Refactor