### PR TITLE
refactor: remove private property declaration to include i18n to CEM

### DIFF
--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -49,10 +49,26 @@ export const I18nMixin = (defaultI18n, superClass) =>
       };
     }
 
+    static get observedAttributes() {
+      return [...super.observedAttributes, 'i18n'];
+    }
+
     constructor() {
       super();
 
       this.i18n = deepMerge({}, defaultI18n);
+    }
+
+    /** @protected */
+    attributeChangedCallback(name, oldValue, newValue) {
+      super.attributeChangedCallback(name, oldValue, newValue);
+      if (name === 'i18n') {
+        try {
+          this.i18n = JSON.parse(newValue);
+        } catch (_) {
+          // Invalid JSON, ignore
+        }
+      }
     }
 
     /**

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { LitElement } from 'lit';
 import { I18nMixin } from '../src/i18n-mixin.js';
 import { PolylitMixin } from '../src/polylit-mixin.js';
@@ -78,5 +78,26 @@ describe('I18nMixin', () => {
     element.i18n = customI18n;
 
     expect(element.__effectiveI18n).to.equal(effectiveI18n);
+  });
+
+  it('should initialize property from i18n attribute JSON string', () => {
+    const i18nJson = JSON.stringify({ foo: 'Custom Foo' });
+    element = fixtureSync(`<i18n-mixin-lit-element i18n='${i18nJson}'></i18n-mixin-lit-element>`);
+
+    expect(element.i18n).to.have.property('foo', 'Custom Foo');
+    expect(element.__effectiveI18n).to.deep.equal({ ...DEFAULT_I18N, foo: 'Custom Foo' });
+  });
+
+  it('should update property when i18n attribute is changed', () => {
+    element.setAttribute('i18n', JSON.stringify({ foo: 'Updated Foo' }));
+
+    expect(element.i18n).to.have.property('foo', 'Updated Foo');
+    expect(element.__effectiveI18n).to.deep.equal({ ...DEFAULT_I18N, foo: 'Updated Foo' });
+  });
+
+  it('should ignore invalid JSON in i18n attribute', () => {
+    element.setAttribute('i18n', 'not valid json');
+
+    expect(element.i18n).to.deep.equal(DEFAULT_I18N);
   });
 });


### PR DESCRIPTION
## Description

This essentially reverts https://github.com/vaadin/web-components/pull/8816

Fixing another finding from Claude while working on CEM config: the `i18n` field is currently excluded from generated `custom-elements.json` due to `@private` JSDoc annotation for a property declared in the mixin. 

Let's remove the property as no longer needed: all components use Lit now, so this is not relevant for the React components [workaround](https://github.com/vaadin/react-components/blob/9461ada88798c9c7e74f4e4b8108e9637b3c5558/packages/react-components/src/utils/createComponent.ts#L95-L99) mentioned in the comment (which could be actually removed as well).

## Type of change

- Refactor

## Note

Can be tested by running `yarn release` - there should be `i18n` in `packages/avatar/custom-elements.json`.