### PR TITLE
chore: revert "fix aura dev page color scheme for Safari 17"

### DIFF
--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -165,7 +165,6 @@ class AuraSchemeControl extends AuraControl {
     // Clear storage and remove inline override
     localStorage.removeItem(this.#storageKey());
     document.documentElement.style.removeProperty(this.#prop);
-    this.#forceRepaint();
 
     // Re-read stylesheet-driven value; default to "light dark"
     const token = getComputedStyle(document.documentElement).getPropertyValue(this.#prop).trim();
@@ -196,7 +195,6 @@ class AuraSchemeControl extends AuraControl {
 
   #setVar(value) {
     document.documentElement.style.setProperty(this.#prop, value);
-    this.#forceRepaint();
   }
 
   // ----- Helpers -----
@@ -214,19 +212,6 @@ class AuraSchemeControl extends AuraControl {
     inputs.forEach((i) => {
       i.checked = i.value === value;
     });
-  }
-
-  #forceRepaint() {
-    // Force repaint. This is needed in Safari 17, but only when the property is updated at runtime.
-    if (!this.__repaintActive) {
-      this.__repaintActive = true;
-      const previousValue = document.documentElement.style.getPropertyValue('--aura-background-color-light');
-      document.documentElement.style.setProperty('--aura-background-color-light', '#000');
-      requestAnimationFrame(() => {
-        document.documentElement.style.setProperty('--aura-background-color-light', previousValue);
-        this.__repaintActive = false;
-      });
-    }
   }
 }
 


### PR DESCRIPTION
This reverts commit e71c6d3ea254ef75bae245acc676ad64cafd6c70.

The fix has a problem where the `--aura-background-color-light` property value is incorrectly parsed as `#000` during page load. Need to come up with a better solution to address Safari 17.