### PR TITLE
refactor!: remove deprecated classNameGenerator API

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-mixin.d.ts
@@ -31,15 +31,10 @@ import type { GridRowDetailsRenderer, RowDetailsMixinClass } from './vaadin-grid
 import type { ScrollMixinClass } from './vaadin-grid-scroll-mixin.js';
 import type { SelectionMixinClass } from './vaadin-grid-selection-mixin.js';
 import type { SortMixinClass } from './vaadin-grid-sort-mixin.js';
-import type {
-  GridCellClassNameGenerator,
-  GridCellPartNameGenerator,
-  StylingMixinClass,
-} from './vaadin-grid-styling-mixin.js';
+import type { GridCellPartNameGenerator, StylingMixinClass } from './vaadin-grid-styling-mixin.js';
 
 export {
   GridBodyRenderer,
-  GridCellClassNameGenerator,
   GridCellPartNameGenerator,
   GridDataProvider,
   GridDataProviderCallback,

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -753,7 +753,6 @@ export const GridMixin = (superClass) =>
       this._resetKeyboardNavigation();
       this.__a11yUpdateHeaderRows();
       this.__a11yUpdateFooterRows();
-      this.generateCellClassNames();
       this.generateCellPartNames();
       this.__updateHeaderAndFooter();
     }
@@ -788,7 +787,6 @@ export const GridMixin = (superClass) =>
 
       if (loading) {
         // Run style generators for the loading row to have custom names cleared
-        this._generateCellClassNames(row);
         this._generateCellPartNames(row);
       }
     }
@@ -819,7 +817,6 @@ export const GridMixin = (superClass) =>
 
       this.__updateRowStateParts(row, model);
 
-      this._generateCellClassNames(row, model);
       this._generateCellPartNames(row, model);
       this._filterDragAndDrop(row, model);
       this.__updateDragSourceParts(row, model);

--- a/packages/grid/src/vaadin-grid-styling-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-styling-mixin.d.ts
@@ -9,36 +9,11 @@ import type { GridColumn } from './vaadin-grid-column.js';
 
 export type GridCellPartNameGenerator<TItem> = (column: GridColumn<TItem>, model: GridItemModel<TItem>) => string;
 
