### PR TITLE
chore: fix incorrectly updated copyright years to use 2025

### DIFF
--- a/packages/component-base/src/i18n-mixin.d.ts
+++ b/packages/component-base/src/i18n-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 

--- a/packages/component-base/src/styles/add-global-styles.js
+++ b/packages/component-base/src/styles/add-global-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 

--- a/packages/component-base/src/styles/loader-styles.js
+++ b/packages/component-base/src/styles/loader-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import './style-props.js';

--- a/packages/details/src/styles/vaadin-details-summary-base-styles.d.ts
+++ b/packages/details/src/styles/vaadin-details-summary-base-styles.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { CSSResult } from 'lit';

--- a/packages/details/src/styles/vaadin-details-summary-base-styles.js
+++ b/packages/details/src/styles/vaadin-details-summary-base-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/component-base/src/styles/style-props.js';

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.d.ts
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { CSSResult } from 'lit';

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/component-base/src/styles/style-props.js';

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-transition-base-styles.d.ts
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-transition-base-styles.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { CSSResult } from 'lit';

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-transition-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-transition-base-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { css } from 'lit';

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement, nothing } from 'lit';


### PR DESCRIPTION
## Description

Some license comments for files added in 2025 were incorrectly updated to use 2026 as a start year. This PR fixes that.

## Type of change

- Internal change