### PR TITLE
chore: filter out private and protected classes from CEM output

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -186,16 +186,51 @@ function readonlyPlugin() {
   };
 }
 
+/**
+ * CEM plugin that marks class declarations with `@private` or `@protected` JSDoc tags
+ * so they can be filtered out during the packageLinkPhase.
+ */
+function classPrivacyPlugin() {
+  return {
+    analyzePhase({ ts, node, moduleDoc }) {
+      if (!ts.isClassDeclaration(node) || !node.name) return;
+
+      const tag = (node.jsDoc || [])
+        .flatMap((doc) => doc.tags || [])
+        .find((t) => t.tagName?.text === 'private' || t.tagName?.text === 'protected');
+
+      if (!tag) return;
+
+      const decl = moduleDoc.declarations?.find((d) => d.name === node.name.text);
+      if (decl) {
+        decl.privacy = tag.tagName.text;
+      }
+    },
+  };
+}
+
 export default {
   globs: ['packages/**/src/(vaadin-*.js|*-mixin.js)'],
   packagejson: false,
   litelement: true,
   plugins: [
+    classPrivacyPlugin(),
     mixesPlugin(),
     readonlyPlugin(),
     {
       packageLinkPhase({ customElementsManifest }) {
         for (const definition of customElementsManifest.modules) {
+          // Filter out class declarations marked as @private or @protected
+          const privateClassNames = new Set(
+            (definition.declarations || [])
+              .filter((d) => d.privacy === 'private' || d.privacy === 'protected')
+              .map((d) => d.name),
+          );
+          if (privateClassNames.size > 0) {
+            definition.declarations = definition.declarations.filter((d) => !privateClassNames.has(d.name));
+            definition.exports = (definition.exports || []).filter((e) => !privateClassNames.has(e.declaration?.name));
+          }
+
           for (const declaration of definition.declarations) {
             // Filter out private and protected API and internal static getters.
             // Transform field members' attribute property from camelCase to dash-case.
@@ -241,6 +276,11 @@ export default {
             }
           }
         }
+
+        // Remove modules with empty declarations and exports
+        customElementsManifest.modules = customElementsManifest.modules.filter(
+          (mod) => mod.declarations?.length || mod.exports?.length,
+        );
       },
     },
   ],


### PR DESCRIPTION
## Description

Added `classPrivacyPlugin` to detect `@private` / `@protected` JSDoc tags on class declarations and exclude them from generated `custom-elements.json` files. Also remove empty modules left after filtering.

Elements like `vaadin-avatar-group-overlay` are not supposed to be used publicly and considered an implementation detail. They should also not end up in `web-types.json` as that is then used to generate React wrappers.

## Type of change

- Internal change