### PR TITLE
refactor: add slider pointerup listeners on window instead of this

### DIFF
--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -227,8 +227,7 @@ class RangeSlider extends FieldMixin(
     this.__inputId0 = `slider-${generateUniqueId()}`;
     this.__inputId1 = `slider-${generateUniqueId()}`;
 
-    this.addEventListener('pointerup', (e) => this.__onPointerUp(e));
-    this.addEventListener('pointercancel', (e) => this.__onPointerUp(e));
+    this.__onPointerUp = this.__onPointerUp.bind(this);
   }
 
   /** @protected */
@@ -249,15 +248,17 @@ class RangeSlider extends FieldMixin(
     if (index !== -1) {
       this.toggleAttribute('start-active', index === 0);
       this.toggleAttribute('end-active', index === 1);
+      window.addEventListener('pointerup', this.__onPointerUp);
+      window.addEventListener('pointercancel', this.__onPointerUp);
     }
   }
 
   /** @private */
-  __onPointerUp(event) {
-    if (this._inputElements.includes(event.composedPath()[0])) {
-      this.removeAttribute('start-active');
-      this.removeAttribute('end-active');
-    }
+  __onPointerUp() {
+    window.removeEventListener('pointerup', this.__onPointerUp);
+    window.removeEventListener('pointercancel', this.__onPointerUp);
+    this.removeAttribute('start-active');
+    this.removeAttribute('end-active');
   }
 
   /**

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -180,8 +180,7 @@ class Slider extends FieldMixin(
     this.__value = [this.value];
     this.__inputId = `slider-${generateUniqueId()}`;
 
-    this.addEventListener('pointerup', (e) => this.__onPointerUp(e));
-    this.addEventListener('pointercancel', (e) => this.__onPointerUp(e));
+    this.__onPointerUp = this.__onPointerUp.bind(this);
   }
 
   /** @protected */
@@ -201,14 +200,16 @@ class Slider extends FieldMixin(
 
     if (event.composedPath()[0] === this._inputElement) {
       this.setAttribute('active', '');
+      window.addEventListener('pointerup', this.__onPointerUp);
+      window.addEventListener('pointercancel', this.__onPointerUp);
     }
   }
 
   /** @private */
-  __onPointerUp(event) {
-    if (event.composedPath()[0] === this._inputElement) {
-      this.removeAttribute('active');
-    }
+  __onPointerUp() {
+    window.removeEventListener('pointerup', this.__onPointerUp);
+    window.removeEventListener('pointercancel', this.__onPointerUp);
+    this.removeAttribute('active');
   }
 
   /**


### PR DESCRIPTION
## Description

Discovered this while working on value bubbles https://github.com/vaadin/web-components/pull/11026#issuecomment-3852470279

Sometimes, the `active` attribute is not removed, so we apparently need to set listeners on `window`.

https://github.com/user-attachments/assets/9c52b2f6-5c30-4838-9f0e-d0cc65446926

Add pointerup and pointercancel listeners on window only during active drag (on pointerdown), and remove them in the pointerup handler. This ensures the events are captured even if the pointer moves outside the element during drag.

## Type of change

- Refactor