### PR TITLE
refactor: use focusVisible: true in FocusTrapController focus

### DIFF
--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getFocusableElements, isElementFocused } from './focus-utils.js';
+import { getFocusableElements, isElementFocused, isKeyboardActive } from './focus-utils.js';
 
 const instances = [];
 
@@ -87,7 +87,7 @@ export class FocusTrapController {
     instances.push(this);
 
     if (this.__focusedElementIndex === -1) {
-      this.__focusableElements[0].focus({ focusVisible: true });
+      this.__focusableElements[0].focus({ focusVisible: isKeyboardActive() });
     }
   }
 

--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -87,7 +87,7 @@ export class FocusTrapController {
     instances.push(this);
 
     if (this.__focusedElementIndex === -1) {
-      this.__focusableElements[0].focus();
+      this.__focusableElements[0].focus({ focusVisible: true });
     }
   }
 
@@ -147,7 +147,7 @@ export class FocusTrapController {
     const currentIndex = this.__focusedElementIndex;
     const nextIndex = (focusableElements.length + currentIndex + step) % focusableElements.length;
     const element = focusableElements[nextIndex];
-    element.focus();
+    element.focus({ focusVisible: true });
     if (element.localName === 'input') {
       element.select();
     }

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { defineLit, fixtureSync } from '@vaadin/testing-helpers';
+import { defineLit, fixtureSync, mousedown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { FocusTrapController } from '../src/focus-trap-controller.js';
@@ -95,7 +95,17 @@ describe('FocusTrapController', () => {
       expect(document.activeElement).to.equal(input);
     });
 
-    it('should use focusVisible: true when focusing the first focusable element', () => {
+    it('should use focusVisible: false when focusing the first focusable element if keyboard not active', () => {
+      const input = trap.querySelector('#trap-input-1');
+      const spy = sinon.spy(input, 'focus');
+      mousedown(document.body);
+      controller.trapFocus(trap);
+      expect(spy.firstCall.args[0]).to.deep.equal({ focusVisible: false });
+    });
+
+    it('should use focusVisible: true when focusing the first focusable element if keyboard active', async () => {
+      // Mimic opening the overlay on key press
+      await sendKeys({ press: 'Enter' });
       const input = trap.querySelector('#trap-input-1');
       const spy = sinon.spy(input, 'focus');
       controller.trapFocus(trap);

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -95,6 +95,13 @@ describe('FocusTrapController', () => {
       expect(document.activeElement).to.equal(input);
     });
 
+    it('should use focusVisible: true when focusing the first focusable element', () => {
+      const input = trap.querySelector('#trap-input-1');
+      const spy = sinon.spy(input, 'focus');
+      controller.trapFocus(trap);
+      expect(spy.firstCall.args[0]).to.deep.equal({ focusVisible: true });
+    });
+
     describe('no focusable elements', () => {
       beforeEach(() => {
         trap.querySelectorAll('input, textarea').forEach((input) => {
@@ -192,6 +199,12 @@ describe('FocusTrapController', () => {
           await tab();
           await tab();
           expect(spy.calledOnce).to.be.false;
+        });
+
+        it('should focus element with focusVisible on Tab', async () => {
+          const spy = sinon.spy(trapInput2, 'focus');
+          await tab();
+          expect(spy.firstCall.args[0]).to.deep.equal({ focusVisible: true });
         });
       });
 


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/437.

As we plan to always set `focus-ring` on programmatic focus, I realised that `FocusTrapController` behavior would be inconsistent since it doesn't enforce that for native elements, such as `<button>`. Modified the logic accordingly.

The change is to use [`focus({ focusVisible: true })`](https://caniuse.com/mdn-api_htmlelement_focus_options_focusvisible_parameter) supported in Firefox and Safari 18 but not in Chrome.

Example in `vaadin-rich-text-editor-popup`:

| Chrome | Firefox |
|---------|--------|
| <img width="215" height="190" alt="Screenshot 2025-08-19 at 12 45 18" src="https://github.com/user-attachments/assets/aaa5256b-073a-4430-9283-31fe9ae82015" /> |  <img width="216" height="188" alt="Screenshot 2025-08-19 at 12 45 00" src="https://github.com/user-attachments/assets/7e99183d-0634-4102-b42e-8190bf924a89" /> |

This is a minor change but IMO it improves the UX in Firefox and Safari a bit. 

## Type of change

- Refactor