### PR TITLE
docs: update state attributes docs to not list part names

### DIFF
--- a/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.d.ts
@@ -58,16 +58,16 @@ export interface CheckboxGroupEventMap extends HTMLElementEventMap, CheckboxGrou
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
- * `readonly`          | Set when the element is readonly          | :host
- * `invalid`           | Set when the element is invalid           | :host
- * `focused`           | Set when the element is focused           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `readonly`          | Set when the element is readonly
+ * `invalid`           | Set when the element is invalid
+ * `focused`           | Set when the element is focused
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -39,16 +39,16 @@ import { CheckboxGroupMixin } from './vaadin-checkbox-group-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
- * `readonly`          | Set when the element is readonly          | :host
- * `invalid`           | Set when the element is invalid           | :host
- * `focused`           | Set when the element is focused           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `readonly`          | Set when the element is readonly
+ * `invalid`           | Set when the element is invalid
+ * `focused`           | Set when the element is focused
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -189,10 +189,10 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  *
  * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
  *
- * Attribute | Description | Part name
- * ----------|-------------|------------
- * `opened`  | Set when the combo box dropdown is open | :host
- * `loading` | Set when new items are expected | :host
+ * Attribute | Description
+ * ----------|----------------------------------------
+ * `opened`  | Set when the combo box dropdown is open
+ * `loading` | Set when new items are expected
  *
  * ### Internal components
  *

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -121,10 +121,10 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  *
  * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
  *
- * Attribute | Description | Part name
- * ----------|-------------|------------
- * `opened`  | Set when the combo box dropdown is open | :host
- * `loading` | Set when new items are expected | :host
+ * Attribute | Description
+ * ----------|----------------------------------------
+ * `opened`  | Set when the combo box dropdown is open
+ * `loading` | Set when new items are expected
  *
  * ### Internal components
  *

--- a/packages/custom-field/src/vaadin-custom-field.d.ts
+++ b/packages/custom-field/src/vaadin-custom-field.d.ts
@@ -67,14 +67,14 @@ export interface CustomFieldEventMap extends HTMLElementEventMap, CustomFieldCus
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `invalid`           | Set when the element is invalid           | :host
- * `focused`           | Set when the element is focused           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|--------------------------------
+ * `invalid`           | Set when the element is invalid
+ * `focused`           | Set when the element is focused
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * You may also manually set `disabled` or `readonly` attribute on this component to make the label
  * part look visually the same as on a `<vaadin-text-field>` when it is disabled or readonly.

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -36,14 +36,14 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `invalid`           | Set when the element is invalid           | :host
- * `focused`           | Set when the element is focused           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|--------------------------------
+ * `invalid`           | Set when the element is invalid
+ * `focused`           | Set when the element is focused
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * You may also manually set `disabled` or `readonly` attribute on this component to make the label
  * part look visually the same as on a `<vaadin-text-field>` when it is disabled or readonly.

--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -69,17 +69,17 @@ export interface DateTimePickerEventMap extends DateTimePickerCustomEventMap, HT
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
- * `focused`           | Set when the element is focused           | :host
- * `focus-ring`        | Set when the element is keyboard focused  | :host
- * `readonly`          | Set when the element is readonly          | :host
- * `invalid`           | Set when the element is invalid           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `focused`           | Set when the element is focused
+ * `focus-ring`        | Set when the element is keyboard focused
+ * `readonly`          | Set when the element is readonly
+ * `invalid`           | Set when the element is invalid
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * ### Internal components
  *

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -41,17 +41,17 @@ import { DateTimePickerMixin } from './vaadin-date-time-picker-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
- * `focused`           | Set when the element is focused           | :host
- * `focus-ring`        | Set when the element is keyboard focused  | :host
- * `readonly`          | Set when the element is readonly          | :host
- * `invalid`           | Set when the element is invalid           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `focused`           | Set when the element is focused
+ * `focus-ring`        | Set when the element is keyboard focused
+ * `readonly`          | Set when the element is readonly
+ * `invalid`           | Set when the element is invalid
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * ### Internal components
  *

--- a/packages/grid/src/vaadin-grid-sorter.d.ts
+++ b/packages/grid/src/vaadin-grid-sorter.d.ts
@@ -41,9 +41,9 @@ export * from './vaadin-grid-sorter-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute    | Description | Part name
- * -------------|-------------|------------
- * `direction` | Sort direction of a sorter | :host
+ * Attribute    | Description
+ * -------------|---------------------------
+ * `direction`  | Sort direction of a sorter
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  * @fires {CustomEvent} sorter-changed - Fired when the `path` or `direction` property changes.

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -44,9 +44,9 @@ import { GridSorterMixin } from './vaadin-grid-sorter-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute    | Description | Part name
- * -------------|-------------|------------
- * `direction` | Sort direction of a sorter | :host
+ * Attribute    | Description
+ * -------------|---------------------------
+ * `direction`  | Sort direction of a sorter
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  * @fires {CustomEvent} sorter-changed - Fired when the `path` or `direction` property changes.

