### PR TITLE
test: update avatar-group snapshots to correctly open overlay

### DIFF
--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -218,6 +218,8 @@ snapshots["vaadin-avatar-group opened default"] =
   >
     <vaadin-avatar-group-menu-item
       aria-selected="false"
+      focus-ring=""
+      focused=""
       role="menuitem"
       tabindex="0"
     >
@@ -298,10 +300,9 @@ snapshots["vaadin-avatar-group opened default"] =
   <vaadin-avatar
     abbr="+2"
     aria-describedby="vaadin-tooltip-7"
-    aria-expanded="false"
+    aria-expanded="true"
     aria-haspopup="menu"
     aria-label="+2"
-    focused=""
     has-tooltip=""
     role="button"
     slot="overflow"
@@ -330,6 +331,7 @@ snapshots["vaadin-avatar-group opened overlay"] =
   exportparts="overlay, content"
   id="overlay"
   no-vertical-overlap=""
+  opened=""
   popover="manual"
   start-aligned=""
   top-aligned=""

--- a/packages/avatar-group/test/dom/avatar-group.test.js
+++ b/packages/avatar-group/test/dom/avatar-group.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextResize, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import '../../src/vaadin-avatar-group.js';
 
 describe('vaadin-avatar-group', () => {
@@ -35,11 +35,11 @@ describe('vaadin-avatar-group', () => {
     };
 
     beforeEach(async () => {
-      group.maxItemsVisible = 3;
       group.items = [{ name: 'Abc Def' }, { name: 'Ghi Jkl' }, { name: 'Mno Pqr' }, { name: 'Stu Vwx' }];
-      await nextRender();
+      group.maxItemsVisible = 3;
+      await nextResize(group);
       group._overflow.click();
-      await nextRender();
+      await oneEvent(group.$.overlay, 'vaadin-overlay-open');
     });
 
     it('default', async () => {


### PR DESCRIPTION
## Description

Fixed an issue in tests that was discovered while working on `PositionMixin` target reset logic fix for https://github.com/vaadin/web-components/pull/10079.

## Type of change

- Test