### PR TITLE
fix: support multiple values in `--vaadin-item-overlay-padding`

### DIFF
--- a/packages/combo-box/src/styles/vaadin-combo-box-overlay-base-styles.js
+++ b/packages/combo-box/src/styles/vaadin-combo-box-overlay-base-styles.js
@@ -31,9 +31,10 @@ export const comboBoxOverlayStyles = [
 
     [part='loader'] {
       position: absolute;
-      inset: calc(var(--vaadin-item-overlay-padding, 4px) + 2px);
+      inset: var(--vaadin-item-overlay-padding, 4px);
       inset-block-end: auto;
       inset-inline-start: auto;
+      margin: 2px;
     }
   `,
 ];

--- a/packages/combo-box/src/styles/vaadin-combo-box-scroller-base-styles.js
+++ b/packages/combo-box/src/styles/vaadin-combo-box-scroller-base-styles.js
@@ -17,7 +17,8 @@ export const comboBoxScrollerStyles = css`
   }
 
   #selector {
-    border: var(--vaadin-item-overlay-padding, 4px) solid transparent;
+    border: 0 solid transparent;
+    border-width: var(--vaadin-item-overlay-padding, 4px);
     position: relative;
     forced-color-adjust: none;
     min-height: var(--_items-min-height, auto);


### PR DESCRIPTION
This fix allows developers to use separate values for block and inline padding for item overlays, e.g.

```css
html {
  --vaadin-item-overlay-padding: 8px 0;
}
```