### PR TITLE
refactor: avoid forced style recalculation on scroll

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -547,8 +547,8 @@ export class IronListAdapter {
       return;
     }
 
-    this._adjustVirtualIndexOffset(this._scrollTop - (this.__previousScrollTop || 0));
-    const delta = this.scrollTarget.scrollTop - this._scrollPosition;
+    this._adjustVirtualIndexOffset(this._scrollTop - this._scrollPosition);
+    const delta = this._scrollTop - this._scrollPosition;
 
     super._scrollHandler();
 
@@ -601,11 +601,9 @@ export class IronListAdapter {
       );
     }
 
-    this.__previousScrollTop = this._scrollTop;
-
     // If the first visible index is not 0 when scrolled to the top,
     // scroll to index 0 to fix the issue.
-    if (this._scrollTop === 0 && this.firstVisibleIndex !== 0 && Math.abs(delta) > 0) {
+    if (this._scrollPosition === 0 && this.firstVisibleIndex !== 0 && Math.abs(delta) > 0) {
       this.scrollToIndex(0);
     }
   }


### PR DESCRIPTION
## Description

This PR updates the virtualizer's scroll handler to read from the cached `_scrollPosition` instead of directly from the element's `scrollTop` since that one can trigger a forced style recalculation if accessed immediately after style writes.

| Before | After |
|-------|-------|
| ![Screenshot 2025-09-11 at 9 56 21](https://github.com/user-attachments/assets/04eb7825-5092-4eb7-bff1-82abab80bf82) | ![Screenshot 2025-09-11 at 9 54 07](https://github.com/user-attachments/assets/6f5881eb-ed27-4cb6-aead-1877189c28a7) |

Part of https://github.com/vaadin/flow-components/issues/7985

## Type of change

- [x] Refactor