--- a/packages/grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-toggle.d.ts
@@ -44,10 +44,10 @@ export * from './vaadin-grid-tree-toggle-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute    | Description | Part name
- * ---|---|---
- * `expanded` | When present, the toggle is expanded | :host
- * `leaf` | When present, the toggle is not expandable, i. e., the current item is a leaf | :host
+ * Attribute  | Description
+ * -----------|-------------------------------------
+ * `expanded` | When present, the toggle is expanded
+ * `leaf`     | When present, the toggle is not expandable, i. e., the current item is a leaf
  *
  * The following custom CSS properties are available on
  * the `<vaadin-grid-tree-toggle>` element:

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -46,10 +46,10 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute    | Description | Part name
- * ---|---|---
- * `expanded` | When present, the toggle is expanded | :host
- * `leaf` | When present, the toggle is not expandable, i. e., the current item is a leaf | :host
+ * Attribute  | Description
+ * -----------|-------------------------------------
+ * `expanded` | When present, the toggle is expanded
+ * `leaf`     | When present, the toggle is not expandable, i. e., the current item is a leaf
  *
  * The following custom CSS properties are available on
  * the `<vaadin-grid-tree-toggle>` element:

--- a/packages/progress-bar/src/vaadin-progress-bar.d.ts
+++ b/packages/progress-bar/src/vaadin-progress-bar.d.ts
@@ -34,9 +34,9 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute       | Description | Part name
- * ----------------|-------------|------------
- * `indeterminate` | Set to an indeterminate progress bar | :host
+ * Attribute       | Description
+ * ----------------|-------------------------------------
+ * `indeterminate` | Set to an indeterminate progress bar
  */
 declare class ProgressBar extends ProgressMixin(ThemableMixin(ElementMixin(HTMLElement))) {}
 

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -39,9 +39,9 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute       | Description | Part name
- * ----------------|-------------|------------
- * `indeterminate` | Set to an indeterminate progress bar | :host
+ * Attribute       | Description
+ * ----------------|-------------------------------------
+ * `indeterminate` | Set to an indeterminate progress bar
  *
  * @customElement
  * @extends HTMLElement

--- a/packages/radio-group/src/vaadin-radio-group.d.ts
+++ b/packages/radio-group/src/vaadin-radio-group.d.ts
@@ -34,16 +34,16 @@ export * from './vaadin-radio-group-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
- * `readonly`          | Set when the element is readonly          | :host
- * `invalid`           | Set when the element is invalid           | :host
- * `focused`           | Set when the element is focused           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `readonly`          | Set when the element is readonly
+ * `invalid`           | Set when the element is invalid
+ * `focused`           | Set when the element is focused
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -38,16 +38,16 @@ import { RadioGroupMixin } from './vaadin-radio-group-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description                               | Part name
- * --------------------|-------------------------------------------|------------
- * `disabled`          | Set when the element is disabled          | :host
- * `readonly`          | Set when the element is readonly          | :host
- * `invalid`           | Set when the element is invalid           | :host
- * `focused`           | Set when the element is focused           | :host
- * `has-label`         | Set when the element has a label          | :host
- * `has-value`         | Set when the element has a value          | :host
- * `has-helper`        | Set when the element has helper text      | :host
- * `has-error-message` | Set when the element has an error message | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `readonly`          | Set when the element is readonly
+ * `invalid`           | Set when the element is invalid
+ * `focused`           | Set when the element is focused
+ * `has-label`         | Set when the element has a label
+ * `has-value`         | Set when the element has a value
+ * `has-helper`        | Set when the element has helper text
+ * `has-error-message` | Set when the element has an error message
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -16,14 +16,14 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * The following state attributes are available for styling:
  *
