### PR TITLE
refactor: do not use phone mode backdrop in select base styles

### DIFF
--- a/packages/select/src/styles/vaadin-select-overlay-base-styles.js
+++ b/packages/select/src/styles/vaadin-select-overlay-base-styles.js
@@ -11,11 +11,15 @@ export const selectOverlayStyles = css`
     justify-content: flex-start;
   }
 
-  :host(:not([phone])) [part='overlay'] {
+  [part='overlay'] {
     min-width: var(--vaadin-select-overlay-width, var(--_vaadin-select-overlay-default-width));
   }
 
   [part='content'] {
     padding: var(--vaadin-item-overlay-padding, 4px);
+  }
+
+  [part='backdrop'] {
+    background: transparent;
   }
 `;

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -651,13 +651,6 @@ describe('vaadin-select', () => {
         expect(overlay.$.overlay.getBoundingClientRect().width).to.equal(400);
       });
 
-      it('should not set overlay part width based on the custom CSS property when phone', async () => {
-        select._phone = true;
-        select.opened = true;
-        await oneEvent(overlay, 'vaadin-overlay-open');
-        expect(overlay.$.overlay.getBoundingClientRect().width).to.not.equal(400);
-      });
-
       it('should store the select width in the custom CSS property on overlay opening', async () => {
         select.style.width = '200px';
         select.opened = true;


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/9958

## Type of change

- Refactor