### PR TITLE
chore: do not checkout aura branch for GitHub pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: aura
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10176 - missed to remove one more `aura` branch reference.

## Type of change

- Internal change