### PR TITLE
fix: fine tune aura palette colors

### DIFF
--- a/packages/aura/src/palette.css
+++ b/packages/aura/src/palette.css
@@ -1,10 +1,10 @@
 :where(:root),
 :where(:host) {
   --aura-red: oklch(0.59 0.2 25);
-  --aura-orange: oklch(0.61 0.4 90);
-  --aura-yellow: oklch(0.9 0.45 105);
-  --aura-green: oklch(0.6 0.2 150);
-  --aura-blue: oklch(0.61 0.2 260);
+  --aura-orange: oklch(0.61 0.35 87);
+  --aura-yellow: oklch(0.89 0.3 98);
+  --aura-green: oklch(0.6 0.2 155);
+  --aura-blue: oklch(0.55 0.2 264);
   --aura-purple: oklch(0.58 0.22 290);
 
   --aura-red-text: light-dark(


### PR DESCRIPTION
Before: 
<img width="495" height="43" alt="Screenshot 2025-12-15 at 13 31 09" src="https://github.com/user-attachments/assets/5606b1b6-4f29-4b07-88e1-e83af5b8552c" />
<img width="494" height="43" alt="Screenshot 2025-12-15 at 13 31 25" src="https://github.com/user-attachments/assets/fdf7aaaf-0eb2-49f7-afba-23141649f343" />

After:
<img width="497" height="45" alt="Screenshot 2025-12-15 at 13 31 39" src="https://github.com/user-attachments/assets/847ee7c9-3945-4c20-aad3-e086a2b417eb" />
<img width="494" height="44" alt="Screenshot 2025-12-15 at 13 31 48" src="https://github.com/user-attachments/assets/77118f35-9815-4e9f-911d-6fb34ea8fe03" />
