### PR TITLE
feat: component variant classnames

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -255,9 +255,15 @@ vaadin-tab,
 }
 
 /* Badges and other content that uses contrast color inside filled variants */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle)[theme~='primary'] > *,
-vaadin-tabs[theme~='filled'] > vaadin-tab[selected] > :not([slot='tooltip']),
-vaadin-side-nav[theme~='filled'] > vaadin-side-nav-item[current] > :not([slot='children']):not([slot='tooltip']),
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle):is(
+    [theme~='primary'],
+    .v-primary
+  )
+  > *,
+vaadin-tabs:is([theme~='filled'], .v-filled) > vaadin-tab[selected] > :not([slot='tooltip']),
+vaadin-side-nav:is([theme~='filled'], .v-filled)
+  > vaadin-side-nav-item[current]
+  > :not([slot='children']):not([slot='tooltip']),
 :is(
     vaadin-combo-box-item,
     vaadin-context-menu-item,
@@ -265,7 +271,7 @@ vaadin-side-nav[theme~='filled'] > vaadin-side-nav-item[current] > :not([slot='c
     vaadin-menu-bar-item,
     vaadin-multi-select-combo-box-item,
     vaadin-select-item[role]
-  )[theme~='filled']:not([disabled], [aria-disabled='true']):hover
+  ):is([theme~='filled'], .v-filled):not([disabled], [aria-disabled='true']):hover
   > * {
   --vaadin-icon-color: currentColor;
   --vaadin-text-color: currentColor;

--- a/packages/aura/src/components/accordion-details.css
+++ b/packages/aura/src/components/accordion-details.css
@@ -4,20 +4,23 @@
   --vaadin-details-summary-gap: var(--vaadin-gap-xs);
 }
 
-:is(vaadin-details, vaadin-accordion-panel):not([theme~='no-padding'])::part(content) {
+vaadin-accordion:not([theme~='no-padding'], .v-no-padding)
+  > vaadin-accordion-panel:not([theme~='no-padding'], .v-no-padding)::part(content),
+vaadin-details:not([theme~='no-padding'], .v-no-padding)::part(content) {
   padding: var(--vaadin-padding-block-container) var(--vaadin-padding-inline-container);
   padding-top: 0;
 }
 
-vaadin-details:not([theme~='no-padding'], [theme~='reverse'])::part(content) {
+vaadin-details:not([theme~='no-padding'], .v-no-padding, [theme~='reverse'], .v-reverse)::part(content) {
   margin-inline-start: calc(var(--vaadin-icon-size, 1lh) + var(--vaadin-details-summary-gap));
 }
 
-vaadin-accordion-panel:not([theme~='no-padding'], [theme~='reverse'])::part(content) {
+vaadin-accordion:not([theme~='no-padding'], .v-no-padding, [theme~='reverse'], .v-reverse)
+  > vaadin-accordion-panel:not([theme~='no-padding'], .v-no-padding, [theme~='reverse'], .v-reverse)::part(content) {
   margin-inline-start: calc(var(--vaadin-icon-size, 1lh) + var(--vaadin-accordion-heading-gap));
 }
 
-:is(vaadin-details, vaadin-accordion-panel)[theme~='reverse'] {
+:is(vaadin-details, vaadin-accordion-panel):is([theme~='reverse'], .v-reverse) {
   > [slot='summary']::part(content) {
     width: 100%;
   }

--- a/packages/aura/src/components/avatar.css
+++ b/packages/aura/src/components/avatar.css
@@ -32,7 +32,7 @@ vaadin-avatar[img][has-color-index] {
   --vaadin-avatar-border-width: 2px;
 }
 
-vaadin-avatar[theme~='filled'] {
+vaadin-avatar:is([theme~='filled'], .v-filled) {
   background: var(--aura-accent-color) content-box;
   color: var(--aura-accent-contrast-color);
 }

--- a/packages/aura/src/components/button.css
+++ b/packages/aura/src/components/button.css
@@ -10,12 +10,12 @@
   --vaadin-button-text-color: var(--aura-accent-text-color);
 }
 
-vaadin-drawer-toggle[theme~='tertiary']::part(icon) {
+vaadin-drawer-toggle:is([theme~='tertiary'], .v-tertiary)::part(icon) {
   opacity: 0.6;
 }
 
 :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):where(
-  :not([theme~='tertiary'])
+  :not([theme~='tertiary'], .v-tertiary)
 ) {
   --aura-surface-level: 4;
   --aura-surface-opacity: 0.5;
@@ -23,13 +23,13 @@ vaadin-drawer-toggle[theme~='tertiary']::part(icon) {
 }
 
 /* prettier-ignore */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):not([theme~='primary'], [theme~='tertiary']) {
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):not([theme~='primary'], .v-primary, [theme~='tertiary'], .v-tertiary) {
   background: var(--vaadin-button-background, var(--_background));
   --vaadin-button-border-color: var(--aura-accent-border-color);
 }
 
 :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):where(
-  :not([theme~='primary'])
+  :not([theme~='primary'], .v-primary)
 ) {
   outline-offset: calc(var(--vaadin-button-border-width, 1px) * -1);
 }
@@ -61,7 +61,7 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
 }
 
 :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):where(
-  [theme~='primary']
+  :is([theme~='primary'], .v-primary)
 ) {
   outline-offset: 2px;
   --vaadin-button-font-weight: var(--aura-font-weight-semibold);
@@ -71,7 +71,9 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
   --vaadin-button-shadow: var(--aura-shadow-s);
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button)[disabled][theme~='primary']::part(label) {
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button)[disabled]:is([theme~='primary'], .v-primary)::part(
+    label
+  ) {
   color: color-mix(in srgb, currentColor 50%, transparent);
 }
 
@@ -105,7 +107,7 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
   }
 
   /* prettier-ignore */
-  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[theme~='primary']:hover:not([disabled], [active])::before {
+  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):is([theme~='primary'], .v-primary):hover:not([disabled], [active])::before {
     opacity: 0.12;
   }
 }
@@ -133,7 +135,7 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
 }
 
 /* prettier-ignore */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[theme~='primary'][active]:not([disabled])::before {
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):is([theme~='primary'], .v-primary)[active]:not([disabled])::before {
   opacity: 0.16;
 }
 

--- a/packages/aura/src/components/card.css
+++ b/packages/aura/src/components/card.css
@@ -16,7 +16,7 @@ vaadin-card {
   --_padding: calc(var(--vaadin-card-padding) - var(--vaadin-card-border-width, 1px));
 }
 
