### PR TITLE
fix: make vaadin-grid-tree-toggle an inline-flex

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-tree-toggle-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-tree-toggle-base-styles.js
@@ -8,7 +8,7 @@ import { css } from 'lit';
 
 export const gridTreeToggleStyles = css`
   :host {
-    display: flex;
+    display: inline-flex;
     max-width: 100%;
     pointer-events: none;
   }
@@ -33,6 +33,13 @@ export const gridTreeToggleStyles = css`
 
   #level-spacer {
     width: calc(var(--_level, 0) * var(--vaadin-grid-tree-toggle-level-offset, 16px));
+  }
+
+  /* Baseline alignment */
+  #level-spacer::before {
+    content: '\\2003' / '';
+    display: inline-block;
+    width: 0;
   }
 
   [part='toggle'] {


### PR DESCRIPTION
Fixes #10439
Related to #10417 

Make the `<vaadin-grid-tree-toggle>` an inline-flex to make it render on the same line as text content. This is how Lumo handles this case as well, where the tree-toggle doesn't contain the cell content, but is placed as a sibling.