### PR TITLE
fix: set display: inline on the label part in base styles

### DIFF
--- a/packages/button/src/styles/vaadin-button-base-styles.js
+++ b/packages/button/src/styles/vaadin-button-base-styles.js
@@ -43,9 +43,12 @@ export const buttonStyles = css`
 
   .vaadin-button-container,
   [part='prefix'],
-  [part='suffix'],
-  [part='label'] {
+  [part='suffix'] {
     display: contents;
+  }
+
+  [part='label'] {
+    display: inline-flex;
   }
 
   :host(:is([focus-ring], :focus-visible)) {

--- a/packages/button/test/visual/base/button.test.js
+++ b/packages/button/test/visual/base/button.test.js
@@ -54,22 +54,25 @@ describe('button', () => {
   });
 
   describe('icon', () => {
-    const PREFIX_ICON = '<vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>';
-    const SUFFIX_ICON = '<vaadin-icon icon="vaadin:reply" slot="suffix"></vaadin-icon>';
+    const getIcon = (slot) => `
+      <vaadin-icon
+        icon="vaadin:reply"
+         ${slot ? `slot="${slot}"` : ''}
+      ></vaadin-icon>
+    `;
 
     it('before text', async () => {
-      element.insertAdjacentHTML('afterbegin', PREFIX_ICON);
+      element.insertAdjacentHTML('afterbegin', getIcon('prefix'));
       await visualDiff(div, 'icon-before-text');
     });
 
     it('after text', async () => {
-      element.insertAdjacentHTML('beforeend', SUFFIX_ICON);
+      element.insertAdjacentHTML('beforeend', getIcon('suffix'));
       await visualDiff(div, 'icon-after-text');
     });
 
     it('without text', async () => {
-      element.textContent = '';
-      element.insertAdjacentHTML('afterbegin', PREFIX_ICON);
+      element.innerHTML = getIcon('');
       await visualDiff(div, 'icon-without-text');
     });
   });


### PR DESCRIPTION
## Description

Using `display: contents` is problematic in different ways:

- it causes anonymous text nodes to disappear in Safari when the tooltip is shown,
- it causes problems in Start where we use `part="label"` for editing button text.

Let's change to `display: inline` as that eliminates both problems.

## Type of change

- Bugfix

### Before

https://github.com/user-attachments/assets/61f22d56-e0e7-42c1-9e35-4899cf2d7644

### After

https://github.com/user-attachments/assets/e1755763-75be-4ee8-915b-c52f5363769a
