### PR TITLE
chore: update GitHub pages workflow to publish from main

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ name: Deploy Pages
 on:
   push:
     branches:
-      - aura
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Description

Now when all the changes from the `aura` branch are ported to `main`, let's deploy GitHub pages from there.

## Type of change

- Internal change