### PR TITLE
fix: prevent upload drop zone from setting attributes during construction

### DIFF
--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -242,6 +242,7 @@ class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
 
   /** @private */
   __syncDisabledState() {
+    if (!this.isConnected) return;
     this.__syncingDisabled = true;
     this.toggleAttribute('disabled', this.__effectiveDisabled);
     this.__syncingDisabled = false;

--- a/packages/upload/test/upload-drop-zone.test.ts
+++ b/packages/upload/test/upload-drop-zone.test.ts
@@ -64,6 +64,20 @@ describe('vaadin-upload-drop-zone', () => {
     await nextRender();
   });
 
+  describe('programmatic creation', () => {
+    it('should not throw when created without a manager', () => {
+      expect(() => document.createElement('vaadin-upload-drop-zone')).to.not.throw();
+    });
+
+    it('should have disabled attribute after being connected without a manager', async () => {
+      const el = document.createElement('vaadin-upload-drop-zone') as UploadDropZone;
+      document.body.appendChild(el);
+      await nextRender();
+      expect(el.hasAttribute('disabled')).to.be.true;
+      el.remove();
+    });
+  });
+
   describe('basic', () => {
     it('should render slotted content', () => {
       expect(dropZone.textContent).to.equal('Drop files here');


### PR DESCRIPTION
## Description

Follow-up fix to https://github.com/vaadin/web-components/pull/11083

Flow creates the elements programmatically, which may result in an exception with dropzone:
<img width="802" height="207" alt="Screenshot 2026-02-11 at 10 36 37" src="https://github.com/user-attachments/assets/4a160dc9-c481-451a-ad93-ef9b6b5645e5" />

## Type of change

Bugfix