### PR TITLE
fix: use proper item comparison

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -534,7 +534,7 @@ export const InlineEditingMixin = (superClass) =>
       const item = this.__getRowItem(row);
       if (this.__edited) {
         const { cell, model } = this.__edited;
-        if (cell.parentNode === row && model.item !== item) {
+        if (cell.parentNode === row && this.getItemId(model.item) !== this.getItemId(item)) {
           this._stopEdit();
         }
       }


### PR DESCRIPTION
## Description

Grid Pro cancels editing if the item in the edited row does not match the edited item anymore. However it always compares by item reference, which does not work if you replace the item instance after changing a field.

This fixes it by comparing by item ID, which would fall back to comparing by reference if no ID is defined.

## Type of change

- Bugfix
