### PR TITLE
refactor: simplify logic that prevents instant scroll chaining

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -579,6 +579,18 @@ export class IronListAdapter {
         timeOut.after(this.timeouts.FIX_INVALID_ITEM_POSITIONING),
         () => this.__fixInvalidItemPositioning(),
       );
+
+      if (!this.__overscrollDebouncer?.isActive()) {
+        this.scrollTarget.style.overscrollBehavior = 'none';
+      }
+
+      this.__overscrollDebouncer = Debouncer.debounce(
+        this.__overscrollDebouncer,
+        timeOut.after(this.timeouts.PREVENT_OVERSCROLL),
+        () => {
+          this.scrollTarget.style.overscrollBehavior = null;
+        },
+      );
     }
 
     if (this.reorderElements) {
@@ -596,18 +608,6 @@ export class IronListAdapter {
     if (this._scrollTop === 0 && this.firstVisibleIndex !== 0 && Math.abs(delta) > 0) {
       this.scrollToIndex(0);
     }
-
-    if (!this.__overscrollDebouncer?.isActive()) {
-      this.scrollTarget.style.overscrollBehavior = 'none';
-    }
-
-    this.__overscrollDebouncer = Debouncer.debounce(
-      this.__overscrollDebouncer,
-      timeOut.after(this.timeouts.PREVENT_OVERSCROLL),
-      () => {
-        this.scrollTarget.style.overscrollBehavior = null;
-      },
-    );
   }
 
   /** @override */

--- a/packages/component-base/test/virtualizer-scrolling.test.js
+++ b/packages/component-base/test/virtualizer-scrolling.test.js
@@ -1,65 +1,28 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
-import Sinon from 'sinon';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import { Virtualizer } from '../src/virtualizer.js';
 
-function canScroll(el, deltaY) {
-  const isScrollableElement = ['auto', 'scroll'].indexOf(getComputedStyle(el).overflow) !== -1;
-  const canScrollAndScrollingDownwards = deltaY > 0 && el.scrollTop < el.scrollHeight - el.offsetHeight;
-  const canScrollAndScrollingUpwards = deltaY < 0 && el.scrollTop > 0;
-
-  return isScrollableElement && (canScrollAndScrollingDownwards || canScrollAndScrollingUpwards);
-}
-
-describe('virtualizer - wheel scrolling', () => {
-  const IGNORE_WHEEL_TIMEOUT = 500;
-  let wrapper;
+describe('virtualizer - overscroll', () => {
+  const PREVENT_OVERSCROLL_TIMEOUT = 500;
   let virtualizer;
   let scrollTarget;
   let clock;
-  let child;
-  let grandchild;
 
   beforeEach(() => {
-    wrapper = fixtureSync(`
-      <div style="height: 100px; overflow: auto;">
-        <div style="height: 200px;">
-          <div></div>
-        </div>
+    scrollTarget = fixtureSync(`
+      <div style="height: 200px;">
+        <div></div>
       </div>
     `);
-    scrollTarget = wrapper.firstElementChild;
     const scrollContainer = scrollTarget.firstElementChild;
-
-    const wheelListener = (e) => {
-      if (!e.defaultPrevented && canScroll(e.currentTarget, e.deltaY)) {
-        e.currentTarget.scrollTop += e.deltaY;
-        e.preventDefault();
-      }
-    };
-
-    wrapper.addEventListener('wheel', wheelListener);
 
     virtualizer = new Virtualizer({
       createElements: (count) => Array.from(Array(count)).map(() => document.createElement('div')),
       updateElement: (el, index) => {
         el.index = index;
         el.id = `item-${index}`;
-
-        if (!el.firstElementChild) {
-          el.innerHTML = `
-            <div class="child" style="height: 20px; overflow: auto;">
-              <div class="grandchild">
-                <div class="content" style="height: 40px;">
-                </div>
-              </div>
-            </div>
-          `;
-          el.querySelector('.child').addEventListener('wheel', wheelListener);
-          el.querySelector('.grandchild').addEventListener('wheel', wheelListener);
-        }
-
-        el.querySelector('.content').textContent = index;
+        el.textContent = index;
       },
       scrollTarget,
       scrollContainer,
@@ -67,129 +30,25 @@ describe('virtualizer - wheel scrolling', () => {
 
     virtualizer.size = 100;
 
-    child = scrollContainer.firstElementChild.querySelector('.child');
-    grandchild = scrollContainer.firstElementChild.querySelector('.grandchild');
-
-    clock = Sinon.useFakeTimers();
+    clock = sinon.useFakeTimers({
+      shouldClearNativeTimers: true,
+    });
   });
 
   afterEach(() => {
     clock.restore();
   });
 
-  function wheel({
-    element = scrollTarget,
-    deltaX = 0,
-    deltaY = 0,
-    deltaMode = WheelEvent.DOM_DELTA_PIXEL,
-    skipFlush = false,
-    ctrlKey = false,
-  }) {
-    const e = new CustomEvent('wheel', { bubbles: true, cancelable: true });
-    e.deltaY = deltaY;
-    e.deltaX = deltaX;
-    e.deltaMode = deltaMode;
-    e.ctrlKey = ctrlKey;
-    element.dispatchEvent(e);
-    if (!skipFlush) {
-      virtualizer.flush();
-    }
-  }
-
-  it('should scroll by pixels when deltaMode is DOM_DELTA_PIXEL (default)', () => {
-    wheel({ deltaY: 1, deltaMode: WheelEvent.DOM_DELTA_PIXEL });
-    expect(scrollTarget.scrollTop).to.equal(1);
+  it('should prevent outer scrolling right after reaching the end', async () => {
+    scrollTarget.scrollTop = scrollTarget.scrollHeight;
+    await clock.tickAsync();
+    expect(scrollTarget.style.overscrollBehavior).to.equal('none');
   });
 
-  it('should scroll by lines when deltaMode is DOM_DELTA_LINE', () => {
-    wheel({ deltaY: 1, deltaMode: WheelEvent.DOM_DELTA_LINE });
-    expect(scrollTarget.scrollTop).to.equal(16);
-  });
-
-  it('should scroll by pages when deltaMode is DOM_DELTA_PAGE', () => {
-    wheel({ deltaY: 1, deltaMode: WheelEvent.DOM_DELTA_PAGE });
-    expect(scrollTarget.scrollTop).to.equal(184);
-  });
-
-  it('should not scroll the wrapper right after virtualizer scrolled to end', () => {
-    // Wheel scroll to end
-    wheel({ deltaY: scrollTarget.scrollHeight });
-    // Wheel momentum settled down
-    wheel({ deltaY: 0 });
-    // Wheel scroll again
-    wheel({ deltaY: 1 });
-    // Expect the underlying wrapper not to have been scrolled
-    expect(wrapper.scrollTop).to.equal(0);
-  });
-
-  it('should scroll the wrapper a while after virtualizer scrolled to end', () => {
-    wheel({ deltaY: scrollTarget.scrollHeight });
-    wheel({ deltaY: 0 });
-    clock.tick(IGNORE_WHEEL_TIMEOUT);
-    wheel({ deltaY: 1 });
-    expect(wrapper.scrollTop).to.equal(1);
-  });
-
-  it('should skip the custom wheel scrolling logic on ctrl-wheel', () => {
-    wheel({ deltaY: scrollTarget.scrollHeight });
-    wheel({ deltaY: 1, ctrlKey: true });
-    expect(wrapper.scrollTop).to.equal(1);
-  });
-
-  it('should not scroll the wrapper while the scroll momentum slowly settles', () => {
-    let deltaY = scrollTarget.scrollHeight;
-    const step = Math.floor(deltaY / 10);
-    while (deltaY > 0) {
-      wheel({ deltaY });
-      deltaY -= step;
-      clock.tick(100);
-    }
-    expect(wrapper.scrollTop).to.equal(0);
-  });
-
-  it('should scroll the wrapper normally if already scrolled to end', () => {
-    wheel({ deltaY: scrollTarget.scrollHeight });
-    wheel({ deltaY: 0 });
-    clock.tick(IGNORE_WHEEL_TIMEOUT);
-    wheel({ deltaY: 2 });
-    wheel({ deltaY: 1 });
-    expect(wrapper.scrollTop).to.equal(3);
-  });
-
-  it('should process wheel delta one per frame', async () => {
-    clock.restore();
-
-    wheel({ deltaY: 1, skipFlush: true });
-    wheel({ deltaY: 1, skipFlush: true });
-    expect(scrollTarget.scrollTop).to.equal(1);
-
-    await nextRender();
-    wheel({ deltaY: 1, skipFlush: true });
-    await nextRender();
-    wheel({ deltaY: 1, skipFlush: true });
-    expect(scrollTarget.scrollTop).to.equal(4);
-  });
-
-  it('should scroll a scrollable child', () => {
-    wheel({ deltaY: 1, element: child });
-    expect(child.scrollTop).to.equal(1);
-    expect(scrollTarget.scrollTop).to.equal(0);
-    expect(wrapper.scrollTop).to.equal(0);
-  });
-
-  it('should scroll a scrollable child from wheel over grandchild', () => {
-    wheel({ deltaY: 1, element: grandchild });
-    expect(child.scrollTop).to.equal(1);
-    expect(scrollTarget.scrollTop).to.equal(0);
-    expect(wrapper.scrollTop).to.equal(0);
-  });
-
-  it('should scroll the scrollTarget from wheel over grandchild', () => {
-    child.style.overflow = 'hidden';
-    wheel({ deltaY: 1, element: grandchild });
-    expect(child.scrollTop).to.equal(0);
-    expect(scrollTarget.scrollTop).to.equal(1);
-    expect(wrapper.scrollTop).to.equal(0);
+  it('should allow outer scrolling again after timeout', async () => {
+    scrollTarget.scrollTop = scrollTarget.scrollHeight;
+    await clock.tickAsync(PREVENT_OVERSCROLL_TIMEOUT);
+    expect(scrollTarget.style.overscrollBehavior).to.be.empty;
   });
 });
 


### PR DESCRIPTION
## Description

This PR replaces the custom mouse wheel logic that prevented instant scroll chaining at the end of the virtualized list with an `overscroll-behavior: none` applied while scrolling and cleared after a short timeout once scrolling finishes. This simplifies the logic while ensuring that multiple touchpad swipes required to get to the end of a large grid still don't accidentally cause the whole page to scroll. Bonus: it now works on touch devices too.

## Type of change

- [x] Refactor
