### PR TITLE
feat: aura upload and progress-bar themes

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -37,6 +37,7 @@
       import '@vaadin/message-input';
       import '@vaadin/multi-select-combo-box';
       import '@vaadin/popover';
+      import '@vaadin/progress-bar';
       import '@vaadin/radio-group';
       import '@vaadin/select';
       import '@vaadin/scroller';
@@ -647,6 +648,10 @@
                   <vaadin-text-field clear-button-visible value="Projects">
                     <vaadin-icon src="./assets/lucide-icons/folder.svg" slot="prefix"></vaadin-icon>
                   </vaadin-text-field>
+                </div>
+
+                <div class="aura-surface component">
+                  <vaadin-progress-bar value="0.5"></vaadin-progress-bar>
                 </div>
 
                 <div class="aura-surface component wide">

--- a/packages/aura/aura.css
+++ b/packages/aura/aura.css
@@ -21,8 +21,10 @@
 @import './src/components/multi-select-combo-box.css';
 @import './src/components/notification.css';
 @import './src/components/overlay.css';
+@import './src/components/progress-bar.css';
 @import './src/components/select.css';
 @import './src/components/side-nav.css';
+@import './src/components/upload.css';
 
 :where(:root, :host) {
   cursor: default;

--- a/packages/aura/src/components/progress-bar.css
+++ b/packages/aura/src/components/progress-bar.css
@@ -1,0 +1,16 @@
+:where(:root, :host) {
+  --vaadin-progress-bar-border-width: 0px;
+  --vaadin-progress-bar-value-background: linear-gradient(
+    90deg,
+    var(--aura-accent-color),
+    color-mix(in hsl, var(--aura-accent-color) 60%, hsl(45, 31%, 95%))
+  );
+}
+
+vaadin-progress-bar {
+  height: var(--vaadin-gap-s);
+
+  &[dir='rtl']::part(value) {
+    scale: -1;
+  }
+}

--- a/packages/aura/src/components/upload.css
+++ b/packages/aura/src/components/upload.css
@@ -1,0 +1,153 @@
+:where(:root, :host) {
+  --vaadin-upload-background: var(--aura-surface) padding-box;
+  --vaadin-upload-border: 1px solid var(--vaadin-border-color-secondary);
+  --vaadin-upload-padding: var(--vaadin-padding-s);
+  --vaadin-upload-file-list-border-color: var(--vaadin-border-color-secondary);
+  --vaadin-upload-file-list-border-width: 1px;
+  --vaadin-upload-file-error-color: var(--vaadin-text-color-secondary);
+  --vaadin-upload-file-warning-color: var(--aura-red);
+  --vaadin-upload-file-done-color: var(--aura-green);
+  --vaadin-upload-file-name-font-weight: var(--aura-font-weight-medium);
+  --vaadin-upload-file-padding: var(--vaadin-padding-s);
+  --vaadin-upload-file-gap: 0 var(--vaadin-gap-s);
+  --vaadin-upload-file-button-padding: var(--vaadin-upload-file-padding);
+  --vaadin-upload-file-button-border-width: 0;
+  --vaadin-upload-file-status-font-size: var(--aura-font-size-s);
+  --vaadin-upload-file-status-line-height: var(--aura-line-height-s);
+  --vaadin-upload-file-error-font-size: var(--aura-font-size-s);
+  --vaadin-upload-file-error-line-height: var(--aura-line-height-s);
+  --vaadin-upload-drop-label-color: var(--vaadin-text-color-secondary);
+  --vaadin-upload-drop-label-font-weight: var(--aura-font-weight-medium);
+}
+
+vaadin-upload {
+  --_divider-offset-start: calc(var(--vaadin-padding-s) + var(--vaadin-icon-size, 1lh) + var(--vaadin-gap-s));
+  --_divider-offset-end: var(--vaadin-padding-s);
+}
+
+vaadin-upload::part(primary-buttons) {
+  flex-wrap: wrap;
+  gap: var(--vaadin-gap-s) var(--vaadin-gap-m);
+}
+
+vaadin-upload:not([nodrop]) vaadin-button[slot='add-button'] {
+  flex: 1;
+}
+
+vaadin-upload::part(drop-label) {
+  flex: 100;
+  padding: var(--vaadin-padding-xs) var(--vaadin-padding-s);
+  min-width: fit-content;
+  margin-inline-start: calc(var(--vaadin-upload-padding) * -1);
+}
+
+vaadin-upload[dragover-valid] {
+  outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+  outline-offset: -1px;
+}
+
+vaadin-upload-file-list li {
+  margin-inline: var(--_divider-offset-start) var(--_divider-offset-end);
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+vaadin-upload:not([theme~='no-border']) vaadin-upload-file-list:has(li) {
+  border-top: 1px solid var(--vaadin-border-color-secondary);
+  margin: calc(var(--vaadin-upload-padding) * -1);
+  margin-top: var(--vaadin-upload-padding);
+}
+
+vaadin-upload-file {
+  --vaadin-icon-visual-size: 0.75lh;
+  border-radius: var(--vaadin-radius-m);
+  padding-block: var(--vaadin-padding-m);
+  margin-inline: calc(var(--_divider-offset-start, 0) * -1) calc(var(--_divider-offset-end, 0) * -1);
+
+  &::part(done-icon),
+  &::part(warning-icon),
+  &::part(commands) {
+    align-self: baseline;
+  }
+
+  &:not([complete], [error])::part(done-icon) {
+    display: block;
+  }
+
+  &:not([complete], [error])::part(done-icon)::before {
+    background: var(--vaadin-border-color-secondary);
+  }
+
+  &::part(commands) {
+    margin-block: calc(var(--vaadin-upload-file-button-padding) * -1);
+    margin-inline-end: calc(var(--vaadin-upload-file-button-padding) * -1);
+  }
+
+  &::part(remove-button),
+  &::part(retry-button) {
+    --vaadin-upload-file-button-text-color: var(--vaadin-text-color-secondary);
+    outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
+  }
+
+  vaadin-progress-bar {
+    display: block;
+    height: var(--vaadin-gap-xs);
+    margin-top: var(--vaadin-gap-xs);
+  }
+
+  &:not([error])::part(status) {
+    max-height: 2lh;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &[complete]::part(status) {
+    height: 1lh; /* ensure some height to transition from */
+    visibility: hidden;
+    transition: 200ms max-height;
+    max-height: 0;
+  }
+
+  &[complete] vaadin-progress-bar {
+    visibility: hidden;
+    transition: 200ms height;
+    height: 0;
+    margin-top: 0;
+  }
+}
+
+vaadin-upload[theme~='no-border'] {
+  --vaadin-upload-padding: 0;
+  --vaadin-upload-background: transparent;
+  --vaadin-upload-border: none;
+  --vaadin-upload-file-list-border-width: 0;
+  --_divider-offset-start: 0px;
+  --_divider-offset-end: 0px;
+  outline-offset: 2px;
+
+  vaadin-upload-file-list::part(list) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--vaadin-gap-s);
+  }
+
+  vaadin-upload-file-list li:first-child {
+    margin-top: var(--vaadin-gap-s);
+  }
+
+  vaadin-upload-file {
+    background: var(--aura-surface) padding-box;
+    border: 1px solid var(--vaadin-border-color-secondary);
+  }
+}
+
+@media (any-hover: hover) {
+  vaadin-upload-file::part(remove-button):hover,
+  vaadin-upload-file::part(retry-button):hover {
+    --vaadin-upload-file-button-text-color: var(--vaadin-text-color);
+  }
+}

--- a/packages/aura/src/surface.css
+++ b/packages/aura/src/surface.css
@@ -18,6 +18,8 @@ vaadin-menu-bar-button,
 vaadin-message-input,
 vaadin-radio-button::part(radio),
 vaadin-side-nav-item::part(content),
+vaadin-upload,
+vaadin-upload-file,
 ::part(input-field),
 ::part(overlay) {
   --aura-surface-opacity: 0.5;


### PR DESCRIPTION
Default theme:
<img width="455" height="257" alt="Screenshot 2025-09-29 at 16 09 10" src="https://github.com/user-attachments/assets/ab63b0c3-1612-4273-bec0-7a69d36044d5" />

No-border variant:
<img width="454" height="266" alt="Screenshot 2025-09-29 at 16 09 34" src="https://github.com/user-attachments/assets/ae6b456b-d5a1-42f6-b21d-fc30822fe66b" />



