### PR TITLE
test: replace renderer with light DOM content in popover tests

### DIFF
--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -19,16 +19,13 @@ describe('a11y', () => {
   beforeEach(async () => {
     [popover, target] = fixtureSync(`
       <div>
-        <vaadin-popover></vaadin-popover>
+        <vaadin-popover>
+          <input />
+        </vaadin-popover>
         <button>Target</button>
       </div>
     `).children;
     popover.target = target;
-    popover.renderer = (root) => {
-      if (!root.firstChild) {
-        root.appendChild(document.createElement('input'));
-      }
-    };
     await nextRender();
     overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
   });

--- a/packages/popover/test/timers.test.js
+++ b/packages/popover/test/timers.test.js
@@ -34,10 +34,7 @@ describe('timers', () => {
   });
 
   beforeEach(async () => {
-    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
-    popover.renderer = (root) => {
-      root.textContent = 'Content';
-    };
+    popover = fixtureSync('<vaadin-popover>Content</vaadin-popover>');
     target = fixtureSync('<button>Target</button>');
     popover.target = target;
     await nextRender();

--- a/packages/popover/test/trigger.test.js
+++ b/packages/popover/test/trigger.test.js
@@ -25,18 +25,14 @@ describe('trigger', () => {
   });
 
   beforeEach(async () => {
-    popover = fixtureSync('<vaadin-popover></vaadin-popover>');
+    popover = fixtureSync(`
+      <vaadin-popover>
+        <input />
+        <div>Some text content</div>
+      </vaadin-popover>
+    `);
     target = fixtureSync('<button>Target</button>');
     popover.target = target;
-    popover.renderer = (root) => {
-      if (!root.firstChild) {
-        root.appendChild(document.createElement('input'));
-
-        const div = document.createElement('div');
-        div.textContent = 'Some text content';
-        root.appendChild(div);
-      }
-    };
     await nextRender();
     overlay = popover.shadowRoot.querySelector('vaadin-popover-overlay');
   });

--- a/packages/popover/test/visual/base/popover.test.js
+++ b/packages/popover/test/visual/base/popover.test.js
@@ -7,13 +7,12 @@ describe('popover', () => {
   let div, target, element;
 
   beforeEach(async () => {
-    element = fixtureSync('<vaadin-popover></vaadin-popover>');
-    element.renderer = (root) => {
-      root.innerHTML = `
+    element = fixtureSync(`
+      <vaadin-popover>
         <div>This is the popover content</div>
         <div>It contains multiple lines</div>
-      `;
-    };
+      </vaadin-popover>
+    `);
     div = fixtureSync(`
       <div style="display: flex; width: 600px; height: 600px; justify-content: center; align-items: center">
         <div style="width: 100px; height: 100px; outline: 1px solid red;"></div>

--- a/packages/popover/test/visual/lumo/popover.test.js
+++ b/packages/popover/test/visual/lumo/popover.test.js
@@ -10,10 +10,7 @@ describe('popover', () => {
   let div, target, element;
 
   beforeEach(async () => {
-    element = fixtureSync('<vaadin-popover></vaadin-popover>');
-    element.renderer = (root) => {
-      root.textContent = 'Content';
-    };
+    element = fixtureSync('<vaadin-popover>Content</vaadin-popover>');
     div = fixtureSync(`
       <div style="display: flex; width: 300px; height: 300px; justify-content: center; align-items: center">
         <div style="width: 100px; height: 100px; outline: 1px solid red;"></div>


### PR DESCRIPTION
## Description

Replaced `renderer` with slotted content in `vaadin-popover` unit and visual tests.
There are dedicated tests for `renderer` property, these are unchanged.

## Type of change

- Test