### PR TITLE
chore: exclude postcss.config.js from publishing to npm

### DIFF
--- a/packages/vaadin-lumo-styles/package.json
+++ b/packages/vaadin-lumo-styles/package.json
@@ -28,6 +28,7 @@
     "*.d.ts",
     "*.js",
     "!gulpfile.js",
+    "!postcss.config.js",
     "components/*.css",
     "dist",
     "mixins/*.d.ts",


### PR DESCRIPTION
## Description

This config file will end up being published to npm thanks to `*.js` glob, let's exclude it similarly to `gulpfile.js`.

## Type of change

- Internal change