### PR TITLE
fix: remove field-base styles from npm files exclusion

### DIFF
--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -22,9 +22,7 @@
   "files": [
     "index.d.ts",
     "index.js",
-    "src",
-    "!src/styles/*-base-styles.d.ts",
-    "!src/styles/*-base-styles.js"
+    "src"
   ],
   "keywords": [
     "Vaadin",


### PR DESCRIPTION
## Description

I missed to remove this so the build for alpha11 fails, will release alpha12 once this is merged 🤦 

## Type of change

- Bugfix