### PR TITLE
feat: add accessibleNameStart and accessibleNameEnd to range-slider

### DIFF
--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -122,6 +122,20 @@ declare class RangeSlider extends FieldMixin(SliderMixin(FocusMixin(ThemableMixi
    */
   value: number[];
 
+  /**
+   * Custom accessible name for the start (minimum) input.
+   * When not set, defaults to "${label} min" or "min" if no label.
+   * @attr {string} accessible-name-start
+   */
+  accessibleNameStart: string | null | undefined;
+
+  /**
+   * Custom accessible name for the end (maximum) input.
+   * When not set, defaults to "${label} max" or "max" if no label.
+   * @attr {string} accessible-name-end
+   */
+  accessibleNameEnd: string | null | undefined;
+
   addEventListener<K extends keyof RangeSliderEventMap>(
     type: K,
     listener: (this: RangeSlider, ev: RangeSliderEventMap[K]) => void,

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -183,6 +183,24 @@ class RangeSlider extends FieldMixin(
         notify: true,
         sync: true,
       },
+
+      /**
+       * Custom accessible name for the start (minimum) input.
+       * When not set, defaults to "${label} min" or "min" if no label.
+       * @attr {string} accessible-name-start
+       */
+      accessibleNameStart: {
+        type: String,
+      },
+
+      /**
+       * Custom accessible name for the end (maximum) input.
+       * When not set, defaults to "${label} max" or "max" if no label.
+       * @attr {string} accessible-name-end
+       */
+      accessibleNameEnd: {
+        type: String,
+      },
     };
   }
 
@@ -277,6 +295,7 @@ class RangeSlider extends FieldMixin(
           type="range"
           id="${this.__inputId0}"
           slot="input"
+          aria-label="${this.accessibleNameStart || this.__getAriaLabel('min')}"
           .min="${min}"
           .max="${max}"
           .step="${step}"
@@ -291,6 +310,7 @@ class RangeSlider extends FieldMixin(
           type="range"
           id="${this.__inputId1}"
           slot="input"
+          aria-label="${this.accessibleNameEnd || this.__getAriaLabel('max')}"
           .min="${min}"
           .max="${max}"
           .step="${step}"
@@ -362,6 +382,11 @@ class RangeSlider extends FieldMixin(
 
     this.toggleAttribute('start-focused', isElementFocused(this._inputElements[0]));
     this.toggleAttribute('end-focused', isElementFocused(this._inputElements[1]));
+  }
+
+  /** @private */
+  __getAriaLabel(suffix) {
+    return this.label ? `${this.label} ${suffix}` : suffix;
   }
 
   /** @private */

--- a/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
@@ -4,6 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-range-slider host default"] = 
 `<vaadin-range-slider>
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="0"
@@ -13,6 +14,7 @@ snapshots["vaadin-range-slider host default"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="0"
@@ -39,6 +41,7 @@ snapshots["vaadin-range-slider host default"] =
 snapshots["vaadin-range-slider host value"] = 
 `<vaadin-range-slider>
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="0"
@@ -48,6 +51,7 @@ snapshots["vaadin-range-slider host value"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="0"
@@ -74,6 +78,7 @@ snapshots["vaadin-range-slider host value"] =
 snapshots["vaadin-range-slider host min"] = 
 `<vaadin-range-slider>
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="20"
@@ -83,6 +88,7 @@ snapshots["vaadin-range-slider host min"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="20"
@@ -109,6 +115,7 @@ snapshots["vaadin-range-slider host min"] =
 snapshots["vaadin-range-slider host max"] = 
 `<vaadin-range-slider>
   <input
+    aria-label="min"
     id="slider-3"
     max="80"
     min="0"
@@ -118,6 +125,7 @@ snapshots["vaadin-range-slider host max"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="80"
     min="0"
@@ -144,6 +152,7 @@ snapshots["vaadin-range-slider host max"] =
 snapshots["vaadin-range-slider host step"] = 
 `<vaadin-range-slider>
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="0"
@@ -153,6 +162,7 @@ snapshots["vaadin-range-slider host step"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="0"
@@ -182,6 +192,7 @@ snapshots["vaadin-range-slider host disabled"] =
   disabled=""
 >
   <input
+    aria-label="min"
     disabled=""
     id="slider-3"
     max="100"
@@ -192,6 +203,7 @@ snapshots["vaadin-range-slider host disabled"] =
     type="range"
   >
   <input
+    aria-label="max"
     disabled=""
     id="slider-4"
     max="100"
@@ -222,6 +234,7 @@ snapshots["vaadin-range-slider host label"] =
   has-label=""
 >
   <input
+    aria-label="Label min"
     id="slider-3"
     max="100"
     min="0"
@@ -231,6 +244,7 @@ snapshots["vaadin-range-slider host label"] =
     type="range"
   >
   <input
+    aria-label="Label max"
     id="slider-4"
     max="100"
     min="0"
@@ -261,6 +275,7 @@ snapshots["vaadin-range-slider host helper"] =
   has-helper=""
 >
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="0"
@@ -270,6 +285,7 @@ snapshots["vaadin-range-slider host helper"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="0"
@@ -305,6 +321,7 @@ snapshots["vaadin-range-slider host required"] =
   required=""
 >
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="0"
@@ -314,6 +331,7 @@ snapshots["vaadin-range-slider host required"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="0"
@@ -344,6 +362,7 @@ snapshots["vaadin-range-slider host error"] =
   invalid=""
 >
   <input
+    aria-label="min"
     id="slider-3"
     max="100"
     min="0"
@@ -353,6 +372,7 @@ snapshots["vaadin-range-slider host error"] =
     type="range"
   >
   <input
+    aria-label="max"
     id="slider-4"
     max="100"
     min="0"
@@ -679,4 +699,78 @@ snapshots["vaadin-range-slider shadow max < value"] =
 </div>
 `;
 /* end snapshot vaadin-range-slider shadow max < value */
+
+snapshots["vaadin-range-slider host accessibleNameStart"] = 
+`<vaadin-range-slider>
+  <input
+    aria-label="Custom Start"
+    id="slider-3"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <input
+    aria-label="max"
+    id="slider-4"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <label
+    id="label-vaadin-range-slider-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-range-slider-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-range-slider>
+`;
+/* end snapshot vaadin-range-slider host accessibleNameStart */
+
+snapshots["vaadin-range-slider host accessibleNameEnd"] = 
+`<vaadin-range-slider>
+  <input
+    aria-label="min"
+    id="slider-3"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <input
+    aria-label="Custom End"
+    id="slider-4"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <label
+    id="label-vaadin-range-slider-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-range-slider-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-range-slider>
+`;
+/* end snapshot vaadin-range-slider host accessibleNameEnd */
 

--- a/packages/slider/test/dom/range-slider.test.ts
+++ b/packages/slider/test/dom/range-slider.test.ts
@@ -55,6 +55,18 @@ describe('vaadin-range-slider', () => {
       await expect(slider).dom.to.equalSnapshot();
     });
 
+    it('accessibleNameStart', async () => {
+      slider.accessibleNameStart = 'Custom Start';
+      await nextUpdate(slider);
+      await expect(slider).dom.to.equalSnapshot();
+    });
+
+    it('accessibleNameEnd', async () => {
+      slider.accessibleNameEnd = 'Custom End';
+      await nextUpdate(slider);
+      await expect(slider).dom.to.equalSnapshot();
+    });
+
     it('disabled', async () => {
       slider.disabled = true;
       await expect(slider).dom.to.equalSnapshot();


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/11050

Add custom accessible name support for the range slider's two input handles. By default, labels are "min"/"max" (or "{label} min"/"{label} max" when a label is set). The new properties allow overriding these for better screen reader experience.

## Type of change

- Feature