### PR TITLE
fix: update slider to set touch-action: none on the input

### DIFF
--- a/packages/slider/src/styles/vaadin-slider-base-styles.js
+++ b/packages/slider/src/styles/vaadin-slider-base-styles.js
@@ -95,7 +95,6 @@ export const sliderStyles = css`
     border: var(--vaadin-slider-thumb-border-width, 1px) solid
       var(--vaadin-slider-thumb-border-color, var(--vaadin-text-color));
     border-radius: var(--vaadin-slider-thumb-border-radius, var(--vaadin-radius-l));
-    touch-action: none;
   }
 
   :host([readonly]) [part='track-fill'] {
@@ -114,6 +113,7 @@ export const sliderStyles = css`
     outline: 0;
     -webkit-tap-highlight-color: transparent;
     cursor: inherit;
+    touch-action: none;
     z-index: 999;
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11152

When dragging on mobile, the browser can intercept touch gesture (e.g. if it can trigger scroll) and fire `pointercancel` event. This is undesirable in case of the slider as it will cause `active` to be reset and value bubble overlay to close.

The original implementation used `touch-action: none` on `<div part="thumb">`. This wasn't changed when updating the implementation to use native `<input type="range">` as an interactive element. This PR fixes that.

## Type of change

- Bugfix

## How to test

1. Open the slider dev page on mobile (e.g. Android Chrome)
2. Zoom in the page so that slider becomes partially visible
3. Try dragging the thumb and observe the behavior