### PR TITLE
docs: add CSS properties and shadow DOM parts to slider JSDoc

### DIFF
--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -39,17 +39,6 @@ export interface RangeSliderEventMap extends HTMLElementEventMap, RangeSliderCus
  *
  * ### Styling
  *
- * The following custom CSS properties are available for styling:
- *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -70,6 +59,17 @@ export interface RangeSliderEventMap extends HTMLElementEventMap, RangeSliderCus
  * ------------|-------------
  * `disabled`  | Set when the slider is disabled
  * `readonly`  | Set when the slider is read-only
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * | `--vaadin-slider-fill-background`      |
+ * | `--vaadin-slider-thumb-height`         |
+ * | `--vaadin-slider-thumb-width`          |
+ * | `--vaadin-slider-track-background`     |
+ * | `--vaadin-slider-track-border-radius`  |
+ * | `--vaadin-slider-track-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -28,17 +28,6 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * ### Styling
  *
- * The following custom CSS properties are available for styling:
- *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -59,6 +48,17 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * ------------|-------------
  * `disabled`  | Set when the slider is disabled
  * `readonly`  | Set when the slider is read-only
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * | `--vaadin-slider-fill-background`      |
+ * | `--vaadin-slider-thumb-height`         |
+ * | `--vaadin-slider-thumb-width`          |
+ * | `--vaadin-slider-track-background`     |
+ * | `--vaadin-slider-track-border-radius`  |
+ * | `--vaadin-slider-track-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/slider/src/vaadin-slider.d.ts
+++ b/packages/slider/src/vaadin-slider.d.ts
@@ -39,17 +39,6 @@ export interface SliderEventMap extends HTMLElementEventMap, SliderCustomEventMa
  *
  * ### Styling
  *
- * The following custom CSS properties are available for styling:
- *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -68,6 +57,17 @@ export interface SliderEventMap extends HTMLElementEventMap, SliderCustomEventMa
  * ------------|-------------
  * `disabled`  | Set when the slider is disabled
  * `readonly`  | Set when the slider is read-only
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * | `--vaadin-slider-fill-background`      |
+ * | `--vaadin-slider-thumb-height`         |
+ * | `--vaadin-slider-thumb-width`          |
+ * | `--vaadin-slider-track-background`     |
+ * | `--vaadin-slider-track-border-radius`  |
+ * | `--vaadin-slider-track-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -27,17 +27,6 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * ### Styling
  *
- * The following custom CSS properties are available for styling:
- *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -56,6 +45,17 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * ------------|-------------
  * `disabled`  | Set when the slider is disabled
  * `readonly`  | Set when the slider is read-only
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                      |
+ * :----------------------------------------|
+ * | `--vaadin-slider-fill-background`      |
+ * | `--vaadin-slider-thumb-height`         |
+ * | `--vaadin-slider-thumb-width`          |
+ * | `--vaadin-slider-track-background`     |
+ * | `--vaadin-slider-track-border-radius`  |
+ * | `--vaadin-slider-track-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Added tables of custom CSS properties and shadow parts for `vaadin-slider` and `vaadin-range-slider`.

## Type of change

- Documentation