### PR TITLE
fix: reflect row aria-expanded state for toggle cells

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getBodyRowCells, iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
+import { findTreeToggleCell, iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -101,7 +101,7 @@ export const A11yMixin = (superClass) =>
      * @protected
      */
     _a11yUpdateRowExpanded(row) {
-      const toggleCell = this.__a11yFindTreeToggleCell(row);
+      const toggleCell = findTreeToggleCell(row);
       if (this.__isRowExpandable(row)) {
         row.setAttribute('aria-expanded', 'false');
         if (toggleCell) {
@@ -118,20 +118,6 @@ export const A11yMixin = (superClass) =>
           toggleCell.removeAttribute('aria-expanded');
         }
       }
-    }
-
-    /**
-     * Finds the cell containing the tree toggle element
-     * @param {!HTMLElement} row
-     * @return {HTMLElement|null}
-     * @private
-     */
-    __a11yFindTreeToggleCell(row) {
-      const cellWithTreeToggle = getBodyRowCells(row).find((cell) => {
-        const toggle = cell._content.querySelector('vaadin-grid-tree-toggle');
-        return toggle && !toggle.leaf;
-      });
-      return cellWithTreeToggle === undefined ? null : cellWithTreeToggle;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -101,21 +101,19 @@ export const A11yMixin = (superClass) =>
      * @protected
      */
     _a11yUpdateRowExpanded(row) {
+      const toggleCell = this.__a11yFindTreeToggleCell(row);
       if (this.__isRowExpandable(row)) {
         row.setAttribute('aria-expanded', 'false');
-        const toggleCell = this.__a11yFindTreeToggleCell(row);
         if (toggleCell) {
           toggleCell.setAttribute('aria-expanded', 'false');
         }
       } else if (this.__isRowCollapsible(row)) {
         row.setAttribute('aria-expanded', 'true');
-        const toggleCell = this.__a11yFindTreeToggleCell(row);
         if (toggleCell) {
           toggleCell.setAttribute('aria-expanded', 'true');
         }
       } else {
         row.removeAttribute('aria-expanded');
-        const toggleCell = this.__a11yFindTreeToggleCell(row);
         if (toggleCell) {
           toggleCell.removeAttribute('aria-expanded');
         }

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
+import { getBodyRowCells, iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
 
 /**
  * @polymerMixin
@@ -103,11 +103,37 @@ export const A11yMixin = (superClass) =>
     _a11yUpdateRowExpanded(row) {
       if (this.__isRowExpandable(row)) {
         row.setAttribute('aria-expanded', 'false');
+        const toggleCell = this.__a11yFindTreeToggleCell(row);
+        if (toggleCell) {
+          toggleCell.setAttribute('aria-expanded', 'false');
+        }
       } else if (this.__isRowCollapsible(row)) {
         row.setAttribute('aria-expanded', 'true');
+        const toggleCell = this.__a11yFindTreeToggleCell(row);
+        if (toggleCell) {
+          toggleCell.setAttribute('aria-expanded', 'true');
+        }
       } else {
         row.removeAttribute('aria-expanded');
+        const toggleCell = this.__a11yFindTreeToggleCell(row);
+        if (toggleCell) {
+          toggleCell.removeAttribute('aria-expanded');
+        }
       }
+    }
+
+    /**
+     * Finds the cell containing the tree toggle element
+     * @param {!HTMLElement} row
+     * @return {HTMLElement|null}
+     * @private
+     */
+    __a11yFindTreeToggleCell(row) {
+      const cellWithTreeToggle = getBodyRowCells(row).find((cell) => {
+        const toggle = cell._content.querySelector('vaadin-grid-tree-toggle');
+        return toggle && !toggle.leaf;
+      });
+      return cellWithTreeToggle === undefined ? null : cellWithTreeToggle;
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -174,6 +174,19 @@ export function updateCellState(cell, attribute, value, part, oldPart) {
 }
 
 /**
+ * Finds the cell containing the tree toggle element
+ * @param {!HTMLElement} row
+ * @return {HTMLElement | null}
+ */
+export function findTreeToggleCell(row) {
+  const cellWithTreeToggle = getBodyRowCells(row).find((cell) => {
+    const toggle = cell._content.querySelector('vaadin-grid-tree-toggle');
+    return toggle && !toggle.leaf;
+  });
+  return cellWithTreeToggle === undefined ? null : cellWithTreeToggle;
+}
+
+/**
  * A helper for observing flattened child column list of an element.
  */
 export class ColumnObserver {

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -179,11 +179,7 @@ export function updateCellState(cell, attribute, value, part, oldPart) {
  * @return {HTMLElement | null}
  */
 export function findTreeToggleCell(row) {
-  const cellWithTreeToggle = getBodyRowCells(row).find((cell) => {
-    const toggle = cell._content.querySelector('vaadin-grid-tree-toggle');
-    return toggle && !toggle.leaf;
-  });
-  return cellWithTreeToggle === undefined ? null : cellWithTreeToggle;
+  return getBodyRowCells(row).find((cell) => cell._content.querySelector('vaadin-grid-tree-toggle'));
 }
 
 /**

--- a/packages/grid/test/accessibility.test.js
+++ b/packages/grid/test/accessibility.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import './grid-test-styles.js';
 import '../all-imports.js';
@@ -218,6 +219,103 @@ describe('accessibility', () => {
       grid.expandItem({ name: '0' });
       grid.collapseItem({ name: '0' });
       expect(grid.$.items.children[1].getAttribute('aria-level')).to.be.null;
+    });
+
+    describe('toggle cell', () => {
+      function setupTreeGrid(additionalColumns = []) {
+        grid = fixtureSync(`
+        <vaadin-grid item-id-path="name">
+          ${additionalColumns.join('')}
+          <vaadin-grid-tree-column path="name" width="200px" header="Name" flex-shrink="0"></vaadin-grid-tree-column>
+          <vaadin-grid-column path="value" header="Value"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+        grid.dataProvider = ({ parentItem }, callback) => {
+          const itemsOnEachLevel = 5;
+          const items = [...Array(itemsOnEachLevel)].map((_, i) => {
+            return {
+              name: `${parentItem ? `${parentItem.name}-` : ''}${i}`,
+              value: `value-${i}`,
+              children: i % 2 === 0,
+              id: `${parentItem ? `${parentItem.id}-` : ''}${i}`,
+            };
+          });
+          callback(items, itemsOnEachLevel);
+        };
+        flushGrid(grid);
+        return grid;
+      }
+
+      function getToggleCell(row) {
+        for (const cell of row.querySelectorAll('td')) {
+          if (cell._content && cell._content.querySelector('vaadin-grid-tree-toggle')) {
+            return cell;
+          }
+        }
+        return null;
+      }
+
+      function getExpandableRows() {
+        return Array.from(grid.$.items.children).filter((row) => row.getAttribute('aria-expanded') !== null);
+      }
+
+      describe('aria-expanded', () => {
+        beforeEach(() => {
+          setupTreeGrid();
+        });
+
+        it('should reflect aria-expanded state of rows', () => {
+          Array.from(grid.$.items.children).forEach((row) => {
+            const toggleCell = getToggleCell(row);
+            expect(toggleCell).to.exist;
+            expect(toggleCell.getAttribute('aria-expanded')).to.equal(row.getAttribute('aria-expanded'));
+          });
+        });
+
+        it('should update cell aria-expanded when row expanded state changes', () => {
+          const row = getExpandableRows()[0];
+          const toggleCell = getToggleCell(row);
+          const itemName = row._item.name;
+
+          expect(row.getAttribute('aria-expanded')).to.equal('false');
+          expect(toggleCell.getAttribute('aria-expanded')).to.equal('false');
+
+          grid.expandItem({ name: itemName });
+          expect(row.getAttribute('aria-expanded')).to.equal('true');
+          expect(toggleCell.getAttribute('aria-expanded')).to.equal('true');
+
+          grid.collapseItem({ name: itemName });
+          expect(row.getAttribute('aria-expanded')).to.equal('false');
+          expect(toggleCell.getAttribute('aria-expanded')).to.equal('false');
+        });
+
+        it('should handle expansion via keyboard interaction', async () => {
+          const toggleCell = getToggleCell(getExpandableRows()[0]);
+          toggleCell.focus();
+          await sendKeys({ press: 'Space' });
+          expect(toggleCell.getAttribute('aria-expanded')).to.equal('true');
+          await sendKeys({ press: 'Space' });
+          expect(toggleCell.getAttribute('aria-expanded')).to.equal('false');
+        });
+      });
+
+      describe('with selection column', () => {
+        beforeEach(() => {
+          setupTreeGrid(['<vaadin-grid-selection-column></vaadin-grid-selection-column>']);
+        });
+
+        it('should update correct cell when selection column is present', () => {
+          const expandableRows = getExpandableRows();
+          expect(expandableRows.length).to.be.above(0);
+          expandableRows.forEach((row) => {
+            const toggleCell = getToggleCell(row);
+            expect(toggleCell).to.exist;
+            expect(toggleCell).to.not.equal(row.querySelector('td'));
+            expect(toggleCell._content.querySelector('vaadin-grid-tree-toggle')).to.exist;
+            expect(toggleCell.getAttribute('aria-expanded')).to.equal(row.getAttribute('aria-expanded'));
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Description

When cell focus mode is active and the row is expanded/collapsed via Space key, the state change is not announced for NVDA and VoiceOver.

This PR reflects the row `aria-expanded` state to the toggle cells so that the announcements in cell focus mode works correctly.

Fixes #5791 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.