### PR TITLE
fix: aura app-layout content styles when drawer is closed

### DIFF
--- a/packages/aura/src/components/app-layout.css
+++ b/packages/aura/src/components/app-layout.css
@@ -112,9 +112,9 @@ vaadin-app-layout:has([slot='navbar']):has([slot='drawer']) {
   }
 }
 
-vaadin-app-layout:has([slot='navbar']):has([slot='drawer']):not([overlay]):not([drawer-opened])
+vaadin-app-layout:has([slot='drawer']):not([overlay]):not([drawer-opened])
   > :nth-child(1 of :not([slot])):nth-last-child(1 of :not([slot])) {
-  border-inline-start-width: min(var(--aura-app-layout-inset), 1px);
+  border-inline-start-width: min(var(--aura-app-layout-inset), var(--_aura-mdl-border));
 }
 
 vaadin-app-layout:has([slot='navbar']):has([slot='drawer'])[drawer-opened]:not([overlay])
@@ -124,7 +124,7 @@ vaadin-app-layout:has([slot='navbar']):has([slot='drawer'])[drawer-opened]:not([
 
 vaadin-app-layout:has([slot='navbar']):has([slot='drawer'])
   > :nth-child(1 of :not([slot])):nth-last-child(1 of :not([slot])) {
-  border-top-width: 1px;
+  border-top-width: var(--_aura-mdl-border);
 }
 
 vaadin-app-layout:has([slot='navbar'])


### PR DESCRIPTION
Previously, with `--aura-app-layout-inset: 0px` there would still be a inline-start border on the app-layout content (the top-most MDL in the Aura dev page), if you didn't have a navbar in the layout as well.

Use the internal property for the border size.