### PR TITLE
docs: add missing @event JSDoc for attachment-click

### DIFF
--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -237,4 +237,9 @@ export const MessageListMixin = (superClass) =>
     __announceChanged(announceMessages) {
       this.ariaLive = announceMessages ? 'polite' : null;
     }
+
+    /**
+     * Fired when an attachment is clicked.
+     * @event attachment-click
+     */
   };

--- a/packages/message-list/src/vaadin-message-mixin.js
+++ b/packages/message-list/src/vaadin-message-mixin.js
@@ -198,4 +198,9 @@ export const MessageMixin = (superClass) =>
         }),
       );
     }
+
+    /**
+     * Fired when an attachment is clicked.
+     * @event attachment-click
+     */
   };


### PR DESCRIPTION
## Description

- Add missing `@event attachment-click` JSDoc annotations to `MessageMixin` and `MessageListMixin` so the Polymer Analyzer detects them
- Without these, the event was absent from `web-types.json`, which meant the React wrapper generator never created an `onAttachmentClick` prop

## Type of change

Bugfix