### PR TITLE
fix: make popover width and height work when set before attach

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -435,7 +435,7 @@ class Popover extends PopoverPositionMixin(
   }
 
   static get observers() {
-    return ['__sizeChanged(width, height, _overlayElement)', '__updateAriaAttributes(opened, role, target)'];
+    return ['__updateAriaAttributes(opened, role, target)'];
   }
 
   /**
@@ -571,6 +571,11 @@ class Popover extends PopoverPositionMixin(
   /** @protected */
   updated(props) {
     super.updated(props);
+
+    if (props.has('width') || props.has('height')) {
+      const { width, height } = this;
+      requestAnimationFrame(() => this.$.overlay.setBounds({ width, height }, false));
+    }
 
     if (props.has('accessibleName')) {
       if (this.accessibleName) {
@@ -1017,13 +1022,6 @@ class Popover extends PopoverPositionMixin(
   /** @private */
   __hasTrigger(trigger) {
     return Array.isArray(this.trigger) && this.trigger.includes(trigger);
-  }
-
-  /** @private */
-  __sizeChanged(width, height, overlay) {
-    if (overlay) {
-      requestAnimationFrame(() => overlay.setBounds({ width, height }, false));
-    }
   }
 
   /**

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -614,6 +614,38 @@ describe('popover', () => {
     });
   });
 
+  describe('dimensions set before attach', () => {
+    beforeEach(() => {
+      popover = document.createElement('vaadin-popover');
+    });
+
+    afterEach(() => {
+      popover.remove();
+    });
+
+    it('should apply overlay width when set before attach', async () => {
+      popover.width = '300px';
+      document.body.appendChild(popover);
+      await nextRender();
+
+      popover.opened = true;
+      await oneEvent(popover.$.overlay, 'vaadin-overlay-open');
+
+      expect(getComputedStyle(popover.$.overlay.$.overlay).width).to.equal('300px');
+    });
+
+    it('should apply overlay height when set before attach', async () => {
+      popover.height = '300px';
+      document.body.appendChild(popover);
+      await nextRender();
+
+      popover.opened = true;
+      await oneEvent(popover.$.overlay, 'vaadin-overlay-open');
+
+      expect(getComputedStyle(popover.$.overlay.$.overlay).height).to.equal('300px');
+    });
+  });
+
   describe('content overflow', () => {
     let overlayHeight;
 


### PR DESCRIPTION
## Description

Fix for a regression in `vaadin-popover`: after removal of `OverlayClassMixin` the `__sizeChanged` observer stopped to work as the `_overlayElement` is no longer a reactive property. Aligned the logic with `DialogSizeMixin` and added tests.

## Type of change

- Bugfix