### PR TITLE
chore: update failed screenshots artifact name for Aura

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
-          name: base-screenshots
+          name: aura-screenshots
           path: |
             packages/*/test/visual/aura/screenshots/dark/*/failed/*.png
             packages/*/test/visual/aura/screenshots/default/*/failed/*.png


### PR DESCRIPTION
## Description

Fixed an incorrect artifact name for Aura failed screenshots (it was a copy-paste from the base styles job).

## Type of change

- Internal change