### PR TITLE
refactor: add arrow part to exportparts, update parts JSDoc

### DIFF
--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -114,6 +114,14 @@ export interface RangeSliderEventMap extends HTMLElementEventMap, RangeSliderCus
  * `--vaadin-slider-track-border-radius`        |
  * `--vaadin-slider-track-height`               |
  *
+ * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
+ *
+ * Part name        | Description
+ * -----------------|----------------------
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
+ * `arrow`          | Arrow pointing to the thumb
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -83,6 +83,14 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * `--vaadin-slider-track-border-radius`        |
  * `--vaadin-slider-track-height`               |
  *
+ * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
+ *
+ * Part name        | Description
+ * -----------------|----------------------
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
+ * `arrow`          | Arrow pointing to the thumb
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/slider/src/vaadin-slider-bubble.js
+++ b/packages/slider/src/vaadin-slider-bubble.js
@@ -62,7 +62,7 @@ class SliderBubble extends ThemePropertyMixin(PolylitMixin(LitElement)) {
         vertical-align="bottom"
         no-vertical-overlap
         modeless
-        exportparts="overlay, content"
+        exportparts="overlay, content, arrow"
       >
         <slot></slot>
       </vaadin-slider-bubble-overlay>

--- a/packages/slider/src/vaadin-slider.d.ts
+++ b/packages/slider/src/vaadin-slider.d.ts
@@ -109,6 +109,14 @@ export interface SliderEventMap extends HTMLElementEventMap, SliderCustomEventMa
  * `--vaadin-slider-track-border-radius`        |
  * `--vaadin-slider-track-height`               |
  *
+ * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
+ *
+ * Part name        | Description
+ * -----------------|----------------------
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
+ * `arrow`          | Arrow pointing to the thumb
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -78,6 +78,14 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * `--vaadin-slider-track-border-radius`        |
  * `--vaadin-slider-track-height`               |
  *
+ * In order to style the slider bubble, use `<vaadin-slider-bubble>` shadow DOM parts:
+ *
+ * Part name        | Description
+ * -----------------|----------------------
+ * `overlay`        | The overlay container
+ * `content`        | The overlay content
+ * `arrow`          | Arrow pointing to the thumb
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} change - Fired when the user commits a value change.

--- a/packages/slider/test/dom/__snapshots__/slider-bubble.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider-bubble.test.snap.js
@@ -1,0 +1,24 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-slider-bubble host"] = 
+`<vaadin-slider-bubble modeless="">
+</vaadin-slider-bubble>
+`;
+/* end snapshot vaadin-slider-bubble host */
+
+snapshots["vaadin-slider-bubble shadow"] = 
+`<vaadin-slider-bubble-overlay
+  exportparts="overlay, content, arrow"
+  id="overlay"
+  modeless=""
+  no-vertical-overlap=""
+  popover="manual"
+  vertical-align="bottom"
+>
+  <slot>
+  </slot>
+</vaadin-slider-bubble-overlay>
+`;
+/* end snapshot vaadin-slider-bubble shadow */
+

--- a/packages/slider/test/dom/slider-bubble.test.ts
+++ b/packages/slider/test/dom/slider-bubble.test.ts
@@ -1,0 +1,20 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import '../../src/vaadin-slider-bubble.js';
+import type { SliderBubble } from '../../src/vaadin-slider-bubble.js';
+
+describe('vaadin-slider-bubble', () => {
+  let bubble: SliderBubble;
+
+  beforeEach(async () => {
+    bubble = fixtureSync('<vaadin-slider-bubble></vaadin-slider-bubble>');
+  });
+
+  it('host', async () => {
+    await expect(bubble).dom.to.equalSnapshot();
+  });
+
+  it('shadow', async () => {
+    await expect(bubble).shadowDom.to.equalSnapshot();
+  });
+});


### PR DESCRIPTION
## Description

Added missing `arrow` part to `exportparts` attribute and documented `vaadin-slider-bubble` shadow parts.

## Type of change

- Refactor / docs