### PR TITLE
refactor: do not force display to inline-flex in icon base styles

### DIFF
--- a/packages/icon/src/styles/vaadin-icon-base-styles.js
+++ b/packages/icon/src/styles/vaadin-icon-base-styles.js
@@ -7,7 +7,7 @@ import { css } from 'lit';
 
 export const iconStyles = css`
   :host {
-    display: inline-flex !important;
+    display: inline-flex;
     justify-content: center !important;
     align-items: center !important;
     font-size: inherit !important;

--- a/packages/icon/test/test-icon-font.js
+++ b/packages/icon/test/test-icon-font.js
@@ -17,10 +17,9 @@ export const iconFontCss = css`
   .my-icon-font {
     font-family: '${unsafeCSS(iconFontFamily)}';
 
-    /* Some popular icon libraries set CSS properties such as line-height and display to the
+    /* Some popular icon libraries set CSS properties such as line-height and font-size to the
     element with the class names applied. We'll replicate that here for testing purposes. */
     line-height: 1.5;
-    display: inline-block;
     vertical-align: top;
     font-size: 24px;
   }


### PR DESCRIPTION
## Description

As discussed internally, forcing `display: inline-flex !important` makes it impossible to hide `vaadin-icon` with CSS.
Let's revert this change for now and see if we get any potential problems with usage of icon libraries.

## Type of change

- Refactor