### PR TITLE
refactor: remove resizer-container from confirm-dialog overlay

### DIFF
--- a/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-base-styles.js
+++ b/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-base-styles.js
@@ -34,11 +34,6 @@ const confirmDialogOverlay = css`
   [part='content'] {
     flex: 1;
   }
-
-  /* TODO remove this wrapper element */
-  #resizerContainer {
-    display: contents;
-  }
 `;
 
 export const confirmDialogOverlayStyles = [overlayStyles, dialogOverlayBase, confirmDialogOverlay];

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -50,23 +50,21 @@ class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMi
     return html`
       <div part="backdrop" id="backdrop" ?hidden="${!this.withBackdrop}"></div>
       <div part="overlay" id="overlay" tabindex="0">
-        <section id="resizerContainer" class="resizer-container">
-          <header part="header"><slot name="header"></slot></header>
-          <div part="content" id="content">
-            <div part="message"><slot></slot></div>
+        <header part="header"><slot name="header"></slot></header>
+        <div part="content" id="content">
+          <div part="message"><slot></slot></div>
+        </div>
+        <footer part="footer" role="toolbar">
+          <div part="cancel-button" ?hidden="${!this.cancelButtonVisible}">
+            <slot name="cancel-button"></slot>
           </div>
-          <footer part="footer" role="toolbar">
-            <div part="cancel-button" ?hidden="${!this.cancelButtonVisible}">
-              <slot name="cancel-button"></slot>
-            </div>
-            <div part="reject-button" ?hidden="${!this.rejectButtonVisible}">
-              <slot name="reject-button"></slot>
-            </div>
-            <div part="confirm-button">
-              <slot name="confirm-button"></slot>
-            </div>
-          </footer>
-        </section>
+          <div part="reject-button" ?hidden="${!this.rejectButtonVisible}">
+            <slot name="reject-button"></slot>
+          </div>
+          <div part="confirm-button">
+            <slot name="confirm-button"></slot>
+          </div>
+        </footer>
       </div>
     `;
   }

--- a/packages/vaadin-lumo-styles/src/components/confirm-dialog-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/confirm-dialog-overlay.css
@@ -4,10 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @media lumo_components_confirm-dialog-overlay {
-  #resizerContainer {
-    height: 100%;
-  }
-
   [part='header'] {
     pointer-events: auto;
     margin-inline-start: calc(var(--lumo-space-l) - var(--lumo-space-m));


### PR DESCRIPTION
## Description

This element is a copy-paste from dialog, it shouldn't be needed as confirm-dialog is not resizable.

## Type of change

- Refactor