### PR TITLE
fix: update position target reset logic to cover margins

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -142,8 +142,18 @@ export const PositionMixin = (superClass) =>
     updated(props) {
       super.updated(props);
 
+      if (props.has('positionTarget')) {
+        const oldTarget = props.get('positionTarget');
+
+        // 1. When position target is removed, always reset position settings
+        // 2. When position target is set, reset if overlay was opened before
+        if ((!this.positionTarget && oldTarget) || (this.positionTarget && !oldTarget && !!this.__margins)) {
+          this.__resetPosition();
+        }
+      }
+
       if (props.has('opened') || props.has('positionTarget')) {
-        this.__updatePositionSettings(this.opened, this.positionTarget, props.get('positionTarget'));
+        this.__updatePositionSettings(this.opened, this.positionTarget);
       }
 
       const positionProps = [
@@ -194,14 +204,8 @@ export const PositionMixin = (superClass) =>
     }
 
     /** @private */
-    __updatePositionSettings(opened, positionTarget, oldTarget) {
+    __updatePositionSettings(opened, positionTarget) {
       this.__removeUpdatePositionEventListeners();
-
-      // 1. When position target is removed, always reset position settings
-      // 2. When position target is set, reset if overlay was opened before
-      if ((!positionTarget && oldTarget) || (positionTarget && !oldTarget && !!this.__margins)) {
-        this.__resetPosition();
-      }
 
       if (positionTarget) {
         positionTarget.__overlay = null;

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -143,11 +143,7 @@ export const PositionMixin = (superClass) =>
       super.updated(props);
 
       if (props.has('opened') || props.has('positionTarget')) {
-        if (!this.positionTarget && props.get('positionTarget')) {
-          this.__resetPosition();
-        }
-
-        this.__overlayOpenedChanged(this.opened, this.positionTarget);
+        this.__updatePositionSettings(this.opened, this.positionTarget, props.get('positionTarget'));
       }
 
       const positionProps = [
@@ -198,8 +194,14 @@ export const PositionMixin = (superClass) =>
     }
 
     /** @private */
-    __overlayOpenedChanged(opened, positionTarget) {
+    __updatePositionSettings(opened, positionTarget, oldTarget) {
       this.__removeUpdatePositionEventListeners();
+
+      // 1. When position target is removed, always reset position settings
+      // 2. When position target is set, reset if overlay was opened before
+      if ((!positionTarget && oldTarget) || (positionTarget && !oldTarget && !!this.__margins)) {
+        this.__resetPosition();
+      }
 
       if (positionTarget) {
         positionTarget.__overlay = null;
@@ -239,6 +241,8 @@ export const PositionMixin = (superClass) =>
 
     /** @private */
     __resetPosition() {
+      this.__margins = null;
+
       Object.assign(this.style, {
         justifyContent: '',
         alignItems: '',

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -118,6 +118,30 @@ describe('position mixin', () => {
     expect(overlay.style.justifyContent).to.equal('');
   });
 
+  it('should reset styles when positionTarget is set', async () => {
+    overlay.positionTarget = null;
+    overlay.opened = false;
+    await nextRender();
+
+    overlay.opened = true;
+    await oneEvent(overlay, 'vaadin-overlay-open');
+
+    // Mimic context-menu logic that modifies styles
+    overlay.style.top = '100px';
+    overlay.style.bottom = '100px';
+    overlay.style.left = '100px';
+    overlay.style.right = '100px';
+
+    overlay.opened = false;
+    overlay.positionTarget = target;
+    await nextRender();
+
+    expect(overlay.style.top).to.equal('');
+    expect(overlay.style.bottom).to.equal('');
+    expect(overlay.style.left).to.equal('');
+    expect(overlay.style.right).to.equal('');
+  });
+
   describe('vertical align top', () => {
     beforeEach(() => {
       overlay.verticalAlign = TOP;


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/10079

Improved `PositionMixin` logic for resetting position settings (and also changed to cover `__margins`).

## Type of change

- Bugfix / refactor