### PR TITLE
test: add missing snapshot tests to popover

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -987,7 +987,7 @@ class Popover extends PopoverPositionMixin(
     }
 
     // Restore pointer-events set when opening on hover.
-    if (this.modal && this.target.style.pointerEvents) {
+    if (this.modal && this.target && this.target.style.pointerEvents) {
       this.target.style.pointerEvents = '';
     }
 

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -143,6 +143,21 @@ describe('popover', () => {
 
       expect(document.activeElement).to.not.equal(target);
     });
+
+    it('should not throw when target is removed', async () => {
+      popover.modal = true;
+
+      // Clear target
+      popover.target = null;
+      await nextUpdate(popover);
+
+      popover.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      // No error should be thrown
+      popover.opened = false;
+      await oneEvent(popover, 'closed');
+    });
   });
 
   describe('for', () => {

--- a/packages/popover/test/dom/__snapshots__/popover.test.snap.js
+++ b/packages/popover/test/dom/__snapshots__/popover.test.snap.js
@@ -1,0 +1,111 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-popover host"] = 
+`<vaadin-popover
+  id="vaadin-popover-0"
+  modeless=""
+  role="dialog"
+>
+  content
+</vaadin-popover>
+`;
+/* end snapshot vaadin-popover host */
+
+snapshots["vaadin-popover shadow"] = 
+`<vaadin-popover-overlay
+  exportparts="backdrop, overlay, content, arrow"
+  id="overlay"
+  modeless=""
+  no-vertical-overlap=""
+  opened=""
+  popover="manual"
+  position="bottom"
+>
+  <slot>
+  </slot>
+</vaadin-popover-overlay>
+`;
+/* end snapshot vaadin-popover shadow */
+
+snapshots["vaadin-popover modal"] = 
+`<vaadin-popover-overlay
+  exportparts="backdrop, overlay, content, arrow"
+  id="overlay"
+  no-vertical-overlap=""
+  opened=""
+  popover="manual"
+  position="bottom"
+>
+  <slot>
+  </slot>
+</vaadin-popover-overlay>
+`;
+/* end snapshot vaadin-popover modal */
+
+snapshots["vaadin-popover theme"] = 
+`<vaadin-popover-overlay
+  exportparts="backdrop, overlay, content, arrow"
+  id="overlay"
+  modeless=""
+  no-vertical-overlap=""
+  opened=""
+  popover="manual"
+  position="bottom"
+  theme="arrow"
+>
+  <slot>
+  </slot>
+</vaadin-popover-overlay>
+`;
+/* end snapshot vaadin-popover theme */
+
+snapshots["vaadin-popover overlay"] = 
+`<div
+  hidden=""
+  id="backdrop"
+  part="backdrop"
+>
+</div>
+<div
+  id="overlay"
+  part="overlay"
+  tabindex="0"
+>
+  <div part="arrow">
+  </div>
+  <div
+    id="content"
+    part="content"
+  >
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-popover overlay */
+
+snapshots["vaadin-popover backdrop"] = 
+`<div
+  id="backdrop"
+  part="backdrop"
+>
+</div>
+<div
+  id="overlay"
+  part="overlay"
+  tabindex="0"
+>
+  <div part="arrow">
+  </div>
+  <div
+    id="content"
+    part="content"
+  >
+    <slot>
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-popover backdrop */
+

--- a/packages/popover/test/dom/popover.test.js
+++ b/packages/popover/test/dom/popover.test.js
@@ -1,0 +1,51 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import '../../src/vaadin-popover.js';
+
+describe('vaadin-popover', () => {
+  let popover, overlay;
+
+  const SNAPSHOT_CONFIG = {
+    // Some inline CSS styles related to the overlay's position
+    // may slightly change depending on the environment, so ignore them.
+    ignoreAttributes: ['style'],
+  };
+
+  beforeEach(async () => {
+    popover = fixtureSync('<vaadin-popover>content</vaadin-popover>');
+    await nextRender();
+    overlay = popover.$.overlay;
+    popover.opened = true;
+    await oneEvent(overlay, 'vaadin-overlay-open');
+  });
+
+  it('host', async () => {
+    await expect(popover).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('shadow', async () => {
+    await expect(popover).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('modal', async () => {
+    popover.modal = true;
+    await nextUpdate(popover);
+    await expect(popover).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('theme', async () => {
+    popover.setAttribute('theme', 'arrow');
+    await nextUpdate(popover);
+    await expect(popover).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('overlay', async () => {
+    await expect(overlay).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+
+  it('backdrop', async () => {
+    popover.withBackdrop = true;
+    await nextUpdate(popover);
+    await expect(overlay).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
+});


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/9942

Added snapshot tests to `vaadin-popover`.

## Type of change

- Test