### PR TITLE
chore: align visual tests workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   base:
     name: Base
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'
 
     steps:
@@ -82,7 +82,7 @@ jobs:
 
   aura:
     name: Aura
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'
 
     steps:


### PR DESCRIPTION
## Description

Some jobs use `ubuntu-22.04` - let's align them with others to use `ubuntu-latest` consistently.

## Type of change

- Internal change