### PR TITLE
test: remove no longer relevant group wrapping unit tests

### DIFF
--- a/packages/checkbox-group/test/checkbox-group.test.js
+++ b/packages/checkbox-group/test/checkbox-group.test.js
@@ -362,45 +362,4 @@ describe('vaadin-checkbox-group', () => {
       expect(console.warn.called).to.be.false;
     });
   });
-
-  describe('wrapping', () => {
-    beforeEach(async () => {
-      group = fixtureSync(`
-        <vaadin-checkbox-group>
-          <vaadin-checkbox value="c_1" label="Checkbox 1"></vaadin-checkbox>
-          <vaadin-checkbox value="c_2" label="Checkbox 2"></vaadin-checkbox>
-          <vaadin-checkbox value="c_3" label="Checkbox 3"></vaadin-checkbox>
-          <vaadin-checkbox value="c_4" label="Checkbox 4"></vaadin-checkbox>
-          <vaadin-checkbox value="c_5" label="Checkbox 5"></vaadin-checkbox>
-          <vaadin-checkbox value="c_6" label="Checkbox 6"></vaadin-checkbox>
-          <vaadin-checkbox value="c_7" label="Checkbox 7"></vaadin-checkbox>
-          <vaadin-checkbox value="c_8" label="Checkbox 8"></vaadin-checkbox>
-          <vaadin-checkbox value="c_9" label="Checkbox 9"></vaadin-checkbox>
-          <vaadin-checkbox value="c_10" label="Checkbox 10"></vaadin-checkbox>
-          <vaadin-checkbox value="c_11" label="Checkbox 11"></vaadin-checkbox>
-          <vaadin-checkbox value="c_12" label="Checkbox 12"></vaadin-checkbox>
-        </vaadin-checkbox-group>
-      `);
-      await nextFrame();
-    });
-
-    it('should not overflow horizontally', () => {
-      const parentWidth = group.parentElement.offsetWidth;
-
-      expect(group.offsetWidth).to.be.lte(parentWidth);
-      expect(group.shadowRoot.querySelector('[part~="group-field"]').offsetWidth).to.be.lte(parentWidth);
-    });
-
-    it('should wrap checkboxes', () => {
-      const checkboxes = Array.from(group.children);
-      const { top: firstTop, left: firstLeft } = checkboxes[0].getBoundingClientRect();
-
-      const wrapped = Array.from(checkboxes)
-        .slice(1)
-        .filter((checkbox) => checkbox.getBoundingClientRect().top > firstTop);
-
-      expect(wrapped).to.not.be.empty;
-      expect(wrapped[0].getBoundingClientRect().left).to.equal(firstLeft);
-    });
-  });
 });

--- a/packages/radio-group/test/radio-group.test.js
+++ b/packages/radio-group/test/radio-group.test.js
@@ -525,47 +525,4 @@ describe('radio-group', () => {
       expect(group.value).to.equal('value2');
     });
   });
-
-  describe('wrapping', () => {
-    let wrapper;
-
-    beforeEach(async () => {
-      wrapper = fixtureSync(`
-        <div style="width: 500px">
-          <vaadin-radio-group>
-            <vaadin-radio-button label="Radio button 1" value="r_1"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 2" value="r_2"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 3" value="r_3"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 4" value="r_4"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 5" value="r_5"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 6" value="r_6"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 7" value="r_7"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 8" value="r_8"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 9" value="r_9"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 10" value="r_10"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 11" value="r_11"></vaadin-radio-button>
-            <vaadin-radio-button label="Radio button 12" value="r_12"></vaadin-radio-button>
-          </vaadin-radio-group>
-        </div>
-      `);
-      group = wrapper.firstElementChild;
-      await nextFrame();
-    });
-
-    it('should not overflow horizontally', () => {
-      const parentWidth = wrapper.offsetWidth;
-      expect(group.offsetWidth).to.be.lte(parentWidth);
-      expect(group.shadowRoot.querySelector('[part~="group-field"]').offsetWidth).to.be.lte(parentWidth);
-    });
-
-    it('should wrap radio-buttons', () => {
-      const radios = Array.from(group.children);
-      const { top: firstTop, left: firstLeft } = radios[0].getBoundingClientRect();
-      const wrappedRadios = Array.from(radios)
-        .slice(1)
-        .filter((radio) => radio.getBoundingClientRect().top > firstTop);
-      expect(wrappedRadios).to.not.be.empty;
-      expect(wrappedRadios[0].getBoundingClientRect().left).to.equal(firstLeft);
-    });
-  });
 });


### PR DESCRIPTION
## Description

Removed unit tests that were added in V14 version:

- https://github.com/vaadin/vaadin-checkbox/pull/150
- https://github.com/vaadin/vaadin-radio-button/pull/111

These don't make sense in V25 as groups are now vertical by default in base styles.
Also, we have visual tests for "horizontal wrapped" state that cover relevant CSS.

## Type of change

- Test