### PR TITLE
fix: adopt Lumo styles in nested shadow DOM on theme switch (CP: 25.0)

### DIFF
--- a/packages/vaadin-lumo-styles/components/accordion-heading.css
+++ b/packages/vaadin-lumo-styles/components/accordion-heading.css
@@ -6,8 +6,8 @@
 @import '../src/components/accordion-heading.css';
 @import '../src/components/details-summary.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-accordion-heading-inject: 1;
   --_lumo-vaadin-accordion-heading-inject-modules:
     lumo_components_details-summary,

--- a/packages/vaadin-lumo-styles/components/accordion-panel.css
+++ b/packages/vaadin-lumo-styles/components/accordion-panel.css
@@ -7,8 +7,8 @@
 @import '../src/components/details.css';
 @import './accordion-heading.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-accordion-panel-inject: 1;
   --_lumo-vaadin-accordion-panel-inject-modules:
     lumo_components_details,

--- a/packages/vaadin-lumo-styles/components/app-layout.css
+++ b/packages/vaadin-lumo-styles/components/app-layout.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/app-layout.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-app-layout-inject: 1;
   --_lumo-vaadin-app-layout-inject-modules: lumo_components_app-layout;
 }

--- a/packages/vaadin-lumo-styles/components/avatar-group.css
+++ b/packages/vaadin-lumo-styles/components/avatar-group.css
@@ -11,8 +11,8 @@
 @import '../src/components/item.css';
 @import '../src/components/list-box.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-avatar-group-inject: 1;
   --_lumo-vaadin-avatar-group-inject-modules: lumo_components_avatar-group;
 

--- a/packages/vaadin-lumo-styles/components/avatar.css
+++ b/packages/vaadin-lumo-styles/components/avatar.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/avatar.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-avatar-inject: 1;
   --_lumo-vaadin-avatar-inject-modules: lumo_components_avatar;
 }

--- a/packages/vaadin-lumo-styles/components/button.css
+++ b/packages/vaadin-lumo-styles/components/button.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/button.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-button-inject: 1;
   --_lumo-vaadin-button-inject-modules: lumo_components_button;
 }

--- a/packages/vaadin-lumo-styles/components/card.css
+++ b/packages/vaadin-lumo-styles/components/card.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/card.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-card-inject: 1;
   --_lumo-vaadin-card-inject-modules: lumo_components_card;
 }

--- a/packages/vaadin-lumo-styles/components/charts.css
+++ b/packages/vaadin-lumo-styles/components/charts.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/chart.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-chart-inject: 1;
   --_lumo-vaadin-chart-inject-modules: lumo_components_chart;
 }

--- a/packages/vaadin-lumo-styles/components/checkbox-group.css
+++ b/packages/vaadin-lumo-styles/components/checkbox-group.css
@@ -11,8 +11,8 @@
 @import '../src/components/checkbox-group.css';
 @import './checkbox.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-checkbox-group-inject: 1;
   --_lumo-vaadin-checkbox-group-inject-modules:
     lumo_mixins_group-field,

--- a/packages/vaadin-lumo-styles/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/components/checkbox.css
@@ -6,8 +6,8 @@
 @import '../src/mixins/checkable-field.css';
 @import '../src/components/checkbox.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-checkbox-inject: 1;
   --_lumo-vaadin-checkbox-inject-modules:
     lumo_mixins_checkable-field,

--- a/packages/vaadin-lumo-styles/components/combo-box.css
+++ b/packages/vaadin-lumo-styles/components/combo-box.css
@@ -20,8 +20,8 @@
 @import '../src/components/item.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-combo-box-inject: 1;
   --_lumo-vaadin-combo-box-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/confirm-dialog.css
+++ b/packages/vaadin-lumo-styles/components/confirm-dialog.css
@@ -8,8 +8,8 @@
 @import '../src/components/dialog-overlay.css';
 @import './button.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-confirm-dialog-overlay-inject: 1;
   --_lumo-vaadin-confirm-dialog-overlay-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/context-menu.css
+++ b/packages/vaadin-lumo-styles/components/context-menu.css
@@ -12,8 +12,8 @@
 @import '../src/components/item.css';
 @import '../src/components/list-box.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-context-menu-overlay-inject: 1;
   --_lumo-vaadin-context-menu-overlay-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/crud.css
+++ b/packages/vaadin-lumo-styles/components/crud.css
@@ -17,8 +17,8 @@
 @import './grid-sorter.css';
 @import './text-field.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-crud-inject: 1;
   --_lumo-vaadin-crud-inject-modules: lumo_components_crud;
 

