### PR TITLE
fix: remove border override in Aura

### DIFF
--- a/packages/aura/src/components/rich-text-editor.css
+++ b/packages/aura/src/components/rich-text-editor.css
@@ -46,7 +46,6 @@ vaadin-rich-text-editor::part(toolbar-button) {
     background-color 80ms,
     scale 180ms;
   outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
-  border: 1px solid transparent;
   position: relative;
 }
 


### PR DESCRIPTION
## Description

This allows setting
`--vaadin-rich-text-editor-toolbar-button-border-width` and `--vaadin-rich-text-editor-toolbar-button-border-color` to work with Aura. The base styles define the same value as fallback, so no change in the end result.

<img width="1040" height="74" alt="image" src="https://github.com/user-attachments/assets/7fd9b75b-5274-4871-9a3a-0e0796d81930" />

