### PR TITLE
refactor: remove dedupeMixin from mixins that are applied once

### DIFF
--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
 import { InputMixin } from './input-mixin.js';
@@ -16,43 +15,41 @@ import { InputMixin } from './input-mixin.js';
  * @mixes DisabledMixin
  * @mixes InputMixin
  */
-export const CheckedMixin = dedupeMixin(
-  (superclass) =>
-    class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
-      static get properties() {
-        return {
-          /**
-           * True if the element is checked.
-           * @type {boolean}
-           */
-          checked: {
-            type: Boolean,
-            value: false,
-            notify: true,
-            reflectToAttribute: true,
-            sync: true,
-          },
-        };
-      }
+export const CheckedMixin = (superclass) =>
+  class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {
+    static get properties() {
+      return {
+        /**
+         * True if the element is checked.
+         * @type {boolean}
+         */
+        checked: {
+          type: Boolean,
+          value: false,
+          notify: true,
+          reflectToAttribute: true,
+          sync: true,
+        },
+      };
+    }
 
-      static get delegateProps() {
-        return [...super.delegateProps, 'checked'];
-      }
+    static get delegateProps() {
+      return [...super.delegateProps, 'checked'];
+    }
 
-      /**
-       * @param {Event} event
-       * @protected
-       * @override
-       */
-      _onChange(event) {
-        const input = event.target;
+    /**
+     * @param {Event} event
+     * @protected
+     * @override
+     */
+    _onChange(event) {
+      const input = event.target;
 
-        this._toggleChecked(input.checked);
-      }
+      this._toggleChecked(input.checked);
+    }
 
-      /** @protected */
-      _toggleChecked(checked) {
-        this.checked = checked;
-      }
-    },
-);
+    /** @protected */
+    _toggleChecked(checked) {
+      this.checked = checked;
+    }
+  };

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { dedupeMixin } from '@open-wc/dedupe-mixin';
 import { LabelController } from './label-controller.js';
 
 /**
@@ -11,53 +10,51 @@ import { LabelController } from './label-controller.js';
  *
  * @polymerMixin
  */
-export const LabelMixin = dedupeMixin(
-  (superclass) =>
-    class LabelMixinClass extends superclass {
-      static get properties() {
-        return {
-          /**
-           * The label text for the input node.
-           * When no light dom defined via [slot=label], this value will be used.
-           */
-          label: {
-            type: String,
-            observer: '_labelChanged',
-          },
-        };
-      }
+export const LabelMixin = (superclass) =>
+  class LabelMixinClass extends superclass {
+    static get properties() {
+      return {
+        /**
+         * The label text for the input node.
+         * When no light dom defined via [slot=label], this value will be used.
+         */
+        label: {
+          type: String,
+          observer: '_labelChanged',
+        },
+      };
+    }
 
-      constructor() {
-        super();
+    constructor() {
+      super();
 
-        this._labelController = new LabelController(this);
+      this._labelController = new LabelController(this);
 
-        this._labelController.addEventListener('slot-content-changed', (event) => {
-          this.toggleAttribute('has-label', event.detail.hasContent);
-        });
-      }
+      this._labelController.addEventListener('slot-content-changed', (event) => {
+        this.toggleAttribute('has-label', event.detail.hasContent);
+      });
+    }
 
-      /** @protected */
-      get _labelId() {
-        const node = this._labelNode;
-        return node && node.id;
-      }
+    /** @protected */
+    get _labelId() {
+      const node = this._labelNode;
+      return node && node.id;
+    }
 
-      /** @protected */
-      get _labelNode() {
-        return this._labelController.node;
-      }
+    /** @protected */
+    get _labelNode() {
+      return this._labelController.node;
+    }
 
-      /** @protected */
-      ready() {
-        super.ready();
+    /** @protected */
+    ready() {
+      super.ready();
 
-        this.addController(this._labelController);
-      }
+      this.addController(this._labelController);
+    }
 
-      /** @protected */
-      _labelChanged(label) {
-        this._labelController.setLabel(label);
-      }
-    },
-);
+    /** @protected */
+    _labelChanged(label) {
+      this._labelController.setLabel(label);
+    }
+  };


### PR DESCRIPTION
## Description

While looking into adding CEM in #11010, I noticed that it doesn't seem to parse mixins using `dedupeMixin`.
Let's remove usage of this helper at least from `CheckedMixin` and `LabelMixin` - these aren't applied twice.

## Type of change

- Refactor