### PR TITLE
fix: set correct CSS prop for card title color in Lumo

### DIFF
--- a/packages/vaadin-lumo-styles/components/card.css
+++ b/packages/vaadin-lumo-styles/components/card.css
@@ -40,7 +40,7 @@
   --vaadin-card-title-line-height: var(
     --lumo-line-height-xs
   );
-  --vaadin-card-subtitle-font-color: var(
+  --vaadin-card-subtitle-color: var(
     --lumo-secondary-text-color
   );
   --vaadin-card-subtitle-font-size: var(


### PR DESCRIPTION
## Description

Base styles defines `--vaadin-card-title-color` and `--vaadin-card-subtitle-color` for the title and subtitle colors, this makes Lumo use the correct props.

## Type of change

- Bugfix
