### PR TITLE
chore: add method to force LumoInjector to update styles synchonously

### DIFF
--- a/packages/vaadin-themable-mixin/src/lumo-injector.js
+++ b/packages/vaadin-themable-mixin/src/lumo-injector.js
@@ -98,6 +98,25 @@ export class LumoInjector {
   }
 
   /**
+   * Forces all monitored components to re-evaluate and update their
+   * injected styles.
+   *
+   * This method can be used to force LumoInjector to clean up component
+   * styles synchonously after the Lumo stylesheet has been removed from
+   * the root element.Without this, there may be a short FOUC, when the
+   * Lumo styles are already removed from the root but still present in
+   * the component Shadow DOMs, since those are removed asynchronously on
+   * `transitionstart` (CSSPropertyObserver). This is problematic for grid
+   * in particular, as that short period is enough to cause the virtualizer
+   * to create excessive rows (ResizeObserver).
+   */
+  forceUpdate() {
+    for (const tagName of this.#styleSheetsByTag.keys()) {
+      this.#updateStyleSheet(tagName);
+    }
+  }
+
+  /**
    * Adds a component to the list of elements monitored for style injection.
    * If the styles have already been detected, they are injected into the
    * component's shadow DOM immediately. Otherwise, the class watches the

--- a/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
@@ -21,6 +21,7 @@ class TestFoo extends LumoInjectionMixin(ThemableMixin(LitElement)) {
 
       [part='content'] {
         transition: background-color 1ms linear;
+        color: black;
         background-color: yellow;
       }
     `;
@@ -97,6 +98,7 @@ const TEST_FOO_STYLES = `
 
   @media lumo_foo {
     [part='content'] {
+      color: red;
       background-color: green;
     }
   }
@@ -557,6 +559,35 @@ describe('Lumo injection', () => {
 
       await contentTransition();
       assertBaseStyle();
+    });
+  });
+
+  describe('forceUpdate', () => {
+    beforeEach(async () => {
+      element = fixtureSync('<test-foo></test-foo>');
+      await nextRender();
+      content = element.shadowRoot.querySelector('[part="content"]');
+    });
+
+    afterEach(() => {
+      document.__lumoInjector?.disconnect();
+      document.__lumoInjector = undefined;
+      document.__cssPropertyObserver?.disconnect();
+      document.__cssPropertyObserver = undefined;
+    });
+
+    it('should update component styles synchronously on forceUpdate', () => {
+      const style = document.createElement('style');
+      style.textContent = TEST_FOO_STYLES;
+      document.head.appendChild(style);
+
+      document.__lumoInjector.forceUpdate();
+      expect(getComputedStyle(content).color).to.equal('rgb(255, 0, 0)'); // red
+
+      style.remove();
+
+      document.__lumoInjector.forceUpdate();
+      expect(getComputedStyle(content).color).to.equal('rgb(0, 0, 0)'); // black
     });
   });
 


### PR DESCRIPTION
## Description

When switching from Lumo to Aura in docs, the Lumo stylesheet gets removed from the example shadow root, but LumoInjector only becomes aware of this after getting the `transitionstart` event, which fires asynchonously. As a result, there is a short period during which the component appears with broken styling. 

https://github.com/user-attachments/assets/bf72e9b5-8eb5-419f-8b68-7589d6184426

This PR introduces a `forceUpdate()` method in `LumoInjector` which can be called after removing the Lumo stylesheet in docs `applyTheme`, forcing `LumoInjector` to clean up styles synchonously. 

## Type of change

- [x] Internal
