### PR TITLE
refactor: rename base styles custom CSS properties for colors

### DIFF
--- a/dev/app-layout.html
+++ b/dev/app-layout.html
@@ -20,7 +20,7 @@
       div[slot~='navbar'] {
         font-size: 1.125rem;
         margin: 0;
-        color: var(--vaadin-color);
+        color: var(--vaadin-text-color);
         font-weight: 600;
       }
 

--- a/dev/aura.html
+++ b/dev/aura.html
@@ -244,7 +244,7 @@
         place-self: stretch;
         margin: var(--vaadin-gap-m) 0;
         border: 0;
-        background: var(--vaadin-border-color-subtle);
+        background: var(--vaadin-border-color-secondary);
         min-height: 1px;
         max-height: 1px;
       }
@@ -402,7 +402,7 @@
                 align-items: center;
                 justify-content: center;
                 border-radius: var(--vaadin-radius-m);
-                border: 1px solid var(--vaadin-border-color-subtle);
+                border: 1px solid var(--vaadin-border-color-secondary);
                 gap: var(--vaadin-gap-s);
                 padding: var(--vaadin-padding-l);
                 box-sizing: border-box;
@@ -477,7 +477,6 @@
                 </div>
 
                 <div class="aura-surface component wide tall">
-
                   <div class="badges">
                     <span theme="badge">Default</span>
                     <span theme="badge accent">Accent</span>

--- a/dev/aura/aura-abstract-control.js
+++ b/dev/aura/aura-abstract-control.js
@@ -15,7 +15,7 @@ export class AuraControl extends HTMLElement {
       }
 
       label {
-        color: var(--vaadin-color);
+        color: var(--vaadin-text-color);
         font-weight: var(--aura-font-weight-medium);
       }
 

