### PR TITLE
fix: reflect popover opened property to attribute

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -311,6 +311,7 @@ class Popover extends PopoverPositionMixin(
         type: Boolean,
         value: false,
         notify: true,
+        reflectToAttribute: true,
         observer: '__openedChanged',
       },
 

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -32,6 +32,16 @@ describe('popover', () => {
     it('should set display: contents on the host element by default', () => {
       expect(getComputedStyle(popover).display).to.equal('contents');
     });
+
+    it('should reflect opened property to attribute', async () => {
+      popover.opened = true;
+      await nextUpdate(popover);
+      expect(popover.hasAttribute('opened')).to.be.true;
+
+      popover.opened = false;
+      await nextUpdate(popover);
+      expect(popover.hasAttribute('opened')).to.be.false;
+    });
   });
 
   describe('renderer', () => {

--- a/packages/popover/test/dom/__snapshots__/popover.test.snap.js
+++ b/packages/popover/test/dom/__snapshots__/popover.test.snap.js
@@ -5,6 +5,7 @@ snapshots["vaadin-popover host"] =
 `<vaadin-popover
   id="vaadin-popover-0"
   modeless=""
+  opened=""
   role="dialog"
 >
   content


### PR DESCRIPTION
## Description

Aligned `vaadin-popover` with other overlay components like `vaadin-dialog` to set `opened` as attribute.

## Type of change

- Bugfix