### PR TITLE
fix: hide opening tooltip on color or background button click

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -662,6 +662,7 @@ export const RichTextEditorMixin = (superClass) =>
 
     /** @private */
     __onColorClick() {
+      this._tooltip.opened = false;
       this._colorEditing = true;
     }
 
@@ -678,6 +679,7 @@ export const RichTextEditorMixin = (superClass) =>
 
     /** @private */
     __onBackgroundClick() {
+      this._tooltip.opened = false;
       this._backgroundEditing = true;
     }
 

--- a/packages/rich-text-editor/test/toolbar.test.js
+++ b/packages/rich-text-editor/test/toolbar.test.js
@@ -677,5 +677,23 @@ describe('toolbar controls', () => {
 
       expect(undo.hasAttribute('aria-describedby')).to.be.false;
     });
+
+    it('should hide tooltip on color button click after mouseenter', async () => {
+      const color = getButton('color');
+      fire(color, 'mouseenter');
+      color.click();
+
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should hide tooltip on background button click after mouseenter', async () => {
+      const background = getButton('background');
+      fire(background, 'mouseenter');
+      background.click();
+
+      await nextRender();
+      expect(overlay.opened).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description

There is an issue in RTE where tooltip for `color` or `background` button is shown above the popup:
<img width="238" height="206" alt="Screenshot 2025-08-19 at 13 04 48" src="https://github.com/user-attachments/assets/6e15fbb8-1c60-4a98-ab04-29054872c73e" />

To reproduce, hover over button and click it during the 500ms tooltip delay. The overlay will open.
I also tried using `shouldShow` but it's called immediately on `mouseenter`, which is too early.

## Type of change

- Bugfix