### PR TITLE
refactor!: remove rich-text-editor base styles custom properties

### DIFF
--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-base-styles.js
@@ -411,10 +411,7 @@ const toolbar = css`
     color: var(--vaadin-rich-text-editor-toolbar-button-text-color, var(--vaadin-text-color));
     cursor: var(--vaadin-clickable-cursor);
     flex-shrink: 0;
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: 500;
-    line-height: inherit;
+    font: inherit;
     padding: var(--vaadin-rich-text-editor-toolbar-button-padding, var(--vaadin-padding-container));
     position: relative;
   }

--- a/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-popup-overlay-base-styles.js
+++ b/packages/rich-text-editor/src/styles/vaadin-rich-text-editor-popup-overlay-base-styles.js
@@ -27,9 +27,8 @@ export const richTextEditorPopupOverlay = css`
       var(--vaadin-rich-text-editor-overlay-color-option-border-color, transparent);
     border-radius: var(--vaadin-rich-text-editor-overlay-color-option-border-radius, 9999px);
     cursor: var(--vaadin-clickable-cursor);
-    font-size: inherit;
+    font: inherit;
     height: var(--vaadin-rich-text-editor-overlay-color-option-height, 1lh);
-    line-height: inherit;
     padding: 0;
     width: var(--vaadin-rich-text-editor-overlay-color-option-width, 1lh);
   }


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

Removed  these properties
- --vaadin-rich-text-editor-toolbar-button-font-family
- --vaadin-rich-text-editor-toolbar-button-font-size
- --vaadin-rich-text-editor-toolbar-button-line-height
- --vaadin-rich-text-editor-toolbar-button-font-weight
- --vaadin-rich-text-editor-toolbar-button-height
- --vaadin-rich-text-editor-overlay-color-option-line-height
- --vaadin-rich-text-editor-overlay-color-option-padding
- --vaadin-rich-text-editor-overlay-color-option-font-size

## Type of change

- Refactor / breaking change