### PR TITLE
refactor: remove theme attribute color scheme rules

### DIFF
--- a/packages/aura/src/color-scheme.css
+++ b/packages/aura/src/color-scheme.css
@@ -3,15 +3,3 @@
   --aura-content-color-scheme: inherit;
   --aura-notification-color-scheme: inherit;
 }
-
-[theme~='light'] {
-  color-scheme: light;
-}
-
-[theme~='dark'] {
-  color-scheme: dark;
-}
-
-[theme~='light-dark'] {
-  color-scheme: light dark;
-}


### PR DESCRIPTION
## Description

Removes the Aura color scheme rules for the `theme` attribute which are no longer necessary with the `ColorScheme` API added in https://github.com/vaadin/flow/pull/22718.

## Type of change

- Refactor