### PR TITLE
refactor: rename icon slot in the badge to prefix

### DIFF
--- a/dev/badge.html
+++ b/dev/badge.html
@@ -27,11 +27,11 @@
     <section class="section">
       <h2 class="heading">Icon</h2>
       <vaadin-badge>
-        <vaadin-icon slot="icon" icon="vaadin:check"></vaadin-icon>
+        <vaadin-icon slot="prefix" icon="vaadin:check"></vaadin-icon>
         <span>Completed</span>
       </vaadin-badge>
       <vaadin-badge>
-        <vaadin-icon slot="icon" icon="vaadin:check"></vaadin-icon>
+        <vaadin-icon slot="prefix" icon="vaadin:check"></vaadin-icon>
       </vaadin-badge>
     </section>
   </body>

--- a/packages/badge/src/styles/vaadin-badge-base-styles.js
+++ b/packages/badge/src/styles/vaadin-badge-base-styles.js
@@ -32,7 +32,7 @@ export const badgeStyles = css`
     display: none !important;
   }
 
-  :host([has-icon]:not([has-content])) {
+  :host([has-prefix]:not([has-content])) {
     padding: var(--vaadin-padding-xs);
     border-radius: 50%;
   }

--- a/packages/badge/src/vaadin-badge.d.ts
+++ b/packages/badge/src/vaadin-badge.d.ts
@@ -15,10 +15,10 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * ### Slots
  *
- * Name   | Description
- * -------|-------------
- * (none) | Default slot for the badge text content
- * `icon` | Slot for an icon element (e.g. `<vaadin-icon>`)
+ * Name     | Description
+ * ---------|-------------
+ * (none)   | Default slot for the badge text content
+ * `prefix` | Slot for an element to place before the text, e.g. an icon
  *
  * ### Styling
  *
@@ -26,7 +26,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * Attribute      | Description
  * ---------------|-------------
- * `has-icon`     | Set when the badge has an icon in the icon slot
+ * `has-prefix`   | Set when the badge has content in the prefix slot
  * `has-content`  | Set when the badge has content in the default slot
  *
  * The following custom CSS properties are available for styling:

--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -22,10 +22,10 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * ### Slots
  *
- * Name   | Description
- * -------|-------------
- * (none) | Default slot for the badge text content
- * `icon` | Slot for an icon element (e.g. `<vaadin-icon>`)
+ * Name     | Description
+ * ---------|-------------
+ * (none)   | Default slot for the badge text content
+ * `prefix` | Slot for an element to place before the text, e.g. an icon
  *
  * ### Styling
  *
@@ -33,7 +33,7 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * Attribute      | Description
  * ---------------|-------------
- * `has-icon`     | Set when the badge has an icon in the icon slot
+ * `has-prefix`   | Set when the badge has content in the prefix slot
  * `has-content`  | Set when the badge has content in the default slot
  *
  * The following custom CSS properties are available for styling:
@@ -76,7 +76,7 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
 
   /** @protected */
   render() {
-    return html`<slot name="icon"></slot><slot></slot>`;
+    return html`<slot name="prefix"></slot><slot></slot>`;
   }
 
   /** @protected */
@@ -88,9 +88,9 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
       this.toggleAttribute('has-content', currentNodes.filter((node) => !isEmptyTextNode(node)).length > 0);
     });
 
-    const iconSlot = this.shadowRoot.querySelector('slot[name="icon"]');
-    this.__iconSlotObserver = new SlotObserver(iconSlot, ({ currentNodes }) => {
-      this.toggleAttribute('has-icon', currentNodes.length > 0);
+    const prefixSlot = this.shadowRoot.querySelector('slot[name="prefix"]');
+    this.__prefixSlotObserver = new SlotObserver(prefixSlot, ({ currentNodes }) => {
+      this.toggleAttribute('has-prefix', currentNodes.length > 0);
     });
   }
 }

--- a/packages/badge/test/badge.test.ts
+++ b/packages/badge/test/badge.test.ts
@@ -65,21 +65,21 @@ describe('vaadin-badge', () => {
     });
   });
 
-  describe('has-icon attribute', () => {
-    it('should not set has-icon attribute by default', () => {
-      expect(badge.hasAttribute('has-icon')).to.be.false;
+  describe('has-prefix attribute', () => {
+    it('should not set has-prefix attribute by default', () => {
+      expect(badge.hasAttribute('has-prefix')).to.be.false;
     });
 
-    it('should toggle has-icon attribute on icon slot content change', async () => {
-      const icon = document.createElement('span');
-      icon.setAttribute('slot', 'icon');
-      badge.appendChild(icon);
+    it('should toggle has-prefix attribute on prefix slot content change', async () => {
+      const prefix = document.createElement('span');
+      prefix.setAttribute('slot', 'prefix');
+      badge.appendChild(prefix);
       await nextUpdate(badge);
-      expect(badge.hasAttribute('has-icon')).to.be.true;
+      expect(badge.hasAttribute('has-prefix')).to.be.true;
 
-      badge.removeChild(icon);
+      badge.removeChild(prefix);
       await nextUpdate(badge);
-      expect(badge.hasAttribute('has-icon')).to.be.false;
+      expect(badge.hasAttribute('has-prefix')).to.be.false;
     });
   });
 });

--- a/packages/badge/test/dom/__snapshots__/badge.test.snap.js
+++ b/packages/badge/test/dom/__snapshots__/badge.test.snap.js
@@ -15,7 +15,7 @@ snapshots["vaadin-badge host content"] =
 /* end snapshot vaadin-badge host content */
 
 snapshots["vaadin-badge shadow default"] = 
-`<slot name="icon">
+`<slot name="prefix">
 </slot>
 <slot>
 </slot>

--- a/packages/badge/test/visual/base/badge.test.ts
+++ b/packages/badge/test/visual/base/badge.test.ts
@@ -27,7 +27,7 @@ describe('badge', () => {
 
   it('icon', async () => {
     const icon = document.createElement('vaadin-icon');
-    icon.setAttribute('slot', 'icon');
+    icon.setAttribute('slot', 'prefix');
     icon.icon = 'vaadin:check';
     element.appendChild(icon);
     element.append('Completed');
@@ -36,7 +36,7 @@ describe('badge', () => {
 
   it('icon-only', async () => {
     const icon = document.createElement('vaadin-icon');
-    icon.setAttribute('slot', 'icon');
+    icon.setAttribute('slot', 'prefix');
     icon.icon = 'vaadin:check';
     element.appendChild(icon);
     await visualDiff(div, 'icon-only');


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/platform/issues/8530

Renamed `icon` slot and `has-icon` attribute to `prefix` and `has-prefix` in order to align with the PRD. 

## Type of change

- Refactor