### PR TITLE
fix: apply filled style to all nested side-nav-items and tabs

### DIFF
--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -46,7 +46,7 @@ vaadin-side-nav-item::part(toggle-button) {
 
 /* Filled variant */
 
-vaadin-side-nav[theme~='filled'] > vaadin-side-nav-item[current]::part(content) {
+vaadin-side-nav[theme~='filled'] vaadin-side-nav-item[current]::part(content) {
   --vaadin-side-nav-item-background: var(--aura-accent-color) border-box;
   --vaadin-side-nav-item-text-color: var(--aura-accent-contrast-color);
   --vaadin-text-color: var(--vaadin-side-nav-item-text-color);

--- a/packages/aura/src/components/tabs.css
+++ b/packages/aura/src/components/tabs.css
@@ -89,7 +89,7 @@ vaadin-tab[selected] {
 
 /* Filled variant */
 
-vaadin-tabs[theme~='filled'] > vaadin-tab[selected] {
+vaadin-tabs[theme~='filled'] vaadin-tab[selected] {
   --vaadin-tab-background: var(--aura-accent-color) border-box;
   --vaadin-tab-text-color: var(--aura-accent-contrast-color);
   --vaadin-text-color: var(--aura-accent-contrast-color);


### PR DESCRIPTION
I mistakenly added the direct child selector in a previous PR, somehow thinking the styles shouldn't leak to nested instances of side-nav or tabs. 

Tabs can't really contain other tabs, so there’s no need to prevent any leakage (_tabsheet_ would be a different story). And in side-nav, the variant should apply to sub-items as well, not just the top level items.