### PR TITLE
refactor: copy styles helper to eliminate circular dependency

### DIFF
--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-    "@vaadin/vaadin-themable-mixin": "25.0.0-beta7",
     "@vaadin/vaadin-usage-statistics": "^2.1.0",
     "lit": "^3.0.0"
   },

--- a/packages/component-base/src/styles/add-global-styles.js
+++ b/packages/component-base/src/styles/add-global-styles.js
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2025 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Add a `<style>` block with given styles to the document.
+ *
+ * @param {string} id the id to set on the created element, only for informational purposes
+ * @param  {CSSResultGroup[]} styles the styles to add
+ */
+export const addGlobalStyles = (id, ...styles) => {
+  const styleTag = document.createElement('style');
+  styleTag.id = id;
+  styleTag.textContent = styles.map((style) => style.toString()).join('\n');
+
+  document.head.insertAdjacentElement('afterbegin', styleTag);
+};

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { addGlobalStyles } from './add-global-styles.js';
 
 // NOTE: Base color CSS custom properties are explicitly registered as `<color>`
 // here to avoid performance issues in Aura. Aura overrides these properties with
@@ -28,7 +28,7 @@ import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-sty
   });
 });
 
-addGlobalThemeStyles(
+addGlobalStyles(
   'vaadin-base',
   css`
     @layer vaadin.base {

--- a/packages/component-base/src/styles/user-colors.js
+++ b/packages/component-base/src/styles/user-colors.js
@@ -4,9 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { addGlobalStyles } from './add-global-styles.js';
 
-addGlobalThemeStyles(
+addGlobalStyles(
   'vaadin-base-user-colors',
   css`
     @layer vaadin.base {


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/10570

There is currently a circular dependency between `@vaadin/component-base` and `@vaadin/vaadin-themable-mixin`:

- In `@vaadin/component-base` we import `addGlobalThemeStyles` from `@vaadin/vaadin-themable-mixin`
- In `@vaadin/vaadin-themable-mixin` we import `issueWarning` from `@vaadin/component-base`

Updated the code to copy `addGlobalStyles` over to `@vaadin/component-base` package to resolve this.

## Type of change

- Refactor