### PR TITLE
refactor: restore icon slot instead of the prefix slot

### DIFF
--- a/dev/badge.html
+++ b/dev/badge.html
@@ -27,11 +27,11 @@
     <section class="section">
       <h2 class="heading">Icon</h2>
       <vaadin-badge>
-        <vaadin-icon slot="prefix" icon="vaadin:check"></vaadin-icon>
+        <vaadin-icon slot="icon" icon="vaadin:check"></vaadin-icon>
         <span>Completed</span>
       </vaadin-badge>
       <vaadin-badge>
-        <vaadin-icon slot="prefix" icon="vaadin:check"></vaadin-icon>
+        <vaadin-icon slot="icon" icon="vaadin:check"></vaadin-icon>
       </vaadin-badge>
     </section>
 

--- a/packages/badge/src/styles/vaadin-badge-base-styles.js
+++ b/packages/badge/src/styles/vaadin-badge-base-styles.js
@@ -33,14 +33,14 @@ export const badgeStyles = css`
     display: none !important;
   }
 
-  :host(:not([has-prefix])) [part='prefix'],
+  :host(:not([has-icon])) [part='icon'],
   :host(:not([has-content])) [part='content'],
   :host(:not([has-number])) [part='number'] {
     display: none;
   }
 
-  :host([has-prefix]:not([has-content], [has-number])),
-  :host([has-number]:not([has-content], [has-prefix])) {
+  :host([has-icon]:not([has-content], [has-number])),
+  :host([has-number]:not([has-content], [has-icon])) {
     padding: var(--vaadin-badge-padding, var(--vaadin-padding-xs));
     border-radius: 50%;
   }

--- a/packages/badge/src/vaadin-badge.d.ts
+++ b/packages/badge/src/vaadin-badge.d.ts
@@ -18,7 +18,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * Name     | Description
  * ---------|-------------
  * (none)   | Default slot for the badge text content
- * `prefix` | Slot for an element to place before the text, e.g. an icon
+ * `icon`   | Slot for an icon to place before the text
  *
  * ### Styling
  *
@@ -26,7 +26,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * Part name  | Description
  * -----------|-------------
- * `prefix`   | The container for the prefix slot
+ * `icon`     | The container for the icon slot
  * `number`   | The container for the number value
  * `content`  | The container for the default slot
  *
@@ -34,7 +34,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * Attribute      | Description
  * ---------------|-------------
- * `has-prefix`   | Set when the badge has content in the prefix slot
+ * `has-icon`     | Set when the badge has content in the icon slot
  * `has-content`  | Set when the badge has content in the default slot
  * `has-number`   | Set when the badge has a number value
  *

--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -25,7 +25,7 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  * Name     | Description
  * ---------|-------------
  * (none)   | Default slot for the badge text content
- * `prefix` | Slot for an element to place before the text, e.g. an icon
+ * `icon`   | Slot for an icon to place before the text
  *
  * ### Styling
  *
@@ -33,7 +33,7 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * Part name  | Description
  * -----------|-------------
- * `prefix`   | The container for the prefix slot
+ * `icon`     | The container for the icon slot
  * `number`   | The container for the number value
  * `content`  | The container for the default slot
  *
@@ -41,7 +41,7 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * Attribute      | Description
  * ---------------|-------------
- * `has-prefix`   | Set when the badge has content in the prefix slot
+ * `has-icon`     | Set when the badge has content in the icon slot
  * `has-content`  | Set when the badge has content in the default slot
  * `has-number`   | Set when the badge has a number value
  *
@@ -98,7 +98,7 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
   /** @protected */
   render() {
     return html`
