### PR TITLE
chore: make popover a11y test more stable

### DIFF
--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -495,12 +495,16 @@ describe('a11y', () => {
         });
 
         it('should not focus the popover on the next element Tab', async () => {
+          // Add another input after the test input that focus can move to
+          // Otherwise playwright sometimes wraps focus back to the popover instead of the body
+          const anotherInput = document.createElement('input');
+          input.after(anotherInput);
+
           input.focus();
 
           await sendKeys({ press: 'Tab' });
 
-          const activeElement = getDeepActiveElement();
-          expect(activeElement).to.not.equal(popover);
+          expect(document.activeElement).to.equal(anotherInput);
         });
 
         it('should focus previous element on target Shift Tab while opened', async () => {


### PR DESCRIPTION
## Description

One run of `should not focus the popover on the next element Tab` always fails for me locally (it's called twice from separate suites). Due to another issue with WTR this stalls the whole popover test suite when it tries to log the error (probably due to circular DOM references).

It looks like the test should verify that the focus rotates to the body, which doesn't always seem to happen. Adding another focusable element that focus can move to seems to help.

## Type of change

- Internal