### PR TITLE
refactor: make card size itself synchronously

### DIFF
--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -126,6 +126,12 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(Li
     `;
   }
 
+  /** @protected */
+  firstUpdated() {
+    super.firstUpdated();
+    this._onSlotChange();
+  }
+
   /** @private */
   _onSlotChange() {
     this.toggleAttribute('_m', this.querySelector(':scope > [slot="media"]'));

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -99,4 +99,20 @@ describe('vaadin-card', () => {
       expect(getCustomTitleElement()).to.exist;
     });
   });
+
+  describe('sizing', () => {
+    it('should size synchronously', async () => {
+      const template = `
+        <vaadin-card>
+          <div slot="title">New Message from Olivia</div>
+        </vaadin-card>`;
+
+      card = fixtureSync(template);
+      await nextRender();
+      const height = card.offsetHeight;
+
+      card = fixtureSync(template);
+      expect(card.offsetHeight).to.equal(height);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Make `<vaadin-card>` update its sizing synchronously after the first update.

Related to https://github.com/vaadin/web-components/issues/9077

This change alone would already workaround the issue referenced above, but it's still better to [fix the root cause of the issue](https://github.com/vaadin/web-components/pull/10370) in virtualizer as it might resurface.
Making this change to card can also make it perform faster in virtual scrolling components since it will skip the new logic introduced in the mentioned virtualizer fix.

## Type of change

Refactor