### PR TITLE
refactor: remove obsolete textAlign fallback

### DIFF
--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -536,24 +536,8 @@ export const ColumnBaseMixin = (superClass) =>
         return;
       }
 
-      let textAlignFallback;
-      if (getComputedStyle(this._grid).direction === 'ltr') {
-        if (textAlign === 'start') {
-          textAlignFallback = 'left';
-        } else if (textAlign === 'end') {
-          textAlignFallback = 'right';
-        }
-      } else if (textAlign === 'start') {
-        textAlignFallback = 'right';
-      } else if (textAlign === 'end') {
-        textAlignFallback = 'left';
-      }
-
       this._allCells.forEach((cell) => {
         cell._content.style.textAlign = textAlign;
-        if (getComputedStyle(cell._content).textAlign !== textAlign) {
-          cell._content.style.textAlign = textAlignFallback;
-        }
       });
     }
 


### PR DESCRIPTION
## Description

The textAlign fallback was originally added in [this commit](https://github.com/vaadin/web-components/commit/51d412db275cf040018907afa53089902573dd3a). It seems there used to be an issue with the `start` and `end` values so `left` and `right` values needed to be used instead. However, that no longer seems to be neccessary. Also, removing this workaround prevents one forced reflow in the Flow component during the first render:

<img width="671" height="196" alt="image" src="https://github.com/user-attachments/assets/b7a08469-3216-4ed6-84a8-d0b42b8cb23f" />

## Type of change

- [x] Refactor
