### PR TITLE
fix: use preventDefault for handling MDL escape press

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -291,9 +291,9 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
 
   /** @private */
   __onDetailKeydown(event) {
-    if (event.key === 'Escape') {
+    if (event.key === 'Escape' && !event.defaultPrevented) {
       // Prevent firing on parent layout when using nested layouts
-      event.stopPropagation();
+      event.preventDefault();
       this.dispatchEvent(new CustomEvent('detail-escape-press'));
     }
   }

--- a/packages/master-detail-layout/test/events.test.js
+++ b/packages/master-detail-layout/test/events.test.js
@@ -95,6 +95,26 @@ describe('events', () => {
 
         expect(spy).to.be.calledOnce;
       });
+
+      it('should call preventDefault on keydown event on pressing Escape', async () => {
+        const spy = sinon.spy();
+        layout.addEventListener('keydown', spy);
+
+        focusable.focus();
+        await sendKeys({ press: 'Escape' });
+
+        expect(spy.firstCall.args[0].defaultPrevented).to.be.true;
+      });
+
+      it('should not call stopPropagation on keydown event on pressing Escape', async () => {
+        const spy = sinon.spy();
+        document.addEventListener('keydown', spy, { once: true });
+
+        focusable.focus();
+        await sendKeys({ press: 'Escape' });
+
+        expect(spy.calledOnce).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Using `stopPropagation()` can be problematic in some cases. I noticed that `vaadin-select` inside of the MDL detail content doesn't close while reviewing https://github.com/vaadin/web-components/pull/10157. Let's use `preventDefault()` instead as we do elsewhere, example:

https://github.com/vaadin/web-components/blob/db441208a344da0985ebf06b955dfb82b1cc4ce2/packages/item/src/vaadin-item-mixin.js#L104

## Type of change

- Bugfix