-/**
- * @deprecated Use `GridCellPartNameGenerator` type and `cellPartNameGenerator` API instead.
- */
-export type GridCellClassNameGenerator<TItem> = GridCellPartNameGenerator<TItem>;
-
 export declare function StylingMixin<TItem, T extends Constructor<HTMLElement>>(
   base: T,
 ): Constructor<StylingMixinClass<TItem>> & T;
 
 export declare class StylingMixinClass<TItem> {
-  /**
-   * A function that allows generating CSS class names for grid cells
-   * based on their row and column. The return value should be the generated
-   * class name as a string, or multiple class names separated by whitespace
-   * characters.
-   *
-   * Receives two arguments:
-   * - `column` The `<vaadin-grid-column>` element (`undefined` for details-cell).
-   * - `model` The object with the properties related with
-   *   the rendered item, contains:
-   *   - `model.index` The index of the item.
-   *   - `model.item` The item.
-   *   - `model.expanded` Sublevel toggle state.
-   *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
-   *   - `model.selected` Selected state.
-   *
-   * @deprecated Use `cellPartNameGenerator` instead.
-   */
-  cellClassNameGenerator: GridCellClassNameGenerator<TItem> | null | undefined;
-
   /**
    * A function that allows generating CSS `part` names for grid cells in Shadow DOM based
    * on their row and column, for styling from outside using the `::part()` selector.
@@ -57,16 +32,6 @@ export declare class StylingMixinClass<TItem> {
    *   - `model.selected` Selected state.
    */
   cellPartNameGenerator: GridCellPartNameGenerator<TItem> | null | undefined;
-
-  /**
-   * Runs the `cellClassNameGenerator` for the visible cells.
-   * If the generator depends on varying conditions, you need to
-   * call this function manually in order to update the styles when
-   * the conditions change.
-   *
-   * @deprecated Use `cellPartNameGenerator` and `generateCellPartNames()` instead.
-   */
-  generateCellClassNames(): void;
 
   /**
    * Runs the `cellPastNameGenerator` for the visible cells.

--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -13,30 +13,6 @@ export const StylingMixin = (superClass) =>
     static get properties() {
       return {
         /**
-         * A function that allows generating CSS class names for grid cells
-         * based on their row and column. The return value should be the generated
-         * class name as a string, or multiple class names separated by whitespace
-         * characters.
-         *
-         * Receives two arguments:
-         * - `column` The `<vaadin-grid-column>` element (`undefined` for details-cell).
-         * - `model` The object with the properties related with
-         *   the rendered item, contains:
-         *   - `model.index` The index of the item.
-         *   - `model.item` The item.
-         *   - `model.expanded` Sublevel toggle state.
-         *   - `model.level` Level of the tree represented with a horizontal offset of the toggle button.
-         *   - `model.selected` Selected state.
-         *
-         * @type {GridCellClassNameGenerator | null | undefined}
-         * @deprecated Use `cellPartNameGenerator` instead.
-         */
-        cellClassNameGenerator: {
-          type: Function,
-          sync: true,
-        },
-
-        /**
          * A function that allows generating CSS `part` names for grid cells in Shadow DOM based
          * on their row and column, for styling from outside using the `::part()` selector.
          *
@@ -63,36 +39,12 @@ export const StylingMixin = (superClass) =>
     }
 
     static get observers() {
-      return [
-        '__cellClassNameGeneratorChanged(cellClassNameGenerator)',
-        '__cellPartNameGeneratorChanged(cellPartNameGenerator)',
-      ];
-    }
-
-    /** @private */
-    __cellClassNameGeneratorChanged() {
-      this.generateCellClassNames();
+      return ['__cellPartNameGeneratorChanged(cellPartNameGenerator)'];
     }
 
     /** @private */
     __cellPartNameGeneratorChanged() {
       this.generateCellPartNames();
-    }
-
-    /**
-     * Runs the `cellClassNameGenerator` for the visible cells.
-     * If the generator depends on varying conditions, you need to
-     * call this function manually in order to update the styles when
-     * the conditions change.
-     *
-     * @deprecated Use `cellPartNameGenerator` and `generateCellPartNames()` instead.
-     */
-    generateCellClassNames() {
-      iterateChildren(this.$.items, (row) => {
-        if (!row.hidden) {
-          this._generateCellClassNames(row, this.__getRowModel(row));
-        }
-      });
     }
 
     /**
@@ -105,22 +57,6 @@ export const StylingMixin = (superClass) =>
       iterateChildren(this.$.items, (row) => {
         if (!row.hidden) {
           this._generateCellPartNames(row, this.__getRowModel(row));
-        }
-      });
-    }
-
-    /** @private */
-    _generateCellClassNames(row, model) {
-      iterateRowCells(row, (cell) => {
-        if (cell.__generatedClasses) {
-          cell.__generatedClasses.forEach((className) => cell.classList.remove(className));
-        }
-        if (this.cellClassNameGenerator && !row.hasAttribute('loading')) {
-          const result = this.cellClassNameGenerator(cell._column, model);
-          cell.__generatedClasses = result && result.split(' ').filter((className) => className.length > 0);
-          if (cell.__generatedClasses) {
-            cell.__generatedClasses.forEach((className) => cell.classList.add(className));
-          }
         }
       });
     }

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -366,18 +366,6 @@ import { flushGrid, getCellContent, getHeaderCellContent } from './helpers.js';
         expectCellsVisualOrderToMatchColumnOrder();
       });
 
