### PR TITLE
fix: do not set aria-hidden attribute on date-picker label

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -911,7 +911,7 @@ export const DatePickerMixin = (subclass) =>
         this._overlayContent.focusDateElement();
       }
 
-      const focusables = this._noInput ? content : [input, content];
+      const focusables = this._noInput ? content : this;
       this.__showOthers = hideOthers(focusables);
     }
 

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -319,16 +319,12 @@ snapshots["vaadin-date-picker host opened default"] =
   top-aligned=""
 >
   <label
-    aria-hidden="true"
-    data-aria-hidden="true"
     for="search-input-vaadin-date-picker-3"
     id="label-vaadin-date-picker-0"
     slot="label"
   >
   </label>
   <div
-    aria-hidden="true"
-    data-aria-hidden="true"
     hidden=""
     id="error-message-vaadin-date-picker-2"
     slot="error-message"


### PR DESCRIPTION
## Description

As we keep `aria-hidden` logic in the date-picker for now, let's update it so that it doesn't set `aria-hidden` on:

- elements in `vaadin-date-picker` light DOM like `<label>`
- elements in `vaadin-date-picker` shadow DOM like `<vaadin-input-container>`
- elements in `vaadin-date-picker-overlay` shadow DOM like `<div id="overlay">`

## Type of change

- Bugfix