### PR TITLE
fix: avoid negative margin in menu-bar base styles

### DIFF
--- a/packages/menu-bar/src/styles/vaadin-menu-bar-base-styles.js
+++ b/packages/menu-bar/src/styles/vaadin-menu-bar-base-styles.js
@@ -17,9 +17,7 @@ export const menuBarStyles = css`
   [part='container'] {
     display: flex;
     flex-wrap: nowrap;
-    margin: calc((var(--vaadin-focus-ring-width) + 2px) * -1);
-    overflow: hidden;
-    padding: calc(var(--vaadin-focus-ring-width) + 2px);
+    contain: layout;
     position: relative;
     width: 100%;
     --_gap: var(--vaadin-menu-bar-gap, 0px);


### PR DESCRIPTION
The negative margins can cause unwanted scrollbars in scrolling containers without any internal padding.