### PR TITLE
chore: don't override focus-ring color in aura dev page

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -282,7 +282,6 @@
         --aura-accent-color-light: var(--aura-blue);
         --aura-accent-color-dark: var(--aura-blue);
         --vaadin-user-color: var(--aura-accent-color);
-        --vaadin-focus-ring-color: var(--aura-blue);
       }
 
       /* prettier-ignore */


### PR DESCRIPTION
The focus ring color is correctly set by Aura color.css, no need to set it manually (let it follow the global accent color).