### PR TITLE
test: update rich-text-editor visual tests to hide caret

### DIFF
--- a/packages/rich-text-editor/test/visual/lumo/rich-text-editor.test.js
+++ b/packages/rich-text-editor/test/visual/lumo/rich-text-editor.test.js
@@ -2,6 +2,7 @@ import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/props.css';
 import '@vaadin/vaadin-lumo-styles/components/rich-text-editor.css';
+import '../common.js';
 import '../../../vaadin-rich-text-editor.js';
 
 describe('rich-text-editor', () => {


### PR DESCRIPTION
## Description

The `common.js` file with styles disabling caret was added in https://github.com/vaadin/web-components/pull/9677 but I missed to add it to Lumo.

## Type of change

- Test