### PR TITLE
chore: remove theme folder files from ESLint and Stylelint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,6 @@ export default [
       'packages/**/dist/*.js',
       'packages/**/test/dom/__snapshots__/*.snap.js',
       'packages/**/test/*.generated.test.js',
-      'packages/**/theme/**/*.d.ts',
     ],
   },
   ...typescript,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "docs": "yarn analyze && web-dev-server --node-resolve --open",
     "icons": "lerna run icons",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:css": "stylelint --ignore-path .gitignore \"packages/**/src/**/*.js\" \"packages/**/theme/**/*-styles.js\" \"packages/**/*.css\" \"dev/**/*.html\"",
+    "lint:css": "stylelint --ignore-path .gitignore \"packages/**/src/**/*.js\" \"packages/**/*.css\" \"dev/**/*.html\"",
     "lint:js": "eslint",
     "lint:types": "tsc",
     "postinstall": "patch-package",


### PR DESCRIPTION
## Description

Removed no longer needed `theme` from linter configuration.

## Type of change

- Internal change