### PR TITLE
fix: forced color mode for side-nav-item

### DIFF
--- a/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
@@ -102,16 +102,21 @@ const sideNavItem = css`
   }
 
   @media (forced-colors: active) {
+    [part='content'] {
+      border: 1px solid Canvas !important;
+    }
+
     :host([current]) [part='content'] {
-      color: Highlight;
+      color: Highlight !important;
+      border-color: Highlight !important;
     }
 
     :host([disabled]) [part='content'] {
-      --vaadin-side-nav-item-color: GrayText;
+      --vaadin-side-nav-item-color: GrayText !important;
     }
 
     :host([disabled]) [part='toggle-button']::before {
-      background: GrayText;
+      background: GrayText !important;
     }
   }
 `;


### PR DESCRIPTION
## Before:
<img width="262" height="245" alt="Screenshot 2025-09-03 at 11 58 20" src="https://github.com/user-attachments/assets/64062c54-9a1c-4f9d-a32c-40a81b4e2415" />


### When a theme defines `--vaadin-side-nav-item-border-width: 1px`:
<img width="257" height="249" alt="Screenshot 2025-09-03 at 11 59 16" src="https://github.com/user-attachments/assets/f8c58ced-6956-4f9e-a252-d4b9da5e79cb" />

## After:
<img width="261" height="249" alt="Screenshot 2025-09-03 at 11 58 01" src="https://github.com/user-attachments/assets/e5e861c1-ae9e-4d3a-9464-da32250e3e6f" />
