### PR TITLE
refactor: introduce grid ResizeMixin for resize observers

### DIFF
--- a/packages/grid/src/vaadin-grid-resize-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-resize-mixin.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+
+export declare function ResizeMixin<T extends Constructor<HTMLElement>>(base: T): Constructor<ResizeMixinClass> & T;
+
+declare class ResizeMixinClass {}

--- a/packages/grid/src/vaadin-grid-resize-mixin.js
+++ b/packages/grid/src/vaadin-grid-resize-mixin.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * A mixin to observe size changes of the grid and its main parts.
+ *
+ * @polymerMixin
+ */
+export const ResizeMixin = (superClass) =>
+  class extends superClass {
+    static get properties() {
+      return {
+        /** @private */
+        __tableRect: Object,
+
+        /** @private */
+        __headerRect: Object,
+
+        /** @private */
+        __itemsRect: Object,
+
+        /** @private */
+        __footerRect: Object,
+      };
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      const resizeObserver = new ResizeObserver((entries) => {
+        const tableEntry = entries.findLast(({ target }) => target === this.$.table);
+        if (tableEntry) {
+          this.__tableRect = tableEntry.contentRect;
+        }
+
+        const headerEntry = entries.findLast(({ target }) => target === this.$.header);
+        if (headerEntry) {
+          this.__headerRect = headerEntry.contentRect;
+        }
+
+        const itemsEntry = entries.findLast(({ target }) => target === this.$.items);
+        if (itemsEntry) {
+          this.__itemsRect = itemsEntry.contentRect;
+        }
+
+        const footerEntry = entries.findLast(({ target }) => target === this.$.footer);
+        if (footerEntry) {
+          this.__footerRect = footerEntry.contentRect;
+        }
+      });
+
+      resizeObserver.observe(this.$.table);
+      resizeObserver.observe(this.$.header);
+      resizeObserver.observe(this.$.items);
+      resizeObserver.observe(this.$.footer);
+    }
+  };

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -23,6 +23,7 @@ import type { ColumnReorderingMixinClass } from '../../src/vaadin-grid-column-re
 import type { DataProviderMixinClass } from '../../src/vaadin-grid-data-provider-mixin';
 import type { DragAndDropMixinClass } from '../../src/vaadin-grid-drag-and-drop-mixin';
 import type { EventContextMixinClass } from '../../src/vaadin-grid-event-context-mixin';
+import type { ResizeMixinClass } from '../../src/vaadin-grid-resize-mixin';
 import type { RowDetailsMixinClass } from '../../src/vaadin-grid-row-details-mixin';
 import type { ScrollMixinClass } from '../../src/vaadin-grid-scroll-mixin';
 import type { GridSelectionColumnBaseMixinClass } from '../../src/vaadin-grid-selection-column-base-mixin';
@@ -85,6 +86,7 @@ assertType<ColumnReorderingMixinClass>(narrowedGrid);
 assertType<EventContextMixinClass<TestGridItem>>(narrowedGrid);
 assertType<StylingMixinClass<TestGridItem>>(narrowedGrid);
 assertType<DragAndDropMixinClass<TestGridItem>>(narrowedGrid);
+assertType<ResizeMixinClass>(narrowedGrid);
 
 narrowedGrid.addEventListener('active-item-changed', (event) => {
   assertType<GridActiveItemChangedEvent<TestGridItem>>(event);


### PR DESCRIPTION
## Description

This PR introduces a grid-specific `ResizeMixin`, moves the main resize observers there, and instead of exposing each observer instance directly, exposes properties that other mixins can subscribe to. This opens the door to refactoring other mixins to reuse precomputed sizes and potentially avoid `getBoundingClientRect` calls which can trigger a reflow.

## Type of change

- [x] Refactor
