### PR TITLE
fix: ensure minimum click target for checkbox and radio-button

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -77,9 +77,12 @@ export const checkable = (part, propName = part) => css`
     margin: 0;
     align-self: stretch;
     appearance: none;
-    width: 100%;
-    height: 100%;
     cursor: var(--_cursor);
+    /* Ensure minimum click target (WCAG) */
+    width: 2px;
+    height: 2px;
+    scale: 12;
+    margin: auto;
   }
 
   /* Control container (checkbox, radio button) */


### PR DESCRIPTION
Related to #10417 

Use a small size to keep the element centered in the grid cell and then scale it up to the required 24x24px size.