### PR TITLE
chore: don't set custom property value on root if not overridden

### DIFF
--- a/dev/aura/aura-number-control.js
+++ b/dev/aura/aura-number-control.js
@@ -147,7 +147,7 @@ class AuraNumberControl extends AuraControl {
     const computed = this.#getComputedNumber();
     const initial = computed != null ? computed : this.#clamp(this.#snap((this.#min + this.#max) / 2));
     this.#initialComputed = computed ?? initial;
-    this.#setValue(initial, { persist: false });
+    this.#setValue(initial, { persist: null });
   }
 
   #getComputedNumber() {


### PR DESCRIPTION
This change avoids setting any `--aura` custom property value on the `<html>` element if they aren't customized/overridden.