### PR TITLE
chore: add missing aura dev dependency to slider

### DIFF
--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -43,6 +43,7 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
+    "@vaadin/aura": "25.1.0-alpha7",
     "@vaadin/chai-plugins": "25.1.0-alpha7",
     "@vaadin/test-runner-commands": "25.1.0-alpha7",
     "@vaadin/testing-helpers": "^2.0.0",


### PR DESCRIPTION
## Description

Added `@vaadin/aura` dev dependency to slider for consistency with other components.
This is needed to ensure that changes to Aura package will trigger slider visual tests.

## Type of change

- Internal change