### PR TITLE
fix: contain sr-only element inside side-nav-item

### DIFF
--- a/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
+++ b/packages/side-nav/src/styles/vaadin-side-nav-item-base-styles.js
@@ -30,6 +30,7 @@ const sideNavItem = css`
     border-radius: var(--vaadin-side-nav-item-border-radius, var(--vaadin-radius-m));
     cursor: var(--vaadin-clickable-cursor);
     touch-action: manipulation;
+    contain: layout;
   }
 
   :host([current]) [part='content'] {

--- a/packages/side-nav/test/side-nav-item.test.js
+++ b/packages/side-nav/test/side-nav-item.test.js
@@ -389,4 +389,20 @@ describe('side-nav-item', () => {
       });
     });
   });
+
+  describe('sr-only element', () => {
+    let scroller;
+
+    beforeEach(async () => {
+      scroller = fixtureSync(`<div style="overflow: auto; height: 5em;"></div>`);
+      for (let i = 0; i < 100; i++) {
+        scroller.innerHTML += '<vaadin-side-nav-item>test</vaadin-side-nav-item>';
+      }
+      await nextRender();
+    });
+
+    it('should not overflow outside side-nav-item', () => {
+      expect(document.documentElement.scrollHeight).to.equal(document.documentElement.clientHeight);
+    });
+  });
 });


### PR DESCRIPTION
If Chrome, Edge, and Safari, the `.sr-only` element with `position: absolute` can end up causing unwanted scrollbars if its position isn't contained together with the side-nav-item element.

This is a regression from #10008.

Reported on the forum: https://vaadin.com/forum/t/double-scrollbar-in-vaadin-24-9-0/178529.