### PR TITLE
fix: add border under rich-text-editor toolbar

### DIFF
--- a/packages/aura/src/components/rich-text-editor.css
+++ b/packages/aura/src/components/rich-text-editor.css
@@ -23,6 +23,7 @@ vaadin-rich-text-editor {
 
 vaadin-rich-text-editor::part(toolbar) {
   contain: paint;
+  border-bottom: 1px solid var(--vaadin-border-color-secondary);
 }
 
 vaadin-rich-text-editor::part(toolbar-group) {


### PR DESCRIPTION
Visually separate the toolbar and the content. This helps especially if the content is scrollable. Maybe we can at some point consider adding the overflow attribute to RTE, so this border can be rendered conditionally.