### PR TITLE
refactor: rename dashboard header gap prop

### DIFF
--- a/packages/aura/src/components/dashboard.css
+++ b/packages/aura/src/components/dashboard.css
@@ -2,7 +2,7 @@
 :where(:host) {
   --vaadin-dashboard-widget-title-font-weight: var(--aura-font-weight-medium);
   --vaadin-dashboard-widget-header-padding: var(--vaadin-padding-s) var(--vaadin-padding-m);
-  --vaadin-dashboard-header-gap: var(--vaadin-gap-xs);
+  --vaadin-dashboard-widget-header-gap: var(--vaadin-gap-xs);
   --vaadin-dashboard-widget-border-color: var(--vaadin-border-color-secondary);
   --vaadin-dashboard-widget-background: var(--aura-surface-color) padding-box;
   --vaadin-dashboard-widget-border-radius: var(--vaadin-radius-m);

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-section-base-styles.js
@@ -60,7 +60,7 @@ export const dashboardWidgetAndSectionStyles = css`
     align-items: center;
     box-sizing: border-box;
     justify-content: space-between;
-    gap: var(--vaadin-dashboard-header-gap, var(--vaadin-gap-s));
+    gap: var(--vaadin-dashboard-widget-header-gap, var(--vaadin-gap-s));
   }
 
   [part='title'] {


### PR DESCRIPTION
## Description

Rename `--vaadin-dashboard-header-gap` to `--vaadin-dashboard-widget-header-gap`, which aligns it with other props that apply to both widgets and sections.

## Type of change

- Refactor