### PR TITLE
fix: allow popovers to close when interacting with non-nested overlays (CP: 24.9)

### DIFF
--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -14,6 +14,25 @@ const getAttachedInstances = () =>
     .sort((a, b) => a.__zIndex - b.__zIndex || 0);
 
 /**
+ * Returns true if all the instances on top of the overlay are nested overlays.
+ * @private
+ */
+export const hasOnlyNestedOverlays = (overlay) => {
+  const instances = getAttachedInstances();
+  const next = instances[instances.indexOf(overlay) + 1];
+  if (!next) {
+    return true;
+  }
+
+  // Check if the overlay contains the owner element of another overlay
+  if (next.owner && !overlay._deepContains(next.owner)) {
+    return false;
+  }
+
+  return hasOnlyNestedOverlays(next);
+};
+
+/**
  * Returns all attached overlay instances excluding notification container,
  * which only needs to be in the stack for zIndex but not pointer-events.
  * @private


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/8339 for Vaadin 24.9

Manual cherry-pick of https://github.com/vaadin/web-components/pull/10322 to `24.9` branch with addition of `hasOnlyNestedOverlays` logic specifically for `vaadin-popover` case (not used by the actual `bringToFront()` unlike in V25).

## Type of change

- Cherry-pick

## Note

Can be tested by modifying the dev page as follows:

```html
<vaadin-horizontal-layout theme="spacing padding">
  <vaadin-button id="button1">Open 1</vaadin-button>
  <vaadin-button id="button2">Open 2</vaadin-button>
  <vaadin-button id="button3">Open 2</vaadin-button>
</vaadin-horizontal-layout>

<vaadin-popover for="button1" position="bottom"></vaadin-popover>
<vaadin-popover for="button2" position="bottom"></vaadin-popover>
<vaadin-popover for="button3" position="bottom"></vaadin-popover>

<script type="module">
  import '@vaadin/button';
  import '@vaadin/horizontal-layout';
  import '@vaadin/popover';

  [...document.querySelectorAll('vaadin-popover')].forEach((el) => {
    el.renderer = (root) => {
      root.textContent = 'Content';
    }
    el.trigger = ['hover', 'focus'];
  });
</script>
```