### PR TITLE
refactor: import global styles helper from component-base

### DIFF
--- a/dev/common.js
+++ b/dev/common.js
@@ -1,7 +1,7 @@
 import { css } from 'lit';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { addGlobalStyles } from '@vaadin/component-base/src/styles/add-global-styles.js';
 
-addGlobalThemeStyles(
+addGlobalStyles(
   'dev-common',
   css`
     :where(body) {

--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -19,7 +19,7 @@
 import '@vaadin/component-base/src/styles/style-props.js';
 import '@vaadin/component-base/src/styles/user-colors.js';
 import { css, unsafeCSS } from 'lit';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { addGlobalStyles } from '@vaadin/component-base/src/styles/add-global-styles.js';
 
 /* Tooltip styles, to support `"tooltip": { "outside": true }` config option */
 // postcss-lit-disable-next-line
@@ -62,7 +62,7 @@ const tooltipStyles = (scope) => css`
   }
 `;
 
-addGlobalThemeStyles(
+addGlobalStyles(
   'vaadin-charts-tooltip',
   css`
     .highcharts-tooltip-container .highcharts-root {

--- a/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
+++ b/packages/form-layout/src/styles/vaadin-form-layout-base-styles.js
@@ -5,9 +5,9 @@
  */
 import '@vaadin/component-base/src/styles/style-props.js';
 import { css } from 'lit';
-import { addGlobalThemeStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+import { addGlobalStyles } from '@vaadin/component-base/src/styles/add-global-styles.js';
 
-addGlobalThemeStyles(
+addGlobalStyles(
   'vaadin-form-layout-base',
   css`
     @layer vaadin.base {


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10571

Now when we have `addGlobalStyles` helper in `@vaadin/component-base`. it makes sense to use it in components.
Once that is done, we can remove `addGlobalThemeStyles` as no longer used (will create a separate PR for that).

## Type of change

- Refactor