### PR TITLE
fix: make it easier to define `--vaadin-input-field-background`

### DIFF
--- a/packages/aura/src/components/input-container.css
+++ b/packages/aura/src/components/input-container.css
@@ -1,14 +1,13 @@
 :where(:root),
 :where(:host),
 :where([theme]) {
-  --vaadin-input-field-background: var(--aura-surface-color);
   --vaadin-input-field-error-color: var(--aura-red-text);
 }
 
 ::part(input-field),
 vaadin-message-input,
 vaadin-input-container {
-  --vaadin-input-field-background: var(--aura-surface-color);
+  background: var(--vaadin-input-field-background, var(--aura-surface-color));
   --aura-surface-level: 4;
   --aura-surface-opacity: 0.7;
   background-clip: padding-box;
@@ -24,7 +23,7 @@ vaadin-message-input:not([readonly], [disabled]) {
 }
 
 [disabled]::part(input-field) {
-  --vaadin-input-field-background: var(--vaadin-background-container);
+  background-color: var(--vaadin-input-field-disabled-background, var(--vaadin-background-container));
 }
 
 ::part(field-button) {

--- a/packages/aura/src/components/message-input.css
+++ b/packages/aura/src/components/message-input.css
@@ -1,5 +1,5 @@
 vaadin-message-input > vaadin-text-area::part(input-field) {
-  --vaadin-input-field-background: transparent;
+  background: var(--vaadin-input-field-background, transparent);
 }
 
 vaadin-message-input[theme~='icon-button'] > vaadin-message-input-button {


### PR DESCRIPTION
## Description

Instead of setting `--vaadin-input-field-background` directly, use it do define the background using aura value as a fallback. Also, make use of `--vaadin-input-field-disabled-background` in the disabled state.

Applying the following CSS:

```css
:root {
  --vaadin-input-field-background: beige;
  --vaadin-input-field-disabled-background: lightsteelblue;
}
```

Results in the following in text-field:
<img width="792" height="512" alt="image" src="https://github.com/user-attachments/assets/c24b04b9-b86a-4953-af55-a0974cdd2cde" />

And in message-list:
<img width="1153" height="655" alt="image" src="https://github.com/user-attachments/assets/88fcda66-d327-43d3-b0c7-46f9e7a44e81" />


## Type of change

- Bugfix
