### PR TITLE
test: unskip icon flex container unit tests

### DIFF
--- a/packages/icon/test/icon.test.js
+++ b/packages/icon/test/icon.test.js
@@ -477,8 +477,7 @@ describe('vaadin-icon', () => {
     });
   });
 
-  // TODO: Enable when unit tests are using the base theme
-  describe.skip('flex container', () => {
+  describe('flex container', () => {
     let container;
 
     beforeEach(async () => {


### PR DESCRIPTION
## Description

These tests were originally skipped in https://github.com/vaadin/web-components/issues/9490, let's enable them.

## Type of change

- Test