### PR TITLE
docs: add dialog and confirm-dialog base properties to JSDoc

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.d.ts
@@ -34,6 +34,24 @@ export * from './vaadin-confirm-dialog-mixin.js';
  * `confirm-button` | The "Confirm" button wrapper
  * `reject-button`  | The "Reject" button wrapper
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * |`--vaadin-confirm-dialog-max-width`     |
+ * |`--vaadin-confirm-dialog-min-width`     |
+ * |`--vaadin-dialog-background`            |
+ * |`--vaadin-dialog-border-color`          |
+ * |`--vaadin-dialog-border-radius`         |
+ * |`--vaadin-dialog-border-width`          |
+ * |`--vaadin-dialog-padding`               |
+ * |`--vaadin-dialog-shadow`                |
+ * |`--vaadin-dialog-title-color`           |
+ * |`--vaadin-dialog-title-font-size`       |
+ * |`--vaadin-dialog-title-font-weight`     |
+ * |`--vaadin-dialog-title-line-height`     |
+ * |`--vaadin-overlay-backdrop-background`  |
+ *
  * Use `confirmTheme`, `cancelTheme` and `rejectTheme` properties to customize buttons theme.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -38,6 +38,24 @@ import { ConfirmDialogMixin } from './vaadin-confirm-dialog-mixin.js';
  * `confirm-button` | The "Confirm" button wrapper
  * `reject-button`  | The "Reject" button wrapper
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * |`--vaadin-confirm-dialog-max-width`     |
+ * |`--vaadin-confirm-dialog-min-width`     |
+ * |`--vaadin-dialog-background`            |
+ * |`--vaadin-dialog-border-color`          |
+ * |`--vaadin-dialog-border-radius`         |
+ * |`--vaadin-dialog-border-width`          |
+ * |`--vaadin-dialog-padding`               |
+ * |`--vaadin-dialog-shadow`                |
+ * |`--vaadin-dialog-title-color`           |
+ * |`--vaadin-dialog-title-font-size`       |
+ * |`--vaadin-dialog-title-font-weight`     |
+ * |`--vaadin-dialog-title-line-height`     |
+ * |`--vaadin-overlay-backdrop-background`  |
+ *
  * Use `confirmTheme`, `cancelTheme` and `rejectTheme` properties to customize buttons theme.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -111,6 +111,24 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  * `has-footer`     | Set when the element has footer renderer
  * `overflow`       | Set to `top`, `bottom`, none or both
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * |`--vaadin-dialog-background`            |
+ * |`--vaadin-dialog-border-color`          |
+ * |`--vaadin-dialog-border-radius`         |
+ * |`--vaadin-dialog-border-width`          |
+ * |`--vaadin-dialog-max-width`             |
+ * |`--vaadin-dialog-min-width`             |
+ * |`--vaadin-dialog-padding`               |
+ * |`--vaadin-dialog-shadow`                |
+ * |`--vaadin-dialog-title-color`           |
+ * |`--vaadin-dialog-title-font-size`       |
+ * |`--vaadin-dialog-title-font-weight`     |
+ * |`--vaadin-dialog-title-line-height`     |
+ * |`--vaadin-overlay-backdrop-background`  |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -68,6 +68,24 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * `has-footer`     | Set when the element has footer renderer
  * `overflow`       | Set to `top`, `bottom`, none or both
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * |`--vaadin-dialog-background`            |
+ * |`--vaadin-dialog-border-color`          |
+ * |`--vaadin-dialog-border-radius`         |
+ * |`--vaadin-dialog-border-width`          |
+ * |`--vaadin-dialog-max-width`             |
+ * |`--vaadin-dialog-min-width`             |
+ * |`--vaadin-dialog-padding`               |
+ * |`--vaadin-dialog-shadow`                |
+ * |`--vaadin-dialog-title-color`           |
+ * |`--vaadin-dialog-title-font-size`       |
+ * |`--vaadin-dialog-title-font-weight`     |
+ * |`--vaadin-dialog-title-line-height`     |
+ * |`--vaadin-overlay-backdrop-background`  |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} resize - Fired when the dialog resize is finished.


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/9617

Added `vaadin-dialog` and `vaadin-confirm-dialog` base style properties.

## Type of change

- Documentation