### PR TITLE
refactor: update Lumo icon to respect size CSS property

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/icon.css
+++ b/packages/vaadin-lumo-styles/src/components/icon.css
@@ -5,7 +5,7 @@
  */
 @media lumo_components_icon {
   :host {
-    width: var(--lumo-icon-size-m);
-    height: var(--lumo-icon-size-m);
+    width: var(--vaadin-icon-size, var(--lumo-icon-size-m));
+    height: var(--vaadin-icon-size, var(--lumo-icon-size-m));
   }
 }


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10160

Changed Lumo for `vaadin-icon` to allow using `--vaadin-icon-size` custom CSS property.

## Type of change

- Refactor