### PR TITLE
refactor: set pointer-events: none for disabled slider in Lumo

### DIFF
--- a/packages/vaadin-lumo-styles/src/mixins/slider.css
+++ b/packages/vaadin-lumo-styles/src/mixins/slider.css
@@ -60,6 +60,7 @@
   :host([disabled]) {
     --vaadin-slider-track-background: var(--lumo-contrast-10pct);
     --vaadin-slider-fill-background: var(--lumo-contrast-30pct);
+    pointer-events: none;
   }
 
   [part='track'] {


### PR DESCRIPTION
## Description

Added missing `pointer-events: none` to slider disabled state Lumo CSS to align with other fields:

https://github.com/vaadin/web-components/blob/7f6c18fca780f6c397621afffb9674617d1888d7/packages/vaadin-lumo-styles/src/mixins/field-base.css#L113-L114

Without this CSS, label color is still unexpectedly changed on hover when disabled. This PR fixes that.

## Type of change

- Refactor