### PR TITLE
fix: checkbox and radio-button specific marker properties

### DIFF
--- a/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
+++ b/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
@@ -9,9 +9,17 @@ import { checkable } from '@vaadin/field-base/src/styles/checkable-base-styles.j
 import { field } from '@vaadin/field-base/src/styles/field-base-styles.js';
 
 const checkbox = css`
+  [part='checkbox'] {
+    color: var(
+      --vaadin-checkbox-checkmark-color,
+      var(--vaadin-checkbox-marker-color, var(--vaadin-input-field-text-color, var(--vaadin-text-color)))
+    );
+  }
+
   [part='checkbox']::after {
     inset: 0;
-    mask: var(--_vaadin-icon-checkmark) 50% / var(--vaadin-checkbox-icon-size, 100%) no-repeat;
+    mask: var(--_vaadin-icon-checkmark) 50% /
+      var(--vaadin-checkbox-checkmark-size, var(--vaadin-checkbox-marker-size, 100%)) no-repeat;
   }
 
   :host([readonly]) {

--- a/packages/radio-group/src/styles/vaadin-radio-button-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-button-base-styles.js
@@ -10,14 +10,18 @@ import { field } from '@vaadin/field-base/src/styles/field-base-styles.js';
 const radioButton = css`
   [part='radio'] {
     border-radius: 50%;
+    color: var(
+      --vaadin-radio-button-dot-color,
+      var(--vaadin-radio-button-marker-color, var(--vaadin-input-field-text-color, var(--vaadin-text-color)))
+    );
   }
 
   [part='radio']::after {
     top: 50%;
     left: 50%;
     translate: -50% -50%;
-    width: var(--vaadin-radio-button-marker-size, 50%);
-    height: var(--vaadin-radio-button-marker-size, 50%);
+    width: var(--vaadin-radio-button-dot-size, var(--vaadin-radio-button-marker-size, 50%));
+    height: var(--vaadin-radio-button-dot-size, var(--vaadin-radio-button-marker-size, 50%));
     border-radius: 50%;
   }
 `;


### PR DESCRIPTION
Restore the following base style custom properties (since #10307), as they have been used in earlier versions of Vaadin. Keep the more generic "marker" properties as a way to customize both at the same time:

- `--vaadin-checkbox-checkmark-color` and `--vaadin-checkbox-checkmark-size`
- `--vaadin-radio-button-dot-color` and `--vaadin-radio-button-dot-size`