### PR TITLE
fix: override checkmark and menu icons from base styles

### DIFF
--- a/packages/aura/aura.css
+++ b/packages/aura/aura.css
@@ -38,6 +38,8 @@
 :where(:host) {
   cursor: default;
   --vaadin-aura-theme: 1;
+  --_vaadin-icon-checkmark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>');
+  --_vaadin-icon-menu: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ><path d="M4 5h16"/><path d="M4 12h16"/><path d="M4 19h16"/></svg>');
 }
 
 vaadin-icon[icon^='vaadin:'] {


### PR DESCRIPTION
Just for a visual preference, these add a tiny bit of more personality to Aura.