### PR TITLE
fix: ensure visible border and value background color in forced color…

### DIFF
--- a/packages/progress-bar/src/styles/vaadin-progress-bar-base-styles.js
+++ b/packages/progress-bar/src/styles/vaadin-progress-bar-base-styles.js
@@ -97,4 +97,14 @@ export const progressBarStyles = css`
       animation: indeterminate-reduced 2s linear infinite alternate;
     }
   }
+
+  @media (forced-colors: active) {
+    [part='bar'] {
+      border-width: max(1px, var(--vaadin-progress-bar-border-width));
+    }
+
+    [part='value'] {
+      background: CanvasText !important;
+    }
+  }
 `;


### PR DESCRIPTION
Don't allow themes to easily override the progress value color or remove the border.