### PR TITLE
refactor: add missing type definitions for dashboard-button

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-button.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-button.d.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { ButtonMixin } from '@vaadin/button/src/vaadin-button-mixin.js';
+import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ * An element used internally by `<vaadin-dashboard>`. Not intended to be used separately.
+ */
+declare class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(HTMLElement))) {}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-dashboard-button': DashboardButton;
+  }
+}
+
+export { DashboardButton };

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -18,6 +18,16 @@ import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dashboardButtonStyles } from './styles/vaadin-dashboard-button-base-styles.js';
 
+/**
+ * An element used internally by `<vaadin-dashboard>`. Not intended to be used separately.
+ *
+ * @customElement
+ * @extends HTMLElement
+ * @mixes ButtonMixin
+ * @mixes ElementMixin
+ * @mixes ThemableMixin
+ * @protected
+ */
 class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-dashboard-button';


### PR DESCRIPTION
## Description

The `vaadin-dashboard-button` doesn't have type definitions. Let's add them so we can use it in tests that use `.ts`.

## Type of change

- Refactor