### PR TITLE
docs: improve code examples in charts JSDoc annotations

### DIFF
--- a/packages/charts/src/vaadin-chart-series.d.ts
+++ b/packages/charts/src/vaadin-chart-series.d.ts
@@ -19,15 +19,15 @@ export * from './vaadin-chart-series-mixin.js';
  * To use `<vaadin-chart-series>`, add it inside a `<vaadin-chart>` element:
  *
  * ```html
- *  <vaadin-chart>
- *    <vaadin-chart-series></vaadin-chart-series>
- *  </vaadin-chart>
+ * <vaadin-chart>
+ *   <vaadin-chart-series></vaadin-chart-series>
+ * </vaadin-chart>
  * ```
  *
  * `<vaadin-chart-series>` accepts `values` as an array attribute, so you can add it to your element definition:
  *
  * ```html
- *  <vaadin-chart-series values="[10,20,30,40,50]"></vaadin-chart-series>
+ * <vaadin-chart-series values="[10, 20, 30, 40, 50]"></vaadin-chart-series>
  * ```
  *
  * which will add a new line series, where each value will be a data point.
@@ -40,18 +40,18 @@ export * from './vaadin-chart-series-mixin.js';
  * To create a new series, call `document.createElement('vaadin-chart-series')` and append it to your `<vaadin-chart>`:
  *
  * ```js
- *  const chart = \* a <vaadin-chart> reference *\
- *  const newSeries = document.createElement('vaadin-chart-series');
- *  newSeries.values = [10,20,30,40,50];
- *  chart.appendChild(newSeries);
+ * const chart = document.querySelector('vaadin-chart');
+ * const newSeries = document.createElement('vaadin-chart-series');
+ * newSeries.values = [10, 20, 30, 40, 50];
+ * chart.appendChild(newSeries);
  * ```
  *
  * In order to remove it, you should use the series to be removed as a reference for the `#removeChild()` call:
  *
  * ```js
- *  const chart = \* a <vaadin-chart> reference *\
- *  const seriesToBeRemoved = \* a <vaadin-chart-series> reference to remove*\
- *  chart.removeChild(seriesToBeRemoved);
+ * const chart = document.querySelector('vaadin-chart');
+ * const seriesToBeRemoved = chart.querySelector('vaadin-chart-series');
+ * chart.removeChild(seriesToBeRemoved);
  * ```
  */
 declare class ChartSeries extends ChartSeriesMixin(HTMLElement) {}

--- a/packages/charts/src/vaadin-chart-series.js
+++ b/packages/charts/src/vaadin-chart-series.js
@@ -21,15 +21,15 @@ import { ChartSeriesMixin } from './vaadin-chart-series-mixin.js';
  * To use `<vaadin-chart-series>`, add it inside a `<vaadin-chart>` element:
  *
  * ```html
- *  <vaadin-chart>
- *    <vaadin-chart-series></vaadin-chart-series>
- *  </vaadin-chart>
+ * <vaadin-chart>
+ *   <vaadin-chart-series></vaadin-chart-series>
+ * </vaadin-chart>
  * ```
  *
  * `<vaadin-chart-series>` accepts `values` as an array attribute, so you can add it to your element definition:
  *
  * ```html
- *  <vaadin-chart-series values="[10,20,30,40,50]"></vaadin-chart-series>
+ * <vaadin-chart-series values="[10, 20, 30, 40, 50]"></vaadin-chart-series>
  * ```
  *
  * which will add a new line series, where each value will be a data point.
@@ -42,18 +42,18 @@ import { ChartSeriesMixin } from './vaadin-chart-series-mixin.js';
  * To create a new series, call `document.createElement('vaadin-chart-series')` and append it to your `<vaadin-chart>`:
  *
  * ```js
- *  const chart = \* a <vaadin-chart> reference *\
- *  const newSeries = document.createElement('vaadin-chart-series');
- *  newSeries.values = [10,20,30,40,50];
- *  chart.appendChild(newSeries);
+ * const chart = document.querySelector('vaadin-chart');
+ * const newSeries = document.createElement('vaadin-chart-series');
+ * newSeries.values = [10, 20, 30, 40, 50];
+ * chart.appendChild(newSeries);
  * ```
  *
  * In order to remove it, you should use the series to be removed as a reference for the `#removeChild()` call:
  *
  * ```js
- *  const chart = \* a <vaadin-chart> reference *\
- *  const seriesToBeRemoved = \* a <vaadin-chart-series> reference to remove*\
- *  chart.removeChild(seriesToBeRemoved);
+ * const chart = document.querySelector('vaadin-chart');
+ * const seriesToBeRemoved = chart.querySelector('vaadin-chart-series');
+ * chart.removeChild(seriesToBeRemoved);
  * ```
  *
  * @customElement

