### PR TITLE
refactor: base style padding and gap properties

### DIFF
--- a/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
+++ b/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
@@ -74,7 +74,7 @@ export const appLayoutStyles = css`
       var(--safe-area-inset-right)
     );
     z-index: 1;
-    gap: var(--vaadin-app-layout-navbar-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-app-layout-navbar-gap, var(--vaadin-gap-s));
     background: var(--vaadin-app-layout-navbar-background, var(--vaadin-background-container));
   }
 

--- a/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
+++ b/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
@@ -62,15 +62,15 @@ export const appLayoutStyles = css`
     top: 0;
     inset-inline: 0;
     transition: inset-inline-start var(--vaadin-app-layout-transition-duration);
-    padding-top: max(var(--vaadin-app-layout-navbar-padding-top, var(--vaadin-padding)), var(--safe-area-inset-top));
-    padding-bottom: var(--vaadin-app-layout-navbar-padding-bottom, var(--vaadin-padding));
+    padding-top: max(var(--vaadin-app-layout-navbar-padding-top, var(--vaadin-padding-s)), var(--safe-area-inset-top));
+    padding-bottom: var(--vaadin-app-layout-navbar-padding-bottom, var(--vaadin-padding-s));
     padding-inline-start: max(
-      var(--vaadin-app-layout-navbar-padding-inline-start, var(--vaadin-padding)),
+      var(--vaadin-app-layout-navbar-padding-inline-start, var(--vaadin-padding-s)),
       var(--safe-area-inset-left)
     );
     /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
     padding-inline-end: max(
-      var(--vaadin-app-layout-navbar-padding-inline-end, var(--vaadin-padding)),
+      var(--vaadin-app-layout-navbar-padding-inline-end, var(--vaadin-padding-s)),
       var(--safe-area-inset-right)
     );
     z-index: 1;
@@ -89,9 +89,9 @@ export const appLayoutStyles = css`
   [part='navbar'][bottom] {
     top: auto;
     bottom: 0;
-    padding-top: var(--vaadin-app-layout-navbar-padding-top, var(--vaadin-padding));
+    padding-top: var(--vaadin-app-layout-navbar-padding-top, var(--vaadin-padding-s));
     padding-bottom: max(
-      var(--vaadin-app-layout-navbar-padding-bottom, var(--vaadin-padding)),
+      var(--vaadin-app-layout-navbar-padding-bottom, var(--vaadin-padding-s)),
       var(--safe-area-inset-bottom)
     );
   }

--- a/packages/button/src/styles/vaadin-button-base-styles.js
+++ b/packages/button/src/styles/vaadin-button-base-styles.js
@@ -12,7 +12,7 @@ export const buttonStyles = css`
     align-items: center;
     justify-content: center;
     text-align: center;
-    gap: var(--vaadin-button-gap, 0 var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-button-gap, 0 var(--vaadin-gap-s));
     white-space: nowrap;
     -webkit-tap-highlight-color: transparent;
     -webkit-user-select: none;

