### PR TITLE
fix: show placeholder in select when no items or renderer is set

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -156,7 +156,10 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_updateAriaExpanded(opened, focusElement)', '_updateSelectedItem(value, _items, placeholder)'];
+      return [
+        '_updateAriaExpanded(opened, focusElement)',
+        '_updateSelectedItem(value, _items, placeholder, focusElement)',
+      ];
     }
 
     constructor() {

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -93,14 +93,12 @@ describe('vaadin-select', () => {
 
     describe('no items', () => {
       beforeEach(async () => {
-        select = fixtureSync('<vaadin-select></vaadin-select>');
+        select = fixtureSync('<vaadin-select placeholder="Select an item"></vaadin-select>');
         await nextRender();
         valueButton = select.querySelector('vaadin-select-value-button');
       });
 
-      it('should display placeholder when no items or renderer is set', async () => {
-        select.placeholder = 'Select an item';
-        await nextUpdate(select);
+      it('should display placeholder when no items or renderer is set', () => {
         expect(valueButton.textContent).to.equal('Select an item');
       });
     });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11084

When items/renderer were not configured, _updateSelectedItem() exited early and never called __updateValueButton(), so the placeholder was never displayed. Add an else branch to handle the placeholder-only case, and guard _items access to prevent crashes when items is undefined.

## Type of change

- Bugfix