### PR TITLE
fix: reduce selector specificity

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -42,7 +42,7 @@
 
 @supports (color: hsl(0 0 0)) {
   @scope (:root) {
-    :scope {
+    :where(:scope) {
       --aura-app-background:
         var(--_bg-accent),
         radial-gradient(circle at 25% 0% in xyz, var(--aura-background-color) 33%, var(--_bg-alt))


### PR DESCRIPTION
Regression from #10626, which broke the following custom styles:

```css
html {
  --aura-app-background: var(--aura-app-background-color);
}
```