### PR TITLE
fix: do not reopen popover when clicking target

### DIFF
--- a/packages/popover/src/vaadin-popover-overlay-mixin.js
+++ b/packages/popover/src/vaadin-popover-overlay-mixin.js
@@ -72,18 +72,4 @@ export const PopoverOverlayMixin = (superClass) =>
         this.style.top = `${overlayRect.top + offset}px`;
       }
     }
-
-    /**
-     * Override method from `OverlayMixin` to prevent closing when clicking on target.
-     * Clicking the target will already close the popover when using the click trigger.
-     *
-     * @override
-     * @protected
-     */
-    _shouldCloseOnOutsideClick(event) {
-      if (event.composedPath().includes(this.positionTarget)) {
-        return false;
-      }
-      return super._shouldCloseOnOutsideClick(event);
-    }
   };

--- a/packages/popover/src/vaadin-popover-overlay-mixin.js
+++ b/packages/popover/src/vaadin-popover-overlay-mixin.js
@@ -72,4 +72,18 @@ export const PopoverOverlayMixin = (superClass) =>
         this.style.top = `${overlayRect.top + offset}px`;
       }
     }
+
+    /**
+     * Override method from `OverlayMixin` to prevent closing when clicking on target.
+     * Clicking the target will already close the popover when using the click trigger.
+     *
+     * @override
+     * @protected
+     */
+    _shouldCloseOnOutsideClick(event) {
+      if (event.composedPath().includes(this.positionTarget)) {
+        return false;
+      }
+      return super._shouldCloseOnOutsideClick(event);
+    }
   };

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -86,6 +86,20 @@ class PopoverOverlay extends PopoverOverlayMixin(
   _shouldAddGlobalListeners() {
     return true;
   }
+
+  /**
+   * Override method from `OverlayMixin` to prevent closing when clicking on target.
+   * Clicking the target will already close the popover when using the click trigger.
+   *
+   * @override
+   * @protected
+   */
+  _shouldCloseOnOutsideClick(event) {
+    if (event.composedPath().includes(this.positionTarget)) {
+      return false;
+    }
+    return super._shouldCloseOnOutsideClick(event);
+  }
 }
 
 defineCustomElement(PopoverOverlay);

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -264,6 +264,7 @@ describe('popover', () => {
       target.click();
       await nextRender();
       expect(overlay.opened).to.be.false;
+      expect(popover.opened).to.be.false;
     });
 
     it('should close overlay on outside click by default', async () => {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { esc, fixtureSync, nextRender, nextUpdate, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-popover.js';
@@ -10,6 +11,10 @@ describe('popover', () => {
     popover = fixtureSync('<vaadin-popover></vaadin-popover>');
     await nextRender();
     overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
+  });
+
+  afterEach(async () => {
+    await resetMouse();
   });
 
   describe('custom element definition', () => {
@@ -261,10 +266,12 @@ describe('popover', () => {
       target.click();
       await oneEvent(overlay, 'vaadin-overlay-open');
 
-      target.click();
+      // Use browser command here to test for possible side effects between the outside click listener and the
+      // target opened toggle behavior. Using browser commands for opening the popover doesn't work consistently as
+      // the opened event might fire before the click promise resolves.
+      await sendMouseToElement({ type: 'click', element: target });
       await nextRender();
       expect(overlay.opened).to.be.false;
-      expect(popover.opened).to.be.false;
     });
 
     it('should close overlay on outside click by default', async () => {

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -13,10 +13,6 @@ describe('popover', () => {
     overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
   });
 
-  afterEach(async () => {
-    await resetMouse();
-  });
-
   describe('custom element definition', () => {
     let tagName;
 
@@ -254,6 +250,10 @@ describe('popover', () => {
       target = fixtureSync('<button>Target</button>');
       popover.target = target;
       await nextUpdate(popover);
+    });
+
+    afterEach(async () => {
+      await resetMouse();
     });
 
     it('should open overlay on target click by default', async () => {


### PR DESCRIPTION
## Description

Addresses a regression from https://github.com/vaadin/web-components/pull/9972

When clicking on the target when the popover is opened, it currently closes due to the outside click, and then reopens immediately as clicking the target also toggles the opened state. This excludes the target from the outside click handling, which should be how it was before with the custom global click handler in popover: https://github.com/vaadin/web-components/pull/9972/files#diff-1171ae48b99c01700dcc87f053aefeeeef342b9c9a12ad3c731a1dccf9188f5dL663-L673

## Type of change

- Bugfix
