### PR TITLE
chore: update Chrome version for Aura tests, fix screenshot path

### DIFF
--- a/web-test-runner-aura.config.js
+++ b/web-test-runner-aura.config.js
@@ -1,3 +1,3 @@
 import { createVisualTestsConfig } from './wtr-utils.js';
 
-export default createVisualTestsConfig('aura', '138');
+export default createVisualTestsConfig('aura', '143');

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -226,7 +226,7 @@ const getScreenshotFileName = ({ name, testFile }, type, diff) => {
     folder = 'field-base/test/visual/screenshots';
   } else {
     const match = testFile.match(/\/packages\/(.+)\.test\.(js|ts)/u);
-    folder = match[1].replace(/(base|lumo)/u, '$1/screenshots');
+    folder = match[1].replace(/(base|lumo|aura)/u, '$1/screenshots');
   }
   return path.join(folder, type, diff ? `${name}-diff` : name);
 };


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/10730

Let's use Chrome 143 which is the latest one before we start adding actual tests.

## Type of change

- Internal change