### PR TITLE
refactor!: remove upload buttons base styles custom properties

### DIFF
--- a/packages/upload/src/styles/vaadin-upload-file-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-base-styles.js
@@ -90,10 +90,7 @@ export const uploadFileStyles = css`
     color: var(--vaadin-upload-file-button-text-color, var(--vaadin-text-color));
     cursor: var(--vaadin-clickable-cursor);
     flex-shrink: 0;
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: 500;
-    line-height: inherit;
+    font: inherit;
     padding: var(--vaadin-upload-file-button-padding, var(--vaadin-padding-container));
   }
 


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

Removed properties --vaadin-upload-file-button-font-family/font-size/font-weight/line-height/height

## Type of change

- Breaking change