### PR TITLE
docs: update popover JSDoc to reduce mentions of the overlay

### DIFF
--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -152,12 +152,12 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   hoverDelay: number;
 
   /**
-   * True if the popover overlay is opened, false otherwise.
+   * True if the popover is opened, false otherwise.
    */
   opened: boolean;
 
   /**
-   * The `role` attribute value to be set on the overlay.
+   * The `role` attribute value to be set on the popover.
    *
    * @attr {string} overlay-role
    * @deprecated Use standard `role` attribute on the popover instead
@@ -165,7 +165,7 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   overlayRole: string;
 
   /**
-   * Custom function for rendering the content of the overlay.
+   * Custom function for rendering the content of the popover.
    * Receives two arguments:
    *
    * - `root` The root container DOM element. Append your content to it.
@@ -183,32 +183,29 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   modal: boolean;
 
   /**
-   * Set to true to disable closing popover overlay on outside click.
+   * Set to true to disable closing popover on outside click.
    *
    * @attr {boolean} no-close-on-outside-click
    */
   noCloseOnOutsideClick: boolean;
 
   /**
-   * Set to true to disable closing popover overlay on Escape press.
-   * When the popover is modal, pressing Escape anywhere in the
-   * document closes the overlay. Otherwise, only Escape press
-   * from the popover itself or its target closes the overlay.
+   * Set to true to disable closing popover on Escape press.
    *
    * @attr {boolean} no-close-on-esc
    */
   noCloseOnEsc: boolean;
 
   /**
-   * Popover trigger mode, used to configure how the overlay is opened or closed.
+   * Popover trigger mode, used to configure how the popover is opened or closed.
    * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
    *
    * Supported values:
    * - `click` (default) - opens and closes on target click.
    * - `hover` - opens on target mouseenter, closes on target mouseleave. Moving mouse
-   * to the popover overlay content keeps the overlay opened.
+   * to the popover content keeps the popover opened.
    * - `focus` - opens on target focus, closes on target blur. Moving focus to the
-   * popover overlay content keeps the overlay opened.
+   * popover content keeps the popover opened.
    *
    * In addition to the behavior specified by `trigger`, the popover can be closed by:
    * - pressing Escape key (unless `noCloseOnEsc` property is true)
@@ -221,7 +218,7 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   trigger: PopoverTrigger[] | null | undefined;
 
   /**
-   * When true, the overlay has a backdrop (modality curtain) on top of the
+   * When true, the popover has a backdrop (modality curtain) on top of the
    * underlying page content, covering the whole viewport.
    *
    * @attr {boolean} with-backdrop

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -172,7 +172,6 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
    * - `popover` The reference to the `vaadin-popover` element.
    *
    * @deprecated Add content elements as children of the popover using default slot
-   * - `popover` The reference to the `vaadin-popover` element.
    */
   renderer: PopoverRenderer | null | undefined;
 

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -109,13 +109,13 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   autofocus: boolean;
 
   /**
-   * Set the height of the overlay.
+   * Set the height of the popover.
    * If a unitless number is provided, pixels are assumed.
    */
   height: string | null;
 
   /**
-   * Set the width of the overlay.
+   * Set the width of the popover.
    * If a unitless number is provided, pixels are assumed.
    */
   width: string | null;
@@ -169,16 +169,17 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
    * Receives two arguments:
    *
    * - `root` The root container DOM element. Append your content to it.
-   * - `popover` The reference to the `vaadin-popover` element (overlay host).
+   * - `popover` The reference to the `vaadin-popover` element.
    *
    * @deprecated Add content elements as children of the popover using default slot
