### PR TITLE
fix: prevent dialog shrinking on right edge (CP: 25.1)

### DIFF
--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -596,6 +596,20 @@ describe('draggable', () => {
     expect(Math.floor(draggedBounds.height)).to.be.eql(Math.floor(bounds.height));
   });
 
+  it('should not shrink dialog when dragged to the right edge', async () => {
+    dialog.renderer = (root) => {
+      root.innerHTML = `<div style="padding: 20px;">Lorem ipsum dolor sit amet</div>`;
+    };
+    await nextRender();
+    const initialWidth = container.offsetWidth;
+    const bounds = container.getBoundingClientRect();
+    const targetX = window.innerWidth - 100;
+    dx = targetX - Math.floor(bounds.left + bounds.width / 2);
+    drag(container);
+    await nextRender();
+    expect(container.offsetWidth).to.equal(initialWidth);
+  });
+
   it('should not reset scroll position on dragstart', async () => {
     dialog.modeless = true;
     dialog.height = '100px';

--- a/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
@@ -109,6 +109,7 @@
     background-image: none;
     outline: none;
     -webkit-tap-highlight-color: transparent;
+    width: max-content;
   }
 
   :host(:is([has-header], [has-title])) [part='header'] + [part='content'] {


### PR DESCRIPTION
Cherry-pick of https://github.com/vaadin/web-components/pull/10400 to 25.1

Previously this was only working in 25 for base styles and Aura, but not for Lumo.