--- a/packages/vaadin-lumo-styles/components/custom-field.css
+++ b/packages/vaadin-lumo-styles/components/custom-field.css
@@ -9,8 +9,8 @@
 @import '../src/mixins/field-required.css';
 @import '../src/components/custom-field.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-custom-field-inject: 1;
   --_lumo-vaadin-custom-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/dashboard.css
+++ b/packages/vaadin-lumo-styles/components/dashboard.css
@@ -10,8 +10,8 @@
 @import '../src/components/dashboard-widget.css';
 @import '../src/components/dashboard.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-dashboard-inject: 1;
   --_lumo-vaadin-dashboard-inject-modules:
     lumo_components_dashboard-layout,

--- a/packages/vaadin-lumo-styles/components/date-picker.css
+++ b/packages/vaadin-lumo-styles/components/date-picker.css
@@ -20,8 +20,8 @@
 @import './button.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-date-picker-inject: 1;
   --_lumo-vaadin-date-picker-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/date-time-picker.css
+++ b/packages/vaadin-lumo-styles/components/date-time-picker.css
@@ -14,8 +14,8 @@
 @import './date-picker.css';
 @import './time-picker.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-date-time-picker-inject: 1;
   --_lumo-vaadin-date-time-picker-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/details-summary.css
+++ b/packages/vaadin-lumo-styles/components/details-summary.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/details-summary.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-details-summary-inject: 1;
   --_lumo-vaadin-details-summary-inject-modules: lumo_components_details-summary;
 }

--- a/packages/vaadin-lumo-styles/components/details.css
+++ b/packages/vaadin-lumo-styles/components/details.css
@@ -6,8 +6,8 @@
 @import '../src/components/details.css';
 @import './details-summary.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-details-inject: 1;
   --_lumo-vaadin-details-inject-modules: lumo_components_details;
 }

--- a/packages/vaadin-lumo-styles/components/dialog.css
+++ b/packages/vaadin-lumo-styles/components/dialog.css
@@ -7,8 +7,8 @@
 @import '../src/mixins/resizable-overlay.css';
 @import '../src/components/dialog-overlay.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-dialog-overlay-inject: 1;
   --_lumo-vaadin-dialog-overlay-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/drawer-toggle.css
+++ b/packages/vaadin-lumo-styles/components/drawer-toggle.css
@@ -6,8 +6,8 @@
 @import '../src/components/button.css';
 @import '../src/components/drawer-toggle.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-drawer-toggle-inject: 1;
   --_lumo-vaadin-drawer-toggle-inject-modules:
     lumo_components_button,

--- a/packages/vaadin-lumo-styles/components/email-field.css
+++ b/packages/vaadin-lumo-styles/components/email-field.css
@@ -12,8 +12,8 @@
 @import '../src/components/email-field.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-email-field-inject: 1;
   --_lumo-vaadin-email-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/field-highlighter.css
+++ b/packages/vaadin-lumo-styles/components/field-highlighter.css
@@ -8,8 +8,8 @@
 @import '../src/components/user-tag.css';
 @import '../src/components/user-tags-overlay.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-user-tags-overlay-inject: 1;
   --_lumo-vaadin-user-tags-overlay-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/form-item.css
+++ b/packages/vaadin-lumo-styles/components/form-item.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/form-item.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-form-item-inject: 1;
   --_lumo-vaadin-form-item-inject-modules: lumo_components_form-item;
 }

--- a/packages/vaadin-lumo-styles/components/grid-filter.css
+++ b/packages/vaadin-lumo-styles/components/grid-filter.css
@@ -6,8 +6,8 @@
 @import '../src/components/grid-filter.css';
 @import './text-field.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-grid-filter-inject: 1;
   --_lumo-vaadin-grid-filter-inject-modules: lumo_components_grid-filter;
 }

--- a/packages/vaadin-lumo-styles/components/grid-pro-edit-column.css
+++ b/packages/vaadin-lumo-styles/components/grid-pro-edit-column.css
@@ -18,8 +18,8 @@
 @import './select.css';
 @import './text-field.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-grid-pro-edit-text-field-inject: 1;
   --_lumo-vaadin-grid-pro-edit-text-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/grid-pro.css
+++ b/packages/vaadin-lumo-styles/components/grid-pro.css
@@ -6,8 +6,8 @@
 @import '../src/components/grid-pro.css';
 @import '../src/components/grid.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-grid-pro-inject: 1;
   --_lumo-vaadin-grid-pro-inject-modules:
     lumo_components_grid,

