### PR TITLE
fix: relocate button tooltip to workaround nvda click issue

### DIFF
--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -99,8 +99,9 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInj
         <span part="suffix" aria-hidden="true">
           <slot name="suffix"></slot>
         </span>
+
+        <slot name="tooltip"></slot>
       </div>
-      <slot name="tooltip"></slot>
     `;
   }
 

--- a/packages/button/test/dom/__snapshots__/button.test.snap.js
+++ b/packages/button/test/dom/__snapshots__/button.test.snap.js
@@ -97,9 +97,9 @@ snapshots["vaadin-button shadow default"] =
     <slot name="suffix">
     </slot>
   </span>
+  <slot name="tooltip">
+  </slot>
 </div>
-<slot name="tooltip">
-</slot>
 `;
 /* end snapshot vaadin-button shadow default */
 


### PR DESCRIPTION
## Description

I discovered a few alternative fixes to `<vaadin-button>` that workaround the NVDA issue in https://github.com/vaadin/web-components/issues/8802
1. Wrap `<div class="vaadin-button-container">` in a `<div style="display: contents;">`
2. Move `<slot name="tooltip"></slot>` inside `<div class="vaadin-button-container">`
3. Change the `:host` style from `display: inline-block;` to `display: inline-flex;`

This PR implements option 2.

Note that the original issue only produces with Lumo (where `.vaadin-button-container` uses `inline-flex`).

Fixes https://github.com/vaadin/web-components/issues/8802

## Type of change

Bugfix