### PR TITLE
refactor: extract shared bubble state machine helper in slider mixin

### DIFF
--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -444,67 +444,21 @@ class RangeSlider extends FieldMixin(
   willUpdate(props) {
     super.willUpdate(props);
 
-    if (props.has('__startActive')) {
-      if (this.__startActive) {
-        // When slider is activated by track pointerdown, the hover flag
-        // isn't set, but the thumb is actually moved, so we set it here.
-        this.__startHover = true;
-      } else if (props.get('__startActive')) {
-        // Close bubble when drag ends unless the thumb has hover
-        this.__startBubbleOpened = this.__startHover;
-      }
-    }
+    this.__updateBubbleState(props, {
+      active: '__startActive',
+      focused: '__startFocused',
+      hover: '__startHover',
+      opened: '__startBubbleOpened',
+      otherOpened: '__endBubbleOpened',
+    });
 
-    if (props.has('__endActive')) {
-      if (this.__endActive) {
-        // When slider is activated by track pointerdown, the hover flag
-        // isn't set, but the thumb is actually moved, so we set it here.
-        this.__endHover = true;
-      } else if (props.get('__endActive')) {
-        // Close bubble when drag ends unless the thumb has hover
-        this.__endBubbleOpened = this.__endHover;
-      }
-    }
-
-    if (props.has('__startFocused')) {
-      if (this.__startFocused) {
-        this.__startBubbleOpened = true;
-        this.__endBubbleOpened = false;
-      } else if (props.get('__startFocused')) {
-        // Close bubble on blur unless the thumb has hover
-        this.__startBubbleOpened = this.__startHover;
-      }
-    }
-
-    if (props.has('__endFocused')) {
-      if (this.__endFocused) {
-        this.__endBubbleOpened = true;
-        this.__startBubbleOpened = false;
-      } else if (props.get('__endFocused')) {
-        // Close bubble on blur unless the thumb has hover
-        this.__endBubbleOpened = this.__endHover;
-      }
-    }
-
-    if (props.has('__startHover')) {
-      if (this.__startHover) {
-        this.__startBubbleOpened = true;
-        this.__endBubbleOpened = false;
-      } else if (props.get('__startHover')) {
-        // Keep bubble open during drag (active state)
-        this.__startBubbleOpened = this.__startActive;
-      }
-    }
-
-    if (props.has('__endHover')) {
-      if (this.__endHover) {
-        this.__endBubbleOpened = true;
-        this.__startBubbleOpened = false;
-      } else if (props.get('__endHover')) {
-        // Keep bubble open during drag (active state)
-        this.__endBubbleOpened = this.__endActive;
-      }
-    }
+    this.__updateBubbleState(props, {
+      active: '__endActive',
+      focused: '__endFocused',
+      hover: '__endHover',
+      opened: '__endBubbleOpened',
+      otherOpened: '__startBubbleOpened',
+    });
   }
 
   /** @protected */

--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -169,6 +169,54 @@ export const SliderMixin = (superClass) =>
     }
 
     /**
+     * Updates bubble visibility for a thumb based on trigger state changes.
+     * @param {Map} props - Changed properties from willUpdate
+     * @param {object} config
+     * @param {string} config.active - Active state property name
+     * @param {string} config.focused - Focused state property name
+     * @param {string} config.hover - Hover state property name
+     * @param {string} config.opened - Bubble opened property name
+     * @param {string} [config.otherOpened] - Other thumb's opened property (range slider)
+     * @private
+     */
+    __updateBubbleState(props, { active, focused, hover, opened, otherOpened }) {
+      if (props.has(active)) {
+        if (this[active]) {
+          // When slider is activated by track pointerdown, the hover flag
+          // isn't set, but the thumb is actually moved, so we set it here.
+          this[hover] = true;
+        } else if (props.get(active)) {
+          // Close bubble when drag ends unless the thumb has hover
+          this[opened] = this[hover];
+        }
+      }
+
+      if (props.has(focused)) {
+        if (this[focused]) {
+          this[opened] = true;
+          if (otherOpened) {
+            this[otherOpened] = false;
+          }
+        } else if (props.get(focused)) {
+          // Close bubble on blur unless the thumb has hover
+          this[opened] = this[hover];
+        }
+      }
+
+      if (props.has(hover)) {
+        if (this[hover]) {
+          this[opened] = true;
+          if (otherOpened) {
+            this[otherOpened] = false;
+          }
+        } else if (props.get(hover)) {
+          // Keep bubble open during drag (active state)
+          this[opened] = this[active];
+        }
+      }
+    }
+
+    /**
      * @param {PointerEvent} event
      * @private
      */

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -314,34 +314,12 @@ class Slider extends FieldMixin(
   willUpdate(props) {
     super.willUpdate(props);
 
-    if (props.has('__active')) {
-      if (this.__active) {
-        // When slider is activated by track pointerdown, the hover flag
-        // isn't set, but the thumb is actually moved, so we set it here.
-        this.__hoverInside = true;
-      } else if (props.get('__active')) {
-        // Close bubble when drag ends unless the thumb has hover
-        this.__bubbleOpened = this.__hoverInside;
-      }
-    }
-
-    if (props.has('__focusInside')) {
-      if (this.__focusInside) {
-        this.__bubbleOpened = true;
-      } else if (props.get('__focusInside')) {
-        // Close bubble on blur unless the thumb has hover
-        this.__bubbleOpened = this.__hoverInside;
-      }
-    }
-
-    if (props.has('__hoverInside')) {
-      if (this.__hoverInside) {
-        this.__bubbleOpened = true;
-      } else if (props.get('__hoverInside')) {
-        // Keep bubble open during drag (active state)
-        this.__bubbleOpened = this.__active;
-      }
-    }
+    this.__updateBubbleState(props, {
+      active: '__active',
+      focused: '__focusInside',
+      hover: '__hoverInside',
+      opened: '__bubbleOpened',
+    });
   }
 
   /** @protected */


### PR DESCRIPTION
## Summary
- Extracted repetitive bubble open/close logic from `willUpdate()` in `vaadin-slider.js` and `vaadin-range-slider.js` into a shared `__updateBubbleState()` helper in `SliderMixin`
- Reduced ~90 lines of duplicated state transitions (3 blocks in slider, 6 blocks in range slider) to a single parameterized method
- Pure refactoring — no behavior changes (all 189 existing slider tests pass)

## Test plan
- [x] `yarn test --group slider` — all 189 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)