### PR TITLE
fix: force link styles for links in tabs

### DIFF
--- a/packages/tabs/src/styles/vaadin-tab-base-styles.js
+++ b/packages/tabs/src/styles/vaadin-tab-base-styles.js
@@ -59,9 +59,9 @@ export const tabStyles = css`
   }
 
   ::slotted(a) {
-    color: inherit;
-    cursor: inherit;
-    text-decoration: inherit;
+    color: inherit !important;
+    cursor: inherit !important;
+    text-decoration: inherit !important;
     display: flex;
     align-items: inherit;
     justify-content: inherit;


### PR DESCRIPTION
Global styles that target anchor tags could otherwise easily override these styles, and make the tabs look inconsistent with tabs that don't use links.