### PR TITLE
fix: remove backdrop filter from opaque overlays

### DIFF
--- a/packages/aura/src/components/overlay.css
+++ b/packages/aura/src/components/overlay.css
@@ -34,4 +34,9 @@
   font-weight: var(--aura-font-weight-regular);
   line-height: var(--aura-line-height-m);
   color: var(--vaadin-text-color);
+
+  @container style(--aura-overlay-surface-opacity: 1) {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }


### PR DESCRIPTION
Theoretically improve rendering performance by not applying a backdrop-filter when overlays are opaque.