### PR TITLE
fix: apply masterSize to master area even without detail content

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -109,11 +109,11 @@ export const masterDetailLayoutStyles = css`
     flex-shrink: 0;
   }
 
-  :host([orientation='horizontal'][has-master-size][has-detail]) [part='master'] {
+  :host([orientation='horizontal'][has-master-size]) [part='master'] {
     width: var(--_master-size);
   }
 
-  :host([orientation='vertical'][has-master-size][has-detail]) [part='master'] {
+  :host([orientation='vertical'][has-master-size]) [part='master'] {
     height: var(--_master-size);
   }
 

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -117,6 +117,13 @@ describe('vaadin-master-detail-layout', () => {
         expect(getComputedStyle(detail).minWidth).to.equal('min(100%, 300px)');
       });
 
+      it('should set fixed width on the master area when masterSize is set and no detail is present', async () => {
+        layout.masterSize = '400px';
+        detailContent.remove();
+        await nextRender();
+        expect(getComputedStyle(master).width).to.equal('400px');
+      });
+
       it('should not overflow in split mode when masterSize is set', async () => {
         layout.masterSize = '500px';
         detail.remove();
@@ -165,6 +172,13 @@ describe('vaadin-master-detail-layout', () => {
         expect(getComputedStyle(detail).flexBasis).to.equal('auto');
         expect(getComputedStyle(detail).flexGrow).to.equal('0');
         expect(getComputedStyle(detail).flexShrink).to.equal('0');
+      });
+
+      it('should set fixed height on the master area when masterSize is set and no detail is present', async () => {
+        layout.masterSize = '200px';
+        detailContent.remove();
+        await nextRender();
+        expect(getComputedStyle(master).height).to.equal('200px');
       });
 
       it('should use masterMinSize as min-height', () => {


### PR DESCRIPTION
## Summary

- Remove `[has-detail]` requirement from CSS selectors that set master `width`/`height` from `masterSize`, so the master area respects its fixed size even when no detail content is present
- Add tests for horizontal and vertical orientations verifying master sizing without detail

Fixes #10318

## Root Cause

The CSS selectors applying `masterSize` to the master part required `[has-detail]`:

```css
:host([orientation='horizontal'][has-master-size][has-detail]) [part='master'] {
  width: var(--_master-size);
}
```

Without detail content, `has-detail` is absent, so the `width`/`height` rules never applied. Combined with `flex-shrink: 0` (which IS applied) and no `flex-grow`/`flex-basis` (blocked by `has-master-size`), the master ended up with no sizing — causing children without intrinsic size (e.g., `<vaadin-grid>`) to collapse to zero.

## Fix

Removed `[has-detail]` from the two selectors. This is safe because:
- `max-width: 100%` / `max-height: 100%` on `[part]` prevents overflow
- `!important` overrides in drawer/stack mode are unaffected

## Test plan

- [x] Existing tests pass (79/79)
- [x] New test: horizontal master gets `400px` width without detail
- [x] New test: vertical master gets `200px` height without detail
- [ ] Manual: `dev/mdl-size.html` — grid should have 400px width


🤖 Generated with [Claude Code](https://claude.com/claude-code)