### PR TITLE
chore: simplify web-test-runner theme plugins config

### DIFF
--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -108,15 +108,10 @@ export default {
     },
     esbuildPlugin({ ts: true }),
 
-    // yarn start
-    theme === 'base' && enforceThemePlugin('base'),
+    // Used by all themes
+    enforceThemePlugin(theme),
 
-    // yarn start --theme=lumo
-    theme === 'lumo' && enforceThemePlugin('lumo'),
-    theme === 'lumo' && cssImportPlugin(),
-
-    // yarn start --theme=aura
-    theme === 'aura' && enforceThemePlugin('aura'),
-    theme === 'aura' && cssImportPlugin(),
+    // Lumo / Aura CSS
+    ['lumo', 'aura'].includes(theme) && cssImportPlugin(),
   ].filter(Boolean),
 };

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -332,12 +332,11 @@ const createVisualTestsConfig = (theme, browserVersion) => {
         update: process.env.TEST_ENV === 'update',
       }),
 
-      // yarn test:base
-      theme === 'base' && enforceThemePlugin('base'),
+      // Used by all themes
+      enforceThemePlugin(theme),
 
-      // yarn test:lumo (uses legacy lumo styles defined in js files)
-      theme === 'lumo' && enforceThemePlugin('lumo'),
-      theme === 'lumo' && cssImportPlugin(),
+      // Lumo / Aura CSS
+      ['lumo', 'aura'].includes(theme) && cssImportPlugin(),
     ].filter(Boolean),
     groups,
     testRunnerHtml: getTestRunnerHtml(),


### PR DESCRIPTION
## Description

Updated WTR config to use `enforceThemePlugin` for all themes, and added `cssImportPlugin()` for Aura visual tests.

## Type of change

- Internal change