### PR TITLE
feat: allow surface color adjustments on app-layout

### DIFF
--- a/packages/aura/src/surface.css
+++ b/packages/aura/src/surface.css
@@ -9,6 +9,7 @@
 .aura-surface,
 .aura-surface-solid,
 vaadin-accordion-panel[theme~='filled'],
+vaadin-app-layout,
 vaadin-app-layout::part(navbar),
 vaadin-app-layout::part(drawer),
 vaadin-button,


### PR DESCRIPTION
Allow developers to adjust the surface color opacity and level on the `<vaadin-app-layout>` element. Makes it easier to control the color of the app layout content area, as the selector for that is very specific: https://github.com/vaadin/web-components/blob/d391dc66f39053ba96cf9cff05f5952f12402478/packages/aura/src/components/app-layout.css#L69