### PR TITLE
fix: prevent virtualizer from creating excess elements when idle cb is late

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -693,7 +693,7 @@ export class IronListAdapter {
    * @override
    */
   _increasePoolIfNeeded(count) {
-    if (this._physicalCount > 2 && count) {
+    if (this._physicalCount > 2 && this._physicalAverage > 0 && count > 0) {
       // The iron-list logic has already created some physical items and
       // has decided to create more. Since each item creation round is
       // expensive, let's try to create the remaining items in one go.


### PR DESCRIPTION
## Description

The PR fixes a timing issue where delayed `requestIdleCallback` execution caused the virtualizer to create too many elements when several virtual elements resized in quick succession.

This was noticed in the docs where switching from Lumo to Aura using the theme switcher caused a huge spike in the number of allocated virtual elements:

https://github.com/user-attachments/assets/bf72e9b5-8eb5-419f-8b68-7589d6184426

## Type of change

- [x] Bugfix
