### PR TITLE
experiment: general-purpose overlay animations

### DIFF
--- a/dev/notification.html
+++ b/dev/notification.html
@@ -150,7 +150,7 @@
         <span slot="suffix">sec</span>
       </vaadin-integer-field>
 
-      <vaadin-button id="show-notification">Show</vaadin-button>
+      <vaadin-button id="show-notification" theme="primary">Show</vaadin-button>
     </section>
   </body>
 </html>

--- a/packages/aura/src/components/dialog.css
+++ b/packages/aura/src/components/dialog.css
@@ -28,3 +28,15 @@ vaadin-confirm-dialog::part(message) {
   border-radius: var(--vaadin-dialog-border-radius, var(--vaadin-radius-l));
   z-index: 1;
 }
+
+vaadin-dialog,
+vaadin-confirm-dialog,
+vaadin-crud {
+  --vaadin-overlay-animation-duration: 0.16s;
+  --vaadin-overlay-scale-closed: 0.97;
+
+  &[closing] {
+    --vaadin-overlay-animation-duration: 0.12s;
+    --vaadin-overlay-animation-delay: 60ms;
+  }
+}

--- a/packages/aura/src/components/item-overlay.css
+++ b/packages/aura/src/components/item-overlay.css
@@ -89,3 +89,20 @@ vaadin-select-item:where([role]) {
   margin-inline: calc(var(--vaadin-gap-xs) + var(--vaadin-padding-inline-container));
   border-color: var(--vaadin-border-color);
 }
