### PR TITLE
feat: add overlay reference to open and close event detail

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -183,7 +183,7 @@ export const OverlayMixin = (superClass) =>
       const event = new CustomEvent('vaadin-overlay-close', {
         bubbles: true,
         cancelable: true,
-        detail: { sourceEvent },
+        detail: { overlay: this, sourceEvent },
       });
       this.dispatchEvent(event);
       // To allow listening for the event globally, also dispatch it on the document body
@@ -347,7 +347,7 @@ export const OverlayMixin = (superClass) =>
 
             // Dispatch the event on the overlay. Not using composed, as propagating the event through shadow roots
             // could have side effects when nesting overlays
-            const event = new CustomEvent('vaadin-overlay-open', { bubbles: true });
+            const event = new CustomEvent('vaadin-overlay-open', { detail: { overlay: this }, bubbles: true });
             this.dispatchEvent(event);
             // To allow listening for the event globally, also dispatch it on the document body
             document.body.dispatchEvent(event);

--- a/packages/overlay/src/vaadin-overlay.d.ts
+++ b/packages/overlay/src/vaadin-overlay.d.ts
@@ -17,13 +17,13 @@ export type OverlayOpenedChangedEvent = CustomEvent<{ value: boolean }>;
 /**
  * Fired after the overlay is opened.
  */
-export type OverlayOpenEvent = CustomEvent;
+export type OverlayOpenEvent = CustomEvent<{ overlay: HTMLElement }>;
 
 /**
  * Fired when the opened overlay is about to be closed.
  * Calling `preventDefault()` on the event cancels the closing.
  */
-export type OverlayCloseEvent = CustomEvent;
+export type OverlayCloseEvent = CustomEvent<{ overlay: HTMLElement }>;
 
 /**
  * Fired after the overlay is closed.

--- a/packages/overlay/test/basic.test.js
+++ b/packages/overlay/test/basic.test.js
@@ -28,6 +28,14 @@ describe('vaadin-overlay', () => {
       expect(spy).to.be.calledOnce;
     });
 
+    it('should provide reference to the overlay in the event detail', async () => {
+      overlay.opened = true;
+      await nextFrame();
+      await aTimeout(0);
+      const event = spy.firstCall.args[0];
+      expect(event.detail.overlay).to.equal(overlay);
+    });
+
     it('should not fire when immediately setting opened property back to false', async () => {
       overlay.opened = true;
       overlay.opened = false;
@@ -61,6 +69,15 @@ describe('vaadin-overlay', () => {
         await nextFrame();
         await aTimeout(0);
         expect(globalSpy).to.be.called;
+        expect(globalSpy.firstCall.args);
+      });
+
+      it('should provide reference to the overlay in the global event detail', async () => {
+        overlay.opened = true;
+        await nextFrame();
+        await aTimeout(0);
+        const event = globalSpy.firstCall.args[0];
+        expect(event.detail.overlay).to.equal(overlay);
       });
     });
   });

--- a/packages/overlay/test/interactions.test.js
+++ b/packages/overlay/test/interactions.test.js
@@ -206,20 +206,30 @@ describe('interactions', () => {
         expect(overlay.opened).to.be.true;
       });
 
+      it('should provide reference to the overlay in the event detail', () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-close', spy);
+        click(parent);
+        const event = spy.firstCall.args[0];
+        expect(event.detail.overlay).to.equal(overlay);
+      });
+
       describe('global', () => {
-        beforeEach(() => {
-          document.addEventListener('vaadin-overlay-close', preventDefaultListener);
-        });
-
-        afterEach(() => {
-          document.removeEventListener('vaadin-overlay-close', preventDefaultListener);
-        });
-
         it('should prevent closing the overlay if the global event was prevented', async () => {
+          document.addEventListener('vaadin-overlay-close', preventDefaultListener, { once: true });
+
           click(parent);
           await aTimeout(1);
 
           expect(overlay.opened).to.be.true;
+        });
+
+        it('should provide reference to the overlay in the global event detail', () => {
+          const globalSpy = sinon.spy();
+          document.addEventListener('vaadin-overlay-close', globalSpy, { once: true });
+          click(parent);
+          const event = globalSpy.firstCall.args[0];
+          expect(event.detail.overlay).to.equal(overlay);
         });
       });
     });


### PR DESCRIPTION
## Description

Updated `vaadin-overlay-open` and `vaadin-overlay-close` events to provide information on which overlay they come from, so that it can be used by Copilot to determine whether to bring itself on top of other overlays or not.

## Type of change

- Feature