### PR TITLE
feat: add custom CSS property to control overlay viewport inset

### DIFF
--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -16,7 +16,7 @@ export const overlayStyles = css`
 
     /* Default position constraints. Themes can
           override this to adjust the gap between the overlay and the viewport. */
-    inset: 8px;
+    inset: var(--vaadin-overlay-viewport-inset, 8px);
     bottom: var(--vaadin-overlay-viewport-bottom);
 
     /* Override native [popover] user agent styles */

--- a/packages/vaadin-lumo-styles/src/mixins/overlay.css
+++ b/packages/vaadin-lumo-styles/src/mixins/overlay.css
@@ -38,7 +38,7 @@
     /* CSS API for host */
     --vaadin-overlay-viewport-bottom: 0;
 
-    inset: var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-m) var(--lumo-space-m);
+    inset: var(--vaadin-overlay-viewport-inset, var(--lumo-space-m));
     /* Workaround for Edge issue (only on Surface), where an overflowing vaadin-list-box inside vaadin-select-overlay makes the overlay transparent */
     /* stylelint-disable-next-line */
     outline: 0px solid transparent;


### PR DESCRIPTION
## Description

This is needed for Vaadin Start which contains following CSS:

```css
vaadin-dialog-overlay {
  bottom: 0;
  left: 0;
  right: 0;
  top: 0;
}

@media (min-width: 640px) {
  vaadin-dialog-overlay {
    bottom: var(--lumo-space-m);
    left: var(--lumo-space-m);
    right: var(--lumo-space-m);
    top: var(--lumo-space-m);
  }
}
```

## Type of change

- Feature