### PR TITLE
refactor: only apply linear-gradient if CSS variable is defined

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -306,9 +306,15 @@ export const gridStyles = css`
   }
 
   [part~='body-cell'] {
+    --_cell-highlight-background-image: linear-gradient(
+      var(--vaadin-grid-row-highlight-background-color, transparent),
+      var(--vaadin-grid-row-highlight-background-color, transparent)
+    );
+
     background-image:
       var(--_row-hover-background-image, none), var(--_row-selected-background-image, none),
-      var(--_row-odd-background-image, none), var(--_cell-background-image, none);
+      var(--_cell-highlight-background-image, none), var(--_row-odd-background-image, none),
+      var(--_cell-background-image, none);
   }
 
   [part~='body-row'][selected] {


### PR DESCRIPTION
## Description

This PR refactors the base styles to avoid stacking effectively transparent linear-gradients, i.e. when their corresponding CSS variables aren't defined. These gradients appear to add slight overhead without any visual effect.


```diff
mixed-rendertime-chrome: performance improved by 19%
```

Follow-up to #10331 

## Type of change

- [x] Refactor
