### PR TITLE
chore: run visual tests for external contributions

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -1,9 +1,15 @@
 name: Visual tests
 
-on: pull_request_target
+on: 
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
 
 permissions:
   contents: read
+
+env:
+  _HEAD_SHA: ${{ github.event.pull_request.head.sha }}}}
 
 jobs:
   base:
@@ -15,6 +21,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
+          ref: ${{env._HEAD_SHA}}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -51,6 +58,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
+          ref: ${{env._HEAD_SHA}}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -89,6 +97,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
+          ref: ${{env._HEAD_SHA}}
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
Allow passing SauceLabs secrets to visual test workflows run from forks. Workflow runs still need manual approval from maintainers, and changes must be reviewed beforehand to verify that there is no malicious code that could exfiltrate the secrets.

This is similar to how the Testbench license is handled in the Flow repo.