--- a/packages/vaadin-lumo-styles/components/grid-sorter.css
+++ b/packages/vaadin-lumo-styles/components/grid-sorter.css
@@ -6,8 +6,8 @@
 @import '../src/components/grid-sorter.css';
 @import '../src/components/grid-sorter-icons.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-grid-sorter-inject: 1;
   --_lumo-vaadin-grid-sorter-inject-modules: lumo_components_grid-sorter;
 }

--- a/packages/vaadin-lumo-styles/components/grid-tree-toggle.css
+++ b/packages/vaadin-lumo-styles/components/grid-tree-toggle.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/grid-tree-toggle.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-grid-tree-toggle-inject: 1;
   --_lumo-vaadin-grid-tree-toggle-inject-modules: lumo_components_grid-tree-toggle;
 }

--- a/packages/vaadin-lumo-styles/components/grid.css
+++ b/packages/vaadin-lumo-styles/components/grid.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/grid.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-grid-inject: 1;
   --_lumo-vaadin-grid-inject-modules: lumo_components_grid;
 }

--- a/packages/vaadin-lumo-styles/components/horizontal-layout.css
+++ b/packages/vaadin-lumo-styles/components/horizontal-layout.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/horizontal-layout.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-horizontal-layout-inject: 1;
   --_lumo-vaadin-horizontal-layout-inject-modules: lumo_components_horizontal-layout;
 }

--- a/packages/vaadin-lumo-styles/components/icon.css
+++ b/packages/vaadin-lumo-styles/components/icon.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/icon.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-icon-inject: 1;
   --_lumo-vaadin-icon-inject-modules: lumo_components_icon;
 }

--- a/packages/vaadin-lumo-styles/components/input-container.css
+++ b/packages/vaadin-lumo-styles/components/input-container.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-input-container-inject: 1;
   --_lumo-vaadin-input-container-inject-modules: lumo_components_input-container;
 }

--- a/packages/vaadin-lumo-styles/components/integer-field.css
+++ b/packages/vaadin-lumo-styles/components/integer-field.css
@@ -12,8 +12,8 @@
 @import '../src/components/number-field.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-integer-field-inject: 1;
   --_lumo-vaadin-integer-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/item.css
+++ b/packages/vaadin-lumo-styles/components/item.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/item.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-item-inject: 1;
   --_lumo-vaadin-item-inject-modules: lumo_components_item;
 }

--- a/packages/vaadin-lumo-styles/components/list-box.css
+++ b/packages/vaadin-lumo-styles/components/list-box.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/list-box.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-list-box-inject: 1;
   --_lumo-vaadin-list-box-inject-modules: lumo_components_list-box;
 }

--- a/packages/vaadin-lumo-styles/components/login-form.css
+++ b/packages/vaadin-lumo-styles/components/login-form.css
@@ -8,8 +8,8 @@
 @import './password-field.css';
 @import './text-field.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-login-form-wrapper-inject: 1;
   --_lumo-vaadin-login-form-wrapper-inject-modules: lumo_components_login-form-wrapper;
 }

--- a/packages/vaadin-lumo-styles/components/login.css
+++ b/packages/vaadin-lumo-styles/components/login.css
@@ -7,8 +7,8 @@
 @import '../src/components/login-overlay-wrapper.css';
 @import './login-form.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-login-overlay-wrapper-inject: 1;
   --_lumo-vaadin-login-overlay-wrapper-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/map.css
+++ b/packages/vaadin-lumo-styles/components/map.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/map.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-map-inject: 1;
   --_lumo-vaadin-map-inject-modules: lumo_components_map;
 }

--- a/packages/vaadin-lumo-styles/components/menu-bar.css
+++ b/packages/vaadin-lumo-styles/components/menu-bar.css
@@ -17,8 +17,8 @@
 @import '../src/components/menu-bar-overlay.css';
 @import '../src/components/menu-bar.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-menu-bar-inject: 1;
   --_lumo-vaadin-menu-bar-inject-modules: lumo_components_menu-bar;
 

--- a/packages/vaadin-lumo-styles/components/message-input-button.css
+++ b/packages/vaadin-lumo-styles/components/message-input-button.css
@@ -5,8 +5,8 @@
  */
 @import './button.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-message-input-button-inject: 1;
   --_lumo-vaadin-message-input-button-inject-modules: lumo_components_button;
 }

