### PR TITLE
refactor: remove not needed dashboard-button min-width

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
@@ -12,10 +12,6 @@ import { css } from 'lit';
 import { buttonStyles } from '@vaadin/button/src/styles/vaadin-button-base-styles.js';
 
 const dashboardButton = css`
-  :host {
-    min-width: 1em;
-  }
-
   :host([theme~='tertiary']) {
     color: var(--vaadin-dashboard-button-text-color, var(--vaadin-color-subtle));
   }


### PR DESCRIPTION
## Description

This CSS was added in https://github.com/vaadin/web-components/pull/9563 as a workaround to make tests pass with old core styles, where empty button could have 0 width by default. This is no longer an issue with new base styles so let's remove min-width.

## Type of change

- Refactor