### PR TITLE
fix: don't adjust surface color based on contrast

### DIFF
--- a/packages/aura/src/surface.css
+++ b/packages/aura/src/surface.css
@@ -36,19 +36,12 @@ vaadin-crud-dialog::part(overlay) {
   --aura-surface-solid: light-dark(
     oklch(
       from var(--aura-background-light)
-        min(
-          1,
-          l + (0.98 - l) * 4 + var(--aura-surface-level) * (0.07 - 0.01 * var(--aura-contrast)) -
-            var(--aura-surface-opacity) / 20
-        )
+        min(1, l + (0.98 - l) * 4 + var(--aura-surface-level) * 0.06 - var(--aura-surface-opacity) / 20)
         clamp(0, c - l / 10 * var(--aura-surface-level) + var(--aura-surface-opacity) / 40, c) h
     ),
     oklch(
       from var(--aura-background-dark)
-        calc(
-          max(l + 0.03, 0.25) + var(--aura-surface-level) * (0.03 - 0.008 * var(--aura-contrast)) -
-            var(--aura-surface-opacity) / 40
-        )
+        calc(max(l + 0.03, 0.25) + var(--aura-surface-level) * 0.022 - var(--aura-surface-opacity) / 40)
         clamp(0, c * (1 + l), 0.2) h
     )
   );


### PR DESCRIPTION
We might add a separate property for controlling the surface color strength and/or “step distance” in the future, but let’s keep those separate from the `--aura-contrast` property which focuses on text and border colors.