### PR TITLE
docs: add more state attributes and CSS properties to slider JSDoc

### DIFF
--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -66,14 +66,25 @@ export interface RangeSliderEventMap extends HTMLElementEventMap, RangeSliderCus
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
+ * Custom CSS property                          |
+ * :--------------------------------------------|
+ * `--vaadin-field-default-width`               |
+ * `--vaadin-input-field-error-color`           |
+ * `--vaadin-input-field-error-font-size`       |
+ * `--vaadin-input-field-error-font-weight`     |
+ * `--vaadin-input-field-helper-color`          |
+ * `--vaadin-input-field-helper-font-size`      |
+ * `--vaadin-input-field-helper-font-weight`    |
+ * `--vaadin-input-field-label-color`           |
+ * `--vaadin-input-field-label-font-size`       |
+ * `--vaadin-input-field-label-font-weight`     |
+ * `--vaadin-input-field-required-indicator`    |
+ * `--vaadin-slider-fill-background`            |
+ * `--vaadin-slider-thumb-height`               |
+ * `--vaadin-slider-thumb-width`                |
+ * `--vaadin-slider-track-background`           |
+ * `--vaadin-slider-track-border-radius`        |
+ * `--vaadin-slider-track-height`               |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -55,14 +55,25 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
+ * Custom CSS property                          |
+ * :--------------------------------------------|
+ * `--vaadin-field-default-width`               |
+ * `--vaadin-input-field-error-color`           |
+ * `--vaadin-input-field-error-font-size`       |
+ * `--vaadin-input-field-error-font-weight`     |
+ * `--vaadin-input-field-helper-color`          |
+ * `--vaadin-input-field-helper-font-size`      |
+ * `--vaadin-input-field-helper-font-weight`    |
+ * `--vaadin-input-field-label-color`           |
+ * `--vaadin-input-field-label-font-size`       |
+ * `--vaadin-input-field-label-font-weight`     |
+ * `--vaadin-input-field-required-indicator`    |
+ * `--vaadin-slider-fill-background`            |
+ * `--vaadin-slider-thumb-height`               |
+ * `--vaadin-slider-thumb-width`                |
+ * `--vaadin-slider-track-background`           |
+ * `--vaadin-slider-track-border-radius`        |
+ * `--vaadin-slider-track-height`               |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/slider/src/vaadin-slider.d.ts
+++ b/packages/slider/src/vaadin-slider.d.ts
@@ -62,14 +62,25 @@ export interface SliderEventMap extends HTMLElementEventMap, SliderCustomEventMa
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
+ * Custom CSS property                          |
+ * :--------------------------------------------|
+ * `--vaadin-field-default-width`               |
+ * `--vaadin-input-field-error-color`           |
+ * `--vaadin-input-field-error-font-size`       |
+ * `--vaadin-input-field-error-font-weight`     |
+ * `--vaadin-input-field-helper-color`          |
+ * `--vaadin-input-field-helper-font-size`      |
+ * `--vaadin-input-field-helper-font-weight`    |
+ * `--vaadin-input-field-label-color`           |
+ * `--vaadin-input-field-label-font-size`       |
+ * `--vaadin-input-field-label-font-weight`     |
+ * `--vaadin-input-field-required-indicator`    |
+ * `--vaadin-slider-fill-background`            |
+ * `--vaadin-slider-thumb-height`               |
+ * `--vaadin-slider-thumb-width`                |
+ * `--vaadin-slider-track-background`           |
+ * `--vaadin-slider-track-border-radius`        |
+ * `--vaadin-slider-track-height`               |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -50,14 +50,25 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-slider-fill-background`      |
- * | `--vaadin-slider-thumb-height`         |
- * | `--vaadin-slider-thumb-width`          |
- * | `--vaadin-slider-track-background`     |
- * | `--vaadin-slider-track-border-radius`  |
- * | `--vaadin-slider-track-height`         |
+ * Custom CSS property                          |
+ * :--------------------------------------------|
+ * `--vaadin-field-default-width`               |
+ * `--vaadin-input-field-error-color`           |
+ * `--vaadin-input-field-error-font-size`       |
+ * `--vaadin-input-field-error-font-weight`     |
+ * `--vaadin-input-field-helper-color`          |
+ * `--vaadin-input-field-helper-font-size`      |
+ * `--vaadin-input-field-helper-font-weight`    |
+ * `--vaadin-input-field-label-color`           |
+ * `--vaadin-input-field-label-font-size`       |
+ * `--vaadin-input-field-label-font-weight`     |
+ * `--vaadin-input-field-required-indicator`    |
+ * `--vaadin-slider-fill-background`            |
+ * `--vaadin-slider-thumb-height`               |
+ * `--vaadin-slider-thumb-width`                |
+ * `--vaadin-slider-track-background`           |
+ * `--vaadin-slider-track-border-radius`        |
+ * `--vaadin-slider-track-height`               |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11039

- Added `focused`, `focus-ring`, `start-focused` and `end-focused` state attributes to JSDoc
- Added field custom CSS properties: default width, label, helper, error and required indicator

## Type of change

- Documentation