### PR TITLE
fix: use default body font size on iOS

### DIFF
--- a/packages/aura/src/typography.css
+++ b/packages/aura/src/typography.css
@@ -34,7 +34,6 @@
 
       /* Support iOS dynamic text size */
       font: -apple-system-body;
-      --aura-base-font-size: 14;
     }
   }
 }


### PR DESCRIPTION
This makes the default font size, `--aura-font-size-m`, match `1rem` which equals 17px.