### PR TITLE
fix: enforce auto maring on checkbox and radio input

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -78,7 +78,6 @@ export const checkable = (part, propName = part) => css`
   /* visually hidden */
   ::slotted(input) {
     cursor: inherit;
-    margin: 0;
     align-self: stretch;
     appearance: none;
     cursor: var(--_cursor);
@@ -86,7 +85,7 @@ export const checkable = (part, propName = part) => css`
     width: 2px;
     height: 2px;
     scale: 12;
-    margin: auto;
+    margin: auto !important;
   }
 
   /* Control container (checkbox, radio button) */


### PR DESCRIPTION
## Description

Added `!important` to the slotted input margin to mitigate the problem that happens e.g. with following CSS:

```css
* {
  margin: 0;
}
```

<img width="316" height="79" alt="Screenshot 2025-11-28 at 17 22 30" src="https://github.com/user-attachments/assets/4bb29f56-1be3-43ed-98ea-211b3f604aa4" />

This block could also be moved to `slotStyles` as we do for `opacity` in https://github.com/vaadin/web-components/pull/8882 but since wrong `margin` breaks the clickable area, IMO we can use `!important` here.

## Type of change

- Bugfix