### PR TITLE
refactor: update dashboard to use base styles, cleanup Lumo CSS

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
@@ -12,6 +12,10 @@ import { css } from 'lit';
 import { buttonStyles } from '@vaadin/button/src/styles/vaadin-button-base-styles.js';
 
 const dashboardButton = css`
+  :host {
+    padding: 4px;
+  }
+
   :host([theme~='tertiary']) {
     color: var(--vaadin-dashboard-button-text-color, var(--vaadin-color-subtle));
   }

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
@@ -77,7 +77,6 @@ export const dashboardWidgetAndSectionStyles = css`
 
   vaadin-dashboard-button {
     z-index: 1;
-    padding: 4px;
   }
 
   vaadin-dashboard-button .icon::before {

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -72,6 +72,12 @@ class DashboardLayout extends DashboardLayoutMixin(
     return dashboardLayoutStyles;
   }
 
+  static get lumoInjector() {
+    return {
+      includeBaseStyles: true,
+    };
+  }
+
   /** @protected */
   render() {
     return html`<div id="grid"><slot></slot></div>`;

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -81,6 +81,12 @@ class DashboardSection extends DashboardItemMixin(
     return dashboardSectionStyles;
   }
 
+  static get lumoInjector() {
+    return {
+      includeBaseStyles: true,
+    };
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -115,6 +115,12 @@ class DashboardWidget extends DashboardItemMixin(
     return dashboardWidgetStyles;
   }
 
+  static get lumoInjector() {
+    return {
+      includeBaseStyles: true,
+    };
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -120,6 +120,12 @@ class Dashboard extends DashboardLayoutMixin(
     return dashboardStyles;
   }
 
+  static get lumoInjector() {
+    return {
+      includeBaseStyles: true,
+    };
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/vaadin-lumo-styles/src/components/dashboard-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard-layout.css
@@ -4,76 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @media lumo_components_dashboard-layout {
-  :host {
-    display: block;
-    overflow: auto;
-    box-sizing: border-box;
-    width: 100%;
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  :host([dense-layout]) #grid {
-    grid-auto-flow: dense;
-  }
-
   #grid {
-    box-sizing: border-box;
-
-    /* Padding around dashboard edges */
     --_default-padding: var(--lumo-space-m);
-    --_padding: max(0px, var(--vaadin-dashboard-padding, var(--_default-padding)));
-    padding: var(--_padding);
-
-    /* Gap between widgets */
     --_default-gap: var(--lumo-space-m);
-    --_gap: max(0px, var(--vaadin-dashboard-gap, var(--_default-gap)));
-    gap: var(--_gap);
-
-    /* Default min and max column widths */
-    --_default-col-min-width: 25rem;
-    --_default-col-max-width: 1fr;
-
-    /* Effective min and max column widths */
-    --_col-min-width: var(--vaadin-dashboard-col-min-width, var(--_default-col-min-width));
-    --_col-max-width: var(--vaadin-dashboard-col-max-width, var(--_default-col-max-width));
-
-    /* Effective max column count */
-    --_col-max-count: var(--vaadin-dashboard-col-max-count, var(--_col-count));
-
-    /* Effective column count */
-    --_effective-col-count: min(var(--_col-count), var(--_col-max-count));
-
-    /* Default row min height */
     --_default-row-min-height: 12rem;
-    /* Effective row min height */
-    --_row-min-height: var(--vaadin-dashboard-row-min-height, var(--_default-row-min-height));
-    /* Effective row height */
-    --_row-height: minmax(var(--_row-min-height, auto), auto);
-
-    display: grid;
-    overflow: hidden;
-    min-width: calc(var(--_col-min-width) + var(--_padding) * 2);
-
-    grid-template-columns: repeat(
-      var(--_effective-col-count, auto-fill),
-      minmax(var(--_col-min-width), var(--_col-max-width))
-    );
-
-    grid-auto-rows: var(--_row-height);
-  }
-
-  ::slotted(*) {
-    /* The grid-column value applied to children */
-    --_item-column: span min(var(--vaadin-dashboard-widget-colspan, 1), var(--_effective-col-count, var(--_col-count)));
-
-    grid-column: var(--_item-column);
-
-    /* The grid-row value applied to children */
-    --_item-row: span var(--vaadin-dashboard-widget-rowspan, 1);
-    grid-row: var(--_item-row);
   }
 
   :host([theme~='shaded-background']) {

--- a/packages/vaadin-lumo-styles/src/components/dashboard-section.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard-section.css
@@ -5,48 +5,21 @@
  */
 @media lumo_components_dashboard-section {
   :host {
-    display: grid;
-    position: relative;
-    grid-template-columns: subgrid;
-    --_section-column: 1 / calc(var(--_effective-col-count) + 1);
-    grid-column: var(--_section-column) !important;
     gap: var(--_gap, 1rem);
-    /* Dashboard section header height */
-    --_section-header-height: minmax(0, auto);
-    grid-template-rows: var(--_section-header-height) repeat(auto-fill, var(--_row-height));
-    grid-auto-rows: var(--_row-height);
     --_section-outline-offset: calc(min(var(--_gap), var(--_padding)) / 3);
     --_focus-ring-offset: calc((var(--_section-outline-offset) - var(--_focus-ring-width)));
     border-radius: var(--lumo-border-radius-l);
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  ::slotted(*) {
-    --_item-column: span min(var(--vaadin-dashboard-widget-colspan, 1), var(--_effective-col-count, var(--_col-count)));
-
-    grid-column: var(--_item-column);
-    --_item-row: span var(--vaadin-dashboard-widget-rowspan, 1);
-    grid-row: var(--_item-row);
+    border: none;
+    margin: 0;
+    padding: 0;
   }
 
   header {
-    grid-column: var(--_section-column);
     margin-bottom: calc(-1 * var(--_section-outline-offset));
     line-height: var(--lumo-line-height-s);
     padding-inline: var(--lumo-space-s);
     min-height: var(--lumo-size-l);
     align-items: center;
-  }
-
-  :host::before {
-    z-index: 2 !important;
-  }
-
-  ::slotted(vaadin-dashboard-widget-wrapper) {
-    display: contents;
   }
 
   [part='title'] {

--- a/packages/vaadin-lumo-styles/src/components/dashboard-section.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard-section.css
@@ -81,6 +81,5 @@
 
   [part~='move-forward-button'] {
     inset-inline-end: calc(-1 * var(--_section-outline-offset));
-    transform: translateY(-50%);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/dashboard-widget.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard-widget.css
@@ -4,43 +4,15 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @media lumo_components_dashboard-widget {
-  :host {
-    display: flex;
-    flex-direction: column;
-    grid-column: var(--_item-column);
-    grid-row: var(--_item-row);
-    background: var(--_widget-background);
-    border-radius: var(--_widget-border-radius);
-    box-shadow: var(--_widget-shadow);
-    position: relative;
-  }
-
   :host::before {
-    content: '';
-    position: absolute;
     inset: calc(-1 * var(--_widget-border-width));
     border: var(--_widget-border-width) solid var(--_widget-border-color);
     border-radius: calc(var(--_widget-border-radius) + var(--_widget-border-width));
-    pointer-events: none;
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  :host(:not([editable])) [part~='resize-button'] {
-    display: none;
-  }
-
-  [part~='content'] {
-    flex: 1;
-    overflow: hidden;
   }
 
   /* Widget states */
 
   :host([editable]) {
-    --vaadin-dashboard-widget-shadow: var(--_widget-editable-shadow);
     --_widget-border-color: var(--lumo-contrast-20pct);
     --_widget-border-width: 1px;
   }
@@ -51,7 +23,6 @@
   }
 
   :host([selected]) {
-    --vaadin-dashboard-widget-shadow: var(--_widget-selected-shadow);
     background: var(--lumo-primary-color-10pct);
   }
 
@@ -62,13 +33,7 @@
   }
 
   :host([resizing])::after {
-    content: '';
-    z-index: 2;
-    position: absolute;
     top: -1px;
-    width: var(--_widget-resizer-width, 0);
-    height: var(--_widget-resizer-height, 0);
-    border-radius: inherit;
     background: var(--_drop-target-background-color);
     border: var(--_drop-target-border);
   }
@@ -81,7 +46,7 @@
   }
 
   :host([editable]) header {
-    padding-inline: var(--lumo-space-xs);
+    padding: var(--lumo-space-xs);
   }
 
   [part='title'] {
@@ -113,23 +78,10 @@
   /* Resize handle */
 
   [part~='resize-button'] {
-    z-index: 1;
-    overflow: hidden;
     --_resize-button-offset: min(var(--_gap), var(--_padding), var(--lumo-space-xs));
-    position: absolute;
     bottom: calc(-1 * var(--_resize-button-offset));
     inset-inline-end: calc(-1 * var(--_resize-button-offset));
-    cursor: nwse-resize;
-    touch-action: none;
     --icon: var(--lumo-icons-resize-handle);
-  }
-
-  :host([dir='rtl']) [part~='resize-button'] {
-    cursor: sw-resize;
-  }
-
-  :host([dir='rtl']) [part~='resize-button'] .icon::before {
-    transform: scaleX(-1);
   }
 
   /* Accessible resize mode controls */
@@ -146,48 +98,11 @@
     min-width: var(--lumo-size-s);
   }
 
-  [part~='resize-shrink-width-button'] + [part~='resize-grow-width-button'] {
-    margin-left: 1px;
-  }
-
   [part~='resize-grow-height-button'],
   [part~='resize-shrink-height-button'] {
     height: var(--lumo-size-s);
     padding-right: 0;
     padding-left: 0;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  [part~='resize-shrink-height-button']:not([hidden]) + [part~='resize-grow-height-button'] {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-  }
-
-  [part~='resize-shrink-height-button'] + [part~='resize-grow-height-button'] {
-    margin-top: 1px;
-  }
-
-  :host(:not([dir='rtl'])) [part~='resize-grow-width-button'],
-  :host(:not([dir='rtl'])) [part~='resize-shrink-width-button'] {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  :host([dir='rtl']) [part~='resize-grow-width-button'],
-  :host([dir='rtl']) [part~='resize-shrink-width-button'] {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  :host(:not([dir='rtl'])) [part~='resize-shrink-width-button']:not([hidden]) + [part~='resize-grow-width-button'] {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  :host([dir='rtl']) [part~='resize-shrink-width-button']:not([hidden]) + [part~='resize-grow-width-button'] {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
   }
 
   [part~='resize-grow-height-button'],

--- a/packages/vaadin-lumo-styles/src/components/dashboard.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard.css
@@ -4,15 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @media lumo_components_dashboard {
-  #grid[item-resizing] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-
-  ::slotted(vaadin-dashboard-widget-wrapper) {
-    display: contents;
-  }
-
   :host {
     --_widget-opacity: 1;
   }

--- a/packages/vaadin-lumo-styles/src/mixins/dashboard-item.css
+++ b/packages/vaadin-lumo-styles/src/mixins/dashboard-item.css
@@ -46,7 +46,6 @@
 
   [part='title'] {
     color: var(--lumo-header-text-color);
-    white-space: var(--vaadin-dashboard-widget-title-wrap, wrap);
     line-height: var(--lumo-line-height-s);
     margin: 0 0 1px;
   }

--- a/packages/vaadin-lumo-styles/src/mixins/dashboard-item.css
+++ b/packages/vaadin-lumo-styles/src/mixins/dashboard-item.css
@@ -6,12 +6,9 @@
 
 @media lumo_mixins_dashboard-item {
   :host {
-    box-sizing: border-box;
     --_widget-background: var(--vaadin-dashboard-widget-background, var(--lumo-base-color));
     --_widget-border-radius: var(--vaadin-dashboard-widget-border-radius, var(--lumo-border-radius-l));
-    --_widget-border-width: var(--vaadin-dashboard-widget-border-width, 1px);
     --_widget-border-color: var(--vaadin-dashboard-widget-border-color, var(--lumo-contrast-20pct));
-    --_widget-shadow: var(--vaadin-dashboard-widget-shadow, 0 0 0 0 transparent);
     --_widget-editable-shadow: var(--lumo-box-shadow-s);
     --_widget-selected-shadow:
       0 2px 4px -1px var(--lumo-primary-color-10pct), 0 3px 12px -1px var(--lumo-primary-color-50pct);
@@ -32,166 +29,41 @@
     filter: var(--_widget-filter);
   }
 
-  :host([dragging]) * {
-    visibility: hidden;
-  }
-
-  :host(:not([editable])) [part~='move-button'],
-  :host(:not([editable])) [part~='remove-button'],
-  :host(:not([editable])) #focus-button,
-  :host(:not([editable])) #focus-button-wrapper,
-  :host(:not([editable])) .mode-controls {
-    display: none;
-  }
-
-  #focustrap {
-    display: contents;
-  }
-
-  #focus-button-wrapper,
-  #focus-button {
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-  }
-
-  #focus-button {
-    pointer-events: none;
-    padding: 0;
-    border: none;
-  }
-
-  .mode-controls {
-    position: absolute;
-    inset: 0;
-    z-index: 2;
-  }
-
-  .mode-controls[hidden] {
-    display: none;
-  }
-
-  /* Move-mode buttons */
-  [part~='move-backward-button'],
-  [part~='move-forward-button'],
   [part~='move-apply-button'] {
-    position: absolute;
-    top: 50%;
-  }
-
-  [part~='move-backward-button'] {
-    inset-inline-start: 0;
-    transform: translateY(-50%);
-  }
-
-  [part~='move-forward-button'] {
-    inset-inline-end: 0;
-    transform: translateY(-50%);
-  }
-
-  [part~='move-apply-button'] {
-    left: 50%;
-    transform: translate(-50%, -50%);
     --icon: var(--lumo-icons-checkmark);
     font-size: var(--lumo-icon-size-m);
   }
 
-  :host([first-child]) [part~='move-backward-button'],
-  :host([last-child]) [part~='move-forward-button'] {
-    display: none;
-  }
-
-  /* Resize-mode buttons */
-  [part~='resize-shrink-width-button'],
-  [part~='resize-shrink-height-button'],
-  [part~='resize-grow-width-button'],
-  [part~='resize-grow-height-button'],
-  [part~='resize-apply-button'] {
-    position: absolute;
-  }
-
-  [part~='resize-shrink-width-button'] {
-    inset-inline-end: 0;
-    top: 50%;
-  }
-
-  :host(:not([dir='rtl'])) [part~='resize-shrink-width-button'] {
-    transform: translateY(-50%) translateX(-100%);
-  }
-
-  :host([dir='rtl']) [part~='resize-shrink-width-button'] {
-    transform: translateY(-50%) translateX(100%);
-  }
-
-  .mode-controls:has([part~='resize-grow-width-button'][hidden]) [part~='resize-shrink-width-button'] {
-    transform: translateY(-50%);
-  }
-
-  [part~='resize-grow-width-button'] {
-    inset-inline-start: 100%;
-    top: 50%;
-  }
-
-  :host(:not([dir='rtl'])) [part~='resize-grow-width-button'] {
-    transform: translateY(-50%) translateX(-100%);
-  }
-
-  :host([dir='rtl']) [part~='resize-grow-width-button'] {
-    transform: translateY(-50%) translateX(100%);
-  }
-
-  [part~='resize-shrink-height-button'] {
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%) translateY(-100%);
-  }
-
-  [part~='resize-grow-height-button'] {
-    top: 100%;
-    left: 50%;
-    transform: translateX(-50%) translateY(-100%);
-  }
-
-  [part~='resize-apply-button'] {
-    left: 50%;
-    top: 50%;
-
-    transform: translate(-50%, -50%);
-  }
-
   :host([focused]) {
-    z-index: 1;
+    outline: none;
   }
 
   header {
     overflow: hidden;
-    display: flex;
     align-items: start;
-    box-sizing: border-box;
-    justify-content: space-between;
+    gap: 0;
   }
 
   [part='title'] {
-    flex: 1;
     color: var(--lumo-header-text-color);
     white-space: var(--vaadin-dashboard-widget-title-wrap, wrap);
-    text-overflow: ellipsis;
-    overflow: hidden;
     line-height: var(--lumo-line-height-s);
     margin: 0 0 1px;
-    align-self: safe center;
   }
 
   vaadin-dashboard-button {
     font-family: 'lumo-icons';
     font-size: var(--lumo-icon-size-m);
     margin: 0;
-    z-index: 1;
   }
 
   vaadin-dashboard-button .icon::before {
     display: block;
     content: var(--icon);
+    background: transparent;
+    mask-image: none;
+    width: auto;
+    height: auto;
   }
 
   /* Common styles for non-mode edit buttons */
@@ -218,13 +90,11 @@
 
   /* Drag handle */
   [part~='move-button'] {
-    cursor: move;
     --icon: var(--lumo-icons-drag-handle);
   }
 
   /* Remove button */
   [part~='remove-button'] {
-    cursor: pointer;
     --icon: var(--lumo-icons-cross);
     margin-inline-start: var(--lumo-space-xs);
   }
@@ -236,17 +106,17 @@
 
   /* Move mode */
 
+  :host([move-mode]) :is([part~='move-forward-button'], [part~='move-backward-button']) .icon {
+    rotate: none;
+  }
+
   :host(:not([dir='rtl'])) [part~='move-backward-button'],
   :host([dir='rtl']) [part~='move-forward-button'] {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
     --icon: var(--lumo-icons-angle-left);
   }
 
   :host(:not([dir='rtl'])) [part~='move-forward-button'],
   :host([dir='rtl']) [part~='move-backward-button'] {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
     --icon: var(--lumo-icons-angle-right);
   }
 }


### PR DESCRIPTION
## Description

- Added `includeBaseStyles: true` to dashboard, dashboard-layout, widget and section elements
- Moved `padding: 4px` to the dashboard-button base styles to not override Lumo theme padding

## Type of change

- Refactor