### PR TITLE
refactor: do not modify active thumb background when readonly

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/range-slider.css
+++ b/packages/vaadin-lumo-styles/src/components/range-slider.css
@@ -4,10 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @media lumo_components_range-slider {
-  :host([start-active]) [part~='thumb-start'],
-  :host([end-active]) [part~='thumb-end'],
-  :host([focus-ring][start-focused]:not([readonly])) [part~='thumb-start'],
-  :host([focus-ring][end-focused]:not([readonly])) [part~='thumb-end'] {
+  :host(:not([readonly]):is([start-active], [focus-ring][start-focused])) [part~='thumb-start'],
+  :host(:not([readonly]):is([end-active], [focus-ring][end-focused])) [part~='thumb-end'] {
     background: linear-gradient(var(--_fill-background), var(--_fill-background)) var(--lumo-base-color);
   }
 

--- a/packages/vaadin-lumo-styles/src/components/slider.css
+++ b/packages/vaadin-lumo-styles/src/components/slider.css
@@ -4,8 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @media lumo_components_slider {
-  :host([focus-ring]:not([readonly])) [part='thumb'],
-  :host([active]) [part='thumb'] {
+  :host(:not([readonly]):is([active], [focus-ring])) [part='thumb'] {
     background: linear-gradient(var(--_fill-background), var(--_fill-background)) var(--lumo-base-color);
   }
 


### PR DESCRIPTION
## Description

Updated Lumo CSS to not change background of the active thumb when `readonly` is true.
Previously it would be shown like this, which is confusing since you can't drag the thumb:

<img width="180" height="104" alt="Screenshot 2026-02-05 at 13 34 10" src="https://github.com/user-attachments/assets/d506124d-f21c-437b-b877-c250443951e5" />


## Type of change

- Refactor