### PR TITLE
feat: class name to set accent color to the global accent color

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -176,6 +176,12 @@ vaadin-tab,
   color: var(--aura-accent-text-color);
 }
 
+:is(#id, .aura-accent-color) {
+  --aura-accent-color-light: var(--aura-accent-color-light-initial);
+  --aura-accent-color-dark: var(--aura-accent-color-dark-initial);
+  --aura-accent-color: light-dark(var(--aura-accent-color-light), var(--aura-accent-color-dark));
+}
+
 :is(#id, .aura-accent-neutral) {
   --aura-accent-color-light: var(--aura-neutral-light);
   --aura-accent-color-dark: var(--aura-neutral-dark);


### PR DESCRIPTION
This class name is useful if an application decides not to apply the global accent color to all components, for example buttons, as you can then selectively apply the global accent color to those components when desired.

For example:

```css
html {
  --aura-accent-color-light: var(--aura-purple);
  --aura-accent-color-dark: var(--aura-purple);
}

vaadin-button {
  --aura-accent-color-light: var(--aura-neutral-light);
  --aura-accent-color-dark: var(--aura-neutral-dark);
}
```

```html
<vaadin-button>Black text</vaadin-button>
<vaadin-button class="aura-accent-color">Purple text</vaadin-button>
```