### PR TITLE
refactor: use LabelledInputController in slider to set for attribute

### DIFF
--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -11,6 +11,7 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
+import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-controller.js';
 import { field } from '@vaadin/field-base/src/styles/field-base-styles.js';
 import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
@@ -148,9 +149,9 @@ class Slider extends FieldMixin(
 
     return html`
       <div class="vaadin-slider-container">
-        <div part="label" @click="${this.focus}">
+        <div part="label">
           <slot name="label"></slot>
-          <span part="required-indicator" aria-hidden="true"></span>
+          <span part="required-indicator" aria-hidden="true" @click="${this.focus}"></span>
         </div>
 
         <div id="controls" style="${styleMap({ '--value': percent })}">
@@ -180,12 +181,14 @@ class Slider extends FieldMixin(
   }
 
   /** @protected */
-  firstUpdated() {
-    super.firstUpdated();
+  ready() {
+    super.ready();
 
     const input = this.querySelector('[slot="input"]');
     this._inputElement = input;
     this.ariaTarget = input;
+
+    this.addController(new LabelledInputController(input, this._labelController));
   }
 
   /**

--- a/packages/slider/test/dom/__snapshots__/slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider.test.snap.js
@@ -13,6 +13,7 @@ snapshots["vaadin-slider host default"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -39,6 +40,7 @@ snapshots["vaadin-slider host value"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -65,6 +67,7 @@ snapshots["vaadin-slider host min"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -91,6 +94,7 @@ snapshots["vaadin-slider host max"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -117,6 +121,7 @@ snapshots["vaadin-slider host step"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -147,6 +152,7 @@ snapshots["vaadin-slider host disabled"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -174,6 +180,7 @@ snapshots["vaadin-slider host label"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -202,6 +209,7 @@ snapshots["vaadin-slider host helper"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -234,6 +242,7 @@ snapshots["vaadin-slider host required"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >
@@ -264,6 +273,7 @@ snapshots["vaadin-slider host error"] =
     type="range"
   >
   <label
+    for="slider-3"
     id="label-vaadin-slider-0"
     slot="label"
   >

--- a/packages/slider/test/slider-pointer.test.ts
+++ b/packages/slider/test/slider-pointer.test.ts
@@ -182,7 +182,7 @@ describe('vaadin-slider - pointer', () => {
     it('should focus an input on pointerdown on the label element', async () => {
       slider.label = 'Label';
       await nextRender();
-      const label = slider.shadowRoot!.querySelector('[part="label"]')!;
+      const label = slider.querySelector('[slot="label"]')!;
       await sendMouseToElement({ type: 'click', element: label });
       expect(document.activeElement).to.equal(input);
     });


### PR DESCRIPTION
## Description

Currently, `vaadin-slider` is missing logic to set `for` attribute on the label. This PR fixes that.
Also moved `focus` call from the `label` part to the required indicator, like in text-field etc.

## Type of change

- Refactor

## Note

We could do the same for `vaadin-range-slider` but I'm not sure if setting `for` to the first input is the right way.