### PR TITLE
fix: unify border on all overlays in forced color mode

### DIFF
--- a/packages/notification/src/styles/vaadin-notification-card-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-card-base-styles.js
@@ -27,7 +27,7 @@ export const notificationCardStyles = css`
 
   @media (forced-colors: active) {
     [part='overlay'] {
-      border: 3px solid;
+      border: 3px solid !important;
     }
   }
 `;

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -81,7 +81,7 @@ export const overlayStyles = css`
 
   @media (forced-colors: active) {
     [part='overlay'] {
-      border: 3px solid;
+      border: 3px solid !important;
     }
   }
 `;

--- a/packages/tooltip/src/styles/vaadin-tooltip-overlay-base-styles.js
+++ b/packages/tooltip/src/styles/vaadin-tooltip-overlay-base-styles.js
@@ -53,7 +53,7 @@ export const tooltipOverlayStyles = css`
 
   @media (forced-colors: active) {
     [part='overlay'] {
-      border: 1px dashed;
+      border: 1px dashed !important;
     }
   }
 `;


### PR DESCRIPTION
Make it hard to break the overlay border in forced color mode. The thicker border is used to convey separation from underlying content, as all shadows are removed in forced color more.