### PR TITLE
test: fix TypeScript warnings in dashboard snapshot tests

### DIFF
--- a/packages/dashboard/test/dom/dashboard-button.test.ts
+++ b/packages/dashboard/test/dom/dashboard-button.test.ts
@@ -1,9 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dashboard-button.js';
+import type { DashboardButton } from '../../src/vaadin-dashboard-button.js';
 
 describe('vaadin-dashboard-button', () => {
-  let button;
+  let button: DashboardButton;
 
   beforeEach(async () => {
     button = fixtureSync('<vaadin-dashboard-button></vaadin-dashboard-button>');

--- a/packages/dashboard/test/dom/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dom/dashboard-layout.test.ts
@@ -1,9 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dashboard-layout.js';
+import type { DashboardLayout } from '../../src/vaadin-dashboard-layout.js';
 
 describe('vaadin-dashboard-layout', () => {
-  let dashboard;
+  let dashboard: DashboardLayout;
 
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard-layout></vaadin-dashboard-layout>');

--- a/packages/dashboard/test/dom/dashboard-section.test.ts
+++ b/packages/dashboard/test/dom/dashboard-section.test.ts
@@ -1,9 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dashboard-section.js';
+import type { DashboardSection } from '../../src/vaadin-dashboard-section.js';
 
 describe('vaadin-dashboard-section', () => {
-  let section;
+  let section: DashboardSection;
 
   beforeEach(async () => {
     section = fixtureSync('<vaadin-dashboard-section></vaadin-dashboard-section>');

--- a/packages/dashboard/test/dom/dashboard-widget.test.ts
+++ b/packages/dashboard/test/dom/dashboard-widget.test.ts
@@ -1,9 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dashboard-widget.js';
+import type { DashboardWidget } from '../../src/vaadin-dashboard-widget.js';
 
 describe('vaadin-dashboard-widget', () => {
-  let widget;
+  let widget: DashboardWidget;
 
   beforeEach(async () => {
     widget = fixtureSync('<vaadin-dashboard-widget></vaadin-dashboard-widget>');

--- a/packages/dashboard/test/dom/dashboard.test.ts
+++ b/packages/dashboard/test/dom/dashboard.test.ts
@@ -1,9 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../../src/vaadin-dashboard.js';
+import type { Dashboard } from '../../src/vaadin-dashboard.js';
 
 describe('vaadin-dashboard', () => {
-  let dashboard;
+  let dashboard: Dashboard;
 
   beforeEach(async () => {
     dashboard = fixtureSync('<vaadin-dashboard></vaadin-dashboard>');


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/10869

Added missing types to fix compilation errors in dashboard snapshot tests.

## Type of change

- Test