### PR TITLE
docs: fix incorrect JSDoc annotation in combo-box-scroller-mixin

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.d.ts
@@ -45,8 +45,7 @@ export declare class ComboBoxScrollerMixinClass<TItem, TOwner> {
   owner: TOwner;
 
   /**
-   * Set true to prevent the overlay from opening automatically.
-   * @attr {boolean} auto-open-disabled
+   * Function used to render the content of every combo-box item.
    */
   renderer: ComboBoxItemRenderer<TItem, TOwner> | null | undefined;
 


### PR DESCRIPTION
## Description

Found this one while looking for "overlay" occurrences, seems like a copy-paste mistake.

## Type of change

- Docs