### PR TITLE
test: extend login-overlay snapshots to cover host element

### DIFF
--- a/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-overlay.test.snap.js
@@ -2,126 +2,372 @@
 export const snapshots = {};
 
 snapshots["vaadin-login-overlay host default"] = 
-`<vaadin-login-overlay-wrapper
-  exportparts="backdrop, overlay, content, card, brand, description, form-wrapper"
-  focus-trap=""
-  id="overlay"
+`<vaadin-login-overlay
+  aria-labelledby="title-vaadin-login-overlay-8"
   opened=""
-  popover="manual"
+  role="dialog"
   with-backdrop=""
 >
-  <slot
-    name="title"
+  <form
+    method="POST"
+    slot="form"
+  >
+    <input
+      id="csrf"
+      type="hidden"
+    >
+    <vaadin-text-field
+      autocapitalize="none"
+      autocomplete="username"
+      autocorrect="off"
+      focused=""
+      has-label=""
+      id="vaadinLoginUsername"
+      manual-validation=""
+      name="username"
+      required=""
+      spellcheck="false"
+    >
+      <input
+        aria-labelledby="label-vaadin-text-field-0"
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        id="input-vaadin-text-field-6"
+        name="username"
+        required=""
+        slot="input"
+        type="text"
+      >
+      <label
+        for="input-vaadin-text-field-6"
+        id="label-vaadin-text-field-0"
+        slot="label"
+      >
+        Username
+      </label>
+      <div
+        hidden=""
+        id="error-message-vaadin-text-field-2"
+        slot="error-message"
+      >
+      </div>
+    </vaadin-text-field>
+    <vaadin-password-field
+      autocomplete="current-password"
+      has-label=""
+      id="vaadinLoginPassword"
+      manual-validation=""
+      name="password"
+      required=""
+      spellcheck="false"
+    >
+      <input
+        aria-labelledby="label-vaadin-password-field-3"
+        autocapitalize="off"
+        autocomplete="current-password"
+        id="input-vaadin-password-field-7"
+        name="password"
+        required=""
+        slot="input"
+        type="password"
+      >
+      <label
+        for="input-vaadin-password-field-7"
+        id="label-vaadin-password-field-3"
+        slot="label"
+      >
+        Password
+      </label>
+      <div
+        hidden=""
+        id="error-message-vaadin-password-field-5"
+        slot="error-message"
+      >
+      </div>
+      <vaadin-password-field-button
+        aria-label="Show password"
+        aria-pressed="false"
+        role="button"
+        slot="reveal"
+        tabindex="0"
+      >
+      </vaadin-password-field-button>
+    </vaadin-password-field>
+  </form>
+  <vaadin-button
+    role="button"
+    slot="submit"
+    tabindex="0"
+    theme="primary submit"
+  >
+    Log in
+  </vaadin-button>
+  <vaadin-button
+    role="button"
+    slot="forgot-password"
+    tabindex="0"
+    theme="tertiary small"
+  >
+    Forgot password
+  </vaadin-button>
+  <div
+    aria-level="1"
+    id="title-vaadin-login-overlay-8"
+    role="heading"
     slot="title"
   >
