### PR TITLE
fix: show placeholder in select when no items or renderer is set (CP: 23.6)

### DIFF
--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -325,7 +325,7 @@ class Select extends DelegateFocusMixin(
   static get observers() {
     return [
       '_updateAriaExpanded(opened)',
-      '_updateSelectedItem(value, _items, placeholder)',
+      '_updateSelectedItem(value, _items, placeholder, focusElement)',
       '_rendererChanged(renderer, _overlayElement)',
     ];
   }
@@ -662,7 +662,7 @@ class Select extends DelegateFocusMixin(
 
     this._valueButton.innerHTML = '';
 
-    const selected = this._items[this._menuElement.selected];
+    const selected = this._items ? this._items[this._menuElement.selected] : undefined;
 
     this._valueButton.removeAttribute('placeholder');
 
@@ -689,7 +689,7 @@ class Select extends DelegateFocusMixin(
   }
 
   /** @private */
-  _updateSelectedItem(value, items) {
+  _updateSelectedItem(value, items, placeholder) {
     if (items) {
       const valueAsString = value == null ? value : value.toString();
       this._menuElement.selected = items.reduce((prev, item, idx) => {
@@ -700,6 +700,8 @@ class Select extends DelegateFocusMixin(
         this.__updateValueButton();
         delete this._valueChanging;
       }
+    } else if (placeholder) {
+      this.__updateValueButton();
     }
   }
 

--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -76,6 +76,51 @@ describe('vaadin-select', () => {
     });
   });
 
+  describe('placeholder', () => {
+    let valueButton;
+
+    describe('no items', () => {
+      beforeEach(async () => {
+        select = fixtureSync('<vaadin-select placeholder="Select an item"></vaadin-select>');
+        await nextFrame();
+        valueButton = select._valueButton;
+      });
+
+      it('should display placeholder when no items or renderer is set', () => {
+        expect(valueButton.textContent).to.equal('Select an item');
+      });
+    });
+
+    describe('with items', () => {
+      beforeEach(async () => {
+        select = fixtureSync('<vaadin-select placeholder="Select an item"></vaadin-select>');
+        await nextFrame();
+        select.renderer = (root) => {
+          render(
+            html`
+              <vaadin-list-box>
+                <vaadin-item>Option 1</vaadin-item>
+                <vaadin-item value="v2" label="o2">Option 2</vaadin-item>
+                <vaadin-item value="">Option 3</vaadin-item>
+                <vaadin-item></vaadin-item>
+                <vaadin-item label="">Empty</vaadin-item>
+              </vaadin-list-box>
+            `,
+            root,
+          );
+        };
+        valueButton = select._valueButton;
+        await nextFrame();
+      });
+
+      it('should show placeholder when setting value property to null', async () => {
+        select.value = null;
+        await nextFrame();
+        expect(valueButton.textContent).to.equal('Select an item');
+      });
+    });
+  });
+
   describe('with items', () => {
     beforeEach(async () => {
       select = fixtureSync('<vaadin-select></vaadin-select>');
@@ -449,14 +494,6 @@ describe('vaadin-select', () => {
         overlay.setAttribute('phone', '');
         overlay.style.setProperty('--vaadin-overlay-viewport-bottom', '50px');
         expect(getComputedStyle(overlay).getPropertyValue('bottom')).to.equal('50px');
-      });
-    });
-
-    describe('placeholder', () => {
-      it('should set placeholder as a value node text content', () => {
-        select.value = null;
-        select.placeholder = 'Select an item';
-        expect(valueButton.textContent).to.equal('Select an item');
       });
     });
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #11085 to branch 23.6.

---

> ## Description
> 
> Fixes https://github.com/vaadin/web-components/issues/11084
> 
> When items/renderer were not configured, _updateSelectedItem() exited early and never called __updateValueButton(), so the placeholder was never displayed. Add an else branch to handle the placeholder-only case, and guard _items access to prevent crashes when items is undefined.
> 
> ## Type of change
> 
> - Bugfix