### PR TITLE
chore: generate custom-elements.json for all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 dist
 analysis.json
+custom-elements.json
 yarn-error.log
 .env
 

--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -1,0 +1,105 @@
+const inheritanceDenyList = ['PolylitMixin', 'DirMixin'];
+
+// Attribute types that can't be set via HTML attributes
+const ignoredAttributeTypes = ['object', 'unknown', 'Array'];
+
+const ignoredStaticMembers = [
+  'is',
+  'cvdlName',
+  'properties',
+  'observers',
+  'addCheckedInitializer',
+  'createProperty',
+  'getOrCreateMap',
+  'getPropertyDescriptor',
+  'enabledWarnings',
+  'shadowRootOptions',
+  'polylitConfig',
+  'constraints',
+  'delegateAttrs',
+  'delegateProps',
+  'lumoInjector',
+];
+
+/**
+ * Convert camelCase to dash-case.
+ * @param {string} str - e.g. "clearButtonVisible"
+ * @returns {string} - e.g. "clear-button-visible"
+ */
+function camelToDash(str) {
+  return str.replace(/([a-z])([A-Z])/gu, '$1-$2').toLowerCase();
+}
+
+/**
+ * @param {{name: string}} a
+ * @param {{name: string}} b
+ * @returns
+ */
+function sortName(a, b) {
+  const nameA = a.name?.toUpperCase(); // ignore upper and lowercase
+  const nameB = b.name?.toUpperCase(); // ignore upper and lowercase
+  if (nameA < nameB) {
+    return -1;
+  }
+  if (nameA > nameB) {
+    return 1;
+  }
+
+  // names must be equal
+  return 0;
+}
+
+export default {
+  globs: ['packages/**/src/(vaadin-*.js|*-mixin.js)'],
+  packagejson: false,
+  litelement: true,
+  plugins: [
+    {
+      packageLinkPhase({ customElementsManifest }) {
+        for (const definition of customElementsManifest.modules) {
+          for (const declaration of definition.declarations) {
+            // Filter out private and protected API and internal static getters.
+            // Transform field members' attribute property from camelCase to dash-case.
+            if (declaration?.members?.length) {
+              declaration.members = declaration.members
+                .filter((member) => member.privacy !== 'private' && member.privacy !== 'protected')
+                .filter((member) => !member.name.startsWith('_'))
+                .filter((member) => !(member.static && ignoredStaticMembers.includes(member.name)))
+                .map((member) => {
+                  if (member.kind === 'field' && member.attribute) {
+                    return { ...member, attribute: camelToDash(member.attribute) };
+                  }
+                  return member;
+                })
+                .sort(sortName);
+            }
+
+            // Transform attributes:
+            // - Filter out starting with underscore e.g. `_lastTabIndex`
+            // - Filter out `dir` attribute inherited from DirMixin.
+            // - Filter out attributes with non-primitive types (can't be set via HTML attributes).
+            // - Transform camelCase attribute names to dash-case.
+            if (declaration?.attributes?.length) {
+              declaration.attributes = declaration.attributes
+                .filter((member) => !inheritanceDenyList.includes(member.inheritedFrom?.name))
+                .filter((member) => !member.name.startsWith('_') && member.name !== 'dir')
+                .filter((member) => !ignoredAttributeTypes.some((type) => member.type?.text?.includes(type)))
+                .map((attr) => ({ ...attr, name: camelToDash(attr.name) }))
+                .sort(sortName);
+            }
+
+            // Filter out events:
+            // - inherited from PolylitMixin
+            // - with type "CustomEvent" but no name (invalid/inherited events)
+            if (declaration?.events?.length) {
+              declaration.events = declaration.events
+                .filter((member) => !inheritanceDenyList.includes(member.inheritedFrom?.name))
+                .filter((member) => !(member.type?.text === 'CustomEvent' && !member.name))
+                .sort(sortName);
+            }
+          }
+        }
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:types": "tsc",
     "postinstall": "patch-package",
     "prepare": "husky",
-    "release": "yarn release:themes && yarn release:web-types",
+    "release": "yarn release:themes && yarn release:web-types && yarn release:cem",
+    "release:cem": "custom-elements-manifest analyze --config custom-elements-manifest.config.js && node ./scripts/split-cem.js",
     "release:themes": "yarn workspace @vaadin/aura build && yarn workspace @vaadin/vaadin-lumo-styles build",
     "release:web-types": "yarn analyze && node scripts/buildWebtypes.js",
     "start": "web-dev-server --node-resolve --open /dev",
@@ -41,6 +42,7 @@
     "update:snapshots": "yarn test --config web-test-runner-snapshots.config.js --update-snapshots"
   },
   "devDependencies": {
+    "@custom-elements-manifest/analyzer": "^0.11.0",
     "@types/mocha": "^10.0.7",
     "@ungap/structured-clone": "^1.3.0",
     "@vaadin/testing-helpers": "^2.0.0",

--- a/packages/a11y-base/package.json
+++ b/packages/a11y-base/package.json
@@ -22,7 +22,8 @@
   "files": [
     "index.d.ts",
     "index.js",
-    "src"
+    "src",
+    "custom-elements.json"
   ],
   "keywords": [
     "Vaadin",
@@ -39,5 +40,6 @@
     "@vaadin/test-runner-commands": "25.1.0-alpha6",
     "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^21.0.0"
-  }
+  },
+  "customElements": "custom-elements.json"
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/app-layout/package.json
+++ b/packages/app-layout/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/avatar-group/package.json
+++ b/packages/avatar-group/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -52,6 +53,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-board",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-chart",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/combo-box/package.json
+++ b/packages/combo-box/package.json
@@ -24,6 +24,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -53,6 +54,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/component-base/package.json
+++ b/packages/component-base/package.json
@@ -23,7 +23,8 @@
     "custom_typings",
     "index.d.ts",
     "index.js",
-    "src"
+    "src",
+    "custom-elements.json"
   ],
   "keywords": [
     "Vaadin",
@@ -41,5 +42,6 @@
     "@vaadin/test-runner-commands": "25.1.0-alpha6",
     "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^21.0.0"
-  }
+  },
+  "customElements": "custom-elements.json"
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -53,6 +54,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -55,6 +56,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-crud",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/custom-field/package.json
+++ b/packages/custom-field/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -58,6 +59,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -51,6 +52,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-dashboard",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -51,6 +52,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/details/package.json
+++ b/packages/details/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -51,6 +52,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/email-field/package.json
+++ b/packages/email-field/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -46,6 +47,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/field-base/package.json
+++ b/packages/field-base/package.json
@@ -22,7 +22,8 @@
   "files": [
     "index.d.ts",
     "index.js",
-    "src"
+    "src",
+    "custom-elements.json"
   ],
   "keywords": [
     "Vaadin",
@@ -41,5 +42,6 @@
     "@vaadin/test-runner-commands": "25.1.0-alpha6",
     "@vaadin/testing-helpers": "^2.0.0",
     "sinon": "^21.0.0"
-  }
+  },
+  "customElements": "custom-elements.json"
 }