-  </slot>
-  <vaadin-login-form-wrapper
-    aria-labelledby="title"
-    exportparts="error-message, error-message-title, error-message-description, footer"
-    id="form"
-    part="form"
-    role="region"
-  >
-    <div
-      aria-level="2"
-      id="title"
-      part="form-title"
-      role="heading"
-      slot="form-title"
-    >
-      Log in
-    </div>
-    <slot
-      name="form"
-      slot="form"
-    >
-    </slot>
-    <slot
-      name="custom-form-area"
-      slot="custom-form-area"
-    >
-    </slot>
-    <slot
-      name="submit"
-      slot="submit"
-    >
-    </slot>
-    <slot
-      name="forgot-password"
-      slot="forgot-password"
-    >
-    </slot>
-    <slot
-      name="footer"
-      slot="footer"
-    >
-    </slot>
-  </vaadin-login-form-wrapper>
-</vaadin-login-overlay-wrapper>
+    App name
+  </div>
+</vaadin-login-overlay>
 `;
 /* end snapshot vaadin-login-overlay host default */
 
 snapshots["vaadin-login-overlay host i18n"] = 
-`<vaadin-login-overlay-wrapper
-  exportparts="backdrop, overlay, content, card, brand, description, form-wrapper"
-  focus-trap=""
-  id="overlay"
+`<vaadin-login-overlay
+  aria-labelledby="title-vaadin-login-overlay-8"
   opened=""
-  popover="manual"
+  role="dialog"
   with-backdrop=""
 >
-  <slot
-    name="title"
+  <form
+    method="POST"
+    slot="form"
+  >
+    <input
+      id="csrf"
+      type="hidden"
+    >
+    <vaadin-text-field
+      autocapitalize="none"
+      autocomplete="username"
+      autocorrect="off"
+      focused=""
+      has-label=""
+      id="vaadinLoginUsername"
+      manual-validation=""
+      name="username"
+      required=""
+      spellcheck="false"
+    >
+      <input
+        aria-labelledby="label-vaadin-text-field-0"
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        id="input-vaadin-text-field-6"
+        name="username"
+        required=""
+        slot="input"
+        type="text"
+      >
+      <label
+        for="input-vaadin-text-field-6"
+        id="label-vaadin-text-field-0"
+        slot="label"
+      >
+        Käyttäjänimi
+      </label>
+      <div
+        hidden=""
+        id="error-message-vaadin-text-field-2"
+        slot="error-message"
+      >
+      </div>
+    </vaadin-text-field>
+    <vaadin-password-field
+      autocomplete="current-password"
+      has-label=""
+      id="vaadinLoginPassword"
+      manual-validation=""
+      name="password"
+      required=""
+      spellcheck="false"
+    >
+      <input
+        aria-labelledby="label-vaadin-password-field-3"
+        autocapitalize="off"
+        autocomplete="current-password"
+        id="input-vaadin-password-field-7"
+        name="password"
+        required=""
+        slot="input"
+        type="password"
+      >
+      <label
+        for="input-vaadin-password-field-7"
+        id="label-vaadin-password-field-3"
+        slot="label"
+      >
+        Salasana
+      </label>
+      <div
+        hidden=""
+        id="error-message-vaadin-password-field-5"
+        slot="error-message"
+      >
+      </div>
+      <vaadin-password-field-button
+        aria-label="Show password"
+        aria-pressed="false"
+        role="button"
+        slot="reveal"
+        tabindex="0"
+      >
+      </vaadin-password-field-button>
+    </vaadin-password-field>
+  </form>
+  <vaadin-button
+    role="button"
+    slot="submit"
+    tabindex="0"
+    theme="primary submit"
+  >
+    Kirjaudu sisään
+  </vaadin-button>
+  <vaadin-button
+    role="button"
+    slot="forgot-password"
+    tabindex="0"
+    theme="tertiary small"
+  >
+    Unohtuiko salasana?
+  </vaadin-button>
+  <div
+    aria-level="1"
+    id="title-vaadin-login-overlay-8"
+    role="heading"
     slot="title"
   >
-  </slot>
-  <vaadin-login-form-wrapper
-    aria-labelledby="title"
-    exportparts="error-message, error-message-title, error-message-description, footer"
-    id="form"
-    part="form"
-    role="region"
-  >
-    <div
-      aria-level="2"
-      id="title"
-      part="form-title"
-      role="heading"
-      slot="form-title"
-    >
-      Kirjaudu sisään
-    </div>
-    <slot
-      name="form"
-      slot="form"
-    >
-    </slot>
-    <slot
-      name="custom-form-area"
-      slot="custom-form-area"
-    >
-    </slot>
-    <slot
-      name="submit"
-      slot="submit"
-    >
-    </slot>
-    <slot
-      name="forgot-password"
-      slot="forgot-password"
-    >
-    </slot>
-    <slot
-      name="footer"
-      slot="footer"
-    >
-    </slot>
-  </vaadin-login-form-wrapper>
-</vaadin-login-overlay-wrapper>
+    Sovelluksen nimi
+  </div>
+</vaadin-login-overlay>
 `;
 /* end snapshot vaadin-login-overlay host i18n */
 
 snapshots["vaadin-login-overlay host i18n-partial"] = 
