### PR TITLE
fix: use correct fallback for slider constraints falsy values

### DIFF
--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -151,9 +151,9 @@ export const SliderMixin = (superClass) =>
      */
     __getConstraints() {
       return {
-        min: this.min || 0,
-        max: this.max || 100,
-        step: this.step || 1,
+        min: this.min !== undefined ? this.min : 0,
+        max: this.max !== undefined ? this.max : 100,
+        step: this.step !== undefined ? this.step : 1,
       };
     }
 

--- a/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
@@ -1024,6 +1024,57 @@ snapshots["vaadin-range-slider shadow negative"] =
 `;
 /* end snapshot vaadin-range-slider shadow negative */
 
+snapshots["vaadin-range-slider shadow max zero"] = 
+`<div class="vaadin-slider-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div
+    id="controls"
+    style="--start-value: 1; --end-value: 1;"
+  >
+    <div part="track">
+      <div part="track-fill">
+      </div>
+    </div>
+    <div part="thumb thumb-start">
+    </div>
+    <div part="thumb thumb-end">
+    </div>
+    <slot name="input">
+    </slot>
+    <slot name="bubble">
+    </slot>
+  </div>
+  <div
+    aria-hidden="true"
+    part="marks"
+  >
+    <span part="min">
+      -50
+    </span>
+    <span part="max">
+      0
+    </span>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-range-slider shadow max zero */
+
 snapshots["vaadin-range-slider shadow min > value"] = 
 `<div class="vaadin-slider-container">
   <div part="label">

--- a/packages/slider/test/dom/__snapshots__/slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider.test.snap.js
@@ -711,6 +711,55 @@ snapshots["vaadin-slider shadow negative"] =
 `;
 /* end snapshot vaadin-slider shadow negative */
 
+snapshots["vaadin-slider shadow max zero"] = 
+`<div class="vaadin-slider-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div
+    id="controls"
+    style="--value: 0;"
+  >
+    <div part="track">
+      <div part="track-fill">
+      </div>
+    </div>
+    <div part="thumb">
+    </div>
+    <slot name="input">
+    </slot>
+    <slot name="bubble">
+    </slot>
+  </div>
+  <div
+    aria-hidden="true"
+    part="marks"
+  >
+    <span part="min">
+      -50
+    </span>
+    <span part="max">
+      0
+    </span>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-slider shadow max zero */
+
 snapshots["vaadin-slider shadow min > value"] = 
 `<div class="vaadin-slider-container">
   <div part="label">

--- a/packages/slider/test/dom/range-slider.test.ts
+++ b/packages/slider/test/dom/range-slider.test.ts
@@ -138,6 +138,13 @@ describe('vaadin-range-slider', () => {
       await expect(slider).shadowDom.to.equalSnapshot();
     });
 
+    it('max zero', async () => {
+      slider.min = -50;
+      slider.max = 0;
+      slider.value = [0, 0];
+      await expect(slider).shadowDom.to.equalSnapshot();
+    });
+
     it('min > value', async () => {
       slider.min = 10;
       await expect(slider).shadowDom.to.equalSnapshot();

--- a/packages/slider/test/dom/slider.test.ts
+++ b/packages/slider/test/dom/slider.test.ts
@@ -126,6 +126,13 @@ describe('vaadin-slider', () => {
       await expect(slider).shadowDom.to.equalSnapshot();
     });
 
+    it('max zero', async () => {
+      slider.min = -50;
+      slider.max = 0;
+      slider.value = -50;
+      await expect(slider).shadowDom.to.equalSnapshot();
+    });
+
     it('min > value', async () => {
       slider.min = 10;
       await expect(slider).shadowDom.to.equalSnapshot();


### PR DESCRIPTION
## Description

Setting max=0 (e.g. for a negative range slider) was silently falling back to 100 because || treats 0 as falsy. Switch to explicit undefined checks so that 0 is respected for min, max and step.

## Type of change

- Bugfix