### PR TITLE
fix: ensure selection column auto width is same regardless whether checkboxes are visible or not

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -162,13 +162,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
       checkbox.checked = checked;
       checkbox.indeterminate = this._indeterminate;
-      if (this._selectAllHidden) {
-        checkbox.style.visibility = 'hidden';
-        checkbox.setAttribute('aria-hidden', 'true');
-      } else {
-        checkbox.style.visibility = '';
-        checkbox.removeAttribute('aria-hidden');
-      }
+      checkbox.style.visibility = this._selectAllHidden ? 'hidden' : '';
     }
 
     /**
@@ -193,7 +187,9 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
       const isSelectable = this._grid.__isItemSelectable(item);
       checkbox.readonly = !isSelectable;
-      checkbox.hidden = !isSelectable && !selected;
+
+      const isHidden = !isSelectable && !selected;
+      checkbox.style.visibility = isHidden ? 'hidden' : '';
     }
 
     /**

--- a/packages/grid/test/selectable-provider.test.js
+++ b/packages/grid/test/selectable-provider.test.js
@@ -48,7 +48,7 @@ describe('selectable-provider', () => {
     it('should hide checkboxes for non-selectable items that are not selected', () => {
       for (let i = 0; i < grid.items.length; i++) {
         expect(getItemCheckbox(i).readonly).to.equal(i < 5);
-        expect(getItemCheckbox(i).hidden).to.equal(i < 5);
+        expect(getItemCheckbox(i).checkVisibility({ visibilityProperty: true })).to.equal(i >= 5);
       }
     });
 
@@ -57,7 +57,7 @@ describe('selectable-provider', () => {
 
       for (let i = 0; i < grid.items.length; i++) {
         expect(getItemCheckbox(i).readonly).to.equal(i < 5);
-        expect(getItemCheckbox(i).hidden).to.be.false;
+        expect(getItemCheckbox(i).checkVisibility({ visibilityProperty: true })).to.be.true;
       }
     });
 
@@ -66,7 +66,7 @@ describe('selectable-provider', () => {
       flushGrid(grid);
 
       for (let i = 0; i < grid.items.length; i++) {
-        expect(getItemCheckbox(i).hidden).to.equal(i >= 5);
+        expect(getItemCheckbox(i).checkVisibility({ visibilityProperty: true })).to.equal(i < 5);
       }
     });
   });
@@ -203,8 +203,7 @@ describe('selectable-provider', () => {
 
   describe('select all', () => {
     it('should hide select all checkbox when using isItemSelectable provider', () => {
-      expect(selectAllCheckbox.style.visibility).to.equal('hidden');
-      expect(selectAllCheckbox.ariaHidden).to.equal('true');
+      expect(selectAllCheckbox.checkVisibility({ visibilityProperty: true })).to.be.false;
     });
 
     it('should hide select all checkbox when adding a selection column to an existing grid with an isItemSelectable provider', async () => {
@@ -220,8 +219,7 @@ describe('selectable-provider', () => {
       await nextFrame();
       selectAllCheckbox = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-checkbox');
 
-      expect(selectAllCheckbox.style.visibility).to.equal('hidden');
-      expect(selectAllCheckbox.getAttribute('aria-hidden')).to.equal('true');
+      expect(selectAllCheckbox.checkVisibility({ visibilityProperty: true })).to.be.false;
     });
 
     it('should show select all checkbox when removing isItemSelectable provider', async () => {

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -424,15 +424,13 @@ describe('multi selection column', () => {
     grid.dataProvider = infiniteDataProvider;
     await nextFrame();
 
-    expect(selectAllCheckbox.style.visibility).to.equal('hidden');
-    expect(selectAllCheckbox.getAttribute('aria-hidden')).to.equal('true');
+    expect(selectAllCheckbox.checkVisibility({ visibilityProperty: true })).to.be.false;
   });
 
   it('should show select all checkbox when items is set', () => {
     grid.items = ['foo'];
 
-    expect(selectAllCheckbox.style.visibility).to.equal('');
-    expect(selectAllCheckbox.hasAttribute('aria-hidden')).to.be.false;
+    expect(selectAllCheckbox.checkVisibility({ visibilityProperty: true })).to.be.true;
   });
 
   it('should be possible to override the body renderer', () => {


### PR DESCRIPTION
## Description

Changes the selection column checkboxes to use `visibility: hidden` to preserve their element box when hidden, in order to have something measure when using auto sizing and none of the checkboxes are visible.

Fixes https://github.com/vaadin/flow-components/issues/8348

## Type of change

- Bugfix
