### PR TITLE
refactor: add missing icon custom properties to map base styles

### DIFF
--- a/packages/map/src/styles/vaadin-map-base-styles.js
+++ b/packages/map/src/styles/vaadin-map-base-styles.js
@@ -274,7 +274,8 @@ export const mapStyles = css`
   }
 
   .ol-compass:empty::before {
-    mask: var(--_vaadin-icon-arrow-up) 50% / var(--vaadin-icon-visual-size, 100%) no-repeat;
+    mask: var(--vaadin-map-icon-compass, var(--_vaadin-icon-arrow-up)) 50% / var(--vaadin-icon-visual-size, 100%)
+      no-repeat;
   }
 
   .ol-full-screen {
@@ -282,11 +283,12 @@ export const mapStyles = css`
   }
 
   .ol-full-screen button:empty::before {
-    mask: var(--_vaadin-icon-fullscreen) 50% / var(--vaadin-icon-visual-size, 100%) no-repeat;
+    mask: var(--vaadin-map-icon-fullscreen, var(--_vaadin-icon-fullscreen)) 50% / var(--vaadin-icon-visual-size, 100%)
+      no-repeat;
   }
 
   .ol-full-screen .ol-full-screen-true:empty::before {
-    mask: var(--_vaadin-icon-cross) 50% / var(--vaadin-icon-visual-size, 100%) no-repeat;
+    mask: var(--vaadin-map-icon-close, var(--_vaadin-icon-cross)) 50% / var(--vaadin-icon-visual-size, 100%) no-repeat;
   }
 
   .ol-overviewmap {


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/docs/pull/4892#discussion_r2588525437

Added the following icons to base styles:

- `--vaadin-map-icon-fullscreen`
- `--vaadin-map-icon-close`
- `--vaadin-map-icon-compass`

Note: didn't add `--vaadin-map-icon-overview-map-expand` as we don't have `chevron-up` in base styles and itherefore base styles are instead using `rotate: 180deg` for the chevron down icon. Not sure if this is a big problem.

## Type of change

- Refactor