### PR TITLE
feat: aura login form & login overlay themes

### DIFF
--- a/packages/aura/aura.css
+++ b/packages/aura/aura.css
@@ -16,6 +16,7 @@
 @import './src/components/dialog.css';
 @import './src/components/grid.css';
 @import './src/components/input-container.css';
+@import './src/components/login.css';
 @import './src/components/master-detail-layout.css';
 @import './src/components/message-input.css';
 @import './src/components/multi-select-combo-box.css';

--- a/packages/aura/src/components/login.css
+++ b/packages/aura/src/components/login.css
@@ -1,0 +1,42 @@
+:where(:root, :host) {
+  --vaadin-login-form-error-color: var(--aura-red-text);
+  --vaadin-login-form-padding: var(--vaadin-padding-xl);
+  --vaadin-login-overlay-brand-padding: var(--vaadin-padding-xl);
+  --vaadin-login-overlay-brand-background: transparent;
+  --vaadin-login-overlay-title-font-size: 1.5em;
+  --vaadin-login-overlay-title-line-height: 1.2;
+  --vaadin-login-overlay-title-font-weight: var(--aura-font-weight-semibold);
+  --vaadin-login-overlay-title-color: var(--vaadin-text-color);
+  --vaadin-login-overlay-description-color: var(--vaadin-text-color-secondary);
+}
+
+vaadin-login-form::part(error-message) {
+  border-radius: var(--vaadin-radius-m);
+  padding: var(--vaadin-padding-m);
+  background: color-mix(in srgb, var(--aura-red) 10%, transparent);
+}
+
+vaadin-login-form::part(error-message-title) {
+  font-weight: var(--aura-font-weight-semibold);
+}
+
+vaadin-login-overlay {
+  --vaadin-overlay-backdrop-background: var(--aura-app-background);
+
+  &::part(overlay) {
+    --aura-surface-level: 2;
+  }
+
+  &::part(brand) {
+    text-align: center;
+    padding-bottom: 0;
+  }
+
+  &::part(form-title) {
+    display: none;
+  }
+
+  [slot='title'] {
+    letter-spacing: -0.03em;
+  }
+}

--- a/packages/aura/src/surface.css
+++ b/packages/aura/src/surface.css
@@ -19,7 +19,10 @@ vaadin-message-input,
 vaadin-radio-button::part(radio),
 vaadin-side-nav-item::part(content),
 ::part(input-field),
-::part(overlay) {
+::part(overlay),
+vaadin-confirm-dialog::part(overlay),
+vaadin-dialog::part(overlay),
+vaadin-login-overlay::part(overlay) {
   --aura-surface-opacity: 0.5;
 
   --aura-surface-solid: light-dark(


### PR DESCRIPTION
Plain and simple for now:

<img width="434" height="436" alt="Screenshot 2025-09-30 at 11 27 31" src="https://github.com/user-attachments/assets/214d98e8-34c3-4325-9f23-8fbc868130b5" />
