### PR TITLE
fix: unify the fallback value for date-picker-month-padding

### DIFF
--- a/packages/date-picker/src/styles/vaadin-date-picker-overlay-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-date-picker-overlay-base-styles.js
@@ -14,7 +14,8 @@ export const datePickerOverlayStyles = css`
     width: var(
       --vaadin-date-picker-overlay-width,
       calc(
-        var(--vaadin-date-picker-date-width, 2rem) * 7 + var(--vaadin-date-picker-month-padding, 0.5rem) * 2 +
+        var(--vaadin-date-picker-date-width, 2rem) * 7 +
+          var(--vaadin-date-picker-month-padding, var(--vaadin-padding-s)) * 2 +
           var(--vaadin-date-picker-year-scroller-width, 3rem)
       )
     );


### PR DESCRIPTION
Use the same fallback value as in `vaadin-month-calendar-base-styles.js`: https://github.com/vaadin/web-components/blob/1ec92b0f355c3d427852c7778a17469967e0c496/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js#L12

Without this, using a larger custom value for `--aura-base-size` breaks the month calendar layout with Aura. Here with `--aura-base-size: 18;`:

<img width="321" height="496" alt="Screenshot 2025-12-18 at 15 09 59" src="https://github.com/user-attachments/assets/928601a4-3f21-402d-8f78-e9dd52e97bae" />
