### PR TITLE
fix: allow reordering grid columns inside a draggable parent

### DIFF
--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -127,9 +127,9 @@ export const ColumnReorderingMixin = (superClass) =>
         return;
       }
 
-      // Cancel reordering if there are draggable nodes on the event path
+      // Cancel reordering if there are draggable nodes on the event path following this element
       const path = e.composedPath && e.composedPath();
-      if (path && path.some((node) => node.hasAttribute && node.hasAttribute('draggable'))) {
+      if (path && path.slice(0, Math.max(0, path.indexOf(this))).some((node) => node.draggable)) {
         return;
       }
 

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -711,6 +711,13 @@ describe('reordering with draggable contents', () => {
     expect(grid.hasAttribute('reordering')).to.be.false;
   });
 
+  it('should start reordering inside draggable parent', () => {
+    const parent = fixtureSync('<div draggable="true"></div>');
+    parent.appendChild(grid);
+    dragStart(visualColumnCellContents[0][1]);
+    expect(grid.hasAttribute('reordering')).to.be.true;
+  });
+
   it('should not start reordering inside draggable footer cell content', () => {
     dragStart(visualColumnCellContents[0][2].children[0]);
     expect(grid.hasAttribute('reordering')).to.be.false;


### PR DESCRIPTION
## Description

Allow reordering grid columns inside a draggable parent

Fixes https://github.com/vaadin/flow-components/issues/7899

## Type of change

Bugfix