### PR TITLE
chore: remove no longer needed flag from Lumo visual tests

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -70,7 +70,7 @@ jobs:
           timeout_minutes: 20
           retry_wait_seconds: 60
           max_attempts: 3
-          command: yarn test:lumo --ported
+          command: yarn test:lumo
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}


### PR DESCRIPTION
## Description

After switching to use base styles and removal of legacy Lumo, the `--ported` flag is no longer used. Let's remove it.

## Type of change

- Internal change