### PR TITLE
refactor: allow reusing CSSPropertyObserver instance for a style root

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-property-observer.js
+++ b/packages/vaadin-themable-mixin/src/css-property-observer.js
@@ -9,23 +9,22 @@
  *
  * @private
  */
-export class CSSPropertyObserver {
+export class CSSPropertyObserver extends EventTarget {
   #root;
-  #callback;
   #properties = new Set();
   #styleSheet;
   #isConnected = false;
 
-  constructor(root, callback) {
+  constructor(root) {
+    super();
     this.#root = root;
-    this.#callback = callback;
     this.#styleSheet = new CSSStyleSheet();
   }
 
   #handleTransitionEvent(event) {
     const { propertyName } = event;
     if (this.#properties.has(propertyName)) {
-      this.#callback(propertyName);
+      this.dispatchEvent(new CustomEvent('property-changed', { detail: { propertyName } }));
     }
   }
 
@@ -77,5 +76,15 @@ export class CSSPropertyObserver {
 
   get #rootHost() {
     return this.#root.documentElement ?? this.#root.host;
+  }
+
+  /**
+   * Gets or creates the CSSPropertyObserver for the given root.
+   * @param {DocumentOrShadowRoot} root
+   * @returns {CSSPropertyObserver}
+   */
+  static for(root) {
+    root.__cssPropertyObserver ||= new CSSPropertyObserver(root);
+    return root.__cssPropertyObserver;
   }
 }

--- a/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
@@ -120,6 +120,8 @@ describe('Lumo injection', () => {
     afterEach(() => {
       document.__lumoInjector?.disconnect();
       document.__lumoInjector = undefined;
+      document.__cssPropertyObserver?.disconnect();
+      document.__cssPropertyObserver = undefined;
     });
 
     describe('styles added after element is connected', () => {
@@ -245,6 +247,8 @@ describe('Lumo injection', () => {
     afterEach(() => {
       host.__lumoInjector?.disconnect();
       host.__lumoInjector = undefined;
+      host.__cssPropertyObserver?.disconnect();
+      host.__cssPropertyObserver = undefined;
     });
 
     describe('styles added after element is connected', () => {
@@ -426,6 +430,8 @@ describe('Lumo injection', () => {
     afterEach(() => {
       host.__lumoInjector?.disconnect();
       host.__lumoInjector = undefined;
+      host.__cssPropertyObserver?.disconnect();
+      host.__cssPropertyObserver = undefined;
     });
 
     it('should inject matching styles added to parent shadow host', async () => {
@@ -465,6 +471,8 @@ describe('Lumo injection', () => {
     afterEach(() => {
       document.__lumoInjector?.disconnect();
       document.__lumoInjector = undefined;
+      document.__cssPropertyObserver?.disconnect();
+      document.__cssPropertyObserver = undefined;
     });
 
     it('should inject matching styles for the extending component', async () => {
@@ -505,6 +513,8 @@ describe('Lumo injection', () => {
       style.remove();
       document.__lumoInjector?.disconnect();
       document.__lumoInjector = undefined;
+      document.__cssPropertyObserver?.disconnect();
+      document.__cssPropertyObserver = undefined;
     });
 
     it('should not remove styles from injected stylesheets when calling registerStyles()', () => {


### PR DESCRIPTION
## Description

As a preparation for adding a theme detection mechanism, this changes `CSSPropertyObserver` so that a single instance on a style root can be used by both the Lumo injection mechanism and the theme detection mechanism:
- Adds a static `CSSPropertyObserver.for` method for either getting or creating an observer instance for a style root
- Make `CSSPropertyObserver` dispatch a property change event instead of having to provide a callback
- Update `LumoInjector` with respective changes

## Type of change

- Refactoring