### PR TITLE
fix: remove z-index from checkbox/radio baseline alignment element

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -65,7 +65,6 @@ export const checkable = (part, propName = part) => css`
     content: '\\2003';
     grid-column: 1;
     grid-row: 1;
-    z-index: -1;
     width: 0;
   }
 


### PR DESCRIPTION
Having a negative z-index doesn't really help in any way, but it causes a rendering bug in Safari 17 on the Aura dev page – notice the missing back arrow icon in the view header (ignore the broken badge colors):

## Before

<img width="496" height="935" alt="Screenshot 2025-09-08 at 14 35 36" src="https://github.com/user-attachments/assets/b3603a6e-8912-4c2b-b849-6e4e4fffe5b2" />


## After

<img width="496" height="935" alt="Screenshot 2025-09-08 at 14 58 23" src="https://github.com/user-attachments/assets/4b859b42-81b9-4f20-b799-85c7cbc1dde1" />
