### PR TITLE
fix: add missing sourceEvent to vaadin-overlay-close event type

### DIFF
--- a/packages/overlay/src/vaadin-overlay.d.ts
+++ b/packages/overlay/src/vaadin-overlay.d.ts
@@ -23,7 +23,7 @@ export type OverlayOpenEvent = CustomEvent<{ overlay: HTMLElement }>;
  * Fired when the opened overlay is about to be closed.
  * Calling `preventDefault()` on the event cancels the closing.
  */
-export type OverlayCloseEvent = CustomEvent<{ overlay: HTMLElement }>;
+export type OverlayCloseEvent = CustomEvent<{ overlay: HTMLElement; sourceEvent?: Event }>;
 
 /**
  * Fired after the overlay is closed.


### PR DESCRIPTION
## Description

In https://github.com/vaadin/web-components/pull/9987, I missed to add `sourceEvent` to typings, this PR fixes that.

```
src/component/vcf-month-picker.ts:380:16 - error TS2339: Property 'sourceEvent' does not exist on type '{ overlay: HTMLElement; }'.

380       e.detail.sourceEvent &&
                   ~~~~~~~~~~~
```

## Type of change

- Bugfix