### PR TITLE
refactor: override slider blur() method to blur the input element

### DIFF
--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -260,6 +260,19 @@ class RangeSlider extends FieldMixin(
   }
 
   /**
+   * @protected
+   * @override
+   */
+  blur() {
+    if (this._inputElements) {
+      const focusedInput = this._inputElements.find((input) => isElementFocused(input));
+      if (focusedInput) {
+        focusedInput.blur();
+      }
+    }
+  }
+
+  /**
    * Override method inherited from `FocusMixin` to set
    * state attributes indicating which thumb has focus.
    *

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -200,6 +200,16 @@ class Slider extends FieldMixin(
   }
 
   /**
+   * @protected
+   * @override
+   */
+  blur() {
+    if (this._inputElement) {
+      this._inputElement.blur();
+    }
+  }
+
+  /**
    * @private
    * @override
    */

--- a/packages/slider/test/range-slider.test.ts
+++ b/packages/slider/test/range-slider.test.ts
@@ -139,6 +139,18 @@ describe('vaadin-range-slider', () => {
     it('should not throw when calling focus() before adding to the DOM', () => {
       expect(() => document.createElement('vaadin-range-slider').focus()).to.not.throw(Error);
     });
+
+    it('should blur the start input on blur()', () => {
+      inputs[0].focus();
+      slider.blur();
+      expect(document.activeElement).to.not.equal(inputs[0]);
+    });
+
+    it('should blur the end input on blur()', () => {
+      inputs[1].focus();
+      slider.blur();
+      expect(document.activeElement).to.not.equal(inputs[1]);
+    });
   });
 
   describe('keyboard input', () => {

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -103,6 +103,12 @@ describe('vaadin-slider', () => {
     it('should not throw when calling focus() before adding to the DOM', () => {
       expect(() => document.createElement('vaadin-slider').focus()).to.not.throw(Error);
     });
+
+    it('should blur the input on blur()', () => {
+      slider.focus();
+      slider.blur();
+      expect(document.activeElement).to.not.equal(input);
+    });
   });
 
   describe('keyboard input', () => {


### PR DESCRIPTION
## Description

While `focus()` method in slider is overridden, `blur()` is not. This PR fixes that.

## Type of change

- Refactor