### PR TITLE
Revert "refactor: remove backdrop filter from opaque overlays (#10621)"

### DIFF
--- a/packages/aura/src/components/overlay.css
+++ b/packages/aura/src/components/overlay.css
@@ -34,9 +34,4 @@
   font-weight: var(--aura-font-weight-regular);
   line-height: var(--aura-line-height-m);
   color: var(--vaadin-text-color);
-
-  @container style(--aura-overlay-surface-opacity: 1) {
-    -webkit-backdrop-filter: none;
-    backdrop-filter: none;
-  }
 }


### PR DESCRIPTION
## Description

This reverts commit f09811a39941563192ad23747939124f18c98b89.

Fixes https://github.com/vaadin/web-components/issues/10678

The CSS added in the above PR caused page crashes, let's revert it.

## Type of change

- Bugfix