### PR TITLE
docs: align wording for custom CSS properties in JSDoc

### DIFF
--- a/packages/form-layout/src/vaadin-form-layout.d.ts
+++ b/packages/form-layout/src/vaadin-form-layout.d.ts
@@ -187,8 +187,7 @@ export * from './vaadin-form-layout-mixin.js';
  *
  * ### CSS Properties Reference
  *
- * The following custom CSS properties are available on the `<vaadin-form-layout>`
- * element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property | Description | Default
  * ---|---|---

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -189,8 +189,7 @@ import { FormLayoutMixin } from './vaadin-form-layout-mixin.js';
  *
  * ### CSS Properties Reference
  *
- * The following custom CSS properties are available on the `<vaadin-form-layout>`
- * element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property | Description | Default
  * ---|---|---

--- a/packages/grid/src/vaadin-grid-tree-toggle.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-toggle.d.ts
@@ -49,8 +49,7 @@ export * from './vaadin-grid-tree-toggle-mixin.js';
  * `expanded` | When present, the toggle is expanded
  * `leaf`     | When present, the toggle is not expandable, i. e., the current item is a leaf
  *
- * The following custom CSS properties are available on
- * the `<vaadin-grid-tree-toggle>` element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property | Description | Default
  * ---|---|---

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -51,8 +51,7 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  * `expanded` | When present, the toggle is expanded
  * `leaf`     | When present, the toggle is not expandable, i. e., the current item is a leaf
  *
- * The following custom CSS properties are available on
- * the `<vaadin-grid-tree-toggle>` element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property | Description | Default
  * ---|---|---

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -53,7 +53,7 @@ export type PopoverEventMap = HTMLElementEventMap & PopoverCustomEventMap;
  *
  * ### Custom CSS Properties
  *
- * The following custom CSS properties are available on the `<vaadin-popover>` element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property              | Description
  * ---------------------------------|-------------

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -188,7 +188,7 @@ const isLastOverlay = (overlay) => {
  *
  * ### Custom CSS Properties
  *
- * The following custom CSS properties are available on the `<vaadin-popover>` element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property              | Description
  * ---------------------------------|-------------

--- a/packages/tooltip/src/vaadin-tooltip.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip.d.ts
@@ -59,7 +59,7 @@ export interface TooltipEventMap extends HTMLElementEventMap, TooltipCustomEvent
  *
  * ### Custom CSS Properties
  *
- * The following custom CSS properties are available on the `<vaadin-tooltip>` element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property              | Description
  * ---------------------------------|-------------

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -51,7 +51,7 @@ import { TooltipMixin } from './vaadin-tooltip-mixin.js';
  *
  * ### Custom CSS Properties
  *
- * The following custom CSS properties are available on the `<vaadin-tooltip>` element:
+ * The following custom CSS properties are available for styling:
  *
  * Custom CSS property              | Description
  * ---------------------------------|-------------


### PR DESCRIPTION
## Description

Updated wording to be consistent across all components. Note: in V24, users had to specify `--vaadin-tooltip-offset-*` and `--vaadin-popover-offset-*` on the `vaadin-tooltip` and `vaadin-popover` respectively, and those then were copied to overlays, which is no longer the case since overlays are not teleported anymore with native popover.

## Type of change

- Documentation