### PR TITLE
chore: fix button playground example

### DIFF
--- a/dev/playground/button.html
+++ b/dev/playground/button.html
@@ -83,7 +83,7 @@
         Reply
       </vaadin-button>
       <vaadin-button style="flex-direction: column">
-        <vaadin-icon icon="vaadin:reply"></vaadin-icon>
+        <vaadin-icon icon="vaadin:reply" slot="prefix"></vaadin-icon>
         Reply
       </vaadin-button>
     </section>


### PR DESCRIPTION
This example broke when the internal label part was reinstated in #10264