### PR TITLE
chore: exclude static get experimental from custom-elements.json

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -19,6 +19,7 @@ const ignoredStaticMembers = [
   'delegateAttrs',
   'delegateProps',
   'lumoInjector',
+  'experimental',
 ];
 
 /**


### PR DESCRIPTION
## Description

Follow-up to #11078 

Added `experimental` to the list of excluded static getters to avoid the following entry in `custom-elements.json`:

```
{
  "kind": "field",
  "name": "experimental",
  "static": true,
  "readonly": true
},
```

## Type of change

- Internal change