### PR TITLE
refactor: do not set active attribute on pointerdown when readonly

### DIFF
--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -335,7 +335,7 @@ class RangeSlider extends FieldMixin(
 
     const index = this._inputElements.indexOf(event.composedPath()[0]);
 
-    if (index !== -1) {
+    if (!this.readonly && index !== -1) {
       this.toggleAttribute('start-active', index === 0);
       this.toggleAttribute('end-active', index === 1);
       window.addEventListener('pointerup', this.__onPointerUp);

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -234,7 +234,7 @@ class Slider extends FieldMixin(
   __onPointerDown(event) {
     super.__onPointerDown(event);
 
-    if (event.composedPath()[0] === this._inputElement) {
+    if (!this.readonly && event.composedPath()[0] === this._inputElement) {
       this.setAttribute('active', '');
       window.addEventListener('pointerup', this.__onPointerUp);
       window.addEventListener('pointercancel', this.__onPointerUp);

--- a/packages/slider/test/range-slider-pointer.test.ts
+++ b/packages/slider/test/range-slider-pointer.test.ts
@@ -422,6 +422,14 @@ window.Vaadin.featureFlags.sliderComponent = true;
 
       expect(slider.hasAttribute('start-active')).to.be.false;
     });
+
+    it('should not set start-active attribute on start thumb pointerdown when readonly', async () => {
+      slider.readonly = true;
+      await sendMouseToElement({ type: 'move', element: thumbs[0] });
+      await sendMouse({ type: 'down' });
+
+      expect(slider.hasAttribute('start-active')).to.be.false;
+    });
   });
 
   describe('end-active', () => {
@@ -455,6 +463,14 @@ window.Vaadin.featureFlags.sliderComponent = true;
       await nextRender();
       const label = slider.querySelector('label')!;
       await sendMouseToElement({ type: 'move', element: label });
+      await sendMouse({ type: 'down' });
+
+      expect(slider.hasAttribute('end-active')).to.be.false;
+    });
+
+    it('should not set end-active attribute on end thumb pointerdown when readonly', async () => {
+      slider.readonly = true;
+      await sendMouseToElement({ type: 'move', element: thumbs[1] });
       await sendMouse({ type: 'down' });
 
       expect(slider.hasAttribute('end-active')).to.be.false;

--- a/packages/slider/test/slider-pointer.test.ts
+++ b/packages/slider/test/slider-pointer.test.ts
@@ -279,6 +279,14 @@ describe('vaadin-slider - pointer', () => {
 
       expect(slider.hasAttribute('active')).to.be.false;
     });
+
+    it('should not set active attribute on thumb pointerdown when readonly', async () => {
+      slider.readonly = true;
+      await sendMouseToElement({ type: 'move', element: thumb });
+      await sendMouse({ type: 'down' });
+
+      expect(slider.hasAttribute('active')).to.be.false;
+    });
   });
 
   describe('bubble', () => {


### PR DESCRIPTION
## Description

Follow-up to #11026 

In https://github.com/vaadin/web-components/pull/11026/changes/025c486a5914cf5eed1f363747d99ee15f1084c8, I changed the logic to show bubble when `active` is set to `true`. However, for a `readonly` slider this makes no sense as the thumb doesn't move (yet the bubble shows). 

Fixed to not set `active` attribute when `readonly`, as the thumb is in fact not activated in that case.

## Type of change

- Bugfix