### PR TITLE
refactor: simplify selectors in menu-bar-button base styles

### DIFF
--- a/packages/menu-bar/src/styles/vaadin-menu-bar-button-base-styles.js
+++ b/packages/menu-bar/src/styles/vaadin-menu-bar-button-base-styles.js
@@ -22,13 +22,13 @@ export const menuBarButtonStyles = css`
     gap: inherit;
   }
 
-  :host(:not([slot='overflow']):not([theme~='icon'])[aria-haspopup]) [part='suffix'] {
+  :host(:not([slot='overflow'])[aria-haspopup]) [part='suffix'] {
     display: flex;
     align-items: center;
     gap: inherit;
   }
 
-  :host(:not([slot='overflow']):not([theme~='icon'])[aria-haspopup]) [part='suffix']::after {
+  :host(:not([slot='overflow'])[aria-haspopup]) [part='suffix']::after {
     background: currentColor;
     content: '';
     height: var(--vaadin-icon-size, 1lh);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

There is no such thing as `theme="icon"` in base styles, so let's remove it from these selectors.

## Type of change

- Refactor