### PR TITLE
chore: fix aura dev page color scheme for Safari 17

### DIFF
--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -165,6 +165,7 @@ class AuraSchemeControl extends AuraControl {
     // Clear storage and remove inline override
     localStorage.removeItem(this.#storageKey());
     document.documentElement.style.removeProperty(this.#prop);
+    this.#forceRepaint();
 
     // Re-read stylesheet-driven value; default to "light dark"
     const token = getComputedStyle(document.documentElement).getPropertyValue(this.#prop).trim();
@@ -195,6 +196,7 @@ class AuraSchemeControl extends AuraControl {
 
   #setVar(value) {
     document.documentElement.style.setProperty(this.#prop, value);
+    this.#forceRepaint();
   }
 
   // ----- Helpers -----
@@ -212,6 +214,19 @@ class AuraSchemeControl extends AuraControl {
     inputs.forEach((i) => {
       i.checked = i.value === value;
     });
+  }
+
+  #forceRepaint() {
+    // Force repaint. This is needed in Safari 17, but only when the property is updated at runtime.
+    if (!this.__repaintActive) {
+      this.__repaintActive = true;
+      const previousValue = document.documentElement.style.getPropertyValue('--aura-background-color-light');
+      document.documentElement.style.setProperty('--aura-background-color-light', '#000');
+      requestAnimationFrame(() => {
+        document.documentElement.style.setProperty('--aura-background-color-light', previousValue);
+        this.__repaintActive = false;
+      });
+    }
   }
 }
 


### PR DESCRIPTION
This fix isn't apparent at the moment, since the app background color/gradient is broken in Safari 17, but I noticed it while working on fixing the colors in Safari 17.

This might end up being a limitation we need to document.