### PR TITLE
refactor: make grid scroller inherit border radius in base styles

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -53,7 +53,6 @@ export const gridStyles = css`
 
   #scroller {
     contain: layout;
-    border-radius: inherit;
     position: relative;
     display: flex;
     width: 100%;


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

Updated grid to just inherit border-radius on the scroller element.

## Type of change

- Refactor