### PR TITLE
feat: add SlotObserver option to force initial callback invocation

### DIFF
--- a/packages/component-base/src/slot-observer.d.ts
+++ b/packages/component-base/src/slot-observer.d.ts
@@ -11,7 +11,7 @@ export class SlotObserver {
   constructor(
     slot: HTMLSlotElement,
     callback: (info: { addedNodes: Node[]; currentNodes: Node[]; movedNodes: Node[]; removedNodes: Node[] }) => void,
-    force?: boolean,
+    forceInitial?: boolean,
   );
 
   /**

--- a/packages/component-base/src/slot-observer.js
+++ b/packages/component-base/src/slot-observer.js
@@ -8,7 +8,7 @@
  * A helper for observing slot changes.
  */
 export class SlotObserver {
-  constructor(slot, callback, force) {
+  constructor(slot, callback, forceInitial) {
     /** @type HTMLSlotElement */
     this.slot = slot;
 
@@ -16,7 +16,7 @@ export class SlotObserver {
     this.callback = callback;
 
     /** @type boolean */
-    this.force = force;
+    this.forceInitial = forceInitial;
 
     /** @type {Node[]} */
     this._storedNodes = [];
@@ -100,9 +100,13 @@ export class SlotObserver {
     }
 
     // By default, callback is not invoked if there is no child nodes in the slot.
-    // Use `force` flag if needed to also invoke it for the initial empty state.
-    if (addedNodes.length || removedNodes.length || movedNodes.length || this.force) {
+    // Use `forceInitial` flag if needed to also invoke it for the initial state.
+    if (addedNodes.length || removedNodes.length || movedNodes.length || this.forceInitial) {
       this.callback({ addedNodes, currentNodes, movedNodes, removedNodes });
+    }
+
+    if (this.forceInitial) {
+      this.forceInitial = false;
     }
 
     this._storedNodes = currentNodes;

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -197,7 +197,7 @@ describe('SlotObserver', () => {
     expect(spy).to.be.not.called;
   });
 
-  it('should run callback if there is no child nodes with force: true', async () => {
+  it('should run callback if there is no child nodes with forceInitial: true', async () => {
     host.innerHTML = '';
 
     spy = sinon.spy();
@@ -205,5 +205,19 @@ describe('SlotObserver', () => {
     await Promise.resolve();
 
     expect(spy).to.be.calledOnce;
+  });
+
+  it('should not run callback again after flush with forceInitial: true', async () => {
+    host.innerHTML = '';
+
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy, true);
+    await Promise.resolve();
+
+    spy.resetHistory();
+
+    observer.flush();
+
+    expect(spy).to.be.not.called;
   });
 });


### PR DESCRIPTION
## Description

Currently, `SlotObserver` doesn't invoke the callback initially if there are no child nodes. This is generally expected, but in some cases we might want to configure it, e.g. `vaadin-bage` sets `empty` attribute on itself if there is no children.

Added `force` flag that is used to invoke the `callback` even if there is no added / removed / moved child nodes.

## Type of change

- Internal feature