### PR TITLE
fix: do not close slotted tooltip on overlay mousedown

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -553,8 +553,14 @@ export const TooltipMixin = (superClass) =>
     }
 
     /** @private */
-    __onMouseDown() {
+    __onMouseDown(event) {
       if (this.manual) {
+        return;
+      }
+
+      // Do not close on bubbling mousedown events when
+      // the tooltip is slotted into the target element
+      if (event.composedPath().includes(this)) {
         return;
       }
 

--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import { AccordionPanel } from '@vaadin/accordion/src/vaadin-accordion-panel.js';
 import { Button } from '@vaadin/button/src/vaadin-button.js';
@@ -151,6 +151,15 @@ before(() => {
         mouseenter(tooltip.target);
         expect(tooltipOverlay.opened).to.be.false;
       }
+    });
+
+    it('should not close slotted tooltip on overlay mousedown', () => {
+      mouseenter(tooltip.target);
+
+      expect(tooltipOverlay.opened).to.be.true;
+      const content = tooltip.querySelector('[slot="overlay"]');
+      mousedown(content);
+      expect(tooltipOverlay.opened).to.be.true;
     });
 
     it('should set has-tooltip attribute on the element', () => {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10255

Added logic to ignore the `mousedown` event on the target when it originates from the slotted tooltip overlay.

## Type of change

- Bugfix