--- a/packages/vaadin-lumo-styles/components/message-input.css
+++ b/packages/vaadin-lumo-styles/components/message-input.css
@@ -7,8 +7,8 @@
 @import './message-input-button.css';
 @import './text-area.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-message-input-inject: 1;
   --_lumo-vaadin-message-input-inject-modules: lumo_components_message-input;
 }

--- a/packages/vaadin-lumo-styles/components/message.css
+++ b/packages/vaadin-lumo-styles/components/message.css
@@ -6,8 +6,8 @@
 @import '../src/components/message.css';
 @import './avatar.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-message-inject: 1;
   --_lumo-vaadin-message-inject-modules: lumo_components_message;
 }

--- a/packages/vaadin-lumo-styles/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/components/multi-select-combo-box.css
@@ -23,8 +23,8 @@
 @import '../src/components/multi-select-combo-box-overlay.css';
 @import '../src/components/multi-select-combo-box.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-multi-select-combo-box-container-inject: 1;
   --_lumo-vaadin-multi-select-combo-box-container-inject-modules:
     lumo_components_input-container,

--- a/packages/vaadin-lumo-styles/components/notification.css
+++ b/packages/vaadin-lumo-styles/components/notification.css
@@ -6,8 +6,8 @@
 @import '../src/components/notification-card.css';
 @import '../src/components/notification-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-notification-container-inject: 1;
   --_lumo-vaadin-notification-container-inject-modules: lumo_components_notification-container;
 

--- a/packages/vaadin-lumo-styles/components/number-field.css
+++ b/packages/vaadin-lumo-styles/components/number-field.css
@@ -12,8 +12,8 @@
 @import '../src/components/number-field.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-number-field-inject: 1;
   --_lumo-vaadin-number-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/overlay.css
+++ b/packages/vaadin-lumo-styles/components/overlay.css
@@ -5,8 +5,8 @@
  */
 @import '../src/mixins/overlay.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-overlay-inject: 1;
   --_lumo-vaadin-overlay-inject-modules: lumo_mixins_overlay;
 }

--- a/packages/vaadin-lumo-styles/components/password-field.css
+++ b/packages/vaadin-lumo-styles/components/password-field.css
@@ -14,8 +14,8 @@
 @import '../src/components/password-field.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-password-field-inject: 1;
   --_lumo-vaadin-password-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/popover.css
+++ b/packages/vaadin-lumo-styles/components/popover.css
@@ -6,8 +6,8 @@
 @import '../src/mixins/overlay.css';
 @import '../src/components/popover-overlay.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-popover-overlay-inject: 1;
   --_lumo-vaadin-popover-overlay-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/progress-bar.css
+++ b/packages/vaadin-lumo-styles/components/progress-bar.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/progress-bar.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-progress-bar-inject: 1;
   --_lumo-vaadin-progress-bar-inject-modules: lumo_components_progress-bar;
 }

--- a/packages/vaadin-lumo-styles/components/radio-button.css
+++ b/packages/vaadin-lumo-styles/components/radio-button.css
@@ -6,8 +6,8 @@
 @import '../src/mixins/checkable-field.css';
 @import '../src/components/radio-button.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-radio-button-inject: 1;
   --_lumo-vaadin-radio-button-inject-modules:
     lumo_mixins_checkable-field,

--- a/packages/vaadin-lumo-styles/components/radio-group.css
+++ b/packages/vaadin-lumo-styles/components/radio-group.css
@@ -11,8 +11,8 @@
 @import '../src/components/radio-group.css';
 @import './radio-button.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-radio-group-inject: 1;
   --_lumo-vaadin-radio-group-inject-modules:
     lumo_mixins_group-field,

--- a/packages/vaadin-lumo-styles/components/rich-text-editor.css
+++ b/packages/vaadin-lumo-styles/components/rich-text-editor.css
@@ -13,8 +13,8 @@
 @import './text-field.css';
 @import './tooltip.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-rich-text-editor-inject: 1;
   --_lumo-vaadin-rich-text-editor-inject-modules:
     lumo_global_typography,

--- a/packages/vaadin-lumo-styles/components/scroller.css
+++ b/packages/vaadin-lumo-styles/components/scroller.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/scroller.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-scroller-inject: 1;
   --_lumo-vaadin-scroller-inject-modules: lumo_components_scroller;
 }

--- a/packages/vaadin-lumo-styles/components/select.css
+++ b/packages/vaadin-lumo-styles/components/select.css
@@ -19,8 +19,8 @@
 @import '../src/components/select.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-select-inject: 1;
   --_lumo-vaadin-select-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/side-nav-item.css
