### PR TITLE
fix: use correct required indicator escaping in Lumo JS mixin

### DIFF
--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -62,7 +62,7 @@ const requiredField = css`
   }
 
   :host([required]) [part='required-indicator']::after {
-    content: var(--vaadin-input-field-required-indicator, var(--lumo-required-field-indicator, '\2022'));
+    content: var(--vaadin-input-field-required-indicator, var(--lumo-required-field-indicator, '\\2022'));
     color: var(
       --vaadin-input-field-required-indicator-color,
       var(--lumo-required-field-indicator-color, var(--lumo-primary-text-color))


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10565

Fixed incorrect slash (there should be two of them in JS file).

## Type of change

- Bugfix