### PR TITLE
fix: disable iOS tap highlight color in item base styles

### DIFF
--- a/packages/aura/src/components/item-overlay.css
+++ b/packages/aura/src/components/item-overlay.css
@@ -56,6 +56,10 @@
     }
   }
 
+  &:active {
+    background: color-mix(in srgb, var(--aura-accent-color) 10%, transparent);
+  }
+
   &[aria-expanded='true']:not(:hover) {
     background: var(--vaadin-background-container-strong);
   }

--- a/packages/item/src/styles/vaadin-item-base-styles.js
+++ b/packages/item/src/styles/vaadin-item-base-styles.js
@@ -16,6 +16,7 @@ export const itemStyles = css`
     gap: var(--vaadin-item-gap, 0 var(--vaadin-gap-s));
     height: var(--vaadin-item-height, auto);
     padding: var(--vaadin-item-padding, var(--vaadin-padding-block-container) var(--vaadin-padding-inline-container));
+    -webkit-tap-highlight-color: transparent;
   }
 
   :host([focused]) {


### PR DESCRIPTION
Add a visual indication in Aura.