### PR TITLE
chore: upgrade marked dependency to ^16.0.0

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -38,7 +38,7 @@
     "@vaadin/vaadin-themable-mixin": "25.0.0-beta1",
     "dompurify": "^3.2.5",
     "lit": "^3.0.0",
-    "marked": "^15.0.11"
+    "marked": "^16.0.0"
   },
   "devDependencies": {
     "@vaadin/chai-plugins": "25.0.0-beta1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8092,10 +8092,10 @@ markdown-it@^14.1.0:
     punycode.js "^2.3.1"
     uc.micro "^2.1.0"
 
-marked@^15.0.11:
-  version "15.0.11"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-15.0.11.tgz#08a8d12c285e16259e44287b89ce0d871c9d55e8"
-  integrity sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==
+marked@^16.0.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-16.4.0.tgz#b0c22707a3add380827a75437131801cd54bf425"
+  integrity sha512-CTPAcRBq57cn3R8n3hwc2REddc28hjR7RzDXQ+lXLmMJYqn20BaI2cGw6QjgZGIgVfp2Wdfw4aMzgNteQ6qJgQ==
 
 marky@^1.2.2:
   version "1.2.5"


### PR DESCRIPTION
## Description

Let's upgrade `marked` dependency to the latest version. While it's a major bump, [release notes](https://github.com/markedjs/marked/releases/tag/v16.0.0) only mention breaking changes regarding CommonJS build removal and that doesn't affect us, since we use ESM version.

## Type of change

- Dependency update