### PR TITLE
fix: forced color mode for radio-button and checkbox

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -136,19 +136,27 @@ export const checkable = (part, propName = part) => css`
 
   @media (forced-colors: active) {
     :host(:is([checked], [indeterminate])) {
-      --vaadin-${unsafeCSS(propName)}-border-color: CanvasText;
+      --vaadin-${unsafeCSS(propName)}-border-color: CanvasText !important;
+    }
+
+    :host(:is([checked], [indeterminate])) [part='${unsafeCSS(part)}'] {
+      background: SelectedItem !important;
+    }
+
+    :host(:is([checked], [indeterminate])) [part='${unsafeCSS(part)}']::after {
+      background: SelectedItemText !important;
     }
 
     :host([readonly]) [part='${unsafeCSS(part)}']::after {
-      background: CanvasText;
+      background: CanvasText !important;
     }
 
     :host([disabled]) {
-      --vaadin-${unsafeCSS(propName)}-border-color: GrayText;
+      --vaadin-${unsafeCSS(propName)}-border-color: GrayText !important;
     }
 
     :host([disabled]) [part='${unsafeCSS(part)}']::after {
-      background: GrayText;
+      background: GrayText !important;
     }
   }
 `;


### PR DESCRIPTION
Before:
<img width="427" height="406" alt="Screenshot 2025-09-03 at 11 51 35" src="https://github.com/user-attachments/assets/8ff67365-179d-4af7-8442-0e602f55c879" />


After:

<img width="435" height="404" alt="Screenshot 2025-09-03 at 11 51 16" src="https://github.com/user-attachments/assets/bd611e87-53a8-4e86-9d98-642150f76665" />
