### PR TITLE
refactor: simplify some CSS selectors related to borders

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -242,15 +242,13 @@ export const gridStyles = css`
   :host([all-rows-visible]),
   :host([overflow~='top']),
   :host([overflow~='bottom']) {
-    #table:not([has-footer]) [part~='last-row']::after,
-    #table:not([has-footer]) [part~='last-row'] [part~='details-cell']::after,
-    #table:not([has-footer]) [part~='last-row-cell']:not([part~='details-opened-row-cell'])::after {
-      bottom: 0;
-    }
-
     #table:not([has-footer]) [part~='last-row'] [part~='details-cell'],
     #table:not([has-footer]) [part~='last-row-cell']:not([part~='details-opened-row-cell']) {
-      border-bottom-style: solid;
+      border-bottom-style: none;
+
+      &::after {
+        bottom: 0;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR refactors the CSS selectors used for grid borders to reduce unnecessary nesting:

```diff
- [part~='last-row'] [part~='cell']
+ [part~='last-row-cell']
```

## Type of change

- [x] Refactor
