### PR TITLE
fix: update readonly and disabled input field surface color

### DIFF
--- a/packages/aura/src/components/input-container.css
+++ b/packages/aura/src/components/input-container.css
@@ -19,9 +19,12 @@ vaadin-message-input:not([readonly], [disabled]) {
   box-shadow: 0 2px 1px -1px hsla(0, 0%, 0%, 0.04);
 }
 
+[readonly]::part(input-field) {
+  --aura-surface-opacity: 0;
+}
+
 [disabled]::part(input-field) {
-  --aura-surface-opacity: 0.5;
-  --aura-surface-level: 1;
+  --vaadin-input-field-background: var(--vaadin-background-container);
 }
 
 ::part(field-button) {


### PR DESCRIPTION
## Before

<img width="399" height="116" alt="Screenshot 2025-10-24 at 11 50 16" src="https://github.com/user-attachments/assets/5a625326-4efc-4817-84b4-490d22415438" />


## After

<img width="390" height="107" alt="Screenshot 2025-10-24 at 11 55 32" src="https://github.com/user-attachments/assets/33d49e48-8e5f-4cd2-a5fc-c2ff84e3d9d8" />

