### PR TITLE
fix: don't use gradient bg in Firefox 145 or below

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -32,18 +32,23 @@
   );
   --aura-app-background: var(--aura-background-color);
 
-  @supports (color: hsl(0 0 0)) {
-    --aura-app-background:
-      var(--_bg-accent),
-      radial-gradient(circle at 25% 0% in xyz, var(--aura-background-color) 33%, var(--_bg-alt))
-        var(--aura-background-color);
-  }
   --vaadin-focus-ring-color: var(--aura-accent-color);
   --vaadin-user-color: var(--aura-blue);
   color: var(--vaadin-text-color);
   background: var(--aura-app-background);
   background-size: 100vw 100vh;
   background-attachment: fixed;
+}
+
+@supports (color: hsl(0 0 0)) {
+  @scope (:root) {
+    :scope {
+      --aura-app-background:
+        var(--_bg-accent),
+        radial-gradient(circle at 25% 0% in xyz, var(--aura-background-color) 33%, var(--_bg-alt))
+          var(--aura-background-color);
+    }
+  }
 }
 
 :where(:root),


### PR DESCRIPTION
Fixes #10403 

Firefox 146 adds support for `@scope` which we use for feature detection.