### PR TITLE
fix: use initial keyword to reset base style custom properties

### DIFF
--- a/packages/vaadin-lumo-styles/src/props/reset.css
+++ b/packages/vaadin-lumo-styles/src/props/reset.css
@@ -4,9 +4,13 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/* Reset properties that are set by the base theme */
+/*
+  Reset base style custom properties using the `initial` keyword to ensure
+  constructions like var(--vaadin-focus-ring-color, red) correctly resolve
+  to the fallback value (red) by default rather than the base style value.
+*/
 :where(:root),
 :where(:host) {
-  --vaadin-focus-ring-color: inherit;
-  --vaadin-focus-ring-width: inherit;
+  --vaadin-focus-ring-color: initial;
+  --vaadin-focus-ring-width: initial;
 }


### PR DESCRIPTION
## Description

Reset base style custom properties using the `initial` keyword instead of `inherit` in Lumo to ensure that constructions like `var(--vaadin-focus-ring-color, red)` correctly resolve to the fallback value (red) by default rather than the base styles' value when Lumo is loaded in a shadow DOM (note, base styles are always added to the global DOM).

Fixes https://github.com/vaadin/web-components/issues/10745

## Type of change

- [x] Bugfix