-      <div part="prefix"><slot name="prefix"></slot></div>
+      <div part="icon"><slot name="icon"></slot></div>
       <div part="number">${this.number}</div>
       <div part="content"><slot></slot></div>
     `;
@@ -122,9 +122,9 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
       this.toggleAttribute('has-content', currentNodes.filter((node) => !isEmptyTextNode(node)).length > 0);
     });
 
-    const prefixSlot = this.shadowRoot.querySelector('slot[name="prefix"]');
-    this.__prefixSlotObserver = new SlotObserver(prefixSlot, ({ currentNodes }) => {
-      this.toggleAttribute('has-prefix', currentNodes.length > 0);
+    const iconSlot = this.shadowRoot.querySelector('slot[name="icon"]');
+    this.__iconSlotObserver = new SlotObserver(iconSlot, ({ currentNodes }) => {
+      this.toggleAttribute('has-icon', currentNodes.length > 0);
     });
   }
 }

--- a/packages/badge/test/badge.test.ts
+++ b/packages/badge/test/badge.test.ts
@@ -99,21 +99,21 @@ describe('vaadin-badge', () => {
     });
   });
 
-  describe('has-prefix attribute', () => {
-    it('should not set has-prefix attribute by default', () => {
-      expect(badge.hasAttribute('has-prefix')).to.be.false;
+  describe('has-icon attribute', () => {
+    it('should not set has-icon attribute by default', () => {
+      expect(badge.hasAttribute('has-icon')).to.be.false;
     });
 
-    it('should toggle has-prefix attribute on prefix slot content change', async () => {
-      const prefix = document.createElement('span');
-      prefix.setAttribute('slot', 'prefix');
-      badge.appendChild(prefix);
+    it('should toggle has-icon attribute on icon slot content change', async () => {
+      const icon = document.createElement('span');
+      icon.setAttribute('slot', 'icon');
+      badge.appendChild(icon);
       await nextUpdate(badge);
-      expect(badge.hasAttribute('has-prefix')).to.be.true;
+      expect(badge.hasAttribute('has-icon')).to.be.true;
 
-      badge.removeChild(prefix);
+      badge.removeChild(icon);
       await nextUpdate(badge);
-      expect(badge.hasAttribute('has-prefix')).to.be.false;
+      expect(badge.hasAttribute('has-icon')).to.be.false;
     });
   });
 });

--- a/packages/badge/test/dom/__snapshots__/badge.test.snap.js
+++ b/packages/badge/test/dom/__snapshots__/badge.test.snap.js
@@ -21,8 +21,8 @@ snapshots["vaadin-badge host number"] =
 /* end snapshot vaadin-badge host number */
 
 snapshots["vaadin-badge shadow default"] = 
-`<div part="prefix">
-  <slot name="prefix">
+`<div part="icon">
+  <slot name="icon">
   </slot>
 </div>
 <div part="number">
@@ -35,8 +35,8 @@ snapshots["vaadin-badge shadow default"] =
 /* end snapshot vaadin-badge shadow default */
 
 snapshots["vaadin-badge shadow number"] = 
-`<div part="prefix">
-  <slot name="prefix">
+`<div part="icon">
+  <slot name="icon">
   </slot>
 </div>
 <div part="number">

--- a/packages/badge/test/visual/base/badge.test.ts
+++ b/packages/badge/test/visual/base/badge.test.ts
@@ -42,7 +42,7 @@ describe('badge', () => {
 
     beforeEach(() => {
       icon = document.createElement('vaadin-icon');
-      icon.setAttribute('slot', 'prefix');
+      icon.setAttribute('slot', 'icon');
       icon.icon = 'vaadin:check';
     });
 

--- a/packages/badge/test/visual/lumo/badge.test.ts
+++ b/packages/badge/test/visual/lumo/badge.test.ts
@@ -44,7 +44,7 @@ describe('badge', () => {
 
     beforeEach(() => {
       icon = document.createElement('vaadin-icon');
-      icon.setAttribute('slot', 'prefix');
+      icon.setAttribute('slot', 'icon');
       icon.icon = 'vaadin:check';
     });
 

--- a/packages/vaadin-lumo-styles/src/components/badge.css
+++ b/packages/vaadin-lumo-styles/src/components/badge.css
@@ -65,7 +65,7 @@
     --vaadin-badge-font-size: var(--lumo-font-size-xxs);
   }
 
-  :host([has-prefix]:not([has-content])) {
+  :host([has-icon]:not([has-content])) {
     padding: 0;
     min-width: 0;
     font-size: 1rem;
@@ -73,7 +73,7 @@
     height: var(--lumo-icon-size-m);
   }
 
-  :host([has-prefix]) ::slotted(vaadin-icon) {
+  :host([has-icon]) ::slotted(vaadin-icon) {
     margin: -0.25em 0;
   }
 }


### PR DESCRIPTION
## Description

As discussed internally, "icon" slot is more clear compared to "prefix", especially as we don't plan to add "suffix" slot.
So let's revert #11148 and restore the original slot name. We can validate slot names during DX tests.

## Type of change

- Refactor