### PR TITLE
chore: simplify charts dev pages to not use lumo subfolder

### DIFF
--- a/dev/charts/area.html
+++ b/dev/charts/area.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | area</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/arearange.html
+++ b/dev/charts/arearange.html
@@ -13,7 +13,7 @@
         });
     </script>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/areaspline.html
+++ b/dev/charts/areaspline.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | area spline</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/areasplinerange.html
+++ b/dev/charts/areasplinerange.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | area spline range</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/bar.html
+++ b/dev/charts/bar.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | bar</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/boxplot.html
+++ b/dev/charts/boxplot.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | box plot</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/bubble.html
+++ b/dev/charts/bubble.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | bubble</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/bullet.html
+++ b/dev/charts/bullet.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | bullet</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/candlestick.html
+++ b/dev/charts/candlestick.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | candle stick</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/column.html
+++ b/dev/charts/column.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | column</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/columnrange.html
+++ b/dev/charts/columnrange.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | column range</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/errorbar.html
+++ b/dev/charts/errorbar.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | error bar</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/funnel.html
+++ b/dev/charts/funnel.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | funnel</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/gantt.html
+++ b/dev/charts/gantt.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | gantt</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/gauge.html
+++ b/dev/charts/gauge.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | gauge</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/gaugedual.html
+++ b/dev/charts/gaugedual.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | gauge with dual axes</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/heatmap.html
+++ b/dev/charts/heatmap.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | heatmap</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/line.html
+++ b/dev/charts/line.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | line</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/ohlc.html
+++ b/dev/charts/ohlc.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | ohlc</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/organization.html
+++ b/dev/charts/organization.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | organization</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/pie.html
+++ b/dev/charts/pie.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | pie</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/polar.html
+++ b/dev/charts/polar.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | polar</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/polygon.html
+++ b/dev/charts/polygon.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | polygon</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/pyramid.html
+++ b/dev/charts/pyramid.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | pyramid</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/scatter.html
+++ b/dev/charts/scatter.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | scatter</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/solidgauge.html
+++ b/dev/charts/solidgauge.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | solid gauge</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/spiderweb.html
+++ b/dev/charts/spiderweb.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | spiderweb</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/timeline.html
+++ b/dev/charts/timeline.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | timeline</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/treemap.html
+++ b/dev/charts/treemap.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | treemap</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';

--- a/dev/charts/waterfall.html
+++ b/dev/charts/waterfall.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vaadin charts | treemap</title>
     <link rel="stylesheet" href="/packages/vaadin-lumo-styles/lumo.css" />
-    <script type="module" src="../../common.js"></script>
+    <script type="module" src="../common.js"></script>
     <script type="module">
       import '@vaadin/charts';
       import './theme-switcher.js';


### PR DESCRIPTION
## Description

The `charts/lumo` subfolder is pointless now when the dev server config handles theme.

## Type of change

- Internal change