### PR TITLE
chore: add Aura dev dependency to packages with visual tests (CP: 25.0)

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -46,6 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/icon": "~25.0.2",
     "@vaadin/icons": "~25.0.2",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -38,6 +38,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/avatar": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -46,6 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/a11y-base": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -46,6 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -47,6 +47,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -43,6 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -44,6 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -44,6 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/a11y-base": "~25.0.2",
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/field-highlighter/package.json
+++ b/packages/field-highlighter/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/checkbox": "~25.0.2",
     "@vaadin/checkbox-group": "~25.0.2",

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/custom-field": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -46,6 +46,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -53,6 +53,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -34,6 +34,7 @@
     "@vaadin/icon": "~25.0.2"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/vaadin-lumo-styles": "~25.0.2"
   }
 }

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -35,6 +35,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/icon": "~25.0.2",
     "@vaadin/icons": "~25.0.2",

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -37,6 +37,7 @@
     "@vaadin/number-field": "~25.0.2"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@vaadin/a11y-base": "~25.0.2",
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/checkbox": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -41,6 +41,7 @@
     "ol": "10.6.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -41,6 +41,7 @@
     "marked": "^16.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/master-detail-layout/package.json
+++ b/packages/master-detail-layout/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "~25.0.2",

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -45,6 +45,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/icon": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -44,6 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -48,6 +48,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/button": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -43,6 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -44,6 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -43,6 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -46,7 +46,8 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@vaadin/a11y-base": "25.0.0-alpha17",
+    "@vaadin/a11y-base": "~25.0.2",
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -49,6 +49,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -40,6 +40,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -39,6 +39,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -41,6 +41,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -44,6 +44,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -43,6 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -42,6 +42,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -38,6 +38,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -43,6 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "~25.0.2",
     "@vaadin/chai-plugins": "~25.0.2",
     "@vaadin/test-runner-commands": "~25.0.2",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -97,17 +97,6 @@ const getAllVisualPackages = () => {
 };
 
 /**
- * Get all available packages with visual tests for given theme.
- */
-const getAllThemePackages = (theme) => {
-  return fs
-    .readdirSync('packages')
-    .filter(
-      (dir) => fs.statSync(`packages/${dir}`).isDirectory() && fs.existsSync(`packages/${dir}/test/visual/${theme}`),
-    );
-};
-
-/**
  * Get packages for running tests.
  */
 const getTestPackages = (allPackages) => {
@@ -277,7 +266,7 @@ const createVisualTestsConfig = (theme, browserVersion) => {
   if (theme === 'base') {
     visualPackages = getAllVisualPackages().filter((dir) => dir !== 'vaadin-lumo-styles');
   } else if (theme === 'aura') {
-    visualPackages = getAllThemePackages('aura');
+    visualPackages = getAllVisualPackages().filter((dir) => dir !== 'vaadin-lumo-styles' && dir !== 'field-base');
   } else {
     visualPackages = getAllVisualPackages().filter((dir) => dir !== 'field-base');
   }


### PR DESCRIPTION
## Description

Manual cherry-pick of https://github.com/vaadin/web-components/pull/10923 to `25.0` branch.

## Type of change

- Cherry-pick