--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -45,7 +45,7 @@ class AuraSchemeControl extends AuraControl {
           cursor: pointer;
           user-select: none;
           display: inline-block;
-          border-right: 1px solid var(--vaadin-border-color-subtle);
+          border-right: 1px solid var(--vaadin-border-color-secondary);
         }
 
         .segmented label:last-of-type {

--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -55,7 +55,7 @@ class AuraSchemeControl extends AuraControl {
         /* Selected state */
         .segmented input:checked + label {
           background: var(--vaadin-background-container);
-          color: var(--vaadin-color);
+          color: var(--vaadin-text-color);
           background-clip: padding-box;
           font-weight: 600;
         }

--- a/dev/aura/aura-view.css
+++ b/dev/aura/aura-view.css
@@ -26,7 +26,7 @@
   font-size: var(--aura-font-size-l);
   font-weight: var(--aura-font-weight-semibold);
   line-height: var(--aura-line-height-m);
-  color: var(--vaadin-color);
+  color: var(--vaadin-text-color);
   flex: 1;
 
   &:first-child {

--- a/dev/aura/badge.css
+++ b/dev/aura/badge.css
@@ -12,9 +12,13 @@
   padding: 0 0.5em;
   border-radius: var(--vaadin-radius-l);
   min-width: calc(1lh - 1em - 2px);
-  --color: var(--vaadin-color);
+  --color: var(--vaadin-text-color);
   --text-opacity: 70%;
-  color: color-mix(in xyz, var(--color) calc(var(--text-opacity) - 15% * var(--aura-contrast)), var(--vaadin-color));
+  color: color-mix(
+    in xyz,
+    var(--color) calc(var(--text-opacity) - 15% * var(--aura-contrast)),
+    var(--vaadin-text-color)
+  );
   --vaadin-icon-size: 0.75lh;
 }
 

--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -27,7 +27,7 @@
     var(--_border-color-base) calc(14% + 6% * var(--aura-contrast)),
     transparent
   );
-  --vaadin-border-color-subtle: light-dark(
+  --vaadin-border-color-secondary: light-dark(
     color-mix(in srgb, var(--_border-color-base) max(5%, 5% + 3% * var(--aura-contrast)), transparent),
     color-mix(in srgb, var(--_border-color-base) max(6%, 5% + 5% * var(--aura-contrast)), transparent)
   );

--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -12,7 +12,7 @@
     color-mix(in srgb, var(--_color-base) calc(90% + 5% * var(--aura-contrast)), transparent),
     color-mix(in srgb, #fff calc(90% + 5% * var(--aura-contrast)), transparent)
   );
-  --vaadin-color-subtle: light-dark(
+  --vaadin-text-color-secondary: light-dark(
     color-mix(in srgb, var(--_color-base) calc(55% + 10% * var(--aura-contrast)), transparent),
     color-mix(in srgb, var(--_color-base) calc(57% + 10% * var(--aura-contrast)), transparent)
   );

--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -8,7 +8,7 @@
     oklch(from var(--aura-background-light) 0.1 calc(c / 2 + c * (1 - c)) h),
     oklch(from var(--aura-background-dark) 1 c h)
   );
-  --vaadin-color: light-dark(
+  --vaadin-text-color: light-dark(
     color-mix(in srgb, var(--_color-base) calc(90% + 5% * var(--aura-contrast)), transparent),
     color-mix(in srgb, #fff calc(90% + 5% * var(--aura-contrast)), transparent)
   );
@@ -62,12 +62,12 @@
   --aura-accent-text-light: color-mix(
     in srgb,
     var(--aura-accent-light) calc(70% - 15% * var(--aura-contrast)),
-    var(--vaadin-color)
+    var(--vaadin-text-color)
   );
   --aura-accent-text-dark: color-mix(
     in srgb,
     var(--aura-accent-dark) calc(70% - 15% * var(--aura-contrast)),
-    var(--vaadin-color)
+    var(--vaadin-text-color)
   );
   --aura-accent-text: light-dark(var(--aura-accent-text-light), var(--aura-accent-text-dark));
 
@@ -86,7 +86,7 @@
     transparent
   );
 
-  color: var(--vaadin-color);
+  color: var(--vaadin-text-color);
   background: var(--aura-app-background);
   background-size: 100vw 100vh;
   background-attachment: fixed;
@@ -99,5 +99,5 @@
 }
 
 :where(h1, h2, h3, h4, h5, h6) {
-  color: var(--vaadin-color);
+  color: var(--vaadin-text-color);
 }

--- a/packages/aura/src/components/app-layout.css
+++ b/packages/aura/src/components/app-layout.css
@@ -76,7 +76,7 @@ vaadin-app-layout > vaadin-scroller:nth-last-child(1 of [slot='drawer']) {
 
 vaadin-app-layout > :nth-child(1 of :not([slot])):nth-last-child(1 of :not([slot])) {
   color-scheme: var(--aura-content-color-scheme);
-  color: var(--vaadin-color);
+  color: var(--vaadin-text-color);
   background: linear-gradient(var(--aura-surface), var(--aura-surface)), var(--aura-app-background);
   background-clip: padding-box;
   background-origin: border-box;

--- a/packages/aura/src/components/app-layout.css
+++ b/packages/aura/src/components/app-layout.css
@@ -83,7 +83,7 @@ vaadin-app-layout > :nth-child(1 of :not([slot])):nth-last-child(1 of :not([slot
   min-height: 100%;
   box-sizing: border-box;
   border-radius: var(--_app-layout-radius);
-  border: var(--_aura-mdl-border) solid var(--vaadin-border-color-subtle);
+  border: var(--_aura-mdl-border) solid var(--vaadin-border-color-secondary);
   border-block-width: min(var(--aura-app-layout-inset), var(--_aura-mdl-border));
   border-inline-end-width: min(var(--aura-app-layout-inset), var(--_aura-mdl-border));
 }
@@ -100,7 +100,7 @@ vaadin-app-layout > vaadin-master-detail-layout:nth-child(1 of :not([slot])):nth
   }
 
   &:is([drawer][has-detail]) {
-    border-color: light-dark(var(--vaadin-border-color), var(--vaadin-border-color-subtle));
+    border-color: light-dark(var(--vaadin-border-color), var(--vaadin-border-color-secondary));
   }
 }
 

--- a/packages/aura/src/components/avatar.css
+++ b/packages/aura/src/components/avatar.css
@@ -1,5 +1,5 @@
 :where(:root, :host) {
-  --vaadin-avatar-border-color: var(--vaadin-border-color-subtle);
+  --vaadin-avatar-border-color: var(--vaadin-border-color-secondary);
   --vaadin-avatar-background: var(--vaadin-background-container);
   --vaadin-avatar-font-weight: var(--aura-font-weight-medium);
   --vaadin-avatar-font-size: var(--aura-font-size-m);

--- a/packages/aura/src/components/button.css
+++ b/packages/aura/src/components/button.css
@@ -55,7 +55,7 @@ vaadin-menu-bar-button[aria-haspopup='true'] {
 }
 
 :is(vaadin-button, vaadin-menu-bar-button, vaadin-drawer-toggle)[disabled][theme~='primary'] {
-  --vaadin-button-text-color: var(--vaadin-color-subtle);
+  --vaadin-button-text-color: var(--vaadin-text-color-secondary);
 }
 
 :is(vaadin-button, vaadin-menu-bar-button, vaadin-drawer-toggle):not([disabled])::before {

--- a/packages/aura/src/components/card.css
+++ b/packages/aura/src/components/card.css
@@ -2,7 +2,7 @@
   --vaadin-card-title-font-weight: var(--aura-font-weight-medium);
   --vaadin-card-padding: var(--vaadin-padding-l);
   --vaadin-card-gap: var(--vaadin-gap-m) var(--vaadin-gap-l);
-  --vaadin-card-border-color: var(--vaadin-border-color-subtle);
+  --vaadin-card-border-color: var(--vaadin-border-color-secondary);
   --vaadin-card-background: var(--aura-surface) padding-box;
 }
 

--- a/packages/aura/src/components/checkbox-radio.css
+++ b/packages/aura/src/components/checkbox-radio.css
@@ -15,7 +15,7 @@ vaadin-checkbox:not([readonly], [disabled])::part(checkbox),
 vaadin-radio-button:not([disabled])::part(radio) {
   --aura-surface-level: 4;
   box-shadow: 0 2px 1px -1px hsla(0, 0%, 0%, 0.07);
-  --_shade: color-mix(in srgb, var(--vaadin-border-color-subtle) 50%, transparent);
+  --_shade: color-mix(in srgb, var(--vaadin-border-color-secondary) 50%, transparent);
   background-image: linear-gradient(
     light-dark(transparent, var(--_shade)),
     transparent 33%,

--- a/packages/aura/src/components/dialog.css
+++ b/packages/aura/src/components/dialog.css
@@ -19,7 +19,7 @@ vaadin-confirm-dialog::part(overlay) {
 }
 
 vaadin-confirm-dialog::part(message) {
-  color: var(--vaadin-color-subtle);
+  color: var(--vaadin-text-color-secondary);
 }
 
 /* TODO probably should be in base styles */

--- a/packages/aura/src/components/input-container.css
+++ b/packages/aura/src/components/input-container.css
@@ -27,11 +27,11 @@ vaadin-message-input:not([readonly], [disabled]) {
 }
 
 :not([readonly], [disabled])::part(field-button):active {
-  color: var(--vaadin-color);
+  color: var(--vaadin-text-color);
 }
 
 @media (any-hover: hover) {
   :not([readonly], [disabled])::part(field-button):hover {
-    color: var(--vaadin-color);
+    color: var(--vaadin-text-color);
   }
 }

--- a/packages/aura/src/components/notification.css
+++ b/packages/aura/src/components/notification.css
@@ -33,7 +33,7 @@ vaadin-notification-card::part(overlay) {
 
 vaadin-notification-card vaadin-card {
   --vaadin-card-gap: var(--vaadin-gap-xs) var(--vaadin-gap-s);
-  color: var(--vaadin-color-subtle);
+  color: var(--vaadin-text-color-secondary);
 }
 
 vaadin-notification-card vaadin-button {

--- a/packages/aura/src/components/overlay.css
+++ b/packages/aura/src/components/overlay.css
@@ -31,5 +31,5 @@
   font-size: var(--aura-font-size-m);
   font-weight: var(--aura-font-weight);
   line-height: var(--aura-line-height-m);
-  color: var(--vaadin-color);
+  color: var(--vaadin-text-color);
 }

--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -25,7 +25,7 @@ vaadin-side-nav-item:not([disabled])::part(content):hover {
 
 vaadin-side-nav-item[current]::part(content) {
   --vaadin-side-nav-item-background: var(--aura-surface);
-  --vaadin-side-nav-item-border-color: var(--vaadin-border-color-subtle);
+  --vaadin-side-nav-item-border-color: var(--vaadin-border-color-secondary);
 }
 
 /* Contrast variant */

--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -20,7 +20,7 @@ vaadin-side-nav-item::part(content) {
 }
 
 vaadin-side-nav-item:not([disabled])::part(content):hover {
-  --vaadin-side-nav-item-color: var(--vaadin-color);
+  --vaadin-side-nav-item-color: var(--vaadin-text-color);
 }
 
 vaadin-side-nav-item[current]::part(content) {
@@ -38,18 +38,18 @@ vaadin-side-nav[theme~='contrast'] vaadin-side-nav-item[current]::part(content) 
 }
 
 vaadin-side-nav[theme~='contrast'] vaadin-side-nav-item[current] > :not([slot='children']) {
-  --aura-red: var(--vaadin-color);
-  --aura-red-text: var(--vaadin-color);
-  --aura-orange: var(--vaadin-color);
-  --aura-orange-text: var(--vaadin-color);
-  --aura-yellow: var(--vaadin-color);
-  --aura-yellow-text: var(--vaadin-color);
-  --aura-green: var(--vaadin-color);
-  --aura-green-text: var(--vaadin-color);
-  --aura-blue: var(--vaadin-color);
-  --aura-blue-text: var(--vaadin-color);
-  --aura-purple: var(--vaadin-color);
-  --aura-purple-text: var(--vaadin-color);
+  --aura-red: var(--vaadin-text-color);
+  --aura-red-text: var(--vaadin-text-color);
+  --aura-orange: var(--vaadin-text-color);
+  --aura-orange-text: var(--vaadin-text-color);
+  --aura-yellow: var(--vaadin-text-color);
+  --aura-yellow-text: var(--vaadin-text-color);
+  --aura-green: var(--vaadin-text-color);
+  --aura-green-text: var(--vaadin-text-color);
+  --aura-blue: var(--vaadin-text-color);
+  --aura-blue-text: var(--vaadin-text-color);
+  --aura-purple: var(--vaadin-text-color);
+  --aura-purple-text: var(--vaadin-text-color);
 }
 
 @container style(--aura-color-scheme: dark) {

--- a/packages/aura/src/palette.css
+++ b/packages/aura/src/palette.css
@@ -24,22 +24,30 @@
     oklch(from var(--aura-accent-dark) 0.7 min(c + 0.05, 0.4) clamp(280 - rem(h, 6), h, 350 - rem(h, 6)))
   );
 
-  --aura-red-text: color-mix(in srgb, var(--aura-red) calc(70% - 15% * var(--aura-contrast)), var(--vaadin-color));
+  --aura-red-text: color-mix(in srgb, var(--aura-red) calc(70% - 15% * var(--aura-contrast)), var(--vaadin-text-color));
   --aura-orange-text: color-mix(
     in srgb,
     var(--aura-orange) calc(60% - 15% * var(--aura-contrast)),
-    var(--vaadin-color)
+    var(--vaadin-text-color)
   );
   --aura-yellow-text: color-mix(
     in srgb,
     var(--aura-yellow) calc(55% - 15% * var(--aura-contrast)),
-    var(--vaadin-color)
+    var(--vaadin-text-color)
   );
-  --aura-green-text: color-mix(in srgb, var(--aura-green) calc(70% - 15% * var(--aura-contrast)), var(--vaadin-color));
-  --aura-blue-text: color-mix(in srgb, var(--aura-blue) calc(70% - 15% * var(--aura-contrast)), var(--vaadin-color));
+  --aura-green-text: color-mix(
+    in srgb,
+    var(--aura-green) calc(70% - 15% * var(--aura-contrast)),
+    var(--vaadin-text-color)
+  );
+  --aura-blue-text: color-mix(
+    in srgb,
+    var(--aura-blue) calc(70% - 15% * var(--aura-contrast)),
+    var(--vaadin-text-color)
+  );
   --aura-purple-text: color-mix(
     in srgb,
     var(--aura-purple) calc(70% - 15% * var(--aura-contrast)),
-    var(--vaadin-color)
+    var(--vaadin-text-color)
   );
 }

--- a/packages/avatar/src/styles/vaadin-avatar-base-styles.js
+++ b/packages/avatar/src/styles/vaadin-avatar-base-styles.js
@@ -13,7 +13,7 @@ export const avatarStyles = css`
     flex: none;
     border-radius: 50%;
     cursor: default;
-    color: var(--vaadin-avatar-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-avatar-color, var(--vaadin-text-color-secondary));
     overflow: hidden;
     --_size: var(--vaadin-avatar-size, calc(1lh + var(--vaadin-padding-xs) * 2));
     height: var(--_size);

--- a/packages/button/src/styles/vaadin-button-base-styles.js
+++ b/packages/button/src/styles/vaadin-button-base-styles.js
@@ -28,7 +28,7 @@ export const buttonStyles = css`
     font-size: var(--vaadin-button-font-size, inherit);
     line-height: var(--vaadin-button-line-height, inherit);
     font-weight: var(--vaadin-button-font-weight, 500);
-    color: var(--vaadin-button-text-color, var(--vaadin-color));
+    color: var(--vaadin-button-text-color, var(--vaadin-text-color));
     background: var(--vaadin-button-background, var(--vaadin-background-container));
     background-origin: border-box;
     border: var(--vaadin-button-border-width, 1px) solid
@@ -54,7 +54,7 @@ export const buttonStyles = css`
   }
 
   :host([theme~='primary']) {
-    --vaadin-button-background: var(--vaadin-color);
+    --vaadin-button-background: var(--vaadin-text-color);
     --vaadin-button-text-color: var(--vaadin-background-color);
     --vaadin-button-border-color: transparent;
   }

--- a/packages/button/src/styles/vaadin-button-base-styles.js
+++ b/packages/button/src/styles/vaadin-button-base-styles.js
@@ -32,7 +32,7 @@ export const buttonStyles = css`
     background: var(--vaadin-button-background, var(--vaadin-background-container));
     background-origin: border-box;
     border: var(--vaadin-button-border-width, 1px) solid
-      var(--vaadin-button-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-button-border-color, var(--vaadin-border-color-secondary));
     border-radius: var(--vaadin-button-border-radius, var(--vaadin-radius-m));
     touch-action: manipulation;
   }

--- a/packages/card/src/styles/vaadin-card-base-styles.js
+++ b/packages/card/src/styles/vaadin-card-base-styles.js
@@ -31,7 +31,8 @@ export const cardStyles = css`
 
   /* Could be an inset outline on the host as well, but let's reserve that for a potential focus outline */
   :host::before {
-    border: var(--vaadin-card-border-width, 0) solid var(--vaadin-card-border-color, var(--vaadin-border-color-subtle));
+    border: var(--vaadin-card-border-width, 0) solid
+      var(--vaadin-card-border-color, var(--vaadin-border-color-secondary));
     border-radius: inherit;
     content: '';
     inset: 0;

--- a/packages/card/src/styles/vaadin-card-base-styles.js
+++ b/packages/card/src/styles/vaadin-card-base-styles.js
@@ -141,7 +141,7 @@ export const cardStyles = css`
   }
 
   ::slotted([slot='subtitle']) {
-    color: var(--vaadin-card-subtitle-color, var(--vaadin-color-subtle)) !important;
+    color: var(--vaadin-card-subtitle-color, var(--vaadin-text-color-secondary)) !important;
     font-size: var(--vaadin-card-subtitle-font-size, inherit) !important;
     font-weight: var(--vaadin-card-subtitle-font-weight, 400) !important;
     line-height: var(--vaadin-card-subtitle-line-height, inherit) !important;

--- a/packages/card/src/styles/vaadin-card-base-styles.js
+++ b/packages/card/src/styles/vaadin-card-base-styles.js
@@ -133,7 +133,7 @@ export const cardStyles = css`
   }
 
   ::slotted([slot='title']) {
-    color: var(--vaadin-card-title-color, var(--vaadin-color)) !important;
+    color: var(--vaadin-card-title-color, var(--vaadin-text-color)) !important;
     font-size: var(--vaadin-card-title-font-size, inherit) !important;
     font-weight: var(--vaadin-card-title-font-weight, 500) !important;
     line-height: var(--vaadin-card-title-line-height, inherit) !important;

--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -119,13 +119,13 @@ export const chartStyles = css`
     --_secondary-label: var(--vaadin-charts-secondary-label, var(--vaadin-text-color-secondary));
     --_disabled-label: var(--vaadin-charts-disabled-label, var(--vaadin-color-disabled));
     --_point-border: var(--vaadin-charts-point-border, var(--_bg));
-    --_axis-line: var(--vaadin-charts-axis-line, var(--vaadin-border-color-subtle));
+    --_axis-line: var(--vaadin-charts-axis-line, var(--vaadin-border-color-secondary));
     --_axis-title: var(--vaadin-charts-axis-title, var(--_secondary-label));
     --_axis-label: var(--vaadin-charts-axis-label, var(--_secondary-label));
-    --_grid-line: var(--vaadin-charts-grid-line, var(--vaadin-border-color-subtle));
+    --_grid-line: var(--vaadin-charts-grid-line, var(--vaadin-border-color-secondary));
     --_minor-grid-line: var(
       --vaadin-charts-minor-grid-line,
-      color-mix(in srgb, var(--vaadin-border-color-subtle) 60%, transparent)
+      color-mix(in srgb, var(--vaadin-border-color-secondary) 60%, transparent)
     );
     --_data-label: var(--vaadin-charts-data-label, var(--_label));
   }

--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -34,7 +34,7 @@ const tooltipStyles = (scope) => css`
 
   ${unsafeCSS(scope)} .highcharts-tooltip text,
   ${unsafeCSS(scope)} .highcharts-tooltip foreignObject span {
-    fill: var(--highcharts-neutral-color-80, var(--vaadin-charts-data-label, var(--vaadin-color)));
+    fill: var(--highcharts-neutral-color-80, var(--vaadin-charts-data-label, var(--vaadin-text-color)));
   }
 
   ${unsafeCSS(scope)} .highcharts-tooltip .highcharts-tracker {
@@ -115,7 +115,7 @@ export const chartStyles = css`
     --_color-positive: light-dark(#19b156, #1ccc62);
     --_color-negative: light-dark(#dc0611, #f7353f);
 
-    --_label: var(--vaadin-charts-label, var(--vaadin-color));
+    --_label: var(--vaadin-charts-label, var(--vaadin-text-color));
     --_secondary-label: var(--vaadin-charts-secondary-label, var(--vaadin-color-subtle));
     --_disabled-label: var(--vaadin-charts-disabled-label, var(--vaadin-color-disabled));
     --_point-border: var(--vaadin-charts-point-border, var(--_bg));

--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -44,7 +44,7 @@ const tooltipStyles = (scope) => css`
 
   ${unsafeCSS(scope)} .highcharts-tooltip .highcharts-header {
     font-size: 0.85em;
-    color: var(--highcharts-neutral-color-60, var(--vaadin-color-subtle));
+    color: var(--highcharts-neutral-color-60, var(--vaadin-text-color-secondary));
   }
 
   ${unsafeCSS(scope)} .highcharts-tooltip-box {
@@ -116,7 +116,7 @@ export const chartStyles = css`
     --_color-negative: light-dark(#dc0611, #f7353f);
 
     --_label: var(--vaadin-charts-label, var(--vaadin-text-color));
-    --_secondary-label: var(--vaadin-charts-secondary-label, var(--vaadin-color-subtle));
+    --_secondary-label: var(--vaadin-charts-secondary-label, var(--vaadin-text-color-secondary));
     --_disabled-label: var(--vaadin-charts-disabled-label, var(--vaadin-color-disabled));
     --_point-border: var(--vaadin-charts-point-border, var(--_bg));
     --_axis-line: var(--vaadin-charts-axis-line, var(--vaadin-border-color-subtle));

--- a/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
+++ b/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
@@ -17,7 +17,7 @@ const checkbox = css`
   :host([readonly]) {
     --vaadin-checkbox-background: transparent;
     --vaadin-checkbox-border-color: var(--vaadin-border-color);
-    --vaadin-checkbox-color: var(--vaadin-color);
+    --vaadin-checkbox-color: var(--vaadin-text-color);
     --_border-style: dashed;
   }
 

--- a/packages/component-base/src/styles/loader-styles.js
+++ b/packages/component-base/src/styles/loader-styles.js
@@ -24,7 +24,7 @@ export const loaderStyles = css`
       spin var(--vaadin-spinner-animation-duration, 1s) linear infinite,
       fade-in 0.3s 0.3s both;
     border: var(--vaadin-spinner-width, 2px) solid;
-    --_spinner-color: var(--vaadin-spinner-color, var(--vaadin-color));
+    --_spinner-color: var(--vaadin-spinner-color, var(--vaadin-text-color));
     --_spinner-color2: color-mix(in srgb, var(--_spinner-color) 20%, transparent);
     border-color: var(--_spinner-color) var(--_spinner-color) var(--_spinner-color2) var(--_spinner-color2);
     border-radius: 50%;

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -32,7 +32,7 @@ addGlobalThemeStyles(
           var(--vaadin-text-color) 48%,
           transparent
         ); /* Above 3:1 contrast */
-        --vaadin-color-subtle: color-mix(
+        --vaadin-text-color-secondary: color-mix(
           in oklab,
           var(--vaadin-text-color) 68%,
           transparent
@@ -102,7 +102,7 @@ addGlobalThemeStyles(
           --vaadin-border-color: CanvasText;
           --vaadin-border-color-strong: CanvasText;
           --vaadin-color-disabled: CanvasText;
-          --vaadin-color-subtle: CanvasText;
+          --vaadin-text-color-secondary: CanvasText;
           --vaadin-text-color: CanvasText;
           --vaadin-icon-color: CanvasText;
           --vaadin-focus-ring-color: Highlight;

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -23,7 +23,7 @@ addGlobalThemeStyles(
         );
 
         /* Border colors */
-        --vaadin-border-color-subtle: color-mix(in oklab, var(--vaadin-text-color) 24%, transparent);
+        --vaadin-border-color-secondary: color-mix(in oklab, var(--vaadin-text-color) 24%, transparent);
         --vaadin-border-color: color-mix(in oklab, var(--vaadin-text-color) 48%, transparent); /* Above 3:1 contrast */
 
         /* Text colors */

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -15,21 +15,29 @@ addGlobalThemeStyles(
         --vaadin-background-color: light-dark(#fff, #222);
 
         /* Container colors */
-        --vaadin-background-container: color-mix(in oklab, var(--vaadin-color) 5%, var(--vaadin-background-color));
+        --vaadin-background-container: color-mix(in oklab, var(--vaadin-text-color) 5%, var(--vaadin-background-color));
         --vaadin-background-container-strong: color-mix(
           in oklab,
-          var(--vaadin-color) 10%,
+          var(--vaadin-text-color) 10%,
           var(--vaadin-background-color)
         );
 
         /* Border colors */
-        --vaadin-border-color-subtle: color-mix(in oklab, var(--vaadin-color) 24%, transparent);
-        --vaadin-border-color: color-mix(in oklab, var(--vaadin-color) 48%, transparent); /* Above 3:1 contrast */
+        --vaadin-border-color-subtle: color-mix(in oklab, var(--vaadin-text-color) 24%, transparent);
+        --vaadin-border-color: color-mix(in oklab, var(--vaadin-text-color) 48%, transparent); /* Above 3:1 contrast */
 
         /* Text colors */
-        --vaadin-color-disabled: color-mix(in oklab, var(--vaadin-color) 48%, transparent); /* Above 3:1 contrast */
-        --vaadin-color-subtle: color-mix(in oklab, var(--vaadin-color) 68%, transparent); /* Above 4.5:1 contrast */
-        --vaadin-color: light-dark(#1f1f1f, white); /* Above 7:1 contrast */
+        --vaadin-color-disabled: color-mix(
+          in oklab,
+          var(--vaadin-text-color) 48%,
+          transparent
+        ); /* Above 3:1 contrast */
+        --vaadin-color-subtle: color-mix(
+          in oklab,
+          var(--vaadin-text-color) 68%,
+          transparent
+        ); /* Above 4.5:1 contrast */
+        --vaadin-text-color: light-dark(#1f1f1f, white); /* Above 7:1 contrast */
 
         /* Padding */
         --vaadin-padding-xs: 6px;
@@ -53,7 +61,7 @@ addGlobalThemeStyles(
 
         /* Focus outline */
         --vaadin-focus-ring-width: 2px;
-        --vaadin-focus-ring-color: var(--vaadin-color);
+        --vaadin-focus-ring-color: var(--vaadin-text-color);
 
         /* Icons, used as mask-image */
         --_vaadin-icon-arrow-up: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18" /></svg>');
@@ -95,7 +103,7 @@ addGlobalThemeStyles(
           --vaadin-border-color-strong: CanvasText;
           --vaadin-color-disabled: CanvasText;
           --vaadin-color-subtle: CanvasText;
-          --vaadin-color: CanvasText;
+          --vaadin-text-color: CanvasText;
           --vaadin-icon-color: CanvasText;
           --vaadin-focus-ring-color: Highlight;
         }

--- a/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-base-styles.js
+++ b/packages/confirm-dialog/src/styles/vaadin-confirm-dialog-overlay-base-styles.js
@@ -20,7 +20,7 @@ const confirmDialogOverlay = css`
   }
 
   [part='header'] {
-    color: var(--vaadin-dialog-title-color, var(--vaadin-color));
+    color: var(--vaadin-dialog-title-color, var(--vaadin-text-color));
     font-weight: var(--vaadin-dialog-title-font-weight, 600);
     font-size: var(--vaadin-dialog-title-font-size, 1em);
     line-height: var(--vaadin-dialog-title-line-height, inherit);

--- a/packages/context-menu/src/styles/vaadin-context-menu-item-base-styles.js
+++ b/packages/context-menu/src/styles/vaadin-context-menu-item-base-styles.js
@@ -9,7 +9,7 @@ import { itemStyles } from '@vaadin/item/src/styles/vaadin-item-base-styles.js';
 
 const menuItemStyles = css`
   :host::after {
-    background: var(--vaadin-color-subtle);
+    background: var(--vaadin-text-color-secondary);
     content: '';
     display: block;
     height: var(--vaadin-icon-size, 1lh);

--- a/packages/crud/src/styles/vaadin-crud-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-base-styles.js
@@ -131,7 +131,7 @@ export const crudStyles = css`
   }
 
   [part='header'] {
-    color: var(--vaadin-crud-header-color, var(--vaadin-color));
+    color: var(--vaadin-crud-header-color, var(--vaadin-text-color));
     font-size: var(--vaadin-crud-header-font-size, 1em);
     font-weight: var(--vaadin-crud-header-font-weight, 600);
     line-height: var(--vaadin-crud-header-line-height, inherit);

--- a/packages/crud/src/styles/vaadin-crud-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-base-styles.js
@@ -18,7 +18,7 @@ export const crudStyles = css`
     --vaadin-crud-editor-max-height: 40%;
     --vaadin-crud-editor-max-width: 40%;
     border: var(--vaadin-crud-border-width, 1px) solid
-      var(--vaadin-crud-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-crud-border-color, var(--vaadin-border-color-secondary));
     border-radius: var(--vaadin-crud-border-radius, var(--vaadin-radius-l));
     height: 400px;
     width: 100%;
@@ -61,7 +61,7 @@ export const crudStyles = css`
 
   :host([editor-position='aside'][editor-opened]) #main {
     border-inline-end: var(--vaadin-crud-border-width, 1px) solid
-      var(--vaadin-crud-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-crud-border-color, var(--vaadin-border-color-secondary));
   }
 
   :host([editor-position='aside'][editor-opened]) ::slotted(vaadin-crud-grid) {
@@ -76,7 +76,7 @@ export const crudStyles = css`
 
   :host([editor-position='bottom'][editor-opened]) #main {
     border-bottom: var(--vaadin-crud-border-width, 1px) solid
-      var(--vaadin-crud-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-crud-border-color, var(--vaadin-border-color-secondary));
   }
 
   :host([editor-position='bottom'][editor-opened]) :is(#container, [part='editor']) {
@@ -88,7 +88,7 @@ export const crudStyles = css`
     align-items: baseline;
     background: var(--vaadin-crud-toolbar-background, transparent);
     border-top: var(--vaadin-crud-border-width, 1px) solid
-      var(--vaadin-crud-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-crud-border-color, var(--vaadin-border-color-secondary));
     display: flex;
     flex-shrink: 0;
     justify-content: flex-end;
@@ -152,7 +152,7 @@ export const crudStyles = css`
   [part='footer'] {
     background: var(--vaadin-crud-footer-background, transparent);
     border-top: var(--vaadin-crud-border-width, 1px) solid
-      var(--vaadin-crud-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-crud-border-color, var(--vaadin-border-color-secondary));
     display: flex;
     flex: none;
     gap: var(--vaadin-crud-footer-gap, var(--vaadin-gap-s));

--- a/packages/crud/src/styles/vaadin-crud-dialog-overlay-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-dialog-overlay-base-styles.js
@@ -43,7 +43,7 @@ const crudDialogOverlay = css`
     justify-content: normal;
     background: var(--vaadin-crud-footer-background, transparent);
     border-top: var(--vaadin-crud-border-width, 1px) solid
-      var(--vaadin-crud-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-crud-border-color, var(--vaadin-border-color-secondary));
   }
 `;
 

--- a/packages/crud/src/styles/vaadin-crud-dialog-overlay-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-dialog-overlay-base-styles.js
@@ -14,7 +14,7 @@ import { dialogOverlayStyles } from '@vaadin/dialog/src/styles/vaadin-dialog-ove
 
 const crudDialogOverlay = css`
   [part='header'] {
-    color: var(--vaadin-crud-dialog-header-color, var(--vaadin-color));
+    color: var(--vaadin-crud-dialog-header-color, var(--vaadin-text-color));
     font-size: var(--vaadin-crud-dialog-header-font-size, 1em);
     font-weight: var(--vaadin-crud-dialog-header-font-weight, 600);
     line-height: var(--vaadin-crud-dialog-header-line-height, inherit);

--- a/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
@@ -17,7 +17,7 @@ const dashboardButton = css`
   }
 
   :host([theme~='tertiary']) {
-    color: var(--vaadin-dashboard-button-text-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-dashboard-button-text-color, var(--vaadin-text-color-secondary));
   }
 `;
 

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
@@ -17,12 +17,12 @@ export const dashboardWidgetAndSectionStyles = css`
     --_widget-background: var(--vaadin-dashboard-widget-background, var(--vaadin-background-color));
     --_widget-border-radius: var(--vaadin-dashboard-widget-border-radius, var(--vaadin-radius-m));
     --_widget-border-width: var(--vaadin-dashboard-widget-border-width, 1px);
-    --_widget-border-color: var(--vaadin-dashboard-widget-border-color, var(--vaadin-border-color-subtle));
+    --_widget-border-color: var(--vaadin-dashboard-widget-border-color, var(--vaadin-border-color-secondary));
     --_widget-shadow: var(--vaadin-dashboard-widget-shadow, 0 0 0 0 transparent);
     --_widget-editable-shadow: 0 1px 4px -1px rgba(0, 0, 0, 0.3);
     --_widget-selected-shadow: 0 3px 12px -1px rgba(0, 0, 0, 0.3);
     --_drop-target-background: var(--vaadin-dashboard-drop-target-background, var(--vaadin-background-container));
-    --_drop-target-border-color: var(--vaadin-dashboard-drop-target-border-color, var(--vaadin-border-color-subtle));
+    --_drop-target-border-color: var(--vaadin-dashboard-drop-target-border-color, var(--vaadin-border-color-secondary));
     --_focus-ring-color: var(--vaadin-focus-ring-color);
     --_focus-ring-width: var(--vaadin-focus-ring-width);
   }

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
@@ -65,7 +65,7 @@ export const dashboardWidgetAndSectionStyles = css`
 
   [part='title'] {
     flex: 1;
-    color: var(--vaadin-dashboard-widget-title-color, var(--vaadin-color));
+    color: var(--vaadin-dashboard-widget-title-color, var(--vaadin-text-color));
     font-size: var(--vaadin-dashboard-widget-title-font-size, 1em);
     font-weight: var(--vaadin-dashboard-widget-title-font-weight, 500);
     line-height: var(--vaadin-dashboard-widget-title-line-height, inherit);

--- a/packages/date-picker/src/styles/vaadin-date-picker-overlay-content-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-date-picker-overlay-content-base-styles.js
@@ -31,7 +31,7 @@ export const overlayContentStyles = css`
     display: inline-flex;
     align-items: center;
     border-radius: var(--vaadin-button-border-radius, var(--vaadin-radius-m));
-    color: var(--vaadin-color);
+    color: var(--vaadin-text-color);
     font-size: var(--vaadin-button-font-size, inherit);
     font-weight: var(--vaadin-button-font-weight, 500);
     height: var(--vaadin-button-height, auto);
@@ -41,7 +41,7 @@ export const overlayContentStyles = css`
   }
 
   :host([years-visible]) [part='years-toggle-button'] {
-    background: var(--vaadin-color);
+    background: var(--vaadin-text-color);
     color: var(--vaadin-background-color);
   }
 

--- a/packages/date-picker/src/styles/vaadin-date-picker-overlay-content-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-date-picker-overlay-content-base-styles.js
@@ -57,7 +57,7 @@ export const overlayContentStyles = css`
   }
 
   :host([desktop]) ::slotted([slot='months']) {
-    border-bottom: 1px solid var(--vaadin-border-color-subtle);
+    border-bottom: 1px solid var(--vaadin-border-color-secondary);
   }
 
   ::slotted([slot='years']) {
@@ -66,7 +66,7 @@ export const overlayContentStyles = css`
     width: var(--vaadin-date-picker-year-scroller-width, 3rem);
     box-sizing: border-box;
     border-inline-start: 1px solid
-      var(--vaadin-date-picker-year-scroller-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-date-picker-year-scroller-border-color, var(--vaadin-border-color-secondary));
     overflow: visible;
     min-height: 0;
     clip-path: inset(0);
@@ -74,7 +74,7 @@ export const overlayContentStyles = css`
 
   ::slotted([slot='years'])::before {
     background: var(--vaadin-overlay-background, var(--vaadin-background-color));
-    border: 1px solid var(--vaadin-date-picker-year-scroller-border-color, var(--vaadin-border-color-subtle));
+    border: 1px solid var(--vaadin-date-picker-year-scroller-border-color, var(--vaadin-border-color-secondary));
     width: 16px;
     height: 16px;
     position: absolute;
@@ -103,6 +103,6 @@ export const overlayContentStyles = css`
 
   :host([fullscreen]) [part='toolbar'] {
     grid-area: header;
-    border-bottom: 1px solid var(--vaadin-border-color-subtle);
+    border-bottom: 1px solid var(--vaadin-border-color-secondary);
   }
 `;

--- a/packages/date-picker/src/styles/vaadin-date-picker-year-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-date-picker-year-base-styles.js
@@ -18,7 +18,7 @@ export const datePickerYearStyles = css`
     height: 50%;
     justify-content: center;
     transform: translateY(-50%);
-    color: var(--vaadin-color-subtle);
+    color: var(--vaadin-text-color-secondary);
   }
 
   :host([current]) [part='year-number'] {

--- a/packages/date-picker/src/styles/vaadin-date-picker-year-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-date-picker-year-base-styles.js
@@ -22,6 +22,6 @@ export const datePickerYearStyles = css`
   }
 
   :host([current]) [part='year-number'] {
-    color: var(--vaadin-date-picker-year-scroller-current-year-color, var(--vaadin-color));
+    color: var(--vaadin-date-picker-year-scroller-current-year-color, var(--vaadin-text-color));
   }
 `;

--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -33,7 +33,7 @@ export const monthCalendarStyles = css`
   }
 
   [part~='weekday'] {
-    color: var(--vaadin-date-picker-weekday-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-date-picker-weekday-color, var(--vaadin-text-color-secondary));
     font-size: var(--vaadin-date-picker-weekday-font-size, 0.75rem);
     font-weight: var(--vaadin-date-picker-weekday-font-weight, 500);
     margin-bottom: 0.375rem;
@@ -46,7 +46,7 @@ export const monthCalendarStyles = css`
   }
 
   [part~='week-number'] {
-    color: var(--vaadin-date-picker-week-number-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-date-picker-week-number-color, var(--vaadin-text-color-secondary));
     font-size: var(--vaadin-date-picker-week-number-font-size, 0.7rem);
     line-height: 1;
     width: 100%;

--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -13,7 +13,7 @@ export const monthCalendarStyles = css`
   }
 
   [part='month-header'] {
-    color: var(--vaadin-date-picker-month-header-color, var(--vaadin-color));
+    color: var(--vaadin-date-picker-month-header-color, var(--vaadin-text-color));
     font-size: var(--vaadin-date-picker-month-header-font-size, 0.9375rem);
     font-weight: var(--vaadin-date-picker-month-header-font-weight, 500);
     line-height: inherit;
@@ -98,7 +98,7 @@ export const monthCalendarStyles = css`
   }
 
   [part~='today'] {
-    color: var(--vaadin-date-picker-date-today-color, var(--vaadin-color));
+    color: var(--vaadin-date-picker-date-today-color, var(--vaadin-text-color));
   }
 
   [part~='selected'] {
@@ -106,7 +106,7 @@ export const monthCalendarStyles = css`
   }
 
   [part~='selected']::after {
-    background: var(--vaadin-date-picker-date-selected-background, var(--vaadin-color));
+    background: var(--vaadin-date-picker-date-selected-background, var(--vaadin-text-color));
     outline-offset: 1px;
   }
 

--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -61,7 +61,7 @@ export const monthCalendarStyles = css`
     flex: 1;
     background: var(
       --vaadin-date-picker-week-divider-color,
-      var(--vaadin-divider-color, var(--vaadin-border-color-subtle))
+      var(--vaadin-divider-color, var(--vaadin-border-color-secondary))
     );
   }
 

--- a/packages/details/src/styles/vaadin-details-summary-base-styles.js
+++ b/packages/details/src/styles/vaadin-details-summary-base-styles.js
@@ -14,7 +14,7 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
     border: var(--${unsafeCSS(partName)}-border, none);
     border-radius: var(--${unsafeCSS(partName)}-border-radius, var(--vaadin-radius-m));
     box-sizing: border-box;
-    color: var(--${unsafeCSS(partName)}-text-color, var(--vaadin-color));
+    color: var(--${unsafeCSS(partName)}-text-color, var(--vaadin-text-color));
     cursor: var(--vaadin-clickable-cursor);
     display: flex;
     font-size: var(--${unsafeCSS(partName)}-font-size, inherit);

--- a/packages/details/src/styles/vaadin-details-summary-base-styles.js
+++ b/packages/details/src/styles/vaadin-details-summary-base-styles.js
@@ -38,7 +38,7 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
   }
 
   [part='toggle'] {
-    color: var(--vaadin-color-subtle);
+    color: var(--vaadin-text-color-secondary);
   }
 
   @media (prefers-reduced-motion: no-preference) {

--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -32,7 +32,7 @@ export const dialogOverlayBase = css`
     background: var(--vaadin-dialog-background, var(--vaadin-background-color));
     background-origin: border-box;
     border: var(--vaadin-dialog-border-width, 1px) solid
-      var(--vaadin-dialog-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-dialog-border-color, var(--vaadin-border-color-secondary));
     box-shadow: var(--vaadin-dialog-box-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3));
     border-radius: var(--vaadin-dialog-border-radius, var(--vaadin-radius-l));
     width: max-content;

--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -92,7 +92,7 @@ export const dialogOverlayBase = css`
   }
 
   [part='title'] {
-    color: var(--vaadin-dialog-title-color, var(--vaadin-color));
+    color: var(--vaadin-dialog-title-color, var(--vaadin-text-color));
     font-weight: var(--vaadin-dialog-title-font-weight, 600);
     font-size: var(--vaadin-dialog-title-font-size, 1em);
     line-height: var(--vaadin-dialog-title-line-height, inherit);

--- a/packages/field-base/src/styles/button-base-styles.js
+++ b/packages/field-base/src/styles/button-base-styles.js
@@ -8,7 +8,7 @@ import { css } from 'lit';
 
 export const button = css`
   [part$='button'] {
-    color: var(--vaadin-input-field-button-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-input-field-button-color, var(--vaadin-text-color-secondary));
     cursor: var(--vaadin-clickable-cursor);
     touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -46,7 +46,7 @@ export const checkable = (part, propName = part) => css`
     font-size: var(--vaadin-${unsafeCSS(propName)}-label-font-size, var(--vaadin-input-field-label-font-size, inherit));
     line-height: var(--vaadin-${unsafeCSS(propName)}-label-line-height, var(--vaadin-input-field-label-line-height, inherit));
     font-weight: var(--vaadin-${unsafeCSS(propName)}-font-weight, var(--vaadin-input-field-label-font-weight, 500));
-    color: var(--vaadin-${unsafeCSS(propName)}-label-color, var(--vaadin-input-field-label-color, var(--vaadin-color)));
+    color: var(--vaadin-${unsafeCSS(propName)}-label-color, var(--vaadin-input-field-label-color, var(--vaadin-text-color)));
     word-break: break-word;
   }
 
@@ -87,14 +87,14 @@ export const checkable = (part, propName = part) => css`
     --_border-width: var(--vaadin-${unsafeCSS(propName)}-border-width, var(--vaadin-input-field-border-width, 1px));
     border-width: var(--_border-width);
     box-sizing: border-box;
-    color: var(--vaadin-${unsafeCSS(propName)}-color, var(--vaadin-input-field-text-color, var(--vaadin-color)));
+    color: var(--vaadin-${unsafeCSS(propName)}-color, var(--vaadin-input-field-text-color, var(--vaadin-text-color)));
     height: var(--vaadin-${unsafeCSS(propName)}-size, 1lh);
     width: var(--vaadin-${unsafeCSS(propName)}-size, 1lh);
     position: relative;
   }
 
   :host(:is([checked], [indeterminate])) {
-    --vaadin-${unsafeCSS(propName)}-background: var(--vaadin-color);
+    --vaadin-${unsafeCSS(propName)}-background: var(--vaadin-text-color);
     --vaadin-${unsafeCSS(propName)}-border-color: transparent;
     --vaadin-${unsafeCSS(propName)}-color: oklch(from var(--vaadin-${unsafeCSS(propName)}-background) clamp(0, (0.62 - l) * 1000, 1) 0 0);
   }

--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -63,7 +63,7 @@ export const field = css`
     position: absolute;
     width: 1em;
     text-align: center;
-    color: var(--vaadin-input-field-required-indicator-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-input-field-required-indicator-color, var(--vaadin-text-color-secondary));
   }
 
   [part='required-indicator']::after {
@@ -90,7 +90,7 @@ export const field = css`
     font-size: var(--vaadin-input-field-helper-font-size, inherit);
     line-height: var(--vaadin-input-field-helper-line-height, inherit);
     font-weight: var(--vaadin-input-field-helper-font-weight, 400);
-    color: var(--vaadin-input-field-helper-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-input-field-helper-color, var(--vaadin-text-color-secondary));
     order: var(--vaadin-input-field-helper-order);
   }
 

--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -35,7 +35,7 @@ export const field = css`
     font-size: var(--vaadin-input-field-label-font-size, inherit);
     line-height: var(--vaadin-input-field-label-line-height, inherit);
     font-weight: var(--vaadin-input-field-label-font-weight, 500);
-    color: var(--vaadin-input-field-label-color, var(--vaadin-color));
+    color: var(--vaadin-input-field-label-color, var(--vaadin-text-color));
     order: var(--vaadin-input-field-helper-order);
     word-break: break-word;
     position: relative;
@@ -98,7 +98,7 @@ export const field = css`
     font-size: var(--vaadin-input-field-error-font-size, inherit);
     line-height: var(--vaadin-input-field-error-line-height, inherit);
     font-weight: var(--vaadin-input-field-error-font-weight, 400);
-    color: var(--vaadin-input-field-error-color, var(--vaadin-color));
+    color: var(--vaadin-input-field-error-color, var(--vaadin-text-color));
     display: flex;
     gap: var(--vaadin-gap-s);
   }

--- a/packages/field-highlighter/src/styles/vaadin-user-tag-base-styles.js
+++ b/packages/field-highlighter/src/styles/vaadin-user-tag-base-styles.js
@@ -19,7 +19,7 @@ export const userTagStyles = css`
     font-weight: var(--vaadin-user-tag-font-weight, 500);
     line-height: var(--vaadin-user-tag-line-height, 1);
     border: var(--vaadin-user-tag-border-width, 0) solid
-      var(--vaadin-user-tag-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-user-tag-border-color, var(--vaadin-border-color-secondary));
     border-radius: var(--vaadin-user-tag-border-radius, var(--vaadin-radius-m));
     cursor: default;
   }

--- a/packages/form-layout/src/styles/vaadin-form-item-base-styles.js
+++ b/packages/form-layout/src/styles/vaadin-form-item-base-styles.js
@@ -29,7 +29,7 @@ export const formItemStyles = css`
   }
 
   [part='label'] {
-    color: var(--vaadin-form-item-label-color, var(--vaadin-color));
+    color: var(--vaadin-form-item-label-color, var(--vaadin-text-color));
     flex: 0 0 auto;
     font-size: var(--vaadin-form-item-label-font-size, inherit);
     font-weight: var(--vaadin-form-item-label-font-weight, 500);

--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -25,7 +25,7 @@ export const gridStyles = css`
     box-sizing: border-box;
     -webkit-tap-highlight-color: transparent;
     background: var(--vaadin-grid-background, var(--vaadin-background-color));
-    border: var(--_border-width) solid var(--vaadin-grid-border-color, var(--vaadin-border-color-subtle));
+    border: var(--_border-width) solid var(--vaadin-grid-border-color, var(--vaadin-border-color-secondary));
     cursor: default;
     --_border-width: 0;
     --_row-border-width: var(--vaadin-grid-cell-border-width, 1px);
@@ -217,11 +217,12 @@ export const gridStyles = css`
 
   [part~='cell']:not([part~='last-column-cell'], [part~='details-cell']) {
     border-inline-end: var(--_column-border-width, 0) solid
-      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-secondary));
   }
 
   [part~='cell']:where(:not([part~='details-cell'], [part~='first-row-cell'])) {
-    border-top: var(--_row-border-width) solid var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-subtle));
+    border-top: var(--_row-border-width) solid
+      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-secondary));
   }
 
   [part~='first-header-row-cell'] {
@@ -230,12 +231,12 @@ export const gridStyles = css`
 
   [part~='last-header-row-cell'] {
     border-bottom: var(--_row-border-width, 1px) solid
-      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-secondary));
   }
 
   [part~='first-footer-row-cell'] {
     border-top: var(--_row-border-width, 1px) solid
-      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-grid-cell-border-color, var(--vaadin-border-color-secondary));
   }
 
   /* Variant: row stripes */

--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -127,7 +127,7 @@ export const gridStyles = css`
   [part~='reorder-ghost'] {
     font-size: var(--vaadin-grid-header-font-size, 1em);
     font-weight: var(--vaadin-grid-header-font-weight, 500);
-    color: var(--vaadin-grid-header-color, var(--vaadin-color));
+    color: var(--vaadin-grid-header-color, var(--vaadin-text-color));
   }
 
   [part~='row'] {

--- a/packages/input-container/src/styles/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-base-styles.js
@@ -24,7 +24,7 @@ export const inputContainerStyles = css`
     padding: var(--vaadin-input-field-padding, var(--vaadin-padding-container));
     gap: var(--vaadin-input-field-gap, var(--vaadin-gap-s));
     background: var(--vaadin-input-field-background, var(--vaadin-background-color));
-    color: var(--vaadin-input-field-value-color, var(--vaadin-color));
+    color: var(--vaadin-input-field-value-color, var(--vaadin-text-color));
     font-size: var(--vaadin-input-field-value-font-size, inherit);
     line-height: var(--vaadin-input-field-value-line-height, inherit);
     font-weight: var(--vaadin-input-field-value-font-weight, 400);
@@ -93,7 +93,7 @@ export const inputContainerStyles = css`
   }
 
   :host([invalid]) {
-    --vaadin-input-field-border-color: var(--vaadin-input-field-error-color, var(--vaadin-color));
+    --vaadin-input-field-border-color: var(--vaadin-input-field-error-color, var(--vaadin-text-color));
   }
 
   :host([readonly]) {

--- a/packages/input-container/src/styles/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-base-styles.js
@@ -84,7 +84,7 @@ export const inputContainerStyles = css`
   }
 
   ::slotted(:is(input, textarea):placeholder-shown) {
-    color: var(--vaadin-input-field-placeholder-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-input-field-placeholder-color, var(--vaadin-text-color-secondary));
   }
 
   :host(:focus-within) {

--- a/packages/list-box/src/styles/vaadin-list-box-base-styles.js
+++ b/packages/list-box/src/styles/vaadin-list-box-base-styles.js
@@ -23,7 +23,7 @@ export const listBoxStyles = css`
   }
 
   [part='items'] ::slotted(hr) {
-    border-color: var(--vaadin-divider-color, var(--vaadin-border-color-subtle));
+    border-color: var(--vaadin-divider-color, var(--vaadin-border-color-secondary));
     border-width: 0 0 1px;
     margin: 4px 8px;
     margin-inline-start: calc(var(--vaadin-icon-size, 1lh) + var(--vaadin-item-gap, var(--vaadin-gap-s)) + 8px);

--- a/packages/login/src/styles/vaadin-login-form-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-form-wrapper-base-styles.js
@@ -30,7 +30,7 @@ export const loginFormWrapperStyles = css`
   }
 
   ::slotted([slot='form-title']) {
-    color: var(--vaadin-login-form-title-color, var(--vaadin-color));
+    color: var(--vaadin-login-form-title-color, var(--vaadin-text-color));
     font-size: var(--vaadin-login-form-title-font-size, 1.25rem);
     font-weight: var(--vaadin-login-form-title-font-weight, 600);
     line-height: var(--vaadin-login-form-title-line-height, inherit);
@@ -41,7 +41,7 @@ export const loginFormWrapperStyles = css`
   }
 
   [part='error-message'] {
-    color: var(--vaadin-login-form-error-color, var(--vaadin-color));
+    color: var(--vaadin-login-form-error-color, var(--vaadin-text-color));
     font-size: var(--vaadin-login-form-error-font-size, inherit);
     font-weight: var(--vaadin-login-form-error-font-weight, 400);
     gap: var(--vaadin-login-form-error-gap, 0 var(--vaadin-gap-s));

--- a/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
@@ -38,7 +38,7 @@ const loginOverlayWrapper = css`
   }
 
   ::slotted([slot='title']) {
-    color: var(--vaadin-login-overlay-title-color, var(--vaadin-color));
+    color: var(--vaadin-login-overlay-title-color, var(--vaadin-text-color));
     font-size: var(--vaadin-login-overlay-title-font-size, inherit);
     font-weight: var(--vaadin-login-overlay-title-font-weight, 600);
     line-height: var(--vaadin-login-overlay-title-line-height, inherit);

--- a/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
@@ -14,7 +14,7 @@ const loginOverlayWrapper = css`
       var(--vaadin-overlay-background, var(--vaadin-background-color))
     );
     border: var(--vaadin-login-overlay-border-width, var(--vaadin-overlay-border-width, 1px)) solid
-      var(--vaadin-login-overlay-border-color, var(--vaadin-overlay-border-color, var(--vaadin-border-color-subtle)));
+      var(--vaadin-login-overlay-border-color, var(--vaadin-overlay-border-color, var(--vaadin-border-color-secondary)));
     border-radius: var(--vaadin-login-overlay-border-radius, var(--vaadin-radius-l));
     box-shadow: var(
       --vaadin-login-overlay-box-shadow,

--- a/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
+++ b/packages/login/src/styles/vaadin-login-overlay-wrapper-base-styles.js
@@ -45,7 +45,7 @@ const loginOverlayWrapper = css`
   }
 
   [part='description'] {
-    color: var(--vaadin-login-overlay-description-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-login-overlay-description-color, var(--vaadin-text-color-secondary));
     font-size: var(--vaadin-login-overlay-description-font-size, inherit);
     font-weight: var(--vaadin-login-overlay-description-font-weight, inherit);
     line-height: var(--vaadin-login-overlay-description-line-height, inherit);

--- a/packages/map/src/styles/vaadin-map-base-styles.js
+++ b/packages/map/src/styles/vaadin-map-base-styles.js
@@ -37,7 +37,7 @@ export const mapStyles = css`
     content: '';
     position: absolute;
     inset: 0;
-    border: 1px solid var(--vaadin-map-border-color, var(--vaadin-border-color-subtle));
+    border: 1px solid var(--vaadin-map-border-color, var(--vaadin-border-color-secondary));
     border-radius: inherit;
     z-index: 1;
     pointer-events: none;

--- a/packages/map/src/styles/vaadin-map-base-styles.js
+++ b/packages/map/src/styles/vaadin-map-base-styles.js
@@ -399,7 +399,7 @@ export const mapStyles = css`
   }
 
   .ol-control button:hover {
-    color: var(--vaadin-map-control-color-hover, var(--vaadin-color));
+    color: var(--vaadin-map-control-color-hover, var(--vaadin-text-color));
   }
 
   .ol-control button:focus-visible {

--- a/packages/map/src/styles/vaadin-map-base-styles.js
+++ b/packages/map/src/styles/vaadin-map-base-styles.js
@@ -247,7 +247,7 @@ export const mapStyles = css`
     gap: 1em;
     list-style: none;
     margin: 0;
-    color: var(--vaadin-map-attribution-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-map-attribution-color, var(--vaadin-text-color-secondary));
     padding: var(--vaadin-padding-container);
     font-size: 0.8em;
   }

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -150,12 +150,12 @@ export const masterDetailLayoutStyles = css`
 
   :host([orientation='horizontal']:not([drawer], [stack])) [part='detail'] {
     border-inline-start: var(--vaadin-master-detail-layout-border-width, 1px) solid
-      var(--vaadin-master-detail-layout-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-master-detail-layout-border-color, var(--vaadin-border-color-secondary));
   }
 
   :host([orientation='vertical']:not([drawer], [stack])) [part='detail'] {
     border-top: var(--vaadin-master-detail-layout-border-width, 1px) solid
-      var(--vaadin-master-detail-layout-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-master-detail-layout-border-color, var(--vaadin-border-color-secondary));
   }
 
   @media (forced-colors: active) {

--- a/packages/message-input/src/styles/vaadin-message-input-button-styles.js
+++ b/packages/message-input/src/styles/vaadin-message-input-button-styles.js
@@ -13,7 +13,7 @@ export const messageInputButtonStyles = css`
     margin: var(--vaadin-input-field-padding, var(--vaadin-padding-container));
     --vaadin-button-border-width: 0;
     --vaadin-button-background: transparent;
-    --vaadin-button-text-color: var(--vaadin-color);
+    --vaadin-button-text-color: var(--vaadin-text-color);
     --vaadin-button-padding: 0;
   }
 `;

--- a/packages/message-list/src/styles/vaadin-message-base-styles.js
+++ b/packages/message-list/src/styles/vaadin-message-base-styles.js
@@ -42,7 +42,7 @@ export const messageStyles = css`
   [part='name'] {
     font-size: var(--vaadin-message-name-font-size, inherit);
     font-weight: var(--vaadin-message-name-font-weight, 500);
-    color: var(--vaadin-message-name-color, var(--vaadin-color));
+    color: var(--vaadin-message-name-color, var(--vaadin-text-color));
   }
 
   [part='time'] {
@@ -56,7 +56,7 @@ export const messageStyles = css`
     font-size: var(--vaadin-message-font-size, inherit);
     font-weight: var(--vaadin-message-font-weight, inherit);
     line-height: var(--vaadin-message-line-height, inherit);
-    color: var(--vaadin-message-color, var(--vaadin-color));
+    color: var(--vaadin-message-color, var(--vaadin-text-color));
   }
 
   ::slotted([slot='avatar']) {

--- a/packages/message-list/src/styles/vaadin-message-base-styles.js
+++ b/packages/message-list/src/styles/vaadin-message-base-styles.js
@@ -48,7 +48,7 @@ export const messageStyles = css`
   [part='time'] {
     font-size: var(--vaadin-message-time-font-size, max(11px, 0.75em));
     font-weight: var(--vaadin-message-time-font-weight, inherit);
-    color: var(--vaadin-message-time-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-message-time-color, var(--vaadin-text-color-secondary));
   }
 
   [part='message'] {

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
@@ -50,7 +50,7 @@ export const multiSelectComboBoxChipStyles = css`
     display: block;
     margin-inline-start: auto;
     margin-block: calc(var(--vaadin-chip-border-width, 1px) * -1);
-    color: var(--vaadin-chip-remove-button-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-chip-remove-button-color, var(--vaadin-text-color-secondary));
     cursor: var(--vaadin-clickable-cursor);
     translate: 25%;
   }

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
@@ -15,7 +15,7 @@ export const multiSelectComboBoxChipStyles = css`
     box-sizing: border-box;
     gap: var(--vaadin-chip-gap, 0);
     background: var(--vaadin-chip-background, var(--vaadin-background-container));
-    color: var(--vaadin-chip-color, var(--vaadin-color));
+    color: var(--vaadin-chip-color, var(--vaadin-text-color));
     font-size: max(11px, var(--vaadin-chip-font-size, 0.875em));
     font-weight: var(--vaadin-chip-font-weight, 500);
     line-height: var(--vaadin-input-field-value-line-height, inherit);

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
@@ -23,7 +23,7 @@ export const multiSelectComboBoxChipStyles = css`
     height: var(--vaadin-chip-height, calc(1lh / 0.875));
     border-radius: var(--vaadin-chip-border-radius, var(--vaadin-radius-m));
     border: var(--vaadin-chip-border-width, 1px) solid
-      var(--vaadin-chip-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-chip-border-color, var(--vaadin-border-color-secondary));
     cursor: default;
   }
 
@@ -88,7 +88,7 @@ export const multiSelectComboBoxChipStyles = css`
     content: '';
     position: absolute;
     inset: calc(var(--vaadin-chip-border-width, 1px) * -1);
-    border-inline-start: 2px solid var(--vaadin-chip-border-color, var(--vaadin-border-color-subtle));
+    border-inline-start: 2px solid var(--vaadin-chip-border-color, var(--vaadin-border-color-secondary));
     border-radius: inherit;
   }
 

--- a/packages/notification/src/styles/vaadin-notification-card-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-card-base-styles.js
@@ -19,7 +19,7 @@ export const notificationCardStyles = css`
     padding: var(--vaadin-notification-padding, var(--vaadin-padding-s));
     background: var(--vaadin-notification-background, var(--vaadin-background-container));
     border: var(--vaadin-notification-border-width, 1px) solid
-      var(--vaadin-notification-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-notification-border-color, var(--vaadin-border-color-secondary));
     box-shadow: var(--vaadin-notification-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3));
     border-radius: var(--vaadin-notification-border-radius, var(--vaadin-radius-l));
     cursor: default;

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -56,7 +56,7 @@ export const overlayStyles = css`
   [part='overlay'] {
     background: var(--vaadin-overlay-background, var(--vaadin-background-color));
     border: var(--vaadin-overlay-border-width, 1px) solid
-      var(--vaadin-overlay-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-overlay-border-color, var(--vaadin-border-color-secondary));
     border-radius: var(--vaadin-overlay-border-radius, var(--vaadin-radius-m));
     box-shadow: var(--vaadin-overlay-box-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3));
     box-sizing: border-box;

--- a/packages/popover/src/styles/vaadin-popover-overlay-base-styles.js
+++ b/packages/popover/src/styles/vaadin-popover-overlay-base-styles.js
@@ -36,7 +36,7 @@ const popoverOverlay = css`
     overflow: visible;
     max-height: 100%;
     border: var(--_border-width) solid
-      var(--vaadin-popover-border-color, var(--vaadin-overlay-border-color, var(--vaadin-border-color-subtle)));
+      var(--vaadin-popover-border-color, var(--vaadin-overlay-border-color, var(--vaadin-border-color-secondary)));
     background: var(--vaadin-popover-background, var(--vaadin-overlay-background, var(--vaadin-background-color)));
     box-shadow: var(--vaadin-popover-box-shadow, var(--vaadin-overlay-box-shadow, 0 8px 24px -4px rgba(0, 0, 0, 0.3)));
   }

--- a/packages/progress-bar/src/styles/vaadin-progress-bar-base-styles.js
+++ b/packages/progress-bar/src/styles/vaadin-progress-bar-base-styles.js
@@ -26,7 +26,7 @@ export const progressBarStyles = css`
     background: var(--vaadin-progress-bar-background, var(--vaadin-background-container));
     border-radius: var(--vaadin-progress-bar-border-radius, var(--vaadin-radius-m));
     border: var(--vaadin-progress-bar-border-width, 1px) solid
-      var(--vaadin-progress-bar-border-color, var(--vaadin-border-color-subtle));
+      var(--vaadin-progress-bar-border-color, var(--vaadin-border-color-secondary));
   }
 
   [part='value'] {

--- a/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
@@ -14,7 +14,7 @@ export const radioGroupStyles = [
     :host([readonly]) ::slotted(vaadin-radio-button) {
       --vaadin-radio-button-background: transparent;
       --vaadin-radio-button-border-color: var(--vaadin-border-color);
-      --vaadin-radio-button-color: var(--vaadin-color);
+      --vaadin-radio-button-color: var(--vaadin-text-color);
       --_border-style: dashed;
     }
   `,

--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
@@ -85,7 +85,7 @@ export const content = css`
 
   .ql-editor {
     box-sizing: border-box;
-    color: var(--vaadin-rich-text-editor-editor-color, var(--vaadin-color));
+    color: var(--vaadin-rich-text-editor-editor-color, var(--vaadin-text-color));
     flex: 1;
     font-size: var(--vaadin-rich-text-editor-editor-font-size, inherit);
     height: 100%;
@@ -398,7 +398,7 @@ const toolbar = css`
     border: var(--vaadin-rich-text-editor-toolbar-button-border-width, 1px) solid
       var(--vaadin-rich-text-editor-toolbar-button-border-color, transparent);
     border-radius: var(--vaadin-rich-text-editor-toolbar-button-border-radius, var(--vaadin-radius-m));
-    color: var(--vaadin-rich-text-editor-toolbar-button-text-color, var(--vaadin-color));
+    color: var(--vaadin-rich-text-editor-toolbar-button-text-color, var(--vaadin-text-color));
     cursor: var(--vaadin-clickable-cursor);
     flex-shrink: 0;
     font-family: var(--vaadin-rich-text-editor-toolbar-button-font-family, inherit);

--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
@@ -357,7 +357,7 @@ export const content = css`
   /* quill core end */
 
   blockquote {
-    border-inline-start: 4px solid var(--vaadin-border-color-subtle);
+    border-inline-start: 4px solid var(--vaadin-border-color-secondary);
     margin: var(--vaadin-padding-container);
     padding-inline-start: var(--vaadin-padding-s);
   }

--- a/packages/scroller/src/styles/vaadin-scroller-base-styles.js
+++ b/packages/scroller/src/styles/vaadin-scroller-base-styles.js
@@ -42,7 +42,7 @@ export const scrollerStyles = css`
     z-index: 9999;
     height: 1px;
     margin-bottom: -1px;
-    background: var(--vaadin-scroller-border-color, var(--vaadin-border-color-subtle));
+    background: var(--vaadin-scroller-border-color, var(--vaadin-border-color-secondary));
   }
 
   :host([theme*='overflow-indicator'])::after {

--- a/packages/select/src/styles/vaadin-select-value-button-base-styles.js
+++ b/packages/select/src/styles/vaadin-select-value-button-base-styles.js
@@ -25,7 +25,7 @@ export const valueButton = css`
   }
 
   :host([placeholder]) {
-    color: var(--vaadin-input-field-placeholder-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-input-field-placeholder-color, var(--vaadin-text-color-secondary));
   }
 
   :host([disabled]) {

--- a/packages/side-nav/src/styles/vaadin-side-nav-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-base-styles.js
@@ -22,7 +22,7 @@ const sideNav = css`
     padding: var(--vaadin-side-nav-item-padding, var(--vaadin-padding-container));
     font-size: var(--vaadin-side-nav-label-font-size, max(11px, 0.875em));
     font-weight: var(--vaadin-side-nav-label-font-weight, 500);
-    color: var(--vaadin-side-nav-label-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-side-nav-label-color, var(--vaadin-text-color-secondary));
     line-height: var(--vaadin-side-nav-label-line-height, inherit);
     border-radius: var(--vaadin-side-nav-item-border-radius, var(--vaadin-radius-m));
     touch-action: manipulation;

--- a/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
@@ -31,7 +31,7 @@ const sideNavItem = css`
 
   :host([current]) [part='content'] {
     --vaadin-side-nav-item-background: var(--vaadin-background-container);
-    --vaadin-side-nav-item-color: var(--vaadin-color);
+    --vaadin-side-nav-item-color: var(--vaadin-text-color);
   }
 
   :host([disabled]) {

--- a/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
@@ -20,7 +20,7 @@ const sideNavItem = css`
     font-size: var(--vaadin-side-nav-item-font-size, 1em);
     font-weight: var(--vaadin-side-nav-item-font-weight, 500);
     line-height: var(--vaadin-side-nav-item-line-height, inherit);
-    color: var(--vaadin-side-nav-item-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-side-nav-item-color, var(--vaadin-text-color-secondary));
     background: var(--vaadin-side-nav-item-background, transparent);
     background-origin: border-box;
     border: var(--vaadin-side-nav-item-border-width, 0) solid var(--vaadin-side-nav-item-border-color, transparent);

--- a/packages/side-nav/src/styles/vaadin-side-nav-shared-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-shared-base-styles.js
@@ -37,7 +37,7 @@ export const sharedStyles = css`
 
   [part='toggle-button'] {
     border-radius: var(--vaadin-side-nav-item-border-radius, var(--vaadin-radius-s));
-    color: var(--vaadin-color-subtle);
+    color: var(--vaadin-text-color-secondary);
   }
 
   [part='toggle-button']::before {

--- a/packages/split-layout/src/styles/vaadin-split-layout-base-styles.js
+++ b/packages/split-layout/src/styles/vaadin-split-layout-base-styles.js
@@ -62,7 +62,7 @@ export const splitLayoutStyles = css`
   }
 
   [part='handle'] {
-    background: var(--vaadin-split-layout-handle-background, var(--vaadin-color-subtle));
+    background: var(--vaadin-split-layout-handle-background, var(--vaadin-text-color-secondary));
     border-radius: var(--vaadin-radius-m);
     flex: none;
     width: var(--_handle-size);

--- a/packages/tabs/src/styles/vaadin-tab-base-styles.js
+++ b/packages/tabs/src/styles/vaadin-tab-base-styles.js
@@ -18,7 +18,7 @@ export const tabStyles = css`
     font-size: var(--vaadin-tab-font-size, 1em);
     font-weight: var(--vaadin-tab-font-weight, 500);
     line-height: var(--vaadin-tab-line-height, inherit);
-    color: var(--vaadin-tab-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-tab-color, var(--vaadin-text-color-secondary));
     background: var(--vaadin-tab-background, transparent);
     border-radius: var(--vaadin-tab-border-radius, var(--vaadin-radius-m));
     -webkit-tap-highlight-color: transparent;

--- a/packages/tabs/src/styles/vaadin-tab-base-styles.js
+++ b/packages/tabs/src/styles/vaadin-tab-base-styles.js
@@ -38,7 +38,7 @@ export const tabStyles = css`
 
   :host([selected]) {
     --vaadin-tab-background: var(--vaadin-background-container);
-    --vaadin-tab-color: var(--vaadin-color);
+    --vaadin-tab-color: var(--vaadin-text-color);
   }
 
   :host([disabled]) {

--- a/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
+++ b/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
@@ -14,7 +14,7 @@ export const tabSheetStyles = [
       display: flex;
       flex-direction: column;
       border: var(--vaadin-tabsheet-border-width, 1px) solid
-        var(--vaadin-tabsheet-border-color, var(--vaadin-border-color-subtle));
+        var(--vaadin-tabsheet-border-color, var(--vaadin-border-color-secondary));
       border-radius: var(--vaadin-tabsheet-border-radius, var(--vaadin-radius-l));
       overflow: hidden;
     }
@@ -58,7 +58,7 @@ export const tabSheetStyles = [
     }
 
     [part='content'][overflow~='top'] {
-      border-top-color: var(--vaadin-tabsheet-border-color, var(--vaadin-border-color-subtle));
+      border-top-color: var(--vaadin-tabsheet-border-color, var(--vaadin-border-color-secondary));
     }
 
     :host([loading]) [part='content'] {

--- a/packages/tooltip/src/styles/vaadin-tooltip-overlay-base-styles.js
+++ b/packages/tooltip/src/styles/vaadin-tooltip-overlay-base-styles.js
@@ -24,7 +24,7 @@ export const tooltipOverlayStyles = css`
     border: 0;
     box-shadow:
       0 0 0 var(--vaadin-tooltip-border-width, 1px)
-        var(--vaadin-tooltip-border-color, var(--vaadin-border-color-subtle)),
+        var(--vaadin-tooltip-border-color, var(--vaadin-border-color-secondary)),
       var(--vaadin-tooltip-box-shadow, 0 3px 8px -1px rgba(0, 0, 0, 0.2));
   }
 

--- a/packages/upload/src/styles/vaadin-upload-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-base-styles.js
@@ -23,7 +23,7 @@ export const uploadStyles = css`
 
   :host([dragover-valid]) {
     --vaadin-upload-background: var(--vaadin-background-container);
-    --vaadin-upload-border: 1px dashed var(--vaadin-color);
+    --vaadin-upload-border: 1px dashed var(--vaadin-text-color);
   }
 
   :host([hidden]) {
@@ -42,7 +42,7 @@ export const uploadStyles = css`
 
   [part='drop-label'] {
     align-items: center;
-    color: var(--vaadin-upload-drop-label-color, var(--vaadin-color));
+    color: var(--vaadin-upload-drop-label-color, var(--vaadin-text-color));
     display: flex;
     font-size: var(--vaadin-upload-drop-label-font-size, inherit);
     font-weight: var(--vaadin-upload-drop-label-font-weight, inherit);

--- a/packages/upload/src/styles/vaadin-upload-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-base-styles.js
@@ -11,7 +11,8 @@ export const uploadStyles = css`
     background: var(--vaadin-upload-background, transparent);
     border: var(
       --vaadin-upload-border,
-      var(--vaadin-upload-border-width, 1px) solid var(--vaadin-upload-border-color, var(--vaadin-border-color-subtle))
+      var(--vaadin-upload-border-width, 1px) solid
+        var(--vaadin-upload-border-color, var(--vaadin-border-color-secondary))
     );
     border-radius: var(--vaadin-upload-border-radius, var(--vaadin-radius-m));
     box-sizing: border-box;

--- a/packages/upload/src/styles/vaadin-upload-file-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-base-styles.js
@@ -62,7 +62,7 @@ export const uploadFileStyles = css`
   }
 
   [part='status'] {
-    color: var(--vaadin-upload-file-status-color, var(--vaadin-color-subtle));
+    color: var(--vaadin-upload-file-status-color, var(--vaadin-text-color-secondary));
     font-size: var(--vaadin-upload-file-status-font-size, inherit);
     font-weight: var(--vaadin-upload-file-status-font-weight, inherit);
     line-height: var(--vaadin-upload-file-status-line-height, inherit);

--- a/packages/upload/src/styles/vaadin-upload-file-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-base-styles.js
@@ -53,7 +53,7 @@ export const uploadFileStyles = css`
   }
 
   [part='name'] {
-    color: var(--vaadin-upload-file-name-color, var(--vaadin-color));
+    color: var(--vaadin-upload-file-name-color, var(--vaadin-text-color));
     font-size: var(--vaadin-upload-file-name-font-size, inherit);
     font-weight: var(--vaadin-upload-file-name-font-weight, inherit);
     line-height: var(--vaadin-upload-file-name-line-height, inherit);
@@ -69,7 +69,7 @@ export const uploadFileStyles = css`
   }
 
   [part='error'] {
-    color: var(--vaadin-upload-file-error-color, var(--vaadin-color));
+    color: var(--vaadin-upload-file-error-color, var(--vaadin-text-color));
     font-size: var(--vaadin-upload-file-error-font-size, inherit);
     font-weight: var(--vaadin-upload-file-error-font-weight, inherit);
     line-height: var(--vaadin-upload-file-error-line-height, inherit);
@@ -83,7 +83,7 @@ export const uploadFileStyles = css`
         var(--vaadin-upload-file-button-border-color, transparent)
     );
     border-radius: var(--vaadin-upload-file-button-border-radius, var(--vaadin-radius-m));
-    color: var(--vaadin-upload-file-button-text-color, var(--vaadin-color));
+    color: var(--vaadin-upload-file-button-text-color, var(--vaadin-text-color));
     cursor: var(--vaadin-clickable-cursor);
     flex-shrink: 0;
     font-family: var(--vaadin-upload-file-button-font-family, inherit);

--- a/packages/upload/src/styles/vaadin-upload-file-list-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-list-base-styles.js
@@ -30,7 +30,7 @@ export const uploadFileListStyles = css`
     border-bottom: var(
       --vaadin-upload-file-list-border,
       var(--vaadin-upload-file-list-border-width, 1px) solid
-        var(--vaadin-upload-file-list-border-color, var(--vaadin-border-color-subtle))
+        var(--vaadin-upload-file-list-border-color, var(--vaadin-border-color-secondary))
     );
   }
 `;

--- a/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
+++ b/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
@@ -36,7 +36,7 @@ export const virtualListStyles = css`
     z-index: 9999;
     height: 1px;
     margin-bottom: -1px;
-    background: var(--vaadin-virtual-list-border-color, var(--vaadin-border-color-subtle));
+    background: var(--vaadin-virtual-list-border-color, var(--vaadin-border-color-secondary));
   }
 
   :host([theme*='overflow-indicator'])::after {


### PR DESCRIPTION
## Description

Renamed base style custom properties:
- vaadin-color → vaadin-text-color
- vaadin-color-subtle → vaadin-text-color-secondary
- vaadin-border-color-subtle → vaadin-border-color-secondary

## Type of change

- Refactor