### PR TITLE
fix: add CSS to make Lumo dialog content overflow work

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
@@ -77,6 +77,7 @@
     min-width: 12em; /* matches the default <vaadin-text-field> width */
     padding: var(--lumo-space-l);
     flex: 1;
+    min-height: 0;
   }
 
   :host([overflow]) [part='content'] {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9992

## Type of change

- Bugfix