### PR TITLE
refactor: update overlay focus trap logic to check for hidden

### DIFF
--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -96,9 +96,11 @@ export class FocusTrapController {
    * so that it becomes possible to tab outside the trap node.
    */
   releaseFocus() {
-    this.__trapNode = null;
+    if (instances.includes(this)) {
+      this.__trapNode = null;
 
-    instances.pop();
+      instances.pop();
+    }
   }
 
   /**

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -111,7 +111,11 @@ export const OverlayFocusMixin = (superClass) =>
      */
     _trapFocus() {
       if (this.focusTrap) {
-        this.__focusTrapController.trapFocus(this._focusTrapRoot);
+        const root = this._focusTrapRoot;
+        // Ensure the focus trap root element is not hidden
+        if (getComputedStyle(root).display !== 'none') {
+          this.__focusTrapController.trapFocus(root);
+        }
       }
     }
 

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -378,9 +378,18 @@ export const OverlayMixin = (superClass) =>
     }
 
     /** @private */
-    _hiddenChanged(hidden) {
+    _hiddenChanged(hidden, oldHidden) {
       if (hidden && this.hasAttribute('closing')) {
         this._flushAnimation('closing');
+      }
+
+      // Trap / release focus when toggling hidden while opened
+      if (this.opened) {
+        if (oldHidden) {
+          this._trapFocus();
+        } else if (hidden) {
+          this._resetFocus();
+        }
       }
     }
 

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -378,18 +378,9 @@ export const OverlayMixin = (superClass) =>
     }
 
     /** @private */
-    _hiddenChanged(hidden, oldHidden) {
+    _hiddenChanged(hidden) {
       if (hidden && this.hasAttribute('closing')) {
         this._flushAnimation('closing');
-      }
-
-      // Trap / release focus when toggling hidden while opened
-      if (this.opened) {
-        if (oldHidden) {
-          this._trapFocus();
-        } else if (hidden) {
-          this._resetFocus();
-        }
       }
     }
 

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -98,6 +98,43 @@ describe('focus-trap', () => {
       focusableElements = getFocusableElements(overlayPart);
       expect(getFocusedElementIndex()).to.equal(-1);
     });
+
+    it('should not trap focus when hiding the overlay part explicitly', async () => {
+      overlay.focusTrap = true;
+      overlay.opened = true;
+      overlayPart.style.display = 'none';
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      focusableElements = getFocusableElements(overlayPart);
+      expect(getFocusedElementIndex()).to.equal(-1);
+    });
+
+    it('should not trap focus after setting hidden to true synchronously', async () => {
+      overlay.focusTrap = true;
+      overlay.opened = true;
+      overlay.hidden = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      focusableElements = getFocusableElements(overlayPart);
+      expect(getFocusedElementIndex()).to.equal(-1);
+    });
+
+    it('should trap focus after setting hidden back to false while opened', async () => {
+      overlay.focusTrap = true;
+      overlay.opened = true;
+      overlay.hidden = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      overlay.hidden = false;
+      focusableElements = getFocusableElements(overlayPart);
+      expect(getFocusedElementIndex()).to.equal(0);
+    });
+
+    it('should release focus after setting hidden to true while opened', async () => {
+      overlay.focusTrap = true;
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      overlay.hidden = true;
+      focusableElements = getFocusableElements(overlayPart);
+      expect(getFocusedElementIndex()).to.equal(-1);
+    });
   });
 
   describe('nested overlay', () => {

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -107,34 +107,6 @@ describe('focus-trap', () => {
       focusableElements = getFocusableElements(overlayPart);
       expect(getFocusedElementIndex()).to.equal(-1);
     });
-
-    it('should not trap focus after setting hidden to true synchronously', async () => {
-      overlay.focusTrap = true;
-      overlay.opened = true;
-      overlay.hidden = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlayPart);
-      expect(getFocusedElementIndex()).to.equal(-1);
-    });
-
-    it('should trap focus after setting hidden back to false while opened', async () => {
-      overlay.focusTrap = true;
-      overlay.opened = true;
-      overlay.hidden = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-      overlay.hidden = false;
-      focusableElements = getFocusableElements(overlayPart);
-      expect(getFocusedElementIndex()).to.equal(0);
-    });
-
-    it('should release focus after setting hidden to true while opened', async () => {
-      overlay.focusTrap = true;
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-      overlay.hidden = true;
-      focusableElements = getFocusableElements(overlayPart);
-      expect(getFocusedElementIndex()).to.equal(-1);
-    });
   });
 
   describe('nested overlay', () => {


### PR DESCRIPTION
## Description

After the recent changes to set `tabindex="0"` on the dialog itself, the error can be thrown because logic for collecting focusable nodes checks for `isElementHiddenDirectly()` and that returns `true`. 

Updated the logic to not trap focus if the `_focusTrapRoot` element becomes hidden after overlay opens.

## Type of change

- Refactor