### PR TITLE
refactor: update slider to fully contain thumbs inside the track

### DIFF
--- a/packages/slider/src/styles/vaadin-slider-base-styles.js
+++ b/packages/slider/src/styles/vaadin-slider-base-styles.js
@@ -8,16 +8,14 @@ import { css } from 'lit';
 
 export const sliderStyles = css`
   :host {
-    display: inline-flex;
-    align-items: center;
+    display: inline-grid;
     box-sizing: border-box;
-    position: relative;
     width: 100%;
-    height: var(--_thumb-size);
     user-select: none;
     -webkit-user-select: none;
-    border-radius: var(--vaadin-slider-track-border-radius, var(--vaadin-radius-m));
-    --_thumb-size: var(--vaadin-slider-thumb-size, 1lh);
+    --_track-radius: var(--vaadin-slider-track-border-radius, var(--vaadin-radius-m));
+    --_thumb-width: var(--vaadin-slider-thumb-width, 1lh);
+    --_thumb-height: var(--vaadin-slider-thumb-height, 1lh);
     --_track-size: var(--vaadin-slider-track-size, 0.25lh);
   }
 
@@ -38,13 +36,21 @@ export const sliderStyles = css`
     --vaadin-slider-fill-background: var(--vaadin-background-color);
   }
 
