### PR TITLE
fix: do not update menu overlay position when not opened

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -57,7 +57,7 @@ export class ContextMenuOverlay extends MenuOverlayMixin(
   _updatePosition() {
     super._updatePosition();
 
-    if (this.parentOverlay == null && this.positionTarget && this.position) {
+    if (this.parentOverlay == null && this.positionTarget && this.position && this.opened) {
       if (this.position === 'bottom' || this.position === 'top') {
         const targetRect = this.positionTarget.getBoundingClientRect();
         const overlayRect = this.$.overlay.getBoundingClientRect();

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -113,7 +113,7 @@ export const MenuOverlayMixin = (superClass) =>
     _updatePosition() {
       super._updatePosition();
 
-      if (this.positionTarget && this.parentOverlay) {
+      if (this.positionTarget && this.parentOverlay && this.opened) {
         // This overlay is positioned by a parent menu item,
         // adjust the position by the overlay content paddings
         const content = this.$.content;


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10079

We should make sure `_updatePosition()` doesn't modify overlay styles when menu isn't opened.

## Type of change

- Bugfix