### PR TITLE
fix: add missing Lumo CSS for big-decimal-field component

### DIFF
--- a/packages/vaadin-lumo-styles/components/big-decimal-field.css
+++ b/packages/vaadin-lumo-styles/components/big-decimal-field.css
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2025 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+@import '../src/mixins/field-base.css';
+@import '../src/mixins/field-button.css';
+@import '../src/mixins/field-error-message.css';
+@import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-label.css';
+@import '../src/mixins/field-required.css';
+@import './input-container.css';
+
+:root::before,
+:host::before {
+  --_lumo-vaadin-big-decimal-field-inject: 1;
+  --_lumo-vaadin-big-decimal-field-inject-modules:
+    lumo_mixins_field-label,
+    lumo_mixins_field-required,
+    lumo_mixins_field-error-message,
+    lumo_mixins_field-button,
+    lumo_mixins_field-helper,
+    lumo_mixins_field-base;
+}

--- a/packages/vaadin-lumo-styles/components/index.css
+++ b/packages/vaadin-lumo-styles/components/index.css
@@ -7,6 +7,7 @@
 @import './app-layout.css';
 @import './avatar-group.css';
 @import './avatar.css';
+@import './big-decimal-field.css';
 @import './button.css';
 @import './card.css';
 @import './charts.css';


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/8350

We missed to add a `big-decimal-field.css` file to Lumo. This PR fixes that.

## Type of change

- Bugfix