### PR TITLE
fix: don't override button surface opacity in notifications

### DIFF
--- a/packages/aura/src/components/notification.css
+++ b/packages/aura/src/components/notification.css
@@ -39,5 +39,4 @@ vaadin-notification-card vaadin-card {
 
 vaadin-notification-card vaadin-button {
   --aura-surface-level: 8;
-  --aura-surface-opacity: 0.3;
 }


### PR DESCRIPTION
Doesn't seem necessary any more, after the surface color computation was updated.