### PR TITLE
fix: remove grid-template from checkbox and radio-button

### DIFF
--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -11,13 +11,9 @@ export const checkable = (part, propName = part) => css`
   :host {
     align-items: baseline;
     column-gap: var(--vaadin-${unsafeCSS(propName)}-gap, var(--vaadin-gap-s));
+    grid-template: none;
     grid-template-columns: auto 1fr;
-    /*
-      Using minmax(auto, max-content) works around a Safari 17 issue where placing a checkbox
-      inside a flex container with flex-direction: column causes the container to unexpectedly
-      grow to the max available height.
-    */
-    grid-template-rows: minmax(auto, max-content);
+    grid-template-rows: repeat(auto-fill, minmax(0, max-content));
     -webkit-tap-highlight-color: transparent;
     --_cursor: var(--vaadin-clickable-cursor);
   }
@@ -65,6 +61,7 @@ export const checkable = (part, propName = part) => css`
   [part='helper-text'],
   [part='error-message'] {
     margin-top: var(--_gap-s);
+    grid-row: auto;
   }
 
   /* Baseline vertical alignment */


### PR DESCRIPTION
Makes a checkbox/radio-button with bigger height render as expected.

Before:

<img width="271" height="265" alt="Screenshot 2025-12-11 at 14 11 07" src="https://github.com/user-attachments/assets/13bc1ad2-659b-4b62-92c4-20230118d929" />

After:

<img width="258" height="263" alt="Screenshot 2025-12-11 at 14 11 58" src="https://github.com/user-attachments/assets/e296a02d-59bb-4d0c-85c0-71572aad2d21" />

Could not reproduce the Safari 17 issue that was in the code comment (#9491).