### PR TITLE
fix: inherit CRUD confirm dialog color scheme

### DIFF
--- a/packages/aura/src/components/crud.css
+++ b/packages/aura/src/components/crud.css
@@ -11,3 +11,7 @@ vaadin-crud-edit {
 vaadin-crud::part(editor) {
   background: var(--aura-surface);
 }
+
+vaadin-crud vaadin-confirm-dialog {
+  color-scheme: inherit;
+}

--- a/packages/aura/src/components/dialog.css
+++ b/packages/aura/src/components/dialog.css
@@ -5,9 +5,8 @@
 }
 
 vaadin-dialog,
-vaadin-confirm-dialog,
-vaadin-crud::part(overlay) {
-  color-scheme: var(--aura-content-color-scheme);
+vaadin-confirm-dialog {
+  color-scheme: var(--aura-content-color-scheme, var(--aura-color-scheme));
 }
 
 vaadin-dialog::part(overlay),


### PR DESCRIPTION
CRUD confirm dialog should follow the color scheme of the main component.