### PR TITLE
fix: encode X-Filename header for files with special characters

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -664,7 +664,7 @@ export const UploadMixin = (superClass) =>
       // Set Content-Type and filename header for raw binary uploads
       if (isRawUpload && file) {
         xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
-        xhr.setRequestHeader('X-Filename', file.name);
+        xhr.setRequestHeader('X-Filename', encodeURIComponent(file.name));
       }
 
       if (this.timeout) {

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -587,7 +587,19 @@ describe('upload', () => {
       upload.uploadFormat = 'raw';
       upload.addEventListener('upload-request', (e) => {
         const filename = e.detail.xhr.getRequestHeader('X-Filename');
-        expect(filename).to.equal(testFile.name);
+        expect(filename).to.equal(encodeURIComponent(testFile.name));
+        done();
+      });
+      upload._uploadFile(testFile);
+    });
+
+    it('should encode special characters in X-Filename header in raw format', (done) => {
+      const testFile = createFile(1000, 'application/pdf');
+      testFile.name = 'religion åk4.pdf';
+      upload.uploadFormat = 'raw';
+      upload.addEventListener('upload-request', (e) => {
+        const filename = e.detail.xhr.getRequestHeader('X-Filename');
+        expect(filename).to.equal('religion%20%C3%A5k4.pdf');
         done();
       });
       upload._uploadFile(testFile);


### PR DESCRIPTION
The X-Filename header now uses encodeURIComponent() to properly encode filenames containing non-ASCII characters (e.g., "religion åk4.pdf"). This prevents HTTP header encoding errors when uploading files with special characters in their names.
