### PR TITLE
fix: close modeless dialog on Esc when dialog itself has focus

### DIFF
--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,14 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
-import {
-  aTimeout,
-  click,
-  esc,
-  fixtureSync,
-  listenOnce,
-  nextRender,
-  nextUpdate,
-  oneEvent,
-} from '@vaadin/testing-helpers';
+import { sendKeys } from '@vaadin/test-runner-commands';
+import { aTimeout, click, fixtureSync, listenOnce, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-dialog.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -61,14 +53,22 @@ describe('vaadin-dialog', () => {
   });
 
   describe('opened', () => {
-    let dialog, backdrop, overlay;
+    let dialog, focusable, backdrop, overlay;
 
     beforeEach(async () => {
-      dialog = fixtureSync('<vaadin-dialog opened></vaadin-dialog>');
+      [dialog, focusable] = fixtureSync(`
+        <div>
+          <vaadin-dialog opened></vaadin-dialog>
+          <input />
+        </div>
+      `).children;
       await nextRender();
 
       dialog.renderer = (root) => {
-        root.innerHTML = '<div>Simple dialog</div>';
+        root.innerHTML = `
+          <div>Simple dialog</div>
+          <input />
+        `;
       };
       await nextUpdate(dialog);
 
@@ -83,15 +83,35 @@ describe('vaadin-dialog', () => {
 
     describe('no-close-on-esc', () => {
       it('should close itself on ESC press by default', async () => {
-        esc(document.body);
+        await sendKeys({ press: 'Escape' });
         await nextUpdate(dialog);
         expect(dialog.opened).to.be.false;
       });
 
       it('should not close itself on ESC press when no-close-on-esc is true', async () => {
         dialog.noCloseOnEsc = true;
-        await nextUpdate(dialog);
-        esc(document.body);
+        await sendKeys({ press: 'Escape' });
+        expect(dialog.opened).to.be.true;
+      });
+
+      it('should close on Escape press when modeless and dialog itself is focused', async () => {
+        dialog.modeless = true;
+        dialog.focus();
+        await sendKeys({ press: 'Escape' });
+        expect(dialog.opened).to.be.false;
+      });
+
+      it('should close on Escape press when modeless and content element is focused', async () => {
+        dialog.modeless = true;
+        dialog.querySelector('input').focus();
+        await sendKeys({ press: 'Escape' });
+        expect(dialog.opened).to.be.false;
+      });
+
+      it('should not close on Escape press when modeless and not focused', async () => {
+        dialog.modeless = true;
+        focusable.focus();
+        await sendKeys({ press: 'Escape' });
         expect(dialog.opened).to.be.true;
       });
     });

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -552,7 +552,7 @@ export const OverlayMixin = (superClass) =>
       }
 
       // Only close modeless overlay on Esc press when it contains focus
-      if (!this._shouldAddGlobalListeners() && !event.composedPath().includes(this.$.overlay)) {
+      if (!this._shouldAddGlobalListeners() && !event.composedPath().includes(this._focusTrapRoot)) {
         return;
       }
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10024

After changing dialog to set `tabindex` on the host, the login in keydown listener no longer works as expected for modeless dialogs because `this.$.overlay` is not in the `event.composedPath()`. Changed to use `_focusTrapRoot` to fix this. Also modified dialog tests to use actual `sendKeys()` instead of `esc()` helper and to cover this case.

## Type of change

- Bugfix