### PR TITLE
fix: side-nav-item surface color, icon color, and text transition

### DIFF
--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -13,11 +13,17 @@ vaadin-side-nav + vaadin-side-nav {
 
 vaadin-side-nav::part(label) {
   gap: var(--vaadin-gap-xs);
+  transition: color 80ms;
+}
+
+vaadin-side-nav::part(label):hover {
+  color: var(--vaadin-text-color);
 }
 
 vaadin-side-nav-item::part(content) {
-  --aura-surface-level: 4;
-  --aura-surface-opacity: 0.6;
+  --aura-surface-level: 6;
+  --aura-surface-opacity: 0.3;
+  transition: color 80ms;
 }
 
 vaadin-side-nav-item:not([disabled], [current])::part(content):active {
@@ -26,7 +32,6 @@ vaadin-side-nav-item:not([disabled], [current])::part(content):active {
 
 @media (any-hover: hover) {
   vaadin-side-nav-item:not([disabled], [current])::part(content):hover {
-    transition: color 120ms;
     --vaadin-side-nav-item-text-color: var(--vaadin-text-color);
   }
 }
@@ -54,4 +59,8 @@ vaadin-side-nav[theme~='filled'] vaadin-side-nav-item[current]::part(content) {
   --vaadin-text-color-disabled: color-mix(in srgb, var(--aura-accent-contrast-color) 50%, transparent);
   --vaadin-icon-color: var(--aura-accent-contrast-color);
   outline-offset: 2px;
+}
+
+vaadin-side-nav-item:not([current]) > vaadin-icon[slot='prefix'] {
+  opacity: 0.8;
 }


### PR DESCRIPTION
Side nav Aura theme updates:

- Use the same surface level and opacity as for buttons.
- Reduce the prominence of prefix icons by using opacity.
- Use text color transition on all states, not just hover.
