### PR TITLE
refactor: deprecate vaadin-cookie-consent

### DIFF
--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -4,6 +4,9 @@ A web component to display a banner for users to give consent to the usage of co
 
 > ℹ️&nbsp; A commercial Vaadin [subscription](https://vaadin.com/pricing) is required to use Cookie Consent in your project.
 
+> [!WARNING]
+> `<vaadin-cookie-consent>` is deprecated and will be removed without a replacement in Vaadin 25.
+
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/cookie-consent)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/cookie-consent)](https://www.npmjs.com/package/@vaadin/cookie-consent)

--- a/packages/cookie-consent/src/vaadin-cookie-consent-mixin.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent-mixin.js
@@ -9,6 +9,7 @@
  * license.
  */
 import 'cookieconsent/build/cookieconsent.min.js';
+import { issueWarning } from '@vaadin/component-base/src/warnings.js';
 
 /**
  * @polymerMixin
@@ -121,6 +122,8 @@ export const CookieConsentMixin = (superClass) =>
         this.cookieName,
         this.position,
       );
+
+      issueWarning('`<vaadin-cookie-consent>` is deprecated and will be removed without a replacement in Vaadin 25.');
     }
 
     /** @protected */

--- a/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.d.ts
@@ -36,6 +36,8 @@ import { CookieConsentMixin } from './vaadin-cookie-consent-mixin.js';
  * `cc-dismiss`    | Dismiss cookie button
  * `cc-btn`        | Dismiss cookie button
  * `cc-link`       | Learn more link element
+ *
+ * @deprecated `<vaadin-cookie-consent>` is deprecated and will be removed without a replacement in Vaadin 25.
  */
 declare class CookieConsent extends CookieConsentMixin(ElementMixin(HTMLElement)) {}
 

--- a/packages/cookie-consent/src/vaadin-cookie-consent.js
+++ b/packages/cookie-consent/src/vaadin-cookie-consent.js
@@ -43,6 +43,7 @@ import { CookieConsentMixin } from './vaadin-cookie-consent-mixin.js';
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes CookieConsentMixin
+ * @deprecated `<vaadin-cookie-consent>` is deprecated and will be removed without a replacement in Vaadin 25.
  */
 class CookieConsent extends CookieConsentMixin(ElementMixin(PolymerElement)) {
   static get template() {


### PR DESCRIPTION
## Description

Deprecates `<vaadin-cookie-consent>` with the intention to remove it in Vaadin 25.

Part of https://github.com/vaadin/web-components/issues/9791

## Type of change

- Refactor