### PR TITLE
fix: make card visible on white background

### DIFF
--- a/packages/aura/src/components/card.css
+++ b/packages/aura/src/components/card.css
@@ -4,39 +4,42 @@
   --vaadin-card-padding: var(--vaadin-padding-l);
   --vaadin-card-gap: var(--vaadin-gap-m) var(--vaadin-gap-l);
   --vaadin-card-border-color: var(--vaadin-border-color-secondary);
-  --vaadin-card-background: var(--aura-surface-color) padding-box;
+  --vaadin-card-border-width: 1px;
 }
 
 vaadin-card {
-  --vaadin-card-background: var(--aura-surface-color) padding-box;
-  --aura-surface-level: 2;
+  background: var(--vaadin-card-background, var(--aura-surface-color) padding-box);
+  background-clip: padding-box;
+  --aura-surface-level: 1;
+  --aura-surface-opacity: 0.5;
+  border: var(--vaadin-card-border-width) solid transparent;
+  --_padding: calc(var(--vaadin-card-padding) - var(--vaadin-card-border-width, 1px));
 }
 
 vaadin-card[theme~='outlined'] {
-  border: var(--vaadin-card-border-width, 1px) solid transparent;
-  --vaadin-card-padding: calc(var(--vaadin-padding-l) - var(--vaadin-card-border-width, 1px));
+  --vaadin-card-border-color: var(--vaadin-border-color);
 }
 
-vaadin-card[theme~='outlined']::before {
-  inset: calc(var(--vaadin-card-border-width, 1px) * -1);
+vaadin-card::before {
+  inset: calc(var(--vaadin-card-border-width) * -1);
 }
 
-vaadin-card[theme~='outlined'][theme~='cover-media'] [slot='media']:is(img, video, svg, vaadin-icon) {
+vaadin-card[theme~='cover-media'] [slot='media']:is(img, video, svg, vaadin-icon) {
   /* TODO relies on internal API - should refactor base styles to support this (background-clip: padding-box) */
-  margin-inline: calc((var(--_padding) + var(--vaadin-card-border-width, 1px)) * -1);
-  margin-top: calc((var(--_padding) + var(--vaadin-card-border-width, 1px)) * -1);
-  width: calc(100% + (var(--_padding) + var(--vaadin-card-border-width, 1px)) * 2);
+  margin-inline: calc((var(--_padding) + var(--vaadin-card-border-width)) * -1);
+  margin-top: calc((var(--_padding) + var(--vaadin-card-border-width)) * -1);
+  width: calc(100% + (var(--_padding) + var(--vaadin-card-border-width)) * 2);
 }
 
 vaadin-card[theme~='elevated'] {
   --aura-surface-opacity: 0.7;
   --aura-surface-level: 3;
+  background: var(--aura-surface-color) padding-box;
   --_shadow-color: light-dark(
     oklch(from var(--aura-background-color-light) calc(l - l * 0.8) calc(c / 10) h / 0.1),
     oklch(from var(--aura-background-color-dark) calc(l - l * 0.8) calc(c / 10) h / 0.2)
   );
-  --vaadin-card-shadow: 0 1px 6px -1px var(--_shadow-color);
-  background-clip: padding-box;
+  --vaadin-card-shadow: 0 1px 4px -1px var(--_shadow-color);
 }
 
 vaadin-card[theme~='stretch-media']:not([theme~='cover-media']) [slot='media']:is(img, video, svg, vaadin-icon) {


### PR DESCRIPTION
Fixes #10544 

## Light
Forced the page background to white, instead of the light gray default.

Default:
<img width="387" height="102" alt="Screenshot 2025-12-01 at 10 41 52" src="https://github.com/user-attachments/assets/06a4e38f-6604-4e29-b3a3-64a4b29ae54d" />

Outlined:
<img width="391" height="105" alt="Screenshot 2025-12-01 at 10 41 59" src="https://github.com/user-attachments/assets/0f7fec55-0d65-4b9d-9402-10e05ed6c3fa" />

Elevated:
<img width="384" height="109" alt="Screenshot 2025-12-01 at 10 42 18" src="https://github.com/user-attachments/assets/b06bb062-31dd-4575-aaf6-e00f0a8ea6a4" />

Outlined + elevated:
<img width="394" height="112" alt="Screenshot 2025-12-01 at 10 42 33" src="https://github.com/user-attachments/assets/83a42a86-1f74-4887-aef9-c2e5d463e1e0" />


## Dark

Default:
<img width="391" height="118" alt="Screenshot 2025-12-01 at 10 43 09" src="https://github.com/user-attachments/assets/422666b1-16f9-46d0-8b58-0bf3f56cd956" />

Outlined:
<img width="390" height="112" alt="Screenshot 2025-12-01 at 10 43 16" src="https://github.com/user-attachments/assets/251d4d8f-3f35-4766-a11a-2a79ce1dbb3e" />

Elevated:
<img width="386" height="114" alt="Screenshot 2025-12-01 at 10 43 34" src="https://github.com/user-attachments/assets/80381ed1-1c78-4fb2-9103-44b87b056926" />

Outlined + elevated:
<img width="394" height="123" alt="Screenshot 2025-12-01 at 10 44 05" src="https://github.com/user-attachments/assets/33d52c33-4dbf-485c-8ce8-cfb798abb551" />
