### PR TITLE
refactor!: aura-text-color → aura-neutral

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -314,8 +314,8 @@
 
       /* prettier-ignore */
       :is(vaadin-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-side-nav, vaadin-tabs):not([theme~="accent"]) {
-        --aura-accent-color-light: var(--aura-text-color-light);
-        --aura-accent-color-dark: var(--aura-text-color-dark);
+        --aura-accent-color-light: var(--aura-neutral-light);
+        --aura-accent-color-dark: var(--aura-neutral-dark);
       }
 
       body {
@@ -652,41 +652,32 @@
 
                 <div class="aura-surface component wide tall">
                   <div class="badges">
-                    <span class="aura-badge aura-accent-neutral">Neutral</span>
                     <span class="aura-badge aura-accent-color">Accent</span>
-                    <span class="aura-badge aura-accent-green">Green</span>
-                    <span class="aura-badge aura-accent-blue">Blue</span>
-                    <span class="aura-badge aura-accent-purple">Purple</span>
+                    <span class="aura-badge aura-accent-neutral">Neutral</span>
                     <span class="aura-badge aura-accent-red">Red</span>
                     <span class="aura-badge aura-accent-orange">Orange</span>
                     <span class="aura-badge aura-accent-yellow">Yellow</span>
+                    <span class="aura-badge aura-accent-green">Green</span>
+                    <span class="aura-badge aura-accent-blue">Blue</span>
+                    <span class="aura-badge aura-accent-purple">Purple</span>
                   </div>
 
                   <div class="badges">
-                    <span class="aura-badge aura-badge-filled aura-accent-neutral">Neutral</span>
                     <span class="aura-badge aura-badge-filled">Accent</span>
-                    <span class="aura-badge aura-badge-filled aura-accent-green">Green</span>
-                    <span class="aura-badge aura-badge-filled aura-accent-blue">Blue</span>
-                    <span class="aura-badge aura-badge-filled aura-accent-purple">Purple</span>
+                    <span class="aura-badge aura-badge-filled aura-accent-neutral">Neutral</span>
                     <span class="aura-badge aura-badge-filled aura-accent-red">Red</span>
                     <span class="aura-badge aura-badge-filled aura-accent-orange">Orange</span>
                     <span class="aura-badge aura-badge-filled aura-accent-yellow">Yellow</span>
+                    <span class="aura-badge aura-badge-filled aura-accent-green">Green</span>
+                    <span class="aura-badge aura-badge-filled aura-accent-blue">Blue</span>
+                    <span class="aura-badge aura-badge-filled aura-accent-purple">Purple</span>
                   </div>
 
                   <div class="badges">
-                    <span class="aura-badge aura-accent-neutral">
-                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
-                    </span>
                     <span class="aura-badge aura-accent-color">
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
-                    <span class="aura-badge aura-accent-green">
-                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
-                    </span>
-                    <span class="aura-badge aura-accent-blue">
-                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
-                    </span>
-                    <span class="aura-badge aura-accent-purple">
+                    <span class="aura-badge aura-accent-neutral">
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
                     <span class="aura-badge aura-accent-red">
@@ -698,22 +689,22 @@
                     <span class="aura-badge aura-accent-yellow">
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
+                    <span class="aura-badge aura-accent-green">
+                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
+                    </span>
+                    <span class="aura-badge aura-accent-blue">
+                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
+                    </span>
+                    <span class="aura-badge aura-accent-purple">
+                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
+                    </span>
                   </div>
 
                   <div class="badges">
-                    <span class="aura-badge aura-badge-filled aura-accent-neutral">
-                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
-                    </span>
                     <span class="aura-badge aura-badge-filled">
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
-                    <span class="aura-badge aura-badge-filled aura-accent-green">
-                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
-                    </span>
-                    <span class="aura-badge aura-badge-filled aura-accent-blue">
-                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
-                    </span>
-                    <span class="aura-badge aura-badge-filled aura-accent-purple">
+                    <span class="aura-badge aura-badge-filled aura-accent-neutral">
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
                     <span class="aura-badge aura-badge-filled aura-accent-red">
@@ -723,6 +714,15 @@
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
                     <span class="aura-badge aura-badge-filled aura-accent-yellow">
+                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
+                    </span>
+                    <span class="aura-badge aura-badge-filled aura-accent-green">
+                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
+                    </span>
+                    <span class="aura-badge aura-badge-filled aura-accent-blue">
+                      <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
+                    </span>
+                    <span class="aura-badge aura-badge-filled aura-accent-purple">
                       <vaadin-icon src="./assets/lucide-icons/file-text.svg"></vaadin-icon>
                     </span>
                   </div>

--- a/dev/aura/colors.html
+++ b/dev/aura/colors.html
@@ -161,8 +161,8 @@
     </vaadin-checkbox-group>
 
     <section class="section">
-      <span class="aura-badge aura-accent-color">Accent</span>
       <span class="aura-badge aura-accent-neutral">Neutral</span>
+      <span class="aura-badge aura-accent-color">Accent</span>
       <span class="aura-badge aura-accent-red">Red</span>
       <span class="aura-badge aura-accent-orange">Orange</span>
       <span class="aura-badge aura-accent-yellow">Yellow</span>

--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -2,8 +2,8 @@
 :where(:host) {
   --aura-contrast-level: 1;
 
-  --aura-accent-color-light: var(--aura-text-color-light);
-  --aura-accent-color-dark: var(--aura-text-color-dark);
+  --aura-accent-color-light: var(--aura-neutral-light);
+  --aura-accent-color-dark: var(--aura-neutral-dark);
 
   --aura-accent-color-light-initial: var(--aura-accent-color-light);
   --aura-accent-color-dark-initial: var(--aura-accent-color-dark);
@@ -71,13 +71,13 @@ vaadin-tab,
   .aura-accent-blue,
   .aura-accent-purple
 ) {
-  --aura-text-color-light: oklch(
+  --aura-neutral-light: oklch(
     from var(--aura-background-color-light) calc(0.2 - 0.05 * var(--aura-contrast-level)) calc(c * 0.1) h
   );
-  --aura-text-color-dark: oklch(
+  --aura-neutral-dark: oklch(
     from var(--aura-background-color-dark) calc(0.9 + 0.1 * var(--aura-contrast-level)) calc(c * l) h
   );
-  --vaadin-text-color: light-dark(var(--aura-text-color-light), var(--aura-text-color-dark));
+  --vaadin-text-color: light-dark(var(--aura-neutral-light), var(--aura-neutral-dark));
   --vaadin-text-color-secondary: light-dark(
     oklch(
       from var(--aura-background-color-light) calc(l * 0.55 - 0.05 * var(--aura-contrast-level) + c / 2) calc(c * 0.6) h
@@ -172,8 +172,8 @@ vaadin-tab,
 }
 
 :is(#id, .aura-accent-neutral) {
-  --aura-accent-color-light: var(--aura-text-color-light);
-  --aura-accent-color-dark: var(--aura-text-color-dark);
+  --aura-accent-color-light: var(--aura-neutral-light);
+  --aura-accent-color-dark: var(--aura-neutral-dark);
   --aura-accent-color: light-dark(var(--aura-accent-color-light), var(--aura-accent-color-dark));
 }
 


### PR DESCRIPTION
Align the property names with the accent color class name.