### PR TITLE
refactor!: fire click on space for cells with text content

### DIFF
--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -70,6 +70,8 @@ export const ActiveItemMixin = (superClass) =>
       return (
         // Something has handled this click already, e. g., <vaadin-grid-sorter>
         e.defaultPrevented ||
+        // Skip if click event explicitly requests to skip cell activation
+        e.skipCellActivate ||
         // No clicked cell available
         !cell ||
         // Cell is a details cell


### PR DESCRIPTION
## Description

Currently the Flow `Grid` only fires an `item-click` event when pressing <kbd>Space</kbd> on a cell that has an element in it, but it doesn't work on cells with only text nodes. The behavior is somewhat accidental at the moment, as it comes from logic in the navigation mixin which fires a synthetic click event when pressing space on a cell with an element in it. The main intention seems to be triggering potential interactive components within the cell.

To make the behavior more consistent, this change makes the mixin always fire a click event on <kbd>Space</kbd>. Thus the `item-click` event of the Flow `Grid` will also work for cells with only text nodes. Note that some types of cells will still prevent the `item-click` event from firing, either due to explicit filtering logic in the Flow connector, or because default is prevented in the web component (tree toggle, focusable elements, detail cells, ...). Regarding those there should be no change to the previous behavior due to this PR.

Closes https://github.com/vaadin/web-components/issues/10335

## Type of change

- Behavior change