### PR TITLE
refactor: add missing dependency, move duplicate code to mixin

### DIFF
--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
+    "@vaadin/a11y-base": "25.1.0-alpha1",
     "@vaadin/component-base": "25.1.0-alpha1",
     "@vaadin/vaadin-themable-mixin": "25.1.0-alpha1",
     "lit": "^3.0.0"

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -227,18 +227,6 @@ class RangeSlider extends SliderMixin(
       event.preventDefault();
     }
   }
-
-  /** @private */
-  __onInput(event) {
-    this.__updateValue(event.target.value);
-    this.__commitValue();
-    this.__detectAndDispatchChange();
-  }
-
-  /** @private */
-  __onChange(event) {
-    event.stopPropagation();
-  }
 }
 
 defineCustomElement(RangeSlider);

--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -99,4 +99,16 @@ export const SliderMixin = (superClass) =>
         this.dispatchEvent(new Event('change', { bubbles: true }));
       }
     }
+
+    /** @private */
+    __onInput(event) {
+      this.__updateValue(event.target.value);
+      this.__commitValue();
+      this.__detectAndDispatchChange();
+    }
+
+    /** @private */
+    __onChange(event) {
+      event.stopPropagation();
+    }
   };

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -175,18 +175,6 @@ class Slider extends SliderMixin(
     // Focus the input to allow modifying value using keyboard
     this.focus({ focusVisible: false });
   }
-
-  /** @private */
-  __onInput(event) {
-    this.__updateValue(event.target.value);
-    this.__commitValue();
-    this.__detectAndDispatchChange();
-  }
-
-  /** @private */
-  __onChange(event) {
-    event.stopPropagation();
-  }
 }
 
 defineCustomElement(Slider);


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/10958

- Added missing `@vaadin/a11y-base` dependency needed to use `FocusMixin`
- Moved duplicate methods `__onInput` and `__onChange` to the `SliderMixin`

## Type of change

- Refactor