### PR TITLE
fix: do not dispatch backdrop click when mousedown is in details

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -31,6 +31,13 @@ export const masterDetailLayoutStyles = css`
   [part='_detail-internal'] {
     display: contents;
     justify-content: end;
+    /* Disable pointer events for the detail wrapper to allow clicks to pass through to the backdrop */
+    pointer-events: none;
+  }
+
+  [part='detail'] {
+    /* Re-enable pointer events for the actual detail content */
+    pointer-events: auto;
   }
 
   :host([orientation='vertical']) [part='_detail-internal'] {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -241,7 +241,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   /** @protected */
   render() {
     return html`
-      <div part="backdrop"></div>
+      <div part="backdrop" @click="${this.__onBackdropClick}"></div>
       <div
         id="master"
         part="master"
@@ -249,7 +249,7 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
       >
         <slot></slot>
       </div>
-      <div part="_detail-internal" @click="${this.__onDetailClick}">
+      <div part="_detail-internal">
         <div
           id="detail"
           part="detail"
@@ -281,12 +281,8 @@ class MasterDetailLayout extends SlotStylesMixin(ResizeMixin(ElementMixin(Themab
   }
 
   /** @private */
-  __onDetailClick(e) {
-    // The detail wrapper element fully covers the backdrop part, so listen
-    // to click event on it and detect if it was outside the detail content
-    if (!e.composedPath().includes(this.$.detail)) {
-      this.dispatchEvent(new CustomEvent('backdrop-click'));
-    }
+  __onBackdropClick() {
+    this.dispatchEvent(new CustomEvent('backdrop-click'));
   }
 
   /** @private */


### PR DESCRIPTION
## Description

https://github.com/vaadin/web-components/pull/9665 introduced a regression where `mousedown` on the details content and `mouseup` on the internal details wrapper can result in a `click` and thus a `backdrop-click` event. This is because the internal details wrapper is a common ancestor for both `mousedown` and `mouseup`. 

This change removes pointer events on the details wrapper and restores them on the details content, which allows clicking the actual backdrop.

Fixes https://github.com/vaadin/web-components/issues/10702

## Type of change

- Bugfix
