### PR TITLE
fix: apply details background only when details is an overlay

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -192,11 +192,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
         background-color: rgba(0, 0, 0, 0.2);
       }
 
-      [part='detail'] {
-        background: #fff;
-      }
-
       :host(:is([drawer], [stack])) [part='detail'] {
+        background-color: #fff;
         box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.3);
       }
 


### PR DESCRIPTION
## Description

For 24.8 and 24.9, https://github.com/vaadin/web-components/pull/9669 changed the MDL base styles so that a background color is applied to the details even if the details are not shown as an overlay. That seems like a mistake as the v25 base styles only apply a background when the details are shown as an overlay:

https://github.com/vaadin/web-components/blob/5a13239200264fcd17da91c958ac182b72645f2e/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js#L146-L149

This moves the background color to the more specific rule that only applies when rendering details as an overlay.

Fixes https://github.com/vaadin/web-components/issues/10299

## Type of change

- Bugfix