-      it('should have cell class names on the revealed cells', async () => {
-        // Add a class name generator
-        grid.cellClassNameGenerator = () => 'foo';
-        await nextFrame();
-        expect(getBodyCell(0, getLastVisibleColumnIndex()).classList.contains('foo')).to.be.true;
-
-        // Scroll back to the beginning
-        await scrollHorizontally(-grid.$.table.scrollWidth);
-        // Expect the cell that was previously not visible to have the class name
-        expect(getBodyCell(0, 0).classList.contains('foo')).to.be.true;
-      });
-
       it('should have cell part names on the revealed cells', async () => {
         // Add a part name generator
         grid.cellPartNameGenerator = () => 'foo';

--- a/packages/grid/test/styling.test.js
+++ b/packages/grid/test/styling.test.js
@@ -21,170 +21,6 @@ describe('styling', () => {
     firstCell = getContainerCell(grid.$.items, 0, 0);
   });
 
-  function runStylingTest(entries, generatorFn, requestFn, assertCallback) {
-    it(`should add ${entries} for cells`, () => {
-      grid[generatorFn] = () => 'test-foo';
-      assertCallback(['test-foo']);
-      assertCallback(['test-foo'], 1, 1);
-    });
-
-    it(`should add all ${entries} separated by whitespaces`, () => {
-      grid[generatorFn] = () => 'test-foo test-bar test-baz';
-      assertCallback(['test-foo', 'test-bar', 'test-baz']);
-    });
-
-    it(`should not remove existing ${entries}`, () => {
-      if (entries === 'classes') {
-        firstCell.classList.add('test-bar');
-      } else {
-        firstCell.setAttribute('part', `${firstCell.getAttribute('part')} test-bar`);
-      }
-
-      grid[generatorFn] = () => 'test-foo';
-      assertCallback(['test-bar', 'test-foo']);
-    });
-
-    it(`should remove old generated ${entries}`, () => {
-      grid[generatorFn] = () => 'test-foo';
-      grid[generatorFn] = () => 'test-bar'; // NOSONAR
-      assertCallback(['test-bar']);
-    });
-
-    it(`should provide column and model as parameters to ${generatorFn}`, () => {
-      grid[generatorFn] = (column, model) => `test-${model.index} test-${model.item.value} test-${column.header}`;
-      assertCallback(['test-5', 'test-foo5', 'test-col1'], 5, 1);
-      assertCallback(['test-10', 'test-foo10', 'test-col0'], 10, 0);
-    });
-
-    it(`should call ${generatorFn} for details cell with undefined column`, async () => {
-      grid.rowDetailsRenderer = () => {};
-      grid[generatorFn] = (column, model) => `test-${model.index} test-${column}`;
-      await nextFrame();
-      flushGrid(grid);
-      assertCallback(['test-0', 'test-undefined'], 0, 2);
-    });
-
-    it(`should add ${entries} when loading new items`, (done) => {
-      grid[generatorFn] = (_, model) => `test-${model.item.value}`;
-      scrollToEnd(grid, () => {
-        const rows = getRows(grid.$.items);
-        assertCallback(['test-foo199'], rows.length - 1, 0);
-        done();
-      });
-    });
-
-    it(`should not throw when ${generatorFn} returns falsy value`, () => {
-      expect(() => {
-        grid[generatorFn] = () => {};
-      }).not.to.throw(Error);
-    });
-
-    it(`should clear generated ${entries} with falsy return value`, () => {
-      grid[generatorFn] = () => 'test-foo';
-      grid[generatorFn] = () => {}; // NOSONAR
-      assertCallback([]);
-    });
-
-    it(`should clear generated ${entries} with falsy property value`, () => {
-      grid[generatorFn] = () => 'test-foo';
-      grid[generatorFn] = undefined; // NOSONAR
-      assertCallback([]);
-    });
-
-    [requestFn, 'clearCache', 'requestContentUpdate'].forEach((funcName) => {
-      it(`should update ${entries} on ${funcName}`, () => {
-        let condition = false;
-        grid[generatorFn] = () => condition && 'test-foo';
-        condition = true;
-        assertCallback([]);
-        grid[funcName]();
-        assertCallback(['test-foo']);
-      });
-    });
-
-    it(`should not run ${generatorFn} for hidden rows`, () => {
-      grid.items = [];
-      expect(grid.$.items.firstElementChild).to.have.property('hidden', true);
-
-      const spy = sinon.spy();
-      grid[generatorFn] = spy;
-      expect(spy.called).to.be.false;
-    });
-
-    it(`should not throw when ${generatorFn} return value contains extra whitespace`, () => {
-      expect(() => {
-        grid[generatorFn] = () => ' test-foo  test-bar ';
-      }).not.to.throw(Error);
-      assertCallback(['test-foo', 'test-bar']);
-    });
-
-    it(`should have the right ${entries} after toggling column visibility`, async () => {
-      grid[generatorFn] = (_column, { index }) => `test-${index % 2 === 0 ? 'even' : 'odd'}`;
-      const column = grid.querySelector('vaadin-grid-column');
-      column.hidden = true;
-      await nextRender();
-      column.hidden = false;
-      await nextRender();
-      assertCallback(['test-odd'], 1, 0);
-      assertCallback(['test-odd'], 1, 1);
-    });
-
-    describe('async data provider', () => {
-      let clock;
-
-      beforeEach(() => {
-        clock = sinon.useFakeTimers({
-          shouldClearNativeTimers: true,
-        });
-
-        grid.dataProvider = (params, callback) => {
-          setTimeout(() => infiniteDataProvider(params, callback), 10);
-        };
-      });
-
-      afterEach(() => {
-        clock.restore();
-      });
-
-      it(`should only run ${generatorFn} for the rows that are loaded`, () => {
-        const spy = sinon.spy();
-        grid[generatorFn] = spy;
-        spy.resetHistory();
-
-        grid[requestFn]();
-        expect(spy.called).to.be.false;
-
-        clock.tick(10);
-        grid[requestFn]();
-        expect(spy.called).to.be.true;
-        expect(spy.getCalls().filter((call) => call.args[1].index === 0).length).to.be.lessThan(5); // NOSONAR
-      });
-
-      it(`should remove custom ${entries} for rows that enter loading state`, () => {
-        grid[generatorFn] = () => 'test-foo'; // NOSONAR
-        clock.tick(10);
-
-        expect(grid._getRenderedRows()[0].hasAttribute('loading')).to.be.false;
-        assertCallback(['test-foo']);
-
-        grid.clearCache();
-
-        expect(grid._getRenderedRows()[0].hasAttribute('loading')).to.be.true;
-        assertCallback([]);
-      });
-    });
-  }
-
-  describe('cell class name generator', () => {
-    const assertClassList = (expectedClasses, row = 0, col = 0) => {
-      const cell = getContainerCell(grid.$.items, row, col);
-      expect([...cell.classList]).to.include('cell');
-      expect([...cell.classList].filter((c) => c.startsWith('test-'))).to.deep.equal(expectedClasses);
-    };
-
-    runStylingTest('classes', 'cellClassNameGenerator', 'generateCellClassNames', assertClassList);
-  });
-
   describe('cell part name generator', () => {
     let initialCellPart;
 
@@ -208,7 +44,153 @@ describe('styling', () => {
       }
     };
 
-    runStylingTest('parts', 'cellPartNameGenerator', 'generateCellPartNames', assertPartNames);
+    it(`should add parts for cells`, () => {
+      grid.cellPartNameGenerator = () => 'test-foo';
+      assertPartNames(['test-foo']);
+      assertPartNames(['test-foo'], 1, 1);
+    });
+
+    it(`should add all parts separated by whitespaces`, () => {
+      grid.cellPartNameGenerator = () => 'test-foo test-bar test-baz';
+      assertPartNames(['test-foo', 'test-bar', 'test-baz']);
+    });
+
+    it(`should not remove existing parts`, () => {
+      firstCell.setAttribute('part', `${firstCell.getAttribute('part')} test-bar`);
+      grid.cellPartNameGenerator = () => 'test-foo';
+      assertPartNames(['test-bar', 'test-foo']);
+    });
+
+    it(`should remove old generated parts`, () => {
+      grid.cellPartNameGenerator = () => 'test-foo';
+      grid.cellPartNameGenerator = () => 'test-bar'; // NOSONAR
+      assertPartNames(['test-bar']);
+    });
+
+    it(`should provide column and model as parameters to cellPartNameGenerator`, () => {
+      grid.cellPartNameGenerator = (column, model) =>
+        `test-${model.index} test-${model.item.value} test-${column.header}`;
+      assertPartNames(['test-5', 'test-foo5', 'test-col1'], 5, 1);
+      assertPartNames(['test-10', 'test-foo10', 'test-col0'], 10, 0);
+    });
+
+    it(`should call cellPartNameGenerator for details cell with undefined column`, async () => {
+      grid.rowDetailsRenderer = () => {};
+      grid.cellPartNameGenerator = (column, model) => `test-${model.index} test-${column}`;
+      await nextFrame();
+      flushGrid(grid);
+      assertPartNames(['test-0', 'test-undefined'], 0, 2);
+    });
+
+    it(`should add parts when loading new items`, (done) => {
+      grid.cellPartNameGenerator = (_, model) => `test-${model.item.value}`;
+      scrollToEnd(grid, () => {
+        const rows = getRows(grid.$.items);
+        assertPartNames(['test-foo199'], rows.length - 1, 0);
+        done();
+      });
+    });
+
+    it(`should not throw when cellPartNameGenerator returns falsy value`, () => {
+      expect(() => {
+        grid.cellPartNameGenerator = () => {};
+      }).not.to.throw(Error);
+    });
+
+    it(`should clear generated parts with falsy return value`, () => {
+      grid.cellPartNameGenerator = () => 'test-foo';
+      grid.cellPartNameGenerator = () => {}; // NOSONAR
+      assertPartNames([]);
+    });
+
+    it(`should clear generated parts with falsy property value`, () => {
+      grid.cellPartNameGenerator = () => 'test-foo';
+      grid.cellPartNameGenerator = undefined; // NOSONAR
+      assertPartNames([]);
+    });
+
+    ['generateCellPartNames', 'clearCache', 'requestContentUpdate'].forEach((funcName) => {
+      it(`should update parts on ${funcName}`, () => {
+        let condition = false;
+        grid.cellPartNameGenerator = () => condition && 'test-foo';
+        condition = true;
+        assertPartNames([]);
+        grid[funcName]();
+        assertPartNames(['test-foo']);
+      });
+    });
+
+    it(`should not run cellPartNameGenerator for hidden rows`, () => {
+      grid.items = [];
+      expect(grid.$.items.firstElementChild).to.have.property('hidden', true);
+
+      const spy = sinon.spy();
+      grid.cellPartNameGenerator = spy;
+      expect(spy.called).to.be.false;
+    });
+
+    it(`should not throw when cellPartNameGenerator return value contains extra whitespace`, () => {
+      expect(() => {
+        grid.cellPartNameGenerator = () => ' test-foo  test-bar ';
+      }).not.to.throw(Error);
+      assertPartNames(['test-foo', 'test-bar']);
+    });
+
+    it(`should have the right parts after toggling column visibility`, async () => {
+      grid.cellPartNameGenerator = (_column, { index }) => `test-${index % 2 === 0 ? 'even' : 'odd'}`;
+      const column = grid.querySelector('vaadin-grid-column');
+      column.hidden = true;
+      await nextRender();
+      column.hidden = false;
+      await nextRender();
+      assertPartNames(['test-odd'], 1, 0);
+      assertPartNames(['test-odd'], 1, 1);
+    });
+
+    describe('async data provider', () => {
+      let clock;
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers({
+          shouldClearNativeTimers: true,
+        });
+
+        grid.dataProvider = (params, callback) => {
+          setTimeout(() => infiniteDataProvider(params, callback), 10);
+        };
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it(`should only run cellPartNameGenerator for the rows that are loaded`, () => {
+        const spy = sinon.spy();
+        grid.cellPartNameGenerator = spy;
+        spy.resetHistory();
+
+        grid.generateCellPartNames();
+        expect(spy.called).to.be.false;
+
+        clock.tick(10);
+        grid.generateCellPartNames();
+        expect(spy.called).to.be.true;
+        expect(spy.getCalls().filter((call) => call.args[1].index === 0).length).to.be.lessThan(5); // NOSONAR
+      });
+
+      it(`should remove custom parts for rows that enter loading state`, () => {
+        grid.cellPartNameGenerator = () => 'test-foo'; // NOSONAR
+        clock.tick(10);
+
+        expect(grid._getRenderedRows()[0].hasAttribute('loading')).to.be.false;
+        assertPartNames(['test-foo']);
+
+        grid.clearCache();
+
+        expect(grid._getRenderedRows()[0].hasAttribute('loading')).to.be.true;
+        assertPartNames([]);
+      });
+    });
   });
 
   describe('header and footer part name', () => {

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -35,7 +35,6 @@ import type {
   GridActiveItemChangedEvent,
   GridBodyRenderer,
   GridCellActivateEvent,
-  GridCellClassNameGenerator,
   GridCellFocusEvent,
   GridColumnReorderEvent,
   GridColumnResizeEvent,
@@ -214,9 +213,6 @@ assertType<(arg0: TestGridItem) => void>(narrowedGrid.deselectItem);
 assertType<boolean>(narrowedGrid.multiSort);
 assertType<'append' | 'prepend'>(narrowedGrid.multiSortPriority);
 assertType<boolean>(narrowedGrid.multiSortOnShiftClick);
-
-assertType<GridCellClassNameGenerator<TestGridItem> | null | undefined>(narrowedGrid.cellClassNameGenerator);
-assertType<() => void>(narrowedGrid.generateCellClassNames);
 
 assertType<boolean>(narrowedGrid.allRowsVisible);
 assertType<() => void>(narrowedGrid.recalculateColumnWidths);


### PR DESCRIPTION
This PR removes the deprecated classNameGenerator API from Grid.