### PR TITLE
docs: update JSDoc comment for the internal theme property

### DIFF
--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.d.ts
@@ -16,14 +16,13 @@ export declare class ThemePropertyMixinClass {
    *
    * Enables the component implementation to propagate the `theme`
    * attribute value to the sub-components in Shadow DOM by binding
-   * the sub-component's "theme" attribute to the `theme` property of
-   * the host.
+   * the sub-component's "theme" attribute using the Lit template:
    *
-   * **NOTE:** Extending the mixin only provides the property for binding,
-   * and does not make the propagation alone.
-   *
-   * See [Styling Components: Sub-components](https://vaadin.com/docs/latest/styling/styling-components/#sub-components).
-   * page for more information.
+   * ```html
+   * <vaadin-notification-card
+   *   theme="${ifDefined(this._theme)}"
+   * ></vaadin-notification-card>
+   * ```
    *
    * @protected
    */

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
@@ -16,14 +16,13 @@ export const ThemePropertyMixin = (superClass) =>
          *
          * Enables the component implementation to propagate the `theme`
          * attribute value to the sub-components in Shadow DOM by binding
-         * the sub-component's "theme" attribute to the `theme` property of
-         * the host.
+         * the sub-component's "theme" attribute using the Lit template:
          *
-         * **NOTE:** Extending the mixin only provides the property for binding,
-         * and does not make the propagation alone.
-         *
-         * See [Styling Components: Sub-components](https://vaadin.com/docs/latest/styling/styling-components/#sub-components).
-         * page for more information.
+         * ```html
+         * <vaadin-notification-card
+         *   theme="${ifDefined(this._theme)}"
+         * ></vaadin-notification-card>
+         * ```
          *
          * @protected
          */


### PR DESCRIPTION
## Description

The current JSDoc is not very helpful as it refers to vaadin.com Styling docs that have been changed.
Updated to explicitly mention the need for `ifDefined()` directive and provided an HTML example.

## Type of change

- Documentation