### PR TITLE
docs: add progress-bar base style properties to JSDoc

### DIFF
--- a/packages/progress-bar/src/vaadin-progress-bar.d.ts
+++ b/packages/progress-bar/src/vaadin-progress-bar.d.ts
@@ -36,6 +36,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  * | `--vaadin-progress-bar-height`             |
  * | `--vaadin-progress-bar-padding`            |
  * | `--vaadin-progress-bar-value-background`   |
+ * | `--vaadin-progress-value`                  |
  *
  * The following state attributes are available for styling:
  *

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -41,6 +41,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  * | `--vaadin-progress-bar-height`             |
  * | `--vaadin-progress-bar-padding`            |
  * | `--vaadin-progress-bar-value-background`   |
+ * | `--vaadin-progress-value`                  |
  *
  * The following state attributes are available for styling:
  *


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/9617

Added base style properties and removed `--vaadin-progress-value` as it's set by the component itself and not supposed to be modified from outside - so in a way, it can be considered internal (also, we don't list it in the new styling docs).

## Type of change

- Documentation