### PR TITLE
refactor: make keepInViewport respect --vaadin-overlay-viewport-inset

### DIFF
--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -132,16 +132,14 @@ export const DialogDraggableMixin = (superClass) =>
         let left = this._originalBounds.left + (event.pageX - this._originalMouseCoords.left);
 
         if (this.keepInViewport) {
+          // Constrain the dialog position so that it stays within the overlay host bounds,
+          // respecting the `--vaadin-overlay-viewport-inset` (offset from the viewport edges).
           const { width, height } = this._originalBounds;
-          // Get the overlay container's position to account for its offset from the viewport
-          const containerBounds = this.$.overlay.getBoundingClientRect();
-          // Calculate bounds so the dialog's visual edges stay within the viewport
-          const minLeft = -containerBounds.left;
-          const maxLeft = window.innerWidth - containerBounds.left - width;
-          const minTop = -containerBounds.top;
-          const maxTop = window.innerHeight - containerBounds.top - height;
-          left = Math.max(minLeft, Math.min(left, maxLeft));
-          top = Math.max(minTop, Math.min(top, maxTop));
+          const overlayHostBounds = this.$.overlay.getBoundingClientRect();
+          const maxLeft = overlayHostBounds.right - overlayHostBounds.left - width;
+          const maxTop = overlayHostBounds.bottom - overlayHostBounds.top - height;
+          left = Math.max(0, Math.min(left, maxLeft));
+          top = Math.max(0, Math.min(top, maxTop));
         }
 
         this.top = top;

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -685,6 +685,8 @@ describe('draggable', () => {
   });
 
   describe('keepInViewport', () => {
+    let overlayHostBounds;
+
     // Helper to drag to absolute coordinates within the viewport
     function dragTo(target, toX, toY) {
       const targetBounds = target.getBoundingClientRect();
@@ -700,6 +702,10 @@ describe('draggable', () => {
     }
 
     beforeEach(async () => {
+      // Re-enable inset on overlay host to verify that keepInViewport respects `--vaadin-overlay-viewport-inset`
+      const overlayHost = dialog.$.overlay;
+      overlayHost.style.inset = '10px';
+      overlayHostBounds = overlayHost.getBoundingClientRect();
       dialog.keepInViewport = true;
       await nextUpdate(dialog);
     });
@@ -709,7 +715,7 @@ describe('draggable', () => {
       await nextRender();
 
       const draggedBounds = container.getBoundingClientRect();
-      expect(Math.floor(draggedBounds.left)).to.be.closeTo(0, 1);
+      expect(Math.floor(draggedBounds.left)).to.be.closeTo(overlayHostBounds.left, 1);
     });
 
     it('should not drag dialog past top viewport edge', async () => {
@@ -717,7 +723,7 @@ describe('draggable', () => {
       await nextRender();
 
       const draggedBounds = container.getBoundingClientRect();
-      expect(Math.floor(draggedBounds.top)).to.closeTo(0, 1);
+      expect(Math.floor(draggedBounds.top)).to.closeTo(overlayHostBounds.top, 1);
     });
 
     it('should not drag dialog past right viewport edge', async () => {
@@ -725,7 +731,7 @@ describe('draggable', () => {
       await nextRender();
 
       const draggedBounds = container.getBoundingClientRect();
-      expect(Math.floor(draggedBounds.right)).to.closeTo(window.innerWidth, 1);
+      expect(Math.floor(draggedBounds.right)).to.closeTo(overlayHostBounds.right, 1);
     });
 
     it('should not drag dialog past bottom viewport edge', async () => {
@@ -733,7 +739,7 @@ describe('draggable', () => {
       await nextRender();
 
       const draggedBounds = container.getBoundingClientRect();
-      expect(Math.floor(draggedBounds.bottom)).to.closeTo(window.innerHeight, 1);
+      expect(Math.floor(draggedBounds.bottom)).to.closeTo(overlayHostBounds.bottom, 1);
     });
 
     it('should allow normal dragging within viewport', async () => {


### PR DESCRIPTION
## Description

Dialogs with centered positioning use `max-width: 100%`, which refers to the overlay host element. That element uses `--vaadin-overlay-viewport-inset` to offset itself from the viewport. Thus center positioned dialogs by default keep an offset from the viewport's edges. However, when dragging with `keepInViewport` enabled it currently does not respect this offset and instead allows dragging to the very edge of the viewport.

IMO it would be more consistent if this feature respects the inset as well. This would also make it easier to implement some follow up features like making the dialog adapt when the viewport size changes in a consistent manner.

Part of https://github.com/vaadin/flow-components/issues/8600

## Type of change

- Refactor