### PR TITLE
refactor: remove getComputedStyle check for colorIndex validation

### DIFF
--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -133,20 +133,11 @@ export const AvatarMixin = (superClass) =>
     /** @private */
     __colorIndexChanged(index) {
       if (index != null) {
-        const prop = `--vaadin-user-color-${index}`;
-
-        // Check if custom CSS property is defined
-        const isValid = Boolean(getComputedStyle(document.documentElement).getPropertyValue(prop));
-
-        if (isValid) {
-          this.setAttribute('has-color-index', '');
-          this.style.setProperty('--vaadin-avatar-user-color', `var(${prop})`);
-        } else {
-          this.removeAttribute('has-color-index');
-          console.warn(`The CSS property --vaadin-user-color-${index} is not defined`);
-        }
+        this.setAttribute('has-color-index', '');
+        this.style.setProperty('--vaadin-avatar-user-color', `var(--vaadin-user-color-${index})`);
       } else {
         this.removeAttribute('has-color-index');
+        this.style.removeProperty('--vaadin-avatar-user-color');
       }
     }
 

--- a/packages/avatar/test/avatar.test.js
+++ b/packages/avatar/test/avatar.test.js
@@ -352,28 +352,6 @@ describe('vaadin-avatar', () => {
         expect(avatar.hasAttribute('has-color-index')).to.be.false;
       });
     });
-
-    describe('incorrect index', () => {
-      beforeEach(() => {
-        sinon.stub(console, 'warn');
-      });
-
-      afterEach(() => {
-        console.warn.restore();
-      });
-
-      it('should not set attribute for invalid index', async () => {
-        avatar.colorIndex = 99;
-        await nextUpdate(avatar);
-        expect(avatar.hasAttribute('has-color-index')).to.be.false;
-      });
-
-      it('should warn about invalid css property used', async () => {
-        avatar.colorIndex = 99;
-        await nextUpdate(avatar);
-        expect(console.warn.called).to.be.true;
-      });
-    });
   });
 
   describe('a11y', () => {


### PR DESCRIPTION
## Description

The avatar's colorIndex property validation was necessary when the corresponding CSS properties were shipped only as part of the Lumo and Material themes and weren't available in the base styles. Since these properties are now included in the base styles, the warning is no longer well justified. Considering that it requires a `getComputedStyle()` call, which can have a significant performance impact as shown below, it's better to remove it altogether.

| Before | After |
|--------|------|
| <img width="714" height="692" alt="image" src="https://github.com/user-attachments/assets/3cb90925-c48a-44c8-b746-679bd9a3464a" /> | <img width="714" height="692" alt="image" src="https://github.com/user-attachments/assets/8ffa2c4a-5d49-46d6-83f4-ac8d4dc9a7a1" /> |

Performance measurements were taken with a 4x CPU throttle on `dev/aura.html`.

## Type of change

- [x] Refactor
