### PR TITLE
fix: allow resetting login overlay I18N

### DIFF
--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -41,6 +41,16 @@ export const LoginOverlayMixin = (superClass) =>
           type: String,
           value: 'App name',
         },
+
+        /** @private */
+        __effectiveTitle: {
+          type: String,
+        },
+
+        /** @private */
+        __effectiveDescription: {
+          type: String,
+        },
       };
     }
 
@@ -62,9 +72,10 @@ export const LoginOverlayMixin = (superClass) =>
     willUpdate(props) {
       super.willUpdate(props);
 
-      if (props.has('__effectiveI18n') && this.__effectiveI18n.header) {
-        this.title = this.__effectiveI18n.header.title;
-        this.description = this.__effectiveI18n.header.description;
+      if (props.has('__effectiveI18n') || props.has('title') || props.has('description')) {
+        const header = this.__effectiveI18n && this.__effectiveI18n.header;
+        this.__effectiveTitle = header && header.title != null ? header.title : this.title;
+        this.__effectiveDescription = header && header.description != null ? header.description : this.description;
       }
     }
 
@@ -72,8 +83,8 @@ export const LoginOverlayMixin = (superClass) =>
     updated(props) {
       super.updated(props);
 
-      if (props.has('title') || props.has('__effectiveI18n')) {
-        this.__titleController.setTitle(this.title);
+      if (props.has('__effectiveTitle')) {
+        this.__titleController.setTitle(this.__effectiveTitle);
       }
 
       if (props.has('headingLevel')) {

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -113,7 +113,7 @@ class LoginOverlay extends LoginFormMixin(LoginOverlayMixin(ElementMixin(Themabl
         id="overlay"
         .owner="${this}"
         .opened="${this.opened}"
-        .description="${this.description}"
+        .description="${this.__effectiveDescription}"
         focus-trap
         with-backdrop
         theme="${ifDefined(this._theme)}"

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -197,9 +197,25 @@ describe('title and description', () => {
 
     expect(titleElement.textContent).to.be.equal('The newest title');
     expect(descriptionElement.textContent).to.be.equal('The newest description');
+  });
 
-    expect(login.title).to.be.equal(login.i18n.header.title);
-    expect(login.description).to.be.equal(login.i18n.header.description);
+  it('should restore default title and description when i18n is reset', async () => {
+    const defaultTitle = login.title;
+    const defaultDescription = login.description;
+
+    // Set custom i18n header
+    login.i18n = { header: { title: 'Custom title', description: 'Custom description' } };
+    await nextUpdate(login);
+
+    expect(titleElement.textContent).to.be.equal('Custom title');
+    expect(descriptionElement.textContent).to.be.equal('Custom description');
+
+    // Reset i18n to empty object
+    login.i18n = {};
+    await nextUpdate(login);
+
+    expect(titleElement.textContent).to.be.equal(defaultTitle);
+    expect(descriptionElement.textContent).to.be.equal(defaultDescription);
   });
 });
 


### PR DESCRIPTION
## Description

Login overlay prioritizes the I18N header title + description over its own properties. However, currently it just overwrites the public properties with the I18N values, and then can not restore the previous values when setting an empty I18N object, which results in the title and description still showing the old values.

This fixes it by calculating an effective title + description, which are reset to the property values when setting an empty I18N object.

## Type of change

- Bugfix
