### PR TITLE
fix: use oklch for default background colors

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -8,8 +8,8 @@
   --aura-accent-color-light-initial: var(--aura-accent-color-light);
   --aura-accent-color-dark-initial: var(--aura-accent-color-dark);
 
-  --aura-background-color-light: #eceff2;
-  --aura-background-color-dark: #13161b;
+  --aura-background-color-light: oklch(0.95 0.005 248);
+  --aura-background-color-dark: oklch(0.2 0.01 260);
 
   --_bg-alt: light-dark(
     oklch(


### PR DESCRIPTION
Relative oklch() colors get a weird reddish tint in some cases (certain darkness, saturation and hue) in Safari if the original color is not oklch( )as well.

Before:
<img width="1250" height="823" alt="Screenshot 2025-11-25 at 0 16 26" src="https://github.com/user-attachments/assets/fddf07fc-eaa2-40b3-9e41-bdf22ac8885d" />


After:
<img width="1250" height="823" alt="Screenshot 2025-11-25 at 0 15 59" src="https://github.com/user-attachments/assets/ca7e6ba6-4709-4833-81a1-6ec30e2ae495" />
