### PR TITLE
refactor: do not set gap on side-nav item without children

### DIFF
--- a/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
@@ -45,6 +45,10 @@ const sideNavItem = css`
     --vaadin-side-nav-item-text-color: var(--vaadin-text-color-disabled);
   }
 
+  :host(:not([has-children])) {
+    gap: 0;
+  }
+
   [part='link'] {
     flex: auto;
     min-width: 0;


### PR DESCRIPTION
## Description

For some reason, the side-nav item without children can get `expanded` attribute set on click in docs.
In this case `<ul>` element has zero height but there is a gap shown. This PR removes that.

## Type of change

- Refactor