### PR TITLE
feat: add ability to ignore elements in SlotController

### DIFF
--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -129,6 +129,10 @@ export class SlotController extends EventTarget {
   getSlotChildren() {
     const { slotName } = this;
     return Array.from(this.host.childNodes).filter((node) => {
+      // Ignore nodes with data-slot-ignore attribute
+      if (node.nodeType === Node.ELEMENT_NODE && node.hasAttribute('data-slot-ignore')) {
+        return false;
+      }
       // Either an element (any slot) or a text node (only un-named slot).
       return (
         (node.nodeType === Node.ELEMENT_NODE && node.slot === slotName) ||
@@ -203,7 +207,13 @@ export class SlotController extends EventTarget {
 
       // Calling `slot.assignedNodes()` includes whitespace text nodes in case of default slot:
       // unlike comment nodes, they are not filtered out. So we need to manually ignore them.
-      const newNodes = addedNodes.filter((node) => !isEmptyTextNode(node) && !current.includes(node));
+      // Also ignore nodes with data-slot-ignore attribute.
+      const newNodes = addedNodes.filter(
+        (node) =>
+          !isEmptyTextNode(node) &&
+          !current.includes(node) &&
+          !(node.nodeType === Node.ELEMENT_NODE && node.hasAttribute('data-slot-ignore')),
+      );
 
       if (removedNodes.length) {
         this.nodes = current.filter((node) => !removedNodes.includes(node));

--- a/packages/component-base/test/slot-controller.test.js
+++ b/packages/component-base/test/slot-controller.test.js
@@ -335,6 +335,166 @@ describe('SlotController', () => {
     });
   });
 
+  describe('data-slot-ignore attribute', () => {
+    let defaultNode;
+
+    describe('single slot with observe enabled', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        controller = new SlotController(element, 'foo', 'div', {
+          initializer: (node) => {
+            node.textContent = 'default content';
+          },
+        });
+        element.addController(controller);
+        defaultNode = element.querySelector('[slot="foo"]');
+        // Wait for initial slotchange event
+        await nextFrame();
+      });
+
+      it('should ignore element with data-slot-ignore when checking slot children', () => {
+        const ignored = document.createElement('div');
+        ignored.setAttribute('slot', 'foo');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        const slotChildren = controller.getSlotChildren();
+        expect(slotChildren).to.not.include(ignored);
+        expect(slotChildren).to.include(defaultNode);
+      });
+
+      it('should not remove default node when element with data-slot-ignore is added', async () => {
+        const ignored = document.createElement('div');
+        ignored.setAttribute('slot', 'foo');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        await nextFrame();
+        expect(defaultNode.isConnected).to.be.true;
+        expect(defaultNode.textContent).to.equal('default content');
+      });
+
+      it('should remove default node when non-ignored element is added', async () => {
+        const ignored = document.createElement('div');
+        ignored.setAttribute('slot', 'foo');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        await nextFrame();
+        expect(defaultNode.isConnected).to.be.true;
+
+        const custom = document.createElement('div');
+        custom.setAttribute('slot', 'foo');
+        custom.textContent = 'custom';
+        element.appendChild(custom);
+
+        await nextFrame();
+        expect(defaultNode.isConnected).to.be.false;
+        expect(controller.node).to.equal(custom);
+      });
+
+      it('should not call initCustomNode for element with data-slot-ignore', async () => {
+        const initSpy = sinon.spy(controller, 'initCustomNode');
+
+        const ignored = document.createElement('div');
+        ignored.setAttribute('slot', 'foo');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        await nextFrame();
+        expect(initSpy.called).to.be.false;
+      });
+    });
+
+    describe('multiple slot with observe enabled', () => {
+      let defaultNode;
+
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag}></${tag}>`);
+        controller = new SlotController(element, '', 'div', {
+          initializer: (node) => {
+            node.textContent = 'default content';
+          },
+          multiple: true,
+        });
+        element.addController(controller);
+        defaultNode = element.querySelector(':not([slot])');
+        // Wait for initial slotchange event
+        await nextFrame();
+      });
+
+      it('should ignore element with data-slot-ignore in multiple mode', () => {
+        const ignored = document.createElement('div');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        const slotChildren = controller.getSlotChildren();
+        expect(slotChildren).to.not.include(ignored);
+        expect(slotChildren).to.include(defaultNode);
+      });
+
+      it('should not remove default node when element with data-slot-ignore is added in multiple mode', async () => {
+        const ignored = document.createElement('div');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        await nextFrame();
+        expect(defaultNode.isConnected).to.be.true;
+        expect(controller.nodes).to.include(defaultNode);
+        expect(controller.nodes).to.not.include(ignored);
+      });
+
+      it('should remove default node when non-ignored element is added in multiple mode', async () => {
+        const ignored = document.createElement('div');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        await nextFrame();
+        expect(defaultNode.isConnected).to.be.true;
+
+        const custom = document.createElement('div');
+        custom.textContent = 'custom';
+        element.appendChild(custom);
+
+        await nextFrame();
+        expect(defaultNode.isConnected).to.be.false;
+        expect(controller.nodes).to.include(custom);
+        expect(controller.nodes).to.not.include(defaultNode);
+        expect(controller.nodes).to.not.include(ignored);
+      });
+
+      it('should allow multiple custom elements alongside ignored elements', async () => {
+        const custom1 = document.createElement('div');
+        custom1.textContent = 'custom1';
+        element.appendChild(custom1);
+
+        const ignored = document.createElement('div');
+        ignored.setAttribute('data-slot-ignore', '');
+        ignored.textContent = 'ignored';
+        element.appendChild(ignored);
+
+        const custom2 = document.createElement('div');
+        custom2.textContent = 'custom2';
+        element.appendChild(custom2);
+
+        await nextFrame();
+
+        expect(defaultNode.isConnected).to.be.false;
+        expect(controller.nodes).to.have.lengthOf(2);
+        expect(controller.nodes).to.include(custom1);
+        expect(controller.nodes).to.include(custom2);
+        expect(controller.nodes).to.not.include(ignored);
+      });
+    });
+  });
+
   describe('multiple nodes', () => {
     let children, initializeSpy;
 


### PR DESCRIPTION
## Description

Adds support for ignoring specific elements in `SlotController` to prevent them from being treated as custom slot content. 

In Flow, when a `ConfirmDialog` is modal and a component with an overlay, such as a `Dialog` or a `Notification` is auto-added to the view, the server-side modality related automation injects it inside the `ConfirmDialog`. This causes the `SlotController` to treat it as custom content, resulting with the `ConfirmDialog`'s `message` [not showing](https://github.com/vaadin/flow-components/issues/5999#issuecomment-1938476755).

Elements with the `data-slot-ignore` attribute are now completely ignored by `SlotController` when determining slot content.

Fixing the original issue will also require a change in `flow-components` to assign the attribute to auto-added components.

Part of https://github.com/vaadin/flow-components/issues/5999

## Type of change

Internal feature