### PR TITLE
refactor: explicitly register base color CSS variables as <color>

### DIFF
--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -17,8 +17,6 @@ import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-sty
   '--vaadin-border-color',
   '--vaadin-border-color-secondary',
   '--vaadin-background-color',
-  '--vaadin-background-container',
-  '--vaadin-background-container-strong',
 ].forEach((propertyName) => {
   CSS.registerProperty({
     name: propertyName,


### PR DESCRIPTION
## Description

It turns out that if we don't explicitly type base color CSS custom properties like `--vaadin-background-color` as `<color>`, the browser (at least Chrome) can't properly optimize them in Aura, which overrides them with values that use complex, nested relative color functions. As a result, Aura performed almost 40% slower than the base styles. This issue was especially noticeable in the grid component, though not limited to it. Once these properties are "declared" using `CSS.registerProperty`, the issue magically disappears...

| Aura (before) | Aura (after) |
|--------|------|
| ![Screenshot 2025-11-14 at 15 14 16](https://github.com/user-attachments/assets/91671ca8-a179-4f9d-817a-a3bf56ef83ae) | ![Screenshot 2025-11-14 at 15 14 21](https://github.com/user-attachments/assets/29475832-aaf0-48f0-9c42-b3a0e80ce95c) |

https://github.com/user-attachments/assets/9d5bfecf-0050-49c1-9fbb-363a28bead1b

## Type of change

- [x] Refactor
