### PR TITLE
refactor: use separate props for details summary border width and color

### DIFF
--- a/packages/details/src/styles/vaadin-details-summary-base-styles.js
+++ b/packages/details/src/styles/vaadin-details-summary-base-styles.js
@@ -11,7 +11,7 @@ export const detailsSummary = (partName = 'vaadin-details-summary') => css`
     align-items: center;
     background: var(--${unsafeCSS(partName)}-background, transparent);
     background-origin: border-box;
-    border: var(--${unsafeCSS(partName)}-border-width, 0px) solid
+    border: var(--${unsafeCSS(partName)}-border-width, 0) solid
       var(--${unsafeCSS(partName)}-border-color, var(--vaadin-border-color-secondary));
     border-radius: var(--${unsafeCSS(partName)}-border-radius, var(--vaadin-radius-m));
     box-sizing: border-box;


### PR DESCRIPTION
Align with other component base styles that have separate properties for border-width and border-color.