### PR TITLE
fix: don't tint progress bar color

### DIFF
--- a/packages/aura/src/components/progress-bar.css
+++ b/packages/aura/src/components/progress-bar.css
@@ -4,7 +4,7 @@
   --vaadin-progress-bar-value-background: linear-gradient(
     90deg,
     var(--aura-accent-color),
-    color-mix(in hsl, var(--aura-accent-color) 60%, hsl(45, 31%, 95%))
+    color-mix(in hsl, var(--aura-accent-color) 60%, hsl(45, 0%, 95%))
   );
 }
 


### PR DESCRIPTION
## Before

Grayscale accent:
<img width="198" height="49" alt="Screenshot 2025-11-17 at 9 24 05" src="https://github.com/user-attachments/assets/fdbc3818-14a2-4512-a8c7-0800e8917cc8" />

Blue accent:
<img width="199" height="49" alt="Screenshot 2025-11-17 at 9 24 37" src="https://github.com/user-attachments/assets/85cef2d0-b862-40d0-95e3-df85a5e83ff5" />


## After

Grayscale accent:
<img width="208" height="46" alt="Screenshot 2025-11-17 at 9 25 02" src="https://github.com/user-attachments/assets/5fe3d6c0-1316-4459-8251-992ba354cbcf" />

Blue accent:
<img width="211" height="43" alt="Screenshot 2025-11-17 at 9 25 19" src="https://github.com/user-attachments/assets/a3df1e3d-0535-4139-941f-9030f1f8843a" />
