### PR TITLE
chore: use correct import in tabsheet playground page

### DIFF
--- a/dev/playground/tabsheet.html
+++ b/dev/playground/tabsheet.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TabSheet</title>
-    <script type="module" src="./common.js"></script>
+    <script type="module" src="../common.js"></script>
 
     <script type="module">
       import '@vaadin/button';


### PR DESCRIPTION
## Description

Dev pages build was broken as a result of using incorrect import in #10218. This PR fixes that.

## Type of change

- Internal change