### PR TITLE
test: do not wait for overlay open to fix flaky select test

### DIFF
--- a/packages/select/test/accessibility.test.js
+++ b/packages/select/test/accessibility.test.js
@@ -376,7 +376,7 @@ describe('accessibility', () => {
       it('should set focus-ring on the item when opened with keyboard', async () => {
         select.focus();
         await sendKeys({ press: 'Enter' });
-        await oneEvent(overlay, 'vaadin-overlay-open');
+        await nextRender();
 
         const item = listBox.querySelector('vaadin-select-item');
         expect(item.hasAttribute('focus-ring')).to.be.true;


### PR DESCRIPTION
## Description

The following test is flaky especially in Firefox:

```
packages/select/test/accessibility.test.js:
 ❌ accessibility > focus > focus-ring > should set focus-ring on the item when opened with keyboard
      Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

It seems that `vaadin-overlay-open` is fired earlier than `sendKeys()` resolves - same problem also manifested in MSCB, see https://github.com/vaadin/web-components/pull/10490. Replaced waiting for the event with `await nextRender()` which should be enough in this test.

## Type of change

- Test