### PR TITLE
fix: update dashboard section role attribute to region

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -159,8 +159,9 @@ class DashboardSection extends DashboardItemMixin(
   /** @protected */
   ready() {
     super.ready();
+
     if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'section');
+      this.setAttribute('role', 'region');
     }
   }
 }

--- a/packages/dashboard/test/dashboard-section.test.ts
+++ b/packages/dashboard/test/dashboard-section.test.ts
@@ -34,13 +34,13 @@ describe('dashboard section', () => {
 
   describe('a11y', () => {
     it('should have role="section"', () => {
-      expect(section.getAttribute('role')).to.eql('section');
+      expect(section.getAttribute('role')).to.eql('region');
     });
 
     it('should not override custom role', async () => {
-      section = fixtureSync(`<vaadin-dashboard-section role="region"></vaadin-dashboard-section>`);
+      section = fixtureSync(`<vaadin-dashboard-section role="banner"></vaadin-dashboard-section>`);
       await nextFrame();
-      expect(section.getAttribute('role')).to.eql('region');
+      expect(section.getAttribute('role')).to.eql('banner');
     });
 
     it('should have text content for the title', async () => {

--- a/packages/dashboard/test/dom/__snapshots__/dashboard-section.test.snap.js
+++ b/packages/dashboard/test/dom/__snapshots__/dashboard-section.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-dashboard-section host"] = 
-`<vaadin-dashboard-section role="section">
+`<vaadin-dashboard-section role="region">
 </vaadin-dashboard-section>
 `;
 /* end snapshot vaadin-dashboard-section host */


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/9472

> The structural section role is an abstract role for categorizing all the section subclass roles. The role must not be used. 

## Type of change

- Bugfix