### PR TITLE
refactor: set aria-modal and tabindex on the confirm-dialog

### DIFF
--- a/dev/confirm-dialog.html
+++ b/dev/confirm-dialog.html
@@ -13,8 +13,11 @@
     </script>
   </head>
   <body>
-    <vaadin-button class="short">Short Message</vaadin-button>
-    <vaadin-button class="long">Long Message</vaadin-button>
+    <section>
+      <h3>Examples</h3>
+      <vaadin-button class="short">Short Message</vaadin-button>
+      <vaadin-button class="long">Long Message</vaadin-button>
+    </section>
 
     <vaadin-confirm-dialog class="short" header="Save Changes" confirm-text="Save" cancel-button-visible>
       Save or not?

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -246,6 +246,7 @@ export const ConfirmDialogMixin = (superClass) =>
       super.ready();
 
       this.role = 'alertdialog';
+      this.setAttribute('aria-modal', 'true');
 
       this._headerController = new SlotController(this, 'header', 'h3', {
         initializer: (node) => {

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -247,6 +247,7 @@ export const ConfirmDialogMixin = (superClass) =>
 
       this.role = 'alertdialog';
       this.setAttribute('aria-modal', 'true');
+      this.setAttribute('tabindex', '0');
 
       this._headerController = new SlotController(this, 'header', 'h3', {
         initializer: (node) => {

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -49,7 +49,7 @@ class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMi
   render() {
     return html`
       <div part="backdrop" id="backdrop" ?hidden="${!this.withBackdrop}"></div>
-      <div part="overlay" id="overlay" tabindex="0">
+      <div part="overlay" id="overlay">
         <header part="header"><slot name="header"></slot></header>
         <div part="content" id="content">
           <div part="message"><slot></slot></div>
@@ -96,6 +96,15 @@ class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMi
    * @override
    */
   get _modalRoot() {
+    return this.owner;
+  }
+
+  /**
+   * Override method from OverlayFocusMixin to use owner as focus trap root
+   * @protected
+   * @override
+   */
+  get _focusTrapRoot() {
     return this.owner;
   }
 }

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -107,6 +107,15 @@ class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMi
   get _focusTrapRoot() {
     return this.owner;
   }
+
+  /**
+   * Override method from OverlayFocusMixin to not set `aria-hidden`
+   * @protected
+   * @override
+   */
+  get _useAriaHidden() {
+    return false;
+  }
 }
 
 defineCustomElement(ConfirmDialogOverlay);

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -83,6 +83,10 @@ class ConfirmDialog extends ConfirmDialogMixin(ElementMixin(ThemePropertyMixin(P
       :host([hidden]) {
         display: none !important;
       }
+
+      :host(:focus) ::part(overlay) {
+        outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+      }
     `;
   }
 

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -75,7 +75,8 @@ class ConfirmDialog extends ConfirmDialogMixin(ElementMixin(ThemePropertyMixin(P
       :host([opened]),
       :host([opening]),
       :host([closing]) {
-        display: contents !important;
+        display: block !important;
+        position: absolute;
       }
 
       :host,

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -36,9 +36,9 @@ describe('vaadin-confirm-dialog', () => {
     });
 
     ['opened', 'opening', 'closing'].forEach((state) => {
-      it(`should use display: contents when ${state} attribute is set`, () => {
+      it(`should use display: block when ${state} attribute is set`, () => {
         confirm.setAttribute(state, '');
-        expect(getComputedStyle(confirm).display).to.equal('contents');
+        expect(getComputedStyle(confirm).display).to.equal('block');
       });
     });
 

--- a/packages/confirm-dialog/test/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/confirm-dialog.test.js
@@ -44,6 +44,7 @@ describe('vaadin-confirm-dialog', () => {
 
     it('should use display: none when hidden while opened', async () => {
       confirm.opened = true;
+      await oneEvent(confirm.$.overlay, 'vaadin-overlay-open');
       confirm.hidden = true;
       await nextRender();
       expect(getComputedStyle(confirm).display).to.equal('none');

--- a/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
+++ b/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
@@ -5,6 +5,7 @@ snapshots["vaadin-confirm-dialog host"] =
 `<vaadin-confirm-dialog
   aria-description="Do you want to save or discard the changes?"
   aria-label="Unsaved changes"
+  aria-modal="true"
   header="Unsaved changes"
   opened=""
   role="alertdialog"

--- a/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
+++ b/packages/confirm-dialog/test/dom/__snapshots__/confirm-dialog.test.snap.js
@@ -9,6 +9,7 @@ snapshots["vaadin-confirm-dialog host"] =
   header="Unsaved changes"
   opened=""
   role="alertdialog"
+  tabindex="0"
   with-backdrop=""
 >
   Do you want to save or discard the changes?
@@ -132,7 +133,6 @@ snapshots["vaadin-confirm-dialog overlay"] =
 <div
   id="overlay"
   part="overlay"
-  tabindex="0"
 >
   <header part="header">
     <slot name="header">

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -9,6 +9,7 @@ snapshots["vaadin-crud host default"] =
   <vaadin-confirm-dialog
     aria-description="There are unsaved changes to this item."
     aria-label="Discard changes"
+    aria-modal="true"
     cancel-button-visible=""
     confirm-theme="primary"
     role="alertdialog"
@@ -50,6 +51,7 @@ snapshots["vaadin-crud host default"] =
   <vaadin-confirm-dialog
     aria-description="Are you sure you want to delete this item? This action cannot be undone."
     aria-label="Delete item"
+    aria-modal="true"
     cancel-button-visible=""
     confirm-theme="primary error"
     role="alertdialog"

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -14,6 +14,7 @@ snapshots["vaadin-crud host default"] =
     confirm-theme="primary"
     role="alertdialog"
     slot="confirm-cancel"
+    tabindex="0"
     with-backdrop=""
   >
     <h3 slot="header">
@@ -56,6 +57,7 @@ snapshots["vaadin-crud host default"] =
     confirm-theme="primary error"
     role="alertdialog"
     slot="confirm-delete"
+    tabindex="0"
     with-backdrop=""
   >
     <h3 slot="header">

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -90,13 +90,24 @@ export const OverlayFocusMixin = (superClass) =>
     }
 
     /**
+     * Override not use a controller for setting `aria-hidden` on
+     * elements outside the overlay, e.g. when using `aria-modal`.
+     * @protected
+     */
+    _useAriaHidden() {
+      return true;
+    }
+
+    /**
      * Release focus and restore focus after the overlay is closed.
      *
      * @protected
      */
     _resetFocus() {
       if (this.focusTrap) {
-        this.__ariaModalController.close();
+        if (this._useAriaHidden) {
+          this.__ariaModalController.close();
+        }
         this.__focusTrapController.releaseFocus();
       }
 
@@ -124,7 +135,9 @@ export const OverlayFocusMixin = (superClass) =>
      */
     _trapFocus() {
       if (this.focusTrap) {
-        this.__ariaModalController.showModal();
+        if (this._useAriaHidden) {
+          this.__ariaModalController.showModal();
+        }
         this.__focusTrapController.trapFocus(this._focusTrapRoot);
       }
     }

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -81,6 +81,15 @@ export const OverlayFocusMixin = (superClass) =>
     }
 
     /**
+     * Override to specify another element used as a focus trap root,
+     * e.g. the overlay's owner element, rather than overlay part.
+     * @protected
+     */
+    get _focusTrapRoot() {
+      return this.$.overlay;
+    }
+
+    /**
      * Release focus and restore focus after the overlay is closed.
      *
      * @protected
@@ -116,7 +125,7 @@ export const OverlayFocusMixin = (superClass) =>
     _trapFocus() {
       if (this.focusTrap) {
         this.__ariaModalController.showModal();
-        this.__focusTrapController.trapFocus(this.$.overlay);
+        this.__focusTrapController.trapFocus(this._focusTrapRoot);
       }
     }
 

--- a/packages/rich-text-editor/test/dom/__snapshots__/rich-text-editor.test.snap.js
+++ b/packages/rich-text-editor/test/dom/__snapshots__/rich-text-editor.test.snap.js
@@ -11,6 +11,7 @@ snapshots["vaadin-rich-text-editor host"] =
     reject-theme="error"
     role="alertdialog"
     slot="link-dialog"
+    tabindex="0"
     with-backdrop=""
   >
     <vaadin-text-field style="width: 100%;">

--- a/packages/rich-text-editor/test/dom/__snapshots__/rich-text-editor.test.snap.js
+++ b/packages/rich-text-editor/test/dom/__snapshots__/rich-text-editor.test.snap.js
@@ -6,6 +6,7 @@ snapshots["vaadin-rich-text-editor host"] =
   <vaadin-confirm-dialog
     aria-description=""
     aria-label="Link address"
+    aria-modal="true"
     cancel-button-visible=""
     reject-theme="error"
     role="alertdialog"


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/9759

- Added `aria-modal="true"` on the `vaadin-confirm-dialog` host element
- Changed from `display: contents` to `display: block` for Safari VoiceOver
- Moved `tabindex="0"` from the overlay part to the confirm-dialog itself

Both `display: contents` and `tabindex` change are needed to make sure Safari VoiceOver web rotor doesn't list elements outside the dialog, which happened especially when focus was on the `overlay` part in shadow DOM.

## Type of change

- Refactor