### PR TITLE
refactor!: rename getIndexLevel to getRowLevel to accept a row

### DIFF
--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -182,6 +182,12 @@ export const DataProviderMixin = (superClass) =>
     }
 
     /** @private */
+    __getRowLevel(row) {
+      const { level } = this._dataProviderController.getFlatIndexContext(row.index);
+      return level;
+    }
+
+    /** @private */
     __getRowItem(row) {
       const { item } = this._dataProviderController.getFlatIndexContext(row.index);
       return item;
@@ -252,16 +258,6 @@ export const DataProviderMixin = (superClass) =>
       if (this._isExpanded(item)) {
         this.expandedItems = this.expandedItems.filter((i) => !this._itemsEqual(i, item));
       }
-    }
-
-    /**
-     * @param {number} index
-     * @return {number}
-     * @protected
-     */
-    _getIndexLevel(index = 0) {
-      const { level } = this._dataProviderController.getFlatIndexContext(index);
-      return level;
     }
 
     /** @protected */

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -840,7 +840,7 @@ export const GridMixin = (superClass) =>
       return {
         index: row.index,
         item: row._item,
-        level: this._getIndexLevel(row.index),
+        level: this.__getRowLevel(row),
         expanded: this._isExpanded(row._item),
         selected: this._isSelected(row._item),
         detailsOpened: !!this.rowDetailsRenderer && this._isDetailsOpened(row._item),


### PR DESCRIPTION
## Description

The PR renames `_getIndexLevel` to `__getRowLevel` and updates it to accept a row instead of an index. This will make it easier to override this method in Flow's connector.

I'm marking this as a breaking change since it also changes the visibility of this method.

Part of https://github.com/vaadin/flow-components/issues/7685

## Type of change

- [x] Refactor
