### PR TITLE
fix: min font-size for side-nav label

### DIFF
--- a/packages/side-nav/src/styles/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-base-styles.js
@@ -20,7 +20,7 @@ const sideNav = css`
     justify-content: start;
     gap: var(--vaadin-side-nav-item-gap, var(--vaadin-gap-s));
     padding: var(--vaadin-side-nav-item-padding, var(--vaadin-padding-container));
-    font-size: var(--vaadin-side-nav-label-font-size, 0.875em);
+    font-size: var(--vaadin-side-nav-label-font-size, max(11px, 0.875em));
     font-weight: var(--vaadin-side-nav-label-font-weight, 500);
     color: var(--vaadin-side-nav-label-color, var(--vaadin-color-subtle));
     line-height: var(--vaadin-side-nav-label-line-height, inherit);


### PR DESCRIPTION
Make sure the label stays legible even if the root font size is made really small.