### PR TITLE
docs: list parts and attributes in JSDoc of all field components (#10068) (CP: 24.9)

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -199,6 +199,7 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * `focused`            | Set when the element is focused
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
+ * `opened`             | Set when the overlay is opened
  * `loading`            | Set when loading items from the data provider
  *
  * If you want to replace the default `<input>` and its container with a custom implementation to get full control

--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -174,21 +174,32 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * `--vaadin-combo-box-overlay-width`      | Width of the overlay       | `auto`
  * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
  *
- * `<vaadin-combo-box>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and buttons
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute | Description
- * ----------|----------------------------------------
- * `opened`  | Set when the combo box dropdown is open
- * `loading` | Set when new items are expected
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ * `loading`            | Set when loading items from the data provider
  *
  * If you want to replace the default `<input>` and its container with a custom implementation to get full control
  * over the input field, consider using the [`<vaadin-combo-box-light>`](#/elements/vaadin-combo-box-light) element.

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -130,6 +130,7 @@ registerStyles('vaadin-combo-box', inputFieldShared, { moduleId: 'vaadin-combo-b
  * `focused`            | Set when the element is focused
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
+ * `opened`             | Set when the overlay is opened
  * `loading`            | Set when loading items from the data provider
  *
  * If you want to replace the default `<input>` and its container with a custom implementation to get full control

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -105,21 +105,32 @@ registerStyles('vaadin-combo-box', inputFieldShared, { moduleId: 'vaadin-combo-b
  * `--vaadin-combo-box-overlay-width`      | Width of the overlay       | `auto`
  * `--vaadin-combo-box-overlay-max-height` | Max height of the overlay  | `65vh`
  *
- * `<vaadin-combo-box>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and buttons
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute | Description
- * ----------|----------------------------------------
- * `opened`  | Set when the combo box dropdown is open
- * `loading` | Set when new items are expected
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ * `loading`            | Set when loading items from the data provider
  *
  * If you want to replace the default `<input>` and its container with a custom implementation to get full control
  * over the input field, consider using the [`<vaadin-combo-box-light>`](#/elements/vaadin-combo-box-light) element.

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -78,23 +78,31 @@ export interface DatePickerEventMap extends HTMLElementEventMap, DatePickerCusto
  * -------------------------------|----------------------------|---------
  * `--vaadin-field-default-width` | Default width of the field | `12em`
  *
- * `<vaadin-date-picker>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and buttons
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * Part name             | Description
- * ----------------------|--------------------
- * `toggle-button`       | Toggle button
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute  | Description                                      | Part name
- * -----------|--------------------------------------------------|-----------
- * `opened`   | Set when the date selector overlay is opened     | :host
- *
- * If you want to replace the default `<input>` and its container with a custom implementation to get full control
- * over the input field, consider using the [`<vaadin-date-picker-light>`](#/elements/vaadin-date-picker-light) element.
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * ### Internal components
  *

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -41,23 +41,31 @@ registerStyles('vaadin-date-picker', [inputFieldShared, datePickerStyles], { mod
  * -------------------------------|----------------------------|---------
  * `--vaadin-field-default-width` | Default width of the field | `12em`
  *
- * `<vaadin-date-picker>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and buttons
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * Part name             | Description
- * ----------------------|--------------------
- * `toggle-button`       | Toggle button
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute  | Description                                      | Part name
- * -----------|--------------------------------------------------|-----------
- * `opened`   | Set when the date selector overlay is opened     | :host
- *
- * If you want to replace the default `<input>` and its container with a custom implementation to get full control
- * over the input field, consider using the [`<vaadin-date-picker-light>`](#/elements/vaadin-date-picker-light) element.
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * ### Internal components
  *

--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -48,8 +48,33 @@ export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCusto
  *
  * ### Styling
  *
- * `<vaadin-email-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ *
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -19,8 +19,33 @@ registerStyles('vaadin-email-field', emailFieldStyles, { moduleId: 'vaadin-email
  *
  * ### Styling
  *
- * `<vaadin-email-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ *
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -55,15 +55,33 @@ export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldC
  *
  * ### Styling
  *
- * `<vaadin-integer-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `increase-button`    | Increase ("plus") button
+ * `decrease-button`    | Decrease ("minus") button
  *
- * Part name         | Description
- * ------------------|-------------------------
- * `increase-button` | Increase ("plus") button
- * `decrease-button` | Decrease ("minus") button
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -15,15 +15,33 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
  *
  * ### Styling
  *
- * `<vaadin-integer-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `increase-button`    | Increase ("plus") button
+ * `decrease-button`    | Decrease ("minus") button
  *
- * Part name         | Description
- * ------------------|-------------------------
- * `increase-button` | Increase ("plus") button
- * `decrease-button` | Decrease ("minus") button
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -57,17 +57,37 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  *
  * ### Styling
  *
- * `<vaadin-number-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `increase-button`    | Increase ("plus") button
+ * `decrease-button`    | Decrease ("minus") button
  *
- * Part name         | Description
- * ------------------|-------------------------
- * `increase-button` | Increase ("plus") button
- * `decrease-button` | Decrease ("minus") button
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Change events
  *

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -25,15 +25,33 @@ registerStyles('vaadin-number-field', [inputFieldShared, numberFieldStyles], {
  *
  * ### Styling
  *
- * `<vaadin-number-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `increase-button`    | Increase ("plus") button
+ * `decrease-button`    | Decrease ("minus") button
  *
- * Part name         | Description
- * ------------------|-------------------------
- * `increase-button` | Increase ("plus") button
- * `decrease-button` | Decrease ("minus") button
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -49,20 +49,35 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  *
  * ### Styling
  *
- * `<vaadin-password-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `reveal-button`      | The eye icon which toggles the password visibility
  *
- * Part name       | Description
- * ----------------|----------------------------------------------------
- * `reveal-button` | The eye icon which toggles the password visibility
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ * `password-visible`   | Set when the password is visible
  *
- * Attribute          | Description
- * -------------------|---------------------------------
- * `password-visible` | Set when the password is visible
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -30,20 +30,35 @@ let memoizedTemplate;
  *
  * ### Styling
  *
- * `<vaadin-password-field>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `reveal-button`      | The eye icon which toggles the password visibility
  *
- * Part name       | Description
- * ----------------|----------------------------------------------------
- * `reveal-button` | The eye icon which toggles the password visibility
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ * `password-visible`   | Set when the password is visible
  *
- * Attribute          | Description
- * -------------------|---------------------------------
- * `password-visible` | Set when the password is visible
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -132,25 +132,30 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * `--vaadin-select-text-field-width` | Effective width of the field | `vaadin-select-overlay` |
  * `--vaadin-select-overlay-width`    | Width of the overlay         | `vaadin-select-overlay` |
  *
- * `<vaadin-select>` provides mostly the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and toggle button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * The following state attributes are available for styling:
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
- *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute | Description                 | Part name
- * ----------|-----------------------------|-----------
- * `opened`  | Set when the select is open | :host
- *
- * There are two exceptions in terms of styling compared to `<vaadin-text-field>`:
- * - the `clear-button` shadow DOM part does not exist in `<vaadin-select>`.
- * - the `input-prevented` state attribute is not supported by `<vaadin-select>`.
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * ### Internal components
  *

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -156,6 +156,7 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * `focused`            | Set when the element is focused
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
+ * `opened`             | Set when the overlay is opened
  *
  * ### Internal components
  *

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -112,6 +112,7 @@ registerStyles('vaadin-select', [inputFieldShared, screenReaderOnly, selectStyle
  * `focused`            | Set when the element is focused
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
+ * `opened`             | Set when the overlay is opened
  *
  * ### Internal components
  *

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -88,25 +88,30 @@ registerStyles('vaadin-select', [inputFieldShared, screenReaderOnly, selectStyle
  * `--vaadin-select-text-field-width` | Effective width of the field | `vaadin-select-overlay` |
  * `--vaadin-select-overlay-width`    | Width of the overlay         | `vaadin-select-overlay` |
  *
- * `<vaadin-select>` provides mostly the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and toggle button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * The following state attributes are available for styling:
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
- *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute | Description                 | Part name
- * ----------|-----------------------------|-----------
- * `opened`  | Set when the select is open | :host
- *
- * There are two exceptions in terms of styling compared to `<vaadin-text-field>`:
- * - the `clear-button` shadow DOM part does not exist in `<vaadin-select>`.
- * - the `input-prevented` state attribute is not supported by `<vaadin-select>`.
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * ### Internal components
  *

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -72,8 +72,31 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  *
  * The following shadow DOM parts are available for styling:
  *
- * `<vaadin-text-area>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ *
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -44,8 +44,33 @@ registerStyles('vaadin-text-area', [inputFieldShared, textAreaStyles], { moduleI
  * -------------------------------|----------------------------|---------
  * `--vaadin-field-default-width` | Default width of the field | `12em`
  *
- * `<vaadin-text-area>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and suffix
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ *
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -83,18 +83,20 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description
- * --------------------|---------------------------------
- * `disabled`          | Set when the element is disabled
- * `has-value`         | Set when the element has a value
- * `has-label`         | Set when the element has a label
- * `has-helper`        | Set when the element has helper text or slot
- * `has-error-message` | Set when the element has an error message
- * `invalid`           | Set when the element is invalid
- * `input-prevented`   | Temporarily set when invalid input is prevented
- * `focused`           | Set when the element is focused
- * `focus-ring`        | Set when the element is keyboard focused
- * `readonly`          | Set when the element is readonly
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ *
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -56,18 +56,20 @@ registerStyles('vaadin-text-field', inputFieldShared, { moduleId: 'vaadin-text-f
  *
  * The following state attributes are available for styling:
  *
- * Attribute           | Description
- * --------------------|---------------------------------
- * `disabled`          | Set when the element is disabled
- * `has-value`         | Set when the element has a value
- * `has-label`         | Set when the element has a label
- * `has-helper`        | Set when the element has helper text or slot
- * `has-error-message` | Set when the element has an error message
- * `invalid`           | Set when the element is invalid
- * `input-prevented`   | Temporarily set when invalid input is prevented
- * `focused`           | Set when the element is focused
- * `focus-ring`        | Set when the element is keyboard focused
- * `readonly`          | Set when the element is readonly
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `input-prevented`    | Temporarily set when invalid input is prevented
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
+ *
+ * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -73,20 +73,31 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * `--vaadin-time-picker-overlay-width`     | Width of the overlay       | `auto`
  * `--vaadin-time-picker-overlay-max-height`| Max height of the overlay  | `65vh`
  *
- * `<vaadin-time-picker>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and buttons
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute | Description
- * ----------|------------------------------------------
- * `opened`  | Set when the time-picker dropdown is open
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * ### Internal components
  *

--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -98,6 +98,7 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * `focused`            | Set when the element is focused
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
+ * `opened`             | Set when the overlay is opened
  *
  * ### Internal components
  *

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -36,20 +36,31 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  * `--vaadin-time-picker-overlay-width`     | Width of the overlay       | `auto`
  * `--vaadin-time-picker-overlay-max-height`| Max height of the overlay  | `65vh`
  *
- * `<vaadin-time-picker>` provides the same set of shadow DOM parts and state attributes as `<vaadin-text-field>`.
- * See [`<vaadin-text-field>`](#/elements/vaadin-text-field) for the styling documentation.
+ * The following shadow DOM parts are available for styling:
  *
- * In addition to `<vaadin-text-field>` parts, the following parts are available for theming:
+ * Part name            | Description
+ * ---------------------|----------------
+ * `label`              | The label element
+ * `input-field`        | The element that wraps prefix, value and buttons
+ * `clear-button`       | The clear button
+ * `error-message`      | The error message element
+ * `helper-text`        | The helper text element wrapper
+ * `required-indicator` | The `required` state indicator element
+ * `toggle-button`      | The toggle button
  *
- * Part name       | Description
- * ----------------|----------------
- * `toggle-button` | The toggle button
+ * The following state attributes are available for styling:
  *
- * In addition to `<vaadin-text-field>` state attributes, the following state attributes are available for theming:
- *
- * Attribute | Description
- * ----------|------------------------------------------
- * `opened`  | Set when the time-picker dropdown is open
+ * Attribute            | Description
+ * ---------------------|---------------------------------
+ * `disabled`           | Set when the element is disabled
+ * `has-value`          | Set when the element has a value
+ * `has-label`          | Set when the element has a label
+ * `has-helper`         | Set when the element has helper text or slot
+ * `has-error-message`  | Set when the element has an error message
+ * `invalid`            | Set when the element is invalid
+ * `focused`            | Set when the element is focused
+ * `focus-ring`         | Set when the element is keyboard focused
+ * `readonly`           | Set when the element is readonly
  *
  * ### Internal components
  *

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -61,6 +61,7 @@ registerStyles('vaadin-time-picker', inputFieldShared, { moduleId: 'vaadin-time-
  * `focused`            | Set when the element is focused
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
+ * `opened`             | Set when the overlay is opened
  *
  * ### Internal components
  *


### PR DESCRIPTION
## Description

Manual cherry-pick of #10068 to `24.9` branch, needed to backport `has-tooltip` attribute feature.

## Type of change

- Cherry-pick