### PR TITLE
fix: do not open sub menus for disabled items

### DIFF
--- a/packages/item/src/styles/vaadin-item-base-styles.js
+++ b/packages/item/src/styles/vaadin-item-base-styles.js
@@ -26,6 +26,7 @@ export const itemStyles = css`
   :host([disabled]) {
     cursor: var(--vaadin-disabled-cursor);
     opacity: 0.5;
+    pointer-events: none;
   }
 
   :host([hidden]) {


### PR DESCRIPTION
## Description

In Lumo, `disabled` items has `pointer-events: none`, which makes sure that the items are cannot be interacted with. The new base styles for the items lack this, which leads to behavior like sub menus opening for disabled items in context menus.

This PR adds the missing style to item base styles.

Fixes #10408

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.