### PR TITLE
docs: add split-layout base style properties to JSDoc

### DIFF
--- a/packages/split-layout/src/vaadin-split-layout.d.ts
+++ b/packages/split-layout/src/vaadin-split-layout.d.ts
@@ -154,7 +154,7 @@ export interface SplitLayoutEventMap extends HTMLElementEventMap, SplitLayoutCus
  * | `--vaadin-split-layout-handle-size`          |
  * | `--vaadin-split-layout-handle-target-size`   |
  * | `--vaadin-split-layout-splitter-background`  |
- * | `--vaadin-accordion-heading-border-width`    |
+ * | `--vaadin-split-layout-splitter-size`        |
  * | `--vaadin-split-layout-splitter-target-size` |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -153,7 +153,7 @@ import { SplitLayoutMixin } from './vaadin-split-layout-mixin.js';
  * | `--vaadin-split-layout-handle-size`          |
  * | `--vaadin-split-layout-handle-target-size`   |
  * | `--vaadin-split-layout-splitter-background`  |
- * | `--vaadin-accordion-heading-border-width`    |
+ * | `--vaadin-split-layout-splitter-size`        |
  * | `--vaadin-split-layout-splitter-target-size` |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/9617

- Added `vaadin-split-layout` base styles properties to JSDoc
- Modified shadow parts table to remove unnecessary column

## Type of change

- Documentation