### PR TITLE
docs: remove irrelevant sentence from JSDoc

### DIFF
--- a/packages/vaadin-themable-mixin/src/lumo-injector.js
+++ b/packages/vaadin-themable-mixin/src/lumo-injector.js
@@ -103,12 +103,10 @@ export class LumoInjector {
    *
    * This method can be used to force LumoInjector to clean up component
    * styles synchonously after the Lumo stylesheet has been removed from
-   * the root element.Without this, there may be a short FOUC, when the
+   * the root element. Without this, there may be a short FOUC, when the
    * Lumo styles are already removed from the root but still present in
    * the component Shadow DOMs, since those are removed asynchronously on
-   * `transitionstart` (CSSPropertyObserver). This is problematic for grid
-   * in particular, as that short period is enough to cause the virtualizer
-   * to create excessive rows (ResizeObserver).
+   * `transitionstart` (CSSPropertyObserver).
    */
   forceUpdate() {
     for (const tagName of this.#styleSheetsByTag.keys()) {


### PR DESCRIPTION
I forgot to remove this sentence from JSDoc after creating https://github.com/vaadin/web-components/pull/10606.

```
This is problematic for grid in particular, as that short period is enough to cause the virtualizer to create excessive rows (ResizeObserver).
```

Follow-up to #10588 