### PR TITLE
chore: add separate release scripts (#10225) (CP: 22.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:js": "eslint --ext .js,.ts *.js scripts packages",
     "lint:types": "tsc",
     "prepare": "husky install",
+    "release": "yarn analyze",
     "serve:dist": "web-dev-server --app-index dist/index.html --open",
     "start": "web-dev-server --node-resolve --open /dev/index.html",
     "test": "web-test-runner",


### PR DESCRIPTION
## Description

Manual cherry-pick of #10225 to `22.1` branch.
There is neither web-types nor Lumo autocomplete CSS in V22, so `release` script is just an alias for `analyze`.

## Type of change

- Cherry-pick