### PR TITLE
fix: scope hover styles with hover media

### DIFF
--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -16,10 +16,6 @@ vaadin-side-nav::part(label) {
   transition: color 80ms;
 }
 
-vaadin-side-nav::part(label):hover {
-  color: var(--vaadin-text-color);
-}
-
 vaadin-side-nav-item::part(content) {
   --aura-surface-level: 6;
   --aura-surface-opacity: 0.3;
@@ -31,6 +27,10 @@ vaadin-side-nav-item:not([disabled], [current])::part(content):active {
 }
 
 @media (any-hover: hover) {
+  vaadin-side-nav::part(label):hover {
+    --vaadin-side-nav-label-color: var(--vaadin-text-color);
+  }
+
   vaadin-side-nav-item:not([disabled], [current])::part(content):hover {
     --vaadin-side-nav-item-text-color: var(--vaadin-text-color);
   }


### PR DESCRIPTION
Only apply hover styles on hover-enabled devices. Use the base style custom property for setting the label color.