### PR TITLE
fix: do not throw on closing popover when target is not set

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -987,7 +987,7 @@ class Popover extends PopoverPositionMixin(
     }
 
     // Restore pointer-events set when opening on hover.
-    if (this.modal && this.target.style.pointerEvents) {
+    if (this.modal && this.target && this.target.style.pointerEvents) {
       this.target.style.pointerEvents = '';
     }
 

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -143,6 +143,21 @@ describe('popover', () => {
 
       expect(document.activeElement).to.not.equal(target);
     });
+
+    it('should not throw when target is removed', async () => {
+      popover.modal = true;
+
+      // Clear target
+      popover.target = null;
+      await nextUpdate(popover);
+
+      popover.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      // No error should be thrown
+      popover.opened = false;
+      await oneEvent(popover, 'closed');
+    });
   });
 
   describe('for', () => {


### PR DESCRIPTION
## Description

Added missing check for `this.target` to avoid following error:

```
      TypeError: Cannot read properties of null (reading 'style')
        at Popover.__onOverlayClosed (packages/popover/src/vaadin-popover.js:990:35)
        at EventPart.handleEvent (node_modules/lit-html/src/lit-html.ts:2105:28)
```

## Type of change

- Bugfix