### PR TITLE
docs: do not mention dom-repeat and combo-box in items JSDoc

### DIFF
--- a/packages/a11y-base/src/list-mixin.d.ts
+++ b/packages/a11y-base/src/list-mixin.d.ts
@@ -36,15 +36,9 @@ export declare class ListMixinClass {
   orientation: 'horizontal' | 'vertical';
 
   /**
-   * The list of items from which a selection can be made.
+   * A read-only list of items from which a selection can be made.
    * It is populated from the elements passed to the light DOM,
    * and updated dynamically when adding or removing items.
-   *
-   * The item elements must implement `Vaadin.ItemMixin`.
-   *
-   * Note: unlike `<vaadin-combo-box>`, this property is read-only,
-   * so if you want to provide items by iterating array of data,
-   * you have to use `dom-repeat` and place it to the light DOM.
    */
   readonly items: Element[] | undefined;
 

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -56,15 +56,9 @@ export const ListMixin = (superClass) =>
         },
 
         /**
-         * The list of items from which a selection can be made.
+         * A read-only list of items from which a selection can be made.
          * It is populated from the elements passed to the light DOM,
          * and updated dynamically when adding or removing items.
-         *
-         * The item elements must implement `Vaadin.ItemMixin`.
-         *
-         * Note: unlike `<vaadin-combo-box>`, this property is read-only,
-         * so if you want to provide items by iterating array of data,
-         * you have to use `dom-repeat` and place it to the light DOM.
          * @type {!Array<!Element> | undefined}
          */
         items: {

--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.d.ts
@@ -21,11 +21,9 @@ export declare class TabSheetMixinClass<Tab extends HTMLElement> {
   selected: number | null | undefined;
 
   /**
-   * The list of `<vaadin-tab>`s from which a selection can be made.
+   * A read-only list of `<vaadin-tab>`s from which a selection can be made.
    * It is populated from the elements passed inside the slotted
    * `<vaadin-tabs>`, and updated dynamically when adding or removing items.
-   *
-   * Note: unlike `<vaadin-combo-box>`, this property is read-only.
    */
   readonly items: Tab[] | undefined;
 }

--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.js
@@ -79,11 +79,9 @@ export const TabSheetMixin = (superClass) =>
     static get properties() {
       return {
         /**
-         * The list of `<vaadin-tab>`s from which a selection can be made.
+         * A read-only list of `<vaadin-tab>`s from which a selection can be made.
          * It is populated from the elements passed inside the slotted
          * `<vaadin-tabs>`, and updated dynamically when adding or removing items.
-         *
-         * Note: unlike `<vaadin-combo-box>`, this property is read-only.
          * @type {!Array<!Tab> | undefined}
          */
         items: {


### PR DESCRIPTION
## Description

Updated JSDoc for `ListMixin` to not mention `dom-repeat` and `<vaadin-combo-box>` - both are leftovers from the very early implementation. Mentions of the internal `ItemMixin` are also somewhat confusing in public JSDoc for `vaadin-tabs` and `vaadin-list-box` so I removed that as well. Also modified the `vaadin-tabsheet` JSDoc accordingly. 

## Type of change

- Documentation