### PR TITLE
fix: remove props.css import from utility.css

### DIFF
--- a/packages/vaadin-lumo-styles/utility.css
+++ b/packages/vaadin-lumo-styles/utility.css
@@ -3,7 +3,6 @@
  * Copyright (c) 2000 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-@import './props.css';
 @import './src/utilities/accessibility.css';
 @import './src/utilities/background.css';
 @import './src/utilities/border.css';


### PR DESCRIPTION
## Description

When injecting `utility.css` into shadow root of a component, I don't expect that it will also override all color CSS properties inherited from `html`. Even though many of those properties are used in Lumo utility classes, importing utilities should expect `lumo.css` being imported separately, similarly to how our component CSS files are structured.

## Type of change

- Bugfix