### PR TITLE
test: do not wait for overlay open to fix MSCB flaky test

### DIFF
--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
-import { fixtureSync, keyboardEventFor, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
@@ -163,7 +163,6 @@ describe('selecting items', () => {
       await sendMouse({ type: 'click', position: [400, 400] });
 
       await sendKeys({ press: 'ArrowDown' });
-      await oneEvent(comboBox._overlayElement, 'vaadin-overlay-open');
 
       const item = getFirstItem(comboBox);
       expect(item.hasAttribute('focused')).to.be.false;


### PR DESCRIPTION
## Description

The following test is flaky and often fails in Firefox / WebKit:

```
packages/multi-select-combo-box/test/selecting-items.test.js:

 ❌ selecting items > basic > should reset the item focused state when closing on outside click
      Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
        at createTimeoutError (node_modules/@web/test-runner-mocha/dist/autorun.js:1:191482)
        at node_modules/@web/test-runner-mocha/dist/autorun.js:1:193800
```

It was added in https://github.com/vaadin/web-components/pull/9814 and apparently flaky already then.
This most probably happens due to `sendKeys` being completed after `vaadin-overlay-open` is fired.

Tested locally and generally the test fails with reverting the fix in https://github.com/vaadin/web-components/pull/9814/commits/41ae485579afc4f1f29e4a298fb2f9e603c3ab04, so let's remove `oneEvent`.

## Type of change

- Test