### PR TITLE
fix: use correct custom CSS property name for spinner color

### DIFF
--- a/packages/combo-box/src/styles/vaadin-combo-box-overlay-base-styles.js
+++ b/packages/combo-box/src/styles/vaadin-combo-box-overlay-base-styles.js
@@ -29,13 +29,6 @@ export const comboBoxOverlayStyles = [
       --_items-min-height: calc(var(--vaadin-icon-size, 1lh) + 4px);
     }
 
-    @media (forced-colors: active) {
-      [part='loader'] {
-        forced-color-adjust: none;
-        --vaadin-spinner-color: CanvasText;
-      }
-    }
-
     [part='loader'] {
       position: absolute;
       inset: calc(var(--vaadin-item-overlay-padding, 4px) + 2px);

--- a/packages/component-base/src/styles/loader-styles.js
+++ b/packages/component-base/src/styles/loader-styles.js
@@ -37,4 +37,11 @@ export const loaderStyles = css`
   :host(:not([loading])) [part~='loader'] {
     display: none;
   }
+
+  @media (forced-colors: active) {
+    [part='loader'] {
+      forced-color-adjust: none;
+      --vaadin-spinner-color: CanvasText;
+    }
+  }
 `;


### PR DESCRIPTION
## Description

Original version of base styles added in https://github.com/vaadin/web-components/pull/9260 used `--vaadin-combo-box-spinner-color` was used, but then in https://github.com/vaadin/web-components/pull/9632 it was changed to `--vaadin-spinner-color`. Fixed the property name and moved CSS to `loader.js`.

## Type of change

- Bugfix