+  #controls {
+    position: relative;
+    box-sizing: border-box;
+    min-width: 100%;
+    display: grid;
+    grid-template-rows: var(--_thumb-height);
+  }
+
   [part='track'] {
     box-sizing: border-box;
-    position: absolute;
     height: var(--_track-size);
-    width: 100%;
     background: var(--vaadin-slider-track-background, var(--vaadin-background-container));
-    border-radius: inherit;
+    border-radius: var(--_track-radius);
+    align-self: center;
+    pointer-events: none;
   }
 
   [part='track-fill'] {
@@ -54,13 +60,14 @@ export const sliderStyles = css`
     background: var(--vaadin-slider-fill-background, var(--vaadin-text-color));
     border-start-start-radius: inherit;
     border-end-start-radius: inherit;
+    pointer-events: none;
   }
 
   [part~='thumb'] {
     position: absolute;
     box-sizing: border-box;
-    width: var(--_thumb-size);
-    height: var(--_thumb-size);
+    width: var(--_thumb-width);
+    height: var(--_thumb-height);
     transform: translateX(-50%);
     background: var(--vaadin-slider-fill-background, var(--vaadin-text-color));
     border-radius: 50%;
@@ -74,9 +81,10 @@ export const sliderStyles = css`
 
   /* visually hidden */
   ::slotted(input) {
-    flex: 1;
+    position: absolute;
+    inset: 0;
     font: inherit;
-    height: var(--_thumb-size);
+    height: var(--_thumb-height);
     opacity: 0 !important;
     margin: 0 !important;
     pointer-events: none;

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -84,18 +84,26 @@ class RangeSlider extends SliderMixin(
     const endPercent = this.__getPercentFromValue(endValue);
 
     return html`
-      <div part="track">
+      <div id="controls">
+        <div part="track">
+          <div
+            part="track-fill"
+            style="${styleMap({
+              insetInlineStart: `${startPercent}%`,
+              insetInlineEnd: `${100 - endPercent}%`,
+            })}"
+          ></div>
+        </div>
         <div
-          part="track-fill"
-          style="${styleMap({
-            insetInlineStart: `${startPercent}%`,
-            insetInlineEnd: `${100 - endPercent}%`,
-          })}"
+          part="thumb thumb-start"
+          style="${styleMap({ insetInlineStart: this.__getThumbPosition(startPercent) })}"
         ></div>
+        <div
+          part="thumb thumb-end"
+          style="${styleMap({ insetInlineStart: this.__getThumbPosition(endPercent) })}"
+        ></div>
+        <slot name="input"></slot>
       </div>
-      <div part="thumb thumb-start" style="${styleMap({ insetInlineStart: `${startPercent}%` })}"></div>
-      <div part="thumb thumb-end" style="${styleMap({ insetInlineStart: `${endPercent}%` })}"></div>
-      <slot name="input"></slot>
     `;
   }
 
@@ -253,8 +261,7 @@ class RangeSlider extends SliderMixin(
       }
     }
 
-    const percent = this.__getEventPercent(event);
-    const value = this.__getValueFromPercent(percent);
+    const value = this.__getEventValue(event);
 
     // First thumb position from the "end"
     const index = this.__value.findIndex((v) => value - v < 0);

--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -164,12 +164,21 @@ export const SliderMixin = (superClass) =>
     }
 
     /**
+     * @param {number} percent
+     * @return {string}
+     * @private
+     */
+    __getThumbPosition(percent) {
+      const controlSize = `calc(100% - var(--_thumb-width))`;
+      return `calc(var(--_thumb-width) / 2 + ${controlSize} * ${percent} / 100)`;
+    }
+
+    /**
      * @param {PointerEvent} event
      * @private
      */
     __onMouseDown(event) {
-      const part = event.composedPath()[0].getAttribute('part');
-      if (!part || (!part.startsWith('track') && !part.startsWith('thumb'))) {
+      if (!event.composedPath().includes(this.$.controls)) {
         return;
       }
 
@@ -189,8 +198,7 @@ export const SliderMixin = (superClass) =>
       }
 
       // Only handle pointerdown on the thumb, track or track-fill
-      const part = event.composedPath()[0].getAttribute('part');
-      if (!part || (!part.startsWith('track') && !part.startsWith('thumb'))) {
+      if (!event.composedPath().includes(this.$.controls)) {
         return;
       }
 
@@ -201,8 +209,8 @@ export const SliderMixin = (superClass) =>
 
       this.__thumbIndex = this.__getThumbIndex(event);
 
-      // Update value on track click
-      if (part.startsWith('track')) {
+      // Update value on click within a track, but outside a thumb.
+      if (event.composedPath()[0] === this.$.controls) {
         const newValue = this.__getEventValue(event);
         this.__updateValue(newValue, this.__thumbIndex);
         this.__commitValue();

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -80,17 +80,19 @@ class Slider extends SliderMixin(
     const percent = this.__getPercentFromValue(value);
 
     return html`
-      <div part="track">
-        <div
-          part="track-fill"
-          style="${styleMap({
-            insetInlineStart: 0,
-            insetInlineEnd: `${100 - percent}%`,
-          })}"
-        ></div>
+      <div id="controls">
+        <div part="track">
+          <div
+            part="track-fill"
+            style="${styleMap({
+              insetInlineStart: 0,
+              insetInlineEnd: `${100 - percent}%`,
+            })}"
+          ></div>
+        </div>
+        <div part="thumb" style="${styleMap({ insetInlineStart: this.__getThumbPosition(percent) })}"></div>
+        <slot name="input"></slot>
       </div>
-      <div part="thumb" style="${styleMap({ insetInlineStart: `${percent}%` })}"></div>
-      <slot name="input"></slot>
     `;
   }
 

--- a/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["vaadin-range-slider host default"] = 
+snapshots["vaadin-range-slider host default"] =
 `<vaadin-range-slider>
   <input
     id="slider-0"
@@ -25,7 +25,7 @@ snapshots["vaadin-range-slider host default"] =
 `;
 /* end snapshot vaadin-range-slider host default */
 
-snapshots["vaadin-range-slider host value"] = 
+snapshots["vaadin-range-slider host value"] =
 `<vaadin-range-slider>
   <input
     id="slider-0"
@@ -49,7 +49,7 @@ snapshots["vaadin-range-slider host value"] =
 `;
 /* end snapshot vaadin-range-slider host value */
 
-snapshots["vaadin-range-slider host min"] = 
+snapshots["vaadin-range-slider host min"] =
 `<vaadin-range-slider>
   <input
     id="slider-0"
@@ -73,7 +73,7 @@ snapshots["vaadin-range-slider host min"] =
 `;
 /* end snapshot vaadin-range-slider host min */
 
-snapshots["vaadin-range-slider host max"] = 
+snapshots["vaadin-range-slider host max"] =
 `<vaadin-range-slider>
   <input
     id="slider-0"
@@ -97,7 +97,7 @@ snapshots["vaadin-range-slider host max"] =
 `;
 /* end snapshot vaadin-range-slider host max */
 
-snapshots["vaadin-range-slider host step"] = 
+snapshots["vaadin-range-slider host step"] =
 `<vaadin-range-slider>
   <input
     id="slider-0"
@@ -121,7 +121,7 @@ snapshots["vaadin-range-slider host step"] =
 `;
 /* end snapshot vaadin-range-slider host step */
 
-snapshots["vaadin-range-slider host disabled"] = 
+snapshots["vaadin-range-slider host disabled"] =
 `<vaadin-range-slider
   aria-disabled="true"
   disabled=""
@@ -151,117 +151,127 @@ snapshots["vaadin-range-slider host disabled"] =
 /* end snapshot vaadin-range-slider host disabled */
 
 snapshots["vaadin-range-slider shadow default"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline-start:0%;inset-inline-end:0%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline-start:0%;inset-inline-end:0%;"
+    part="thumb thumb-start"
+    style="inset-inline-start:calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 0 / 100);"
   >
   </div>
+  <div
+    part="thumb thumb-end"
+    style="inset-inline-start:calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 100 / 100);"
+  >
+  </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb thumb-start"
-  style="inset-inline-start:0%;"
->
-</div>
-<div
-  part="thumb thumb-end"
-  style="inset-inline-start:100%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-range-slider shadow default */
 
 snapshots["vaadin-range-slider shadow value"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 10% 80%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 10% 80%;"
+    part="thumb thumb-start"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 10 / 100);"
   >
   </div>
+  <div
+    part="thumb thumb-end"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 20 / 100);"
+  >
+  </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb thumb-start"
-  style="inset-inline-start: 10%;"
->
-</div>
-<div
-  part="thumb thumb-end"
-  style="inset-inline-start: 20%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-range-slider shadow value */
 
 snapshots["vaadin-range-slider shadow min"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 25%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 25%;"
+    part="thumb thumb-start"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 25 / 100);"
   >
   </div>
+  <div
+    part="thumb thumb-end"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 75 / 100);"
+  >
+  </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb thumb-start"
-  style="inset-inline-start: 25%;"
->
-</div>
-<div
-  part="thumb thumb-end"
-  style="inset-inline-start: 75%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-range-slider shadow min */
 
 snapshots["vaadin-range-slider shadow max"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 25%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 25%;"
+    part="thumb thumb-start"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 25 / 100);"
   >
   </div>
+  <div
+    part="thumb thumb-end"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 75 / 100);"
+  >
+  </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb thumb-start"
-  style="inset-inline-start: 25%;"
->
-</div>
-<div
-  part="thumb thumb-end"
-  style="inset-inline-start: 75%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-range-slider shadow max */
 
 snapshots["vaadin-range-slider shadow step"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 20% 40%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 20% 40%;"
+    part="thumb thumb-start"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 20 / 100);"
   >
   </div>
+  <div
+    part="thumb thumb-end"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 60 / 100);"
+  >
+  </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb thumb-start"
-  style="inset-inline-start: 20%;"
->
-</div>
-<div
-  part="thumb thumb-end"
-  style="inset-inline-start: 60%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-range-slider shadow step */
 

--- a/packages/slider/test/dom/__snapshots__/slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider.test.snap.js
@@ -96,92 +96,102 @@ snapshots["vaadin-slider host disabled"] =
 /* end snapshot vaadin-slider host disabled */
 
 snapshots["vaadin-slider shadow default"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline-start:0;inset-inline-end:100%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline-start:0;inset-inline-end:100%;"
+    part="thumb"
+    style="inset-inline-start:calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 0 / 100);"
   >
   </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb"
-  style="inset-inline-start:0%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-slider shadow default */
 
 snapshots["vaadin-slider shadow value"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 0px 50%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 0px 50%;"
+    part="thumb"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 50 / 100);"
   >
   </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb"
-  style="inset-inline-start: 50%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-slider shadow value */
 
 snapshots["vaadin-slider shadow min"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 0px 25%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 0px 25%;"
+    part="thumb"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 75 / 100);"
   >
   </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb"
-  style="inset-inline-start: 75%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-slider shadow min */
 
 snapshots["vaadin-slider shadow max"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 0px 75%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 0px 75%;"
+    part="thumb"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 25 / 100);"
   >
   </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb"
-  style="inset-inline-start: 25%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-slider shadow max */
 
 snapshots["vaadin-slider shadow step"] = 
-`<div part="track">
+`<div id="controls">
+  <div part="track">
+    <div
+      part="track-fill"
+      style="inset-inline: 0px 50%;"
+    >
+    </div>
+  </div>
   <div
-    part="track-fill"
-    style="inset-inline: 0px 50%;"
+    part="thumb"
+    style="inset-inline-start: calc(var(--_thumb-width) / 2 + calc(100% - var(--_thumb-width)) * 50 / 100);"
   >
   </div>
+  <slot name="input">
+  </slot>
 </div>
-<div
-  part="thumb"
-  style="inset-inline-start: 50%;"
->
-</div>
-<slot name="input">
-</slot>
 `;
 /* end snapshot vaadin-slider shadow step */
 

--- a/packages/slider/test/range-slider-pointer.test.ts
+++ b/packages/slider/test/range-slider-pointer.test.ts
@@ -24,7 +24,9 @@ window.Vaadin.featureFlags.sliderComponent = true;
   }
 
   beforeEach(async () => {
-    slider = fixtureSync('<vaadin-range-slider style="width: 200px; margin: 10px"></vaadin-range-slider>');
+    slider = fixtureSync(`
+      <vaadin-range-slider style="width: 200px; --vaadin-slider-thumb-width: 20px"></vaadin-range-slider>
+    `);
     await nextRender();
     thumbs = [...slider.shadowRoot!.querySelectorAll('[part~="thumb"]')];
     inputs = [...slider.querySelectorAll('input')];
@@ -36,21 +38,17 @@ window.Vaadin.featureFlags.sliderComponent = true;
 
   describe('value', () => {
     it('should update slider value property on first thumb pointermove', async () => {
-      const { x, y } = middleOfThumb(0);
-
       await sendMouseToElement({ type: 'move', element: thumbs[0] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x + 20, y] });
+      await sendMouse({ type: 'move', position: [20, 10] });
 
       expect(slider.value).to.deep.equal([10, 100]);
     });
 
     it('should update slider value property on second thumb pointermove', async () => {
-      const { x, y } = middleOfThumb(1);
-
       await sendMouseToElement({ type: 'move', element: thumbs[1] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x - 20, y] });
+      await sendMouse({ type: 'move', position: [180, 10] });
 
       expect(slider.value).to.deep.equal([0, 90]);
     });
@@ -87,13 +85,11 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should not fire on pointerup if value remains the same', async () => {
-      const { x, y } = middleOfThumb(0);
-
       await sendMouseToElement({ type: 'move', element: thumbs[0] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x + 20, y] });
+      await sendMouse({ type: 'move', position: [20, 10] });
 
-      await sendMouse({ type: 'move', position: [x, y] });
+      await sendMouse({ type: 'move', position: [0, 10] });
       await sendMouse({ type: 'up' });
 
       expect(spy).to.be.not.called;
@@ -120,9 +116,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should focus first input on track pointerdown before the first thumb', async () => {
-      const { x, y } = middleOfThumb(0);
-
-      await sendMouse({ type: 'move', position: [x - 20, y] });
+      await sendMouse({ type: 'move', position: [20, 10] });
       await sendMouse({ type: 'down' });
 
       expect(slider.value).to.deep.equal([10, 80]);
@@ -130,9 +124,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should focus second input on track pointerdown after the second thumb', async () => {
-      const { x, y } = middleOfThumb(1);
-
-      await sendMouse({ type: 'move', position: [x + 20, y] });
+      await sendMouse({ type: 'move', position: [180, 10] });
       await sendMouse({ type: 'down' });
 
       expect(slider.value).to.deep.equal([20, 90]);
@@ -140,9 +132,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should focus first input on track pointerdown between thumbs closer to the first one', async () => {
-      const { x, y } = middleOfThumb(0);
-
-      await sendMouse({ type: 'move', position: [x + 40, y] });
+      await sendMouse({ type: 'move', position: [80, 10] });
       await sendMouse({ type: 'down' });
 
       expect(slider.value).to.deep.equal([40, 80]);
@@ -150,9 +140,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should focus second input on track pointerdown between thumbs closer to the second one', async () => {
-      const { x, y } = middleOfThumb(1);
-
-      await sendMouse({ type: 'move', position: [x - 40, y] });
+      await sendMouse({ type: 'move', position: [120, 10] });
       await sendMouse({ type: 'down' });
 
       expect(slider.value).to.deep.equal([20, 60]);
@@ -261,7 +249,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
 
       await sendMouse({ type: 'move', position: [x - 5, y] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x + 20, y] });
+      await sendMouse({ type: 'move', position: [20, y] });
 
       expect(slider.value).to.deep.equal([0, 10]);
     });
@@ -272,7 +260,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
 
       await sendMouse({ type: 'move', position: [x + 5, y] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x - 20, y] });