--- a/packages/card/src/styles/vaadin-card-base-styles.js
+++ b/packages/card/src/styles/vaadin-card-base-styles.js
@@ -15,7 +15,7 @@ export const cardStyles = css`
     --_header-prefix: 0;
     --_header-suffix: 0;
     --_media: 0;
-    --_padding: var(--vaadin-card-padding, var(--vaadin-padding));
+    --_padding: var(--vaadin-card-padding, var(--vaadin-padding-s));
     --_subtitle: 0;
     --_title: 0;
     background: var(--vaadin-card-background, var(--vaadin-background-container));

--- a/packages/card/src/styles/vaadin-card-base-styles.js
+++ b/packages/card/src/styles/vaadin-card-base-styles.js
@@ -10,7 +10,7 @@ export const cardStyles = css`
   :host {
     --_content: 0;
     --_footer: 0;
-    --_gap: var(--vaadin-card-gap, var(--vaadin-gap-container-block) var(--vaadin-gap-container-inline));
+    --_gap: var(--vaadin-card-gap, var(--vaadin-gap-s));
     --_header: max(var(--_header-prefix), var(--_title), var(--_subtitle), var(--_header-suffix));
     --_header-prefix: 0;
     --_header-suffix: 0;

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -44,8 +44,9 @@ addGlobalThemeStyles(
         --vaadin-padding-container: var(--vaadin-padding-xs) var(--vaadin-padding-s);
 
         /* Gap/spacing */
-        --vaadin-gap-container-inline: 0.5em;
-        --vaadin-gap-container-block: 0.5em;
+        --vaadin-gap-s: 8px;
+        --vaadin-gap-m: 12px;
+        --vaadin-gap-l: 16px;
 
         /* Border radius */
         --vaadin-radius-s: 3px;

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -36,8 +36,12 @@ addGlobalThemeStyles(
         --vaadin-color: light-dark(#1f1f1f, white); /* Above 7:1 contrast */
 
         /* Padding */
-        --vaadin-padding: 8px;
-        --vaadin-padding-container: 6px 8px;
+        --vaadin-padding-xs: 6px;
+        --vaadin-padding-s: 8px;
+        --vaadin-padding-m: 12px;
+        --vaadin-padding-l: 16px;
+        --vaadin-padding-xl: 24px;
+        --vaadin-padding-container: var(--vaadin-padding-xs) var(--vaadin-padding-s);
 
         /* Gap/spacing */
         --vaadin-gap-container-inline: 0.5em;

--- a/packages/crud/src/styles/vaadin-crud-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-base-styles.js
@@ -90,7 +90,7 @@ export const crudStyles = css`
     display: flex;
     flex-shrink: 0;
     justify-content: flex-end;
-    padding: var(--vaadin-crud-toolbar-padding, var(--vaadin-padding));
+    padding: var(--vaadin-crud-toolbar-padding, var(--vaadin-padding-s));
   }
 
   :host([no-toolbar]) [part='toolbar'] {
@@ -133,7 +133,7 @@ export const crudStyles = css`
     font-size: var(--vaadin-crud-header-font-size, 1em);
     font-weight: var(--vaadin-crud-header-font-weight, 600);
     line-height: var(--vaadin-crud-header-line-height, inherit);
-    padding: var(--vaadin-crud-header-padding, var(--vaadin-padding));
+    padding: var(--vaadin-crud-header-padding, var(--vaadin-padding-s));
   }
 
   ::slotted([slot='header']) {
@@ -144,7 +144,7 @@ export const crudStyles = css`
   }
 
   ::slotted([slot='form']) {
-    padding: var(--vaadin-crud-form-padding, var(--vaadin-padding));
+    padding: var(--vaadin-crud-form-padding, var(--vaadin-padding-s));
   }
 
   [part='footer'] {
@@ -153,7 +153,7 @@ export const crudStyles = css`
     display: flex;
     flex: none;
     gap: var(--vaadin-crud-footer-gap, var(--vaadin-gap-container-inline));
-    padding: var(--vaadin-crud-footer-padding, var(--vaadin-padding));
+    padding: var(--vaadin-crud-footer-padding, var(--vaadin-padding-s));
   }
 
   ::slotted([slot='delete-button']) {

--- a/packages/crud/src/styles/vaadin-crud-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-base-styles.js
@@ -152,7 +152,7 @@ export const crudStyles = css`
     border-top: var(--vaadin-crud-border-width, 1px) solid var(--vaadin-crud-border-color, var(--vaadin-border-color));
     display: flex;
     flex: none;
-    gap: var(--vaadin-crud-footer-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-crud-footer-gap, var(--vaadin-gap-s));
     padding: var(--vaadin-crud-footer-padding, var(--vaadin-padding-s));
   }
 

--- a/packages/crud/src/styles/vaadin-crud-dialog-overlay-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-dialog-overlay-base-styles.js
@@ -18,7 +18,7 @@ const crudDialogOverlay = css`
     font-size: var(--vaadin-crud-dialog-header-font-size, 1em);
     font-weight: var(--vaadin-crud-dialog-header-font-weight, 600);
     line-height: var(--vaadin-crud-dialog-header-line-height, inherit);
-    padding: var(--vaadin-crud-header-padding, var(--vaadin-padding));
+    padding: var(--vaadin-crud-header-padding, var(--vaadin-padding-s));
   }
 
   ::slotted([slot='header']) {
@@ -31,7 +31,7 @@ const crudDialogOverlay = css`
   :host(:is(*, #id)) [part='content'] {
     overflow: auto;
     overscroll-behavior: contain;
-    padding: var(--vaadin-crud-form-padding, var(--vaadin-padding));
+    padding: var(--vaadin-crud-form-padding, var(--vaadin-padding-s));
   }
 
   ::slotted([slot='form']) {

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -98,7 +98,7 @@ const widgetStyles = css`
   }
 
   :host([editable]) header {
-    padding: var(--vaadin-dashboard-widget-header-padding, var(--vaadin-padding));
+    padding: var(--vaadin-dashboard-widget-header-padding, var(--vaadin-padding-s));
   }
 
   header:has([part~='title'][hidden]) {

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
@@ -60,7 +60,7 @@ export const dashboardWidgetAndSectionStyles = css`
     align-items: center;
     box-sizing: border-box;
     justify-content: space-between;
-    gap: var(--vaadin-dashboard-header-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-dashboard-header-gap, var(--vaadin-gap-s));
   }
 
   [part='title'] {

--- a/packages/date-picker/src/styles/vaadin-date-picker-overlay-content-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-date-picker-overlay-content-base-styles.js
@@ -97,7 +97,7 @@ export const overlayContentStyles = css`
     display: flex;
     grid-area: toolbar;
     justify-content: space-between;
-    padding: var(--vaadin-date-picker-toolbar-padding, var(--vaadin-padding));
+    padding: var(--vaadin-date-picker-toolbar-padding, var(--vaadin-padding-s));
   }
 
   :host([fullscreen]) [part='toolbar'] {

--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -9,7 +9,7 @@ import { css } from 'lit';
 export const monthCalendarStyles = css`
   :host {
     display: block;
-    padding: var(--vaadin-date-picker-month-padding, var(--vaadin-padding));
+    padding: var(--vaadin-date-picker-month-padding, var(--vaadin-padding-s));
   }
 
   [part='month-header'] {

--- a/packages/date-time-picker/src/styles/vaadin-date-time-picker-base-styles.js
+++ b/packages/date-time-picker/src/styles/vaadin-date-time-picker-base-styles.js
@@ -8,15 +8,12 @@ import { css } from 'lit';
 
 export const dateTimePickerStyles = css`
   .vaadin-date-time-picker-container {
-    width: calc(
-      var(--vaadin-field-default-width, 12em) * 2 +
-        var(--vaadin-date-time-picker-gap, var(--vaadin-gap-container-inline))
-    );
+    width: calc(var(--vaadin-field-default-width, 12em) * 2 + var(--vaadin-date-time-picker-gap, var(--vaadin-gap-s)));
   }
 
   .slots {
     display: flex;
-    gap: var(--vaadin-date-time-picker-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-date-time-picker-gap, var(--vaadin-gap-s));
   }
 
   .slots ::slotted([slot='date-picker']) {

--- a/packages/details/src/styles/vaadin-details-summary-base-styles.js
+++ b/packages/details/src/styles/vaadin-details-summary-base-styles.js
@@ -19,7 +19,7 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
     display: flex;
     font-size: var(--${unsafeCSS(partName)}-font-size, inherit);
     font-weight: var(--${unsafeCSS(partName)}-font-weight, 500);
-    gap: var(--${unsafeCSS(partName)}-gap, 0 var(--vaadin-gap-container-inline));
+    gap: var(--${unsafeCSS(partName)}-gap, 0 var(--vaadin-gap-s));
     height: var(--${unsafeCSS(partName)}-height, auto);
     outline: calc(var(--vaadin-focus-ring-width) * var(--_focus-ring, 0)) solid var(--vaadin-focus-ring-color);
     outline-offset: 1px;

--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -59,7 +59,7 @@ export const dialogOverlayBase = css`
   [part='header'],
   [part='content'],
   [part='footer'] {
-    padding: var(--vaadin-dialog-padding, var(--vaadin-padding));
+    padding: var(--vaadin-dialog-padding, var(--vaadin-padding-s));
   }
 
   :host([theme~='no-padding']) [part='content'] {

--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -49,7 +49,7 @@ export const dialogOverlayBase = css`
     flex: none;
     pointer-events: none;
     z-index: 1;
-    gap: var(--vaadin-dialog-toolbar-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-dialog-toolbar-gap, var(--vaadin-gap-s));
   }
 
   ::slotted(*) {

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -11,7 +11,7 @@ export const checkable = (part, propName = part) => css`
   :host {
     align-items: center;
     display: inline-grid;
-    gap: var(--vaadin-${unsafeCSS(propName)}-gap, 0.25lh var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-${unsafeCSS(propName)}-gap, 0.25lh var(--vaadin-gap-s));
     grid-template-columns: auto 1fr;
     /*
       Using minmax(auto, max-content) works around a Safari 17 issue where placing a checkbox

--- a/packages/field-base/src/styles/container-base-styles.js
+++ b/packages/field-base/src/styles/container-base-styles.js
@@ -10,7 +10,7 @@ export const container = css`
   [class$='container'] {
     display: flex;
     flex-direction: column;
-    gap: var(--vaadin-input-field-container-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-input-field-container-gap, var(--vaadin-gap-s));
     min-width: 100%;
     max-width: 100%;
     width: var(--vaadin-field-default-width, 12em);

--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -99,7 +99,7 @@ export const field = css`
     font-weight: var(--vaadin-input-field-error-font-weight, 400);
     color: var(--vaadin-input-field-error-color, var(--vaadin-color));
     display: flex;
-    gap: var(--vaadin-gap-container-inline);
+    gap: var(--vaadin-gap-s);
   }
 
   [part='error-message']::before {

--- a/packages/field-base/src/styles/group-base-styles.js
+++ b/packages/field-base/src/styles/group-base-styles.js
@@ -19,7 +19,7 @@ export const group = (name = 'checkbox') => css`
   [part='group-field'] {
     display: flex;
     flex-direction: column;
-    gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-${unsafeCSS(name)}-group-gap, var(--vaadin-gap-s));
   }
 
   [part='group-field'] {

--- a/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
+++ b/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
@@ -9,10 +9,10 @@ import { css } from 'lit';
 export const formLayoutStyles = css`
   :host {
     /* Default values */
-    --vaadin-form-layout-label-spacing: var(--vaadin-gap-container-inline);
+    --vaadin-form-layout-label-spacing: var(--vaadin-gap-s);
     --vaadin-form-layout-label-width: 8em;
-    --vaadin-form-layout-column-spacing: calc(var(--vaadin-gap-container-inline) * 2);
-    --vaadin-form-layout-row-spacing: calc(var(--vaadin-gap-container-block) * 2);
+    --vaadin-form-layout-column-spacing: calc(var(--vaadin-gap-s) * 2);
+    --vaadin-form-layout-row-spacing: calc(var(--vaadin-gap-s) * 2);
 
     align-self: stretch;
     display: block;

--- a/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
+++ b/packages/form-layout/test/dom/__snapshots__/form-layout.test.snap.js
@@ -312,11 +312,11 @@ snapshots["vaadin-form-layout responsive-steps host default"] =
 `<vaadin-form-layout>
   <input
     placeholder="First name"
-    style="width: calc(50% - 0.5em); margin-left: 0px;"
+    style="width: calc(50% - 8px); margin-left: 0px;"
   >
   <input
     placeholder="Last name"
-    style="width: calc(50% - 0.5em); margin-right: 0px;"
+    style="width: calc(50% - 8px); margin-right: 0px;"
   >
 </vaadin-form-layout>
 `;

--- a/packages/form-layout/test/form-layout.test.js
+++ b/packages/form-layout/test/form-layout.test.js
@@ -72,19 +72,19 @@ describe('form layout', () => {
     });
 
     it('should apply default --vaadin-form-layout-label-spacing', () => {
-      expect(getComputedStyle(layout).getPropertyValue('--vaadin-form-layout-label-spacing')).to.equal('0.5em');
+      expect(getComputedStyle(layout).getPropertyValue('--vaadin-form-layout-label-spacing')).to.equal('8px');
       expect(getComputedStyle(item.$.spacing).width).to.equal('8px');
     });
 
     it('should apply default --vaadin-form-layout-row-spacing', () => {
-      expect(getComputedStyle(layout).getPropertyValue('--vaadin-form-layout-row-spacing')).to.equal('calc(0.5em * 2)');
+      expect(getComputedStyle(layout).getPropertyValue('--vaadin-form-layout-row-spacing')).to.equal('calc(8px * 2)');
       expect(getComputedStyle(item).marginTop).to.equal('8px');
       expect(getComputedStyle(item).marginBottom).to.equal('8px');
     });
 
     it('should apply default --vaadin-form-layout-column-spacing', () => {
       expect(getComputedStyle(layout).getPropertyValue('--vaadin-form-layout-column-spacing')).to.equal(
-        'calc(0.5em * 2)',
+        'calc(8px * 2)',
       );
       expect(getComputedStyle(item).marginLeft).to.equal('8px');
       expect(getComputedStyle(item).marginRight).to.equal('8px');

--- a/packages/grid/src/styles/vaadin-grid-sorter-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-sorter-base-styles.js
@@ -12,7 +12,7 @@ export const gridSorterStyles = css`
     align-items: center;
     cursor: pointer;
     max-width: 100%;
-    gap: var(--vaadin-gap-container-inline);
+    gap: var(--vaadin-gap-s);
     -webkit-user-select: none;
     user-select: none;
     -webkit-tap-highlight-color: transparent;

--- a/packages/grid/src/styles/vaadin-grid-tree-toggle-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-tree-toggle-base-styles.js
@@ -36,7 +36,7 @@ export const gridTreeToggleStyles = css`
   }
 
   [part='toggle'] {
-    margin-inline-end: var(--vaadin-gap-container-inline);
+    margin-inline-end: var(--vaadin-gap-s);
   }
 
   [part='toggle']::before {

--- a/packages/horizontal-layout/src/styles/vaadin-horizontal-layout-base-styles.js
+++ b/packages/horizontal-layout/src/styles/vaadin-horizontal-layout-base-styles.js
@@ -18,11 +18,11 @@ export const baseStyles = css`
 
   /* Theme variations */
   :host([theme~='margin']) {
-    margin: var(--vaadin-horizontal-layout-margin, var(--vaadin-padding));
+    margin: var(--vaadin-horizontal-layout-margin, var(--vaadin-padding-s));
   }
 
   :host([theme~='padding']) {
-    padding: var(--vaadin-horizontal-layout-margin, var(--vaadin-padding));
+    padding: var(--vaadin-horizontal-layout-margin, var(--vaadin-padding-s));
   }
 
   :host([theme~='spacing']) {

--- a/packages/horizontal-layout/src/styles/vaadin-horizontal-layout-base-styles.js
+++ b/packages/horizontal-layout/src/styles/vaadin-horizontal-layout-base-styles.js
@@ -26,7 +26,7 @@ export const baseStyles = css`
   }
 
   :host([theme~='spacing']) {
-    gap: var(--vaadin-horizontal-layout-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-horizontal-layout-gap, var(--vaadin-gap-s));
   }
 
   :host([theme~='wrap']) {

--- a/packages/input-container/src/styles/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-base-styles.js
@@ -22,7 +22,7 @@ export const inputContainerStyles = css`
     box-sizing: border-box;
     cursor: text;
     padding: var(--vaadin-input-field-padding, var(--vaadin-padding-container));
-    gap: var(--vaadin-input-field-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-input-field-gap, var(--vaadin-gap-s));
     background: var(--vaadin-input-field-background, var(--vaadin-background-color));
     color: var(--vaadin-input-field-value-color, var(--vaadin-color));
     font-size: var(--vaadin-input-field-value-font-size, inherit);

--- a/packages/item/src/styles/vaadin-item-base-styles.js
+++ b/packages/item/src/styles/vaadin-item-base-styles.js
@@ -13,7 +13,7 @@ export const itemStyles = css`
     box-sizing: border-box;
     cursor: var(--vaadin-clickable-cursor);
     display: flex;
-    gap: var(--vaadin-item-gap, 0 var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-item-gap, 0 var(--vaadin-gap-s));
     height: var(--vaadin-item-height, auto);
     padding: var(--vaadin-item-padding, var(--vaadin-padding-container));
   }

--- a/packages/list-box/src/styles/vaadin-list-box-base-styles.js
+++ b/packages/list-box/src/styles/vaadin-list-box-base-styles.js
@@ -26,8 +26,6 @@ export const listBoxStyles = css`
     border-color: var(--vaadin-divider-color, var(--vaadin-border-color));
     border-width: 0 0 1px;
     margin: 4px 8px;
-    margin-inline-start: calc(
-      var(--vaadin-icon-size, 1lh) + var(--vaadin-item-gap, var(--vaadin-gap-container-inline)) + 8px
-    );
+    margin-inline-start: calc(var(--vaadin-icon-size, 1lh) + var(--vaadin-item-gap, var(--vaadin-gap-s)) + 8px);
   }
 `;

--- a/packages/login/src/styles/vaadin-login-form-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-form-wrapper-base-styles.js
@@ -13,7 +13,7 @@ export const loginFormWrapperStyles = css`
     display: flex;
     box-sizing: border-box;
     flex-direction: column;
-    gap: var(--vaadin-login-form-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-login-form-gap, var(--vaadin-gap-s));
     padding: var(--vaadin-login-form-padding, var(--vaadin-padding-s));
     max-width: 100%;
     width: var(--vaadin-login-form-width, 360px);
@@ -26,7 +26,7 @@ export const loginFormWrapperStyles = css`
   ::slotted(form) {
     display: flex;
     flex-direction: column;
-    gap: var(--vaadin-login-form-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-login-form-gap, var(--vaadin-gap-s));
   }
 
   ::slotted([slot='form-title']) {
@@ -44,7 +44,7 @@ export const loginFormWrapperStyles = css`
     color: var(--vaadin-login-form-error-color, var(--vaadin-color));
     font-size: var(--vaadin-login-form-error-font-size, inherit);
     font-weight: var(--vaadin-login-form-error-font-weight, 400);
-    gap: var(--vaadin-login-form-error-gap, 0 var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-login-form-error-gap, 0 var(--vaadin-gap-s));
     grid-template-columns: auto 1fr;
     line-height: var(--vaadin-login-form-error-line-height, inherit);
   }

--- a/packages/login/src/styles/vaadin-login-form-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-form-wrapper-base-styles.js
@@ -14,7 +14,7 @@ export const loginFormWrapperStyles = css`
     box-sizing: border-box;
     flex-direction: column;
     gap: var(--vaadin-login-form-gap, var(--vaadin-gap-container-block));
-    padding: var(--vaadin-login-form-padding, var(--vaadin-padding));
+    padding: var(--vaadin-login-form-padding, var(--vaadin-padding-s));
     max-width: 100%;
     width: var(--vaadin-login-form-width, 360px);
   }

--- a/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
@@ -34,7 +34,7 @@ const loginOverlayWrapper = css`
     background: var(--vaadin-login-overlay-brand-background, var(--vaadin-background-container));
     display: flex;
     flex-direction: column;
-    padding: var(--vaadin-login-overlay-brand-padding, var(--vaadin-padding));
+    padding: var(--vaadin-login-overlay-brand-padding, var(--vaadin-padding-s));
   }
 
   ::slotted([slot='title']) {

--- a/packages/message-list/src/styles/vaadin-message-base-styles.js
+++ b/packages/message-list/src/styles/vaadin-message-base-styles.js
@@ -11,7 +11,7 @@ export const messageStyles = css`
     display: flex;
     flex-direction: row;
     padding: var(--vaadin-message-padding, var(--vaadin-padding-s));
-    gap: var(--vaadin-message-gap, var(--vaadin-gap-container-inline) var(--vaadin-gap-container-block));
+    gap: var(--vaadin-message-gap, var(--vaadin-gap-s) var(--vaadin-gap-s));
   }
 
   :host([hidden]) {

--- a/packages/message-list/src/styles/vaadin-message-base-styles.js
+++ b/packages/message-list/src/styles/vaadin-message-base-styles.js
@@ -10,7 +10,7 @@ export const messageStyles = css`
   :host {
     display: flex;
     flex-direction: row;
-    padding: var(--vaadin-message-padding, var(--vaadin-padding));
+    padding: var(--vaadin-message-padding, var(--vaadin-padding-s));
     gap: var(--vaadin-message-gap, var(--vaadin-gap-container-inline) var(--vaadin-gap-container-block));
   }
 

--- a/packages/notification/src/styles/vaadin-notification-card-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-card-base-styles.js
@@ -16,7 +16,7 @@ export const notificationCardStyles = css`
     box-sizing: border-box;
     width: var(--vaadin-notification-width, 40ch);
     max-width: 100%;
-    padding: var(--vaadin-notification-padding, var(--vaadin-padding));
+    padding: var(--vaadin-notification-padding, var(--vaadin-padding-s));
     background: var(--vaadin-notification-background, var(--vaadin-background-container));
     border: var(--vaadin-notification-border-width, 1px) solid
       var(--vaadin-notification-border-color, var(--vaadin-border-color));

--- a/packages/notification/src/styles/vaadin-notification-container-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-container-base-styles.js
@@ -13,7 +13,7 @@ export const notificationContainerStyles = css`
     /* Space between notifications and the viewport */
     --_padding: var(--vaadin-notification-viewport-inset, var(--vaadin-padding-s));
     /* Space between notifications */
-    --_gap: var(--vaadin-notification-gap, var(--vaadin-gap-container-block));
+    --_gap: var(--vaadin-notification-gap, var(--vaadin-gap-s));
     display: grid;
     /* top-stretch, top and bottom regions, bottom-stretch */
     grid-template-rows: auto 1fr auto;

--- a/packages/notification/src/styles/vaadin-notification-container-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-container-base-styles.js
@@ -11,7 +11,7 @@ export const notificationContainerStyles = css`
     /* How much space to reserve for overlay box shadow, to prevent clipping it with overflow:auto */
     --_paint-area: 2em;
     /* Space between notifications and the viewport */
-    --_padding: var(--vaadin-notification-viewport-inset, var(--vaadin-padding));
+    --_padding: var(--vaadin-notification-viewport-inset, var(--vaadin-padding-s));
     /* Space between notifications */
     --_gap: var(--vaadin-notification-gap, var(--vaadin-gap-container-block));
     display: grid;

--- a/packages/popover/src/styles/vaadin-popover-overlay-base-styles.js
+++ b/packages/popover/src/styles/vaadin-popover-overlay-base-styles.js
@@ -46,7 +46,7 @@ const popoverOverlay = css`
     overscroll-behavior: contain;
     box-sizing: border-box;
     max-height: 100%;
-    padding: var(--vaadin-popover-padding, var(--vaadin-padding));
+    padding: var(--vaadin-popover-padding, var(--vaadin-padding-s));
   }
 
   :host([theme~='no-padding']) [part='content'] {

--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
@@ -159,7 +159,7 @@ const toolbar = css`
     display: flex;
     flex-shrink: 0;
     flex-wrap: wrap;
-    gap: var(--vaadin-rich-text-editor-toolbar-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-rich-text-editor-toolbar-gap, var(--vaadin-gap-s));
     padding: var(--vaadin-rich-text-editor-toolbar-padding, var(--vaadin-padding-s));
   }
 

--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
@@ -123,7 +123,7 @@ export const content = css`
   blockquote {
     border-inline-start: 4px solid var(--vaadin-border-color);
     margin: var(--vaadin-padding-container);
-    padding-inline-start: var(--vaadin-padding);
+    padding-inline-start: var(--vaadin-padding-s);
   }
 
   code,
@@ -134,7 +134,7 @@ export const content = css`
 
   pre {
     white-space: pre-wrap;
-    margin-block: var(--vaadin-padding);
+    margin-block: var(--vaadin-padding-s);
     padding: var(--vaadin-padding-container);
   }
 
@@ -160,7 +160,7 @@ const toolbar = css`
     flex-shrink: 0;
     flex-wrap: wrap;
     gap: var(--vaadin-rich-text-editor-toolbar-gap, var(--vaadin-gap-container-inline));
-    padding: var(--vaadin-rich-text-editor-toolbar-padding, var(--vaadin-padding));
+    padding: var(--vaadin-rich-text-editor-toolbar-padding, var(--vaadin-padding-s));
   }
 
   [part~='toolbar-group'] {

--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-popup-overlay-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-popup-overlay-base-styles.js
@@ -18,7 +18,7 @@ export const richTextEditorPopupOverlay = css`
 
   [part='content'] {
     display: grid;
-    gap: var(--vaadin-rich-text-editor-overlay-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-rich-text-editor-overlay-gap, var(--vaadin-gap-s));
     grid-template-columns: repeat(7, minmax(0, 1fr));
   }
 

--- a/packages/side-nav/src/styles/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-base-styles.js
@@ -18,7 +18,7 @@ const sideNav = css`
     display: flex;
     align-items: center;
     justify-content: start;
-    gap: var(--vaadin-side-nav-item-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-side-nav-item-gap, var(--vaadin-gap-s));
     padding: var(--vaadin-side-nav-item-padding, var(--vaadin-padding-container));
     font-size: var(--vaadin-side-nav-label-font-size, 0.875em);
     font-weight: var(--vaadin-side-nav-label-font-weight, 500);

--- a/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
@@ -12,7 +12,7 @@ const sideNavItem = css`
     display: flex;
     align-items: center;
     padding: var(--vaadin-side-nav-item-padding, var(--vaadin-padding-container));
-    gap: var(--vaadin-side-nav-item-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-side-nav-item-gap, var(--vaadin-gap-s));
     font-size: var(--vaadin-side-nav-item-font-size, 1em);
     font-weight: var(--vaadin-side-nav-item-font-weight, 500);
     line-height: var(--vaadin-side-nav-item-line-height, inherit);
@@ -90,10 +90,10 @@ const sideNavItem = css`
   [part='content']::before {
     content: '';
     --_hierarchy-indent: calc(var(--_level, 0) * var(--vaadin-side-nav-child-indent, var(--vaadin-icon-size, 1lh)));
-    --_icon-indent: calc(var(--_level, 0) * var(--vaadin-side-nav-item-gap, var(--vaadin-gap-container-inline)));
+    --_icon-indent: calc(var(--_level, 0) * var(--vaadin-side-nav-item-gap, var(--vaadin-gap-s)));
     width: calc(var(--_hierarchy-indent) + var(--_icon-indent));
     flex: none;
-    margin-inline-start: calc(var(--vaadin-side-nav-item-gap, var(--vaadin-gap-container-inline)) * -1);
+    margin-inline-start: calc(var(--vaadin-side-nav-item-gap, var(--vaadin-gap-s)) * -1);
   }
 
   slot[name='children'] {

--- a/packages/side-nav/src/styles/vaadin-side-nav-shared-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-shared-base-styles.js
@@ -10,7 +10,7 @@ export const sharedStyles = css`
   :host {
     display: flex;
     flex-direction: column;
-    gap: var(--vaadin-side-nav-items-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-side-nav-items-gap, var(--vaadin-gap-s));
     cursor: default;
     -webkit-tap-highlight-color: transparent;
   }
@@ -76,7 +76,7 @@ export const sharedStyles = css`
     list-style-type: none;
     display: flex;
     flex-direction: column;
-    gap: var(--vaadin-side-nav-items-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-side-nav-items-gap, var(--vaadin-gap-s));
   }
 
   :focus-visible {

--- a/packages/tabs/src/styles/vaadin-tab-base-styles.js
+++ b/packages/tabs/src/styles/vaadin-tab-base-styles.js
@@ -12,7 +12,7 @@ export const tabStyles = css`
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: var(--vaadin-tab-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-tab-gap, var(--vaadin-gap-s));
     padding: var(--vaadin-tab-padding, var(--vaadin-padding-container));
     cursor: var(--vaadin-clickable-cursor);
     font-size: var(--vaadin-tab-font-size, 1em);

--- a/packages/tabs/src/styles/vaadin-tabs-base-styles.js
+++ b/packages/tabs/src/styles/vaadin-tabs-base-styles.js
@@ -28,7 +28,7 @@ export const tabsStyles = css`
     overscroll-behavior: contain;
     display: flex;
     flex-direction: column;
-    gap: var(--vaadin-tabs-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-tabs-gap, var(--vaadin-gap-s));
   }
 
   :host([orientation='horizontal']) [part='tabs'] {

--- a/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
+++ b/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
@@ -28,7 +28,7 @@ export const tabSheetStyles = [
       display: flex;
       align-items: center;
       gap: var(--vaadin-tabsheet-gap, var(--vaadin-gap-container-inline));
-      padding: var(--vaadin-tabsheet-padding, var(--vaadin-padding));
+      padding: var(--vaadin-tabsheet-padding, var(--vaadin-padding-s));
       box-sizing: border-box;
     }
 
@@ -42,7 +42,7 @@ export const tabSheetStyles = [
       position: relative;
       flex: 1;
       box-sizing: border-box;
-      padding: var(--vaadin-tabsheet-padding, var(--vaadin-padding));
+      padding: var(--vaadin-tabsheet-padding, var(--vaadin-padding-s));
       border-top: var(--vaadin-tabsheet-border-width, 1px) solid transparent;
       margin-top: calc(var(--vaadin-tabsheet-border-width, 1px) * -1);
     }

--- a/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
+++ b/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
@@ -27,7 +27,7 @@ export const tabSheetStyles = [
       position: relative;
       display: flex;
       align-items: center;
-      gap: var(--vaadin-tabsheet-gap, var(--vaadin-gap-container-inline));
+      gap: var(--vaadin-tabsheet-gap, var(--vaadin-gap-s));
       padding: var(--vaadin-tabsheet-padding, var(--vaadin-padding-s));
       box-sizing: border-box;
     }

--- a/packages/upload/src/styles/vaadin-upload-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-base-styles.js
@@ -37,7 +37,7 @@ export const uploadStyles = css`
   [part='primary-buttons'] {
     align-items: center;
     display: flex;
-    gap: var(--vaadin-gap-container-inline);
+    gap: var(--vaadin-gap-s);
   }
 
   [part='drop-label'] {
@@ -46,7 +46,7 @@ export const uploadStyles = css`
     display: flex;
     font-size: var(--vaadin-upload-drop-label-font-size, inherit);
     font-weight: var(--vaadin-upload-drop-label-font-weight, inherit);
-    gap: var(--vaadin-upload-drop-label-gap, var(--vaadin-gap-container-inline));
+    gap: var(--vaadin-upload-drop-label-gap, var(--vaadin-gap-s));
     line-height: var(--vaadin-upload-drop-label-line-height, inherit);
   }
 

--- a/packages/upload/src/styles/vaadin-upload-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-base-styles.js
@@ -17,7 +17,7 @@ export const uploadStyles = css`
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    padding: var(--vaadin-upload-padding, var(--vaadin-padding));
+    padding: var(--vaadin-upload-padding, var(--vaadin-padding-s));
     position: relative;
   }
 

--- a/packages/upload/src/styles/vaadin-upload-file-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-base-styles.js
@@ -12,7 +12,7 @@ export const uploadFileStyles = css`
     display: grid;
     gap: var(--vaadin-upload-file-gap, var(--vaadin-gap-container-block));
     grid-template-columns: var(--vaadin-icon-size, 1lh) minmax(0, 1fr) auto;
-    padding: var(--vaadin-upload-file-padding, var(--vaadin-padding));
+    padding: var(--vaadin-upload-file-padding, var(--vaadin-padding-s));
   }
 
   [hidden] {

--- a/packages/upload/src/styles/vaadin-upload-file-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-base-styles.js
@@ -10,7 +10,7 @@ export const uploadFileStyles = css`
   :host {
     align-items: center;
     display: grid;
-    gap: var(--vaadin-upload-file-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-upload-file-gap, var(--vaadin-gap-s));
     grid-template-columns: var(--vaadin-icon-size, 1lh) minmax(0, 1fr) auto;
     padding: var(--vaadin-upload-file-padding, var(--vaadin-padding-s));
   }

--- a/packages/upload/src/styles/vaadin-upload-file-list-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-list-base-styles.js
@@ -22,7 +22,7 @@ export const uploadFileListStyles = css`
   }
 
   ::slotted(:first-child) {
-    margin-top: var(--vaadin-upload-gap, var(--vaadin-gap-container-block));
+    margin-top: var(--vaadin-upload-gap, var(--vaadin-gap-s));
   }
 
   ::slotted(li:not(:last-of-type)) {

--- a/packages/vertical-layout/src/styles/vaadin-vertical-layout-base-styles.js
+++ b/packages/vertical-layout/src/styles/vaadin-vertical-layout-base-styles.js
@@ -28,7 +28,7 @@ export const baseStyles = css`
   }
 
   :host([theme~='spacing']) {
-    gap: var(--vaadin-vertical-layout-gap, var(--vaadin-gap-container-block));
+    gap: var(--vaadin-vertical-layout-gap, var(--vaadin-gap-s));
   }
 
   :host([theme~='wrap']) {

--- a/packages/vertical-layout/src/styles/vaadin-vertical-layout-base-styles.js
+++ b/packages/vertical-layout/src/styles/vaadin-vertical-layout-base-styles.js
@@ -20,11 +20,11 @@ export const baseStyles = css`
 
   /* Theme variations */
   :host([theme~='margin']) {
-    margin: var(--vaadin-vertical-layout-margin, var(--vaadin-padding));
+    margin: var(--vaadin-vertical-layout-margin, var(--vaadin-padding-s));
   }
 
   :host([theme~='padding']) {
-    padding: var(--vaadin-vertical-layout-margin, var(--vaadin-padding));
+    padding: var(--vaadin-vertical-layout-margin, var(--vaadin-padding-s));
   }
 
   :host([theme~='spacing']) {


### PR DESCRIPTION
The distinction between inline and block direction gaps hasn't proven meaningful, so let’s just use one scale for gap/spacing.

For padding, some components would benefit from larger padding, so let’s add a full scale of them to allow flexibility. Once this is merged, I’m planning on updating some components, at least dialog, to use the new properties.