### PR TITLE
fix: handle tabsheet initialization without panels

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.js
@@ -104,6 +104,7 @@ export const TabSheetMixin = (superClass) =>
          */
         __tabs: {
           type: Object,
+          value: () => [],
         },
 
         /**
@@ -111,6 +112,7 @@ export const TabSheetMixin = (superClass) =>
          */
         __panels: {
           type: Array,
+          value: () => [],
         },
       };
     }
@@ -189,7 +191,7 @@ export const TabSheetMixin = (superClass) =>
      * @private
      */
     __itemsOrPanelsChanged(items, panels) {
-      if (!items || !panels) {
+      if (!items) {
         return;
       }
       items.forEach((tabItem) => {
@@ -202,7 +204,7 @@ export const TabSheetMixin = (superClass) =>
      * @private
      */
     __selectedTabItemChanged(selected, items, panels) {
-      if (!items || !panels || selected === undefined) {
+      if (!items || selected === undefined) {
         return;
       }
       this.__togglePanels(items[selected], panels);

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-tabsheet.js';
 
@@ -425,6 +425,30 @@ describe('tabsheet - full height content', () => {
 
     // Panel bottom should not exceed tabsheet bottom
     expect(panelRect.bottom).to.be.at.most(tabsheetRect.bottom);
+  });
+});
+
+describe('tabsheet - without nodes in default slot', () => {
+  let tabsheet, tab;
+
+  beforeEach(async () => {
+    // Do not format, as TabSheet should only contain nodes in the tabs slot, but no nodes (like text nodes) in default slot
+    tabsheet = fixtureSync(`
+      <vaadin-tabsheet style="height: 300px;"><vaadin-tabs slot="tabs"><vaadin-tab id="tab-1">Tab 1</vaadin-tab></vaadin-tabs></vaadin-tabsheet>
+    `);
+    tab = tabsheet.querySelector('vaadin-tab');
+
+    // Wait for tabsheet to initialize and set up MutationObserver
+    await aTimeout(0);
+  });
+
+  it('should not throw when tab id is set and there are no panels', async () => {
+    await expect(async () => {
+      // SlotObserver for default slot has not fired, as there are no nodes in the default slot
+      // When MutationObserver runs due to changing the tab ID, it should not fail if no panels have been detected
+      tab.id = 'tab-1';
+      await aTimeout(0);
+    }).not.to.throw();
   });
 });
 


### PR DESCRIPTION
## Description

TabSheet does not initialize `__panels` with a default value and relies on its `SlotObserver` firing to initialize the property with an array (even if empty). However `SlotObserver` does not fire if no node is added to the default slot, leaving the property undefined. Now when the TabSheet tries to link tabs to panels or toggle panels it fails with:
```
     TypeError: Cannot read properties of undefined (reading 'find')                                                                                                                            
       at TabSheet.__linkTabAndPanel (vaadin-tabsheet-mixin.js:236:28)  
```

This change initializes the property with an empty array by default to avoid the issue.

Fixes: https://github.com/vaadin/react-components/issues/362

## Type of change

- Bugfix
