### PR TITLE
fix: slider thumb NaN and incorrect positioning when max <= min

### DIFF
--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -188,6 +188,9 @@ export const SliderMixin = (superClass) =>
      */
     __getPercentFromValue(value) {
       const { min, max } = this.__getConstraints();
+      if (max <= min) {
+        return 0;
+      }
       const safeValue = Math.min(Math.max(value, min), max);
       return (safeValue - min) / (max - min);
     }

--- a/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
@@ -1177,3 +1177,105 @@ snapshots["vaadin-range-slider shadow max < value"] =
 `;
 /* end snapshot vaadin-range-slider shadow max < value */
 
+snapshots["vaadin-range-slider shadow min == max"] = 
+`<div class="vaadin-slider-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div
+    id="controls"
+    style="--start-value: 0; --end-value: 0;"
+  >
+    <div part="track">
+      <div part="track-fill">
+      </div>
+    </div>
+    <div part="thumb thumb-start">
+    </div>
+    <div part="thumb thumb-end">
+    </div>
+    <slot name="input">
+    </slot>
+    <slot name="bubble">
+    </slot>
+  </div>
+  <div
+    aria-hidden="true"
+    part="marks"
+  >
+    <span part="min">
+      0
+    </span>
+    <span part="max">
+      0
+    </span>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-range-slider shadow min == max */
+
+snapshots["vaadin-range-slider shadow max < min"] = 
+`<div class="vaadin-slider-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div
+    id="controls"
+    style="--start-value: 0; --end-value: 0;"
+  >
+    <div part="track">
+      <div part="track-fill">
+      </div>
+    </div>
+    <div part="thumb thumb-start">
+    </div>
+    <div part="thumb thumb-end">
+    </div>
+    <slot name="input">
+    </slot>
+    <slot name="bubble">
+    </slot>
+  </div>
+  <div
+    aria-hidden="true"
+    part="marks"
+  >
+    <span part="min">
+      0
+    </span>
+    <span part="max">
+      -10
+    </span>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-range-slider shadow max < min */
+

--- a/packages/slider/test/dom/__snapshots__/slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider.test.snap.js
@@ -858,3 +858,101 @@ snapshots["vaadin-slider shadow max < value"] =
 `;
 /* end snapshot vaadin-slider shadow max < value */
 
+snapshots["vaadin-slider shadow min == max"] = 
+`<div class="vaadin-slider-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div
+    id="controls"
+    style="--value:0;"
+  >
+    <div part="track">
+      <div part="track-fill">
+      </div>
+    </div>
+    <div part="thumb">
+    </div>
+    <slot name="input">
+    </slot>
+    <slot name="bubble">
+    </slot>
+  </div>
+  <div
+    aria-hidden="true"
+    part="marks"
+  >
+    <span part="min">
+      0
+    </span>
+    <span part="max">
+      0
+    </span>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-slider shadow min == max */
+
+snapshots["vaadin-slider shadow max < min"] = 
+`<div class="vaadin-slider-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div
+    id="controls"
+    style="--value:0;"
+  >
+    <div part="track">
+      <div part="track-fill">
+      </div>
+    </div>
+    <div part="thumb">
+    </div>
+    <slot name="input">
+    </slot>
+    <slot name="bubble">
+    </slot>
+  </div>
+  <div
+    aria-hidden="true"
+    part="marks"
+  >
+    <span part="min">
+      0
+    </span>
+    <span part="max">
+      -10
+    </span>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+`;
+/* end snapshot vaadin-slider shadow max < min */
+

--- a/packages/slider/test/dom/range-slider.test.ts
+++ b/packages/slider/test/dom/range-slider.test.ts
@@ -156,5 +156,17 @@ describe('vaadin-range-slider', () => {
       slider.value = [0, 0];
       await expect(slider).shadowDom.to.equalSnapshot();
     });
+
+    it('min == max', async () => {
+      slider.min = 0;
+      slider.max = 0;
+      await expect(slider).shadowDom.to.equalSnapshot();
+    });
+
+    it('max < min', async () => {
+      slider.min = 0;
+      slider.max = -10;
+      await expect(slider).shadowDom.to.equalSnapshot();
+    });
   });
 });

--- a/packages/slider/test/dom/slider.test.ts
+++ b/packages/slider/test/dom/slider.test.ts
@@ -144,5 +144,17 @@ describe('vaadin-slider', () => {
       slider.value = 0;
       await expect(slider).shadowDom.to.equalSnapshot();
     });
+
+    it('min == max', async () => {
+      slider.min = 0;
+      slider.max = 0;
+      await expect(slider).shadowDom.to.equalSnapshot();
+    });
+
+    it('max < min', async () => {
+      slider.min = 0;
+      slider.max = -10;
+      await expect(slider).shadowDom.to.equalSnapshot();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes https://github.com/vaadin/web-components/issues/11135

- Guard against `NaN` in `__getPercentFromValue()` when `min === max` (division by zero)
- Fix incorrect thumb positioning (100% instead of 0%) when `max < min`
- Add DOM snapshot tests for both slider and range-slider covering `min == max` and `max < min` edge cases

## Test plan
- [x] `yarn test --group slider` — all 189 tests pass
- [x] `yarn update:snapshots --group slider` — snapshots updated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)