### PR TITLE
refactor: override base properties in avatar Lumo, add JSDoc

### DIFF
--- a/packages/avatar/src/vaadin-avatar.d.ts
+++ b/packages/avatar/src/vaadin-avatar.d.ts
@@ -18,12 +18,24 @@ export { AvatarI18n } from './vaadin-avatar-mixin.js';
  *
  * ### Styling
  *
- * The following shadow DOM parts are exposed for styling:
+ * The following shadow DOM parts are available for styling:
  *
  * Part name | Description
  * --------- | ---------------
  * `abbr`    | The abbreviation element
  * `icon`    | The icon element
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property            | Description
+ * -------------------------------|-------------
+ * `--vaadin-avatar-background`   | Background color of the avatar
+ * `--vaadin-avatar-border-color` | Border color of the avatar
+ * `--vaadin-avatar-border-width` | Border width of the avatar
+ * `--vaadin-avatar-font-size`    | Font size of the avatar
+ * `--vaadin-avatar-font-weight`  | Font weight of the avatar
+ * `--vaadin-avatar-size`         | Size of the avatar
+ * `--vaadin-avatar-text-color`   | Text color of the avatar
  *
  * The following state attributes are available for styling:
  *

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -24,12 +24,24 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  *
  * ### Styling
  *
- * The following shadow DOM parts are exposed for styling:
+ * The following shadow DOM parts are available for styling:
  *
  * Part name | Description
  * --------- | ---------------
  * `abbr`    | The abbreviation element
  * `icon`    | The icon element
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property            | Description
+ * -------------------------------|-------------
+ * `--vaadin-avatar-background`   | Background color of the avatar
+ * `--vaadin-avatar-border-color` | Border color of the avatar
+ * `--vaadin-avatar-border-width` | Border width of the avatar
+ * `--vaadin-avatar-font-size`    | Font size of the avatar
+ * `--vaadin-avatar-font-weight`  | Font weight of the avatar
+ * `--vaadin-avatar-size`         | Size of the avatar
+ * `--vaadin-avatar-text-color`   | Text color of the avatar
  *
  * The following state attributes are available for styling:
  *

--- a/packages/vaadin-lumo-styles/src/components/avatar.css
+++ b/packages/vaadin-lumo-styles/src/components/avatar.css
@@ -8,8 +8,8 @@
     --vaadin-avatar-outline-width: var(--vaadin-focus-ring-width, 2px);
     border: var(--vaadin-avatar-outline-width) solid transparent;
     margin: calc(var(--vaadin-avatar-outline-width) * -1);
-    color: var(--lumo-secondary-text-color);
-    background-color: var(--lumo-contrast-10pct);
+    color: var(--vaadin-avatar-text-color, var(--lumo-secondary-text-color));
+    background-color: var(--vaadin-avatar-background, var(--lumo-contrast-10pct));
     outline: none;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/9617

- Updated `vaadin-avatar` Lumo CSS to allow using background / text color custom CSS properties
- Added tables of custom CSS properties to the Styling section in the API docs of `vaadin-avatar`

## Type of change

- Refactor