--- a/packages/form-layout/package.json
+++ b/packages/form-layout/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/grid-pro/package.json
+++ b/packages/grid-pro/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -55,6 +56,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-grid-pro",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -27,6 +27,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -60,6 +61,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/horizontal-layout/package.json
+++ b/packages/horizontal-layout/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -45,6 +46,7 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -46,6 +47,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/input-container/package.json
+++ b/packages/input-container/package.json
@@ -22,7 +22,8 @@
   "files": [
     "src",
     "vaadin-*.d.ts",
-    "vaadin-*.js"
+    "vaadin-*.js",
+    "custom-elements.json"
   ],
   "keywords": [
     "Vaadin",
@@ -43,5 +44,6 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
-  }
+  },
+  "customElements": "custom-elements.json"
 }

--- a/packages/integer-field/package.json
+++ b/packages/integer-field/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -44,6 +45,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/item/package.json
+++ b/packages/item/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -47,6 +48,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/list-box/package.json
+++ b/packages/list-box/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -52,6 +53,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-map",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -47,6 +48,7 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/master-detail-layout/package.json
+++ b/packages/master-detail-layout/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -45,6 +46,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/menu-bar/package.json
+++ b/packages/menu-bar/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -53,6 +54,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/message-input/package.json
+++ b/packages/message-input/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/message-list/package.json
+++ b/packages/message-list/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -51,6 +52,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/multi-select-combo-box/package.json
+++ b/packages/multi-select-combo-box/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -55,6 +56,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -22,7 +22,8 @@
   "files": [
     "src",
     "vaadin-*.d.ts",
-    "vaadin-*.js"
+    "vaadin-*.js",
+    "custom-elements.json"
   ],
   "keywords": [
     "Vaadin",
@@ -45,5 +46,6 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
-  }
+  },
+  "customElements": "custom-elements.json"
 }

--- a/packages/password-field/package.json
+++ b/packages/password-field/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -51,6 +52,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -46,6 +47,7 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -55,6 +55,7 @@
     "sinon": "^21.0.0"
   },
   "cvdlName": "vaadin-rich-text-editor",
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/scroller/package.json
+++ b/packages/scroller/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -46,6 +47,7 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -56,6 +57,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/side-nav/package.json
+++ b/packages/side-nav/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "lit": "^3.0.0",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -47,6 +48,7 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/split-layout/package.json
+++ b/packages/split-layout/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -46,6 +47,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/tabsheet/package.json
+++ b/packages/tabsheet/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -48,6 +49,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/text-area/package.json
+++ b/packages/text-area/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -52,6 +53,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -49,6 +50,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/vertical-layout/package.json
+++ b/packages/vertical-layout/package.json
@@ -23,6 +23,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -44,6 +45,7 @@
     "@vaadin/testing-helpers": "^2.0.0",
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/packages/virtual-list/package.json
+++ b/packages/virtual-list/package.json
@@ -25,6 +25,7 @@
     "src",
     "vaadin-*.d.ts",
     "vaadin-*.js",
+    "custom-elements.json",
     "web-types.json",
     "web-types.lit.json"
   ],
@@ -50,6 +51,7 @@
     "@vaadin/vaadin-lumo-styles": "25.1.0-alpha6",
     "sinon": "^21.0.0"
   },
