### PR TITLE
fix: set dialog position on drag start

### DIFF
--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -95,7 +95,8 @@ export const DialogDraggableMixin = (superClass) =>
           window.addEventListener('touchmove', this._drag);
           if (this.$.overlay.$.overlay.style.position !== 'absolute') {
             const { top, left } = this._originalBounds;
-            this.$.overlay.setBounds({ top, left });
+            this.top = top;
+            this.left = left;
           }
         }
       }


### PR DESCRIPTION
## Description

On drag start, the dialog currently applies position absolute, left and top styles to the overlay. But it does not update the `left` and `top` properties of the dialog. On drag end it always fires a `dragged` event with the coordinates from those properties. However, if you never move the dialog, then the properties will still be undefined and so will the coordinates in the event. That causes an issue for the Flow component which listens for the `dragged` event to update its own properties, which then get synced back to the client as `null`. The property change listener triggers and dialog resets the styles on the overlay, except for the `position`, which causes the jump reported in https://github.com/vaadin/web-components/issues/10154.

Before https://github.com/vaadin/web-components/pull/9456 this was working without the jump because the logic in `setBounds` calculated a top / left style of `nullpx`, which resulted in keeping the previous style set on drag start.

This change "locks" the current position into the `top` and `left` properties right on drag start, so that the `dragged` event reports correct coordinates even if the dialog is not moved. Given that previously the position / top / left style was already kept on the overlay even without moving it this seems fine. An even better approach would probably be to not fire the `dragged` event in that case, but that seems to be a bigger undertaking.

Fixes https://github.com/vaadin/web-components/issues/10154

## Type of change

- Bugfix
