### PR TITLE
fix: update style for organization chart

### DIFF
--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -776,6 +776,10 @@ export const chartStyles = css`
     stroke-width: 0;
   }
 
+  :where([styled-mode]) .highcharts-organization-series .highcharts-null-point {
+    fill: transparent;
+  }
+
   :where([styled-mode]) .highcharts-polygon-series .highcharts-graph {
     fill: inherit;
     stroke-width: 0;
@@ -1106,7 +1110,7 @@ export const chartStyles = css`
   }
 
   :where([styled-mode]) .highcharts-null-point {
-    fill: var(--highcharts-neutral-color-3, transparent);
+    fill: var(--highcharts-neutral-color-3, var(--vaadin-charts-button-background, var(--vaadin-background-container)));
   }
 
   /* 3d charts */


### PR DESCRIPTION
## Description

Updates the charts' base style to apply the same fix done in Highcharts for the issue of the lines connecting data points receiving a background color.

<img width="734" height="612" alt="image" src="https://github.com/user-attachments/assets/25b56801-a0fd-4c91-bdfc-a0bcc87125f7" />

Reference:
https://github.com/highcharts/highcharts/commit/cec1fe3c28e177d3d357fd7acf13715ef996b138

