### PR TITLE
fix: update horizontal scroll position on data change

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -339,6 +339,12 @@ export const GridMixin = (superClass) =>
 
         // Make sure the body has a tabbable element
         this._resetKeyboardNavigation();
+
+        // Updating data can change the visibility of the scroll bar. Therefore, the scroll position
+        // has to be recalculated.
+        requestAnimationFrame(() => {
+          this.__updateHorizontalScrollPosition();
+        });
       }
     }
 


### PR DESCRIPTION
## Description

When the data changes but there is no resize or scroll, the column widths are not recalculated with a new scroll position. On Windows, this leads to frozen-to-end columns not properly moved to the end, displaying data from other columns where the scroll bar was previously located.

This PR updates horizontal scroll position when the data changes. This makes sure that the frozen-to-end columns are always located at the end, even when there is no resize or scroll.

Fixes https://github.com/vaadin/flow-components/issues/6666.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.