+   * - `popover` The reference to the `vaadin-popover` element.
    */
   renderer: PopoverRenderer | null | undefined;
 
   /**
    * When true, the popover prevents interacting with background elements
    * by setting `pointer-events` style on the document body to `none`.
-   * This also enables trapping focus inside the overlay.
+   * This also enables trapping focus inside the popover.
    */
   modal: boolean;
 

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -152,7 +152,7 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   hoverDelay: number;
 
   /**
-   * True if the popover is opened, false otherwise.
+   * True if the popover is visible and available for interaction.
    */
   opened: boolean;
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -305,7 +305,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * True if the popover overlay is opened, false otherwise.
+       * True if the popover is opened, false otherwise.
        */
       opened: {
         type: Boolean,
@@ -325,7 +325,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * The `role` attribute value to be set on the overlay.
+       * The `role` attribute value to be set on the popover.
        *
        * @attr {string} overlay-role
        * @deprecated Use standard `role` attribute on the popover instead
@@ -335,7 +335,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Custom function for rendering the content of the overlay.
+       * Custom function for rendering the content of the popover.
        * Receives two arguments:
        *
        * - `root` The root container DOM element. Append your content to it.
@@ -358,7 +358,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Set to true to disable closing popover overlay on outside click.
+       * Set to true to disable closing popover on outside click.
        *
        * @attr {boolean} no-close-on-outside-click
        */
@@ -368,10 +368,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Set to true to disable closing popover overlay on Escape press.
-       * When the popover is modal, pressing Escape anywhere in the
-       * document closes the overlay. Otherwise, only Escape press
-       * from the popover itself or its target closes the overlay.
+       * Set to true to disable closing popover on Escape press.
        *
        * @attr {boolean} no-close-on-esc
        */
@@ -381,15 +378,15 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Popover trigger mode, used to configure how the overlay is opened or closed.
+       * Popover trigger mode, used to configure how the popover is opened or closed.
        * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
        *
        * Supported values:
        * - `click` (default) - opens and closes on target click.
        * - `hover` - opens on target mouseenter, closes on target mouseleave. Moving mouse
-       * to the popover overlay content keeps the overlay opened.
+       * to the popover content keeps the popover opened.
        * - `focus` - opens on target focus, closes on target blur. Moving focus to the
-       * popover overlay content keeps the overlay opened.
+       * popover content keeps the popover opened.
        *
        * In addition to the behavior specified by `trigger`, the popover can be closed by:
        * - pressing Escape key (unless `noCloseOnEsc` property is true)
@@ -405,7 +402,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * When true, the overlay has a backdrop (modality curtain) on top of the
+       * When true, the popover has a backdrop (modality curtain) on top of the
        * underlying page content, covering the whole viewport.
        *
        * @attr {boolean} with-backdrop

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -252,7 +252,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Set the height of the overlay.
+       * Set the height of the popover.
        * If a unitless number is provided, pixels are assumed.
        */
       height: {
@@ -260,7 +260,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * Set the width of the overlay.
+       * Set the width of the popover.
        * If a unitless number is provided, pixels are assumed.
        */
       width: {
@@ -339,9 +339,10 @@ class Popover extends PopoverPositionMixin(
        * Receives two arguments:
        *
        * - `root` The root container DOM element. Append your content to it.
-       * - `popover` The reference to the `vaadin-popover` element (overlay host).
+       * - `popover` The reference to the `vaadin-popover` element.
        *
        * @deprecated Use the content in the `vaadin-popover` via default slot
+       * - `popover` The reference to the `vaadin-popover` element.
        */
       renderer: {
         type: Object,
@@ -350,7 +351,7 @@ class Popover extends PopoverPositionMixin(
       /**
        * When true, the popover prevents interacting with background elements
        * by setting `pointer-events` style on the document body to `none`.
-       * This also enables trapping focus inside the overlay.
+       * This also enables trapping focus inside the popover.
        */
       modal: {
         type: Boolean,

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -342,7 +342,6 @@ class Popover extends PopoverPositionMixin(
        * - `popover` The reference to the `vaadin-popover` element.
        *
        * @deprecated Use the content in the `vaadin-popover` via default slot
-       * - `popover` The reference to the `vaadin-popover` element.
        */
       renderer: {
         type: Object,

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -305,7 +305,7 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
-       * True if the popover is opened, false otherwise.
+       * True if the popover is visible and available for interaction.
        */
       opened: {
         type: Boolean,


### PR DESCRIPTION
## Description

Replaced some mentions of the `overlay` with the `popover` as the overlay is more of implementation detail in V25.
Also updated JSDoc for `noCloseOnEsc` to match the new behavior after changing to global listener in  https://github.com/vaadin/web-components/pull/9972.

## Type of change

- Documentation