### PR TITLE
refactor: use toolbar-button-pressed attribute for button styles

### DIFF
--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
@@ -430,7 +430,7 @@ const toolbar = css`
     z-index: 1;
   }
 
-  [part~='toolbar-button'][on],
+  [part~='toolbar-button-pressed'],
   [part~='toolbar-button'][aria-expanded='true'] {
     --vaadin-rich-text-editor-toolbar-button-background: var(--vaadin-background-container-strong);
   }
@@ -560,11 +560,11 @@ const toolbar = css`
       background: CanvasText;
     }
 
-    [part~='toolbar-button'][on] {
+    [part~='toolbar-button-pressed'] {
       background: Highlight;
     }
 
-    [part~='toolbar-button'][on]::before {
+    [part~='toolbar-button-pressed']::before {
       background: HighlightText;
     }
   }

--- a/packages/vaadin-lumo-styles/src/components/rich-text-editor.css
+++ b/packages/vaadin-lumo-styles/src/components/rich-text-editor.css
@@ -80,7 +80,7 @@
       color 100ms;
   }
 
-  [part~='toolbar-button']:hover {
+  [part~='toolbar-button']:not([part~='toolbar-button-pressed']):hover {
     outline: none;
     background-color: var(--lumo-contrast-5pct);
     color: var(--lumo-contrast-80pct);
@@ -92,7 +92,7 @@
       outline: 1px solid !important;
     }
 
-    [part~='toolbar-button'][on] {
+    [part~='toolbar-button-pressed'] {
       outline: 2px solid;
       outline-offset: -1px;
     }
@@ -256,12 +256,12 @@
     }
   }
 
-  [part~='toolbar-button'][on] {
+  [part~='toolbar-button-pressed'] {
     background-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     color: var(--lumo-primary-contrast-color);
   }
 
-  [part~='toolbar-button']:active {
+  [part~='toolbar-button']:not([part~='toolbar-button-pressed']):active {
     background-color: var(--lumo-contrast-10pct);
     color: var(--lumo-contrast-90pct);
   }


### PR DESCRIPTION
## Description

Let's use the `toolbar-button-pressed` part instead of the internal `on` attribute so it can be removed in V25.
The part name was added in https://github.com/vaadin/web-components/pull/6691 for `::part()` styling, but internal styles were not updated accordingly.

Note, I had to update Lumo `:hover` and `:focus` states due to lower selector specificity.

## Type of change

- Refactor