### PR TITLE
refactor: add missing type definitions for browser-utils.js

### DIFF
--- a/packages/component-base/src/browser-utils.d.ts
+++ b/packages/component-base/src/browser-utils.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+export const isAndroid: boolean;
+
+export const isChrome: boolean;
+
+export const isFirefox: boolean;
+
+export const isIPad: boolean;
+
+export const isIPhone: boolean;
+
+export const isIOS: boolean;
+
+export const isSafari: boolean;
+
+export const isTouch: boolean;


### PR DESCRIPTION
## Description

Added missing type definitions for `browser-utils.js` needed to use them in tests written in `.ts`, for example:
https://github.com/vaadin/web-components/blob/4e16c1a8fe1ddb4967d3ab732d0ece918d70d6eb/packages/dashboard/test/dashboard-widget-resizing.test.ts#L5

## Type of change

- Refactor