### PR TITLE
chore: remove unused radius-full property

### DIFF
--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -47,7 +47,6 @@ addGlobalThemeStyles(
         --vaadin-radius-s: 3px;
         --vaadin-radius-m: 6px;
         --vaadin-radius-l: 12px;
-        --vaadin-radius-full: 999px;
 
         /* Focus outline */
         --vaadin-focus-ring-width: 2px;


### PR DESCRIPTION
This property isn't used anywhere.