### PR TITLE
fix: popover Tab trapping when overlay contains focusable elements in dialog (CP: 24.10)

### DIFF
--- a/packages/a11y-base/src/focus-trap-controller.d.ts
+++ b/packages/a11y-base/src/focus-trap-controller.d.ts
@@ -6,6 +6,12 @@
 import type { ReactiveController } from 'lit';
 
 /**
+ * Returns the innermost active focus trap node that contains the given element,
+ * or null if the element is not inside any active focus trap.
+ */
+export declare function getActiveTrappingNode(element: HTMLElement): HTMLElement | null;
+
+/**
  * A controller for trapping focus within a DOM node.
  */
 export class FocusTrapController implements ReactiveController {

--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -8,6 +8,23 @@ import { getFocusableElements, isElementFocused, isKeyboardActive } from './focu
 const instances = [];
 
 /**
+ * Returns the innermost active focus trap node that contains the given element,
+ * or null if the element is not inside any active focus trap.
+ *
+ * @param {HTMLElement} element
+ * @return {HTMLElement | null}
+ */
+export function getActiveTrappingNode(element) {
+  // Iterate backwards since instances are ordered outer-to-inner (push/pop)
+  for (let i = instances.length - 1; i >= 0; i--) {
+    if (instances[i].__trapNode?.contains(element)) {
+      return instances[i].__trapNode;
+    }
+  }
+  return null;
+}
+
+/**
  * A controller for trapping focus within a DOM node.
  */
 export class FocusTrapController {
@@ -123,6 +140,11 @@ export class FocusTrapController {
     }
 
     if (event.key === 'Tab') {
+      // Skip if another handler already processed this event
+      if (event.defaultPrevented) {
+        return;
+      }
+
       event.preventDefault();
 
       const backward = event.shiftKey;

--- a/packages/a11y-base/test/focus-trap-controller.test.js
+++ b/packages/a11y-base/test/focus-trap-controller.test.js
@@ -374,4 +374,47 @@ describe('FocusTrapController', () => {
       expect(document.activeElement).to.equal(trapInput1);
     });
   });
+
+  describe('defaultPrevented', () => {
+    let trapInput1;
+
+    beforeEach(() => {
+      element = fixtureSync(`<${tag}></${tag}>`);
+      controller = new FocusTrapController(element);
+      element.addController(controller);
+      trap = element.querySelector('#trap');
+      trapInput1 = trap.querySelector('#trap-input-1');
+    });
+
+    it('should not handle Tab when event.defaultPrevented is true', () => {
+      controller.trapFocus(trap);
+      trapInput1.focus();
+
+      // Simulate another handler (e.g., popover) calling preventDefault in capture phase
+      document.addEventListener('keydown', (e) => e.preventDefault(), { capture: true, once: true });
+
+      const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+      trapInput1.dispatchEvent(event);
+
+      expect(document.activeElement).to.equal(trapInput1);
+    });
+
+    it('should not handle Shift+Tab when event.defaultPrevented is true', () => {
+      controller.trapFocus(trap);
+      trapInput1.focus();
+
+      // Simulate another handler (e.g., popover) calling preventDefault in capture phase
+      const captureHandler = (e) => {
+        e.preventDefault();
+      };
+      document.addEventListener('keydown', captureHandler, true);
+
+      const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+      trapInput1.dispatchEvent(event);
+
+      document.removeEventListener('keydown', captureHandler, true);
+
+      expect(document.activeElement).to.equal(trapInput1);
+    });
+  });
 });

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -6,6 +6,7 @@
 import './vaadin-popover-overlay.js';
 import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { getActiveTrappingNode } from '@vaadin/a11y-base/src/focus-trap-controller.js';
 import {
   getDeepActiveElement,
   getFocusableElements,
@@ -662,24 +663,76 @@ class Popover extends PopoverPositionMixin(
       return;
     }
 
-    // Move focus to the next element after target on content Tab
-    const lastFocusable = this.__getLastFocusable(overlayPart);
-    if (lastFocusable && isElementFocused(lastFocusable)) {
-      const focusable = this.__getNextBodyFocusable(this.__getTargetFocusable());
-      if (focusable && focusable !== overlayPart) {
+    // Handle Tab within the overlay content explicitly. The overlay is
+    // teleported to the body and is outside the dialog's focus trap, so the
+    // FocusTrapController would otherwise intercept the Tab event.
+    if (isElementFocused(overlayPart)) {
+      const contentFocusables = getFocusableElements(this._overlayElement.$.content);
+      if (contentFocusables.length > 0) {
+        event.preventDefault();
+        contentFocusables[0].focus();
+        return;
+      }
+      // No focusable content - fall through to isFocusOut handling below
+    } else if (this._overlayElement.contains(getDeepActiveElement())) {
+      const contentFocusables = getFocusableElements(this._overlayElement.$.content);
+      const activeEl = getDeepActiveElement();
+      const idx = contentFocusables.indexOf(activeEl);
+      if (idx >= 0 && idx < contentFocusables.length - 1) {
+        event.preventDefault();
+        contentFocusables[idx + 1].focus();
+        return;
+      }
+      // Last content focusable - fall through to isFocusOut handling below
+    }
+
+    // Cache filtered focusable list for this keystroke to avoid redundant DOM traversals
+    const focusables = this.__getScopeFocusables();
+
+    // Move focus to the next element after target on last content Tab,
+    // or when overlay part itself is focused and has no focusable content
+    const lastFocusable = this.__getLastFocusable();
+    const isFocusOut = lastFocusable ? isElementFocused(lastFocusable) : isElementFocused(overlayPart);
+    if (isFocusOut) {
+      let focusable = this.__getNextScopeFocusable(this.__getTargetFocusable(), focusables);
+      // If the next element after the target is the overlay part (DOM position
+      // differs from logical position), skip past it to the actual next element.
+      if (focusable === overlayPart) {
+        focusable = this.__getNextScopeFocusable(overlayPart, focusables);
+      }
+      if (focusable) {
         event.preventDefault();
         focusable.focus();
         return;
       }
+      // No next element after the target in the scope. When inside a focus trap,
+      // wrap explicitly to the first focusable. Don't fall through - the
+      // FocusTrapController uses DOM order which may differ from the popover's
+      // logical tab position.
+      if (getActiveTrappingNode(this) && focusables[0]) {
+        event.preventDefault();
+        focusables[0].focus();
+        return;
+      }
     }
 
-    // Prevent focusing the popover content on previous element Tab
+    // Handle cases where Tab from the current element would land on the overlay
     const activeElement = getDeepActiveElement();
-    const nextFocusable = this.__getNextBodyFocusable(activeElement);
-    if (nextFocusable === overlayPart && lastFocusable) {
-      // Move focus to the last overlay focusable and do NOT prevent keydown
-      // to move focus outside the popover content (e.g. to the URL bar).
-      lastFocusable.focus();
+    const nextFocusable = this.__getNextScopeFocusable(activeElement, focusables);
+    if (nextFocusable === overlayPart) {
+      // The overlay should only be Tab-reachable from its target (handled above).
+      // Skip the overlay when Tab from any other element would land on it
+      // due to its DOM position.
+      const focusableAfterOverlay = this.__getNextScopeFocusable(overlayPart, focusables);
+      if (focusableAfterOverlay) {
+        event.preventDefault();
+        focusableAfterOverlay.focus();
+      } else if (getActiveTrappingNode(this) && focusables[0]) {
+        // Overlay is last in DOM scope but shouldn't be Tab-reachable from
+        // non-target elements. Wrap to first focusable in focus trap.
+        event.preventDefault();
+        focusables[0].focus();
+      }
     }
   }
 
@@ -700,28 +753,134 @@ class Popover extends PopoverPositionMixin(
       return;
     }
 
-    // Move focus back to the popover on next element Shift + Tab
-    const nextFocusable = this.__getNextBodyFocusable(this.__getTargetFocusable());
-    if (nextFocusable && isElementFocused(nextFocusable)) {
-      const lastFocusable = this.__getLastFocusable(overlayPart);
-      if (lastFocusable) {
+    // Handle Shift+Tab within the overlay content explicitly. The overlay is
+    // teleported to the body and is outside the dialog's focus trap, so the
+    // FocusTrapController would otherwise intercept the Shift+Tab event.
+    const activeElement = getDeepActiveElement();
+    if (this._overlayElement.contains(activeElement)) {
+      const contentFocusables = getFocusableElements(this._overlayElement.$.content);
+      const idx = contentFocusables.indexOf(activeElement);
+      if (idx > 0) {
         event.preventDefault();
-        lastFocusable.focus();
+        contentFocusables[idx - 1].focus();
+        return;
+      }
+      // First content focusable or not found - move to overlay part
+      event.preventDefault();
+      overlayPart.focus();
+      return;
+    }
+
+    // Cache filtered focusable list for this keystroke to avoid redundant DOM traversals
+    const focusables = this.__getScopeFocusables();
+
+    // Get previous focusable element excluding the overlay
+    const prevFocusable = this.__getPrevScopeFocusable(activeElement, focusables);
+    const targetFocusable = this.__getTargetFocusable();
+
+    // Intercept Shift+Tab when the previous focusable (excluding the overlay)
+    // is the target. Instead of moving to the target, redirect focus into
+    // the overlay's last focusable content (or the overlay part itself).
+    if (prevFocusable === targetFocusable) {
+      event.preventDefault();
+      this.__focusLastOrSelf();
+      return;
+    }
+
+    // Move focus into the overlay when:
+    // 1. There is no previous focusable element in the focus trap (at the
+    //    beginning, would wrap around), and
+    // 2. The target is the last focusable in the focus trap (making the
+    //    overlay logically last).
+    // Don't fall through - the FocusTrapController uses DOM order which
+    // may differ from the popover's logical tab position.
+    if (!prevFocusable && getActiveTrappingNode(this)) {
+      const list = focusables.filter((el) => el !== overlayPart);
+      if (list.at(-1) === targetFocusable) {
+        event.preventDefault();
+        this.__focusLastOrSelf();
+        return;
+      }
+      // Overlay is last in DOM but target is not the last focusable.
+      // Wrap to last non-overlay focusable to prevent FocusTrapController
+      // from landing on the overlay.
+      const last = list.at(-1);
+      if (last) {
+        event.preventDefault();
+        last.focus();
+        return;
+      }
+    }
+
+    // Get previous focusable element including the overlay (simulates native Tab order)
+    const prevFocusableNative = this.__getPrevScopeFocusable(activeElement, focusables, true);
+    // Skip the overlay when native Shift+Tab would land on it
+    // and redirect to the actual previous element
+    if (prevFocusableNative === overlayPart) {
+      if (prevFocusable) {
+        event.preventDefault();
+        prevFocusable.focus();
+      } else if (getActiveTrappingNode(this)) {
+        // Overlay is first in DOM scope but shouldn't be Shift+Tab-reachable
+        // from non-target elements. Wrap to last non-overlay focusable.
+        const list = focusables.filter((el) => el !== overlayPart);
+        const last = list.at(-1);
+        if (last) {
+          event.preventDefault();
+          last.focus();
+        }
       }
     }
   }
 
-  /** @private */
-  __getNextBodyFocusable(target) {
-    const focusables = getFocusableElements(document.body);
-    const idx = focusables.findIndex((el) => el === target);
-    return focusables[idx + 1];
+  /**
+   * Returns whether the element is an overlay content child of this popover
+   * (i.e. content rendered inside the overlay, excluding the overlay part itself).
+   * @param {Element} el
+   * @return {boolean}
+   * @private
+   */
+  __isPopoverContent(el) {
+    return this._overlayElement && el !== this._overlayElement && this._overlayElement.contains(el);
+  }
+
+  /**
+   * Returns focusable elements within the current scope (active focus trap or
+   * document body) with popover overlay content children filtered out.
+   * @return {Element[]}
+   * @private
+   */
+  __getScopeFocusables() {
+    const scope = getActiveTrappingNode(this) || document.body;
+    return getFocusableElements(scope).filter((el) => !this.__isPopoverContent(el));
   }
 
   /** @private */
-  __getLastFocusable(container) {
-    const focusables = getFocusableElements(container);
+  __getNextScopeFocusable(target, focusables = this.__getScopeFocusables()) {
+    const idx = focusables.findIndex((el) => el === target);
+    return idx >= 0 ? focusables[idx + 1] : undefined;
+  }
+
+  /** @private */
+  __getPrevScopeFocusable(target, focusables = this.__getScopeFocusables(), includeOverlay = false) {
+    const overlayPart = this._overlayElement.$.overlay;
+    const list = includeOverlay ? focusables : focusables.filter((el) => el !== overlayPart);
+    const idx = list.findIndex((el) => el === target);
+    // Returns null both when target is the first element (idx === 0)
+    // and when target is not found in the list (idx === -1)
+    return idx > 0 ? list[idx - 1] : null;
+  }
+
+  /** @private */
+  __getLastFocusable() {
+    // Search within the overlay's content area to avoid returning the overlay part itself
+    const focusables = getFocusableElements(this._overlayElement.$.content);
     return focusables.pop();
+  }
+
+  /** @private */
+  __focusLastOrSelf() {
+    (this.__getLastFocusable() || this._overlayElement.$.overlay).focus();
   }
 
   /** @private */

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -443,12 +443,17 @@ describe('a11y', () => {
         });
 
         it('should not focus the overlay part on the next element Tab', async () => {
+          // Add another input after the test input that focus can move to.
+          // Otherwise the browser sometimes wraps focus back to the overlay
+          // instead of the body.
+          const anotherInput = document.createElement('input');
+          input.after(anotherInput);
+
           input.focus();
 
           await sendKeys({ press: 'Tab' });
 
-          const activeElement = getDeepActiveElement();
-          expect(activeElement).to.not.equal(overlay.$.overlay);
+          expect(document.activeElement).to.equal(anotherInput);
         });
 
         it('should focus previous element on target Shift Tab while opened', async () => {

--- a/test/integration/dialog-popover.test.js
+++ b/test/integration/dialog-popover.test.js
@@ -1,9 +1,18 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
-import { fixtureSync, mousedown, nextFrame, nextRender, nextUpdate, touchstart } from '@vaadin/testing-helpers';
+import {
+  fixtureSync,
+  mousedown,
+  nextFrame,
+  nextRender,
+  nextUpdate,
+  oneEvent,
+  touchstart,
+} from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/dialog/src/vaadin-dialog.js';
-import '@vaadin/popover/src/vaadin-popover.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { Popover } from '@vaadin/popover/src/vaadin-popover.js';
 
 describe('popover in dialog', () => {
   let dialog, popover, button, overlay;
@@ -172,6 +181,172 @@ describe('dialog in popover', () => {
         await sendKeys({ press: 'Escape' });
 
         expect(popover.opened).to.be.false;
+      });
+    });
+  });
+});
+
+describe('popover Tab navigation in dialog', () => {
+  let dialog, popover, overlay, overlayPart, btn1, btn2, btn3, btn4, btn5, popoverInput;
+
+  before(() => {
+    Popover.setDefaultFocusDelay(0);
+  });
+
+  beforeEach(async () => {
+    dialog = fixtureSync('<vaadin-dialog opened></vaadin-dialog>');
+    await nextRender();
+
+    dialog.renderer = (root) => {
+      if (root.firstChild) {
+        return;
+      }
+      root.innerHTML = `
+        <button id="btn1">Button 1</button>
+        <button id="btn2">Button 2</button>
+        <button id="btn3">Button 3</button>
+        <button id="btn4">Button 4</button>
+        <button id="btn5">Button 5</button>
+      `;
+
+      // Create popover and append to dialog content
+      const popoverEl = document.createElement('vaadin-popover');
+      popoverEl.trigger = [];
+      root.appendChild(popoverEl);
+    };
+    await nextUpdate(dialog);
+
+    // Content is rendered into the dialog overlay
+    const dialogOverlay = dialog.$.overlay;
+    btn1 = dialogOverlay.querySelector('#btn1');
+    btn2 = dialogOverlay.querySelector('#btn2');
+    btn3 = dialogOverlay.querySelector('#btn3');
+    btn4 = dialogOverlay.querySelector('#btn4');
+    btn5 = dialogOverlay.querySelector('#btn5');
+    popover = dialogOverlay.querySelector('vaadin-popover');
+    popover.target = btn4;
+    await nextUpdate(popover);
+
+    overlay = popover._overlayElement;
+    overlayPart = overlay.$.overlay;
+  });
+
+  afterEach(async () => {
+    dialog.opened = false;
+    await nextRender();
+  });
+
+  [
+    { name: 'with focusable content', hasFocusable: true },
+    { name: 'with no focusable content', hasFocusable: false },
+  ].forEach(({ name, hasFocusable }) => {
+    describe(name, () => {
+      beforeEach(async () => {
+        if (hasFocusable) {
+          popover.renderer = (root) => {
+            if (!root.firstChild) {
+              popoverInput = document.createElement('input');
+              popoverInput.id = 'popover-input';
+              root.appendChild(popoverInput);
+            }
+          };
+        } else {
+          popover.renderer = (root) => {
+            if (!root.firstChild) {
+              const span = document.createElement('span');
+              span.textContent = 'Tooltip-like content';
+              root.appendChild(span);
+            }
+          };
+        }
+        await nextUpdate(popover);
+      });
+
+      [
+        { name: 'after last button', position: 'afterLast' },
+        { name: 'before first button', position: 'beforeFirst' },
+        { name: 'right before target', position: 'beforeTarget' },
+        { name: 'right after target', position: 'afterTarget' },
+      ].forEach(({ name, position }) => {
+        describe(`popover ${name} in DOM`, () => {
+          beforeEach(async () => {
+            const root = btn1.parentNode;
+            if (position === 'beforeFirst') {
+              root.insertBefore(popover, btn1);
+            } else if (position === 'beforeTarget') {
+              root.insertBefore(popover, btn4);
+            } else if (position === 'afterTarget') {
+              root.insertBefore(popover, btn5);
+            }
+            // 'afterLast' — no move needed, popover is already after btn5
+            popover.opened = true;
+            await oneEvent(overlay, 'vaadin-overlay-open');
+          });
+
+          it('should Tab forward through all elements in correct order', async () => {
+            btn1.focus();
+            expect(getDeepActiveElement()).to.equal(btn1);
+
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(btn2);
+
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(btn3);
+
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(btn4);
+
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(overlayPart);
+
+            if (hasFocusable) {
+              await sendKeys({ press: 'Tab' });
+              expect(getDeepActiveElement()).to.equal(popoverInput);
+            }
+
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(btn5);
+
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(dialog.$.overlay.$.overlay);
+
+            // Should wrap back to the first button
+            await sendKeys({ press: 'Tab' });
+            expect(getDeepActiveElement()).to.equal(btn1);
+          });
+
+          it('should Shift+Tab backward through all elements in correct order', async () => {
+            btn5.focus();
+            expect(getDeepActiveElement()).to.equal(btn5);
+
+            if (hasFocusable) {
+              await sendKeys({ press: 'Shift+Tab' });
+              expect(getDeepActiveElement()).to.equal(popoverInput);
+            }
+
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(overlayPart);
+
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(btn4);
+
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(btn3);
+
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(btn2);
+
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(btn1);
+
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(dialog.$.overlay.$.overlay);
+
+            // Should wrap back to the last button, not to the popover
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(getDeepActiveElement()).to.equal(btn5);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #11107 to branch 24.10.

---

> ## Summary
> 
> Fixes Tab/Shift+Tab keyboard navigation for popovers rendered inside dialogs. The popover's custom Tab handling conflicted with the dialog's focus trap, causing focus to get stuck cycling between popover content and adjacent elements.
> 
> ### Problem
> 
> When a popover is opened inside a dialog, its DOM position may differ from its logical position (which should be immediately after the target). This caused several issues:
> - Popover light DOM children (slotted content) appeared in the body focusable list, creating unexpected Tab stops
> - Tab/Shift+Tab from non-target elements could land on the popover due to its DOM position rather than skipping it
> - The dialog's `FocusTrapController` would intercept Tab events already handled by the popover, fighting over focus
> - Popovers with no focusable content were not handled correctly
> 
> ### Changes
> 
> **`packages/popover/src/vaadin-popover.js`**
> - Add `__onGlobalTab()` / `__onGlobalShiftTab()` handlers that scope popover focus navigation to the active focus trap (dialog) instead of the full document body
> - Filter popover light DOM children from the scope focusable list via `__getScopeFocusables()`, so Tab order only includes the popover element itself (not its content separately)
> - Skip the popover when Tab/Shift+Tab from a non-target element would land on it due to DOM position
> - Handle wrap-around at focus trap boundaries — prevent Tab from the last dialog button landing on the popover, and prevent Shift+Tab from the dialog wrapping into the popover
> - Handle popovers with no focusable content (focus the popover element itself)
> 
> **`packages/a11y-base/src/focus-trap-controller.js`**
> - Skip Tab handling when `event.defaultPrevented` is true, so the dialog's focus trap doesn't override Tab events already processed by the popover
> 
> **Tests**
> - Add `defaultPrevented` unit tests for `FocusTrapController`
> - Add comprehensive integration tests covering four DOM positions (`afterLast`, `beforeFirst`, `beforeTarget`, `afterTarget`) to verify focus order is correct regardless of where the popover sits in the DOM
> - Test both focusable and non-focusable popover content variants
> - Verify full forward Tab and backward Shift+Tab traversal including wrap-around
> 
> Fixes #10934