### PR TITLE
refactor: define all LumoInjector-related styles on ::before

### DIFF
--- a/packages/vaadin-themable-mixin/src/lumo-injector.js
+++ b/packages/vaadin-themable-mixin/src/lumo-injector.js
@@ -82,7 +82,7 @@ export class LumoInjector {
 
   constructor(root = document) {
     this.#root = root;
-    this.#cssPropertyObserver = new CSSPropertyObserver(this.#root, 'vaadin-lumo-injector', (propertyName) => {
+    this.#cssPropertyObserver = new CSSPropertyObserver(this.#root, (propertyName) => {
       const tagName = propertyName.slice(2).replace('-lumo-inject', '');
       this.#updateStyleSheet(tagName);
     });


### PR DESCRIPTION
## Description

The PR ensures all LumoInjector-related CSS properties are defined on the `::before` pseudo-element to avoid cluttering the DOM inspector:

<img width="1223" height="352" alt="image" src="https://github.com/user-attachments/assets/50707dd2-e725-439d-909c-5189dc9c14f1" />

Depends on 
- https://github.com/vaadin/web-components/pull/10172

## Type of change

- [x] Refactor