- * Attribute  | Description | Part name
- * -----------|-------------|------------
- * `disabled` | Set to a disabled tab | :host
- * `focused` | Set when the element is focused | :host
- * `focus-ring` | Set when the element is keyboard focused | :host
- * `selected` | Set when the tab is selected | :host
- * `active` | Set when mousedown or enter/spacebar pressed | :host
- * `orientation` | Set to `horizontal` or `vertical` depending on the direction of items  | :host
+ * Attribute      | Description | Part name
+ * ---------------|---------------------------------
+ * `disabled`     | Set when the element is disabled
+ * `focused`      | Set when the element is focused
+ * `focus-ring`   | Set when the element is keyboard focused
+ * `selected`     | Set when the tab is selected
+ * `active`       | Set when mousedown or enter/spacebar pressed
+ * `orientation`  | Set to `horizontal` or `vertical` depending on the direction of items
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -22,14 +22,14 @@ import { tabStyles } from './styles/vaadin-tab-base-styles.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute  | Description | Part name
- * -----------|-------------|------------
- * `disabled` | Set to a disabled tab | :host
- * `focused` | Set when the element is focused | :host
- * `focus-ring` | Set when the element is keyboard focused | :host
- * `selected` | Set when the tab is selected | :host
- * `active` | Set when mousedown or enter/spacebar pressed | :host
- * `orientation` | Set to `horizontal` or `vertical` depending on the direction of items  | :host
+ * Attribute      | Description | Part name
+ * ---------------|---------------------------------
+ * `disabled`     | Set when the element is disabled
+ * `focused`      | Set when the element is focused
+ * `focus-ring`   | Set when the element is keyboard focused
+ * `selected`     | Set when the tab is selected
+ * `active`       | Set when mousedown or enter/spacebar pressed
+ * `orientation`  | Set to `horizontal` or `vertical` depending on the direction of items
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/tabs/src/vaadin-tabs.d.ts
+++ b/packages/tabs/src/vaadin-tabs.d.ts
@@ -51,10 +51,10 @@ export interface TabsEventMap extends HTMLElementEventMap, TabsCustomEventMap {}
  *
  * The following state attributes are available for styling:
  *
- * Attribute  | Description | Part name
- * -----------|-------------|------------
- * `orientation` | Tabs disposition, valid values are `horizontal` and `vertical`. | :host
- * `overflow` | It's set to `start`, `end`, none or both. | :host
+ * Attribute      | Description
+ * ---------------|--------------------------------------
+ * `orientation`  | Tabs disposition, valid values are `horizontal` and `vertical`
+ * `overflow`     | It's set to `start`, `end`, none or both.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -37,10 +37,10 @@ import { TabsMixin } from './vaadin-tabs-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute  | Description | Part name
- * -----------|-------------|------------
- * `orientation` | Tabs disposition, valid values are `horizontal` and `vertical`. | :host
- * `overflow` | It's set to `start`, `end`, none or both. | :host
+ * Attribute      | Description
+ * ---------------|--------------------------------------
+ * `orientation`  | Tabs disposition, valid values are `horizontal` and `vertical`
+ * `overflow`     | It's set to `start`, `end`, none or both.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -83,18 +83,18 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description | Part name
- * --------------------|-------------|------------
- * `disabled`          | Set to a disabled text field | :host
- * `has-value`         | Set when the element has a value | :host
- * `has-label`         | Set when the element has a label | :host
- * `has-helper`        | Set when the element has helper text or slot | :host
- * `has-error-message` | Set when the element has an error message | :host
- * `invalid`           | Set when the element is invalid | :host
- * `input-prevented`   | Temporarily set when invalid input is prevented | :host
- * `focused`           | Set when the element is focused | :host
- * `focus-ring`        | Set when the element is keyboard focused | :host
- * `readonly`          | Set to a readonly text field | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `has-value`         | Set when the element has a value
+ * `has-label`         | Set when the element has a label
+ * `has-helper`        | Set when the element has helper text or slot
+ * `has-error-message` | Set when the element has an error message
+ * `invalid`           | Set when the element is invalid
+ * `input-prevented`   | Temporarily set when invalid input is prevented
+ * `focused`           | Set when the element is focused
+ * `focus-ring`        | Set when the element is keyboard focused
+ * `readonly`          | Set when the element is readonly
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -57,18 +57,18 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description | Part name
- * --------------------|-------------|------------
- * `disabled`          | Set to a disabled text field | :host
- * `has-value`         | Set when the element has a value | :host
- * `has-label`         | Set when the element has a label | :host
- * `has-helper`        | Set when the element has helper text or slot | :host
- * `has-error-message` | Set when the element has an error message | :host
- * `invalid`           | Set when the element is invalid | :host
- * `input-prevented`   | Temporarily set when invalid input is prevented | :host
- * `focused`           | Set when the element is focused | :host
- * `focus-ring`        | Set when the element is keyboard focused | :host
- * `readonly`          | Set to a readonly text field | :host
+ * Attribute           | Description
+ * --------------------|---------------------------------
+ * `disabled`          | Set when the element is disabled
+ * `has-value`         | Set when the element has a value
+ * `has-label`         | Set when the element has a label
+ * `has-helper`        | Set when the element has helper text or slot
+ * `has-error-message` | Set when the element has an error message
+ * `invalid`           | Set when the element is invalid
+ * `input-prevented`   | Temporarily set when invalid input is prevented
+ * `focused`           | Set when the element is focused
+ * `focus-ring`        | Set when the element is keyboard focused
+ * `readonly`          | Set when the element is readonly
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Removed "part name" from most of API docs tables for state attributes since these are generally set on the host.
Using `:host` only makes sense for the shadow DOM styling injection and we don't recommend that nowadays.

## Type of change

- Docs