### PR TITLE
feat: Add support for initially closed accordion

### DIFF
--- a/packages/accordion/src/vaadin-accordion-mixin.d.ts
+++ b/packages/accordion/src/vaadin-accordion-mixin.d.ts
@@ -22,6 +22,12 @@ export declare class AccordionMixinClass {
   opened: number | null;
 
   /**
+   * Indicates whether all the accordion panels are closed.
+   * Setting this property to true closes all the accordion panels.
+   */
+  closed: boolean | null;
+
+  /**
    * The list of `<vaadin-accordion-panel>` child elements.
    * It is populated from the elements passed to the light DOM,
    * and updated dynamically when adding or removing panels.

--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -31,6 +31,16 @@ export const AccordionMixin = (superClass) =>
         },
 
         /**
+         * Indicates whether all the accordion panels are closed.
+         * Setting this property to true closes all the accordion panels.
+         */
+        closed: {
+          type: Boolean,
+          notify: true,
+          reflectToAttribute: true,
+        },
+
+        /**
          * The list of `<vaadin-accordion-panel>` child elements.
          * It is populated from the elements passed to the light DOM,
          * and updated dynamically when adding or removing panels.
@@ -45,7 +55,7 @@ export const AccordionMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_updateItems(items, opened)'];
+      return ['_updateItems(items, opened, closed)'];
     }
 
     constructor() {
@@ -112,13 +122,21 @@ export const AccordionMixin = (superClass) =>
     }
 
     /** @private */
-    _updateItems(items, opened) {
+    _updateItems(items, opened, closed) {
       if (items) {
         this.__itemsSync = true;
-        const itemToOpen = items[opened];
-        items.forEach((item) => {
-          item.opened = item === itemToOpen;
-        });
+        if (closed) {
+          items.forEach((item) => {
+            item.opened = false;
+          });
+          this.opened = null;
+        } else {
+          const itemToOpen = items[opened];
+          items.forEach((item) => {
+            item.opened = item === itemToOpen;
+          });
+        }
+
         this.__itemsSync = false;
       }
     }
@@ -147,6 +165,7 @@ export const AccordionMixin = (superClass) =>
       if (this.__itemsSync) {
         return;
       }
+
       const target = this._filterItems(e.composedPath())[0];
       const idx = this.items.indexOf(target);
       if (e.detail.value) {
@@ -155,8 +174,12 @@ export const AccordionMixin = (superClass) =>
         }
 
         this.opened = idx;
+        this.closed = null;
       } else if (!this.items.some((item) => item.opened)) {
         this.opened = null;
+        this.closed = true;
+      } else {
+        this.closed = true;
       }
     }
   };

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -89,6 +89,7 @@ describe('vaadin-accordion', () => {
     it('should open the first panel by default', () => {
       expect(accordion.opened).to.equal(0);
       expect(accordion.items[0].opened).to.be.true;
+      expect(accordion.closed).to.be.null;
     });
 
     it('should reflect opened property to attribute', () => {
@@ -100,6 +101,7 @@ describe('vaadin-accordion', () => {
       await nextUpdate(accordion);
       expect(accordion.items[1].opened).to.be.true;
       expect(accordion.opened).to.equal(1);
+      expect(accordion.closed).to.be.null;
     });
 
     it('should not update opened to new index when clicking disabled panel', async () => {
@@ -108,6 +110,7 @@ describe('vaadin-accordion', () => {
       await nextUpdate(accordion);
       expect(accordion.items[1].opened).to.be.false;
       expect(accordion.opened).to.equal(0);
+      expect(accordion.closed).to.be.null;
     });
 
     it('should close currently opened panel when another one is opened', async () => {
@@ -115,19 +118,29 @@ describe('vaadin-accordion', () => {
       await nextUpdate(accordion);
       expect(accordion.items[1].opened).to.be.true;
       expect(accordion.items[0].opened).to.be.false;
+      expect(accordion.closed).to.be.null;
     });
 
-    it('should set opened to null when the opened panel is closed', async () => {
+    it('should set opened to null and add closed to true when the opened panel is closed', async () => {
       getHeading(0).click();
       await nextUpdate(accordion);
       expect(accordion.items[0].opened).to.be.false;
       expect(accordion.opened).to.equal(null);
+      expect(accordion.closed).to.be.true;
     });
 
     it('should close currently opened panel when opened set to null', async () => {
       accordion.opened = null;
       await nextUpdate(accordion);
       expect(accordion.items[0].opened).to.be.false;
+      expect(accordion.closed).to.be.true;
+    });
+
+    it('should close currently opened panel when closed set to true', async () => {
+      accordion.closed = true;
+      await nextUpdate(accordion);
+      expect(accordion.items[0].opened).to.be.false;
+      expect(accordion.closed).to.be.true;
     });
 
     it('should not change opened state if panel has been removed', async () => {


### PR DESCRIPTION
## Description
Adds support for accordion to load without any opened panels. 
For this, I introduced "closed" attribute / property that does not interfere with the old logic if it's not specified. 

Using this as an exercise to learn web-components better, so detailed feedback would be appreciated. It's OK if this PR is closed / not accepted. 

```html
<vaadin-accordion closed>
  <vaadin-accordion-panel>
    <vaadin-accordion-heading slot="summary">Panel 1</vaadin-accordion-heading>
    <div>Panel 1 content</div>
  </vaadin-accordion-panel>
  <vaadin-accordion-panel>
    <vaadin-accordion-heading slot="summary">Panel 2</vaadin-accordion-heading>
    <div>Panel 2 content</div>
  </vaadin-accordion-panel>
</vaadin-accordion>
```

Fixes # (issue)
https://github.com/vaadin/flow-components/issues/1638

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [ ] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
Nothing specific discussed, but straight forward implementation in my opinion.