### PR TITLE
chore: filter out attributes for non-public members in CEM config

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -76,12 +76,15 @@ export default {
             }
 
             // Transform attributes:
+            // - Filter out attributes whose corresponding field member is not public.
             // - Filter out starting with underscore e.g. `_lastTabIndex`
             // - Filter out `dir` attribute inherited from DirMixin.
             // - Filter out attributes with non-primitive types (can't be set via HTML attributes).
             // - Transform camelCase attribute names to dash-case.
             if (declaration?.attributes?.length) {
+              const publicMemberNames = new Set((declaration.members || []).map((m) => m.name));
               declaration.attributes = declaration.attributes
+                .filter((attr) => !attr.fieldName || publicMemberNames.has(attr.fieldName))
                 .filter((member) => !inheritanceDenyList.includes(member.inheritedFrom?.name))
                 .filter((member) => !member.name.startsWith('_') && member.name !== 'dir')
                 .filter((member) => !ignoredAttributeTypes.some((type) => member.type?.text?.includes(type)))


### PR DESCRIPTION
## Summary
- Attributes whose corresponding field member is protected or private (e.g. `type` from `InputMixin`) were not being excluded from the custom elements manifest
- Adds a filter in the CEM config that removes attributes when their `fieldName` does not match any remaining public member

## Test plan
- [ ] Run `yarn release:cem` and verify that `packages/checkbox/custom-elements.json` no longer contains the `type` attribute
- [ ] Verify other packages (e.g. `text-field`) are not affected by the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)