### PR TITLE
test: remove Lit tests for controllers and mixins from 24.9

### DIFF
--- a/packages/a11y-base/test/active-mixin.test.js
+++ b/packages/a11y-base/test/active-mixin.test.js
@@ -1,20 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import {
-  defineLit,
-  definePolymer,
-  fixtureSync,
-  mousedown,
-  mouseup,
-  touchend,
-  touchstart,
-} from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { definePolymer, fixtureSync, mousedown, mouseup, touchend, touchstart } from '@vaadin/testing-helpers';
 import { ActiveMixin } from '../src/active-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('active-mixin', '<slot></slot>', (Base) => class extends ActiveMixin(baseMixin(Base)) {});
+describe('ActiveMixin', () => {
+  const tag = definePolymer('active-mixin', '<slot></slot>', (Base) => class extends ActiveMixin(Base) {});
 
   let element;
 
@@ -121,12 +111,4 @@ const runTests = (defineHelper, baseMixin) => {
     element.parentNode.removeChild(element);
     expect(element.hasAttribute('active')).to.be.false;
   });
-};
-
-describe('ActiveMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ActiveMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/aria-modal-controller.test.js
+++ b/packages/a11y-base/test/aria-modal-controller.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { AriaModalController } from '../src/aria-modal-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('AriaModalController', () => {
   let wrapper, elements, modal, controller;
 
-  const tag = defineHelper('aria-modal', '<slot></slot>', (Base) => class extends baseMixin(Base) {});
+  const tag = definePolymer('aria-modal', '<slot></slot>', (Base) => class extends ControllerMixin(Base) {});
 
   beforeEach(async () => {
     wrapper = fixtureSync(`
@@ -82,12 +81,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('AriaModalController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('AriaModalController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/delegate-focus-mixin.test.js
+++ b/packages/a11y-base/test/delegate-focus-mixin.test.js
@@ -1,21 +1,19 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, focusin, focusout, nextFrame } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, focusin, focusout, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DelegateFocusMixin } from '../src/delegate-focus-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('DelegateFocusMixin', () => {
   let setFocusedSpy;
 
-  const tag = defineHelper(
+  const tag = definePolymer(
     'delegate-focus-mixin',
     `
       <slot name="input"></slot>
       <slot name="suffix"></slot>
     `,
     (Base) =>
-      class extends DelegateFocusMixin(baseMixin(Base)) {
+      class extends DelegateFocusMixin(Base) {
         ready() {
           super.ready();
           const input = this.querySelector('input');
@@ -306,12 +304,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('DelegateFocusMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('DelegateFocusMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/disabled-mixin.test.js
+++ b/packages/a11y-base/test/disabled-mixin.test.js
@@ -1,16 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DisabledMixin } from '../src/disabled-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
-    'disabled-mixin',
-    '<slot></slot>',
-    (Base) => class extends DisabledMixin(baseMixin(Base)) {},
-  );
+describe('DisabledMixin', () => {
+  const tag = definePolymer('disabled-mixin', '<slot></slot>', (Base) => class extends DisabledMixin(Base) {});
 
   let element;
 
@@ -46,12 +40,4 @@ const runTests = (defineHelper, baseMixin) => {
     element.click();
     expect(spy.called).to.be.false;
   });
-};
-
-describe('DisabledMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('DisabledMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -1,11 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FieldAriaController } from '../src/field-aria-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('field-aria', '<slot></slot>', (Base) => class extends baseMixin(Base) {});
+describe('FieldAriaController', () => {
+  const tag = definePolymer('field-aria', '<slot></slot>', (Base) => class extends ControllerMixin(Base) {});
 
   let element, input, controller;
 
@@ -216,12 +215,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('FieldAriaController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FieldAriaController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/focus-mixin.test.js
+++ b/packages/a11y-base/test/focus-mixin.test.js
@@ -1,23 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import {
-  defineLit,
-  definePolymer,
-  fixtureSync,
-  focusin,
-  focusout,
-  keyDownOn,
-  mousedown,
-} from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { definePolymer, fixtureSync, focusin, focusout, keyDownOn, mousedown } from '@vaadin/testing-helpers';
 import { FocusMixin } from '../src/focus-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('FocusMixin', () => {
+  const tag = definePolymer(
     'focus-mixin',
     '<slot></slot>',
     (Base) =>
-      class extends FocusMixin(baseMixin(Base)) {
+      class extends FocusMixin(Base) {
         ready() {
           super.ready();
           const input = document.createElement('input');
@@ -65,12 +55,4 @@ const runTests = (defineHelper, baseMixin) => {
     focusin(input);
     expect(element.hasAttribute('focus-ring')).to.be.false;
   });
-};
-
-describe('FocusMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FocusMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -1,9 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FocusTrapController } from '../src/focus-trap-controller.js';
 
 async function tab() {
@@ -16,12 +15,12 @@ async function shiftTab() {
   return document.activeElement;
 }
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('FocusTrapController', () => {
+  const tag = definePolymer(
     'focus-trap',
     '<slot></slot>',
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends ControllerMixin(Base) {
         ready() {
           super.ready();
           this.innerHTML = `
@@ -43,11 +42,11 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  const wrapperTag = defineHelper(
+  const wrapperTag = definePolymer(
     'focus-trap-wrapper',
     '<slot></slot>',
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends ControllerMixin(Base) {
         ready() {
           super.ready();
           this.innerHTML = `
@@ -352,12 +351,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(document.activeElement).to.equal(trapInput1);
     });
   });
-};
-
-describe('FocusTrapController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FocusTrapController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/keyboard-direction-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-direction-mixin.test.js
@@ -4,7 +4,6 @@ import {
   arrowLeftKeyDown,
   arrowRightKeyDown,
   arrowUpKeyDown,
-  defineLit,
   definePolymer,
   endKeyDown,
   fixtureSync,
@@ -13,11 +12,10 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { KeyboardDirectionMixin } from '../src/keyboard-direction-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('KeyboardDirectionMixin', () => {
+  const tag = definePolymer(
     'keyboard-direction-mixin',
     `
       <style>
@@ -32,7 +30,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot></slot>
     `,
     (Base) =>
-      class extends KeyboardDirectionMixin(baseMixin(Base)) {
+      class extends KeyboardDirectionMixin(ControllerMixin(Base)) {
         get _vertical() {
           return this.hasAttribute('vertical');
         }
@@ -246,12 +244,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.focused).to.not.equal(items[0]);
     });
   });
-};
-
-describe('KeyboardDirectionMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('KeyboardDirectionMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/keyboard-mixin.test.js
+++ b/packages/a11y-base/test/keyboard-mixin.test.js
@@ -1,19 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { KeyboardMixin } from '../src/keyboard-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('KeyboardMixin', () => {
   let element, enterSpy, escapeSpy, keyDownSpy, keyUpSpy;
 
-  const tag = defineHelper(
+  const tag = definePolymer(
     'keyboard-mixin',
     '<slot></slot>',
     (Base) =>
-      class extends KeyboardMixin(baseMixin(Base)) {
+      class extends KeyboardMixin(Base) {
         _onKeyDown(event) {
           super._onKeyDown(event);
 
@@ -83,12 +81,4 @@ const runTests = (defineHelper, baseMixin) => {
     expect(enterSpy.args[0][0]).to.be.an.instanceOf(KeyboardEvent);
     expect(enterSpy.args[0][0].type).to.equal('keydown');
   });
-};
-
-describe('KeyboardMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('KeyboardMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -4,7 +4,6 @@ import {
   arrowLeft,
   arrowRight,
   arrowUp,
-  defineLit,
   definePolymer,
   end,
   fixtureSync,
@@ -15,14 +14,12 @@ import {
   oneEvent,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ListMixin } from '../src/list-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('ListMixin', () => {
   let list;
 
-  const listTag = defineHelper(
+  const listTag = definePolymer(
     'list',
     `
       <style>
@@ -45,14 +42,14 @@ const runTests = (defineHelper, baseMixin) => {
       </div>
     `,
     (Base) =>
-      class extends ListMixin(baseMixin(Base)) {
+      class extends ListMixin(Base) {
         get _scrollerElement() {
           return this.$.scroll;
         }
       },
   );
 
-  const itemTag = defineHelper(
+  const itemTag = definePolymer(
     'item',
     `
       <style>
@@ -71,7 +68,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot></slot>
     `,
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends Base {
         static get properties() {
           return {
             disabled: {
@@ -857,18 +854,10 @@ const runTests = (defineHelper, baseMixin) => {
     });
 
     it('should warn when creating an element without focusElement', () => {
-      const tag = defineHelper('no-scroller', '<slot></slot>', (Base) => class extends ListMixin(baseMixin(Base)) {});
+      const tag = definePolymer('no-scroller', '<slot></slot>', (Base) => class extends ListMixin(Base) {});
       const instance = document.createElement(tag);
       expect(instance._scrollerElement).to.equal(instance);
       expect(console.warn.calledOnce).to.be.true;
     });
   });
-};
-
-describe('ListMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ListMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/a11y-base/test/tabindex-mixin.test.js
+++ b/packages/a11y-base/test/tabindex-mixin.test.js
@@ -1,15 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import { TabindexMixin } from '../src/tabindex-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
-    'tabindex-mixin',
-    '<slot></slot>',
-    (Base) => class extends TabindexMixin(baseMixin(Base)) {},
-  );
+describe('TabindexMixin', () => {
+  const tag = definePolymer('tabindex-mixin', '<slot></slot>', (Base) => class extends TabindexMixin(Base) {});
 
   let element;
 
@@ -89,12 +83,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.tabindex).to.equal(1);
     });
   });
-};
-
-describe('TabindexMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('TabindexMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/controller-mixin.test.js
+++ b/packages/component-base/test/controller-mixin.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer } from '@vaadin/testing-helpers';
+import { definePolymer } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { LitElement } from 'lit';
 import { ControllerMixin } from '../src/controller-mixin.js';
 
 class SpyController {
@@ -18,8 +17,8 @@ class SpyController {
   }
 }
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('controller-mixin', 'Content', (Base) => class extends baseMixin(Base) {});
+describe('ControllerMixin', () => {
+  const tag = definePolymer('controller-mixin', 'Content', (Base) => class extends ControllerMixin(Base) {});
 
   let element, controller;
 
@@ -70,21 +69,5 @@ const runTests = (defineHelper, baseMixin) => {
       document.body.appendChild(element);
       expect(controller.hostConnected.calledTwice).to.be.true;
     });
-  });
-};
-
-describe('ControllerMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ControllerMixin + Lit', () => {
-  runTests(defineLit, ControllerMixin);
-
-  it('should not apply ControllerMixin to LitElement-based classes', () => {
-    class TestElement extends LitElement {}
-
-    const mixinResult = ControllerMixin(TestElement);
-
-    expect(mixinResult).to.equal(TestElement);
   });
 });

--- a/packages/component-base/test/delegate-state-mixin.test.js
+++ b/packages/component-base/test/delegate-state-mixin.test.js
@@ -1,15 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '../src/controller-mixin.js';
+import { definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { DelegateStateMixin } from '../src/delegate-state-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('DelegateStateMixin', () => {
+  const tag = definePolymer(
     'delegate-state-mixin',
     '<input id="input">',
     (Base) =>
-      class extends DelegateStateMixin(baseMixin(Base)) {
+      class extends DelegateStateMixin(Base) {
         static get properties() {
           return {
             title: {
@@ -146,12 +144,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(target.indeterminate).to.be.false;
     });
   });
-};
-
-describe('DelegateStateMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('DelegateStateMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -1,9 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { nextRender } from '@vaadin/testing-helpers';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { LitElement } from 'lit';
 import { I18nMixin } from '../src/i18n-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 
 const DEFAULT_I18N = {
   foo: 'Foo',
@@ -21,19 +19,11 @@ class I18nMixinPolymerElement extends I18nMixin(DEFAULT_I18N, PolymerElement) {
 
 customElements.define(I18nMixinPolymerElement.is, I18nMixinPolymerElement);
 
-class I18nMixinLitElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElement)) {
-  static get is() {
-    return 'i18n-mixin-lit-element';
-  }
-}
-
-customElements.define(I18nMixinLitElement.is, I18nMixinLitElement);
-
-const runTests = (baseClass) => {
+describe('I18nMixin', () => {
   let element;
 
   beforeEach(async () => {
-    element = document.createElement(baseClass.is);
+    element = document.createElement(I18nMixinPolymerElement.is);
     document.body.appendChild(element);
     await nextRender();
   });
@@ -88,12 +78,4 @@ const runTests = (baseClass) => {
 
     expect(element.__effectiveI18n).to.equal(effectiveI18n);
   });
-};
-
-describe('I18nMixin + Polymer', () => {
-  runTests(I18nMixinPolymerElement);
-});
-
-describe('I18nMixin + Lit', () => {
-  runTests(I18nMixinLitElement);
 });

--- a/packages/component-base/test/media-query-controller.test.js
+++ b/packages/component-base/test/media-query-controller.test.js
@@ -1,12 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { MediaQueryController } from '../src/media-query-controller.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('media-query-controller', `<slot></slot>`, (Base) => class extends baseMixin(Base) {});
+describe('MediaQueryController', () => {
+  const tag = definePolymer(
+    'media-query-controller',
+    `<slot></slot>`,
+    (Base) => class extends ControllerMixin(Base) {},
+  );
 
   let element, controller;
 
@@ -41,12 +44,4 @@ const runTests = (defineHelper, baseMixin) => {
 
     expect(stub.calledTwice).to.be.true;
   });
-};
-
-describe('MediaQueryController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('MediaQueryController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/overflow-controller.test.js
+++ b/packages/component-base/test/overflow-controller.test.js
@@ -1,11 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
 import { OverflowController } from '../src/overflow-controller.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('OverflowController', () => {
+  const tag = definePolymer(
     'overflow',
     `
       <style>
@@ -25,10 +24,10 @@ const runTests = (defineHelper, baseMixin) => {
       </style>
       <slot></slot>
     `,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends ControllerMixin(Base) {},
   );
 
-  const wrapperTag = defineHelper(
+  const wrapperTag = definePolymer(
     'overflow-wrapper',
     `
       <style>
@@ -55,7 +54,7 @@ const runTests = (defineHelper, baseMixin) => {
         <slot></slot>
       </div>
     `,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends ControllerMixin(Base) {},
   );
 
   describe('default', () => {
@@ -283,12 +282,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('OverflowController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('OverflowController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/overlay-class-mixin.test.js
+++ b/packages/component-base/test/overlay-class-mixin.test.js
@@ -1,15 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '../src/controller-mixin.js';
+import { definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { OverlayClassMixin } from '../src/overlay-class-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('OverlayClassMixin', () => {
+  const tag = definePolymer(
     'overlay-class-mixin',
     '<slot name="overlay">',
     (Base) =>
-      class extends OverlayClassMixin(baseMixin(Base)) {
+      class extends OverlayClassMixin(Base) {
         ready() {
           super.ready();
 
@@ -169,12 +167,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(overlay.classList.contains('xyz')).to.be.true;
     });
   });
-};
-
-describe('OverlayClassMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('OverlayClassMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/resize-mixin.test.js
+++ b/packages/component-base/test/resize-mixin.test.js
@@ -1,14 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, defineLit, definePolymer, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, definePolymer, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '../src/controller-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 import { ResizeMixin } from '../src/resize-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('ResizeMixin', () => {
   let observeParent;
 
-  const tag = defineHelper(
+  const tag = definePolymer(
     'resize-mixin',
     `
       <style>
@@ -19,7 +17,7 @@ const runTests = (defineHelper, baseMixin) => {
       <div></div>
     `,
     (Base) =>
-      class extends ResizeMixin(baseMixin(Base)) {
+      class extends ResizeMixin(Base) {
         get _observeParent() {
           return observeParent;
         }
@@ -119,12 +117,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('ResizeMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ResizeMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineCE, defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { defineCE, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '../src/controller-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 import { SlotController } from '../src/slot-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('SlotController', () => {
+  const tag = definePolymer(
     'slot-controller',
     `<slot name="foo"></slot><slot></slot>`,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends ControllerMixin(Base) {},
   );
 
   let element, child, controller;
@@ -122,11 +121,11 @@ const runTests = (defineHelper, baseMixin) => {
 
       const initializeSpy = sinon.spy();
 
-      const innerTag = defineHelper(
+      const innerTag = definePolymer(
         'slot-controller-inner',
         `<slot></slot>`,
         (Base) =>
-          class extends baseMixin(Base) {
+          class extends ControllerMixin(Base) {
             ready() {
               super.ready();
 
@@ -484,12 +483,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('SlotController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('SlotController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/slot-styles-mixin.test.js
+++ b/packages/component-base/test/slot-styles-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '../src/controller-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 import { SlotController } from '../src/slot-controller.js';
 import { SlotStylesMixin } from '../src/slot-styles-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
+describe('SlotStylesMixin', () => {
   const COLOR = 'rgb(0, 100, 0)';
 
-  const tag = defineHelper(
+  const tag = definePolymer(
     'slot-styles-mixin',
     `
       <style>
@@ -19,7 +18,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="button"></slot>
       `,
     (Base) =>
-      class extends SlotStylesMixin(baseMixin(Base)) {
+      class extends SlotStylesMixin(ControllerMixin(Base)) {
         get slotStyles() {
           return [
             `
@@ -85,12 +84,4 @@ const runTests = (defineHelper, baseMixin) => {
     wrapper.appendChild(element);
     expect(getComputedStyle(button).color).to.equal(COLOR);
   });
-};
-
-describe('SlotStylesMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('SlotStylesMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/component-base/test/tooltip-controller.test.js
+++ b/packages/component-base/test/tooltip-controller.test.js
@@ -1,16 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '../src/controller-mixin.js';
-import { PolylitMixin } from '../src/polylit-mixin.js';
 import { TooltipController } from '../src/tooltip-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('TooltipController', () => {
+  const tag = definePolymer(
     'tooltip-host',
     `<slot></slot><slot name="tooltip"></slot>
     `,
-    (Base) => class extends baseMixin(Base) {},
+    (Base) => class extends ControllerMixin(Base) {},
   );
 
   let host, tooltip, controller;
@@ -186,12 +185,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy).to.be.calledTwice;
     });
   });
-};
-
-describe('TooltipController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('TooltipController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/checked-mixin.test.js
+++ b/packages/field-base/test/checked-mixin.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { definePolymer, fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { DelegateFocusMixin } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { CheckedMixin } from '../src/checked-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('CheckedMixin', () => {
+  const tag = definePolymer(
     'checked-mixin',
     `
       <div>
@@ -16,7 +15,7 @@ const runTests = (defineHelper, baseMixin) => {
       </div>
     `,
     (Base) =>
-      class extends CheckedMixin(DelegateFocusMixin(baseMixin(Base))) {
+      class extends CheckedMixin(DelegateFocusMixin(ControllerMixin(Base))) {
         constructor() {
           super();
 
@@ -113,12 +112,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('CheckedMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('CheckedMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/clear-button-mixin.test.js
+++ b/packages/field-base/test/clear-button-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
-  defineLit,
   definePolymer,
   escKeyDown,
   fixtureSync,
@@ -12,19 +11,18 @@ import {
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ClearButtonMixin } from '../src/clear-button-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('ClearButtonMixin', () => {
+  const tag = definePolymer(
     'clear-button-mixin',
     `
       <slot name="input"></slot>
       <button id="clearButton">Clear</button>
     `,
     (Base) =>
-      class extends ClearButtonMixin(baseMixin(Base)) {
+      class extends ClearButtonMixin(ControllerMixin(Base)) {
         get clearElement() {
           return this.$.clearButton;
         }
@@ -183,12 +181,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.called).to.be.false;
     });
   });
-};
-
-describe('ClearButtonMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ClearButtonMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -1,13 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FieldMixin } from '../src/field-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('FieldMixin', () => {
+  const tag = definePolymer(
     'field-mixin',
     `
       <style>
@@ -36,7 +35,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends FieldMixin(InputMixin(baseMixin(Base))) {
+      class extends FieldMixin(InputMixin(ControllerMixin(Base))) {
         ready() {
           super.ready();
 
@@ -51,7 +50,7 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  const groupTag = defineHelper(
+  const groupTag = definePolymer(
     'field-mixin-group',
     `
       <slot name="label"></slot>
@@ -59,7 +58,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends FieldMixin(baseMixin(Base)) {
+      class extends FieldMixin(ControllerMixin(Base)) {
         ready() {
           super.ready();
 
@@ -476,7 +475,7 @@ const runTests = (defineHelper, baseMixin) => {
 
     describe('slotted custom element', () => {
       beforeEach(async () => {
-        const helperTag = defineHelper('custom-helper', '<div>Helper</div>', (Base) => Base);
+        const helperTag = definePolymer('custom-helper', '<div>Helper</div>', (Base) => Base);
         element = fixtureSync(`
           <${tag}>
             <${helperTag} slot="helper"></${helperTag}>
@@ -1010,12 +1009,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input.getAttribute('aria-describedby')).to.include(helper.id);
     });
   });
-};
-
-describe('FieldMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('FieldMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-constraints-mixin.test.js
+++ b/packages/field-base/test/input-constraints-mixin.test.js
@@ -1,17 +1,16 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputConstraintsMixin } from '../src/input-constraints-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputConstraintsMixin', () => {
+  const tag = definePolymer(
     'input-constraints-mixin',
     '<slot name="input"></slot>',
     (Base) =>
-      class extends InputConstraintsMixin(baseMixin(Base)) {
+      class extends InputConstraintsMixin(ControllerMixin(Base)) {
         static get properties() {
           return {
             minlength: {
@@ -310,12 +309,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(field.checkValidity()).to.be.false;
     });
   });
-};
-
-describe('InputConstraintsMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputConstraintsMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-control-mixin.test.js
+++ b/packages/field-base/test/input-control-mixin.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import {
-  defineLit,
   definePolymer,
   escKeyDown,
   fixtureSync,
@@ -14,12 +13,11 @@ import {
 import sinon from 'sinon';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputControlMixin } from '../src/input-control-mixin.js';
 import { InputController } from '../src/input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputControlMixin', () => {
+  const tag = definePolymer(
     'input-control-mixin',
     `
       <div part="label">
@@ -33,7 +31,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends InputControlMixin(baseMixin(Base)) {
+      class extends InputControlMixin(ControllerMixin(Base)) {
         get clearElement() {
           return this.$.clearButton;
         }
@@ -487,12 +485,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('InputControlMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputControlMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-controller.test.js
+++ b/packages/field-base/test/input-controller.test.js
@@ -1,17 +1,16 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputController', () => {
+  const tag = definePolymer(
     'input-mixin',
     `<slot name="input"></slot>`,
-    (Base) => class extends InputMixin(baseMixin(Base)) {},
+    (Base) => class extends InputMixin(ControllerMixin(Base)) {},
   );
 
   describe('default', () => {
@@ -127,12 +126,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(input1.id).to.not.equal(input2.id);
     });
   });
-};
-
-describe('InputController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-field-mixin.test.js
+++ b/packages/field-base/test/input-field-mixin.test.js
@@ -1,14 +1,13 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { InputFieldMixin } from '../src/input-field-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('InputFieldMixin', () => {
+  const tag = definePolymer(
     'input-field-mixin',
     `
       <div part="label">
@@ -22,7 +21,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot name="helper"></slot>
     `,
     (Base) =>
-      class extends InputFieldMixin(baseMixin(Base)) {
+      class extends InputFieldMixin(ControllerMixin(Base)) {
         get clearElement() {
           return this.$.clearButton;
         }
@@ -247,12 +246,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(console.warn.called).to.be.false;
     });
   });
-};
-
-describe('InputFieldMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputFieldMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/input-mixin.test.js
+++ b/packages/field-base/test/input-mixin.test.js
@@ -1,16 +1,11 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
-    'input-mixin',
-    '<slot name="input"></slot>',
-    (Base) => class extends InputMixin(baseMixin(Base)) {},
-  );
+describe('InputMixin', () => {
+  const tag = definePolymer('input-mixin', '<slot name="input"></slot>', (Base) => class extends InputMixin(Base) {});
 
   let element, input;
 
@@ -133,11 +128,11 @@ const runTests = (defineHelper, baseMixin) => {
       inputSpy = sinon.spy();
       changeSpy = sinon.spy();
 
-      eventsTag = defineHelper(
+      eventsTag = definePolymer(
         'input-mixin-events',
         '<slot name="input"></slot>',
         (Base) =>
-          class extends InputMixin(baseMixin(Base)) {
+          class extends InputMixin(ControllerMixin(Base)) {
             _onInput() {
               inputSpy();
             }
@@ -189,12 +184,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(changeSpy.called).to.be.false;
     });
   });
-};
-
-describe('InputMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('InputMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/label-mixin.test.js
+++ b/packages/field-base/test/label-mixin.test.js
@@ -1,15 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import { LabelMixin } from '../src/label-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
-    'label-mixin',
-    '<slot name="label"></slot>',
-    (Base) => class extends LabelMixin(baseMixin(Base)) {},
-  );
+describe('LabelMixin', () => {
+  const tag = definePolymer('label-mixin', '<slot name="label"></slot>', (Base) => class extends LabelMixin(Base) {});
 
   let element, label;
 
@@ -331,12 +325,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('LabelMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('LabelMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/labelled-input-controller.test.js
+++ b/packages/field-base/test/labelled-input-controller.test.js
@@ -1,23 +1,22 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 import { LabelMixin } from '../src/label-mixin.js';
 import { LabelledInputController } from '../src/labelled-input-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const inputTag = defineHelper(
+describe('LabelledInputController', () => {
+  const inputTag = definePolymer(
     'input',
     `<slot name="label"></slot><slot name="input"></slot>`,
-    (Base) => class extends InputMixin(LabelMixin(baseMixin(Base))) {},
+    (Base) => class extends InputMixin(LabelMixin(ControllerMixin(Base))) {},
   );
 
-  const textareaTag = defineHelper(
+  const textareaTag = definePolymer(
     'textarea',
     `<slot name="label"></slot><slot name="textarea"></slot>`,
-    (Base) => class extends InputMixin(LabelMixin(baseMixin(Base))) {},
+    (Base) => class extends InputMixin(LabelMixin(ControllerMixin(Base))) {},
   );
 
   let element, target, label;
@@ -69,12 +68,4 @@ const runTests = (defineHelper, baseMixin) => {
       });
     });
   });
-};
-
-describe('LabelledInputController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('LabelledInputController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/pattern-mixin.test.js
+++ b/packages/field-base/test/pattern-mixin.test.js
@@ -1,18 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { definePolymer, fire, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputController } from '../src/input-controller.js';
 import { PatternMixin } from '../src/pattern-mixin.js';
 import { TextAreaController } from '../src/text-area-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('PatternMixin', () => {
+  const tag = definePolymer(
     'pattern-mixin',
     '<slot name="input"></slot>',
     (Base) =>
-      class extends PatternMixin(baseMixin(Base)) {
+      class extends PatternMixin(ControllerMixin(Base)) {
         ready() {
           super.ready();
 
@@ -26,11 +25,11 @@ const runTests = (defineHelper, baseMixin) => {
       },
   );
 
-  const textareaTag = defineHelper(
+  const textareaTag = definePolymer(
     'pattern-mixin-textarea',
     '<slot name="textarea"></slot>',
     (Base) =>
-      class extends PatternMixin(baseMixin(Base)) {
+      class extends PatternMixin(ControllerMixin(Base)) {
         ready() {
           super.ready();
 
@@ -186,12 +185,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.checkValidity()).to.be.true;
     });
   });
-};
-
-describe('PatternMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('PatternMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/text-area-controller.test.js
+++ b/packages/field-base/test/text-area-controller.test.js
@@ -1,15 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { InputMixin } from '../src/input-mixin.js';
 import { TextAreaController } from '../src/text-area-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('TextAreaController', () => {
+  const tag = definePolymer(
     'input-mixin',
     `<slot name="textarea"></slot>`,
-    (Base) => class extends InputMixin(baseMixin(Base)) {},
+    (Base) => class extends InputMixin(ControllerMixin(Base)) {},
   );
 
   describe('default', () => {
@@ -94,12 +93,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(textarea1.id).to.not.equal(textarea2.id);
     });
   });
-};
-
-describe('TextAreaController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('TextAreaController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/validate-mixin.test.js
+++ b/packages/field-base/test/validate-mixin.test.js
@@ -1,12 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ValidateMixin } from '../src/validate-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('validate-mixin', '<input>', (Base) => class extends ValidateMixin(baseMixin(Base)) {});
+describe('ValidateMixin', () => {
+  const tag = definePolymer('validate-mixin', '<input>', (Base) => class extends ValidateMixin(Base) {});
 
   let element;
 
@@ -165,11 +163,11 @@ const runTests = (defineHelper, baseMixin) => {
   });
 
   describe('invalid cannot be set to false', () => {
-    const tagWithShouldSetInvalid = defineHelper(
+    const tagWithShouldSetInvalid = definePolymer(
       'validate-mixin-with-should-set-invalid',
       '<input>',
       (Base) =>
-        class extends ValidateMixin(baseMixin(Base)) {
+        class extends ValidateMixin(Base) {
           _shouldSetInvalid(invalid) {
             return invalid;
           }
@@ -190,12 +188,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(element.invalid).to.be.true;
     });
   });
-};
-
-describe('ValidateMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ValidateMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -1,16 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, definePolymer, fixtureSync, touchstart } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, touchstart } from '@vaadin/testing-helpers';
 import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { VirtualKeyboardController } from '../src/virtual-keyboard-controller.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper(
+describe('VirtualKeyboardController', () => {
+  const tag = definePolymer(
     'virtual-keyboard-controller',
     `<slot></slot>`,
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends ControllerMixin(Base) {
         constructor() {
           super();
           this.inputElement = document.createElement('input');
@@ -65,12 +64,4 @@ const runTests = (defineHelper, baseMixin) => {
     await sendKeys({ press: 'Tab' });
     expect(input.inputMode).to.equal('');
   });
-};
-
-describe('VirtualKeyboardController + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('VirtualKeyboardController + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/item/test/item-mixin.test.js
+++ b/packages/item/test/item-mixin.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
-  defineLit,
   definePolymer,
   enterKeyDown,
   fixtureSync,
@@ -16,12 +15,10 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { ItemMixin } from '../src/vaadin-item-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const tag = defineHelper('item-mixin', '<slot></slot>', (Base) => class extends ItemMixin(baseMixin(Base)) {});
+describe('ItemMixin', () => {
+  const tag = definePolymer('item-mixin', '<slot></slot>', (Base) => class extends ItemMixin(Base) {});
 
   let item;
 
@@ -258,12 +255,4 @@ const runTests = (defineHelper, baseMixin) => {
       expect(spy.called).to.be.false;
     });
   });
-};
-
-describe('ItemMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('ItemMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -1,12 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineLit, definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { definePolymer, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { ControllerMixin } from '@vaadin/component-base/src/controller-mixin.js';
-import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { MultiSelectListMixin } from '../src/vaadin-multi-select-list-mixin.js';
 
-const runTests = (defineHelper, baseMixin) => {
-  const listTag = defineHelper(
+describe('MultiSelectListMixin', () => {
+  const listTag = definePolymer(
     'multi-select-list-element',
     `
       <style>
@@ -29,14 +27,14 @@ const runTests = (defineHelper, baseMixin) => {
       </div>
     `,
     (Base) =>
-      class extends MultiSelectListMixin(baseMixin(Base)) {
+      class extends MultiSelectListMixin(Base) {
         get _scrollerElement() {
           return this.$.scroll;
         }
       },
   );
 
-  const itemTag = defineHelper(
+  const itemTag = definePolymer(
     'item-element',
     `
       <style>
@@ -47,7 +45,7 @@ const runTests = (defineHelper, baseMixin) => {
       <slot></slot>
     `,
     (Base) =>
-      class extends baseMixin(Base) {
+      class extends Base {
         static get properties() {
           return {
             _hasVaadinItemMixin: {
@@ -221,12 +219,4 @@ const runTests = (defineHelper, baseMixin) => {
     await nextUpdate(list);
     expect(list.items[2].selected).to.be.true;
   });
-};
-
-describe('MultiSelectListMixin + Polymer', () => {
-  runTests(definePolymer, ControllerMixin);
-});
-
-describe('MultiSelectListMixin + Lit', () => {
-  runTests(defineLit, PolylitMixin);
 });


### PR DESCRIPTION
## Description

We no longer have Lit based components in V24.9 except a few ones like Popover, SideNav and Dashboard.
They only use a small subset of mixins like `DisabledMixin` which doesn't have any Lit specific logic.

IMO it's ok to remove LitElement tests for these controllers and mixins and only keep them tested with Polymer.
One exception where I preserved Lit tests is `DirMixin` which does have some LitElement specific logic.

## Type of change

- Test