### PR TITLE
fix: update slider to handle PageUp, PageDown Home and End keys

### DIFF
--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -645,8 +645,8 @@ class RangeSlider extends FieldMixin(
 
   /** @private */
   __onKeyDown(event) {
-    const prevKeys = ['ArrowLeft', 'ArrowDown'];
-    const nextKeys = ['ArrowRight', 'ArrowUp'];
+    const prevKeys = ['ArrowLeft', 'ArrowDown', 'PageDown', 'Home'];
+    const nextKeys = ['ArrowRight', 'ArrowUp', 'PageUp', 'End'];
 
     const isNextKey = nextKeys.includes(event.key);
     const isPrevKey = prevKeys.includes(event.key);

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -391,8 +391,8 @@ class Slider extends FieldMixin(
 
   /** @private */
   __onKeyDown(event) {
-    const arrowKeys = ['ArrowLeft', 'ArrowDown', 'ArrowRight', 'ArrowUp'];
-    if (this.readonly && arrowKeys.includes(event.key)) {
+    const inputKeys = ['ArrowLeft', 'ArrowDown', 'ArrowRight', 'ArrowUp', 'PageUp', 'PageDown', 'Home', 'End'];
+    if (this.readonly && inputKeys.includes(event.key)) {
       event.preventDefault();
     }
   }

--- a/packages/slider/test/range-slider-keyboard.test.ts
+++ b/packages/slider/test/range-slider-keyboard.test.ts
@@ -92,6 +92,41 @@ describe('vaadin-range-slider - keyboard input', () => {
       await sendKeys({ press: 'ArrowRight' });
       expect(spy).to.be.calledOnce;
     });
+
+    it('should increase lower value on PageUp', async () => {
+      await sendKeys({ press: 'PageUp' });
+      expect(slider.value).to.deep.equal([10, 100]);
+    });
+
+    it('should decrease lower value on PageDown', async () => {
+      slider.value = [50, 100];
+      await sendKeys({ press: 'PageDown' });
+      expect(slider.value).to.deep.equal([40, 100]);
+    });
+
+    it('should set lower value to min on Home', async () => {
+      slider.value = [50, 100];
+      await sendKeys({ press: 'Home' });
+      expect(slider.value).to.deep.equal([0, 100]);
+    });
+
+    it('should set lower value up to upper boundary on End', async () => {
+      slider.value = [50, 80];
+      await sendKeys({ press: 'End' });
+      expect(slider.value).to.deep.equal([80, 80]);
+    });
+
+    it('should suppress PageUp when values are equal', async () => {
+      slider.value = [10, 10];
+      await sendKeys({ press: 'PageUp' });
+      expect(slider.value).to.deep.equal([10, 10]);
+    });
+
+    it('should suppress End when values are equal', async () => {
+      slider.value = [10, 10];
+      await sendKeys({ press: 'End' });
+      expect(slider.value).to.deep.equal([10, 10]);
+    });
   });
 
   describe('end thumb', () => {
@@ -186,6 +221,51 @@ describe('vaadin-range-slider - keyboard input', () => {
       slider.readonly = true;
       await sendKeys({ press: 'ArrowRight' });
       expect(slider.value).to.deep.equal([0, 100]);
+    });
+
+    it('should increase upper value on PageUp', async () => {
+      slider.value = [0, 50];
+      await sendKeys({ press: 'PageUp' });
+      expect(slider.value).to.deep.equal([0, 60]);
+    });
+
+    it('should decrease upper value on PageDown', async () => {
+      slider.value = [0, 50];
+      await sendKeys({ press: 'PageDown' });
+      expect(slider.value).to.deep.equal([0, 40]);
+    });
+
+    it('should set upper value to max on End', async () => {
+      slider.value = [0, 50];
+      await sendKeys({ press: 'End' });
+      expect(slider.value).to.deep.equal([0, 100]);
+    });
+
+    it('should set upper value down to lower boundary on Home', async () => {
+      slider.value = [20, 50];
+      await sendKeys({ press: 'Home' });
+      expect(slider.value).to.deep.equal([20, 20]);
+    });
+
+    it('should suppress PageDown when values are equal', async () => {
+      slider.value = [10, 10];
+      await sendKeys({ press: 'PageDown' });
+      expect(slider.value).to.deep.equal([10, 10]);
+    });
+
+    it('should suppress Home when values are equal', async () => {
+      slider.value = [10, 10];
+      await sendKeys({ press: 'Home' });
+      expect(slider.value).to.deep.equal([10, 10]);
+    });
+
+    ['PageUp', 'PageDown', 'Home', 'End'].forEach((key) => {
+      it(`should not change value on ${key} when readonly`, async () => {
+        slider.readonly = true;
+        slider.value = [0, 50];
+        await sendKeys({ press: key });
+        expect(slider.value).to.deep.equal([0, 50]);
+      });
     });
   });
 });

--- a/packages/slider/test/slider-keyboard.test.ts
+++ b/packages/slider/test/slider-keyboard.test.ts
@@ -86,4 +86,47 @@ describe('vaadin-slider - keyboard input', () => {
     await sendKeys({ press: 'ArrowRight' });
     expect(slider.value).to.equal(0);
   });
+
+  it('should increase value on PageUp', async () => {
+    await sendKeys({ press: 'PageUp' });
+    expect(slider.value).to.equal(10);
+  });
+
+  it('should decrease value on PageDown', async () => {
+    slider.value = 50;
+    await sendKeys({ press: 'PageDown' });
+    expect(slider.value).to.equal(40);
+  });
+
+  it('should set value to min on Home', async () => {
+    slider.value = 50;
+    await sendKeys({ press: 'Home' });
+    expect(slider.value).to.equal(0);
+  });
+
+  it('should set value to max on End', async () => {
+    await sendKeys({ press: 'End' });
+    expect(slider.value).to.equal(100);
+  });
+
+  it('should not increase value past max on PageUp', async () => {
+    slider.value = 95;
+    await sendKeys({ press: 'PageUp' });
+    expect(slider.value).to.equal(100);
+  });
+
+  it('should not decrease value past min on PageDown', async () => {
+    slider.value = 5;
+    await sendKeys({ press: 'PageDown' });
+    expect(slider.value).to.equal(0);
+  });
+
+  ['PageUp', 'PageDown', 'Home', 'End'].forEach((key) => {
+    it(`should not change value on ${key} when readonly`, async () => {
+      slider.readonly = true;
+      slider.value = 50;
+      await sendKeys({ press: key });
+      expect(slider.value).to.equal(50);
+    });
+  });
 });


### PR DESCRIPTION
## Description

The readonly guard and range-slider boundary check only blocked arrow keys, allowing PageUp/PageDown/Home/End to bypass those protections.

## Type of change

- Bugfix