+`<vaadin-login-overlay
+  aria-labelledby="title-vaadin-login-overlay-8"
+  opened=""
+  role="dialog"
+  with-backdrop=""
+>
+  <form
+    method="POST"
+    slot="form"
+  >
+    <input
+      id="csrf"
+      type="hidden"
+    >
+    <vaadin-text-field
+      autocapitalize="none"
+      autocomplete="username"
+      autocorrect="off"
+      focused=""
+      has-label=""
+      id="vaadinLoginUsername"
+      manual-validation=""
+      name="username"
+      required=""
+      spellcheck="false"
+    >
+      <input
+        aria-labelledby="label-vaadin-text-field-0"
+        autocapitalize="none"
+        autocomplete="username"
+        autocorrect="off"
+        id="input-vaadin-text-field-6"
+        name="username"
+        required=""
+        slot="input"
+        type="text"
+      >
+      <label
+        for="input-vaadin-text-field-6"
+        id="label-vaadin-text-field-0"
+        slot="label"
+      >
+        Username
+      </label>
+      <div
+        hidden=""
+        id="error-message-vaadin-text-field-2"
+        slot="error-message"
+      >
+      </div>
+    </vaadin-text-field>
+    <vaadin-password-field
+      autocomplete="current-password"
+      has-label=""
+      id="vaadinLoginPassword"
+      manual-validation=""
+      name="password"
+      required=""
+      spellcheck="false"
+    >
+      <input
+        aria-labelledby="label-vaadin-password-field-3"
+        autocapitalize="off"
+        autocomplete="current-password"
+        id="input-vaadin-password-field-7"
+        name="password"
+        required=""
+        slot="input"
+        type="password"
+      >
+      <label
+        for="input-vaadin-password-field-7"
+        id="label-vaadin-password-field-3"
+        slot="label"
+      >
+        Password
+      </label>
+      <div
+        hidden=""
+        id="error-message-vaadin-password-field-5"
+        slot="error-message"
+      >
+      </div>
+      <vaadin-password-field-button
+        aria-label="Show password"
+        aria-pressed="false"
+        role="button"
+        slot="reveal"
+        tabindex="0"
+      >
+      </vaadin-password-field-button>
+    </vaadin-password-field>
+  </form>
+  <vaadin-button
+    role="button"
+    slot="submit"
+    tabindex="0"
+    theme="primary submit"
+  >
+    Log in
+  </vaadin-button>
+  <vaadin-button
+    role="button"
+    slot="forgot-password"
+    tabindex="0"
+    theme="tertiary small"
+  >
+    Custom forgot password
+  </vaadin-button>
+  <div
+    aria-level="1"
+    id="title-vaadin-login-overlay-8"
+    role="heading"
+    slot="title"
+  >
+    App name
+  </div>
+</vaadin-login-overlay>
+`;
+/* end snapshot vaadin-login-overlay host i18n-partial */
+
+snapshots["vaadin-login-overlay shadow default"] = 
 `<vaadin-login-overlay-wrapper
   exportparts="backdrop, overlay, content, card, brand, description, form-wrapper"
   focus-trap=""
@@ -179,9 +425,9 @@ snapshots["vaadin-login-overlay host i18n-partial"] =
   </vaadin-login-form-wrapper>
 </vaadin-login-overlay-wrapper>
 `;
-/* end snapshot vaadin-login-overlay host i18n-partial */
+/* end snapshot vaadin-login-overlay shadow default */
 
-snapshots["vaadin-login-overlay shadow default"] = 
+snapshots["vaadin-login-overlay shadow wrapper"] = 
 `<div
   id="backdrop"
   part="backdrop"
@@ -212,7 +458,7 @@ snapshots["vaadin-login-overlay shadow default"] =
   </div>
 </div>
 `;
-/* end snapshot vaadin-login-overlay shadow default */
+/* end snapshot vaadin-login-overlay shadow wrapper */
 
 snapshots["vaadin-login-overlay shadow i18n"] = 
 `<div

--- a/packages/login/test/dom/login-overlay.test.js
+++ b/packages/login/test/dom/login-overlay.test.js
@@ -34,24 +34,28 @@ describe('vaadin-login-overlay', () => {
 
   describe('host', () => {
     it('default', async () => {
-      await expect(wrapper).dom.to.equalSnapshot();
+      await expect(overlay).dom.to.equalSnapshot();
     });
 
     it('i18n', async () => {
       overlay.i18n = I18N_FINNISH;
       await nextUpdate(overlay);
-      await expect(wrapper).dom.to.equalSnapshot();
+      await expect(overlay).dom.to.equalSnapshot();
     });
 
     it('i18n-partial', async () => {
       overlay.i18n = { form: { forgotPassword: 'Custom forgot password' } };
       await nextUpdate(overlay);
-      await expect(wrapper).dom.to.equalSnapshot();
+      await expect(overlay).dom.to.equalSnapshot();
     });
   });
 
   describe('shadow', () => {
     it('default', async () => {
+      await expect(overlay).shadowDom.to.equalSnapshot();
+    });
+
+    it('wrapper', async () => {
       await expect(wrapper).shadowDom.to.equalSnapshot();
     });
 


### PR DESCRIPTION
## Description

Updated snapshot tests to cover `vaadin-login-overlay` itself and its shadow root after switching to native `popover`.

## Type of change

- Test