### PR TITLE
refactor: hide context-menu and menu-bar submenu backdrop

### DIFF
--- a/packages/context-menu/src/styles/vaadin-context-menu-overlay-base-styles.js
+++ b/packages/context-menu/src/styles/vaadin-context-menu-overlay-base-styles.js
@@ -31,10 +31,6 @@ const contextMenuOverlay = css`
   :host([position^='end'][end-aligned]) [part='overlay'] {
     margin-inline-end: var(--vaadin-context-menu-offset-end, var(--_default-offset));
   }
-
-  [part='backdrop'] {
-    background: transparent;
-  }
 `;
 
 export const contextMenuOverlayStyles = [overlayStyles, menuOverlayStyles, contextMenuOverlay];

--- a/packages/context-menu/src/styles/vaadin-menu-overlay-base-styles.js
+++ b/packages/context-menu/src/styles/vaadin-menu-overlay-base-styles.js
@@ -20,6 +20,10 @@ export const menuOverlayStyles = css`
     justify-content: flex-end;
   }
 
+  [part='backdrop'] {
+    background: transparent;
+  }
+
   [part='content'] {
     padding: var(--vaadin-item-overlay-padding, 4px);
   }


### PR DESCRIPTION
Could perhaps be hidden in base styles already…