### PR TITLE
refactor!: remove bottom state attribute from navbar-bottom part

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -139,7 +139,7 @@ class AppLayout extends AppLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(L
       <div content>
         <slot></slot>
       </div>
-      <div part="navbar navbar-bottom" id="navbarBottom" bottom hidden>
+      <div part="navbar navbar-bottom" id="navbarBottom" hidden>
         <slot name="navbar-bottom"></slot>
       </div>
       <div hidden>

--- a/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
@@ -65,7 +65,6 @@ snapshots["vaadin-app-layout shadow desktop layout default"] =
   </slot>
 </div>
 <div
-  bottom=""
   hidden=""
   id="navbarBottom"
   part="navbar navbar-bottom"
@@ -108,7 +107,6 @@ snapshots["vaadin-app-layout shadow desktop layout drawer closed"] =
   </slot>
 </div>
 <div
-  bottom=""
   hidden=""
   id="navbarBottom"
   part="navbar navbar-bottom"
@@ -154,7 +152,6 @@ snapshots["vaadin-app-layout shadow mobile layout default"] =
   </slot>
 </div>
 <div
-  bottom=""
   hidden=""
   id="navbarBottom"
   part="navbar navbar-bottom"
@@ -200,7 +197,6 @@ snapshots["vaadin-app-layout shadow mobile layout drawer opened"] =
   </slot>
 </div>
 <div
-  bottom=""
   hidden=""
   id="navbarBottom"
   part="navbar navbar-bottom"


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/10313

Similarly to the [RTE change](https://github.com/vaadin/web-components/pull/9999), let's add proper part names and drop shadow CSS specific `bottom` attribute.

## Type of change

- Breaking change