### PR TITLE
feat: add --vaadin-grid-cell-text-overflow CSS custom property

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -387,7 +387,7 @@ export const gridStyles = css`
   .cell ::slotted(vaadin-grid-cell-content) {
     display: block;
     overflow: hidden;
-    text-overflow: ellipsis;
+    text-overflow: var(--vaadin-grid-cell-text-overflow, ellipsis);
     padding: var(--_cell-padding);
     flex: 1;
     min-height: 1lh;

--- a/packages/vaadin-lumo-styles/src/components/grid.css
+++ b/packages/vaadin-lumo-styles/src/components/grid.css
@@ -190,7 +190,7 @@
     width: 100%;
     box-sizing: border-box;
     overflow: hidden;
-    text-overflow: ellipsis;
+    text-overflow: var(--vaadin-grid-cell-text-overflow, ellipsis);
     cursor: inherit;
     padding: var(--_cell-padding);
   }


### PR DESCRIPTION
## Description

The PR introduces a new `--vaadin-grid-cell-text-overflow` CSS custom property to simplify customizing the `text-overflow` CSS property on individual `<vaadin-grid-cell-content>` elements.

```css
vaadin-grid::part(cell cell-custom-part) {
  --vaadin-grid-cell-text-overflow: clip; /* to override the default value "ellipsis" */
}
```

Follows up on https://github.com/vaadin/web-components/pull/10488#issuecomment-3674117008 and https://github.com/vaadin/web-components/issues/10719 by @knoobie 

## Type of change

- [x] Bugfix