--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -21,89 +21,67 @@ export * from './vaadin-chart-mixin.js';
  * There are two ways of configuring your `<vaadin-chart>` element: **HTML API**, **JS API** and **JSON API**.
  * Note that you can make use of all APIs in your element.
  *
- * #### Configuring your chart using HTML API
+ * #### Using HTML API
  *
  * `vaadin-chart` has a set of attributes to make it easier for you to customize your chart.
  *
  * ```html
- *  <vaadin-chart title="The chart title" subtitle="The chart subtitle">
- *    <vaadin-chart-series
- *          type="column"
- *          title="The series title"
- *          values="[10,20,30]">
- *    </vaadin-chart-series>
- *  </vaadin-chart>
+ * <vaadin-chart title="The chart title" subtitle="The chart subtitle">
+ *   <vaadin-chart-series
+ *     type="column"
+ *     title="The series title"
+ *     values="[10, 20, 30]"
+ *   ></vaadin-chart-series>
+ * </vaadin-chart>
  * ```
  *
  * > Note that while you can set type for each series individually, for some types, such as `'bar'`, `'gauge'` and `'solidgauge'`, you
  * > have to set it as the default series type on `<vaadin-chart>` in order to work properly.
  *
- * #### Configuring your chart using JS API
+ * #### Using JS API
  *
