### PR TITLE
chore: remove unnecessary gap from reset button

### DIFF
--- a/dev/aura/aura-abstract-control.js
+++ b/dev/aura/aura-abstract-control.js
@@ -23,6 +23,7 @@ export class AuraControl extends HTMLElement {
       #reset {
         background: transparent;
         border: 0;
+        gap: 0;
       }
 
       #reset:not(:hover, :focus-visible) {


### PR DESCRIPTION
It was adding unnecessary padding/white space to the end of the button.