### PR TITLE
fix: upload drop zone dragover effect

### DIFF
--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -193,7 +193,7 @@ class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
     event.preventDefault();
     // Only remove dragover if we're actually leaving the drop zone
     // (not just entering a child element)
-    if (event.relatedTarget && this.contains(event.relatedTarget)) {
+    if (event.target !== this) {
       return;
     }
     this.__dragover = false;

--- a/packages/upload/test/upload-drop-zone.test.ts
+++ b/packages/upload/test/upload-drop-zone.test.ts
@@ -167,9 +167,9 @@ describe('vaadin-upload-drop-zone', () => {
       await nextFrame();
       expect(dropZone.hasAttribute('dragover')).to.be.true;
 
-      // Simulate dragleave when entering child element (relatedTarget is the child)
-      const dragleaveEvent = createDragEvent('dragleave', [], child);
-      dropZone.dispatchEvent(dragleaveEvent);
+      // Simulate dragleave from a child element (event bubbles up from child)
+      const dragleaveEvent = createDragEvent('dragleave');
+      child.dispatchEvent(dragleaveEvent);
       await nextFrame();
 
       // Should still have dragover because we're still inside the drop zone


### PR DESCRIPTION
## Description

https://github.com/vaadin/web-components/pull/11143 fixed the flickering issue mentioned in the description, but it caused a regression where full sized drop zones would not clear the dragover curtain.

This PR reverts the change from https://github.com/vaadin/web-components/pull/11143 and applies a better fix for the original issue.

## Type of change

Bugfix