### PR TITLE
refactor!: remove no longer used addGlobalThemeStyles helper

### DIFF
--- a/packages/vaadin-themable-mixin/register-styles.d.ts
+++ b/packages/vaadin-themable-mixin/register-styles.d.ts
@@ -1,9 +1,6 @@
-import type { CSSResultGroup } from 'lit';
-
 /**
  * @license
  * Copyright (c) 2017 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 export { registerStyles, css, unsafeCSS } from './vaadin-themable-mixin.js';
-export const addGlobalThemeStyles: (id: string, ...styles: CSSResultGroup[]) => void;

--- a/packages/vaadin-themable-mixin/register-styles.js
+++ b/packages/vaadin-themable-mixin/register-styles.js
@@ -4,20 +4,3 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 export { registerStyles, css, unsafeCSS } from './vaadin-themable-mixin.js';
-
-/**
- * This is for use internally by Lumo and Material styles.
- *
- * @param {string} id the id to set on the created element, only for informational purposes
- * @param  {CSSResultGroup[]} styles the styles to add
- */
-export const addGlobalThemeStyles = (id, ...styles) => {
-  const styleTag = document.createElement('style');
-  styleTag.id = id;
-  styleTag.textContent = styles
-    .map((style) => style.toString())
-    .join('\n')
-    .replace(':host', 'html');
-
-  document.head.insertAdjacentElement('afterbegin', styleTag);
-};


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/10672

This helper is considered internal and in case anyone else uses it, they can import `addGlobalStyles` instead.

## Type of change

- Internal breaking change