### PR TITLE
feat: add invalid-changed and validated event types to slider

### DIFF
--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -24,12 +24,26 @@ export type RangeSliderInputEvent = Event & {
 };
 
 /**
+ * Fired when the `invalid` property changes.
+ */
+export type RangeSliderInvalidChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type RangeSliderValueChangedEvent = CustomEvent<{ value: number[] }>;
 
+/**
+ * Fired whenever the slider is validated.
+ */
+export type RangeSliderValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface RangeSliderCustomEventMap {
+  'invalid-changed': RangeSliderInvalidChangedEvent;
+
   'value-changed': RangeSliderValueChangedEvent;
+
+  validated: RangeSliderValidatedEvent;
 }
 
 export interface RangeSliderEventMap extends HTMLElementEventMap, RangeSliderCustomEventMap {

--- a/packages/slider/src/vaadin-slider.d.ts
+++ b/packages/slider/src/vaadin-slider.d.ts
@@ -24,12 +24,26 @@ export type SliderInputEvent = Event & {
 };
 
 /**
+ * Fired when the `invalid` property changes.
+ */
+export type SliderInvalidChangedEvent = CustomEvent<{ value: boolean }>;
+
+/**
  * Fired when the `value` property changes.
  */
 export type SliderValueChangedEvent = CustomEvent<{ value: number }>;
 
+/**
+ * Fired whenever the slider is validated.
+ */
+export type SliderValidatedEvent = CustomEvent<{ valid: boolean }>;
+
 export interface SliderCustomEventMap {
+  'invalid-changed': SliderInvalidChangedEvent;
+
   'value-changed': SliderValueChangedEvent;
+
+  validated: SliderValidatedEvent;
 }
 
 export interface SliderEventMap extends HTMLElementEventMap, SliderCustomEventMap {

--- a/packages/slider/test/typings/range-slider.types.ts
+++ b/packages/slider/test/typings/range-slider.types.ts
@@ -11,6 +11,8 @@ import type {
   RangeSlider,
   RangeSliderChangeEvent,
   RangeSliderInputEvent,
+  RangeSliderInvalidChangedEvent,
+  RangeSliderValidatedEvent,
   RangeSliderValueChangedEvent,
 } from '../../vaadin-range-slider.js';
 
@@ -23,6 +25,16 @@ assertType<RangeSlider>(slider);
 slider.addEventListener('value-changed', (event) => {
   assertType<RangeSliderValueChangedEvent>(event);
   assertType<number[]>(event.detail.value);
+});
+
+slider.addEventListener('invalid-changed', (event) => {
+  assertType<RangeSliderInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+slider.addEventListener('validated', (event) => {
+  assertType<RangeSliderValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 slider.addEventListener('change', (event) => {

--- a/packages/slider/test/typings/slider.types.ts
+++ b/packages/slider/test/typings/slider.types.ts
@@ -7,7 +7,14 @@ import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { SliderMixinClass } from '../../src/vaadin-slider-mixin.js';
-import type { Slider, SliderChangeEvent, SliderInputEvent, SliderValueChangedEvent } from '../../vaadin-slider.js';
+import type {
+  Slider,
+  SliderChangeEvent,
+  SliderInputEvent,
+  SliderInvalidChangedEvent,
+  SliderValidatedEvent,
+  SliderValueChangedEvent,
+} from '../../vaadin-slider.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -18,6 +25,16 @@ assertType<Slider>(slider);
 slider.addEventListener('value-changed', (event) => {
   assertType<SliderValueChangedEvent>(event);
   assertType<number>(event.detail.value);
+});
+
+slider.addEventListener('invalid-changed', (event) => {
+  assertType<SliderInvalidChangedEvent>(event);
+  assertType<boolean>(event.detail.value);
+});
+
+slider.addEventListener('validated', (event) => {
+  assertType<SliderValidatedEvent>(event);
+  assertType<boolean>(event.detail.valid);
 });
 
 slider.addEventListener('change', (event) => {


### PR DESCRIPTION
## Description

Added type definitions for events inherited from `FieldMixin`: `invalid-changed` and `validated`.
For now the slider doesn't implement its own validation logic yet, but we can consider adding it.

## Type of change

- Feature