### PR TITLE
refactor: cleanup scroller Lumo CSS covered by base styles

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/scroller.css
+++ b/packages/vaadin-lumo-styles/src/components/scroller.css
@@ -5,36 +5,17 @@
  */
 @media lumo_components_scroller {
   :host {
-    outline: none;
     --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
   }
 
   :host([focus-ring]) {
+    outline: none;
     box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
   }
 
-  /* Show dividers when content overflows */
-
   :host([theme~='overflow-indicators'])::before,
   :host([theme~='overflow-indicators'])::after {
-    content: '';
-    display: none;
-    position: sticky;
-    inset: 0;
-    z-index: 9999;
-    height: 1px;
-    margin-bottom: -1px;
     background: var(--lumo-contrast-10pct);
-  }
-
-  :host([theme~='overflow-indicators'])::after {
-    margin-bottom: 0;
-    margin-top: -1px;
-  }
-
-  :host([theme~='overflow-indicators'][overflow~='top'])::before,
-  :host([theme~='overflow-indicators'][overflow~='bottom'])::after {
-    display: block;
   }
 }


### PR DESCRIPTION
## Description

Removed duplicated CSS for `overflow-indicators` variant present in base styles.
Also fixed the `focus-ring` to reset `outline: none` coming from base styles.

## Type of change

- Refactor