### PR TITLE
fix: clip dialog header, content and footer to border radius

### DIFF
--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -134,14 +134,32 @@ const dialogResizableOverlay = css`
     min-height: 0;
     overflow: auto;
     overscroll-behavior: contain;
+    clip-path: border-box;
+  }
+
+  [part='header'],
+  :host(:not([has-header])) [part='content'] {
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+  }
+
+  [part='footer'],
+  :host(:not([has-footer])) [part='content'] {
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
   }
 
   .resizer-container {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    border-radius: inherit;
     max-width: 100%;
+    border-radius: calc(
+      var(--vaadin-dialog-border-radius, var(--vaadin-radius-l)) - var(
+          --vaadin-dialog-border-width,
+          var(--vaadin-overlay-border-width, 1px)
+        )
+    );
   }
 
   :host(:not([resizable])) .resizer {


### PR DESCRIPTION
Before:
<img width="660" height="331" alt="Screenshot 2025-12-04 at 20 18 47" src="https://github.com/user-attachments/assets/3c7791ba-5a0a-417a-9a4a-bbfc37c35047" />

After:
<img width="670" height="345" alt="Screenshot 2025-12-04 at 20 19 26" src="https://github.com/user-attachments/assets/f2922c44-806e-437e-857d-f0436e7f561a" />

