### PR TITLE
fix: prevent tooltip click and mousedown from bubbling to target

### DIFF
--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -617,6 +617,13 @@ export const TooltipMixin = (superClass) =>
       }
     }
 
+    /** @protected */
+    __onOverlayClick(event) {
+      // Prevent click listeners from being called when
+      // the tooltip is slotted into the target element
+      event.stopPropagation();
+    }
+
     /** @private */
     __handleMouseLeave() {
       if (this.manual) {

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -553,14 +553,8 @@ export const TooltipMixin = (superClass) =>
     }
 
     /** @private */
-    __onMouseDown(event) {
+    __onMouseDown() {
       if (this.manual) {
-        return;
-      }
-
-      // Do not close on bubbling mousedown events when
-      // the tooltip is slotted into the target element
-      if (event.composedPath().includes(this)) {
         return;
       }
 
@@ -615,6 +609,13 @@ export const TooltipMixin = (superClass) =>
       if (event.relatedTarget !== this.target) {
         this.__handleMouseLeave();
       }
+    }
+
+    /** @protected */
+    __onOverlayMouseDown(event) {
+      // Prevent mousedown listeners from being called when
+      // the tooltip is slotted into the target element
+      event.stopPropagation();
     }
 
     /** @protected */

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -85,6 +85,7 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(
         ?no-vertical-overlap="${this.__computeNoVerticalOverlap(effectivePosition)}"
         .horizontalAlign="${this.__computeHorizontalAlign(effectivePosition)}"
         .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
+        @click="${this.__onOverlayClick}"
         @mouseenter="${this.__onOverlayMouseEnter}"
         @mouseleave="${this.__onOverlayMouseLeave}"
         modeless

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -86,6 +86,7 @@ class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(
         .horizontalAlign="${this.__computeHorizontalAlign(effectivePosition)}"
         .verticalAlign="${this.__computeVerticalAlign(effectivePosition)}"
         @click="${this.__onOverlayClick}"
+        @mousedown="${this.__onOverlayMouseDown}"
         @mouseenter="${this.__onOverlayMouseEnter}"
         @mouseleave="${this.__onOverlayMouseLeave}"
         modeless

--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown, nextRender, tabKeyDown } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './not-animated-styles.js';
 import { AccordionPanel } from '@vaadin/accordion/src/vaadin-accordion-panel.js';
 import { Button } from '@vaadin/button/src/vaadin-button.js';
@@ -160,6 +161,16 @@ before(() => {
       const content = tooltip.querySelector('[slot="overlay"]');
       mousedown(content);
       expect(tooltipOverlay.opened).to.be.true;
+    });
+
+    it('should not fire target click listeners on overlay click', () => {
+      const spy = sinon.spy();
+      tooltip.target.addEventListener('click', spy);
+
+      mouseenter(tooltip.target);
+      tooltipOverlay.click();
+
+      expect(spy.called).to.be.false;
     });
 
     it('should set has-tooltip attribute on the element', () => {

--- a/test/integration/component-tooltip.test.js
+++ b/test/integration/component-tooltip.test.js
@@ -173,6 +173,17 @@ before(() => {
       expect(spy.called).to.be.false;
     });
 
+    it('should not fire target mousedown listeners on overlay mousedown', () => {
+      const spy = sinon.spy();
+      tooltip.target.addEventListener('mousedown', spy);
+
+      mouseenter(tooltip.target);
+      const content = tooltip.querySelector('[slot="overlay"]');
+      mousedown(content);
+
+      expect(spy.called).to.be.false;
+    });
+
     it('should set has-tooltip attribute on the element', () => {
       expect(element.hasAttribute('has-tooltip')).to.be.true;
     });


### PR DESCRIPTION
## Description

Part of #10255

Fixes the finding from https://github.com/vaadin/web-components/issues/10255#issuecomment-3347224080

## Type of change

- Bugfix