+
+vaadin-combo-box,
+vaadin-multi-select-combo-box,
+vaadin-date-picker,
+vaadin-date-time-picker,
+vaadin-time-picker,
+vaadin-select,
+vaadin-menu-bar,
+vaadin-context-menu,
+vaadin-popover {
+  --vaadin-overlay-animation-duration: 80ms;
+
+  &[closing] {
+    --vaadin-overlay-animation-delay: 60ms;
+    --vaadin-overlay-animation-timing-function: ease-in;
+  }
+}

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -97,6 +97,21 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
 
   static get styles() {
     return css`
+      :host {
+        --vaadin-overlay-animation-duration: inherit;
+        --vaadin-overlay-animation-delay: inherit;
+        --vaadin-overlay-animation-direction: inherit;
+        --vaadin-overlay-animation-timing-function: inherit;
+        --vaadin-overlay-opacity-closed: inherit;
+        --vaadin-overlay-opacity-opened: inherit;
+        --vaadin-overlay-translate-closed: inherit;
+        --vaadin-overlay-translate-opened: inherit;
+        --vaadin-overlay-scale-closed: inherit;
+        --vaadin-overlay-scale-opened: inherit;
+        --vaadin-overlay-transform-closed: inherit;
+        --vaadin-overlay-transform-opened: inherit;
+      }
+
       :host([opened]),
       :host([opening]),
       :host([closing]) {

--- a/packages/notification/src/styles/vaadin-notification-card-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-card-base-styles.js
@@ -5,10 +5,46 @@
  */
 import '@vaadin/component-base/src/styles/style-props.js';
 import { css } from 'lit';
+import { overlayAnimationStyles } from '@vaadin/overlay/src/styles/vaadin-overlay-base-styles.js';
 
 export const notificationCardStyles = css`
+  ${overlayAnimationStyles}
+
   :host {
     display: block;
+    --vaadin-overlay-animation-duration: 0.3s;
+    --vaadin-overlay-animation-delay: 0.1s;
+  }
+
+  :host([slot^='top']) {
+    display: flex;
+    align-items: end;
+  }
+
+  :host([slot^='top']) {
+    --vaadin-overlay-translate-closed: 0% -30%;
+  }
+
+  :host([slot^='bottom']) {
+    --vaadin-overlay-translate-closed: 0% 30%;
+  }
+
+  @media (min-width: 600px) and (min-height: 600px) {
+    :host([slot$='start']) {
+      --vaadin-overlay-translate-closed: -30% 0%;
+      --vaadin-overlay-animation-delay: var(--vaadin-overlay-animation-duration);
+    }
+
+    :host([slot$='end']) {
+      --vaadin-overlay-translate-closed: 30% 0%;
+      --vaadin-overlay-animation-delay: var(--vaadin-overlay-animation-duration);
+    }
+  }
+
+  :host([closing]) {
+    --vaadin-overlay-translate-closed: 0%;
+    --vaadin-overlay-scale-closed: 0.98;
+    --vaadin-overlay-animation-delay: 0s;
   }
 
   [part='overlay'] {
@@ -28,6 +64,67 @@ export const notificationCardStyles = css`
   @media (forced-colors: active) {
     [part='overlay'] {
       border: 3px solid !important;
+    }
+  }
+
+  @supports (interpolate-size: allow-keywords) {
+    :host {
+      interpolate-size: allow-keywords;
+      transition-duration: var(--vaadin-overlay-animation-duration);
+      transition-property: height, margin-top, margin-bottom;
+    }
+
+    @starting-style {
+      :host(:not(:nth-child(1 of [slot='middle']))) {
+        height: 0;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+      }
+    }
+
+    :host([closing]) {
+      height: 0;
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+      transition-delay: var(--vaadin-overlay-animation-duration);
+      animation-duration: calc(var(--vaadin-overlay-animation-duration) * 2);
+    }
+  }
+
+  @supports not (interpolate-size: allow-keywords) {
+    :host {
+      transition-duration: var(--vaadin-overlay-animation-duration);
+      transition-property: max-height, margin-top, margin-bottom;
+      max-height: 25em;
+    }
+
+    :host([opening]:not(:nth-child(1 of [slot='middle']))) {
+      animation: --notification-enter
+        calc(var(--vaadin-overlay-animation-duration) + var(--vaadin-overlay-animation-delay));
+    }
+
+    :host([closing]) {
+      max-height: 0;
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+      animation-duration: calc(var(--vaadin-overlay-animation-duration) * 1.5);
+      transition-delay: calc(var(--vaadin-overlay-animation-duration) / 2);
+    }
+  }
+
+  @media (prefers-reduced-motion) {
+    :host {
+      transition-duration: 0s;
+    }
+
+    :host([closing]) {
+      transition-delay: var(--vaadin-overlay-animation-duration);
+    }
+  }
+
+  @keyframes --notification-enter {
+    0% {
+      max-height: 0;
     }
   }
 `;

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -6,6 +6,162 @@
 import '@vaadin/component-base/src/styles/style-props.js';
 import { css } from 'lit';
 
+['--vaadin-overlay-animation-duration', '--vaadin-overlay-animation-delay'].forEach((propertyName) => {
+  CSS.registerProperty({
+    name: propertyName,
+    syntax: '<time>',
+    inherits: false,
+    initialValue: '0s',
+  });
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-animation-timing-function',
+  syntax: '*',
+  inherits: false,
+  initialValue: 'ease',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-animation-direction',
+  syntax: '<custom-ident>',
+  inherits: false,
+  initialValue: 'normal',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-opacity-closed',
+  syntax: '<number>',
+  inherits: false,
+  initialValue: '0',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-opacity-opened',
+  syntax: '<number>',
+  inherits: false,
+  initialValue: '1',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-translate-closed',
+  syntax: '<length>+ | <percentage>+',
+  inherits: false,
+  initialValue: '0',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-translate-opened',
+  syntax: '<length>+ | <percentage>+',
+  inherits: false,
+  initialValue: '0',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-scale-closed',
+  syntax: '<number> | <percentage>',
+  inherits: false,
+  initialValue: '1',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-scale-opened',
+  syntax: '<number> | <percentage>',
+  inherits: false,
+  initialValue: '1',
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-transform-closed',
+  syntax: '*',
+  inherits: false,
+});
+
+CSS.registerProperty({
+  name: '--vaadin-overlay-transform-opened',
+  syntax: '*',
+  inherits: false,
+});
+
+/* Reusable animation styles for overlay enter and exit */
+export const overlayAnimationStyles = css`
+  :host,
+  [part='overlay'],
+  [part='backdrop'] {
+    --vaadin-overlay-animation-duration: inherit;
+    --vaadin-overlay-animation-delay: inherit;
+    --vaadin-overlay-animation-direction: inherit;
+    --vaadin-overlay-animation-timing-function: inherit;
+    --vaadin-overlay-opacity-closed: inherit;
+    --vaadin-overlay-opacity-opened: inherit;
+    --vaadin-overlay-translate-closed: inherit;
+    --vaadin-overlay-translate-opened: inherit;
+    --vaadin-overlay-scale-closed: inherit;
+    --vaadin-overlay-scale-opened: inherit;
+    --vaadin-overlay-transform-closed: inherit;
+    --vaadin-overlay-transform-opened: inherit;
+  }
+
+  :host(:is([opening], [closing])) {
+    animation-name: --no-op;
+    animation-duration: var(--vaadin-overlay-animation-duration);
+    animation-delay: var(--vaadin-overlay-animation-delay);
+  }
+
+  :host([closing]) [part='overlay'],
+  :host([closing]) ::slotted(*) {
+    pointer-events: none !important;
+  }
+
+  :host(:is([opening], [closing])) :is([part='overlay'], [part='backdrop']) {
+    animation-name: --fade, --transform;
+    animation-duration: var(--vaadin-overlay-animation-duration);
+    animation-timing-function: var(--vaadin-overlay-animation-timing-function);
+    animation-delay: var(--vaadin-overlay-animation-delay);
+    animation-fill-mode: both;
+    animation-direction: var(--vaadin-overlay-animation-direction);
+
+    @media (prefers-reduced-motion) {
+      animation-name: --fade;
+    }
+  }
+
+  :host(:is([opening], [closing])) [part='backdrop'] {
+    animation-name: --fade;
+    animation-timing-function: linear;
+    --vaadin-overlay-opacity-closed: 0;
+  }
+
+  :host([closing]) {
+    --vaadin-overlay-animation-direction: reverse;
+  }
+
+  @keyframes --no-op {
+  }
+
+  @keyframes --transform {
+    0% {
+      transform: var(--vaadin-overlay-transform-closed);
+      translate: var(--vaadin-overlay-translate-closed);
+      scale: var(--vaadin-overlay-scale-closed);
+    }
+    100% {
+      transform: var(--vaadin-overlay-transform-opened);
+      translate: var(--vaadin-overlay-translate-opened);
+      scale: var(--vaadin-overlay-scale-opened);
+    }
+  }
+
+  @keyframes --fade {
+    0% {
+      opacity: var(--vaadin-overlay-opacity-closed);
+    }
+    100% {
+      opacity: var(--vaadin-overlay-opacity-opened);
+    }
+  }
+`;
+
 export const overlayStyles = css`
   :host {
     z-index: 200;
@@ -102,4 +258,6 @@ export const overlayStyles = css`
       border: 3px solid !important;
     }
   }
+
+  ${overlayAnimationStyles}
 `;


### PR DESCRIPTION
Fixes #11321 

Adds built-in keyframe animations to all overlays, which a theme can then turn on via CSS custom properties (see the changed files for examples how). For a simple fade-in/out animation, all that is needed is to define the `--animation-duration` property on a component with an overlay.

Experimented with notification animations at the same time, as they require a bit more elaborate configuration so that the stacking notifications enter and leave without all the other notifications jumping suddenly.