### PR TITLE
fix: notification padding and card border when inside notification

### DIFF
--- a/packages/aura/src/components/notification.css
+++ b/packages/aura/src/components/notification.css
@@ -2,6 +2,7 @@
 :where(:host) {
   --vaadin-notification-border-width: 0px;
   --vaadin-ease-fluid: cubic-bezier(0.78, 0, 0.22, 1);
+  --vaadin-notification-padding: var(--vaadin-padding-m);
 }
 
 vaadin-notification-container {
@@ -33,6 +34,7 @@ vaadin-notification-card::part(overlay) {
 }
 
 vaadin-notification-card vaadin-card {
+  --vaadin-card-border-width: 0px;
   --vaadin-card-gap: var(--vaadin-gap-xs) var(--vaadin-gap-s);
   color: var(--vaadin-text-color-secondary);
 }


### PR DESCRIPTION
The larger padding works better especially for plain text content.

Before:
<img width="390" height="78" alt="Screenshot 2025-12-15 at 15 49 34" src="https://github.com/user-attachments/assets/1c3c4091-667d-44c7-817d-5614c64d0ac7" />

After:
<img width="390" height="87" alt="Screenshot 2025-12-15 at 15 49 42" src="https://github.com/user-attachments/assets/51167925-b846-4a4e-a63a-e294b2ff9dff" />

The unwanted card border was leftover/regression from #10555 