### PR TITLE
fix: avoid stretching form items when layout is stretched

### DIFF
--- a/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
+++ b/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
@@ -87,6 +87,7 @@ export const formLayoutStyles = css`
     */
     grid-auto-columns: 0;
 
+    align-self: start;
     grid-template-columns: repeat(auto-fill, var(--_grid-repeat));
     place-items: baseline start;
 


### PR DESCRIPTION
When setting an explicit height on a form layout, the CSS grid cells stretch to fill the height. This change avoids that, and keeps the form items at the start/top of the layout.