### PR TITLE
chore: prevent FOUC on dev pages using display: none

### DIFF
--- a/wds-utils.js
+++ b/wds-utils.js
@@ -4,11 +4,7 @@ export function appendStyles(html) {
   const preventFouc = `
     <style>
       body:not(.resolved) {
-        opacity: 0;
-      }
-
-      body {
-        transition: opacity 0.2s;
+        display: none;
       }
     </style>
 

--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -51,7 +51,14 @@ export function enforceThemePlugin(theme) {
 
       if (theme === 'aura' && context.response.is('html')) {
         // For dev pages: add Aura Stylesheet
-        body = body.replace('</title>', '</title><link rel="stylesheet" href="/packages/aura/aura.css" />');
+        body = body.replace(
+          '</title>',
+          `
+          </title>
+          <link rel="preload" href="/packages/aura/src/fonts/InstrumentSans/InstrumentSans.woff2" as="font" type="font/woff2" crossorigin>
+          <link rel="stylesheet" href="/packages/aura/aura.css" />
+          `,
+        );
       }
 
       return body;


### PR DESCRIPTION
## Description

This PR replaces the `opacity` transition with a straightforward `display: none` to prevent flashes of unstyled web components on dev pages. It also preloads the `InstrumentSans` font on Aura pages to avoid flashes of unstyled text. Using a CSS transition seems unnecessary and can be distracting when profiling performance.


## Type of change

- [x] Internal
