### PR TITLE
test: fix flaky grid-pro test on webkit

### DIFF
--- a/packages/grid-pro/test/edit-column.test.js
+++ b/packages/grid-pro/test/edit-column.test.js
@@ -54,6 +54,7 @@ describe('edit column', () => {
       await sendKeys({ press: 'Tab' });
       expect(getCellEditor(selectCell)).to.be.ok;
       await nextFrame();
+      await nextFrame();
 
       // Press Tab to edit the age cell
       await sendKeys({ press: 'Tab' });


### PR DESCRIPTION
## Description

Due to a timing change somewhere, a test case in grid-pro has become [flaky](https://github.com/vaadin/web-components/actions/runs/21393533107/job/61586072182?pr=10607) on Webkit.
This PR works around the timing issue.

## Type of change

Tests