### PR TITLE
refactor: inherit text-align on slotted input and textarea

### DIFF
--- a/packages/input-container/src/styles/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-base-styles.js
@@ -65,6 +65,7 @@ export const inputContainerStyles = css`
     color: inherit;
     background: transparent;
     cursor: inherit;
+    text-align: inherit;
     caret-color: var(--vaadin-input-field-value-color);
   }
 


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

Text-align on host of input fields should inherit down to the field

## Type of change

- Refactor