-vaadin-card[theme~='outlined'] {
+vaadin-card:is([theme~='outlined'], .v-outlined) {
   --vaadin-card-border-color: var(--vaadin-border-color);
 }
 
@@ -24,20 +24,21 @@ vaadin-card::before {
   inset: calc(var(--vaadin-card-border-width) * -1);
 }
 
-vaadin-card[theme~='cover-media'] [slot='media']:is(img, video, svg, vaadin-icon) {
+vaadin-card:is([theme~='cover-media'], .v-cover-media) [slot='media']:is(img, video, svg, vaadin-icon) {
   /* TODO relies on internal API - should refactor base styles to support this (background-clip: padding-box) */
   margin-inline: calc((var(--_padding) + var(--vaadin-card-border-width)) * -1);
   margin-top: calc((var(--_padding) + var(--vaadin-card-border-width)) * -1);
   width: calc(100% + (var(--_padding) + var(--vaadin-card-border-width)) * 2);
 }
 
-vaadin-card[theme~='elevated'] {
+vaadin-card:is([theme~='elevated'], .v-elevated) {
   --aura-surface-opacity: 0.7;
   --aura-surface-level: 3;
   background: var(--aura-surface-color) padding-box;
   box-shadow: var(--vaadin-card-shadow, var(--aura-shadow-s));
 }
 
-vaadin-card[theme~='stretch-media']:not([theme~='cover-media']) [slot='media']:is(img, video, svg, vaadin-icon) {
+vaadin-card:is([theme~='stretch-media'], .v-stretch-media):not([theme~='cover-media'], .v-cover-media)
+  [slot='media']:is(img, video, svg, vaadin-icon) {
   border-radius: var(--vaadin-radius-s);
 }

--- a/packages/aura/src/components/dashboard.css
+++ b/packages/aura/src/components/dashboard.css
@@ -29,11 +29,11 @@ vaadin-dashboard-widget {
     transition-duration: 50ms;
   }
 
-  &[theme~='outlined'] {
+  &:is([theme~='outlined'], .v-outlined) {
     --vaadin-dashboard-widget-border-color: var(--vaadin-border-color);
   }
 
-  &[theme~='elevated'] {
+  &:is([theme~='elevated'], .v-elevated) {
     --aura-surface-opacity: 0.7;
     --aura-surface-level: 3;
     box-shadow: var(--vaadin-dashboard-widget-shadow, var(--aura-shadow-s));

--- a/packages/aura/src/components/grid.css
+++ b/packages/aura/src/components/grid.css
@@ -20,10 +20,10 @@ vaadin-grid-sorter::part(indicators) {
   transition: color 120ms;
 }
 
-:is(vaadin-grid, vaadin-crud, vaadin-grid-pro)[theme~='column-borders'] {
+:is(vaadin-grid, vaadin-crud, vaadin-grid-pro):is([theme~='column-borders'], .v-column-borders) {
   --vaadin-grid-column-border-width: 1px;
 }
 
-:is(vaadin-grid, vaadin-crud, vaadin-grid-pro)[theme~='no-row-borders'] {
+:is(vaadin-grid, vaadin-crud, vaadin-grid-pro):is([theme~='no-row-borders'], .v-no-row-borders) {
   --vaadin-grid-row-border-width: 0px;
 }

--- a/packages/aura/src/components/item-overlay.css
+++ b/packages/aura/src/components/item-overlay.css
@@ -52,7 +52,7 @@ vaadin-select-item:where([role]) {
     &:not([disabled], [aria-disabled='true']):hover {
       background: var(--_highlight-color);
 
-      &[theme~='filled'] {
+      &:is([theme~='filled'], .v-filled) {
         background: var(--aura-accent-color);
         color: var(--aura-accent-contrast-color);
         --vaadin-text-color: var(--aura-accent-contrast-color);

--- a/packages/aura/src/components/message-input.css
+++ b/packages/aura/src/components/message-input.css
@@ -6,7 +6,7 @@ vaadin-message-input:not([readonly], [disabled]) > vaadin-text-area::part(input-
   box-shadow: none;
 }
 
-vaadin-message-input[theme~='icon-button'] > vaadin-message-input-button {
+vaadin-message-input:is([theme~='icon-button'], .v-icon-button) > vaadin-message-input-button {
   width: var(--vaadin-icon-size, 1lh);
   height: var(--vaadin-icon-size, 1lh);
   color: transparent;
@@ -14,7 +14,7 @@ vaadin-message-input[theme~='icon-button'] > vaadin-message-input-button {
   contain: strict;
 }
 
-vaadin-message-input[theme~='icon-button'] > vaadin-message-input-button::before {
+vaadin-message-input:is([theme~='icon-button'], .v-icon-button) > vaadin-message-input-button::before {
   content: '';
   position: absolute;
   inset: 0;
@@ -22,12 +22,12 @@ vaadin-message-input[theme~='icon-button'] > vaadin-message-input-button::before
   background: var(--vaadin-button-text-color);
 }
 
-vaadin-message-input[theme~='icon-button'][dir='rtl'] > vaadin-message-input-button::before {
+vaadin-message-input:is([theme~='icon-button'], .v-icon-button)[dir='rtl'] > vaadin-message-input-button::before {
   scale: -1;
 }
 
 @media (forced-colors: active) {
-  vaadin-message-input[theme~='icon-button'] > vaadin-message-input-button {
+  vaadin-message-input:is([theme~='icon-button'], .v-icon-button) > vaadin-message-input-button {
     forced-color-adjust: none;
     --vaadin-button-text-color: CanvasText;
   }

--- a/packages/aura/src/components/side-nav.css
+++ b/packages/aura/src/components/side-nav.css
@@ -51,7 +51,7 @@ vaadin-side-nav-item::part(toggle-button) {
 
 /* Filled variant */
 
-vaadin-side-nav[theme~='filled'] > vaadin-side-nav-item[current]::part(content) {
+vaadin-side-nav:is([theme~='filled'], .v-filled) > vaadin-side-nav-item[current]::part(content) {
   --vaadin-side-nav-item-background: var(--aura-accent-color) border-box;
   --vaadin-side-nav-item-text-color: var(--aura-accent-contrast-color);
   --vaadin-text-color: var(--vaadin-side-nav-item-text-color);

--- a/packages/aura/src/components/tabs.css
+++ b/packages/aura/src/components/tabs.css
@@ -92,7 +92,7 @@ vaadin-tab[selected] {
 
 /* Filled variant */
 
-vaadin-tabs[theme~='filled'] > vaadin-tab[selected] {
+vaadin-tabs:is([theme~='filled'], .v-filled) > vaadin-tab[selected] {
   --vaadin-tab-background: var(--aura-accent-color) border-box;
   --vaadin-tab-text-color: var(--aura-accent-contrast-color);
   --vaadin-text-color: var(--aura-accent-contrast-color);

--- a/packages/aura/src/components/upload.css
+++ b/packages/aura/src/components/upload.css
@@ -54,7 +54,7 @@ vaadin-upload-file-list li {
   }
 }
 
-vaadin-upload:not([theme~='no-border']) > vaadin-upload-file-list:has(> ul > li) {
+vaadin-upload:not(:is([theme~='no-border'], .v-no-border)) > vaadin-upload-file-list:has(> ul > li) {
   border-top: 1px solid var(--vaadin-border-color-secondary);
   margin: calc(var(--vaadin-upload-padding) * -1);
   margin-top: var(--vaadin-upload-padding);
@@ -108,7 +108,7 @@ vaadin-upload-file {
   }
 }
 
-vaadin-upload[theme~='no-border'] {
+vaadin-upload:is([theme~='no-border'], .v-no-border) {
   --vaadin-upload-padding: 0;
   --vaadin-upload-background: transparent;
   --vaadin-upload-border-width: 0;

--- a/packages/avatar-group/src/styles/vaadin-avatar-group-base-styles.js
+++ b/packages/avatar-group/src/styles/vaadin-avatar-group-base-styles.js
@@ -15,7 +15,7 @@ export const avatarGroupStyles = css`
     --_dir: 1;
   }
 
-  :host([theme~='reverse']) {
+  :host(:is([theme~='reverse'], .v-reverse)) {
     --_dir: -1;
   }
 
@@ -48,9 +48,9 @@ export const avatarGroupStyles = css`
     margin-inline-start: calc((var(--_outline-width) + var(--_overlap) - var(--_gap)) * -1);
   }
 
-  :host(:not([theme~='reverse'])) ::slotted(vaadin-avatar:last-child),
-  :host(:not([theme~='reverse']):not([has-overflow])) ::slotted(vaadin-avatar:nth-last-child(2)),
-  :host([theme~='reverse']) ::slotted(vaadin-avatar:first-of-type) {
+  :host(:not([theme~='reverse'], .v-reverse)) ::slotted(vaadin-avatar:last-child),
+  :host(:not([theme~='reverse'], .v-reverse):not([has-overflow])) ::slotted(vaadin-avatar:nth-last-child(2)),
+  :host(:is([theme~='reverse'], .v-reverse)) ::slotted(vaadin-avatar:first-of-type) {
     mask-image: none;
   }
 `;

--- a/packages/button/src/styles/vaadin-button-base-styles.js
+++ b/packages/button/src/styles/vaadin-button-base-styles.js
@@ -55,13 +55,13 @@ export const buttonStyles = css`
     outline-offset: 1px;
   }
 
-  :host([theme~='primary']) {
+  :host(:is([theme~='primary'], .v-primary)) {
     --vaadin-button-background: var(--vaadin-text-color);
     --vaadin-button-text-color: var(--vaadin-background-color);
     --vaadin-button-border-color: transparent;
   }
 
-  :host([theme~='tertiary']) {
+  :host(:is([theme~='tertiary'], .v-tertiary)) {
     background: transparent;
     border-color: transparent;
   }
@@ -72,7 +72,7 @@ export const buttonStyles = css`
     opacity: 0.5;
   }
 
-  :host([disabled][theme~='primary']) {
+  :host([disabled]:is([theme~='primary'], .v-primary)) {
     --vaadin-button-text-color: var(--vaadin-background-container-strong);
     --vaadin-button-background: var(--vaadin-text-color-disabled);
   }
@@ -84,7 +84,7 @@ export const buttonStyles = css`
       --vaadin-button-text-color: ButtonText;
     }
 
-    :host([theme~='primary']) {
+    :host(:is([theme~='primary'], .v-primary)) {
       forced-color-adjust: none;
       --vaadin-button-background: CanvasText;
       --vaadin-button-text-color: Canvas;

--- a/packages/card/src/styles/vaadin-card-base-styles.js
+++ b/packages/card/src/styles/vaadin-card-base-styles.js
@@ -44,7 +44,7 @@ export const cardStyles = css`
     display: none !important;
   }
 
-  :host(:not([theme~='horizontal'])) {
+  :host(:not([theme~='horizontal'], .v-horizontal)) {
     justify-content: space-between;
   }
 
@@ -157,17 +157,17 @@ export const cardStyles = css`
   }
 
   /* Horizontal */
-  :host([theme~='horizontal']) {
+  :host(:is([theme~='horizontal'], .v-horizontal)) {
     align-items: start;
     display: grid;
     grid-template-columns: repeat(var(--_media), minmax(auto, max-content)) 1fr;
   }
 
-  :host([theme~='horizontal'][_f]) {
+  :host(:is([theme~='horizontal'], .v-horizontal)[_f]) {
     grid-template-rows: 1fr auto;
   }
 
-  :host([theme~='horizontal'][_c]) {
+  :host(:is([theme~='horizontal'], .v-horizontal)[_c]) {
     grid-template-rows: repeat(var(--_header), auto) 1fr;
   }
 
@@ -197,11 +197,11 @@ export const cardStyles = css`
     grid-row: calc(1 + var(--_header) + var(--_content));
   }
 
-  :host([theme~='horizontal']) [part='footer'] {
+  :host(:is([theme~='horizontal'], .v-horizontal)) [part='footer'] {
     align-self: end;
   }
 
-  :host(:not([theme~='horizontal'])) ::slotted([slot='media']:is(img, video, svg)) {
+  :host(:not([theme~='horizontal'], .v-horizontal)) ::slotted([slot='media']:is(img, video, svg)) {
     max-width: 100%;
   }
 
@@ -209,7 +209,7 @@ export const cardStyles = css`
     vertical-align: middle;
   }
 
-  :host(:is([theme~='cover-media'], [theme~='stretch-media']))
+  :host(:is([theme~='cover-media'], .v-cover-media, [theme~='stretch-media'], .v-stretch-media))
     ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
     aspect-ratio: var(--vaadin-card-media-aspect-ratio, 16/9);
     height: auto;
@@ -219,17 +219,31 @@ export const cardStyles = css`
     width: 100%;
   }
 
-  :host([theme~='horizontal']:is([theme~='cover-media'], [theme~='stretch-media'])) {
+  :host(
+    :is([theme~='horizontal'], .v-horizontal):is(
+      [theme~='cover-media'],
+      .v-cover-media,
+      [theme~='stretch-media'],
+      .v-stretch-media
+    )
+  ) {
     grid-template-columns: repeat(var(--_media), minmax(auto, 0.5fr)) 1fr;
   }
 
-  :host([theme~='horizontal']:is([theme~='cover-media'], [theme~='stretch-media']))
+  :host(
+      :is([theme~='horizontal'], .v-horizontal):is(
+        [theme~='cover-media'],
+        .v-cover-media,
+        [theme~='stretch-media'],
+        .v-stretch-media
+      )
+    )
     ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
     aspect-ratio: auto;
     height: 100%;
   }
 
-  :host([theme~='cover-media']) ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
+  :host(:is([theme~='cover-media'], .v-cover-media)) ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
     border-radius: inherit;
     border-end-end-radius: 0;
     border-end-start-radius: 0;
@@ -239,7 +253,8 @@ export const cardStyles = css`
     width: calc(100% + var(--_padding) * 2);
   }
 
-  :host([theme~='horizontal'][theme~='cover-media']) ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
+  :host(:is([theme~='horizontal'], .v-horizontal):is([theme~='cover-media'], .v-cover-media))
+    ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
     border-radius: inherit;
     border-end-end-radius: 0;
     border-start-end-radius: 0;
@@ -260,12 +275,12 @@ export const cardStyles = css`
   }
 
   /* Outlined */
-  :host([theme~='outlined']) {
+  :host(:is([theme~='outlined'], .v-outlined)) {
     --vaadin-card-border-width: 1px;
   }
 
   /* Elevated */
-  :host([theme~='elevated']) {
+  :host(:is([theme~='elevated'], .v-elevated)) {
     --vaadin-card-background: var(--vaadin-background-color);
     box-shadow: var(--vaadin-card-shadow, 0 1px 4px -1px rgba(0, 0, 0, 0.3));
   }

--- a/packages/crud/src/styles/vaadin-crud-base-styles.js
+++ b/packages/crud/src/styles/vaadin-crud-base-styles.js
@@ -164,7 +164,7 @@ export const crudStyles = css`
     margin-inline-start: auto;
   }
 
-  :host([theme~='no-border']) {
+  :host(:is([theme~='no-border'], .v-no-border)) {
     border: 0;
     border-radius: 0;
   }

--- a/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-button-base-styles.js
@@ -16,7 +16,7 @@ const dashboardButton = css`
     padding: 4px;
   }
 
-  :host([theme~='tertiary']) {
+  :host(:is([theme~='tertiary'], .v-tertiary)) {
     color: var(--vaadin-dashboard-button-text-color, var(--vaadin-text-color-secondary));
   }
 `;

--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -63,7 +63,7 @@ export const dialogOverlayBase = css`
     padding: var(--vaadin-dialog-padding, var(--vaadin-padding-l));
   }
 
-  :host([theme~='no-padding']) [part='content'] {
+  :host(:is([theme~='no-padding'], .v-no-padding)) [part='content'] {
     padding: 0 !important;
   }
 

--- a/packages/field-base/src/styles/field-base-styles.js
+++ b/packages/field-base/src/styles/field-base-styles.js
@@ -194,7 +194,7 @@ export const field = css`
     background: currentColor;
   }
 
-  :host([theme~='helper-above-field']) {
+  :host(:is([theme~='helper-above-field'], .v-helper-above)) {
     --_helper-above-field: initial;
     --_helper-below-field: ;
   }

--- a/packages/grid-pro/src/styles/vaadin-grid-pro-base-styles.js
+++ b/packages/grid-pro/src/styles/vaadin-grid-pro-base-styles.js
@@ -47,7 +47,8 @@ const gridPro = css`
 
   /* Indicate editable cells */
 
-  :host([theme~='highlight-editable-cells']) .body-cell:is([part~='editable-cell'], :has([part~='editable-cell'])) {
+  :host(:is([theme~='highlight-editable-cells'], .v-highlight-editable-cells))
+    .body-cell:is([part~='editable-cell'], :has([part~='editable-cell'])) {
     --vaadin-grid-row-highlight-background-color: var(
       --vaadin-grid-pro-editable-cell-background-color,
       var(--_highlight-color)
@@ -56,7 +57,8 @@ const gridPro = css`
 
   /* Indicate read-only cells */
 
-  :host([theme~='highlight-read-only-cells']) .body-cell:not([part~='editable-cell'], :has([part~='editable-cell'])) {
+  :host(:is([theme~='highlight-read-only-cells'], .v-highlight-read-only-cells))
+    .body-cell:not([part~='editable-cell'], :has([part~='editable-cell'])) {
     --_cell-highlight-background-image: repeating-linear-gradient(
       -45deg,
       transparent,

--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -40,7 +40,7 @@ export const gridStyles = css`
   }
 
   /* Variant: No outer border */
-  :host([theme~='no-border']) {
+  :host(:is([theme~='no-border'], .v-no-border)) {
     border-width: 0;
     border-radius: 0;
   }
@@ -351,7 +351,7 @@ export const gridStyles = css`
     }
   }
 
-  :host([theme~='row-stripes']) .odd-row {
+  :host(:is([theme~='row-stripes'], .v-row-stripes)) .odd-row {
     --_row-odd-background-color: var(
       --vaadin-grid-row-odd-background-color,
       color-mix(in srgb, var(--vaadin-text-color) 4%, transparent)
@@ -361,7 +361,7 @@ export const gridStyles = css`
 
   /* Variant: wrap cell contents */
 
-  :host([theme~='wrap-cell-content']) .cell:not(.details-cell) {
+  :host(:is([theme~='wrap-cell-content'], .v-wrap-cell-content)) .cell:not(.details-cell) {
     white-space: normal;
   }
 

--- a/packages/horizontal-layout/src/styles/vaadin-horizontal-layout-base-styles.js
+++ b/packages/horizontal-layout/src/styles/vaadin-horizontal-layout-base-styles.js
@@ -29,7 +29,7 @@ export const baseStyles = css`
     gap: var(--vaadin-horizontal-layout-gap, var(--vaadin-gap-s));
   }
 
-  :host([theme~='wrap']) {
+  :host(:is([theme~='wrap'], .v-wrap)) {
     flex-wrap: wrap;
   }
 

--- a/packages/input-container/src/styles/vaadin-input-container-base-styles.js
+++ b/packages/input-container/src/styles/vaadin-input-container-base-styles.js
@@ -118,23 +118,23 @@ export const inputContainerStyles = css`
     --vaadin-input-field-border-color: transparent;
   }
 
-  :host([theme~='align-start']) slot:not([name])::slotted(*) {
+  :host(:is([theme~='align-start'], .v-align-start)) slot:not([name])::slotted(*) {
     text-align: start;
   }
 
-  :host([theme~='align-center']) slot:not([name])::slotted(*) {
+  :host(:is([theme~='align-center'], .v-align-center)) slot:not([name])::slotted(*) {
     text-align: center;
   }
 
-  :host([theme~='align-end']) slot:not([name])::slotted(*) {
+  :host(:is([theme~='align-end'], .v-align-end)) slot:not([name])::slotted(*) {
     text-align: end;
   }
 
-  :host([theme~='align-left']) slot:not([name])::slotted(*) {
+  :host(:is([theme~='align-left'], .v-align-left)) slot:not([name])::slotted(*) {
     text-align: left;
   }
 
-  :host([theme~='align-right']) slot:not([name])::slotted(*) {
+  :host(:is([theme~='align-right'], .v-align-right)) slot:not([name])::slotted(*) {
     text-align: right;
   }
 

--- a/packages/map/src/styles/vaadin-map-base-styles.js
+++ b/packages/map/src/styles/vaadin-map-base-styles.js
@@ -28,12 +28,12 @@ export const mapStyles = css`
     outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
   }
 
-  :host(:not([theme~='no-border'])) {
+  :host(:not(:is([theme~='no-border'], .v-no-border))) {
     border-radius: var(--vaadin-map-border-radius, var(--vaadin-radius-m));
     position: relative;
   }
 
-  :host(:not([theme~='no-border']))::before {
+  :host(:not(:is([theme~='no-border'], .v-no-border)))::before {
     content: '';
     position: absolute;
     inset: 0;

--- a/packages/menu-bar/src/styles/vaadin-menu-bar-base-styles.js
+++ b/packages/menu-bar/src/styles/vaadin-menu-bar-base-styles.js
@@ -36,19 +36,19 @@ export const menuBarStyles = css`
 
   ::slotted([first-visible]),
   :host([has-single-button]) ::slotted([slot='overflow']),
-  ::slotted(vaadin-menu-bar-button[theme~='tertiary']) {
+  ::slotted(vaadin-menu-bar-button:is([theme~='tertiary'], .v-tertiary)) {
     border-start-start-radius: var(--_rad-button);
     border-end-start-radius: var(--_rad-button);
   }
 
   ::slotted(:is([last-visible], [slot='overflow'])),
-  ::slotted(vaadin-menu-bar-button[theme~='tertiary']) {
+  ::slotted(vaadin-menu-bar-button:is([theme~='tertiary'], .v-tertiary)) {
     border-start-end-radius: var(--_rad-button);
     border-end-end-radius: var(--_rad-button);
   }
 
-  :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button[first-visible]),
-  :host([theme~='end-aligned'][has-single-button]) ::slotted(vaadin-menu-bar-button) {
+  :host(:is([theme~='end-aligned'], .v-align-end)) ::slotted(vaadin-menu-bar-button[first-visible]),
+  :host(:is([theme~='end-aligned'], .v-align-end)[has-single-button]) ::slotted(vaadin-menu-bar-button) {
     margin-inline-start: auto;
   }
 `;

--- a/packages/popover/src/styles/vaadin-popover-overlay-base-styles.js
+++ b/packages/popover/src/styles/vaadin-popover-overlay-base-styles.js
@@ -50,7 +50,7 @@ const popoverOverlay = css`
     padding: var(--vaadin-popover-padding, var(--vaadin-padding-s));
   }
 
-  :host([theme~='no-padding']) [part='content'] {
+  :host(:is([theme~='no-padding'], .v-no-padding)) [part='content'] {
     padding: 0 !important;
   }
 

--- a/packages/scroller/src/styles/vaadin-scroller-base-styles.js
+++ b/packages/scroller/src/styles/vaadin-scroller-base-styles.js
@@ -77,13 +77,13 @@ export const scrollerStyles = css`
     opacity: var(--vaadin-scroller-overflow-indicator-bottom-opacity);
   }
 
-  :host([theme~='overflow-indicator-top'][overflow~='top']),
-  :host([theme~='overflow-indicators'][overflow~='top']) {
+  :host(:is([theme~='overflow-indicator-top'], .v-overflow-indicator-top)[overflow~='top']),
+  :host(:is([theme~='overflow-indicators'], .v-overflow-indicators)[overflow~='top']) {
     --vaadin-scroller-overflow-indicator-top-opacity: 1;
   }
 
-  :host([theme~='overflow-indicators'][overflow~='bottom']),
-  :host([theme~='overflow-indicator-bottom'][overflow~='bottom']) {
+  :host(:is([theme~='overflow-indicators'], .v-overflow-indicators)[overflow~='bottom']),
+  :host(:is([theme~='overflow-indicator-bottom'], .v-overflow-indicator-bottom)[overflow~='bottom']) {
     --vaadin-scroller-overflow-indicator-bottom-opacity: 1;
   }
 `;

--- a/packages/select/src/styles/vaadin-select-base-styles.js
+++ b/packages/select/src/styles/vaadin-select-base-styles.js
@@ -40,43 +40,43 @@ export const selectStyles = css`
     display: none;
   }
 
-  :host([theme~='align-start']) {
+  :host(:is([theme~='align-start'], .v-align-start)) {
     --vaadin-item-text-align: start;
   }
 
-  :host([theme~='align-center']) {
+  :host(:is([theme~='align-center'], .v-align-center)) {
     --vaadin-item-text-align: center;
   }
 
-  :host([theme~='align-end']) {
+  :host(:is([theme~='align-end'], .v-align-end)) {
     --vaadin-item-text-align: end;
   }
 
-  :host([theme~='align-left']) {
+  :host(:is([theme~='align-left'], .v-align-left)) {
     --vaadin-item-text-align: left;
   }
 
-  :host([theme~='align-right']) {
+  :host(:is([theme~='align-right'], .v-align-right)) {
     --vaadin-item-text-align: right;
   }
 
-  :host([theme~='align-start']) ::slotted([slot='value']) {
+  :host(:is([theme~='align-start'], .v-align-start)) ::slotted([slot='value']) {
     justify-content: start;
   }
 
-  :host([theme~='align-center']) ::slotted([slot='value']) {
+  :host(:is([theme~='align-center'], .v-align-center)) ::slotted([slot='value']) {
     justify-content: center;
   }
 
-  :host([theme~='align-end']) ::slotted([slot='value']) {
+  :host(:is([theme~='align-end'], .v-align-end)) ::slotted([slot='value']) {
     justify-content: end;
   }
 
-  :host([theme~='align-left']) ::slotted([slot='value']) {
+  :host(:is([theme~='align-left'], .v-align-left)) ::slotted([slot='value']) {
     justify-content: left;
   }
 
-  :host([theme~='align-right']) ::slotted([slot='value']) {
+  :host(:is([theme~='align-right'], .v-align-right)) ::slotted([slot='value']) {
     justify-content: right;
   }
 `;

--- a/packages/split-layout/src/styles/vaadin-split-layout-base-styles.js
+++ b/packages/split-layout/src/styles/vaadin-split-layout-base-styles.js
@@ -89,22 +89,22 @@ export const splitLayoutStyles = css`
     border-radius: 50%;
   }
 
-  :host([theme~='small']) > [part='splitter'] {
+  :host(:is([theme~='small'], .v-small)) > [part='splitter'] {
     --vaadin-split-layout-splitter-size: 1px;
     --vaadin-split-layout-splitter-target-size: 5px;
     --vaadin-split-layout-handle-size: 3px;
   }
 
-  :host([theme~='small']) [part='splitter'] [part='handle'] {
+  :host(:is([theme~='small'], .v-small)) [part='splitter'] [part='handle'] {
     opacity: 0;
   }
 
-  :host([theme~='small']) [part='splitter']:active [part='handle'] {
+  :host(:is([theme~='small'], .v-small)) [part='splitter']:active [part='handle'] {
     opacity: 1;
   }
 
   @media (any-hover: hover) {
-    :host([theme~='small']) [part='splitter']:hover [part='handle'] {
+    :host(:is([theme~='small'], .v-small)) [part='splitter']:hover [part='handle'] {
       opacity: 1;
     }
   }

--- a/packages/tabs/src/styles/vaadin-tabs-base-styles.js
+++ b/packages/tabs/src/styles/vaadin-tabs-base-styles.js
@@ -88,12 +88,12 @@ export const tabsStyles = css`
     rotate: -90deg;
   }
 
-  :host(:is([orientation='vertical'], [theme~='hide-scroll-buttons'])) [part$='button'] {
+  :host(:is([orientation='vertical'], [theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)) [part$='button'] {
     display: none;
   }
 
   @media (pointer: coarse) {
-    :host(:not([theme~='show-scroll-buttons'])) [part$='button'] {
+    :host(:not([theme~='show-scroll-buttons'], .v-show-scroll-buttons)) [part$='button'] {
       display: none;
     }
   }

--- a/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
+++ b/packages/tabsheet/src/styles/vaadin-tabsheet-base-styles.js
@@ -65,12 +65,12 @@ export const tabSheetStyles = [
       margin: auto;
     }
 
-    :host([theme~='no-border']) {
+    :host(:is([theme~='no-border'], .v-no-border)) {
       border: 0;
       border-radius: 0;
     }
 
-    :host([theme~='no-padding']) [part='content'] {
+    :host(:is([theme~='no-padding'], .v-no-padding)) [part='content'] {
       padding: 0 !important;
       --vaadin-scroller-padding-block: 0px !important;
       --vaadin-scroller-padding-inline: 0px !important;

--- a/packages/upload/src/styles/vaadin-upload-file-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-base-styles.js
@@ -31,12 +31,12 @@ export const uploadFileStyles = css`
     display: none;
   }
 
-  :host([theme~='thumbnails']) {
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) {
     grid-template-columns: 3rem minmax(0, 1fr) auto;
   }
 
-  :host([theme~='thumbnails']) [part='thumbnail']:not([hidden]),
-  :host([theme~='thumbnails']) [part='file-icon']:not([hidden]) {
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) [part='thumbnail']:not([hidden]),
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) [part='file-icon']:not([hidden]) {
     display: block;
     width: 3rem;
     height: 3rem;
@@ -56,8 +56,8 @@ export const uploadFileStyles = css`
     display: flex;
   }
 
-  :host([theme~='thumbnails']) [part='done-icon'],
-  :host([theme~='thumbnails']) [part='warning-icon'] {
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) [part='done-icon'],
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) [part='warning-icon'] {
     display: none !important;
   }
 

--- a/packages/upload/src/styles/vaadin-upload-file-list-base-styles.js
+++ b/packages/upload/src/styles/vaadin-upload-file-list-base-styles.js
@@ -32,17 +32,17 @@ export const uploadFileListStyles = css`
   }
 
   /* Thumbnails theme variant */
-  :host([theme~='thumbnails']) [part='list'] {
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) [part='list'] {
     display: flex;
     flex-wrap: wrap;
     gap: var(--vaadin-gap-s);
   }
 
-  :host([theme~='thumbnails']) ::slotted(:first-child) {
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) ::slotted(:first-child) {
     margin-top: 0;
   }
 
-  :host([theme~='thumbnails']) ::slotted(li) {
+  :host(:is([theme~='thumbnails'], .v-thumbnails)) ::slotted(li) {
     border-bottom: none;
   }
 `;

--- a/packages/vaadin-lumo-styles/mixins/helper.js
+++ b/packages/vaadin-lumo-styles/mixins/helper.js
@@ -38,30 +38,30 @@ export const helper = css`
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::before {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='helper-text']::before {
     display: none;
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::after {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='helper-text']::after {
     content: '';
     display: block;
     height: var(--_helper-spacing);
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='label'] {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='label'] {
     order: 0;
     padding-bottom: var(--_helper-spacing);
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text'] {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='helper-text'] {
     order: 1;
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='label'] + * {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='label'] + * {
     order: 2;
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='error-message'] {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='error-message'] {
     order: 3;
   }
 `;

--- a/packages/vaadin-lumo-styles/mixins/input-field-shared.js
+++ b/packages/vaadin-lumo-styles/mixins/input-field-shared.js
@@ -137,16 +137,16 @@ const inputField = css`
   }
 
   /* Small theme */
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     font-size: var(--lumo-font-size-s);
     --lumo-text-field-size: var(--lumo-size-s);
   }
 
-  :host([theme~='small']) [part='label'] {
+  :host(:is([theme~='small'], .v-small)) [part='label'] {
     font-size: var(--lumo-font-size-xs);
   }
 
-  :host([theme~='small']) [part='error-message'] {
+  :host(:is([theme~='small'], .v-small)) [part='error-message'] {
     font-size: var(--lumo-font-size-xxs);
   }
 

--- a/packages/vaadin-lumo-styles/mixins/required-field.js
+++ b/packages/vaadin-lumo-styles/mixins/required-field.js
@@ -49,7 +49,7 @@ const requiredField = css`
     margin-top: calc(var(--lumo-font-size-s) * 1.5);
   }
 
-  :host([has-label][theme~='small'])::before {
+  :host([has-label]:is([theme~='small'], .v-small))::before {
     margin-top: calc(var(--lumo-font-size-xs) * 1.5);
   }
 

--- a/packages/vaadin-lumo-styles/src/components/accordion-heading.css
+++ b/packages/vaadin-lumo-styles/src/components/accordion-heading.css
@@ -35,7 +35,7 @@
     padding: var(--lumo-space-s) 0;
   }
 
-  :host([theme~='filled']) {
+  :host(:is([theme~='filled'], .v-filled)) {
     padding-top: 0;
     padding-bottom: 0;
   }

--- a/packages/vaadin-lumo-styles/src/components/accordion-panel.css
+++ b/packages/vaadin-lumo-styles/src/components/accordion-panel.css
@@ -28,11 +28,11 @@
     border-bottom: none;
   }
 
-  :host([theme~='filled']) {
+  :host(:is([theme~='filled'], .v-filled)) {
     border-bottom: none;
   }
 
-  :host([theme~='filled']:not(:last-child)) {
+  :host(:is([theme~='filled'], .v-filled):not(:last-child)) {
     margin-bottom: 2px;
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/avatar-group.css
+++ b/packages/vaadin-lumo-styles/src/components/avatar-group.css
@@ -21,25 +21,25 @@
     margin-inline-start: calc(var(--_overlap) * -1 - var(--vaadin-avatar-outline-width));
   }
 
-  :host([theme~='xlarge']) {
+  :host(:is([theme~='xlarge'], .v-xlarge)) {
     --vaadin-avatar-group-overlap: 12px;
     --vaadin-avatar-group-overlap-border: 3px;
     --vaadin-avatar-size: var(--lumo-size-xl);
   }
 
-  :host([theme~='large']) {
+  :host(:is([theme~='large'], .v-large)) {
     --vaadin-avatar-group-overlap: 10px;
     --vaadin-avatar-group-overlap-border: 3px;
     --vaadin-avatar-size: var(--lumo-size-l);
   }
 
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     --vaadin-avatar-group-overlap: 6px;
     --vaadin-avatar-group-overlap-border: 2px;
     --vaadin-avatar-size: var(--lumo-size-s);
   }
 
-  :host([theme~='xsmall']) {
+  :host(:is([theme~='xsmall'], .v-xsmall)) {
     --vaadin-avatar-group-overlap: 4px;
     --vaadin-avatar-group-overlap-border: 2px;
     --vaadin-avatar-size: var(--lumo-size-xs);

--- a/packages/vaadin-lumo-styles/src/components/avatar.css
+++ b/packages/vaadin-lumo-styles/src/components/avatar.css
@@ -52,35 +52,35 @@
     border-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
   }
 
-  :host([theme~='xlarge']) [part='abbr'] {
+  :host(:is([theme~='xlarge'], .v-xlarge)) [part='abbr'] {
     font-size: 2.5em;
   }
 
-  :host([theme~='large']) [part='abbr'] {
+  :host(:is([theme~='large'], .v-large)) [part='abbr'] {
     font-size: 2.375em;
   }
 
-  :host([theme~='small']) [part='abbr'] {
+  :host(:is([theme~='small'], .v-small)) [part='abbr'] {
     font-size: 2.75em;
   }
 
-  :host([theme~='xsmall']) [part='abbr'] {
+  :host(:is([theme~='xsmall'], .v-xsmall)) [part='abbr'] {
     font-size: 3em;
   }
 
-  :host([theme~='xlarge']) {
+  :host(:is([theme~='xlarge'], .v-xlarge)) {
     --vaadin-avatar-size: var(--lumo-size-xl);
   }
 
-  :host([theme~='large']) {
+  :host(:is([theme~='large'], .v-large)) {
     --vaadin-avatar-size: var(--lumo-size-l);
   }
 
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     --vaadin-avatar-size: var(--lumo-size-s);
   }
 
-  :host([theme~='xsmall']) {
+  :host(:is([theme~='xsmall'], .v-xsmall)) {
     --vaadin-avatar-size: var(--lumo-size-xs);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/button.css
+++ b/packages/vaadin-lumo-styles/src/components/button.css
@@ -84,12 +84,12 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
     padding: calc(var(--lumo-button-size) / 6) 0;
   }
 
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     font-size: var(--lumo-font-size-s);
     --lumo-button-size: var(--lumo-size-s);
   }
 
-  :host([theme~='large']) {
+  :host(:is([theme~='large'], .v-large)) {
     font-size: var(--lumo-font-size-l);
     --lumo-button-size: var(--lumo-size-l);
   }
@@ -144,30 +144,30 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
       0 0 0 calc(var(--_focus-ring-width) + 1px * var(--_focus-ring-gap-on, 0)) var(--_focus-ring-color);
   }
 
-  :host([theme~='primary'][focus-ring]) {
+  :host(:is([theme~='primary'], .v-primary)[focus-ring]) {
     --_focus-ring-gap-on: 1;
   }
 
   /* Types (primary, tertiary, tertiary-inline */
 
-  :host([theme~='tertiary']),
-  :host([theme~='tertiary-inline']) {
+  :host(:is([theme~='tertiary'], .v-tertiary)),
+  :host(:is([theme~='tertiary-inline'], .v-text)) {
     background: var(--vaadin-button-tertiary-background, transparent) !important;
     min-width: 0;
   }
 
-  :host([theme~='tertiary']) {
+  :host(:is([theme~='tertiary'], .v-tertiary)) {
     border: var(--vaadin-button-tertiary-border, none);
     color: var(--vaadin-button-tertiary-text-color, var(--lumo-primary-text-color));
     font-weight: var(--vaadin-button-tertiary-font-weight, 500);
     padding: var(--vaadin-button-tertiary-padding, 0 calc(var(--_button-size) / 6));
   }
 
-  :host([theme~='tertiary-inline'])::before {
+  :host(:is([theme~='tertiary-inline'], .v-text))::before {
     display: none;
   }
 
-  :host([theme~='tertiary-inline']) {
+  :host(:is([theme~='tertiary-inline'], .v-text)) {
     margin: 0;
     height: auto;
     padding: 0;
@@ -175,13 +175,13 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
     font-size: inherit;
   }
 
-  :host([theme~='tertiary-inline']) [part='label'] {
+  :host(:is([theme~='tertiary-inline'], .v-text)) [part='label'] {
     padding: 0;
     overflow: visible;
     line-height: inherit;
   }
 
-  :host([theme~='primary']) {
+  :host(:is([theme~='primary'], .v-primary)) {
     background: var(--_lumo-button-primary-background);
     border: var(--vaadin-button-primary-border, none);
     color: var(--_lumo-button-primary-text-color);
@@ -189,58 +189,58 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
     min-width: calc(var(--lumo-button-size) * 2.5);
   }
 
-  :host([theme~='primary'])::before {
+  :host(:is([theme~='primary'], .v-primary))::before {
     background-color: black;
   }
 
   @media (any-hover: hover) {
-    :host([theme~='primary']:not([disabled]):hover)::before {
+    :host(:is([theme~='primary'], .v-primary):not([disabled]):hover)::before {
       opacity: 0.05;
     }
   }
 
-  :host([theme~='primary'][active])::before {
+  :host(:is([theme~='primary'], .v-primary)[active])::before {
     opacity: 0.1;
   }
 
-  :host([theme~='primary'][active])::after {
+  :host(:is([theme~='primary'], .v-primary)[active])::after {
     opacity: 0.2;
   }
 
   /* Colors (success, warning, error, contrast) */
 
-  :host([theme~='success']) {
+  :host(:is([theme~='success'], .v-success)) {
     color: var(--lumo-success-text-color);
   }
 
-  :host([theme~='success'][theme~='primary']) {
+  :host(:is([theme~='success'], .v-success):is([theme~='primary'], .v-primary)) {
     background-color: var(--lumo-success-color);
     color: var(--lumo-success-contrast-color);
   }
 
-  :host([theme~='warning']) {
+  :host(:is([theme~='warning'], .v-warning)) {
     color: var(--lumo-warning-text-color);
   }
 
-  :host([theme~='warning'][theme~='primary']) {
+  :host(:is([theme~='warning'], .v-warning):is([theme~='primary'], .v-primary)) {
     background-color: var(--lumo-warning-color);
     color: var(--lumo-warning-contrast-color);
   }
 
-  :host([theme~='error']) {
+  :host(:is([theme~='error'], .v-error)) {
     color: var(--lumo-error-text-color);
   }
 
-  :host([theme~='error'][theme~='primary']) {
+  :host(:is([theme~='error'], .v-error):is([theme~='primary'], .v-primary)) {
     background-color: var(--lumo-error-color);
     color: var(--lumo-error-contrast-color);
   }
 
-  :host([theme~='contrast']) {
+  :host(:is([theme~='contrast'], .v-contrast)) {
     color: var(--lumo-contrast);
   }
 
-  :host([theme~='contrast'][theme~='primary']) {
+  :host(:is([theme~='contrast'], .v-contrast):is([theme~='primary'], .v-primary)) {
     background-color: var(--lumo-contrast);
     color: var(--lumo-base-color);
   }
@@ -253,12 +253,12 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
     cursor: not-allowed;
   }
 
-  :host([theme~='primary'][disabled]) {
+  :host(:is([theme~='primary'], .v-primary)[disabled]) {
     background-color: var(--lumo-contrast-30pct);
     color: var(--lumo-base-color);
   }
 
-  :host([theme~='primary'][disabled]) [part] {
+  :host(:is([theme~='primary'], .v-primary)[disabled]) [part] {
     opacity: 0.7;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/card.css
+++ b/packages/vaadin-lumo-styles/src/components/card.css
@@ -9,12 +9,12 @@
     border-radius: var(--_card-border-pseudo-radius, inherit);
   }
 
-  :host([theme~='outlined']) {
+  :host(:is([theme~='outlined'], .v-outlined)) {
     --vaadin-card-border-width: 1px;
     --vaadin-card-background: var(--lumo-base-color);
   }
 
-  :host([theme~='elevated']) {
+  :host(:is([theme~='elevated'], .v-elevated)) {
     --vaadin-card-background: linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct)) var(--lumo-base-color);
     --vaadin-card-shadow: var(--lumo-box-shadow-xs);
     --vaadin-card-border-width: 1px;
@@ -22,15 +22,17 @@
     --_card-border-pseudo-radius: calc(var(--vaadin-card-border-radius) + var(--vaadin-card-border-width));
   }
 
-  :host([theme~='elevated']:not([theme~='outlined'])) {
+  :host(:is([theme~='elevated'], .v-elevated):not([theme~='outlined'], .v-outlined)) {
     --vaadin-card-border-color: var(--lumo-contrast-10pct);
   }
 
-  :host(:where([theme~='stretch-media'])) ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
+  :host(:where(:is([theme~='stretch-media'], .v-stretch-media)))
+    ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
     border-radius: var(--lumo-border-radius-m);
   }
 
-  :host([theme~='elevated'][theme~='cover-media']) ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
+  :host(:is([theme~='elevated'], .v-elevated):is([theme~='cover-media'], .v-cover-media))
+    ::slotted([slot='media']:is(img, video, svg, vaadin-icon)) {
     margin-top: calc((var(--_padding) + var(--vaadin-card-border-width)) * -1);
     margin-inline: calc((var(--_padding) + var(--vaadin-card-border-width)) * -1);
     width: calc(100% + (var(--_padding) + var(--vaadin-card-border-width)) * 2);

--- a/packages/vaadin-lumo-styles/src/components/confirm-dialog-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/confirm-dialog-overlay.css
@@ -30,7 +30,7 @@
     max-width: 100%;
   }
 
-  ::slotted([slot$='button'][theme~='tertiary']) {
+  ::slotted([slot$='button']:is([theme~='tertiary'], .v-tertiary)) {
     padding-left: var(--lumo-space-s);
     padding-right: var(--lumo-space-s);
   }

--- a/packages/vaadin-lumo-styles/src/components/crud.css
+++ b/packages/vaadin-lumo-styles/src/components/crud.css
@@ -118,7 +118,7 @@
     margin-right: var(--lumo-space-s);
   }
 
-  :host([theme~='no-border']) [part='toolbar'] {
+  :host(:is([theme~='no-border'], .v-no-border)) [part='toolbar'] {
     border: 0;
   }
 
@@ -139,11 +139,11 @@
     box-shadow: var(--lumo-box-shadow-m);
   }
 
-  :host(:not([theme~='no-border']):not([editor-position=''])) [part='editor']:not([hidden]) {
+  :host(:not(:is([theme~='no-border'], .v-no-border)):not([editor-position=''])) [part='editor']:not([hidden]) {
     border: 1px solid var(--lumo-contrast-20pct);
   }
 
-  :host(:not([theme~='no-border'])[editor-position='bottom']) [part='editor']:not([hidden]) {
+  :host(:not(:is([theme~='no-border'], .v-no-border))[editor-position='bottom']) [part='editor']:not([hidden]) {
     border-top: 0;
   }
 
@@ -151,7 +151,8 @@
     border-left: 0;
   }
 
-  :host([dir='rtl']:not([theme~='no-border'])[editor-position='aside']) [part='editor']:not([hidden]) {
+  :host([dir='rtl']:not(:is([theme~='no-border'], .v-no-border))[editor-position='aside'])
+    [part='editor']:not([hidden]) {
     border-right: 0;
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/custom-field.css
+++ b/packages/vaadin-lumo-styles/src/components/custom-field.css
@@ -82,16 +82,16 @@
   }
 
   /* Small theme */
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     font-size: var(--lumo-font-size-s);
     --lumo-text-field-size: var(--lumo-size-s);
   }
 
-  :host([theme~='small'][has-label]) [part='label'] {
+  :host(:is([theme~='small'], .v-small)[has-label]) [part='label'] {
     font-size: var(--lumo-font-size-xs);
   }
 
-  :host([theme~='small'][has-label]) [part='error-message'] {
+  :host(:is([theme~='small'], .v-small)[has-label]) [part='error-message'] {
     font-size: var(--lumo-font-size-xxs);
   }
 

--- a/packages/vaadin-lumo-styles/src/components/dashboard-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/dashboard-layout.css
@@ -10,18 +10,18 @@
     --_default-row-min-height: 12rem;
   }
 
-  :host([theme~='shaded-background']) {
+  :host(:is([theme~='shaded-background'], .v-shaded-background)) {
     background: var(--lumo-shade-5pct);
   }
 
-  :host([theme~='elevated-widgets']) {
+  :host(:is([theme~='elevated-widgets'], .v-elevated-widgets)) {
     --vaadin-dashboard-widget-shadow: var(--lumo-box-shadow-xs);
     --vaadin-dashboard-widget-border-color: var(--lumo-contrast-10pct);
     --vaadin-dashboard-widget-background: linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct))
       var(--lumo-base-color);
   }
 
-  :host([theme~='flat-widgets']) {
+  :host(:is([theme~='flat-widgets'], .v-flat-widgets)) {
     --vaadin-dashboard-widget-background: var(--lumo-contrast-5pct);
     --vaadin-dashboard-widget-border-color: transparent;
   }

--- a/packages/vaadin-lumo-styles/src/components/details-summary.css
+++ b/packages/vaadin-lumo-styles/src/components/details-summary.css
@@ -88,44 +88,44 @@
   }
 
   /* Small */
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     padding-top: var(--lumo-space-xs);
     padding-bottom: var(--lumo-space-xs);
   }
 
-  :host([theme~='small']) [part='toggle'] {
+  :host(:is([theme~='small'], .v-small)) [part='toggle'] {
     margin-right: calc(var(--lumo-space-xs) / 2);
   }
 
-  :host([theme~='small'][dir='rtl']) [part='toggle'] {
+  :host(:is([theme~='small'], .v-small)[dir='rtl']) [part='toggle'] {
     margin-left: calc(var(--lumo-space-xs) / 2);
   }
 
   /* Filled */
-  :host([theme~='filled']) {
+  :host(:is([theme~='filled'], .v-filled)) {
     padding: var(--lumo-space-s) calc(var(--lumo-space-s) + var(--lumo-space-xs) / 2);
   }
 
   /* Reverse */
-  :host([theme~='reverse']) {
+  :host(:is([theme~='reverse'], .v-reverse)) {
     justify-content: space-between;
   }
 
-  :host([theme~='reverse']) [part='toggle'] {
+  :host(:is([theme~='reverse'], .v-reverse)) [part='toggle'] {
     order: 1;
     margin-right: 0;
   }
 
-  :host([theme~='reverse'][dir='rtl']) [part='toggle'] {
+  :host(:is([theme~='reverse'], .v-reverse)[dir='rtl']) [part='toggle'] {
     margin-left: 0;
   }
 
   /* Filled reverse */
-  :host([theme~='reverse'][theme~='filled']) {
+  :host(:is([theme~='reverse'], .v-reverse):is([theme~='filled'], .v-filled)) {
     padding-left: var(--lumo-space-m);
   }
 
-  :host([theme~='reverse'][theme~='filled'][dir='rtl']) {
+  :host(:is([theme~='reverse'], .v-reverse):is([theme~='filled'], .v-filled)[dir='rtl']) {
     padding-right: var(--lumo-space-m);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/details.css
+++ b/packages/vaadin-lumo-styles/src/components/details.css
@@ -21,17 +21,17 @@
     line-height: var(--lumo-line-height-m);
   }
 
-  :host([theme~='filled']) {
+  :host(:is([theme~='filled'], .v-filled)) {
     background-color: var(--lumo-contrast-5pct);
     border-radius: var(--lumo-border-radius-m);
   }
 
-  :host([theme~='filled']) [part='content'] {
+  :host(:is([theme~='filled'], .v-filled)) [part='content'] {
     padding-left: var(--lumo-space-m);
     padding-right: var(--lumo-space-m);
   }
 
-  :host([theme~='small']) [part$='content'] {
+  :host(:is([theme~='small'], .v-small)) [part$='content'] {
     font-size: var(--lumo-font-size-s);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/dialog-overlay.css
@@ -117,7 +117,7 @@
   }
 
   /* No padding */
-  :host([theme~='no-padding']) [part='content'] {
+  :host(:is([theme~='no-padding'], .v-no-padding)) [part='content'] {
     padding: 0 !important;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/grid-pro.css
+++ b/packages/vaadin-lumo-styles/src/components/grid-pro.css
@@ -24,19 +24,19 @@
 
   /* Indicate editable cells */
 
-  :host([theme~='highlight-editable-cells']) [part~='editable-cell'] {
+  :host(:is([theme~='highlight-editable-cells'], .v-highlight-editable-cells)) [part~='editable-cell'] {
     background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
   }
 
-  :host([theme~='highlight-editable-cells']) [part~='editable-cell']:hover,
-  :host([theme~='highlight-editable-cells']) [part~='editable-cell']:focus {
+  :host(:is([theme~='highlight-editable-cells'], .v-highlight-editable-cells)) [part~='editable-cell']:hover,
+  :host(:is([theme~='highlight-editable-cells'], .v-highlight-editable-cells)) [part~='editable-cell']:focus {
     background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-10pct), var(--lumo-contrast-10pct));
   }
 
   /* Indicate read-only cells */
 
   /* prettier-ignore */
-  :host([theme~='highlight-read-only-cells']) [tabindex]:not([part~='editable-cell']):not([part~='header-cell']):not([part~='footer-cell']) {
+  :host(:is([theme~='highlight-read-only-cells'], .v-highlight-read-only-cells)) [tabindex]:not([part~='editable-cell']):not([part~='header-cell']):not([part~='footer-cell']) {
     background-image: repeating-linear-gradient(
       135deg,
       transparent,

--- a/packages/vaadin-lumo-styles/src/components/grid.css
+++ b/packages/vaadin-lumo-styles/src/components/grid.css
@@ -375,19 +375,19 @@
 
   /* No (outer) border */
 
-  :host(:not([theme~='no-border'])) {
+  :host(:not([theme~='no-border'], .v-no-border)) {
     border: var(--_lumo-grid-border-width) solid var(--_lumo-grid-border-color);
   }
 
   /* Cell styles */
 
   /* Apply row borders by default and introduce the "no-row-borders" variant */
-  :host(:not([theme~='no-row-borders'])) .cell:not(.details-cell) {
+  :host(:not([theme~='no-row-borders'], .v-no-row-borders)) .cell:not(.details-cell) {
     border-top: var(--_lumo-grid-border-width) solid var(--_lumo-grid-secondary-border-color);
   }
 
   /* Hide first body row top border */
-  :host(:not([theme~='no-row-borders'])) .first-row .cell:not(.details-cell) {
+  :host(:not([theme~='no-row-borders'], .v-no-row-borders)) .first-row .cell:not(.details-cell) {
     border-top: 0;
     min-height: calc(var(--lumo-size-m) - var(--_lumo-grid-border-width));
   }
@@ -450,7 +450,7 @@
     right: -1px;
   }
 
-  :host([theme~='no-row-borders']) [dragover] .cell::after {
+  :host(:is([theme~='no-row-borders'], .v-no-row-borders)) [dragover] .cell::after {
     height: 2px;
   }
 
@@ -537,7 +537,7 @@
   /* Header borders */
 
   /* Hide first header row top border */
-  :host(:not([theme~='no-row-borders'])) .first-header-row .header-cell {
+  :host(:not([theme~='no-row-borders'], .v-no-row-borders)) .first-header-row .header-cell {
     border-top: 0;
   }
 
@@ -550,7 +550,7 @@
     border-bottom: var(--_lumo-grid-border-width) solid transparent;
   }
 
-  :host(:not([theme~='no-row-borders'])) .last-header-row .header-cell {
+  :host(:not([theme~='no-row-borders'], .v-no-row-borders)) .last-header-row .header-cell {
     border-bottom-color: var(--_lumo-grid-secondary-border-color);
   }
 
@@ -565,7 +565,7 @@
     border-top: var(--_lumo-grid-border-width) solid transparent;
   }
 
-  :host(:not([theme~='no-row-borders'])) .first-footer-row .footer-cell {
+  :host(:not([theme~='no-row-borders'], .v-no-row-borders)) .first-footer-row .footer-cell {
     border-top-color: var(--_lumo-grid-secondary-border-color);
   }
 
@@ -620,7 +620,7 @@
 
   /* Column borders */
 
-  :host([theme~='column-borders']) .cell:not([last-column]):not(.details-cell) {
+  :host(:is([theme~='column-borders'], .v-column-borders)) .cell:not([last-column]):not(.details-cell) {
     border-right: var(--_lumo-grid-border-width) solid var(--_lumo-grid-secondary-border-color);
   }
 
@@ -641,8 +641,8 @@
 
   /* Row stripes */
 
-  :host([theme~='row-stripes']) .even-row .body-cell,
-  :host([theme~='row-stripes']) .even-row .details-cell {
+  :host(:is([theme~='row-stripes'], .v-row-stripes)) .even-row .body-cell,
+  :host(:is([theme~='row-stripes'], .v-row-stripes)) .even-row .details-cell {
     background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
     background-repeat: repeat-x;
   }
@@ -660,32 +660,32 @@
   }
 
   /* Cover the border of an unselected row */
-  :host(:not([theme~='no-row-borders'])) .row[selected] .cell:not(.details-cell) {
+  :host(:not([theme~='no-row-borders'], .v-no-row-borders)) .row[selected] .cell:not(.details-cell) {
     box-shadow: 0 var(--_lumo-grid-border-width) 0 0 var(--_lumo-grid-selected-row-color);
   }
 
   /* Compact */
 
-  :host([theme~='compact']) .header-row:only-child .header-cell {
+  :host(:is([theme~='compact'], .v-compact)) .header-row:only-child .header-cell {
     min-height: var(--lumo-size-m);
   }
 
-  :host([theme~='compact']) .cell {
+  :host(:is([theme~='compact'], .v-compact)) .cell {
     min-height: var(--lumo-size-s);
     --_cell-default-padding: var(--lumo-space-xs) var(--lumo-space-s);
   }
 
-  :host([theme~='compact']) .first-row .cell:not(.details-cell) {
+  :host(:is([theme~='compact'], .v-compact)) .first-row .cell:not(.details-cell) {
     min-height: calc(var(--lumo-size-s) - var(--_lumo-grid-border-width));
   }
 
-  :host([theme~='compact']) .empty-state {
+  :host(:is([theme~='compact'], .v-compact)) .empty-state {
     padding: var(--lumo-space-s);
   }
 
   /* Wrap cell contents */
 
-  :host([theme~='wrap-cell-content']) .cell ::slotted(vaadin-grid-cell-content) {
+  :host(:is([theme~='wrap-cell-content'], .v-wrap-cell-content)) .cell ::slotted(vaadin-grid-cell-content) {
     white-space: normal;
   }
 
@@ -699,7 +699,7 @@
     border-radius: 0 var(--lumo-border-radius-s) var(--lumo-border-radius-s) 0;
   }
 
-  :host([dir='rtl'][theme~='column-borders']) .cell:not([last-column]):not(.details-cell) {
+  :host([dir='rtl']:is([theme~='column-borders'], .v-column-borders)) .cell:not([last-column]):not(.details-cell) {
     border-right: none;
     border-left: var(--_lumo-grid-border-width) solid var(--_lumo-grid-secondary-border-color);
   }

--- a/packages/vaadin-lumo-styles/src/components/input-container.css
+++ b/packages/vaadin-lumo-styles/src/components/input-container.css
@@ -166,31 +166,31 @@
     }
   }
 
-  :host([theme~='align-left']) ::slotted(:not([slot$='fix'])) {
+  :host(:is([theme~='align-left'], .v-align-left)) ::slotted(:not([slot$='fix'])) {
     text-align: start;
     --_lumo-text-field-overflow-mask-image: none;
   }
 
-  :host([theme~='align-center']) ::slotted(:not([slot$='fix'])) {
+  :host(:is([theme~='align-center'], .v-align-center)) ::slotted(:not([slot$='fix'])) {
     text-align: center;
     --_lumo-text-field-overflow-mask-image: none;
   }
 
-  :host([theme~='align-right']) ::slotted(:not([slot$='fix'])) {
+  :host(:is([theme~='align-right'], .v-align-right)) ::slotted(:not([slot$='fix'])) {
     text-align: end;
     --_lumo-text-field-overflow-mask-image: none;
   }
 
   @-moz-document url-prefix() {
     /* Firefox is smart enough to align overflowing text to right */
-    :host([theme~='align-right']) ::slotted(:not([slot$='fix'])) {
+    :host(:is([theme~='align-right'], .v-align-right)) ::slotted(:not([slot$='fix'])) {
       --_lumo-text-field-overflow-mask-image: linear-gradient(to right, transparent 0.25em, #000 1.5em);
     }
   }
 
   @-moz-document url-prefix() {
     /* Firefox is smart enough to align overflowing text to right */
-    :host([theme~='align-left']) ::slotted(:not([slot$='fix'])) {
+    :host(:is([theme~='align-left'], .v-align-left)) ::slotted(:not([slot$='fix'])) {
       --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent 0.25em, #000 1.5em);
     }
   }
@@ -200,28 +200,28 @@
     transform-origin: 0% 0;
   }
 
-  :host([theme~='align-left'][dir='rtl']) ::slotted(:not([slot$='fix'])) {
+  :host(:is([theme~='align-left'], .v-align-left)[dir='rtl']) ::slotted(:not([slot$='fix'])) {
     --_lumo-text-field-overflow-mask-image: none;
   }
 
-  :host([theme~='align-center'][dir='rtl']) ::slotted(:not([slot$='fix'])) {
+  :host(:is([theme~='align-center'], .v-align-center)[dir='rtl']) ::slotted(:not([slot$='fix'])) {
     --_lumo-text-field-overflow-mask-image: none;
   }
 
-  :host([theme~='align-right'][dir='rtl']) ::slotted(:not([slot$='fix'])) {
+  :host(:is([theme~='align-right'], .v-align-right)[dir='rtl']) ::slotted(:not([slot$='fix'])) {
     --_lumo-text-field-overflow-mask-image: none;
   }
 
   @-moz-document url-prefix() {
     /* Firefox is smart enough to align overflowing text to right */
-    :host([theme~='align-right'][dir='rtl']) ::slotted(:not([slot$='fix'])) {
+    :host(:is([theme~='align-right'], .v-align-right)[dir='rtl']) ::slotted(:not([slot$='fix'])) {
       --_lumo-text-field-overflow-mask-image: linear-gradient(to right, transparent 0.25em, #000 1.5em);
     }
   }
 
   @-moz-document url-prefix() {
     /* Firefox is smart enough to align overflowing text to right */
-    :host([theme~='align-left'][dir='rtl']) ::slotted(:not([slot$='fix'])) {
+    :host(:is([theme~='align-left'], .v-align-left)[dir='rtl']) ::slotted(:not([slot$='fix'])) {
       --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent 0.25em, #000 1.5em);
     }
   }

--- a/packages/vaadin-lumo-styles/src/components/map.css
+++ b/packages/vaadin-lumo-styles/src/components/map.css
@@ -19,11 +19,11 @@
     --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
   }
 
-  :host(:not([theme~='no-border'])) {
+  :host(:not(:is([theme~='no-border'], .v-no-border))) {
     border-radius: var(--vaadin-map-border-radius, var(--lumo-border-radius-l));
   }
 
-  :host(:not([theme~='no-border']))::before {
+  :host(:not(:is([theme~='no-border'], .v-no-border)))::before {
     border: 1px solid var(--vaadin-map-border-color, var(--lumo-contrast-10pct));
   }
 

--- a/packages/vaadin-lumo-styles/src/components/menu-bar-button.css
+++ b/packages/vaadin-lumo-styles/src/components/menu-bar-button.css
@@ -25,26 +25,26 @@
     padding-right: calc(var(--lumo-size-m) / 3 + var(--lumo-border-radius-m) / 2);
   }
 
-  :host([theme~='small']) [part='label'] ::slotted(vaadin-menu-bar-item) {
+  :host(:is([theme~='small'], .v-small)) [part='label'] ::slotted(vaadin-menu-bar-item) {
     min-height: var(--lumo-size-s);
     margin: 0 calc((var(--lumo-size-s) / 3 + var(--lumo-border-radius-m) / 2) * -1);
     padding-left: calc(var(--lumo-size-s) / 3 + var(--lumo-border-radius-m) / 2);
     padding-right: calc(var(--lumo-size-s) / 3 + var(--lumo-border-radius-m) / 2);
   }
 
-  :host([theme~='tertiary']) [part='label'] ::slotted(vaadin-menu-bar-item) {
+  :host(:is([theme~='tertiary'], .v-tertiary)) [part='label'] ::slotted(vaadin-menu-bar-item) {
     margin: 0 calc((var(--lumo-button-size) / 6) * -1);
     padding-left: calc(var(--lumo-button-size) / 6);
     padding-right: calc(var(--lumo-button-size) / 6);
   }
 
-  :host([theme~='tertiary-inline']) {
+  :host(:is([theme~='tertiary-inline'], .v-text)) {
     margin-top: calc(var(--lumo-space-xs) / 2);
     margin-bottom: calc(var(--lumo-space-xs) / 2);
     margin-right: calc(var(--lumo-space-xs) / 2);
   }
 
-  :host([theme~='tertiary-inline']) [part='label'] ::slotted(vaadin-menu-bar-item) {
+  :host(:is([theme~='tertiary-inline'], .v-text)) [part='label'] ::slotted(vaadin-menu-bar-item) {
     margin: 0;
     padding: 0;
   }
@@ -61,8 +61,8 @@
     border-radius: 0 var(--lumo-border-radius-m) var(--lumo-border-radius-m) 0;
   }
 
-  :host([theme~='tertiary']),
-  :host([theme~='tertiary-inline']) {
+  :host(:is([theme~='tertiary'], .v-tertiary)),
+  :host(:is([theme~='tertiary-inline'], .v-text)) {
     border-radius: var(--lumo-border-radius-m);
   }
 
@@ -100,12 +100,12 @@
   }
 
   /* prettier-ignore */
-  :host([theme~='dropdown-indicators']:not([slot='overflow']):not([theme~='icon'])[theme~='tertiary'][aria-haspopup]) [part='suffix'] {
+  :host([theme~='dropdown-indicators']:not([slot='overflow']):not([theme~='icon']):is([theme~='tertiary'], .v-tertiary)[aria-haspopup]) [part='suffix'] {
     inset-inline-start: 0.05em;
   }
 
   /* prettier-ignore */
-  :host([theme~='dropdown-indicators']:not([slot='overflow']):not([theme~='icon'])[theme~='tertiary-inline'][aria-haspopup]) [part='suffix'] {
+  :host([theme~='dropdown-indicators']:not([slot='overflow']):not([theme~='icon']):is([theme~='tertiary-inline'], .v-text)[aria-haspopup]) [part='suffix'] {
     inset-inline-start: 0;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/menu-bar.css
+++ b/packages/vaadin-lumo-styles/src/components/menu-bar.css
@@ -24,8 +24,8 @@
     border-radius: var(--lumo-border-radius-m);
   }
 
-  :host([theme~='end-aligned']) ::slotted(vaadin-menu-bar-button[first-visible]),
-  :host([theme~='end-aligned'][has-single-button]) ::slotted(vaadin-menu-bar-button) {
+  :host(:is([theme~='end-aligned'], .v-align-end)) ::slotted(vaadin-menu-bar-button[first-visible]),
+  :host(:is([theme~='end-aligned'], .v-align-end)[has-single-button]) ::slotted(vaadin-menu-bar-button) {
     margin-inline-start: auto;
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/number-field.css
+++ b/packages/vaadin-lumo-styles/src/components/number-field.css
@@ -8,7 +8,7 @@
     pointer-events: none;
   }
 
-  :host([step-buttons-visible]:not([theme~='align-right'])) ::slotted(input) {
+  :host([step-buttons-visible]:not([theme~='align-right'], .v-align-right)) ::slotted(input) {
     text-align: center;
   }
 
@@ -47,7 +47,7 @@
     direction: ltr;
   }
 
-  :host([dir='rtl']:not([theme~='align-right'])) ::slotted(input) {
+  :host([dir='rtl']:not([theme~='align-right'], .v-align-right)) ::slotted(input) {
     --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/progress-bar.css
+++ b/packages/vaadin-lumo-styles/src/components/progress-bar.css
@@ -148,8 +148,8 @@
   }
 
   /* Contrast color */
-  :host([theme~='contrast']) [part='value'],
-  :host([theme~='contrast']) [part='value']::before {
+  :host(:is([theme~='contrast'], .v-contrast)) [part='value'],
+  :host(:is([theme~='contrast'], .v-contrast)) [part='value']::before {
     background-color: var(--lumo-contrast-80pct);
     --lumo-progress-indeterminate-progress-bar-background: linear-gradient(
       to right,
@@ -164,8 +164,8 @@
   }
 
   /* Error color */
-  :host([theme~='error']) [part='value'],
-  :host([theme~='error']) [part='value']::before {
+  :host(:is([theme~='error'], .v-error)) [part='value'],
+  :host(:is([theme~='error'], .v-error)) [part='value']::before {
     background-color: var(--lumo-error-color);
     --lumo-progress-indeterminate-progress-bar-background: linear-gradient(
       to right,
@@ -180,8 +180,8 @@
   }
 
   /* Primary color */
-  :host([theme~='success']) [part='value'],
-  :host([theme~='success']) [part='value']::before {
+  :host(:is([theme~='success'], .v-success)) [part='value'],
+  :host(:is([theme~='success'], .v-success)) [part='value']::before {
     background-color: var(--lumo-success-color);
     --lumo-progress-indeterminate-progress-bar-background: linear-gradient(
       to right,
@@ -249,8 +249,8 @@
   }
 
   /* Contrast color */
-  :host([theme~='contrast'][dir='rtl']) [part='value'],
-  :host([theme~='contrast'][dir='rtl']) [part='value']::before {
+  :host(:is([theme~='contrast'], .v-contrast)[dir='rtl']) [part='value'],
+  :host(:is([theme~='contrast'], .v-contrast)[dir='rtl']) [part='value']::before {
     --lumo-progress-indeterminate-progress-bar-background: linear-gradient(
       to left,
       var(--lumo-contrast-5pct) 10%,
@@ -264,8 +264,8 @@
   }
 
   /* Error color */
-  :host([theme~='error'][dir='rtl']) [part='value'],
-  :host([theme~='error'][dir='rtl']) [part='value']::before {
+  :host(:is([theme~='error'], .v-error)[dir='rtl']) [part='value'],
+  :host(:is([theme~='error'], .v-error)[dir='rtl']) [part='value']::before {
     --lumo-progress-indeterminate-progress-bar-background: linear-gradient(
       to left,
       var(--lumo-error-color-10pct) 10%,
@@ -279,8 +279,8 @@
   }
 
   /* Primary color */
-  :host([theme~='success'][dir='rtl']) [part='value'],
-  :host([theme~='success'][dir='rtl']) [part='value']::before {
+  :host(:is([theme~='success'], .v-success)[dir='rtl']) [part='value'],
+  :host(:is([theme~='success'], .v-success)[dir='rtl']) [part='value']::before {
     --lumo-progress-indeterminate-progress-bar-background: linear-gradient(
       to left,
       var(--lumo-success-color-10pct) 10%,

--- a/packages/vaadin-lumo-styles/src/components/rich-text-editor.css
+++ b/packages/vaadin-lumo-styles/src/components/rich-text-editor.css
@@ -301,37 +301,37 @@
   /* Theme variants */
 
   /* No border */
-  :host(:not([theme~='no-border'])) {
+  :host(:not([theme~='no-border'], .v-no-border)) {
     border: 1px solid var(--lumo-contrast-20pct);
   }
 
-  :host(:not([theme~='no-border']):not([readonly])) [part='content'] {
+  :host(:not([theme~='no-border'], .v-no-border):not([readonly])) [part='content'] {
     border-top: 1px solid var(--lumo-contrast-20pct);
   }
 
-  :host([theme~='no-border']) [part='toolbar'] {
+  :host(:is([theme~='no-border'], .v-no-border)) [part='toolbar'] {
     --vaadin-rich-text-editor-toolbar-padding: var(--lumo-space-s) var(--lumo-space-xs);
   }
 
   /* Compact */
-  :host([theme~='compact']) {
+  :host(:is([theme~='compact'], .v-compact)) {
     min-height: calc(var(--lumo-size-m) * 6);
   }
 
-  :host([theme~='compact']) [part='toolbar'] {
+  :host(:is([theme~='compact'], .v-compact)) [part='toolbar'] {
     --vaadin-rich-text-editor-toolbar-padding: var(--lumo-space-xs) 0;
   }
 
-  :host([theme~='compact'][theme~='no-border']) [part='toolbar'] {
+  :host(:is([theme~='compact'], .v-compact):is([theme~='no-border'], .v-no-border)) [part='toolbar'] {
     --vaadin-rich-text-editor-toolbar-padding: calc(var(--lumo-space-xs) + 1px) 0;
   }
 
-  :host([theme~='compact']) [part~='toolbar-button'] {
+  :host(:is([theme~='compact'], .v-compact)) [part~='toolbar-button'] {
     width: var(--lumo-size-s);
     height: var(--lumo-size-s);
   }
 
-  :host([theme~='compact']) [part~='toolbar-group'] {
+  :host(:is([theme~='compact'], .v-compact)) [part~='toolbar-group'] {
     margin: 0 calc(var(--lumo-space-m) / 2 - 1px);
   }
 

--- a/packages/vaadin-lumo-styles/src/components/select-overlay.css
+++ b/packages/vaadin-lumo-styles/src/components/select-overlay.css
@@ -34,15 +34,15 @@
     margin-block-end: var(--lumo-space-xs);
   }
 
-  :host([theme~='align-left']) {
+  :host(:is([theme~='align-left'], .v-align-left)) {
     text-align: left;
   }
 
-  :host([theme~='align-right']) {
+  :host(:is([theme~='align-right'], .v-align-right)) {
     text-align: right;
   }
 
-  :host([theme~='align-center']) {
+  :host(:is([theme~='align-center'], .v-align-center)) {
     text-align: center;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/select.css
+++ b/packages/vaadin-lumo-styles/src/components/select.css
@@ -53,7 +53,7 @@
     color: var(--lumo-contrast-80pct);
   }
 
-  :host([theme~='small']) [part='input-field'] ::slotted([slot='value']) {
+  :host(:is([theme~='small'], .v-small)) [part='input-field'] ::slotted([slot='value']) {
     --_lumo-selected-item-height: var(--lumo-size-s);
     --_lumo-selected-item-padding: 0;
   }

--- a/packages/vaadin-lumo-styles/src/components/split-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/split-layout.css
@@ -24,23 +24,23 @@
   }
 
   /* Small overrides */
-  :host([theme~='small']) > [part='splitter'] {
+  :host(:is([theme~='small'], .v-small)) > [part='splitter'] {
     --vaadin-split-layout-handle-size: 5px;
     background: var(--lumo-contrast-10pct);
   }
 
   /* Minimal */
-  :host([theme~='minimal']) > [part='splitter'] {
+  :host(:is([theme~='minimal'], .v-minimal)) > [part='splitter'] {
     --vaadin-split-layout-splitter-size: 0px;
     --vaadin-split-layout-handle-size: 5px;
     --vaadin-split-layout-splitter-target-size: 5px;
   }
 
-  :host([theme~='minimal']) > [part='splitter'] > [part='handle'] {
+  :host(:is([theme~='minimal'], .v-minimal)) > [part='splitter'] > [part='handle'] {
     opacity: 0;
   }
 
-  :host([theme~='minimal']) > [part='splitter']:is(:hover, :active) > [part='handle'] {
+  :host(:is([theme~='minimal'], .v-minimal)) > [part='splitter']:is(:hover, :active) > [part='handle'] {
     opacity: 1;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/tab.css
+++ b/packages/vaadin-lumo-styles/src/components/tab.css
@@ -158,7 +158,7 @@
     margin-right: 0;
   }
 
-  :host([theme~='icon-on-top']) {
+  :host(:is([theme~='icon-on-top'], .v-icon-on-top)) {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -168,14 +168,14 @@
     padding-top: 0.25rem;
   }
 
-  :host([theme~='icon-on-top']) ::slotted(a) {
+  :host(:is([theme~='icon-on-top'], .v-icon-on-top)) ::slotted(a) {
     flex-direction: column;
     align-items: center;
     margin-top: -0.25rem;
     padding-top: 0.25rem;
   }
 
-  :host([theme~='icon-on-top']) ::slotted(vaadin-icon) {
+  :host(:is([theme~='icon-on-top'], .v-icon-on-top)) ::slotted(vaadin-icon) {
     margin: 0;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/tabs.css
+++ b/packages/vaadin-lumo-styles/src/components/tabs.css
@@ -40,7 +40,7 @@
     margin: 0 0.75rem;
   }
 
-  :host([orientation='horizontal']) [part='tabs'] ::slotted(vaadin-tab:not([theme~='icon-on-top'])) {
+  :host([orientation='horizontal']) [part='tabs'] ::slotted(vaadin-tab:not([theme~='icon-on-top'], .v-icon-on-top)) {
     justify-content: center;
   }
 
@@ -155,40 +155,44 @@
 
   /* Centered */
 
-  :host([theme~='centered'][orientation='horizontal']) ::slotted(vaadin-tab:first-of-type) {
+  :host(:is([theme~='centered'], .v-centered)[orientation='horizontal']) ::slotted(vaadin-tab:first-of-type) {
     margin-inline-start: auto;
   }
 
-  :host([theme~='centered'][orientation='horizontal']) ::slotted(vaadin-tab:last-of-type) {
+  :host(:is([theme~='centered'], .v-centered)[orientation='horizontal']) ::slotted(vaadin-tab:last-of-type) {
     margin-inline-end: auto;
   }
 
   /* Small */
 
-  :host([theme~='small']),
-  :host([theme~='small']) [part='tabs'] {
+  :host(:is([theme~='small'], .v-small)),
+  :host(:is([theme~='small'], .v-small)) [part='tabs'] {
     min-height: var(--lumo-size-m);
   }
 
-  :host([theme~='small']) [part='tabs'] ::slotted(vaadin-tab) {
+  :host(:is([theme~='small'], .v-small)) [part='tabs'] ::slotted(vaadin-tab) {
     font-size: var(--lumo-font-size-s);
   }
 
   /* Minimal */
 
-  :host([theme~='minimal']) {
+  :host(:is([theme~='minimal'], .v-minimal)) {
     box-shadow: none;
     --_lumo-tab-marker-display: none;
   }
 
   /* Hide-scroll-buttons */
 
-  :host([theme~='hide-scroll-buttons']) [part='back-button'],
-  :host([theme~='hide-scroll-buttons']) [part='forward-button'] {
+  :host(:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)) [part='back-button'],
+  :host(:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)) [part='forward-button'] {
     display: none;
   }
 
-  :host([theme~='hide-scroll-buttons'][overflow~='start'][overflow~='end']:not([orientation='vertical']))
+  :host(
+      :is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)[overflow~='start'][overflow~='end']:not(
+          [orientation='vertical']
+        )
+    )
     [part='tabs'] {
     --_lumo-tabs-overflow-mask-image: linear-gradient(
       90deg,
@@ -199,20 +203,22 @@
     );
   }
 
-  :host([theme~='hide-scroll-buttons'][overflow~='end']:not([orientation='vertical'])) [part='tabs'] {
+  :host(:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)[overflow~='end']:not([orientation='vertical']))
+    [part='tabs'] {
     --_lumo-tabs-overflow-mask-image: linear-gradient(90deg, #000 calc(100% - 2em), transparent 100%);
   }
 
-  :host([theme~='hide-scroll-buttons'][overflow~='start']:not([orientation='vertical'])) [part='tabs'] {
+  :host(:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)[overflow~='start']:not([orientation='vertical']))
+    [part='tabs'] {
     --_lumo-tabs-overflow-mask-image: linear-gradient(90deg, transparent, #000 2em);
   }
 
   /* Equal-width tabs */
-  :host([theme~='equal-width-tabs']) {
+  :host(:is([theme~='equal-width-tabs'], .v-stretch-tabs)) {
     flex: auto;
   }
 
-  :host([theme~='equal-width-tabs']) [part='tabs'] ::slotted(vaadin-tab) {
+  :host(:is([theme~='equal-width-tabs'], .v-stretch-tabs)) [part='tabs'] ::slotted(vaadin-tab) {
     flex: 1 0 0%;
   }
 
@@ -264,7 +270,11 @@
     --_lumo-tabs-overflow-mask-image: linear-gradient(-90deg, transparent 2em, #000 4em);
   }
 
-  :host([dir='rtl'][theme~='hide-scroll-buttons'][overflow~='start'][overflow~='end']:not([orientation='vertical']))
+  :host(
+      [dir='rtl']:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)[overflow~='start'][overflow~='end']:not(
+          [orientation='vertical']
+        )
+    )
     [part='tabs'] {
     --_lumo-tabs-overflow-mask-image: linear-gradient(
       -90deg,
@@ -275,11 +285,21 @@
     );
   }
 
-  :host([dir='rtl'][theme~='hide-scroll-buttons'][overflow~='end']:not([orientation='vertical'])) [part='tabs'] {
+  :host(
+      [dir='rtl']:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)[overflow~='end']:not(
+          [orientation='vertical']
+        )
+    )
+    [part='tabs'] {
     --_lumo-tabs-overflow-mask-image: linear-gradient(-90deg, #000 calc(100% - 2em), transparent 100%);
   }
 
-  :host([dir='rtl'][theme~='hide-scroll-buttons'][overflow~='start']:not([orientation='vertical'])) [part='tabs'] {
+  :host(
+      [dir='rtl']:is([theme~='hide-scroll-buttons'], .v-hide-scroll-buttons)[overflow~='start']:not(
+          [orientation='vertical']
+        )
+    )
+    [part='tabs'] {
     --_lumo-tabs-overflow-mask-image: linear-gradient(-90deg, transparent, #000 2em);
   }
 }

--- a/packages/vaadin-lumo-styles/src/components/tabsheet.css
+++ b/packages/vaadin-lumo-styles/src/components/tabsheet.css
@@ -58,7 +58,7 @@
     justify-content: center;
   }
 
-  :host([theme~='no-padding']) [part='content'] {
+  :host(:is([theme~='no-padding'], .v-no-padding)) [part='content'] {
     padding: 0 !important;
     --vaadin-scroller-padding-block: 0px !important;
     --vaadin-scroller-padding-inline: 0px !important;

--- a/packages/vaadin-lumo-styles/src/mixins/field-base.css
+++ b/packages/vaadin-lumo-styles/src/mixins/field-base.css
@@ -147,16 +147,16 @@
   }
 
   /* Small theme */
-  :host([theme~='small']) {
+  :host(:is([theme~='small'], .v-small)) {
     font-size: var(--lumo-font-size-s);
     --lumo-text-field-size: var(--lumo-size-s);
   }
 
-  :host([theme~='small']) [part='label'] {
+  :host(:is([theme~='small'], .v-small)) [part='label'] {
     font-size: var(--lumo-font-size-xs);
   }
 
-  :host([theme~='small']) [part='error-message'] {
+  :host(:is([theme~='small'], .v-small)) [part='error-message'] {
     font-size: var(--lumo-font-size-xxs);
   }
 

--- a/packages/vaadin-lumo-styles/src/mixins/field-helper.css
+++ b/packages/vaadin-lumo-styles/src/mixins/field-helper.css
@@ -33,30 +33,30 @@
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::before {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='helper-text']::before {
     display: none;
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::after {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='helper-text']::after {
     content: '';
     display: block;
     height: var(--_helper-spacing);
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='label'] {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='label'] {
     order: 0;
     padding-bottom: var(--_helper-spacing);
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text'] {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='helper-text'] {
     order: 1;
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='label'] + * {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='label'] + * {
     order: 2;
   }
 
-  :host([has-helper][theme~='helper-above-field']) [part='error-message'] {
+  :host([has-helper]:is([theme~='helper-above-field'], .v-helper-above)) [part='error-message'] {
     order: 3;
   }
 }

--- a/packages/vaadin-lumo-styles/src/mixins/field-label.css
+++ b/packages/vaadin-lumo-styles/src/mixins/field-label.css
@@ -48,7 +48,7 @@
     margin-top: calc(var(--lumo-font-size-s) * 1.5);
   }
 
-  :host([has-label][theme~='small'])::before {
+  :host([has-label]:is([theme~='small'], .v-small))::before {
     margin-top: calc(var(--lumo-font-size-xs) * 1.5);
   }
 

--- a/packages/vaadin-lumo-styles/src/mixins/slider.css
+++ b/packages/vaadin-lumo-styles/src/mixins/slider.css
@@ -41,15 +41,15 @@
     width: var(--vaadin-field-default-width, 12em);
   }
 
-  :host([theme~='contrast']) {
+  :host(:is([theme~='contrast'], .v-contrast)) {
     --vaadin-slider-fill-background: var(--lumo-contrast-80pct);
   }
 
-  :host([theme~='error']) {
+  :host(:is([theme~='error'], .v-error)) {
     --vaadin-slider-fill-background: var(--lumo-error-color);
   }
 
-  :host([theme~='success']) {
+  :host(:is([theme~='success'], .v-success)) {
     --vaadin-slider-fill-background: var(--lumo-success-color);
   }
 

--- a/packages/vertical-layout/src/styles/vaadin-vertical-layout-base-styles.js
+++ b/packages/vertical-layout/src/styles/vaadin-vertical-layout-base-styles.js
@@ -31,7 +31,7 @@ export const baseStyles = css`
     gap: var(--vaadin-vertical-layout-gap, var(--vaadin-gap-s));
   }
 
-  :host([theme~='wrap']) {
+  :host(:is([theme~='wrap'], .v-wrap)) {
     flex-wrap: wrap;
   }
 `;

--- a/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
+++ b/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
@@ -65,13 +65,13 @@ export const virtualListStyles = css`
     opacity: var(--vaadin-virtual-list-overflow-indicator-bottom-opacity);
   }
 
-  :host([theme~='overflow-indicator-top'][overflow~='top']),
-  :host([theme~='overflow-indicators'][overflow~='top']) {
+  :host(:is([theme~='overflow-indicator-top'], .v-overflow-indicator-top)[overflow~='top']),
+  :host(:is([theme~='overflow-indicators'], .v-overflow-indicators)[overflow~='top']) {
     --vaadin-virtual-list-overflow-indicator-top-opacity: 1;
   }
 
-  :host([theme~='overflow-indicators'][overflow~='bottom']),
-  :host([theme~='overflow-indicator-bottom'][overflow~='bottom']) {
+  :host(:is([theme~='overflow-indicators'], .v-overflow-indicators)[overflow~='bottom']),
+  :host(:is([theme~='overflow-indicator-bottom'], .v-overflow-indicator-bottom)[overflow~='bottom']) {
     --vaadin-virtual-list-overflow-indicator-bottom-opacity: 1;
   }
 `;


### PR DESCRIPTION
Add support for component variants using CSS classnames. Variant classnames are prefixed with `v-` to avoid naming collisions with application styles.

| Before | After
| --- | ---
| `<vaadin-button theme="primary">` | `<vaadin-button class="v-primary">`

The names of the variants are the same as the existing theme attribute values, apart from these exceptions:

| Theme attribute | Classname
| --- | ---
| `theme="helper-above-field"` | `class="v-helper-above"`
| `theme="end-aligned"` | `class="v-align-end"`
| `theme="tertiary-inline"` | `class="v-text"`
| `theme="equal-width-tabs"` | `class="v-stretch-tabs"`

Certain Lumo-only theme attribute values/variants are not included, as those should eventually be removed without a replacing variant:

- Button `icon` variant: the plan is to use the same implementation as in Aura, where the slot contents define the padding.
- Menu Bar `overflow-indicators` variant: the plan is to use the same default as in Aura, where dropdown indicators are always visible on the root items.
- Global `dark` variant: Lumo should also eventually simply respect the `color-scheme` property.

The Aura-only `filled` variant for Details and Accordion is getting redesigned/refactored, so I left that out for now as well.