+++ b/packages/vaadin-lumo-styles/components/side-nav-item.css
@@ -6,8 +6,8 @@
 @import '../src/mixins/field-button.css';
 @import '../src/components/side-nav-item.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-side-nav-item-inject: 1;
   --_lumo-vaadin-side-nav-item-inject-modules:
     lumo_mixins_field-button,

--- a/packages/vaadin-lumo-styles/components/side-nav.css
+++ b/packages/vaadin-lumo-styles/components/side-nav.css
@@ -6,8 +6,8 @@
 @import '../src/components/side-nav.css';
 @import './side-nav-item.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-side-nav-inject: 1;
   --_lumo-vaadin-side-nav-inject-modules: lumo_components_side-nav;
 }

--- a/packages/vaadin-lumo-styles/components/split-layout.css
+++ b/packages/vaadin-lumo-styles/components/split-layout.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/split-layout.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-split-layout-inject: 1;
   --_lumo-vaadin-split-layout-inject-modules: lumo_components_split-layout;
 }

--- a/packages/vaadin-lumo-styles/components/tab.css
+++ b/packages/vaadin-lumo-styles/components/tab.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/tab.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-tab-inject: 1;
   --_lumo-vaadin-tab-inject-modules: lumo_components_tab;
 }

--- a/packages/vaadin-lumo-styles/components/tabs.css
+++ b/packages/vaadin-lumo-styles/components/tabs.css
@@ -6,8 +6,8 @@
 @import '../src/components/tabs.css';
 @import './tab.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-tabs-inject: 1;
   --_lumo-vaadin-tabs-inject-modules: lumo_components_tabs;
 }

--- a/packages/vaadin-lumo-styles/components/tabsheet.css
+++ b/packages/vaadin-lumo-styles/components/tabsheet.css
@@ -8,8 +8,8 @@
 @import './scroller.css';
 @import './tabs.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-tabsheet-inject: 1;
   --_lumo-vaadin-tabsheet-inject-modules:
     lumo_mixins_loader,

--- a/packages/vaadin-lumo-styles/components/text-area.css
+++ b/packages/vaadin-lumo-styles/components/text-area.css
@@ -12,8 +12,8 @@
 @import '../src/components/text-area.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-text-area-inject: 1;
   --_lumo-vaadin-text-area-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/text-field.css
+++ b/packages/vaadin-lumo-styles/components/text-field.css
@@ -11,8 +11,8 @@
 @import '../src/mixins/field-required.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-text-field-inject: 1;
   --_lumo-vaadin-text-field-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/time-picker.css
+++ b/packages/vaadin-lumo-styles/components/time-picker.css
@@ -18,8 +18,8 @@
 @import '../src/components/time-picker.css';
 @import './input-container.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-time-picker-inject: 1;
   --_lumo-vaadin-time-picker-inject-modules:
     lumo_mixins_field-label,

--- a/packages/vaadin-lumo-styles/components/tooltip.css
+++ b/packages/vaadin-lumo-styles/components/tooltip.css
@@ -6,8 +6,8 @@
 @import '../src/mixins/overlay.css';
 @import '../src/components/tooltip-overlay.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-tooltip-overlay-inject: 1;
   --_lumo-vaadin-tooltip-overlay-inject-modules:
     lumo_mixins_overlay,

--- a/packages/vaadin-lumo-styles/components/upload.css
+++ b/packages/vaadin-lumo-styles/components/upload.css
@@ -10,8 +10,8 @@
 @import './button.css';
 @import './progress-bar.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-upload-inject: 1;
   --_lumo-vaadin-upload-inject-modules: lumo_components_upload;
 

--- a/packages/vaadin-lumo-styles/components/vertical-layout.css
+++ b/packages/vaadin-lumo-styles/components/vertical-layout.css
@@ -5,8 +5,8 @@
  */
 @import '../src/components/vertical-layout.css';
 
-:root::before,
-:host::before {
+:root,
+:host {
   --_lumo-vaadin-vertical-layout-inject: 1;
   --_lumo-vaadin-vertical-layout-inject-modules: lumo_components_vertical-layout;
 }


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #11110 to branch 25.0.

---

> ## Summary
> 
> Fixes #11108 
> 
> Fixes a regression introduced by moving the Lumo theme injection properties to the `::before` pseudo-element in https://github.com/vaadin/web-components/pull/9621. That change succeeded in reducing DevTools inspector clutter but broke Lumo stylesheet adoption for components nested within shadow DOM when dynamically switching between themes while the Lumo stylesheet is in the regular DOM.
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)