### PR TITLE
fix: focus first color button when opening color popups

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
@@ -35,7 +35,7 @@ class RichTextEditorPopup extends PolylitMixin(LitElement) {
       :host([opened]),
       :host([opening]),
       :host([closing]) {
-        display: contents !important;
+        display: block !important;
         position: fixed;
       }
 

--- a/packages/rich-text-editor/test/toolbar.test.js
+++ b/packages/rich-text-editor/test/toolbar.test.js
@@ -241,6 +241,14 @@ describe('toolbar controls', () => {
             overlay = popup.shadowRoot.querySelector('vaadin-rich-text-editor-popup-overlay');
           });
 
+          it(`should focus first color button in ${style} popup when opened`, async () => {
+            getButton(style).click();
+            await oneEvent(overlay, 'vaadin-overlay-open');
+
+            const firstButton = popup.querySelector('button');
+            expect(document.activeElement).to.equal(firstButton);
+          });
+
           it(`should apply ${style} when clicking the "toolbar-button-${style}" and selecting value`, async () => {
             getButton(style).click();
             await oneEvent(overlay, 'vaadin-overlay-open');


### PR DESCRIPTION
## Description

Currently, opening one of the color popups in RTE does not move focus into the popup. This is a regression from https://github.com/vaadin/web-components/pull/10732, which detects the popup as invisible as it uses `display: contents`.

This changes the popup to use `display: block`, which aligns it with other overlay components, and restores the behavior that focuses the first button.

## Type of change

- Bugfix
