### PR TITLE
fix: reduce base size on touch devices

### DIFF
--- a/packages/aura/src/size.css
+++ b/packages/aura/src/size.css
@@ -44,6 +44,6 @@
 @media (pointer: coarse) {
   :where(:root),
   :where(:host) {
-    --aura-base-size: 19;
+    --aura-base-size: 18;
   }
 }


### PR DESCRIPTION
An ever-so-subtle size reduction, still keeping it large enough for fat fingers.