### PR TITLE
docs: add button base style properties to JSDoc

### DIFF
--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -34,6 +34,23 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  * `focused`      | Set when the button is focused
  * `has-tooltip`  | Set when the button has a slotted tooltip
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-button-background`     |
+ * | `--vaadin-button-border-color`   |
+ * | `--vaadin-button-border-radius`  |
+ * | `--vaadin-button-border-width`   |
+ * | `--vaadin-button-font-size`      |
+ * | `--vaadin-button-font-weight`    |
+ * | `--vaadin-button-gap`            |
+ * | `--vaadin-button-height`         |
+ * | `--vaadin-button-line-height`    |
+ * | `--vaadin-button-margin`         |
+ * | `--vaadin-button-padding`        |
+ * | `--vaadin-button-text-color`     |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
 declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(HTMLElement))) {

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -40,6 +40,23 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  * `focused`      | Set when the button is focused
  * `has-tooltip`  | Set when the button has a slotted tooltip
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-button-background`     |
+ * | `--vaadin-button-border-color`   |
+ * | `--vaadin-button-border-radius`  |
+ * | `--vaadin-button-border-width`   |
+ * | `--vaadin-button-font-size`      |
+ * | `--vaadin-button-font-weight`    |
+ * | `--vaadin-button-gap`            |
+ * | `--vaadin-button-height`         |
+ * | `--vaadin-button-line-height`    |
+ * | `--vaadin-button-margin`         |
+ * | `--vaadin-button-padding`        |
+ * | `--vaadin-button-text-color`     |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @customElement


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/9617

Added `vaadin-button` base styles properties to JSDoc.

## Type of change

- Documentation