### PR TITLE
docs: add missing fires JSDoc annotations to checkbox

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -106,6 +106,8 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  * @fires {Event} change - Fired when the checkbox is checked or unchecked by the user.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   addEventListener<K extends keyof CheckboxEventMap>(

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -71,6 +71,8 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  * @fires {Event} change - Fired when the checkbox is checked or unchecked by the user.
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  * @fires {CustomEvent} indeterminate-changed - Fired when the `indeterminate` property changes.
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
  * @customElement vaadin-checkbox
  * @extends HTMLElement


### PR DESCRIPTION
## Description

These events were not added to `custom-elements.json` due to missing `@fires` annotations. This PR fixes that.

## Type of change

- Documentation