### PR TITLE
chore: don't use lumo prop for padding on dev page

### DIFF
--- a/dev/card.html
+++ b/dev/card.html
@@ -146,7 +146,7 @@
       }
 
       :where(body) {
-        margin: var(--lumo-space-l);
+        margin: 2rem;
       }
 
       .playground:not(.resize-width),


### PR DESCRIPTION
Lumo isn't always loaded on the dev pages, so this makes the padding work regardless of the theme.