### PR TITLE
refactor: only set focusVisible on closing drawer with keyboard

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -5,6 +5,7 @@
  */
 import { AriaModalController } from '@vaadin/a11y-base/src/aria-modal-controller.js';
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
+import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
@@ -443,7 +444,7 @@ export const AppLayoutMixin = (superclass) =>
       // Move focus to the drawer toggle when closing the drawer.
       const toggle = this.querySelector('vaadin-drawer-toggle');
       if (toggle) {
-        toggle.focus();
+        toggle.focus({ focusVisible: isKeyboardActive() });
       }
     }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -4,6 +4,7 @@ import {
   esc,
   fixtureSync,
   makeSoloTouchEvent,
+  mousedown,
   nextFrame,
   nextRender,
   nextResize,
@@ -457,6 +458,21 @@ describe('vaadin-app-layout', () => {
           layout.drawerOpened = true;
           await nextFrame();
           expect(spy.called).to.be.false;
+        });
+
+        it('should focus the drawer toggle with focusVisible: false on closing with mouse', async () => {
+          const spy = sinon.spy(toggle, 'focus');
+          mousedown(document.body);
+          layout.drawerOpened = false;
+          await nextFrame();
+          expect(spy.firstCall.args[0]).to.eql({ focusVisible: false });
+        });
+
+        it('should focus the drawer toggle with focusVisible: true on closing with keyboard', async () => {
+          const spy = sinon.spy(toggle, 'focus');
+          esc(drawer);
+          await nextFrame();
+          expect(spy.firstCall.args[0]).to.eql({ focusVisible: true });
         });
 
         it('should remove drawer tabindex when it resizes from the overlay mode', async () => {


### PR DESCRIPTION
## Description

As discussed, let's only set `focusVisible: true` on focusing the drawer toggle when closing drawer from keyboard.

## Type of change

- Refactor