### PR TITLE
docs: remove part name from remaining state attributes JSDoc

### DIFF
--- a/packages/overlay/src/vaadin-overlay.d.ts
+++ b/packages/overlay/src/vaadin-overlay.d.ts
@@ -98,10 +98,10 @@ export type OverlayEventMap = HTMLElementEventMap & OverlayCustomEventMap;
  *
  * The following state attributes are available for styling:
  *
- * Attribute | Description | Part
- * ---|---|---
- * `opening` | Applied just after the overlay is attached to the DOM. You can apply a CSS @keyframe animation for this state. | `:host`
- * `closing` | Applied just before the overlay is detached from the DOM. You can apply a CSS @keyframe animation for this state. | `:host`
+ * Attribute | Description
+ * ----------|------------
+ * `opening` | Applied just after the overlay is opened. You can apply a CSS animation for this state.
+ * `closing` | Applied just before the overlay is closed. You can apply a CSS animation for this state.
  *
  * The following custom CSS properties are available for styling:
  *

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -50,10 +50,10 @@ import { OverlayMixin } from './vaadin-overlay-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute | Description | Part
- * ---|---|---
- * `opening` | Applied just after the overlay is attached to the DOM. You can apply a CSS @keyframe animation for this state. | `:host`
- * `closing` | Applied just before the overlay is detached from the DOM. You can apply a CSS @keyframe animation for this state. | `:host`
+ * Attribute | Description
+ * ----------|------------
+ * `opening` | Applied just after the overlay is opened. You can apply a CSS animation for this state.
+ * `closing` | Applied just before the overlay is closed. You can apply a CSS animation for this state.
  *
  * The following custom CSS properties are available for styling:
  *

--- a/packages/radio-group/src/vaadin-radio-button.d.ts
+++ b/packages/radio-group/src/vaadin-radio-button.d.ts
@@ -31,14 +31,14 @@ export * from './vaadin-radio-button-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute    | Description | Part name
- * -------------|-------------|------------
- * `active`     | Set when the radio button is pressed down, either with a pointer or the keyboard. | `:host`
- * `disabled`   | Set when the radio button is disabled. | `:host`
- * `focus-ring` | Set when the radio button is focused using the keyboard. | `:host`
- * `focused`    | Set when the radio button is focused. | `:host`
- * `checked`    | Set when the radio button is checked. | `:host`
- * `has-label`  | Set when the radio button has a label. | `:host`
+ * Attribute    | Description
+ * -------------|--------------------------
+ * `active`     | Set when the radio button is pressed, either with a pointer or the keyboard.
+ * `disabled`   | Set when the radio button is disabled.
+ * `focus-ring` | Set when the radio button is focused using the keyboard.
+ * `focused`    | Set when the radio button is focused.
+ * `checked`    | Set when the radio button is checked.
+ * `has-label`  | Set when the radio button has a label.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -34,14 +34,14 @@ import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute    | Description | Part name
- * -------------|-------------|------------
- * `active`     | Set when the radio button is pressed down, either with a pointer or the keyboard. | `:host`
- * `disabled`   | Set when the radio button is disabled. | `:host`
- * `focus-ring` | Set when the radio button is focused using the keyboard. | `:host`
- * `focused`    | Set when the radio button is focused. | `:host`
- * `checked`    | Set when the radio button is checked. | `:host`
- * `has-label`  | Set when the radio button has a label. | `:host`
+ * Attribute    | Description
+ * -------------|--------------------------
+ * `active`     | Set when the radio button is pressed, either with a pointer or the keyboard.
+ * `disabled`   | Set when the radio button is disabled.
+ * `focus-ring` | Set when the radio button is focused using the keyboard.
+ * `focused`    | Set when the radio button is focused.
+ * `checked`    | Set when the radio button is checked.
+ * `has-label`  | Set when the radio button has a label.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/tabs/src/vaadin-tab.d.ts
+++ b/packages/tabs/src/vaadin-tab.d.ts
@@ -16,7 +16,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * The following state attributes are available for styling:
  *
- * Attribute      | Description | Part name
+ * Attribute      | Description
  * ---------------|---------------------------------
  * `disabled`     | Set when the element is disabled
  * `focused`      | Set when the element is focused

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -22,7 +22,7 @@ import { tabStyles } from './styles/vaadin-tab-base-styles.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute      | Description | Part name
+ * Attribute      | Description
  * ---------------|---------------------------------
  * `disabled`     | Set when the element is disabled
  * `focused`      | Set when the element is focused

--- a/packages/upload/src/vaadin-upload.d.ts
+++ b/packages/upload/src/vaadin-upload.d.ts
@@ -133,13 +133,13 @@ export interface UploadEventMap extends HTMLElementEventMap, UploadCustomEventMa
  *
  * The following state attributes are available for styling:
  *
- * Attribute | Description | Part name
- * ---|---|---
- * `disabled` | Set when the element is disabled | `:host`
- * `nodrop` | Set when drag and drop is disabled (e. g., on touch devices) | `:host`
- * `dragover` | A file is being dragged over the element | `:host`
- * `dragover-valid` | A dragged file is valid with `maxFiles` and `accept` criteria | `:host`
- * `max-files-reached` | The maximum number of files that the user is allowed to add to the upload has been reached | `:host`
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `nodrop`             | Set when drag and drop is disabled (e.g., on touch devices)
+ * `dragover`           | Set when the file is being dragged over the element
+ * `dragover-valid`     | Set when the dragged file is valid with `maxFiles` and `accept` criteria
+ * `max-files-reached`  | Set when maximum number of files that the user is allowed to add has been reached
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -37,13 +37,13 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  *
  * The following state attributes are available for styling:
  *
- * Attribute | Description | Part name
- * ---|---|---
- * `disabled` | Set when the element is disabled | `:host`
- * `nodrop` | Set when drag and drop is disabled (e. g., on touch devices) | `:host`
- * `dragover` | A file is being dragged over the element | `:host`
- * `dragover-valid` | A dragged file is valid with `maxFiles` and `accept` criteria | `:host`
- * `max-files-reached` | The maximum number of files that the user is allowed to add to the upload has been reached | `:host`
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `nodrop`             | Set when drag and drop is disabled (e.g., on touch devices)
+ * `dragover`           | Set when the file is being dragged over the element
+ * `dragover-valid`     | Set when the dragged file is valid with `maxFiles` and `accept` criteria
+ * `max-files-reached`  | Set when maximum number of files that the user is allowed to add has been reached
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10000

I missed to update JSDoc for some components in the above PR. This PR fixes that.

## Type of change

- Docs