+  "customElements": "custom-elements.json",
   "web-types": [
     "web-types.json",
     "web-types.lit.json"

--- a/scripts/split-cem.js
+++ b/scripts/split-cem.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+/**
+ * This script splits the root custom-elements.json manifest into
+ * per-package custom-elements.json files.
+ *
+ * Run with: node scripts/split-cem.js
+ */
+import { globSync } from 'glob';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const packagesDir = path.join(rootDir, 'packages');
+
+// Read root manifest
+const rootManifestPath = path.join(rootDir, 'custom-elements.json');
+const rootManifest = JSON.parse(fs.readFileSync(rootManifestPath, 'utf-8'));
+
+/**
+ * Extract package name from a module path.
+ * @param {string} modulePath - e.g. "packages/button/src/vaadin-button.js"
+ * @returns {string|null} - e.g. "button"
+ */
+function extractPackageName(modulePath) {
+  const match = modulePath.match(/^packages\/([^/]+)\//u);
+  return match ? match[1] : null;
+}
+
+/**
+ * Transform a module reference from root manifest format to per-package format.
+ * Handles both "module" and "package" references.
+ *
+ * @param {object} ref - Reference object with "module" or "package" property
+ * @param {string} currentPackage - The package being processed (e.g. "button")
+ * @returns {object} - Transformed reference
+ */
+function transformReference(ref, currentPackage) {
+  if (!ref || typeof ref !== 'object') return ref;
+
+  const transformed = { ...ref };
+
+  if (transformed.module) {
+    const modulePath = transformed.module;
+
+    // Handle leading slash (same-package reference in root manifest)
+    // e.g. "/packages/button/src/vaadin-button-mixin.js"
+    if (modulePath.startsWith('/packages/')) {
+      const withoutSlash = modulePath.slice(1); // Remove leading slash
+      const refPackage = extractPackageName(withoutSlash);
+
+      if (refPackage === currentPackage) {
+        // Same package - convert to relative path
+        // "/packages/button/src/foo.js" -> "src/foo.js"
+        transformed.module = withoutSlash.replace(`packages/${currentPackage}/`, '');
+      } else {
+        // Different package - convert to npm package reference
+        // "/packages/a11y-base/src/foo.js" -> "@vaadin/a11y-base/src/foo.js"
+        delete transformed.module;
+        transformed.package = `@vaadin/${withoutSlash.replace('packages/', '')}`;
+      }
+    }
+    // Handle no leading slash (cross-package reference or self-reference)
+    // e.g. "packages/a11y-base/src/disabled-mixin.js"
+    else if (modulePath.startsWith('packages/')) {
+      const refPackage = extractPackageName(modulePath);
+
+      if (refPackage === currentPackage) {
+        // Same package - convert to relative path
+        transformed.module = modulePath.replace(`packages/${currentPackage}/`, '');
+      } else {
+        // Different package - convert to npm package reference
+        delete transformed.module;
+        transformed.package = `@vaadin/${modulePath.replace('packages/', '')}`;
+      }
+    }
+    // Relative paths within the package stay as-is
+  }
+
+  // External packages stay as-is (e.g. "@open-wc/dedupe-mixin", "lit")
+  return transformed;
+}
+
+/**
+ * Recursively traverse an object and transform all module references.
+ * @param {any} obj - Object to traverse
+ * @param {string} currentPackage - The package being processed
+ * @returns {any} - Transformed object
+ */
+function deepTransform(obj, currentPackage) {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    return obj.map((item) => deepTransform(item, currentPackage));
+  }
+
+  // First, check if the current object itself is a reference object
+  // (e.g., a mixin entry like {name: "Foo", module: "/packages/..."})
+  // and transform it before recursing into its properties
+  const transformed = 'module' in obj ? transformReference(obj, currentPackage) : obj;
+
+  const result = {};
+  for (const [key, value] of Object.entries(transformed)) {
+    if (typeof value === 'object' && value !== null) {
+      result[key] = deepTransform(value, currentPackage);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Transform a module's path from root format to per-package format.
+ * @param {string} modulePath - e.g. "packages/button/src/vaadin-button.js"
+ * @param {string} currentPackage - e.g. "button"
+ * @returns {string} - e.g. "src/vaadin-button.js"
+ */
+function transformModulePath(modulePath, currentPackage) {
+  return modulePath.replace(`packages/${currentPackage}/`, '');
+}
+
+/**
+ * Find entry point files for a package (vaadin-*.js in package root).
+ * @param {string} packageName - e.g. "button"
+ * @returns {string[]} - Array of entry point file names
+ */
+function findEntryPoints(packageName) {
+  const packageDir = path.join(packagesDir, packageName);
+  const pattern = path.join(packageDir, 'vaadin-*.js');
+  const files = globSync(pattern);
+  return files.map((f) => path.basename(f));
+}
+
+/**
+ * Generate entry point module for the manifest.
+ * @param {string} entryFile - e.g. "vaadin-button.js"
+ * @returns {object} - Module object for the manifest
+ */
+function generateEntryPointModule(entryFile) {
+  const srcFile = `src/${entryFile}`;
+  return {
+    kind: 'javascript-module',
+    path: entryFile,
+    declarations: [],
+    exports: [
+      {
+        kind: 'js',
+        name: '*',
+        declaration: {
+          name: '*',
+          module: srcFile,
+        },
+      },
+    ],
+  };
+}
+
+// Group modules by package
+const packageModules = new Map();
+
+for (const mod of rootManifest.modules) {
+  const packageName = extractPackageName(mod.path);
+  if (!packageName) {
+    console.warn(`Skipping module with unexpected path: ${mod.path}`);
+    continue;
+  }
+
+  if (!packageModules.has(packageName)) {
+    packageModules.set(packageName, []);
+  }
+  packageModules.get(packageName).push(mod);
+}
+
+console.log(`Found ${packageModules.size} packages in root manifest`);
+
+// Process each package
+for (const [packageName, modules] of packageModules) {
+  // Transform modules
+  const transformedModules = modules.map((mod) => {
+    // Transform the path
+    const transformedPath = transformModulePath(mod.path, packageName);
+
+    // Deep transform the rest of the module
+    const transformedMod = deepTransform(mod, packageName);
+    transformedMod.path = transformedPath;
+
+    return transformedMod;
+  });
+
+  // Find and add entry point modules
+  const entryPoints = findEntryPoints(packageName);
+  const entryPointModules = [];
+
+  for (const entryFile of entryPoints) {
+    // Check if there's a corresponding src file in the modules
+    const srcPath = `src/${entryFile}`;
+    const hasSrcModule = transformedModules.some((m) => m.path === srcPath);
+
+    if (hasSrcModule) {
+      // Only add entry point if the src file exists in the manifest
+      entryPointModules.push(generateEntryPointModule(entryFile));
+    }
+  }
+
+  // Combine entry points (first) with transformed modules
+  const allModules = [...entryPointModules, ...transformedModules];
+
+  // Create the per-package manifest
+  const packageManifest = {
+    schemaVersion: '1.0.0',
+    readme: '',
+    modules: allModules,
+  };
+
+  // Write to package directory
+  const outputPath = path.join(packagesDir, packageName, 'custom-elements.json');
+  fs.writeFileSync(outputPath, `${JSON.stringify(packageManifest, null, 2)}\n`);
+  console.log(`Written: ${outputPath} (${allModules.length} modules)`);
+}
+
+console.log('Done!');

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,30 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz#037817b574262134cabd68fc4ec1a454f168407b"
   integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
 
+"@custom-elements-manifest/analyzer@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.11.0.tgz#021d88b319c06d42b89796ade22126b7bf54c4cd"
+  integrity sha512-F2jQFk6igV5vrTZYDBLVr0GDQF3cTJ2VwwzPdsmkzUE+SHiYAQNKYebIq8qphZdJeTcZtVhvw336FQVZsMqh4A==
+  dependencies:
+    "@custom-elements-manifest/find-dependencies" "^0.0.7"
+    "@github/catalyst" "^1.6.0"
+    "@web/config-loader" "0.1.3"
+    chokidar "3.5.2"
+    command-line-args "5.1.2"
+    comment-parser "1.2.4"
+    custom-elements-manifest "1.0.0"
+    debounce "1.2.1"
+    globby "11.0.4"
+    typescript "~5.4.2"
+
+"@custom-elements-manifest/find-dependencies@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/find-dependencies/-/find-dependencies-0.0.7.tgz#1aff55373a5c82349d560c0abc3b441285b066c1"
+  integrity sha512-icHEBPHcOXSrpDOFkQhvM7vljEbqrEReW251RBxSzDctXzYWIL0Hk2yMDINn3d6mZ4KSsqLZlaFiGFp/2nn9rA==
+  dependencies:
+    oxc-resolver "^11.9.0"
+    rs-module-lexer "^2.5.1"
+
 "@dual-bundle/import-meta-resolve@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz#519c1549b0e147759e7825701ecffd25e5819f7b"
@@ -316,25 +340,25 @@
     buffer-crc32 "~0.2.3"
     fd-slicer2 "^1.2.0"
 
-"@emnapi/core@^1.1.0", "@emnapi/core@^1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.3.tgz#9ac52d2d5aea958f67e52c40a065f51de59b77d6"
-  integrity sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==
+"@emnapi/core@^1.1.0", "@emnapi/core@^1.4.3", "@emnapi/core@^1.7.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
+  integrity sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==
   dependencies:
-    "@emnapi/wasi-threads" "1.0.2"
+    "@emnapi/wasi-threads" "1.1.0"
     tslib "^2.4.0"
 
-"@emnapi/runtime@^1.1.0", "@emnapi/runtime@^1.4.3":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.4.5.tgz#c67710d0661070f38418b6474584f159de38aba9"
-  integrity sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==
+"@emnapi/runtime@^1.1.0", "@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.7.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.8.1.tgz#550fa7e3c0d49c5fb175a116e8cd70614f9a22a5"
+  integrity sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/wasi-threads@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz#977f44f844eac7d6c138a415a123818c655f874c"
-  integrity sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==
+"@emnapi/wasi-threads@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz#60b2102fddc9ccb78607e4a3cf8403ea69be41bf"
+  integrity sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==
   dependencies:
     tslib "^2.4.0"
 
@@ -530,6 +554,11 @@
   dependencies:
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
+
+"@github/catalyst@^1.6.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@github/catalyst/-/catalyst-1.7.0.tgz#12dd1097a66260f0dde1d1d1f5ebfe7d1f576a80"
+  integrity sha512-qOAxrDdRZz9+v4y2WoAfh11rpRY/x4FRofPNmJyZFzAjubtzE3sCa/tAycWWufmQGoYiwwzL/qJBBgyg7avxPw==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -916,6 +945,15 @@
     "@emnapi/core" "^1.4.3"
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
+
+"@napi-rs/wasm-runtime@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
+  integrity sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==
+  dependencies:
+    "@emnapi/core" "^1.7.1"
+    "@emnapi/runtime" "^1.7.1"
+    "@tybys/wasm-util" "^0.10.1"
 
 "@niceties/logger@^1.1.4", "@niceties/logger@^1.1.5":
   version "1.1.13"
@@ -1369,6 +1407,108 @@
     "@types/chai" "^4.3.1"
     "@web/test-runner-commands" "^0.9.0"
 
+"@oxc-resolver/binding-android-arm-eabi@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.16.3.tgz#536ad397111ac45b95327a437973aec68da31c0b"
+  integrity sha512-CVyWHu6ACDqDcJxR4nmGiG8vDF4TISJHqRNzac5z/gPQycs/QrP/1pDsJBy0MD7jSw8nVq2E5WqeHQKabBG/Jg==
+
+"@oxc-resolver/binding-android-arm64@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.16.3.tgz#19a9c43aafad93e2121263ffa87e6664b1b0a9f5"
+  integrity sha512-tTIoB7plLeh2o6Ay7NnV5CJb6QUXdxI7Shnsp2ECrLSV81k+oVE3WXYrQSh4ltWL75i0OgU5Bj3bsuyg5SMepw==
+
+"@oxc-resolver/binding-darwin-arm64@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.16.3.tgz#14f90192349cfee3b5107cdd214fdf17746d6119"
+  integrity sha512-OXKVH7uwYd3Rbw1s2yJZd6/w+6b01iaokZubYhDAq4tOYArr+YCS+lr81q1hsTPPRZeIsWE+rJLulmf1qHdYZA==
+
+"@oxc-resolver/binding-darwin-x64@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.16.3.tgz#890da8ec9c95e09c4647d135ced9da63e814f1a6"
+  integrity sha512-WwjQ4WdnCxVYZYd3e3oY5XbV3JeLy9pPMK+eQQ2m8DtqUtbxnvPpAYC2Knv/2bS6q5JiktqOVJ2Hfia3OSo0/A==
+
+"@oxc-resolver/binding-freebsd-x64@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.16.3.tgz#260ee462b9466219190cf7fb62c22ebba136b079"
+  integrity sha512-4OHKFGJBBfOnuJnelbCS4eBorI6cj54FUxcZJwEXPeoLc8yzORBoJ2w+fQbwjlQcUUZLEg92uGhKCRiUoqznjg==
+
+"@oxc-resolver/binding-linux-arm-gnueabihf@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.16.3.tgz#89b32eaf88eda78f79e9f3f974e64e0d90dabfe5"
+  integrity sha512-OM3W0NLt9u7uKwG/yZbeXABansZC0oZeDF1nKgvcZoRw4/Yak6/l4S0onBfDFeYMY94eYeAt2bl60e30lgsb5A==
+
+"@oxc-resolver/binding-linux-arm-musleabihf@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.16.3.tgz#d099644276c0651d4af127f7e73a3b38634bfe64"
+  integrity sha512-MRs7D7i1t7ACsAdTuP81gLZES918EpBmiUyEl8fu302yQB+4L7L7z0Ui8BWnthUTQd3nAU9dXvENLK/SqRVH8A==
+
+"@oxc-resolver/binding-linux-arm64-gnu@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.16.3.tgz#8643f63382345c7fb6927b4965362567fae869c3"
+  integrity sha512-0eVYZxSceNqGADzhlV4ZRqkHF0fjWxRXQOB7Qwl5y1gN/XYUDvMfip+ngtzj4dM7zQT4U97hUhJ7PUKSy/JIGQ==
+
+"@oxc-resolver/binding-linux-arm64-musl@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.16.3.tgz#1436757f6b802180173743941d2332d575c34387"
+  integrity sha512-B1BvLeZbgDdVN0FvU40l5Q7lej8310WlabCBaouk8jY7H7xbI8phtomTtk3Efmevgfy5hImaQJu6++OmcFb2NQ==
+
+"@oxc-resolver/binding-linux-ppc64-gnu@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.16.3.tgz#73dad74401544058b82c5ef69ff5bb04019cc2cc"
+  integrity sha512-q7khglic3Jqak7uDgA3MFnjDeI7krQT595GDZpvFq785fmFYSx8rlTkoHzmhQtUisYtl4XG7WUscwsoidFUI4w==
+
+"@oxc-resolver/binding-linux-riscv64-gnu@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.16.3.tgz#82e13b33295dcfa3cbb786d6517dfa13e46c513d"
+  integrity sha512-aFRNmQNPzDgQEbw2s3c8yJYRimacSDI+u9df8rn5nSKzTVitHmbEpZqfxpwNLCKIuLSNmozHR1z1OT+oZVeYqg==
+
+"@oxc-resolver/binding-linux-riscv64-musl@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.16.3.tgz#5b511719119f4d59e473329d9f618d4c617384d4"
+  integrity sha512-vZI85SvSMADcEL9G1TIrV0Rlkc1fY5Mup0DdlVC5EHPysZB4hXXHpr+h09pjlK5y+5om5foIzDRxE1baUCaWOA==
+
+"@oxc-resolver/binding-linux-s390x-gnu@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.16.3.tgz#c8b20ba45c6bc4fa8c41fb67b6a6f274a49423cf"
+  integrity sha512-xiLBnaUlddFEzRHiHiSGEMbkg8EwZY6VD8F+3GfnFsiK3xg/4boaUV2bwXd+nUzl3UDQOMW1QcZJ4jJSb0qiJA==
+
+"@oxc-resolver/binding-linux-x64-gnu@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.16.3.tgz#9eb948696848a97bdafe7d70264ac07ff0baaa61"
+  integrity sha512-6y0b05wIazJJgwu7yU/AYGFswzQQudYJBOb/otDhiDacp1+6ye8egoxx63iVo9lSpDbipL++54AJQFlcOHCB+g==
+
+"@oxc-resolver/binding-linux-x64-musl@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.16.3.tgz#ab7e588b752dfbd6d29df8ca3ff6278c6d8487c3"
+  integrity sha512-RmMgwuMa42c9logS7Pjprf5KCp8J1a1bFiuBFtG9/+yMu0BhY2t+0VR/um7pwtkNFvIQqAVh6gDOg/PnoKRcdQ==
+
+"@oxc-resolver/binding-openharmony-arm64@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.16.3.tgz#0995907ca0d11648bad7115aaad8fea7f5ab0c14"
+  integrity sha512-/7AYRkjjW7xu1nrHgWUFy99Duj4/ydOBVaHtODie9/M6fFngo+8uQDFFnzmr4q//sd/cchIerISp/8CQ5TsqIA==
+
+"@oxc-resolver/binding-wasm32-wasi@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.16.3.tgz#070aed480e966182576355d9471d6872c15c0d84"
+  integrity sha512-urM6aIPbi5di4BSlnpd/TWtDJgG6RD06HvLBuNM+qOYuFtY1/xPbzQ2LanBI2ycpqIoIZwsChyplALwAMdyfCQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^1.1.1"
+
+"@oxc-resolver/binding-win32-arm64-msvc@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.16.3.tgz#aca846d2ca636c00b8a03c573a8f35c712e6acec"
+  integrity sha512-QuvLqGKf7frxWHQ5TnrcY0C/hJpANsaez99Q4dAk1hen7lDTD4FBPtBzPnntLFXeaVG3PnSmnVjlv0vMILwU7Q==
+
+"@oxc-resolver/binding-win32-ia32-msvc@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.16.3.tgz#77a0e7d920511d23214b1bb3f67ed6524b0489c2"
+  integrity sha512-QR/witXK6BmYTlEP8CCjC5fxeG5U9A6a50pNpC1nLnhAcJjtzFG8KcQ5etVy/XvCLiDc7fReaAWRNWtCaIhM8Q==
+
+"@oxc-resolver/binding-win32-x64-msvc@11.16.3":
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.16.3.tgz#7e2befaecbb8d1cfb0673aba5d7b298d383c5f0d"
+  integrity sha512-bFuJRKOscsDAEZ/a8BezcTMAe2BQ/OBRfuMLFUuINfTR5qGVcm4a3xBIrQVepBaPxFj16SJdRjGe05vDiwZmFw==
+
 "@petamoriken/float16@^3.4.7":
   version "3.6.6"
   resolved "https://registry.yarnpkg.com/@petamoriken/float16/-/float16-3.6.6.tgz#641f73913a6be402b34e4bdfca98d6832ed55586"
@@ -1687,7 +1827,7 @@
     "@tufjs/canonical-json" "2.0.0"
     minimatch "^9.0.5"
 
-"@tybys/wasm-util@^0.10.0":
+"@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
   integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
@@ -2326,6 +2466,13 @@
   dependencies:
     errorstacks "^2.2.0"
 
+"@web/config-loader@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.1.3.tgz#8325ea54f75ef2ee7166783e64e66936db25bff7"
+  integrity sha512-XVKH79pk4d3EHRhofete8eAnqto1e8mCRAqPV00KLNFzCWSe8sWmLnqKCqkPNARC6nksMaGrATnA5sPDRllMpQ==
+  dependencies:
+    semver "^7.3.4"
+
 "@web/config-loader@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.3.1.tgz#0917fd549c264e565e75bd6c7d73acd7365df26b"
@@ -2555,6 +2702,51 @@
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.11.1.tgz#add19d5e0db4a014e143d2278921347dcd8f0a55"
   integrity sha512-qSok/oMynEgS99wFY5fKT6cR1y64i01RkHGYOspkh2JQsLSM8pjciER+gu3fqTx589y/7LoSuyB5G9Rh7dyXaQ==
+
+"@xn-sakina/rml-darwin-arm64@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-darwin-arm64/-/rml-darwin-arm64-2.6.0.tgz#dac9df3c1eefc04e1c2c1f67f7da1139994f6eee"
+  integrity sha512-RuFHj6ro6Q24gPqNQGvH4uxpsvbgqBBy+ZUK+jbMuMaw4wyti7F6klQWuikBJAxhWpmRbhAB/jrq0PC82qlh5A==
+
+"@xn-sakina/rml-darwin-x64@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-darwin-x64/-/rml-darwin-x64-2.6.0.tgz#e08a923fbac6de6a435bedc1d6344abd3b5efce9"
+  integrity sha512-85bsP7viqtgw5nVYBdl8I4c2+q4sYFcBMTeFnTf4RqhUUwBLerP7D+XXnWwv3waO+aZ0Fe0ij9Fji3oTiREOCg==
+
+"@xn-sakina/rml-linux-arm-gnueabihf@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-linux-arm-gnueabihf/-/rml-linux-arm-gnueabihf-2.6.0.tgz#49321378be024aedaad9f980eeae80f51fe2acb4"
+  integrity sha512-ySI529TPraG1Mf/YiKhLLNGJ1js0Y3BnZRAihUpF4IlyFKmeL3slXEdvK2tVndyX2O21EYWv/DcSAmFMNOolfA==
+
+"@xn-sakina/rml-linux-arm64-gnu@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-linux-arm64-gnu/-/rml-linux-arm64-gnu-2.6.0.tgz#5d1c0ec4591899f998a34490c0ce62fcd3eb0e44"
+  integrity sha512-Ytzkmty4vVWAqe+mbu/ql5dqwUH49eVgPT38uJK78LTZRsdogxlQbuAoLKlb/N8CIXAE7BRoywz3lSEGToXylw==
+
+"@xn-sakina/rml-linux-arm64-musl@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-linux-arm64-musl/-/rml-linux-arm64-musl-2.6.0.tgz#2c73c8934a80e367cfda108cae0ca4fb69d52d99"
+  integrity sha512-DIBSDWlTmWk+r6Xp7mL9Cw8DdWNyJGg7YhOV1sSSRykdGs2TNtS3z0nbHRuUBMqrbtDk0IwqFSepLx12Bix/zw==
+
+"@xn-sakina/rml-linux-x64-gnu@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-linux-x64-gnu/-/rml-linux-x64-gnu-2.6.0.tgz#e892f81fd20095df9c4fcb951717ee2f4889b82e"
+  integrity sha512-8Pks6hMicFGWYQmylKul7Gmn64pG4HkRL7skVWEPAF0LZHeI5yvV/EnQUnXXbxPp4Viy2H4420jl6BVS7Uetng==
+
+"@xn-sakina/rml-linux-x64-musl@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-linux-x64-musl/-/rml-linux-x64-musl-2.6.0.tgz#8c1888696e9b0053a6f9a25e990cb3a7b55f2ea2"
+  integrity sha512-xHX/rNKcATVrJt2no0FdO6kqnV4P5cP/3MgHA0KwhD/YJmWa66JIfWtzrPv9n/s0beGSorLkh8PLt5lVLFGvlQ==
+
+"@xn-sakina/rml-win32-arm64-msvc@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-win32-arm64-msvc/-/rml-win32-arm64-msvc-2.6.0.tgz#763b4edc5d4efdce5d75ec582eede71abb7898ba"
+  integrity sha512-aIOu5frDsxRp5naN6YjBtbCHS4K2WHIx2EClGclv3wGFrOn1oSROxpVOV/MODUuWITj/26pWbZ/tnbvva6ZV8A==
+
+"@xn-sakina/rml-win32-x64-msvc@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@xn-sakina/rml-win32-x64-msvc/-/rml-win32-x64-msvc-2.6.0.tgz#5fa0b40422939e0ac34ee1b8799025ae67407105"
+  integrity sha512-XXbzy2gLEs6PpHdM2IUC5QujOIjz6LpSQpJ+ow43gVc7BhagIF5YlMyTFZCbJehjK9yNgPCzdrzsukCjsH5kIA==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -2788,7 +2980,7 @@ array-back@^3.0.1, array-back@^3.1.0:
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
   integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
 
-array-back@^6.2.2:
+array-back@^6.1.2, array-back@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
   integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
@@ -3456,6 +3648,21 @@ cheerio@^1.0.0-rc.12:
     undici "^6.19.5"
     whatwg-mimetype "^4.0.0"
 
+chokidar@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^3.3.0, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -3679,6 +3886,16 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-line-args@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.2.tgz#25908e573d2214bc23a8437e3df853b02dffa425"
+  integrity sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==
+  dependencies:
+    array-back "^6.1.2"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
 command-line-args@^5.1.1, command-line-args@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
@@ -3728,6 +3945,11 @@ commander@^9.3.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
+comment-parser@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
+  integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
 
 comment-parser@^1.4.1:
   version "1.4.1"
@@ -4071,6 +4293,11 @@ cuint@^0.2.2:
   resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
   integrity sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==
 
+custom-elements-manifest@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz#b35c2129076a1dc9f95d720c6f7b5b71a857274b"
+  integrity sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==
+
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
@@ -4123,7 +4350,7 @@ dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debounce@^1.2.0:
+debounce@1.2.1, debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
@@ -5211,7 +5438,7 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@^3.2.9, fast-glob@^3.3.3:
+fast-glob@^3.1.1, fast-glob@^3.2.9, fast-glob@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -5819,6 +6046,18 @@ globalthis@^1.0.4:
     define-properties "^1.2.1"
     gopd "^1.0.1"
 
+globby@11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -6209,7 +6448,7 @@ ignore-walk@^8.0.0:
   dependencies:
     minimatch "^10.0.3"
 
-ignore@^5.2.0:
+ignore@^5.1.4, ignore@^5.2.0:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
@@ -8573,6 +8812,32 @@ own-keys@^1.0.1:
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
 
+oxc-resolver@^11.9.0:
+  version "11.16.3"
+  resolved "https://registry.yarnpkg.com/oxc-resolver/-/oxc-resolver-11.16.3.tgz#79b538ac74438f8f28eaff423b465080e821ac07"
+  integrity sha512-goLOJH3x69VouGWGp5CgCIHyksmOZzXr36lsRmQz1APg3SPFORrvV2q7nsUHMzLVa6ZJgNwkgUSJFsbCpAWkCA==
+  optionalDependencies:
+    "@oxc-resolver/binding-android-arm-eabi" "11.16.3"
+    "@oxc-resolver/binding-android-arm64" "11.16.3"
+    "@oxc-resolver/binding-darwin-arm64" "11.16.3"
+    "@oxc-resolver/binding-darwin-x64" "11.16.3"
+    "@oxc-resolver/binding-freebsd-x64" "11.16.3"
+    "@oxc-resolver/binding-linux-arm-gnueabihf" "11.16.3"
+    "@oxc-resolver/binding-linux-arm-musleabihf" "11.16.3"
+    "@oxc-resolver/binding-linux-arm64-gnu" "11.16.3"
+    "@oxc-resolver/binding-linux-arm64-musl" "11.16.3"
+    "@oxc-resolver/binding-linux-ppc64-gnu" "11.16.3"
+    "@oxc-resolver/binding-linux-riscv64-gnu" "11.16.3"
+    "@oxc-resolver/binding-linux-riscv64-musl" "11.16.3"
+    "@oxc-resolver/binding-linux-s390x-gnu" "11.16.3"
+    "@oxc-resolver/binding-linux-x64-gnu" "11.16.3"
+    "@oxc-resolver/binding-linux-x64-musl" "11.16.3"
+    "@oxc-resolver/binding-openharmony-arm64" "11.16.3"
+    "@oxc-resolver/binding-wasm32-wasi" "11.16.3"
+    "@oxc-resolver/binding-win32-arm64-msvc" "11.16.3"
+    "@oxc-resolver/binding-win32-ia32-msvc" "11.16.3"
+    "@oxc-resolver/binding-win32-x64-msvc" "11.16.3"
+
 p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
@@ -10008,6 +10273,21 @@ rollup@^4.4.0, rollup@^4.46.2:
     "@rollup/rollup-win32-x64-msvc" "4.46.2"
     fsevents "~2.3.2"
 
+rs-module-lexer@^2.5.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/rs-module-lexer/-/rs-module-lexer-2.6.0.tgz#9fda37a3560bfc4e535f6db5fdb33ae7ff5f9114"
+  integrity sha512-aT0lO0icZ3Hq0IWvo+ORgVc6BJDoKfaDBdRIDQkL2PtBnFQJ0DuvExiiWI4GxjEjH8Yyro++NPArHFaD8bvS9w==
+  optionalDependencies:
+    "@xn-sakina/rml-darwin-arm64" "2.6.0"
+    "@xn-sakina/rml-darwin-x64" "2.6.0"
+    "@xn-sakina/rml-linux-arm-gnueabihf" "2.6.0"
+    "@xn-sakina/rml-linux-arm64-gnu" "2.6.0"
+    "@xn-sakina/rml-linux-arm64-musl" "2.6.0"
+    "@xn-sakina/rml-linux-x64-gnu" "2.6.0"
+    "@xn-sakina/rml-linux-x64-musl" "2.6.0"
+    "@xn-sakina/rml-win32-arm64-msvc" "2.6.0"
+    "@xn-sakina/rml-win32-x64-msvc" "2.6.0"
+
 run-async@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-4.0.6.tgz#d53b86acb71f42650fe23de2b3c1b6b6b34b9294"
@@ -11251,6 +11531,11 @@ typescript-eslint@8.50.0:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@~5.4.2:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/11077

- Added a script to run CEM analyzer and then split `custom-elements.json` into separate packages,
- Added `custom-elements-manifest.config.js` with a plugin to transform / filter the analyzer output,
- Added `"customElements": "custom-elements.json"` to the `package.json` in individual packages,
- Added `custom-elements.json` to `"files"` in the `package.json` so that it gets published to npm.

This PR doesn't change existing logic for API docs / `web-types.json` and we still use `analysis.json` for those.
We can update those later, it will first require to check if the CEM analyzer output contains everything we need.

## Type of change

- Internal change

## Note

Known issue: mixins using `dedupeMixin` e.g. `DisabledMixin` are not recognized by CEM. They would work if we split `dedupeMixin` like suggested [here](https://github.com/open-wc/custom-elements-manifest/blob/df0795b2bdd41a8109fa531ce00edae025726c1a/packages/analyzer/src/features/analyse-phase/reexported-wrapped-mixin-exports.js#L11-L16), but this structure, in turn, doesn't seem to be recognized by `polymer-analyzer`. IMO we should refactor these mixins later when we eventually fully switch from Polymer CLI to CEM.