### PR TITLE
refactor: update popover to use global overlay listeners (#9972) (CP: 24.9)

### DIFF
--- a/packages/overlay/test/interactions.test.js
+++ b/packages/overlay/test/interactions.test.js
@@ -115,6 +115,13 @@ describe('interactions', () => {
         expect(overlay.opened).to.be.false;
       });
 
+      it('should not close on outside click when modeless', () => {
+        overlay.modeless = true;
+        click(parent);
+
+        expect(overlay.opened).to.be.true;
+      });
+
       it('should close on backdrop click', () => {
         overlay.withBackdrop = true;
 
@@ -167,6 +174,30 @@ describe('interactions', () => {
         click(backdrop);
 
         expect(overlay.opened).to.be.true;
+      });
+
+      it('should not fire the event on outside click when modeless set to true', () => {
+        overlay.modeless = true;
+
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-outside-click', spy);
+
+        click(parent);
+
+        expect(spy).to.be.not.called;
+      });
+
+      it('should not fire the event on outside click when modeless set back to false', () => {
+        overlay.modeless = true;
+
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-outside-click', spy);
+
+        overlay.modeless = false;
+
+        click(parent);
+
+        expect(spy.calledOnce).to.be.true;
       });
     });
 

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -123,6 +123,17 @@ class PopoverOverlay extends PopoverOverlayMixin(DirMixin(ThemableMixin(PolylitM
       }
     }
   }
+
+  /**
+   * Override method from `OverlayMixin` to always add outside
+   * click listener so that it can be used by modeless popover.
+   * @return {boolean}
+   * @protected
+   * @override
+   */
+  _shouldAddGlobalListeners() {
+    return true;
+  }
 }
 
 defineCustomElement(PopoverOverlay);

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -468,7 +468,6 @@ class Popover extends PopoverPositionMixin(
 
     this.__overlayId = `vaadin-popover-${generateUniqueId()}`;
 
-    this.__onGlobalClick = this.__onGlobalClick.bind(this);
     this.__onGlobalKeyDown = this.__onGlobalKeyDown.bind(this);
     this.__onTargetClick = this.__onTargetClick.bind(this);
     this.__onTargetFocusIn = this.__onTargetFocusIn.bind(this);
@@ -540,17 +539,8 @@ class Popover extends PopoverPositionMixin(
   }
 
   /** @protected */
-  connectedCallback() {
-    super.connectedCallback();
-
-    document.documentElement.addEventListener('click', this.__onGlobalClick, true);
-  }
-
-  /** @protected */
   disconnectedCallback() {
     super.disconnectedCallback();
-
-    document.documentElement.removeEventListener('click', this.__onGlobalClick, true);
 
     // Automatically close popover when it is removed from DOM
     // Avoid closing if the popover is just moved in the DOM
@@ -623,23 +613,6 @@ class Popover extends PopoverPositionMixin(
     }
   }
 
-  /**
-   * Overlay's global outside click listener doesn't work when
-   * the overlay is modeless, so we use a separate listener.
-   * @private
-   */
-  __onGlobalClick(event) {
-    if (
-      this.opened &&
-      !this.modal &&
-      !event.composedPath().some((el) => el === this._overlayElement || el === this.target) &&
-      !this.noCloseOnOutsideClick &&
-      isLastOverlay(this._overlayElement)
-    ) {
-      this._openedStateController.close(true);
-    }
-  }
-
   /** @private */
   __onTargetClick() {
     if (this.__hasTrigger('click')) {
@@ -660,15 +633,9 @@ class Popover extends PopoverPositionMixin(
    * @private
    */
   __onGlobalKeyDown(event) {
-    // Modal popover uses overlay logic for Esc key and focus trap.
+    // Modal popover uses overlay logic focus trap.
     if (this.modal) {
       return;
-    }
-
-    if (event.key === 'Escape' && !this.noCloseOnEsc && this.opened && isLastOverlay(this._overlayElement)) {
-      // Prevent closing parent overlay (e.g. dialog)
-      event.stopPropagation();
-      this._openedStateController.close(true);
     }
 
     // Include popover content in the Tab order after the target.

--- a/packages/popover/test/basic.test.js
+++ b/packages/popover/test/basic.test.js
@@ -295,6 +295,31 @@ describe('popover', () => {
       expect(overlay.opened).to.be.true;
     });
 
+    it('should not close on outside click if overlay close event is prevented', async () => {
+      target.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      document.addEventListener('vaadin-overlay-close', (e) => e.preventDefault(), { once: true });
+
+      outsideClick();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on outside click if overlay close event is prevented when modal', async () => {
+      popover.modal = true;
+      await nextUpdate(popover);
+
+      target.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      document.addEventListener('vaadin-overlay-close', (e) => e.preventDefault(), { once: true });
+
+      outsideClick();
+      await nextRender();
+      expect(overlay.opened).to.be.true;
+    });
+
     it('should close overlay when popover is detached', async () => {
       target.click();
       await oneEvent(overlay, 'vaadin-overlay-open');
@@ -313,14 +338,6 @@ describe('popover', () => {
       parent.appendChild(popover);
       await nextRender();
       expect(overlay.opened).to.be.true;
-    });
-
-    it('should remove document click listener when popover is detached', async () => {
-      const spy = sinon.spy(document.documentElement, 'removeEventListener');
-      popover.remove();
-      await nextRender();
-      expect(spy).to.be.called;
-      expect(spy.firstCall.args[0]).to.equal('click');
     });
 
     describe('Escape press', () => {
@@ -358,6 +375,25 @@ describe('popover', () => {
         popover.modal = true;
         popover.noCloseOnEsc = true;
         await nextUpdate(popover);
+
+        esc(document.body);
+        await nextRender();
+        expect(overlay.opened).to.be.true;
+      });
+
+      it('should not close on global Escape press if overlay close event was prevented', async () => {
+        document.addEventListener('vaadin-overlay-close', (e) => e.preventDefault(), { once: true });
+
+        esc(document.body);
+        await nextRender();
+        expect(overlay.opened).to.be.true;
+      });
+
+      it('should not close on global Escape press if overlay close event was prevented when modal', async () => {
+        popover.modal = true;
+        await nextUpdate(popover);
+
+        document.addEventListener('vaadin-overlay-close', (e) => e.preventDefault(), { once: true });
 
         esc(document.body);
         await nextRender();


### PR DESCRIPTION
Cherry-pick of #9972

This makes Popover reuse the mousedown/mouseup tracking from Overlay, which avoids the popover closing on outside clicks that did not start within it.

Fixes https://github.com/vaadin/web-components/issues/10381