### PR TITLE
fix: do not use !important as part of custom CSS property

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/button.css
+++ b/packages/vaadin-lumo-styles/src/components/button.css
@@ -152,8 +152,7 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
 
   :host([theme~='tertiary']),
   :host([theme~='tertiary-inline']) {
-    --_background: transparent !important;
-    background: var(--vaadin-button-tertiary-background, var(--_background));
+    background: var(--vaadin-button-tertiary-background, transparent) !important;
     min-width: 0;
   }
 


### PR DESCRIPTION
## Description

This is a finding from TaskMob where the following CSS breaks `transparent` background for `tertiary-inline` button:

```css
:host(:not([theme~="tertiary"]):not([theme~="primary"])) {
    background-color: var(--lumo-primary-color-10pct);
}
```

When used as part of custom CSS property value, `!important` apparently gets lost.
This problem was introduced long ago in https://github.com/vaadin/web-components/pull/6672 (exists in V24.3+).

## Type of change

- Bugfix