### PR TITLE
feat: add `overflow-indicator-top` and `oveflow-indicator-bottom` variants

### DIFF
--- a/dev/scroller.html
+++ b/dev/scroller.html
@@ -31,8 +31,20 @@
       <div class="content"></div>
     </vaadin-scroller>
 
-    <h2 class="heading">Overflow indicators variant</h2>
+    <h2 class="heading">Overflow Indicator Variants</h2>
+
+    <h3 class="heading">Top &amp; Bottom</h3>
     <vaadin-scroller theme="overflow-indicators">
+      <div class="content"></div>
+    </vaadin-scroller>
+
+    <h3 class="heading">Top Only</h3>
+    <vaadin-scroller theme="overflow-indicator-top">
+      <div class="content"></div>
+    </vaadin-scroller>
+
+    <h3 class="heading">Bottom Only</h3>
+    <vaadin-scroller theme="overflow-indicator-bottom">
       <div class="content"></div>
     </vaadin-scroller>
   </body>

--- a/packages/scroller/src/styles/vaadin-scroller-base-styles.js
+++ b/packages/scroller/src/styles/vaadin-scroller-base-styles.js
@@ -33,8 +33,8 @@ export const scrollerStyles = css`
     overflow: hidden;
   }
 
-  :host([theme~='overflow-indicators'])::before,
-  :host([theme~='overflow-indicators'])::after {
+  :host([theme*='overflow-indicator'])::before,
+  :host([theme*='overflow-indicator'])::after {
     content: '';
     display: none;
     position: sticky;
@@ -45,13 +45,15 @@ export const scrollerStyles = css`
     background: var(--vaadin-scroller-border-color, var(--vaadin-border-color-subtle));
   }
 
-  :host([theme~='overflow-indicators'])::after {
+  :host([theme*='overflow-indicator'])::after {
     margin-bottom: 0;
     margin-top: -1px;
   }
 
+  :host([theme~='overflow-indicator-top'][overflow~='top'])::before,
   :host([theme~='overflow-indicators'][overflow~='top'])::before,
-  :host([theme~='overflow-indicators'][overflow~='bottom'])::after {
+  :host([theme~='overflow-indicators'][overflow~='bottom'])::after,
+  :host([theme~='overflow-indicator-bottom'][overflow~='bottom'])::after {
     display: block;
   }
 `;

--- a/packages/scroller/test/visual/base/scroller.test.js
+++ b/packages/scroller/test/visual/base/scroller.test.js
@@ -31,7 +31,7 @@ describe('scroller', () => {
   });
 
   it('theme-overflow-indicators-bottom', async () => {
-    element.setAttribute('theme', 'overflow-indicators');
+    element.setAttribute('theme', 'overflow-indicator-bottom');
     await visualDiff(div, 'theme-overflow-indicators-bottom');
   });
 
@@ -42,7 +42,7 @@ describe('scroller', () => {
   });
 
   it('theme-overflow-indicators-top', async () => {
-    element.setAttribute('theme', 'overflow-indicators');
+    element.setAttribute('theme', 'overflow-indicator-top');
     element.scrollTop = element.scrollHeight - element.clientHeight;
     await visualDiff(div, 'theme-overflow-indicators-top');
   });

--- a/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
+++ b/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
@@ -27,8 +27,8 @@ export const virtualListStyles = css`
     position: relative;
   }
 
-  :host([theme~='overflow-indicators'])::before,
-  :host([theme~='overflow-indicators'])::after {
+  :host([theme*='overflow-indicator'])::before,
+  :host([theme*='overflow-indicator'])::after {
     content: '';
     display: none;
     position: sticky;
@@ -39,13 +39,15 @@ export const virtualListStyles = css`
     background: var(--vaadin-virtual-list-border-color, var(--vaadin-border-color-subtle));
   }
 
-  :host([theme~='overflow-indicators'])::after {
+  :host([theme*='overflow-indicator'])::after {
     margin-bottom: 0;
     margin-top: -1px;
   }
 
+  :host([theme~='overflow-indicator-top'][overflow~='top'])::before,
   :host([theme~='overflow-indicators'][overflow~='top'])::before,
-  :host([theme~='overflow-indicators'][overflow~='bottom'])::after {
+  :host([theme~='overflow-indicators'][overflow~='bottom'])::after,
+  :host([theme~='overflow-indicator-bottom'][overflow~='bottom'])::after {
     display: block;
   }
 `;

--- a/packages/virtual-list/test/visual/base/virtual-list.test.js
+++ b/packages/virtual-list/test/visual/base/virtual-list.test.js
@@ -28,7 +28,7 @@ describe('virtual-list', () => {
   });
 
   it('theme-overflow-indicators-bottom', async () => {
-    element.setAttribute('theme', 'overflow-indicators');
+    element.setAttribute('theme', 'overflow-indicator-bottom');
     await visualDiff(div, 'theme-overflow-indicators-bottom');
   });
 
@@ -39,7 +39,7 @@ describe('virtual-list', () => {
   });
 
   it('theme-overflow-indicators-top', async () => {
-    element.setAttribute('theme', 'overflow-indicators');
+    element.setAttribute('theme', 'overflow-indicator-top');
     element.scrollTop = element.scrollHeight - element.clientHeight;
     await visualDiff(div, 'theme-overflow-indicators-top');
   });


### PR DESCRIPTION
Allow developers to choose if the want to show the indicator at the top, bottom, or both edges of Scroller and Virtual List.