### PR TITLE
fix: keep button radius and allow more space for focus outline

### DIFF
--- a/packages/menu-bar/src/styles/vaadin-menu-bar-base-styles.js
+++ b/packages/menu-bar/src/styles/vaadin-menu-bar-base-styles.js
@@ -17,16 +17,15 @@ export const menuBarStyles = css`
   [part='container'] {
     display: flex;
     flex-wrap: nowrap;
-    margin: calc((var(--vaadin-focus-ring-width) + 1px) * -1);
+    margin: calc((var(--vaadin-focus-ring-width) + 2px) * -1);
     overflow: hidden;
-    padding: calc(var(--vaadin-focus-ring-width) + 1px);
+    padding: calc(var(--vaadin-focus-ring-width) + 2px);
     position: relative;
     width: 100%;
     --_gap: var(--vaadin-menu-bar-gap, 0px);
     --_bw: var(--vaadin-button-border-width, 1px);
     gap: var(--_gap);
     --_rad-button: var(--vaadin-button-border-radius, var(--vaadin-radius-m));
-    --_rad: min(var(--_gap) * 1000, var(--_rad-button));
   }
 
   ::slotted(vaadin-menu-bar-button:not(:first-of-type)) {
@@ -34,16 +33,18 @@ export const menuBarStyles = css`
   }
 
   ::slotted(vaadin-menu-bar-button) {
-    border-radius: var(--_rad);
+    border-radius: 0;
   }
 
   ::slotted([first-visible]),
-  :host([has-single-button]) ::slotted([slot='overflow']) {
+  :host([has-single-button]) ::slotted([slot='overflow']),
+  ::slotted(vaadin-menu-bar-button[theme~='tertiary']) {
     border-start-start-radius: var(--_rad-button);
     border-end-start-radius: var(--_rad-button);
   }
 
-  ::slotted(:is([last-visible], [slot='overflow'])) {
+  ::slotted(:is([last-visible], [slot='overflow'])),
+  ::slotted(vaadin-menu-bar-button[theme~='tertiary']) {
     border-start-end-radius: var(--_rad-button);
     border-end-end-radius: var(--_rad-button);
   }


### PR DESCRIPTION
Always remove border radius from buttons in the middle of the menu bar, except for tertiary-variant. This makes them look more connected, and tries to avoid confusion how the tab stop works. If you want the previous look, you should consider using separate, single-item menu bars instead.

This only affects the buttons when `--vaadin-menu-bar-gap` is bigger than zero.

## Before

<img width="497" height="70" alt="Screenshot 2025-09-12 at 15 32 28" src="https://github.com/user-attachments/assets/ec9224d8-9451-4c66-b473-6eb104708a58" />


## After

<img width="488" height="58" alt="Screenshot 2025-09-12 at 15 31 05" src="https://github.com/user-attachments/assets/e6af212e-d224-47f8-930d-56ae966ce33f" />