+      await sendMouse({ type: 'move', position: [180, y] });
 
       expect(slider.value).to.deep.equal([90, 100]);
     });
@@ -284,11 +272,9 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should not update value property on thumb pointermove', async () => {
-      const { x, y } = middleOfThumb(0);
-
       await sendMouseToElement({ type: 'move', element: thumbs[0] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x + 20, y] });
+      await sendMouse({ type: 'move', position: [20, 10] });
 
       expect(slider.value).to.deep.equal([0, 100]);
     });
@@ -296,9 +282,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
     it('should not update value property on track pointerdown', async () => {
       slider.value = [20, 80];
 
-      const { x, y } = middleOfThumb(0);
-
-      await sendMouse({ type: 'move', position: [x - 20, y] });
+      await sendMouse({ type: 'move', position: [10, 10] });
       await sendMouse({ type: 'down' });
 
       expect(slider.value).to.deep.equal([20, 80]);
@@ -311,11 +295,9 @@ window.Vaadin.featureFlags.sliderComponent = true;
     });
 
     it('should not update value property on thumb pointermove', async () => {
-      const { x, y } = middleOfThumb(0);
-
       await sendMouseToElement({ type: 'move', element: thumbs[0] });
       await sendMouse({ type: 'down' });
-      await sendMouse({ type: 'move', position: [x + 20, y] });
+      await sendMouse({ type: 'move', position: [20, 10] });
 
       expect(slider.value).to.deep.equal([0, 100]);
     });
