### PR TITLE
refactor: reflect opened attribute in tooltip

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
@@ -68,8 +68,9 @@ export declare class TooltipMixinClass {
   manual: boolean;
 
   /**
-   * When true, the tooltip is opened programmatically.
-   * Only works if `manual` is set to `true`.
+   * When true, the tooltip is opened.
+   * In manual mode, this can be set programmatically.
+   * In automatic mode, this is set automatically by internal logic.
    */
   opened: boolean;
 

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -76,7 +76,7 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(
         id="overlay"
         .owner="${this}"
         theme="${ifDefined(this._theme)}"
-        .opened="${this._isConnected && (this.manual ? this.opened : this._autoOpened)}"
+        .opened="${this._isConnected && this.opened}"
         .positionTarget="${this.target}"
         .position="${effectivePosition}"
         ?no-horizontal-overlap="${this.__computeNoHorizontalOverlap(effectivePosition)}"

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -282,13 +282,14 @@ describe('vaadin-tooltip', () => {
 
       it('should still target correct element after sorting the items differently', async () => {
         const container = fixtureSync('<div></div>');
+
         function renderTooltips(items) {
           render(
             html`
               ${items.map(
                 (item) => html`
                   <vaadin-tooltip for="${item}"></vaadin-tooltip>
-                  <div id=${item}></div>
+                  <div id="${item}"></div>
                 `,
               )}
             `,
@@ -581,6 +582,18 @@ describe('vaadin-tooltip', () => {
 
       expect(overlay.opened).to.be.false;
     });
+
+    it('should reflect opened attribute', async () => {
+      mouseenter(target);
+      await nextUpdate(tooltip);
+      expect(tooltip.hasAttribute('opened')).to.be.true;
+      expect(overlay.opened).to.be.true;
+
+      mouseleave(target);
+      await nextUpdate(tooltip);
+      expect(tooltip.hasAttribute('opened')).to.be.false;
+      expect(overlay.opened).to.be.false;
+    });
   });
 
   describe('inside a scrollable container', () => {
@@ -864,6 +877,16 @@ describe('vaadin-tooltip', () => {
       await nextRender();
 
       expect(overlay.opened).to.be.true;
+    });
+
+    it('should reflect opened attribute', async () => {
+      tooltip.opened = true;
+      await nextUpdate(tooltip);
+      expect(tooltip.hasAttribute('opened')).to.be.true;
+
+      tooltip.opened = false;
+      await nextUpdate(tooltip);
+      expect(tooltip.hasAttribute('opened')).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

Reflect the `opened` property to an attribute and uses the `opened` property for both auto and manual mode . Internally this refactors tooltip to remove the `_autoOpened` property which kept track on whether the tooltip was opened automatically. Instead logic now uses the `opened` and `manual` states.

Fixes https://github.com/vaadin/web-components/issues/9779

## Type of change

- Refactor