### PR TITLE
fix: use correct padding property for baseline align input height

### DIFF
--- a/packages/aura/src/size.css
+++ b/packages/aura/src/size.css
@@ -39,10 +39,6 @@
   --vaadin-gap-m: var(--vaadin-padding-m);
   --vaadin-gap-l: var(--vaadin-padding-l);
   --vaadin-gap-xl: var(--vaadin-padding-xl);
-
-  --vaadin-field-baseline-input-height: calc(
-    1lh + round(var(--vaadin-padding-s) / 1.4, 1px) * 2 + var(--vaadin-input-field-border-width, 1px) * 2
-  );
 }
 
 @media (pointer: coarse) {

--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -75,7 +75,7 @@ export const field = css`
         calc(
           var(
               --vaadin-field-baseline-input-height,
-              (1lh + var(--vaadin-padding-xs) * 2 + var(--vaadin-input-field-border-width, 1px) * 2)
+              (1lh + var(--vaadin-padding-block-container) * 2 + var(--vaadin-input-field-border-width, 1px) * 2)
             ) *
             -1
         )
@@ -139,6 +139,7 @@ export const field = css`
   [part='error-message'] {
     width: min-content;
     min-width: 100%;
+    box-sizing: border-box;
   }
 
   [part='input-field'],


### PR DESCRIPTION
This removes the need to override the custom property in Aura.