### PR TITLE
refactor!: update standalone avatar to not be keyboard focusable

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -156,6 +156,7 @@ export const AvatarGroupMixin = (superClass) =>
       this._overflowController = new SlotController(this, 'overflow', 'vaadin-avatar', {
         initializer: (overflow) => {
           overflow.setAttribute('role', 'button');
+          overflow.setAttribute('tabindex', '0');
           overflow.setAttribute('aria-haspopup', 'menu');
           overflow.setAttribute('aria-expanded', 'false');
           overflow.addEventListener('click', (e) => this._onOverflowClick(e));
@@ -259,7 +260,6 @@ export const AvatarGroupMixin = (superClass) =>
                   class="${ifDefined(item.className)}"
                   theme="${ifDefined(this._theme)}"
                   aria-hidden="true"
-                  tabindex="-1"
                 ></vaadin-avatar>
                 ${item.name || ''}
               </vaadin-avatar-group-menu-item>
@@ -334,6 +334,7 @@ export const AvatarGroupMixin = (superClass) =>
                 .i18n="${this.__effectiveI18n}"
                 theme="${ifDefined(this._theme)}"
                 class="${ifDefined(item.className)}"
+                tabindex="0"
                 with-tooltip
               ></vaadin-avatar>
             `,

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -229,7 +229,6 @@ snapshots["vaadin-avatar-group opened default"] =
         aria-label="Mno Pqr (MP)"
         name="Mno Pqr"
         role="img"
-        tabindex="-1"
       >
       </vaadin-avatar>
       Mno Pqr
@@ -245,7 +244,6 @@ snapshots["vaadin-avatar-group opened default"] =
         aria-label="Stu Vwx (SV)"
         name="Stu Vwx"
         role="img"
-        tabindex="-1"
       >
       </vaadin-avatar>
       Stu Vwx

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -124,10 +124,6 @@ export const AvatarMixin = (superClass) =>
         this.setAttribute('role', 'img');
       }
 
-      if (!this.hasAttribute('tabindex')) {
-        this.setAttribute('tabindex', '0');
-      }
-
       // Should set `anonymous` if name / abbr is not provided
       if (!this.name && !this.abbr) {
         this.__setTooltip();

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -279,6 +279,7 @@ describe('vaadin-avatar', () => {
         container.appendChild(avatar);
 
         const overlay = tooltip.shadowRoot.querySelector('vaadin-tooltip-overlay');
+        avatar.setAttribute('tabindex', '0');
         tabKeyDown(avatar);
         avatar.focus();
         expect(overlay.opened).to.be.true;
@@ -297,8 +298,8 @@ describe('vaadin-avatar', () => {
   });
 
   describe('focus', () => {
-    it('should set tabindex="0" on the avatar', () => {
-      expect(avatar.getAttribute('tabindex')).to.equal('0');
+    beforeEach(() => {
+      avatar.setAttribute('tabindex', '0');
     });
 
     it('should set focused attribute on avatar focusin', () => {

--- a/packages/avatar/test/visual/base/avatar.test.js
+++ b/packages/avatar/test/visual/base/avatar.test.js
@@ -76,6 +76,7 @@ describe('avatar', () => {
   });
 
   it('focus-ring', async () => {
+    element.setAttribute('tabindex', '0');
     await sendKeys({ press: 'Tab' });
     await visualDiff(div, 'focus-ring');
   });
@@ -84,6 +85,7 @@ describe('avatar', () => {
     div.style.width = '90px';
     div.style.height = '75px';
     div.style.textAlign = 'center';
+    element.setAttribute('tabindex', '0');
     element.withTooltip = true;
     await sendKeys({ press: 'Tab' });
     await visualDiff(div, 'tooltip');

--- a/packages/avatar/test/visual/lumo/avatar.test.js
+++ b/packages/avatar/test/visual/lumo/avatar.test.js
@@ -119,6 +119,7 @@ describe('avatar', () => {
     div.style.height = '90px';
     div.style.textAlign = 'center';
     element.withTooltip = true;
+    element.setAttribute('tabindex', '0');
     await sendKeys({ press: 'Tab' });
     await visualDiff(div, 'tooltip');
   });

--- a/packages/message-list/src/vaadin-message-mixin.js
+++ b/packages/message-list/src/vaadin-message-mixin.js
@@ -95,7 +95,6 @@ export const MessageMixin = (superClass) =>
 
       this._avatarController = new SlotController(this, 'avatar', 'vaadin-avatar', {
         initializer: (avatar) => {
-          avatar.setAttribute('tabindex', '-1');
           avatar.setAttribute('aria-hidden', 'true');
           this._avatar = avatar;
         },

--- a/packages/message-list/test/dom/__snapshots__/message-list.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message-list.test.snap.js
@@ -27,7 +27,6 @@ snapshots["vaadin-message-list items"] =
       name="Jane Doe"
       role="img"
       slot="avatar"
-      tabindex="-1"
     >
     </vaadin-avatar>
   </vaadin-message>
@@ -43,7 +42,6 @@ snapshots["vaadin-message-list items"] =
       name="Lina Roy"
       role="img"
       slot="avatar"
-      tabindex="-1"
     >
     </vaadin-avatar>
   </vaadin-message>
@@ -69,7 +67,6 @@ snapshots["vaadin-message-list theme"] =
       name="Admin"
       role="img"
       slot="avatar"
-      tabindex="-1"
     >
     </vaadin-avatar>
   </vaadin-message>
@@ -95,7 +92,6 @@ snapshots["vaadin-message-list className"] =
       name="Admin"
       role="img"
       slot="avatar"
-      tabindex="-1"
     >
     </vaadin-avatar>
   </vaadin-message>

--- a/packages/message-list/test/dom/__snapshots__/message.test.snap.js
+++ b/packages/message-list/test/dom/__snapshots__/message.test.snap.js
@@ -66,7 +66,6 @@ snapshots["vaadin-message avatar username"] =
     name="Joan Doe"
     role="img"
     slot="avatar"
-    tabindex="-1"
   >
   </vaadin-avatar>
 </vaadin-message>
@@ -81,7 +80,6 @@ snapshots["vaadin-message avatar abbr"] =
     aria-label="JD"
     role="img"
     slot="avatar"
-    tabindex="-1"
   >
   </vaadin-avatar>
 </vaadin-message>
@@ -95,7 +93,6 @@ snapshots["vaadin-message avatar img"] =
     img="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
     role="img"
     slot="avatar"
-    tabindex="-1"
   >
   </vaadin-avatar>
 </vaadin-message>
@@ -110,7 +107,6 @@ snapshots["vaadin-message avatar userColorIndex"] =
     role="img"
     slot="avatar"
     style="--vaadin-avatar-user-color: var(--vaadin-user-color-2);"
-    tabindex="-1"
   >
   </vaadin-avatar>
 </vaadin-message>


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9299

Changed `vaadin-avatar` to not be keyboard focusable and set `tabindex` when used in `vaadin-avatar-group`.
This eliminates the need for setting `tabindex="-1"` on avatars in avatar-group submenu and the message-list.

## Type of change

- Behavior altering change