### PR TITLE
fix: respect dark theme when set on shadow host

### DIFF
--- a/packages/vaadin-lumo-styles/src/global/color-scheme.css
+++ b/packages/vaadin-lumo-styles/src/global/color-scheme.css
@@ -10,6 +10,7 @@
   color-scheme: light;
 }
 
+:host([theme~='dark']),
 [theme~='dark'] {
   /* Base (background) */
   --lumo-base-color: hsl(214, 35%, 21%);


### PR DESCRIPTION
## Description

This PR fixes an issue with the dark theme not applying when Lumo is loaded into a Shadow DOM and `theme="dark"` is set on the Shadow DOM host.

Example:

```html
<exported-web-component theme="dark"></exported-web-component>
```

## Type of change

- [x] Bugfix
