### PR TITLE
test: remove indentation test that randomly fails in WebKit

### DIFF
--- a/packages/rich-text-editor/test/a11y.test.js
+++ b/packages/rich-text-editor/test/a11y.test.js
@@ -332,16 +332,6 @@ describe('accessibility', () => {
       expect(rte.htmlValue).to.include(`${'\t'.repeat(7)}Level 7`);
       expect(rte.htmlValue).to.include(`${'\t'.repeat(8)}Level 8`);
     });
-
-    it('should handle nested elements with indentation', () => {
-      rte.value = JSON.stringify([
-        { insert: 'Normal\n' },
-        { insert: 'Indented with ', attributes: { indent: 1 } },
-        { insert: 'nested', attributes: { bold: true, indent: 1 } },
-        { insert: ' content\n', attributes: { indent: 1 } },
-      ]);
-      expect(rte.htmlValue).to.equal('<p>Normal</p><p>\tIndented with <strong>nested</strong> content</p>');
-    });
   });
 
   describe('code block', () => {


### PR DESCRIPTION
## Description

Removed the test that seems flaky and sometimes fails in WebKit:

```
 ❌ accessibility > indent > should handle nested elements with indentation
      AssertionError: expected '<p>Normal</p><p>\tIndented with <stro…' to equal '<p>Normal</p><p>\tIndented with <stro…'
      + expected - actual
      
      -<p>Normal</p><p>	Indented with <strong>nested content</strong></p>
      +<p>Normal</p><p>	Indented with <strong>nested</strong> content</p>
```

Also, it actually uses incorrect setup: in fact, `indent` is only applied at the end when typing:

```
[
    {  insert: 'Indented with ' },
    { attributes: { bold: true },  insert: 'nested'  },
    {  insert: ' content"  },
    {  attributes: { indent: 1 }, insert: '\n' }
]
````

## Type of change

- Test