### PR TITLE
refactor: prefix DataProviderController's private methods with #

### DIFF
--- a/packages/component-base/src/data-provider-controller/cache.js
+++ b/packages/component-base/src/data-provider-controller/cache.js
@@ -48,7 +48,7 @@ export class Cache {
    * @type {Record<number, Cache>}
    * @private
    */
-  __subCacheByIndex = {};
+  #subCacheByIndex = {};
 
   /**
    * The number of items.
@@ -56,7 +56,7 @@ export class Cache {
    * @type {number}
    * @private
    */
-  __size = 0;
+  #size = 0;
 
   /**
    * The total number of items, including items from expanded sub-caches.
@@ -64,7 +64,7 @@ export class Cache {
    * @type {number}
    * @private
    */
-  __flatSize = 0;
+  #flatSize = 0;
 
   /**
    * @param {Cache['context']} context
@@ -79,7 +79,7 @@ export class Cache {
     this.size = size;
     this.parentCache = parentCache;
     this.parentCacheIndex = parentCacheIndex;
-    this.__flatSize = size || 0;
+    this.#flatSize = size || 0;
   }
 
   /**
@@ -98,7 +98,7 @@ export class Cache {
    * @return {Cache[]}
    */
   get subCaches() {
-    return Object.values(this.__subCacheByIndex);
+    return Object.values(this.#subCacheByIndex);
   }
 
   /**
@@ -120,7 +120,7 @@ export class Cache {
    * @return {number}
    */
   get flatSize() {
-    return this.__flatSize;
+    return this.#flatSize;
   }
 
   /**
@@ -129,7 +129,7 @@ export class Cache {
    * @return {number}
    */
   get size() {
-    return this.__size;
+    return this.#size;
   }
 
   /**
@@ -138,12 +138,12 @@ export class Cache {
    * @param {number} size
    */
   set size(size) {
-    const oldSize = this.__size;
+    const oldSize = this.#size;
     if (oldSize === size) {
       return;
     }
 
-    this.__size = size;
+    this.#size = size;
 
     if (this.context.placeholder !== undefined) {
       this.items.length = size || 0;
@@ -164,7 +164,7 @@ export class Cache {
    * Recalculates the flattened size for the cache and its descendant caches recursively.
    */
   recalculateFlatSize() {
-    this.__flatSize =
+    this.#flatSize =
       !this.parentItem || this.context.isExpanded(this.parentItem)
         ? this.size +
           this.subCaches.reduce((total, subCache) => {
@@ -199,7 +199,7 @@ export class Cache {
    * @return {Cache | undefined}
    */
   getSubCache(index) {
-    return this.__subCacheByIndex[index];
+    return this.#subCacheByIndex[index];
   }
 
   /**
@@ -209,14 +209,14 @@ export class Cache {
    * @param {number} index
    */
   removeSubCache(index) {
-    delete this.__subCacheByIndex[index];
+    delete this.#subCacheByIndex[index];
   }
 
   /**
    * Removes all sub-caches.
    */
   removeSubCaches() {
-    this.__subCacheByIndex = {};
+    this.#subCacheByIndex = {};
   }
 
   /**
@@ -228,7 +228,7 @@ export class Cache {
    */
   createSubCache(index) {
     const subCache = new Cache(this.context, this.pageSize, 0, this, index);
-    this.__subCacheByIndex[index] = subCache;
+    this.#subCacheByIndex[index] = subCache;
     return subCache;
   }
 

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.js
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.js
@@ -85,7 +85,7 @@ export class DataProviderController extends EventTarget {
     this.isPlaceholder = isPlaceholder;
     this.dataProvider = dataProvider;
     this.dataProviderParams = dataProviderParams;
-    this.rootCache = this.__createRootCache(size);
+    this.rootCache = this.#createRootCache(size);
   }
 
   /**
@@ -96,7 +96,7 @@ export class DataProviderController extends EventTarget {
   }
 
   /** @private */
-  get __cacheContext() {
+  get #cacheContext() {
     return {
       isExpanded: this.isExpanded,
       placeholder: this.placeholder,
@@ -143,7 +143,7 @@ export class DataProviderController extends EventTarget {
    * Clears the cache.
    */
   clearCache() {
-    this.rootCache = this.__createRootCache(this.rootCache.size);
+    this.rootCache = this.#createRootCache(this.rootCache.size);
   }
 
   /**
@@ -198,8 +198,8 @@ export class DataProviderController extends EventTarget {
   ensureFlatIndexLoaded(flatIndex) {
     const { cache, page, item } = this.getFlatIndexContext(flatIndex);
 
-    if (!this.__isItemLoaded(item)) {
-      this.__loadCachePage(cache, page);
+    if (!this.#isItemLoaded(item)) {
+      this.#loadCachePage(cache, page);
     }
   }
 
@@ -213,9 +213,9 @@ export class DataProviderController extends EventTarget {
   ensureFlatIndexHierarchy(flatIndex) {
     const { cache, item, index } = this.getFlatIndexContext(flatIndex);
 
-    if (this.__isItemLoaded(item) && this.isExpanded(item) && !cache.getSubCache(index)) {
+    if (this.#isItemLoaded(item) && this.isExpanded(item) && !cache.getSubCache(index)) {
       const subCache = cache.createSubCache(index);
-      this.__loadCachePage(subCache, 0);
+      this.#loadCachePage(subCache, 0);
     }
   }
 
@@ -223,16 +223,16 @@ export class DataProviderController extends EventTarget {
    * Loads the first page into the root cache.
    */
   loadFirstPage() {
-    this.__loadCachePage(this.rootCache, 0);
+    this.#loadCachePage(this.rootCache, 0);
   }
 
   /** @private */
-  __createRootCache(size) {
-    return new Cache(this.__cacheContext, this.pageSize, size);
+  #createRootCache(size) {
+    return new Cache(this.#cacheContext, this.pageSize, size);
   }
 
   /** @private */
-  __loadCachePage(cache, page) {
+  #loadCachePage(cache, page) {
     if (!this.dataProvider || cache.pendingRequests[page]) {
       return;
     }
@@ -277,7 +277,7 @@ export class DataProviderController extends EventTarget {
   }
 
   /** @private */
-  __isItemLoaded(item) {
+  #isItemLoaded(item) {
     if (this.isPlaceholder) {
       return !this.isPlaceholder(item);
     } else if (this.placeholder) {


### PR DESCRIPTION
## Description

Makes DataProviderController's private methods truly private by prefixing them with `#`.

## Type of change

- [x] Refactor
