### PR TITLE
docs: deprecate popover renderer property and Lit directive

### DIFF
--- a/packages/popover/src/lit/renderer-directives.d.ts
+++ b/packages/popover/src/lit/renderer-directives.d.ts
@@ -51,6 +51,7 @@ export class PopoverRendererDirective extends LitRendererDirective<Popover, Popo
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add content elements as children of the popover using default slot
  */
 export declare function popoverRenderer(
   renderer: PopoverLitRenderer,

--- a/packages/popover/src/lit/renderer-directives.js
+++ b/packages/popover/src/lit/renderer-directives.js
@@ -56,5 +56,6 @@ export class PopoverRendererDirective extends LitRendererDirective {
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add content elements as children of the popover using default slot
  */
 export const popoverRenderer = directive(PopoverRendererDirective);

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -170,6 +170,8 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
    *
    * - `root` The root container DOM element. Append your content to it.
    * - `popover` The reference to the `vaadin-popover` element (overlay host).
+   *
+   * @deprecated Add content elements as children of the popover using default slot
    */
   renderer: PopoverRenderer | null | undefined;
 
@@ -231,6 +233,8 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
    * While performing the update, it invokes the renderer passed in the `renderer` property.
    *
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   *
+   * @deprecated Add content elements as children of the popover using default slot
    */
   requestContentUpdate(): void;
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -340,6 +340,8 @@ class Popover extends PopoverPositionMixin(
        *
        * - `root` The root container DOM element. Append your content to it.
        * - `popover` The reference to the `vaadin-popover` element (overlay host).
+       *
+       * @deprecated Use the content in the `vaadin-popover` via default slot
        */
       renderer: {
         type: Object,
@@ -515,6 +517,8 @@ class Popover extends PopoverPositionMixin(
    * While performing the update, it invokes the renderer passed in the `renderer` property.
    *
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   *
+   * @deprecated Add content elements as children of the popover using default slot
    */
   requestContentUpdate() {
     if (!this.renderer || !this._overlayElement) {


### PR DESCRIPTION
## Description

In V25 users can pass content to `vaadin-popover` using default slot, so let's deprecate `renderer`.

## Type of change

- Docs