### PR TITLE
fix: handle tabsheet initialization without panels (CP: 24.9)

### DIFF
--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.js
@@ -106,6 +106,7 @@ export const TabSheetMixin = (superClass) =>
          */
         __tabs: {
           type: Object,
+          value: () => [],
         },
 
         /**
@@ -113,6 +114,7 @@ export const TabSheetMixin = (superClass) =>
          */
         __panels: {
           type: Array,
+          value: () => [],
         },
       };
     }
@@ -191,7 +193,7 @@ export const TabSheetMixin = (superClass) =>
      * @private
      */
     __itemsOrPanelsChanged(items, panels) {
-      if (!items || !panels) {
+      if (!items) {
         return;
       }
       items.forEach((tabItem) => {
@@ -204,7 +206,7 @@ export const TabSheetMixin = (superClass) =>
      * @private
      */
     __selectedTabItemChanged(selected, items, panels) {
-      if (!items || !panels || selected === undefined) {
+      if (!items || selected === undefined) {
         return;
       }
       this.__togglePanels(items[selected], panels);

--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/tabs/src/vaadin-tabs.js';
 import '../src/vaadin-tabsheet.js';
@@ -399,6 +399,30 @@ describe('tabsheet - lazy tabs', () => {
     expect(getPanels()[0].hidden).to.be.false;
     expect(getPanels()[1].hidden).to.be.true;
     expect(getPanels()[2].hidden).to.be.true;
+  });
+});
+
+describe('tabsheet - without nodes in default slot', () => {
+  let tabsheet, tab;
+
+  beforeEach(async () => {
+    // Do not format, as TabSheet should only contain nodes in the tabs slot, but no nodes (like text nodes) in default slot
+    tabsheet = fixtureSync(`
+      <vaadin-tabsheet style="height: 300px;"><vaadin-tabs slot="tabs"><vaadin-tab id="tab-1">Tab 1</vaadin-tab></vaadin-tabs></vaadin-tabsheet>
+    `);
+    tab = tabsheet.querySelector('vaadin-tab');
+
+    // Wait for tabsheet to initialize and set up MutationObserver
+    await aTimeout(0);
+  });
+
+  it('should not throw when tab id is set and there are no panels', async () => {
+    await expect(async () => {
+      // SlotObserver for default slot has not fired, as there are no nodes in the default slot
+      // When MutationObserver runs due to changing the tab ID, it should not fail if no panels have been detected
+      tab.id = 'tab-1';
+      await aTimeout(0);
+    }).not.to.throw();
   });
 });
 


### PR DESCRIPTION
Cherry-pick of https://github.com/vaadin/web-components/pull/10942