### PR TITLE
fix: compute tabs border radius

### DIFF
--- a/packages/aura/src/components/tabs.css
+++ b/packages/aura/src/components/tabs.css
@@ -3,7 +3,7 @@
   --vaadin-tab-border-radius: var(--vaadin-radius-m);
   --vaadin-tab-font-weight: var(--aura-font-weight-medium);
   --vaadin-tabs-gap: 2px;
-  --vaadin-tabs-border-radius: calc(var(--vaadin-tab-border-radius) + 3px);
+  --vaadin-tabs-border-radius: calc(var(--vaadin-tab-border-radius) + var(--vaadin-tabs-padding));
   --vaadin-tabs-padding: 3px;
 }
 


### PR DESCRIPTION
Compute the tabs container border radius using the padding value and the individual tab border radius.