### PR TITLE
refactor: deprecate vaadin-board

### DIFF
--- a/packages/board/README.md
+++ b/packages/board/README.md
@@ -4,6 +4,9 @@ A powerful and easy to use layout web component for building responsive views.
 
 > ℹ️&nbsp; A commercial Vaadin [subscription](https://vaadin.com/pricing) is required to use Board in your project.
 
+> [!WARNING]
+> `<vaadin-board>` is deprecated and will be removed in Vaadin 26. Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
+
 [Documentation + Live Demo ↗](https://vaadin.com/docs/latest/components/board)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/board)](https://www.npmjs.com/package/@vaadin/board)

--- a/packages/board/src/vaadin-board-row.d.ts
+++ b/packages/board/src/vaadin-board-row.d.ts
@@ -44,6 +44,9 @@ import { BoardRowMixin } from './vaadin-board-row-mixin.js';
  * ----------------|-------------|-------------
  * `--vaadin-board-width-small` | Determines the width where mode changes from `small` to `medium` | `600px`
  * `--vaadin-board-width-medium` | Determines the width where mode changes from `medium` to `large` | `960px`
+ *
+ * @deprecated `<vaadin-board-row>` is deprecated and will be removed in Vaadin 26.
+ * Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
  */
 declare class BoardRow extends BoardRowMixin(ElementMixin(HTMLElement)) {}
 

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -52,6 +52,8 @@ import { BoardRowMixin } from './vaadin-board-row-mixin.js';
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes BoardRowMixin
+ * @deprecated `<vaadin-board-row>` is deprecated and will be removed in Vaadin 26.
+ * Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
  */
 class BoardRow extends BoardRowMixin(ElementMixin(PolylitMixin(LitElement))) {
   static get is() {

--- a/packages/board/src/vaadin-board.d.ts
+++ b/packages/board/src/vaadin-board.d.ts
@@ -28,6 +28,9 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
  *   </vaadin-board-row>
  * </vaadin-board>
  * ```
+ *
+ * @deprecated `<vaadin-board>` is deprecated and will be removed in Vaadin 26.
+ * Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
  */
 declare class Board extends ElementMixin(HTMLElement) {
   /**

--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -13,6 +13,7 @@ import { css, html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { issueWarning } from '@vaadin/component-base/src/warnings.js';
 import { BoardRow } from './vaadin-board-row.js';
 
 /**
@@ -37,6 +38,8 @@ import { BoardRow } from './vaadin-board-row.js';
  * @customElement
  * @extends HTMLElement
  * @mixes ElementMixin
+ * @deprecated `<vaadin-board>` is deprecated and will be removed in Vaadin 26.
+ * Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
  */
 class Board extends ElementMixin(PolylitMixin(LitElement)) {
   static get is() {
@@ -60,8 +63,17 @@ class Board extends ElementMixin(PolylitMixin(LitElement)) {
   }
 
   /** @protected */
+  firstUpdated() {
+    super.firstUpdated();
+
+    issueWarning(
+      '`<vaadin-board>` is deprecated and will be removed in Vaadin 26. Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.',
+    );
+  }
+
+  /** @protected */
   render() {
-    return html`<slot></slot>`;
+    return html` <slot></slot>`;
   }
 
   /**

--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -73,7 +73,7 @@ class Board extends ElementMixin(PolylitMixin(LitElement)) {
 
   /** @protected */
   render() {
-    return html` <slot></slot>`;
+    return html`<slot></slot>`;
   }
 
   /**


### PR DESCRIPTION
## Description

Deprecate `<vaadin-board>` with the intention to remove it in Vaadin 26.

Part of https://github.com/vaadin/web-components/issues/9741

## Type of change

- Refactor