### PR TITLE
fix: ensure rows have min height even if Lumo vars are undefined

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/grid.css
+++ b/packages/vaadin-lumo-styles/src/components/grid.css
@@ -156,7 +156,14 @@
 
   .cell {
     outline: none;
-    min-height: var(--lumo-size-m);
+    /*
+      Min height is critical for the virtualizer to avoid creating excessive rows,
+      so we provide a fallback value here to ensure it stays non-zero even if the
+      Lumo variables are temporarily undefined. This can happen for a short moment
+      when the Lumo stylesheet is removed from the document but LumoInjector hasn't
+      cleaned up the component styles yet.
+    */
+    min-height: var(--lumo-size-m, 2.25rem);
     background-color: var(--vaadin-grid-cell-background, var(--lumo-base-color));
     cursor: default;
     --_cell-padding: var(--vaadin-grid-cell-padding, var(--_cell-default-padding));


### PR DESCRIPTION
## Description

The PR ensures that rows have a non-zero min height even if Lumo variables are undefined. This situation can occur for a short moment when the Lumo stylesheet is already removed from the root element but LumoInjector hasn't cleaned up the component styles yet.

This was noticed in the docs, where without this safeguard switching from Lumo to Aura in the docs causes a huge spike in the number of virtualized elements:

https://github.com/user-attachments/assets/bf72e9b5-8eb5-419f-8b68-7589d6184426

## Type of change

- [x] Bugfix
