### PR TITLE
refactor: cleanup not needed indicator override from scroller Lumo

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/scroller.css
+++ b/packages/vaadin-lumo-styles/src/components/scroller.css
@@ -13,9 +13,4 @@
     outline: none;
     box-shadow: 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
   }
-
-  :host([theme*='overflow-indicator'])::before,
-  :host([theme*='overflow-indicator'])::after {
-    background: var(--lumo-contrast-10pct);
-  }
 }


### PR DESCRIPTION
## Description

Starting from https://github.com/vaadin/web-components/issues/10450 where `--vaadin-border-color-secondary` override was added, we don't need to set `background` to `--lumo-contrast-10pct` in scroller indicators. Let's instead use the default value:

https://github.com/vaadin/web-components/blob/e70a2f955778f347ca7d08c91b7a395e211e8cfa/packages/scroller/src/styles/vaadin-scroller-base-styles.js#L57

## Type of change

- Refactor