@@ -323,9 +305,7 @@ window.Vaadin.featureFlags.sliderComponent = true;
     it('should not update value property on track pointerdown', async () => {
       slider.value = [20, 80];
 
-      const { x, y } = middleOfThumb(0);
-
-      await sendMouse({ type: 'move', position: [x - 20, y] });
+      await sendMouse({ type: 'move', position: [10, 10] });
       await sendMouse({ type: 'down' });
 
       expect(slider.value).to.deep.equal([20, 80]);

--- a/packages/slider/test/slider-pointer.test.ts
+++ b/packages/slider/test/slider-pointer.test.ts
@@ -94,22 +94,28 @@ describe('vaadin-slider - pointer', () => {
   });
 
   describe('focus', () => {
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      input = slider.querySelector('input')!;
+    });
+
     it('should focus slotted range input on thumb pointerdown', async () => {
       await sendMouseToElement({ type: 'move', element: thumb });
       await sendMouse({ type: 'down' });
-      expect(document.activeElement).to.equal(slider.querySelector('input'));
+      expect(document.activeElement).to.equal(input);
     });
 
     it('should focus slotted range input on track pointerdown', async () => {
       await sendMouse({ type: 'move', position: [50, y] });
       await sendMouse({ type: 'down' });
-      expect(document.activeElement).to.equal(slider.querySelector('input'));
+      expect(document.activeElement).to.equal(input);
     });
 
-    it('should not focus slotted range input on pointerdown below the track', async () => {
+    it('should focus slotted range input on pointerdown below the visible track', async () => {
       await sendMouse({ type: 'move', position: [50, y + 5] });
       await sendMouse({ type: 'down' });
-      expect(document.activeElement).to.not.equal(slider.querySelector('input'));
+      expect(document.activeElement).to.equal(input);
     });
   });
 


### PR DESCRIPTION
## Description

Changed the DOM structure and positioning logic to apply thumb adjustment as in [Base UI slider](https://github.com/mui/base-ui/blob/50e164e86fb6e78c1d82c710187922b28a792874/packages/react/src/slider/thumb/prehydrationScript.template.js#L42-L46).

### Before

<img width="225" height="67" alt="Screenshot 2026-01-19 at 15 57 28" src="https://github.com/user-attachments/assets/3ce2ba9d-7cde-4e7d-8535-8ce6ea281550" />

### After

<img width="213" height="74" alt="Screenshot 2026-01-19 at 15 57 13" src="https://github.com/user-attachments/assets/7e3177a2-6a8d-4aa7-bfd2-4bc67ea3bd76" />


## Type of change

- Refactor