### PR TITLE
fix: use correct method to ignore overlay content scroll

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -217,7 +217,7 @@ export const PositionMixin = (superClass) =>
     /** @private */
     __onScroll(e) {
       // If the scroll event occurred inside the overlay, ignore it.
-      if (e.target instanceof Node && this.contains(e.target)) {
+      if (e.target instanceof Node && this._deepContains(e.target)) {
         return;
       }
 


### PR DESCRIPTION
## Description

Updated to use `_deepContains` which uses `_contentRoot` internally to correctly handle scroll in V25.

## Type of change

- Bugfix