### PR TITLE
fix: avoid rendering overlays in iOS viewport safe areas

### DIFF
--- a/packages/notification/src/styles/vaadin-notification-container-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-container-base-styles.js
@@ -21,7 +21,8 @@ export const notificationContainerStyles = css`
     width: 100%;
     height: 100%;
     overflow: hidden;
-    padding: var(--_padding);
+    padding: max(env(safe-area-inset-top, 0px), var(--_padding)) max(env(safe-area-inset-right, 0px), var(--_padding))
+      max(env(safe-area-inset-bottom, 0px), var(--_padding)) max(env(safe-area-inset-left, 0px), var(--_padding));
     border: 0;
     background: transparent;
     pointer-events: none;

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -16,8 +16,10 @@ export const overlayStyles = css`
 
     /* Default position constraints. Themes can
           override this to adjust the gap between the overlay and the viewport. */
-    inset: var(--vaadin-overlay-viewport-inset, 8px);
-    bottom: var(--vaadin-overlay-viewport-bottom);
+    inset: max(env(safe-area-inset-top, 0px), var(--vaadin-overlay-viewport-inset, 8px))
+      max(env(safe-area-inset-right, 0px), var(--vaadin-overlay-viewport-inset, 8px))
+      max(env(safe-area-inset-bottom, 0px), var(--vaadin-overlay-viewport-bottom))
+      max(env(safe-area-inset-left, 0px), var(--vaadin-overlay-viewport-inset, 8px));
 
     /* Override native [popover] user agent styles */
     width: auto;


### PR DESCRIPTION
Part of #10417 