### PR TITLE
fix: do not close submenu on hovering button without items

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -874,10 +874,11 @@ export const MenuBarMixin = (superClass) =>
         this._hideTooltip();
       } else if (button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
+        // Switch sub-menu when moving cursor over another button
+        // with children, regardless of whether openOnHover is set.
+        // If the button has no children, keep the sub-menu opened.
         if (button.item.children && (this.openOnHover || isOpened)) {
           this.__openSubMenu(button, false);
-        } else if (isOpened) {
-          this._close();
         }
 
         if (button === this._overflow || (this.openOnHover && button.item.children)) {

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -873,11 +873,10 @@ export const MenuBarMixin = (superClass) =>
         // Hide tooltip on mouseover to disabled button
         this._hideTooltip();
       } else if (button !== this._expandedButton) {
-        const isOpened = this._subMenu.opened;
         // Switch sub-menu when moving cursor over another button
         // with children, regardless of whether openOnHover is set.
         // If the button has no children, keep the sub-menu opened.
-        if (button.item.children && (this.openOnHover || isOpened)) {
+        if (button.item.children && (this.openOnHover || this._subMenu.opened)) {
           this.__openSubMenu(button, false);
         }
 

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -522,12 +522,12 @@ describe('open on hover', () => {
     expect(subMenu.listenOn).to.equal(buttons[0]);
   });
 
-  it('should close open sub-menu on mouseover on button without nested items', async () => {
+  it('should not close open sub-menu on mouseover on button without nested items', async () => {
     fire(buttons[0], openOnHoverEvent);
     await nextRender();
     fire(buttons[1], openOnHoverEvent);
     await nextRender();
-    expect(subMenu.opened).to.be.false;
+    expect(subMenu.opened).to.be.true;
   });
 
   it('should switch opened sub-menu on hover also when open-on-hover is false', async () => {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/6918
Fixes https://github.com/vaadin/web-components/issues/5942

## Note

Currently, menu-bar behaves is as follows:

- Moving cursor on the item without children closes sub-menu (which is aligned with the [ARIA example](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-navigation/)).
- But unlike in the example above, sub-menu doesn't get reopened (see the second issue linked above).

Now when we have a BFP (the first issue linked above) about closing being problematic, it sounds easier to just keep the sub-menu opened in the first place. We can then reconsider making it configurable in case someone requests that.

## Type of change

- Bugfix