### PR TITLE
feat: add custom CSS property for progress-bar height

### DIFF
--- a/packages/progress-bar/src/styles/vaadin-progress-bar-base-styles.js
+++ b/packages/progress-bar/src/styles/vaadin-progress-bar-base-styles.js
@@ -10,7 +10,7 @@ export const progressBarStyles = css`
   :host {
     display: block;
     width: 100%; /* prevent collapsing inside non-stretching column flex */
-    height: 0.5lh;
+    height: var(--vaadin-progress-bar-height, 0.5lh);
     contain: layout size;
   }
 


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/10417

Added a custom CSS property with `0.5lh` used as a fallback.

## Type of change

- Feature