### PR TITLE
refactor!: replace custom grid logic with overflow controller

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -4,9 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { isElementHidden } from '@vaadin/a11y-base';
-import { animationFrame, microTask, timeOut } from '@vaadin/component-base/src/async.js';
+import { microTask, timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
+import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 
 const timeouts = {
@@ -150,6 +151,9 @@ export const ScrollMixin = (superClass) =>
       });
 
       this.$.table.addEventListener('scroll', () => this._afterScroll());
+
+      this.__overflowController = new OverflowController(this, this.$.table);
+      this.addController(this.__overflowController);
     }
 
     /**
@@ -157,7 +161,6 @@ export const ScrollMixin = (superClass) =>
      * @override
      */
     _onResize() {
-      this._updateOverflow();
       this.__updateHorizontalScrollPosition();
 
       // For Firefox, manually restore last scroll position when grid becomes
@@ -231,8 +234,6 @@ export const ScrollMixin = (superClass) =>
       if (!this.hasAttribute('navigating')) {
         this._hideTooltip(true);
       }
-
-      this._updateOverflow();
 
       this._debounceColumnContentVisibility = Debouncer.debounce(
         this._debounceColumnContentVisibility,
@@ -358,58 +359,6 @@ export const ScrollMixin = (superClass) =>
       }
 
       this.__updateColumnsBodyContentHidden();
-    }
-
-    /** @private */
-    _updateOverflow() {
-      this._debounceOverflow = Debouncer.debounce(this._debounceOverflow, animationFrame, () => {
-        this.__doUpdateOverflow();
-      });
-    }
-
-    /** @private */
-    __doUpdateOverflow() {
-      // Set overflow styling attributes
-      let overflow = '';
-      const table = this.$.table;
-      if (table.scrollTop < table.scrollHeight - table.clientHeight) {
-        overflow += ' bottom';
-      }
-
-      if (table.scrollTop > 0) {
-        overflow += ' top';
-      }
-
-      const scrollLeft = getNormalizedScrollLeft(table, this.getAttribute('dir'));
-      if (scrollLeft > 0) {
-        overflow += ' start';
-      }
-
-      if (scrollLeft < table.scrollWidth - table.clientWidth) {
-        overflow += ' end';
-      }
-
-      if (this.__isRTL) {
-        overflow = overflow.replace(/start|end/giu, (matched) => {
-          return matched === 'start' ? 'end' : 'start';
-        });
-      }
-
-      // TODO: Remove "right" and "left" values in the next major.
-      if (table.scrollLeft < table.scrollWidth - table.clientWidth) {
-        overflow += ' right';
-      }
-
-      if (table.scrollLeft > 0) {
-        overflow += ' left';
-      }
-
-      const value = overflow.trim();
-      if (value.length > 0 && this.getAttribute('overflow') !== value) {
-        this.setAttribute('overflow', value);
-      } else if (value.length === 0 && this.hasAttribute('overflow')) {
-        this.removeAttribute('overflow');
-      }
     }
 
     /** @protected */

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -8,7 +8,6 @@ export const flushGrid = (grid) => {
     grid.__clearCacheDebouncer,
     grid.__updateColumnTreeDebouncer,
     grid._debounceScrolling,
-    grid._debounceOverflow,
     grid._debouncerHiddenChanged,
     grid._debouncerApplyCachedData,
     grid.__debounceUpdateFrozenColumn,

--- a/packages/grid/test/scrolling-mode.test.js
+++ b/packages/grid/test/scrolling-mode.test.js
@@ -47,19 +47,19 @@ describe('scrolling mode', () => {
   });
 
   describe('overflow attribute', () => {
-    it('bottom end right', async () => {
+    it('bottom end', async () => {
       grid.scrollToIndex(0);
       await nextFrame();
       flushGrid(grid);
-      expect(grid.getAttribute('overflow')).to.equal('bottom end right');
+      expect(grid.getAttribute('overflow')).to.equal('bottom end');
     });
 
-    it('bottom start left', async () => {
+    it('bottom start', async () => {
       grid.scrollToIndex(0);
       grid.$.table.scrollLeft = grid.$.table.scrollWidth;
       await nextFrame();
       flushGrid(grid);
-      expect(grid.getAttribute('overflow')).to.equal('bottom start left');
+      expect(grid.getAttribute('overflow')).to.equal('bottom start');
     });
 
     it('bottom top', async () => {
@@ -70,14 +70,6 @@ describe('scrolling mode', () => {
       expect(grid.getAttribute('overflow')).to.contain('bottom');
     });
 
-    it('left right', async () => {
-      grid.$.table.scrollLeft = 1;
-      await nextFrame();
-      flushGrid(grid);
-      expect(grid.getAttribute('overflow')).to.contain('left');
-      expect(grid.getAttribute('overflow')).to.contain('right');
-    });
-
     it('start end', async () => {
       grid.$.table.scrollLeft = 1;
       await nextFrame();
@@ -86,19 +78,19 @@ describe('scrolling mode', () => {
       expect(grid.getAttribute('overflow')).to.contain('end');
     });
 
-    it('top end right', async () => {
+    it('top end', async () => {
       scrollToEnd(grid);
       await nextFrame();
       flushGrid(grid);
-      expect(grid.getAttribute('overflow')).to.equal('top end right');
+      expect(grid.getAttribute('overflow')).to.equal('top end');
     });
 
-    it('top start left', async () => {
+    it('top start', async () => {
       scrollToEnd(grid);
       grid.$.table.scrollLeft = grid.$.table.scrollWidth;
       await nextFrame();
       flushGrid(grid);
-      expect(grid.getAttribute('overflow')).to.equal('top start left');
+      expect(grid.getAttribute('overflow')).to.equal('top start');
     });
 
     it('update on resize', async () => {
@@ -110,7 +102,7 @@ describe('scrolling mode', () => {
       grid.style.width = '50px';
       await nextResize(grid);
       await nextFrame();
-      expect(grid.getAttribute('overflow')).to.equal('bottom end right');
+      expect(grid.getAttribute('overflow')).to.equal('bottom end');
     });
 
     describe('RTL', () => {


### PR DESCRIPTION
## Description

Replace the custom overflow logic in Grid's `ScrollMixin` in favor of using `OverflowController`.

This removes "left" and "right" values from the "overflow" attribute

## Type of change

Refactor / breaking change