### PR TITLE
docs: add tag name to customElement JSDoc annotations

### DIFF
--- a/WEB_COMPONENT_GUIDELINES.md
+++ b/WEB_COMPONENT_GUIDELINES.md
@@ -267,7 +267,7 @@ import { {ComponentName}Mixin } from './vaadin-{name}-mixin.js';
  * @fires {Event} change - Fired when the value changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
- * @customElement
+ * @customElement vaadin-{name}
  * @extends HTMLElement
  * @mixes {ComponentName}Mixin
  * @mixes ElementMixin
@@ -1722,7 +1722,7 @@ For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistic
  * @fires {Event} change - Fired when the value changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
- * @customElement
+ * @customElement vaadin-{name}
  * @extends HTMLElement
  * @mixes {ComponentName}Mixin
  * @mixes ElementMixin

--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -60,7 +60,7 @@ import { accordionHeading } from './styles/vaadin-accordion-heading-base-styles.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-accordion-heading
  * @extends HTMLElement
  * @mixes ActiveMixin
  * @mixes DirMixin

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -37,7 +37,7 @@ import { AccordionPanelMixin } from './vaadin-accordion-panel-mixin.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
- * @customElement
+ * @customElement vaadin-accordion-panel
  * @extends HTMLElement
  * @mixes AccordionPanelMixin
  * @mixes ThemableMixin

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -49,7 +49,7 @@ import { AccordionMixin } from './vaadin-accordion-mixin.js';
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
- * @customElement
+ * @customElement vaadin-accordion
  * @extends HTMLElement
  * @mixes AccordionMixin
  * @mixes ElementMixin

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -126,7 +126,7 @@ import { AppLayoutMixin } from './vaadin-app-layout-mixin.js';
  * @fires {CustomEvent} overlay-changed - Fired when the `overlay` property changes.
  * @fires {CustomEvent} primary-section-changed - Fired when the `primarySection` property changes.
  *
- * @customElement
+ * @customElement vaadin-app-layout
  * @extends HTMLElement
  * @mixes AppLayoutMixin
  * @mixes ElementMixin

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -55,7 +55,7 @@ import { drawerToggle } from './styles/vaadin-drawer-toggle-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-drawer-toggle
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes DirMixin

--- a/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
@@ -15,7 +15,7 @@ import { avatarGroupMenuItemStyles } from './styles/vaadin-avatar-group-menu-ite
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-avatar-group-menu-item
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ItemMixin

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.js
@@ -15,7 +15,7 @@ import { avatarGroupMenuStyles } from './styles/vaadin-avatar-group-menu-base-st
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-avatar-group-menu
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ListMixin

--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -16,7 +16,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-avatar-group-overlay
  * @extends HTMLElement
  * @mixes PositionMixin
  * @mixes OverlayMixin

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -58,7 +58,7 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  * - `<vaadin-avatar-group-menu>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  * - `<vaadin-avatar-group-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  *
- * @customElement
+ * @customElement vaadin-avatar-group
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes AvatarGroupMixin

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -54,7 +54,7 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-avatar
  * @extends HTMLElement
  * @mixes AvatarMixin
  * @mixes ElementMixin

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -48,7 +48,7 @@ import { BoardRowMixin } from './vaadin-board-row-mixin.js';
  * `--vaadin-board-width-small` | Determines the width where mode changes from `small` to `medium` | `600px`
  * `--vaadin-board-width-medium` | Determines the width where mode changes from `medium` to `large` | `960px`
  *
- * @customElement
+ * @customElement vaadin-board-row
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes BoardRowMixin

--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -35,7 +35,7 @@ import { BoardRow } from './vaadin-board-row.js';
  * </vaadin-board>
  * ```
  *
- * @customElement
+ * @customElement vaadin-board
  * @extends HTMLElement
  * @mixes ElementMixin
  * @deprecated `<vaadin-board>` is deprecated and will be removed in Vaadin 26.

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -59,7 +59,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-button
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes ElementMixin

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -60,7 +60,7 @@ import { cardStyles } from './styles/vaadin-card-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-card
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/charts/src/vaadin-chart-series.js
+++ b/packages/charts/src/vaadin-chart-series.js
@@ -56,7 +56,7 @@ import { ChartSeriesMixin } from './vaadin-chart-series-mixin.js';
  * chart.removeChild(seriesToBeRemoved);
  * ```
  *
- * @customElement
+ * @customElement vaadin-chart-series
  * @extends HTMLElement
  * @mixes ChartSeriesMixin
  */

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -150,7 +150,7 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  * @fires {CustomEvent} xaxes-extremes-set - Fired when the minimum and maximum is set for the X axis.
  * @fires {CustomEvent} yaxes-extremes-set - Fired when the minimum and maximum is set for the Y axis.
  *
