### PR TITLE
docs: improve grid JSDoc, add missing fires annotations

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
@@ -28,7 +28,7 @@ export declare class GridSelectionColumnBaseMixinClass<TItem> {
   selectAll: boolean;
 
   /**
-   * When true, the active gets automatically selected.
+   * When true, the active item gets automatically selected.
    * @attr {boolean} auto-select
    */
   autoSelect: boolean;

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -63,7 +63,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * When true, the active gets automatically selected.
+         * When true, the active item gets automatically selected.
          * @attr {boolean} auto-select
          * @type {boolean}
          */

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -34,6 +34,8 @@ export * from './vaadin-grid-selection-column-mixin.js';
  * selection for all the items at once.
  *
  * __The default content can also be overridden__
+ *
+ * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
 declare class GridSelectionColumn<TItem = GridDefaultItem> extends HTMLElement {}
 

--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -30,8 +30,9 @@ import { GridSelectionColumnMixin } from './vaadin-grid-selection-column-mixin.j
  *
  * __The default content can also be overridden__
  *
- * @customElement
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
+ *
+ * @customElement
  * @extends GridColumn
  * @mixes GridSelectionColumnMixin
  */

--- a/packages/grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-column.d.ts
@@ -21,6 +21,8 @@ export * from './vaadin-grid-sort-column-mixin.js';
  *  <vaadin-grid-column>
  *    ...
  * ```
+ *
+ * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  */
 declare class GridSortColumn<TItem = GridDefaultItem> extends HTMLElement {}
 

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -257,6 +257,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
+ * @fires {CustomEvent} item-toggle - Fired when the user selects or deselects an item through the selection column.
  *
  * @customElement
  * @extends HTMLElement


### PR DESCRIPTION
## Description

Aligned `@fires` annotation in `.js` and `.d.ts` files to match each other. Also improved `selectAll` wording a bit.

## Type of change

- Documentation