### PR TITLE
fix: hide default outline on confirm-dialog and login-overlay

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -77,6 +77,7 @@ class ConfirmDialog extends ConfirmDialogMixin(ElementMixin(ThemePropertyMixin(P
       :host([closing]) {
         display: block !important;
         position: absolute;
+        outline: none;
       }
 
       :host,

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -73,6 +73,7 @@ class LoginOverlay extends LoginFormMixin(LoginOverlayMixin(ElementMixin(Themabl
       :host([closing]) {
         display: block !important;
         position: absolute;
+        outline: none;
       }
 
       :host,


### PR DESCRIPTION
## Description

Fixed the incorrect outline that appears in Firefox.

## Type of change

- Bugfix