### PR TITLE
refactor: use font-weight medium for select value button

### DIFF
--- a/packages/aura/src/components/select.css
+++ b/packages/aura/src/components/select.css
@@ -28,3 +28,7 @@ vaadin-select[theme~='subtle'][focus-ring]::part(toggle-button) {
 vaadin-select[theme~='auto-size'] {
   --vaadin-field-default-width: auto;
 }
+
+vaadin-select-value-button {
+  font-weight: var(--aura-font-weight-medium);
+}


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10418

> select value button: use font-weight-medium

## Type of change

- Refactor