### PR TITLE
refactor: remove base styles CSS properties for chip min-width

### DIFF
--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-base-styles.js
@@ -13,7 +13,7 @@ export const multiSelectComboBoxStyles = [
     :host {
       max-width: 100%;
       --_input-min-width: var(--vaadin-multi-select-combo-box-input-min-width, 4rem);
-      --_chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, var(--vaadin-chip-min-width, 48px));
+      --_chip-min-width: var(--vaadin-multi-select-combo-box-chip-min-width, 48px);
       --_wrapper-gap: var(--vaadin-multi-select-combo-box-chips-gap, 2px);
     }
 

--- a/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
+++ b/packages/multi-select-combo-box/src/styles/vaadin-multi-select-combo-box-chip-base-styles.js
@@ -28,10 +28,7 @@ export const multiSelectComboBoxChipStyles = css`
   }
 
   :host(:not([slot='overflow'])) {
-    min-width: min(
-      max-content,
-      var(--vaadin-multi-select-combo-box-chip-min-width, var(--vaadin-chip-min-width, 48px))
-    );
+    min-width: min(max-content, var(--vaadin-multi-select-combo-box-chip-min-width, 48px));
   }
 
   :host([focused]) {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

Separate `--vaadin-chip-min-width` isn't needed as related CSS is considered an implementation detail of the MSCB.

## Type of change

- Refactor