### PR TITLE
fix: prevent opening or selecting item if modifier key is used (#10508) (CP: 24.8)

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -340,6 +340,10 @@ export const SelectBaseMixin = (superClass) =>
      * @override
      */
     _onKeyDown(e) {
+      if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
+        return;
+      }
+
       if (e.target === this.focusElement && !this.readonly && !this.disabled && !this.opened) {
         if (/^(Enter|SpaceBar|\s|ArrowDown|Down|ArrowUp|Up)$/u.test(e.key)) {
           e.preventDefault();

--- a/packages/select/test/keyboard.test.js
+++ b/packages/select/test/keyboard.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { aTimeout, fixtureSync, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, keyboardEventFor, nextRender, nextUpdate, outsideClick } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '../src/vaadin-select.js';
@@ -166,6 +166,17 @@ describe('keyboard', () => {
 
         const clone = valueButton.firstChild;
         expect(clone.hasAttribute(attr)).to.be.false;
+      });
+    });
+
+    ['ctrl', 'meta', 'alt', 'shift'].forEach((modifierKey) => {
+      it(`should not select item when ${modifierKey}+key is pressed`, async () => {
+        // 79 is the key code for 'o'
+        const event = keyboardEventFor('keydown', 79, [modifierKey], 'o');
+        valueButton.dispatchEvent(event);
+        await nextUpdate(select);
+
+        expect(select.value).to.equal('');
       });
     });
   });


### PR DESCRIPTION
## Description

Manual cherry-pick of #10508 to `24.8` branch - the conflict was caused by `super._onKeyDown` on main branch.

## Type of change

- Cherry-pick