- * 1. Set an id for the `<vaadin-chart>` in the template
- * ```html
- *     <vaadin-chart id="mychart"></vaadin-chart>
- * ```
- * 1. Add a function that uses `configuration` property (JS Api) to set chart title, categories and data
+ * Use [`configuration`](#/elements/vaadin-chart#property-configuration) property to set chart title, categories and data:
+ *
  * ```js
- * initChartWithJSApi() {
- *     requestAnimationFrame(() => {
- *        const configuration = this.$.mychart.configuration;
- *        configuration.setTitle({ text: 'The chart title' });
- *        // By default there is one X axis, it is referenced by configuration.xAxis[0].
- *        configuration.xAxis[0].setCategories(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
- *        configuration.addSeries({
- *            type: 'column',
- *            data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
- *        });
- *     });
- * }
+ * const chart = document.querySelector('vaadin-chart');
+ *
+ * // Wait for default configuration to be ready
+ * requestAnimationFrame(() => {
+ *   const configuration = chart.configuration;
+ *   configuration.setTitle({ text: 'The chart title' });
+ *   // By default there is one X axis, it is referenced by configuration.xAxis[0].
+ *   configuration.xAxis[0].setCategories(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
+ *   configuration.addSeries({
+ *     type: 'column',
+ *     data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+ *   });
+ * });
  * ```
- * 1. Call that function from connectedCallback (when the element is added to a document)
+ *
+ * #### Using JS JSON API
+ *
+ * Use [`updateConfiguration`](#/elements/vaadin-chart#method-updateConfiguration) method to set chart title, categories and data:
+ *
  * ```js
- * connectedCallback() {
- *     super.connectedCallback();
- *     this.initChartWithJSApi();
- * }
+ * const chart = document.querySelector('vaadin-chart');
+ * chart.updateConfiguration({
+ *   title: {
+ *     text: 'The chart title'
+ *   },
+ *   subtitle: {
+ *     text: 'Subtitle'
+ *   },
+ *   xAxis: {
+ *     categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+ *   },
+ *   series: [{
+ *     type: 'column',
+ *     data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+ *   }]
+ * });
  * ```
  *
- * #### Configuring your chart using JS JSON API
- *
- * JS JSON API is a simple alternative to the JS API.
- *
- * 1. Set an id for the `<vaadin-chart>` in the template
- * ```html
- *     <vaadin-chart id="mychart"></vaadin-chart>
- * ```
- * 1. Add a function that uses `updateConfiguration` method (JS JSON Api) to set chart title, categories and data
- * ```js
- * initChartWithJSJSONApi() {
- *     this.$.mychart.updateConfiguration({
- *       title: {
- *         text: 'The chart title'
- *       },
- *       subtitle: {
- *         text: 'Subtitle'
- *       },
- *       xAxis: {
- *         categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
- *       },
- *       series: [{
- *         type: 'column',
- *         data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
- *       }]
- *     });
- * }
- * ```
- * 1. Call that function from connectedCallback (when the element is added to a document)
- * ```js
- * connectedCallback() {
- *     super.connectedCallback();
- *     this.initChartWithJSJSONApi();
- * }
- * ```
- *
- * It should be noted that chart style customization cannot be done via the JS or JSON API.
+ * **Note:** chart style customization cannot be done via the JS or JSON API.
  * Styling properties in the JSON configuration will be ignored. The following section discusses chart styling.
  *
  * ### CSS Styling

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -26,89 +26,67 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  * There are two ways of configuring your `<vaadin-chart>` element: **HTML API**, **JS API** and **JSON API**.
  * Note that you can make use of all APIs in your element.
  *
- * #### Configuring your chart using HTML API
+ * #### Using HTML API
  *
  * `vaadin-chart` has a set of attributes to make it easier for you to customize your chart.
  *
  * ```html
- *  <vaadin-chart title="The chart title" subtitle="The chart subtitle">
- *    <vaadin-chart-series
- *          type="column"
- *          title="The series title"
- *          values="[10,20,30]">
- *    </vaadin-chart-series>
- *  </vaadin-chart>
+ * <vaadin-chart title="The chart title" subtitle="The chart subtitle">
+ *   <vaadin-chart-series
+ *     type="column"
+ *     title="The series title"
+ *     values="[10, 20, 30]"
+ *   ></vaadin-chart-series>
+ * </vaadin-chart>
  * ```
  *
  * > Note that while you can set type for each series individually, for some types, such as `'bar'`, `'gauge'` and `'solidgauge'`, you
  * > have to set it as the default series type on `<vaadin-chart>` in order to work properly.
  *
- * #### Configuring your chart using JS API
+ * #### Using JS API
  *
- * 1. Set an id for the `<vaadin-chart>` in the template
- * ```html
- *     <vaadin-chart id="mychart"></vaadin-chart>
- * ```
- * 1. Add a function that uses `configuration` property (JS Api) to set chart title, categories and data
+ * Use [`configuration`](#/elements/vaadin-chart#property-configuration) property to set chart title, categories and data:
+ *
  * ```js
- * initChartWithJSApi() {
- *     requestAnimationFrame(() => {
- *        const configuration = this.$.mychart.configuration;
- *        configuration.setTitle({ text: 'The chart title' });
- *        // By default there is one X axis, it is referenced by configuration.xAxis[0].
- *        configuration.xAxis[0].setCategories(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
- *        configuration.addSeries({
- *            type: 'column',
- *            data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
- *        });
- *     });
- * }
+ * const chart = document.querySelector('vaadin-chart');
+ *
+ * // Wait for default configuration to be ready
+ * requestAnimationFrame(() => {
+ *   const configuration = chart.configuration;
+ *   configuration.setTitle({ text: 'The chart title' });
+ *   // By default there is one X axis, it is referenced by configuration.xAxis[0].
+ *   configuration.xAxis[0].setCategories(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
+ *   configuration.addSeries({
+ *     type: 'column',
+ *     data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+ *   });
+ * });
  * ```
- * 1. Call that function from connectedCallback (when the element is added to a document)
+ *
+ * #### Using JS JSON API
+ *
+ * Use [`updateConfiguration`](#/elements/vaadin-chart#method-updateConfiguration) method to set chart title, categories and data:
+ *
  * ```js
- * connectedCallback() {
- *     super.connectedCallback();
- *     this.initChartWithJSApi();
- * }
+ * const chart = document.querySelector('vaadin-chart');
+ * chart.updateConfiguration({
+ *   title: {
+ *     text: 'The chart title'
+ *   },
+ *   subtitle: {
+ *     text: 'Subtitle'
+ *   },
+ *   xAxis: {
+ *     categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+ *   },
+ *   series: [{
+ *     type: 'column',
+ *     data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+ *   }]
+ * });
  * ```
  *
- * #### Configuring your chart using JS JSON API
- *
- * JS JSON API is a simple alternative to the JS API.
- *
- * 1. Set an id for the `<vaadin-chart>` in the template
- * ```html
- *     <vaadin-chart id="mychart"></vaadin-chart>
- * ```
- * 1. Add a function that uses `updateConfiguration` method (JS JSON Api) to set chart title, categories and data
- * ```js
- * initChartWithJSJSONApi() {
- *     this.$.mychart.updateConfiguration({
- *       title: {
- *         text: 'The chart title'
- *       },
- *       subtitle: {
- *         text: 'Subtitle'
- *       },
- *       xAxis: {
- *         categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
- *       },
- *       series: [{
- *         type: 'column',
- *         data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
- *       }]
- *     });
- * }
- * ```
- * 1. Call that function from connectedCallback (when the element is added to a document)
- * ```js
- * connectedCallback() {
- *     super.connectedCallback();
- *     this.initChartWithJSJSONApi();
- * }
- * ```
- *
- * It should be noted that chart style customization cannot be done via the JS or JSON API.
+ * **Note:** chart style customization cannot be done via the JS or JSON API.
  * Styling properties in the JSON configuration will be ignored. The following section discusses chart styling.
  *
  * ### CSS Styling


### PR DESCRIPTION
## Description

- Fixed indentation in `vaadin-chart` and `vaadin-chart-series` JSDoc to align with other components
- Removed mentions of `this.$.mychart` and `connectedCallback()` as those assume using Polymer
- Simplified headings so that they would look nicer in the "table of contents" of new static API docs

## Type of change

- Documentation