### PR TITLE
refactor!: remove select subtle and auto-size Aura variants

### DIFF
--- a/packages/aura/src/components/select.css
+++ b/packages/aura/src/components/select.css
@@ -4,31 +4,6 @@ vaadin-select-item::part(content) {
   gap: inherit;
 }
 
-vaadin-select[theme~='subtle']::part(input-field) {
-  --vaadin-input-field-border-color: transparent;
-  --vaadin-input-field-background: transparent;
-}
-
-vaadin-select[theme~='subtle']::part(toggle-button) {
-  transition: opacity 200ms;
-  opacity: 0;
-  --vaadin-icon-size: 0.75lh;
-}
-
-vaadin-select[theme~='subtle'][focus-ring]::part(toggle-button) {
-  opacity: 1;
-}
-
-@media (any-hover: hover) {
-  vaadin-select[theme~='subtle']:hover::part(toggle-button) {
-    opacity: 1;
-  }
-}
-
-vaadin-select[theme~='auto-size'] {
-  --vaadin-field-default-width: auto;
-}
-
 vaadin-select-value-button {
   font-weight: var(--aura-font-weight-medium);
 }


### PR DESCRIPTION
## Description

Discussed these variants only present in `vaadin-select` and agreed to remove them for now. 
We might consider adding a "subtle" variant for field components in the future, see also https://github.com/vaadin/web-components/issues/746

## Type of change

- Refactor