### PR TITLE
fix: add missing sr-only element styles to Lumo select

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/select.css
+++ b/packages/vaadin-lumo-styles/src/components/select.css
@@ -57,4 +57,17 @@
     --_lumo-selected-item-height: var(--lumo-size-s);
     --_lumo-selected-item-padding: 0;
   }
+
+  .sr-only {
+    border: 0 !important;
+    clip: rect(1px, 1px, 1px, 1px) !important;
+    clip-path: inset(50%) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+    white-space: nowrap !important;
+  }
 }


### PR DESCRIPTION
## Description

These styles are included in `vaadin-select` but it doesn't use base styles to currently `sr-only` has display: block.

## Type of change

- Bugfix