### PR TITLE
refactor: update tabIndex logic to match standard HTML property

### DIFF
--- a/packages/a11y-base/src/tabindex-mixin.d.ts
+++ b/packages/a11y-base/src/tabindex-mixin.d.ts
@@ -20,7 +20,7 @@ export declare class TabindexMixinClass {
   /**
    * Indicates whether the element can be focused and where it participates in sequential keyboard navigation.
    */
-  tabindex: number | null | undefined;
+  tabIndex: number;
 
   /**
    * Stores the last known tabindex since the element has been disabled.

--- a/packages/a11y-base/src/tabindex-mixin.js
+++ b/packages/a11y-base/src/tabindex-mixin.js
@@ -23,9 +23,10 @@ export const TabindexMixin = (superclass) =>
          *
          * @protected
          */
-        tabindex: {
+        tabIndex: {
           type: Number,
           reflectToAttribute: true,
+          attribute: 'tabindex',
           observer: '_tabindexChanged',
           sync: true,
         },
@@ -39,6 +40,15 @@ export const TabindexMixin = (superclass) =>
           type: Number,
         },
       };
+    }
+
+    /**
+     * Override to indicate that the component should not set tabindex attribute
+     * on the host element but instead delegate it to an element in light DOM.
+     * @protected
+     */
+    get _shouldUseHostTabIndex() {
+      return true;
     }
 
     /**
@@ -58,16 +68,12 @@ export const TabindexMixin = (superclass) =>
       }
 
       if (disabled) {
-        if (this.tabindex !== undefined) {
-          this._lastTabIndex = this.tabindex;
+        if (this.tabIndex !== undefined) {
+          this._lastTabIndex = this.tabIndex;
         }
         this.setAttribute('tabindex', '-1');
       } else if (oldDisabled) {
-        if (this._lastTabIndex !== undefined) {
-          this.setAttribute('tabindex', this._lastTabIndex);
-        } else {
-          this.tabindex = undefined;
-        }
+        this.tabIndex = this._lastTabIndex;
       }
     }
 
@@ -80,6 +86,10 @@ export const TabindexMixin = (superclass) =>
      */
     _tabindexChanged(tabindex) {
       if (this.__shouldAllowFocusWhenDisabled()) {
+        return;
+      }
+
+      if (!this._shouldUseHostTabIndex) {
         return;
       }
 

--- a/packages/a11y-base/test/tabindex-mixin.test.js
+++ b/packages/a11y-base/test/tabindex-mixin.test.js
@@ -21,11 +21,6 @@ describe('TabindexMixin', () => {
       expect(element.hasAttribute('tabindex')).to.be.false;
     });
 
-    it('should reflect tabindex property to the attribute', () => {
-      element.tabindex = 1;
-      expect(element.getAttribute('tabindex')).to.be.equal('1');
-    });
-
     it('should reflect native tabIndex property to the attribute', () => {
       element.tabIndex = 1;
       expect(element.getAttribute('tabindex')).to.be.equal('1');
@@ -33,7 +28,7 @@ describe('TabindexMixin', () => {
 
     it('should reflect tabindex attribute to the property', () => {
       element.setAttribute('tabindex', '1');
-      expect(element.tabindex).to.be.equal(1);
+      expect(element.tabIndex).to.be.equal(1);
     });
 
     it('should set tabindex attribute to -1 when disabled', () => {
@@ -85,7 +80,7 @@ describe('TabindexMixin', () => {
     });
 
     it('should set tabindex property to the custom value', () => {
-      expect(element.tabindex).to.equal(1);
+      expect(element.tabIndex).to.equal(1);
     });
   });
 });

--- a/packages/button/src/vaadin-button-mixin.js
+++ b/packages/button/src/vaadin-button-mixin.js
@@ -29,7 +29,7 @@ export const ButtonMixin = (superClass) =>
       });
 
       // Set tabindex to 0 by default
-      this.tabindex = 0;
+      this.tabIndex = 0;
     }
 
     /**

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -94,7 +94,7 @@ export const CheckboxMixin = (superclass) =>
 
       // Set tabindex to 0 by default to not lose focus on click in Safari
       // See https://github.com/vaadin/web-components/pull/6780
-      this.tabindex = 0;
+      this.tabIndex = 0;
     }
 
     /** @protected */

--- a/packages/radio-group/src/vaadin-radio-button-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-button-mixin.js
@@ -55,7 +55,7 @@ export const RadioButtonMixin = (superclass) =>
 
       // Set tabindex to 0 by default to not lose focus on click in Safari
       // See https://github.com/vaadin/web-components/pull/6780
-      this.tabindex = 0;
+      this.tabIndex = 0;
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

The usage of `tabindex` was necessary with Polymer: back in the day, `tabIndex` would be converted to `tab-index` attribute and there was no way to configure this. With Lit, we can use `attribute: 'tabindex'` instead.

## Type of change

- Refactor