### PR TITLE
fix: prevent stack overflow on clearCache during grid-pro edit

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -537,7 +537,8 @@ export const InlineEditingMixin = (superClass) =>
         if (!this._isCellEditable(cell)) {
           // Cell is no longer editable, cancel edit
           this._stopEdit(true, true);
-        } else if (cell.parentNode === row && this.getItemId(model.item) !== this.getItemId(item)) {
+        } else if (cell.parentNode === row && item && this.getItemId(model.item) !== this.getItemId(item)) {
+          // Edited item identity has changed, stop edit
           this._stopEdit();
         }
       }


### PR DESCRIPTION
## Description

Fixes stack overflow error ("Maximum call stack size exceeded") when the grid-pro cache is cleared in the "item-property-changed" event handler during grid-pro inline editing.

Fixes https://github.com/vaadin/flow-components/issues/8261

## Type of change

Bugfix