### PR TITLE
fix: do not close submenu on hovering button without items (#10274) (CP: 24.9)

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -878,11 +878,11 @@ export const MenuBarMixin = (superClass) =>
         // Hide tooltip on mouseover to disabled button
         this._hideTooltip();
       } else if (button !== this._expandedButton) {
-        const isOpened = this._subMenu.opened;
-        if (button.item.children && (this.openOnHover || isOpened)) {
+        // Switch sub-menu when moving cursor over another button
+        // with children, regardless of whether openOnHover is set.
+        // If the button has no children, keep the sub-menu opened.
+        if (button.item.children && (this.openOnHover || this._subMenu.opened)) {
           this.__openSubMenu(button, false);
-        } else if (isOpened) {
-          this._close();
         }
 
         if (button === this._overflow || (this.openOnHover && button.item.children)) {

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -525,12 +525,12 @@ describe('open on hover', () => {
     expect(subMenu.listenOn).to.equal(buttons[0]);
   });
 
-  it('should close open sub-menu on mouseover on button without nested items', async () => {
+  it('should not close open sub-menu on mouseover on button without nested items', async () => {
     fire(buttons[0], openOnHoverEvent);
     await nextRender(subMenu);
     fire(buttons[1], openOnHoverEvent);
     await nextRender(subMenu);
-    expect(subMenu.opened).to.be.false;
+    expect(subMenu.opened).to.be.true;
   });
 
   it('should switch opened sub-menu on hover also when open-on-hover is false', async () => {


### PR DESCRIPTION
## Description

Cherry-pick or #10274 to `24.9` branch.

There was a merge conflict due to `nextRender(subMenu)` in v24 and `nextRender()` on main.

## Type of change

- Cherry-pick