### PR TITLE
refactor: do not apply justify-content to navbar part

### DIFF
--- a/packages/aura/src/components/app-layout.css
+++ b/packages/aura/src/components/app-layout.css
@@ -39,7 +39,6 @@ vaadin-app-layout:not(:has([slot='drawer'])) {
 }
 
 vaadin-app-layout::part(navbar) {
-  justify-content: space-between;
   --vaadin-app-layout-navbar-background: transparent;
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);


### PR DESCRIPTION
## Description

This CSS makes `h1` look incorrectly aligned in docs examples. We discussed this and agreed that theme shouldn't probably handle this and instead the slotted navbar child element like a horizontal layout should be used.

## Type of change

- Refactor