### PR TITLE
fix: restore proper gap on side-nav-items, adjust label gap

### DIFF
--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -4,12 +4,15 @@
   --vaadin-side-nav-label-font-weight: var(--aura-font-weight-medium);
   --vaadin-side-nav-item-font-weight: var(--aura-font-weight-medium);
   --vaadin-side-nav-item-border-width: 1px;
-  --vaadin-side-nav-item-gap: var(--vaadin-gap-xs);
   --vaadin-side-nav-items-gap: var(--vaadin-gap-xs);
 }
 
 vaadin-side-nav + vaadin-side-nav {
   margin-top: var(--vaadin-gap-l);
+}
+
+vaadin-side-nav::part(label) {
+  gap: var(--vaadin-gap-xs);
 }
 
 vaadin-side-nav-item::part(content) {


### PR DESCRIPTION
Accidentally adjusted the gap of all items in #10525. I only meant to adjust the gap between the side-nav label and the toggle button.