- * @customElement
+ * @customElement vaadin-chart
  * @extends HTMLElement
  * @mixes ChartMixin
  * @mixes ThemableMixin

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -76,7 +76,7 @@ import { CheckboxGroupMixin } from './vaadin-checkbox-group-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-checkbox-group
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -72,7 +72,7 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
  *
- * @customElement
+ * @customElement vaadin-checkbox
  * @extends HTMLElement
  * @mixes CheckboxMixin
  * @mixes ThemableMixin

--- a/packages/combo-box/src/vaadin-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-combo-box-item.js
@@ -33,7 +33,7 @@ import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-combo-box-item
  * @mixes ComboBoxItemMixin
  * @mixes ThemableMixin
  * @mixes DirMixin

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -17,7 +17,7 @@ import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-combo-box>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-combo-box-overlay
  * @extends HTMLElement
  * @mixes ComboBoxOverlayMixin
  * @mixes DirMixin

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -12,7 +12,7 @@ import { ComboBoxScrollerMixin } from './vaadin-combo-box-scroller-mixin.js';
 /**
  * An element used internally by `<vaadin-combo-box>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-combo-box-scroller
  * @extends HTMLElement
  * @mixes ComboBoxScrollerMixin
  * @private

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -158,7 +158,7 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-combo-box
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -15,7 +15,7 @@ import { confirmDialogOverlayStyles } from './styles/vaadin-confirm-dialog-overl
 /**
  * An element used internally by `<vaadin-confirm-dialog>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-confirm-dialog-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes OverlayMixin

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -77,7 +77,7 @@ import { ConfirmDialogMixin } from './vaadin-confirm-dialog-mixin.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the confirm dialog is closed.
  *
- * @customElement
+ * @customElement vaadin-confirm-dialog
  * @extends HTMLElement
  * @mixes ConfirmDialogMixin
  * @mixes ElementMixin

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -15,7 +15,7 @@ import { contextMenuItemStyles } from './styles/vaadin-context-menu-item-base-st
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-context-menu-item
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ItemMixin

--- a/packages/context-menu/src/vaadin-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.js
@@ -15,7 +15,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-context-menu-list-box
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ListMixin

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -16,7 +16,7 @@ import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-context-menu-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes MenuOverlayMixin

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -214,7 +214,7 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
  * @fires {CustomEvent} closed - Fired when the context menu is closed.
  *
- * @customElement
+ * @customElement vaadin-context-menu
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ContextMenuMixin

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -23,7 +23,7 @@ import { crudDialogOverlayStyles } from './styles/vaadin-crud-dialog-overlay-bas
 /**
  * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-crud-dialog
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes OverlayMixin

--- a/packages/crud/src/vaadin-crud-edit-column.js
+++ b/packages/crud/src/vaadin-crud-edit-column.js
@@ -28,7 +28,7 @@ import { editColumnDefaultRenderer } from './vaadin-crud-helpers.js';
  *    ...
  * ```
  *
- * @customElement
+ * @customElement vaadin-crud-edit-column
  * @extends GridColumn
  */
 class CrudEditColumn extends GridColumn {

--- a/packages/crud/src/vaadin-crud-edit.js
+++ b/packages/crud/src/vaadin-crud-edit.js
@@ -21,7 +21,7 @@ import { crudEditStyles } from './styles/vaadin-crud-edit-base-styles.js';
  * Typical usage is in a `<vaadin-grid-column>` of a custom `<vaadin-grid>` inside
  * a `<vaadin-crud>` to enable editing.
  *
- * @customElement
+ * @customElement vaadin-crud-edit
  * @extends Button
  */
 class CrudEdit extends Button {

--- a/packages/crud/src/vaadin-crud-form.js
+++ b/packages/crud/src/vaadin-crud-form.js
@@ -17,7 +17,7 @@ import { IncludedMixin } from './vaadin-crud-include-mixin.js';
 /**
  * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-crud-form
  * @extends FormLayout
  * @mixes IncludedMixin
  * @private

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -180,7 +180,7 @@ import { CrudMixin } from './vaadin-crud-mixin.js';
  * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item.
  * @fires {CustomEvent} cancel - Fired when user discards edition.
  *
- * @customElement
+ * @customElement vaadin-crud
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -75,7 +75,7 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-custom-field
  * @extends HTMLElement
  * @mixes CustomFieldMixin
  * @mixes ElementMixin

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -21,7 +21,7 @@ import { dashboardButtonStyles } from './styles/vaadin-dashboard-button-base-sty
 /**
  * An element used internally by `<vaadin-dashboard>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-dashboard-button
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes ElementMixin

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -51,7 +51,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-dashboard-layout
  * @extends HTMLElement
  * @mixes DashboardLayoutMixin
  * @mixes ElementMixin

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -64,7 +64,7 @@ import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-dashboard-section
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -98,7 +98,7 @@ import { DashboardSection } from './vaadin-dashboard-section.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-dashboard-widget
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -101,7 +101,7 @@ const DEFAULT_I18N = getDefaultI18n();
  * @fires {CustomEvent} dashboard-item-move-mode-changed - Fired when an item move mode changed
  * @fires {CustomEvent} dashboard-item-resize-mode-changed - Fired when an item resize mode changed
  *
- * @customElement
+ * @customElement vaadin-dashboard
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes DashboardLayoutMixin

--- a/packages/date-picker/src/vaadin-date-picker-month-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-month-scroller.js
@@ -21,7 +21,7 @@ stylesTemplate.innerHTML = `
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-date-picker-month-scroller
  * @extends InfiniteScroller
  * @private
  */

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -18,7 +18,7 @@ import { overlayContentStyles } from './styles/vaadin-date-picker-overlay-conten
 import { DatePickerOverlayContentMixin } from './vaadin-date-picker-overlay-content-mixin.js';
 
 /**
- * @customElement
+ * @customElement vaadin-date-picker-overlay-content
  * @extends HTMLElement
  * @private
  */

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -16,7 +16,7 @@ import { DatePickerOverlayMixin } from './vaadin-date-picker-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-date-picker-overlay
  * @extends HTMLElement
  * @mixes DatePickerOverlayMixin
  * @mixes DirMixin

--- a/packages/date-picker/src/vaadin-date-picker-year-scroller.js
+++ b/packages/date-picker/src/vaadin-date-picker-year-scroller.js
@@ -44,7 +44,7 @@ stylesTemplate.innerHTML = `
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-date-picker-year-scroller
  * @extends InfiniteScroller
  * @private
  */

--- a/packages/date-picker/src/vaadin-date-picker-year.js
+++ b/packages/date-picker/src/vaadin-date-picker-year.js
@@ -13,7 +13,7 @@ import { datePickerYearStyles } from './styles/vaadin-date-picker-year-base-styl
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-date-picker-year
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @private

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -150,7 +150,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-date-picker
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -12,7 +12,7 @@ import { monthCalendarStyles } from './styles/vaadin-month-calendar-base-styles.
 import { MonthCalendarMixin } from './vaadin-month-calendar-mixin.js';
 
 /**
- * @customElement
+ * @customElement vaadin-month-calendar
  * @extends HTMLElement
  * @private
  */

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -112,7 +112,7 @@ import { DateTimePickerMixin } from './vaadin-date-time-picker-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-date-time-picker
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -51,7 +51,7 @@ import { detailsSummary } from './styles/vaadin-details-summary-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-details-summary
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes DirMixin

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -47,7 +47,7 @@ import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
- * @customElement
+ * @customElement vaadin-details
  * @extends HTMLElement
  * @mixes DetailsBaseMixin
  * @mixes ElementMixin

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -15,7 +15,7 @@ import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-dialog-overlay
  * @extends HTMLElement
  * @mixes DialogOverlayMixin
  * @mixes DirMixin

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -95,7 +95,7 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the dialog is closed.
  *
- * @customElement
+ * @customElement vaadin-dialog
  * @extends HTMLElement
  * @mixes ThemePropertyMixin
  * @mixes ElementMixin

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -54,7 +54,7 @@ import { emailFieldStyles } from './styles/vaadin-email-field-base-styles.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-email-field
  * @extends TextField
  */
 export class EmailField extends TextField {

--- a/packages/field-highlighter/src/vaadin-field-highlighter.js
+++ b/packages/field-highlighter/src/vaadin-field-highlighter.js
@@ -153,7 +153,7 @@ export class FieldHighlighterController {
  *
  * See https://vaadin.com/collaboration for Collaboration Engine documentation.
  *
- * @customElement
+ * @customElement vaadin-field-highlighter
  */
 export class FieldHighlighter extends HTMLElement {
   static get is() {

--- a/packages/field-highlighter/src/vaadin-user-tag.js
+++ b/packages/field-highlighter/src/vaadin-user-tag.js
@@ -14,7 +14,7 @@ import { userTagStyles } from './styles/vaadin-user-tag-base-styles.js';
 /**
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-user-tag
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ThemableMixin

--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -16,7 +16,7 @@ import { userTagsOverlayStyles } from './styles/vaadin-user-tags-overlay-base-st
 /**
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-user-tags-overlay
  * @extends HTMLElement
  * @mixes PositionMixin
  * @mixes OverlayMixin

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -24,7 +24,7 @@ const listenOnce = (elem, type) => {
 /**
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-user-tags
  * @extends HTMLElement
  * @private
  */

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -87,7 +87,7 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-form-item
  * @extends HTMLElement
  * @mixes FormItemMixin
  * @mixes ThemableMixin

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -198,7 +198,7 @@ import { FormLayoutMixin } from './vaadin-form-layout-mixin.js';
  * `--vaadin-form-layout-label-width` | Width of the label when labels are displayed aside | `8em`
  * `--vaadin-form-layout-label-spacing` | Length of the spacing between the label and the input when labels are displayed aside | `1em`
  *
- * @customElement
+ * @customElement vaadin-form-layout
  * @extends HTMLElement
  * @mixes FormLayoutMixin
  * @mixes ElementMixin

--- a/packages/form-layout/src/vaadin-form-row.js
+++ b/packages/form-layout/src/vaadin-form-row.js
@@ -17,7 +17,7 @@ import { formRowStyles } from './styles/vaadin-form-row-base-styles.js';
  * the available columns wrap to a new row, which then remains reserved
  * exclusively for the fields of that `<vaadin-form-row>` element.
  *
- * @customElement
+ * @customElement vaadin-form-row
  * @extends HTMLElement
  * @mixes ThemableMixin
  */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-checkbox.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-checkbox.js
@@ -14,7 +14,7 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 /**
  * An element used internally by `<vaadin-grid-pro>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-grid-pro-edit-checkbox
  * @extends Checkbox
  * @private
  */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -30,7 +30,7 @@ import { GridProEditColumnMixin } from './vaadin-grid-pro-edit-column-mixin.js';
  *    ...
  * ```
  *
- * @customElement
+ * @customElement vaadin-grid-pro-edit-column
  * @extends GridColumn
  * @mixes GridProEditColumnMixin
  */

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -15,7 +15,7 @@ import { GridProEditSelectMixin } from './vaadin-grid-pro-edit-select-mixin.js';
 /**
  * An element used internally by `<vaadin-grid-pro>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-grid-pro-edit-select
  * @extends Select
  * @mixes GridProEditSelectMixin
  * @private

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-text-field.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-text-field.js
@@ -14,7 +14,7 @@ import { TextField } from '@vaadin/text-field/src/vaadin-text-field.js';
 /**
  * An element used internally by `<vaadin-grid-pro>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-grid-pro-edit-text-field
  * @extends TextField
  * @private
  */

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -47,7 +47,7 @@ import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
  * @fires {CustomEvent} loading-changed - Fired when the `loading` property changes.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  *
- * @customElement
+ * @customElement vaadin-grid-pro
  * @extends Grid
  * @mixes InlineEditingMixin
  */

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -38,7 +38,7 @@ export * from './vaadin-grid-column-group-mixin.js';
  * column2.renderer = (root, column, model) => { ... };
  * ```
  *
- * @customElement
+ * @customElement vaadin-grid-column-group
  * @extends HTMLElement
  * @mixes GridColumnGroupMixin
  */

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -15,7 +15,7 @@ import { GridColumnMixin } from './vaadin-grid-column-mixin.js';
  * See [`<vaadin-grid>`](#/elements/vaadin-grid) documentation for instructions on how
  * to configure the `<vaadin-grid-column>`.
  *
- * @customElement
+ * @customElement vaadin-grid-column
  * @extends HTMLElement
  * @mixes GridColumnMixin
  */

--- a/packages/grid/src/vaadin-grid-filter-column.js
+++ b/packages/grid/src/vaadin-grid-filter-column.js
@@ -21,7 +21,7 @@ import { GridFilterColumnMixin } from './vaadin-grid-filter-column-mixin.js';
  *    ...
  * ```
  *
- * @customElement
+ * @customElement vaadin-grid-filter-column
  * @extends GridColumn
  * @mixes GridFilterColumnMixin
  */

--- a/packages/grid/src/vaadin-grid-filter.js
+++ b/packages/grid/src/vaadin-grid-filter.js
@@ -37,7 +37,7 @@ import { GridFilterElementMixin } from './vaadin-grid-filter-element-mixin.js';
  *
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
- * @customElement
+ * @customElement vaadin-grid-filter
  * @extends HTMLElement
  * @mixes GridFilterElementMixin
  */

--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -32,7 +32,7 @@ import { GridSelectionColumnMixin } from './vaadin-grid-selection-column-mixin.j
  *
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  *
- * @customElement
+ * @customElement vaadin-grid-selection-column
  * @extends GridColumn
  * @mixes GridSelectionColumnMixin
  */

--- a/packages/grid/src/vaadin-grid-sort-column.js
+++ b/packages/grid/src/vaadin-grid-sort-column.js
@@ -23,7 +23,7 @@ import { GridSortColumnMixin } from './vaadin-grid-sort-column-mixin.js';
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  *
- * @customElement
+ * @customElement vaadin-grid-sort-column
  * @extends GridColumn
  * @mixes GridSortColumnMixin
  */

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -51,7 +51,7 @@ import { GridSorterMixin } from './vaadin-grid-sorter-mixin.js';
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  * @fires {CustomEvent} sorter-changed - Fired when the `path` or `direction` property changes.
  *
- * @customElement
+ * @customElement vaadin-grid-sorter
  * @extends HTMLElement
  * @mixes GridSorterMixin
  * @mixes ThemableMixin

--- a/packages/grid/src/vaadin-grid-tree-column.js
+++ b/packages/grid/src/vaadin-grid-tree-column.js
@@ -20,7 +20,7 @@ import { GridTreeColumnMixin } from './vaadin-grid-tree-column-mixin.js';
  *  <vaadin-grid-column>
  *    ...
  * ```
- * @customElement
+ * @customElement vaadin-grid-tree-column
  * @extends GridColumn
  * @mixes GridTreeColumnMixin
  */

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -59,7 +59,7 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *
- * @customElement
+ * @customElement vaadin-grid-tree-toggle
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DirMixin

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -265,7 +265,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} item-toggle - Fired when the user selects or deselects an item through the selection column.
  *
- * @customElement
+ * @customElement vaadin-grid
  * @extends HTMLElement
  * @mixes GridMixin
  * @mixes ThemableMixin

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -55,7 +55,7 @@ import { HorizontalLayoutMixin } from './vaadin-horizontal-layout-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-horizontal-layout
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -72,7 +72,7 @@ import { ensureSvgLiteral } from './vaadin-icon-svg.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-icon
  * @extends HTMLElement
  * @mixes IconMixin
  * @mixes ThemableMixin

--- a/packages/icon/src/vaadin-iconset.js
+++ b/packages/icon/src/vaadin-iconset.js
@@ -9,7 +9,7 @@ import { IconsetMixin } from './vaadin-iconset-mixin.js';
 /**
  * `<vaadin-iconset>` is a Web Component for creating SVG icon collections.
  *
- * @customElement
+ * @customElement vaadin-iconset
  * @extends HTMLElement
  * @mixes IconsetMixin
  */

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -12,7 +12,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { inputContainerStyles } from './styles/vaadin-input-container-base-styles.js';
 
 /**
- * @customElement
+ * @customElement vaadin-input-container
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DirMixin

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -73,7 +73,7 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-integer-field
  * @extends NumberField
  */
 export class IntegerField extends NumberField {

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -60,7 +60,7 @@ import { ItemMixin } from './vaadin-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-item
  * @extends HTMLElement
  * @mixes ItemMixin
  * @mixes ThemableMixin

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -45,7 +45,7 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes.
  *
- * @customElement
+ * @customElement vaadin-list-box
  * @extends HTMLElement
  * @mixes MultiSelectListMixin
  * @mixes ThemableMixin

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -65,7 +65,7 @@ import { LoginFormMixin } from './vaadin-login-form-mixin.js';
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login.
  *
- * @customElement
+ * @customElement vaadin-login-form
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -73,7 +73,7 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  * @fires {CustomEvent} login - Fired when a user submits the login.
  * @fires {CustomEvent} closed - Fired when the overlay is closed.
  *
- * @customElement
+ * @customElement vaadin-login-overlay
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -51,7 +51,7 @@ import { MapMixin } from './vaadin-map-mixin.js';
  * </script>
  * ```
  *
- * @customElement
+ * @customElement vaadin-map
  * @extends HTMLElement
  * @mixes MapMixin
  * @mixes ThemableMixin

--- a/packages/markdown/src/vaadin-markdown.js
+++ b/packages/markdown/src/vaadin-markdown.js
@@ -22,7 +22,7 @@ import { renderMarkdownToElement } from './markdown-helpers.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-markdown
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -54,7 +54,7 @@ import { masterDetailLayoutTransitionStyles } from './styles/vaadin-master-detai
  * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the drawer mode.
  * @fires {CustomEvent} detail-escape-press - Fired when the user presses Escape in the detail area.
  *
- * @customElement
+ * @customElement vaadin-master-detail-layout
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/menu-bar/src/vaadin-menu-bar-button.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-button.js
@@ -10,7 +10,7 @@ import { menuBarButtonStyles } from './styles/vaadin-menu-bar-button-base-styles
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-menu-bar-button
  * @extends Button
  * @private
  */

--- a/packages/menu-bar/src/vaadin-menu-bar-item.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.js
@@ -15,7 +15,7 @@ import { menuBarItemStyles } from './styles/vaadin-menu-bar-item-base-styles.js'
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-menu-bar-item
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ItemMixin

--- a/packages/menu-bar/src/vaadin-menu-bar-list-box.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-list-box.js
@@ -15,7 +15,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-menu-bar-list-box
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ListMixin

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -16,7 +16,7 @@ import { menuBarOverlayStyles } from './styles/vaadin-menu-bar-overlay-base-styl
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-menu-bar-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes MenuOverlayMixin

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -16,7 +16,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-menu-bar-submenu
  * @extends HTMLElement
  * @mixes ContextMenuMixin
  * @mixes ThemePropertyMixin

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -68,7 +68,7 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  *
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *
- * @customElement
+ * @customElement vaadin-menu-bar
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes MenuBarMixin

--- a/packages/message-input/src/vaadin-message-input-button.js
+++ b/packages/message-input/src/vaadin-message-input-button.js
@@ -16,7 +16,7 @@ import { messageInputButtonStyles } from './styles/vaadin-message-input-button-s
 /**
  * An element used internally by `<vaadin-message-input>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-message-input-button
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes DirMixin

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -45,7 +45,7 @@ import { MessageInputMixin } from './vaadin-message-input-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-message-input
  * @extends HTMLElement
  * @mixes MessageInputMixin
  * @mixes ThemableMixin

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -47,7 +47,7 @@ import { MessageListMixin } from './vaadin-message-list-mixin.js';
  *
  * @fires {CustomEvent} attachment-click - Fired when an attachment is clicked.
  *
- * @customElement
+ * @customElement vaadin-message-list
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -51,7 +51,7 @@ import { MessageMixin } from './vaadin-message-mixin.js';
  *
  * @fires {CustomEvent} attachment-click - Fired when an attachment is clicked.
  *
- * @customElement
+ * @customElement vaadin-message
  * @extends HTMLElement
  * @mixes MessageMixin
  * @mixes ThemableMixin

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
@@ -24,7 +24,7 @@ import { multiSelectComboBoxChipStyles } from './styles/vaadin-multi-select-comb
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-multi-select-combo-box-chip
  * @extends HTMLElement
  * @private
  */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-container.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-container.js
@@ -10,7 +10,7 @@ import { InputContainer } from '@vaadin/input-container/src/vaadin-input-contain
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-multi-select-combo-box-container
  * @extends InputContainer
  * @private
  */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
@@ -33,7 +33,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-multi-select-combo-box-item
  * @mixes ComboBoxItemMixin
  * @mixes ThemableMixin
  * @mixes DirMixin

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -17,7 +17,7 @@ import { multiSelectComboBoxOverlayStyles } from './styles/vaadin-multi-select-c
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-multi-select-combo-box-overlay
  * @extends HTMLElement
  * @mixes ComboBoxOverlayMixin
  * @mixes DirMixin

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -13,7 +13,7 @@ import { multiSelectComboBoxScrollerStyles } from './styles/vaadin-multi-select-
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-multi-select-combo-box-scroller
  * @extends HTMLElement
  * @mixes ComboBoxScrollerMixin
  * @private

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -96,7 +96,7 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-multi-select-combo-box
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -17,7 +17,7 @@ import { NotificationContainerMixin, NotificationMixin } from './vaadin-notifica
 /**
  * An element used internally by `<vaadin-notification>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-notification-container
  * @extends HTMLElement
  * @mixes NotificationContainerMixin
  * @mixes ElementMixin
@@ -58,7 +58,7 @@ class NotificationContainer extends NotificationContainerMixin(
 /**
  * An element used internally by `<vaadin-notification>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-notification-card
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @private
@@ -137,7 +137,7 @@ class NotificationCard extends ThemableMixin(PolylitMixin(LumoInjectionMixin(Lit
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the notification is closed.
  *
- * @customElement
+ * @customElement vaadin-notification
  * @extends HTMLElement
  * @mixes NotificationMixin
  * @mixes ElementMixin

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -84,7 +84,7 @@ import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-number-field
  * @extends HTMLElement
  * @mixes NumberFieldMixin
  * @mixes ElementMixin

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -71,7 +71,7 @@ import { OverlayMixin } from './vaadin-overlay-mixin.js';
  * @fires {CustomEvent} vaadin-overlay-outside-click - Fired before the overlay is closed on outside click. Calling `preventDefault()` on the event cancels the closing.
  * @fires {CustomEvent} vaadin-overlay-escape-press - Fired before the overlay is closed on Escape key press. Calling `preventDefault()` on the event cancels the closing.
  *
- * @customElement
+ * @customElement vaadin-overlay
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DirMixin

--- a/packages/password-field/src/vaadin-password-field-button.js
+++ b/packages/password-field/src/vaadin-password-field-button.js
@@ -15,7 +15,7 @@ import { passwordFieldButton } from './styles/vaadin-password-field-button-base-
 /**
  * An element used internally by `<vaadin-password-field>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-password-field-button
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes DirMixin

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -59,7 +59,7 @@ import { PasswordFieldMixin } from './vaadin-password-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-password-field
  * @extends TextField
  * @mixes PasswordFieldMixin
  */

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -16,7 +16,7 @@ import { PopoverOverlayMixin } from './vaadin-popover-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-popover>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-popover-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes PopoverOverlayMixin

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -209,7 +209,7 @@ const isLastOverlay = (overlay) => {
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the popover is closed.
  *
- * @customElement
+ * @customElement vaadin-popover
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes PopoverPositionMixin

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -51,7 +51,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-progress-bar
  * @extends HTMLElement
  * @mixes ProgressMixin
  * @mixes ThemableMixin

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -63,7 +63,7 @@ import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
  *
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  *
- * @customElement
+ * @customElement vaadin-radio-button
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -75,7 +75,7 @@ import { RadioGroupMixin } from './vaadin-radio-group-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-radio-group
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
@@ -21,7 +21,7 @@ import { richTextEditorPopupOverlayStyles } from './styles/vaadin-rich-text-edit
 /**
  * An element used internally by `<vaadin-rich-text-editor>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-rich-text-editor-popup
  * @extends HTMLElement
  * @private
  */
@@ -135,7 +135,7 @@ export { RichTextEditorPopup };
 /**
  * An element used internally by `<vaadin-rich-text-editor>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-rich-text-editor-popup-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ThemableMixin

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -116,7 +116,7 @@ import { RichTextEditorMixin } from './vaadin-rich-text-editor-mixin.js';
  * @fires {CustomEvent} html-value-changed - Fired when the `htmlValue` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
- * @customElement
+ * @customElement vaadin-rich-text-editor
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes RichTextEditorMixin

--- a/packages/scroller/src/vaadin-scroller.js
+++ b/packages/scroller/src/vaadin-scroller.js
@@ -53,7 +53,7 @@ import { ScrollerMixin } from './vaadin-scroller-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-scroller
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -15,7 +15,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-select-item
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ItemMixin

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -15,7 +15,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-select-list-box
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ListMixin

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -15,7 +15,7 @@ import { SelectOverlayMixin } from './vaadin-select-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-select-overlay
  * @extends HTMLElement
  * @mixes SelectOverlayMixin
  * @mixes ThemableMixin

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -14,7 +14,7 @@ import { valueButton } from './styles/vaadin-select-value-button-base-styles.js'
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-select-value-button
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes ThemableMixin

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -134,7 +134,7 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-select
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes SelectBaseMixin

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -76,7 +76,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *
- * @customElement
+ * @customElement vaadin-side-nav-item
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DisabledMixin

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -67,7 +67,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  *
- * @customElement
+ * @customElement vaadin-side-nav
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -85,7 +85,7 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * @fires {Event} input - Fired when the slider value changes during user interaction.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
- * @customElement
+ * @customElement vaadin-range-slider
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes FieldMixin

--- a/packages/slider/src/vaadin-slider-bubble-overlay.js
+++ b/packages/slider/src/vaadin-slider-bubble-overlay.js
@@ -16,7 +16,7 @@ import { sliderBubbleOverlayStyles } from './styles/vaadin-slider-bubble-overlay
 /**
  * An element used internally by `<vaadin-slider>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-slider-bubble-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes OverlayMixin

--- a/packages/slider/src/vaadin-slider-bubble.js
+++ b/packages/slider/src/vaadin-slider-bubble.js
@@ -13,7 +13,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 /**
  * An element used internally by `<vaadin-slider>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-slider-bubble
  * @extends HTMLElement
  * @private
  */

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -80,7 +80,7 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * @fires {Event} input - Fired when the slider value changes during user interaction.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
- * @customElement
+ * @customElement vaadin-slider
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes FieldMixin

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -160,7 +160,7 @@ import { SplitLayoutMixin } from './vaadin-split-layout-mixin.js';
  *
  * @fires {Event} splitter-dragend - Fired after dragging the splitter have ended.
  *
- * @customElement
+ * @customElement vaadin-split-layout
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes SplitLayoutMixin

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -47,7 +47,7 @@ import { tabStyles } from './styles/vaadin-tab-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-tab
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ItemMixin

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -60,7 +60,7 @@ import { TabsMixin } from './vaadin-tabs-mixin.js';
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  *
- * @customElement
+ * @customElement vaadin-tabs
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes TabsMixin

--- a/packages/tabsheet/src/vaadin-tabsheet-scroller.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-scroller.js
@@ -9,7 +9,7 @@ import { Scroller } from '@vaadin/scroller/src/vaadin-scroller.js';
 /**
  * An element used internally by `<vaadin-tabsheet>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-tabsheet-scroller
  * @extends Scroller
  * @private
  */

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -66,7 +66,7 @@ import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  *
- * @customElement
+ * @customElement vaadin-tabsheet
  * @extends HTMLElement
  * @mixes TabSheetMixin
  * @mixes ElementMixin

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -83,7 +83,7 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-text-area
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes TextAreaMixin

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -82,7 +82,7 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-text-field
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -33,7 +33,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-time-picker-item
  * @mixes ComboBoxItemMixin
  * @mixes ThemableMixin
  * @mixes DirMixin

--- a/packages/time-picker/src/vaadin-time-picker-scroller.js
+++ b/packages/time-picker/src/vaadin-time-picker-scroller.js
@@ -12,7 +12,7 @@ import { timePickerScrollerStyles } from './styles/vaadin-time-picker-scroller-b
 /**
  * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-time-picker-scroller
  * @extends HTMLElement
  * @mixes ComboBoxScrollerMixin
  * @private

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -102,7 +102,7 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
- * @customElement
+ * @customElement vaadin-time-picker
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -16,7 +16,7 @@ import { tooltipOverlayStyles } from './styles/vaadin-tooltip-overlay-base-style
 /**
  * An element used internally by `<vaadin-tooltip>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-tooltip-overlay
  * @extends HTMLElement
  * @mixes DirMixin
  * @mixes ThemableMixin

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -73,7 +73,7 @@ import { TooltipMixin } from './vaadin-tooltip-mixin.js';
  *
  * @fires {CustomEvent} content-changed - Fired when the tooltip text content is changed.
  *
- * @customElement
+ * @customElement vaadin-tooltip
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemePropertyMixin

--- a/packages/upload/src/vaadin-upload-button.js
+++ b/packages/upload/src/vaadin-upload-button.js
@@ -70,7 +70,7 @@ import { UploadManager } from './vaadin-upload-manager.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-upload-button
  * @extends HTMLElement
  * @mixes ButtonMixin
  * @mixes ElementMixin

--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -47,7 +47,7 @@ import { UploadManager } from './vaadin-upload-manager.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-upload-drop-zone
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin

--- a/packages/upload/src/vaadin-upload-file-list.js
+++ b/packages/upload/src/vaadin-upload-file-list.js
@@ -75,7 +75,7 @@ import { UploadFileListMixin } from './vaadin-upload-file-list-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-upload-file-list
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes UploadFileListMixin

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -77,7 +77,7 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-upload-file
  * @extends HTMLElement
  * @mixes UploadFileMixin
  * @mixes ThemableMixin

--- a/packages/upload/src/vaadin-upload-icon.js
+++ b/packages/upload/src/vaadin-upload-icon.js
@@ -12,7 +12,7 @@ import { uploadIconStyles } from './styles/vaadin-upload-icon-base-styles.js';
 /**
  * An element used internally by `<vaadin-upload>`. Not intended to be used separately.
  *
- * @customElement
+ * @customElement vaadin-upload-icon
  * @extends HTMLElement
  * @private
  */

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -101,7 +101,7 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  * @fires {CustomEvent} upload-retry - Fired when retry upload is requested.
  * @fires {CustomEvent} upload-abort - Fired when upload abort is requested.
  *
- * @customElement
+ * @customElement vaadin-upload
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -44,7 +44,7 @@ import { verticalLayoutStyles } from './styles/vaadin-vertical-layout-base-style
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-vertical-layout
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes ElementMixin

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -55,7 +55,7 @@ import { VirtualListMixin } from './vaadin-virtual-list-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-virtual-list
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin


### PR DESCRIPTION
## Description

This PR is a pre-requisite for adding `custom-elements.json` to our web components. The CEM analyzer doesn't recognize our `defineCustomElement` helper but picks up [class annotations](https://github.com/open-wc/custom-elements-manifest/blob/df0795b2bdd41a8109fa531ce00edae025726c1a/packages/analyzer/src/features/analyse-phase/class-jsdoc.js#L88-L91) so we should specify the tag name there.

## Type of change

- Documentation