### PR TITLE
fix: always set overflow: auto on dialog content part

### DIFF
--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -132,9 +132,6 @@ const dialogResizableOverlay = css`
   [part='content'] {
     flex: 1;
     min-height: 0;
-  }
-
-  :host([overflow]) [part='content'] {
     overflow: auto;
     overscroll-behavior: contain;
   }

--- a/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
@@ -78,9 +78,6 @@
     padding: var(--lumo-space-l);
     flex: 1;
     min-height: 0;
-  }
-
-  :host([overflow]) [part='content'] {
     overflow: auto;
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/8321

Previously in https://github.com/vaadin/web-components/pull/9903 the logic was changed to set `overflow` on dialog resizer container resize and only apply `overflow: auto` if `overflow` attribute is set, which is different from the V24 version.

However, in case of expanding `vaadin-details` component there is no change in `.resizer-container` and therefore the content overflows. This PR changes the CSS to always apply `overflow: auto` which handles such cases correctly.

## Type of change

- Bugfix