### PR TITLE
feat: `keepInViewport` enhancements (#11199) (CP: 24.10)

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.d.ts
@@ -70,4 +70,14 @@ export declare class DialogBaseMixinClass {
    * If a unitless number is provided, pixels are assumed.
    */
   height: string;
+
+  /**
+   * Set to true to prevent the dialog from moving outside the viewport bounds.
+   * When enabled, all four edges of the dialog will remain visible, for example
+   * when dragging the dialog or when the viewport is resized. Note that the
+   * dialog will also adjust any programmatically configured size and position
+   * so that it stays within the viewport.
+   * @attr {boolean} keep-in-viewport
+   */
+  keepInViewport: boolean;
 }

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -100,6 +100,21 @@ export const DialogBaseMixin = (superClass) =>
           type: String,
           value: 'dialog',
         },
+
+        /**
+         * Set to true to prevent the dialog from moving outside the viewport bounds.
+         * When enabled, all four edges of the dialog will remain visible, for example
+         * when dragging the dialog or when the viewport is resized. Note that the
+         * dialog will also adjust any programmatically configured size and position
+         * so that it stays within the viewport.
+         * @attr {boolean} keep-in-viewport
+         * @type {boolean}
+         */
+        keepInViewport: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+        },
       };
     }
 

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.d.ts
@@ -21,12 +21,4 @@ export declare class DialogDraggableMixinClass {
    * "`draggable-leaf-only`" class name.
    */
   draggable: boolean;
-
-  /**
-   * Set to true to prevent dragging the dialog outside the viewport bounds.
-   * When enabled, all four edges of the dialog will remain visible during dragging.
-   * The dialog may still become partially hidden when the viewport is resized.
-   * @attr {boolean} keep-in-viewport
-   */
-  keepInViewport: boolean;
 }

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -31,19 +31,6 @@ export const DialogDraggableMixin = (superClass) =>
           reflectToAttribute: true,
         },
 
-        /**
-         * Set to true to prevent dragging the dialog outside the viewport bounds.
-         * When enabled, all four edges of the dialog will remain visible during dragging.
-         * The dialog may still become partially hidden when the viewport is resized.
-         * @attr {boolean} keep-in-viewport
-         * @type {boolean}
-         */
-        keepInViewport: {
-          type: Boolean,
-          value: false,
-          reflectToAttribute: true,
-        },
-
         /** @private */
         _touchDevice: {
           type: Boolean,

--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.d.ts
@@ -35,6 +35,11 @@ export declare class DialogOverlayMixinClass {
   headerTitle: string;
 
   /**
+   * Whether to keep the overlay within the viewport.
+   */
+  keepInViewport: boolean;
+
+  /**
    * Custom function for rendering the dialog header.
    */
   headerRenderer: DialogRenderer | null | undefined;

--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.js
@@ -33,6 +33,14 @@ export const DialogOverlayMixin = (superClass) =>
         footerRenderer: {
           type: Object,
         },
+
+        /**
+         * Whether to keep the overlay within the viewport.
+         */
+        keepInViewport: {
+          type: Boolean,
+          reflectToAttribute: true,
+        },
       };
     }
 
@@ -40,6 +48,7 @@ export const DialogOverlayMixin = (superClass) =>
       return [
         '_headerFooterRendererChange(headerRenderer, footerRenderer, opened)',
         '_headerTitleChanged(headerTitle, opened)',
+        '__keepInViewportChanged(keepInViewport, opened)',
       ];
     }
 
@@ -50,6 +59,7 @@ export const DialogOverlayMixin = (superClass) =>
       // Update overflow attribute on resize
       this.__resizeObserver = new ResizeObserver(() => {
         this.__updateOverflow();
+        this.__adjustPosition();
       });
       this.__resizeObserver.observe(this.$.resizerContainer);
 
@@ -57,6 +67,8 @@ export const DialogOverlayMixin = (superClass) =>
       this.$.content.addEventListener('scroll', () => {
         this.__updateOverflow();
       });
+
+      this.__handleWindowResize = this.__handleWindowResize.bind(this);
     }
 
     /** @private */
@@ -214,6 +226,8 @@ export const DialogOverlayMixin = (superClass) =>
       });
 
       Object.assign(overlay.style, parsedBounds);
+
+      this.__adjustPosition();
     }
 
     /**
@@ -253,6 +267,56 @@ export const DialogOverlayMixin = (superClass) =>
         this.setAttribute('overflow', value);
       } else if (value.length === 0 && this.hasAttribute('overflow')) {
         this.removeAttribute('overflow');
+      }
+    }
+
+    /** @private */
+    __keepInViewportChanged(keepInViewport, opened) {
+      if (opened && keepInViewport) {
+        window.addEventListener('resize', this.__handleWindowResize);
+      } else {
+        window.removeEventListener('resize', this.__handleWindowResize);
+      }
+    }
+
+    /** @private */
+    __handleWindowResize() {
+      this.__adjustPosition();
+    }
+
+    /**
+     * Adjusts the position of the overlay to keep it within the viewport if `keepInViewport` is true.
+     * @private
+     */
+    __adjustPosition() {
+      if (!this.opened || !this.keepInViewport) {
+        return;
+      }
+
+      // Centered dialogs do not use absolute positioning and automatically adjust their position / size to fit the viewport
+      const style = getComputedStyle(this.$.overlay);
+      if (style.position !== 'absolute') {
+        return;
+      }
+
+      const overlayHostBounds = this.getBoundingClientRect();
+      const bounds = this.getBounds();
+      // Prefer dimensions from getComputedStyle, as bounding rect is affected
+      // by scale transform applied by opening animation in Lumo
+      const width = parseFloat(style.width) || bounds.width;
+      const height = parseFloat(style.height) || bounds.height;
+
+      const maxLeft = overlayHostBounds.right - overlayHostBounds.left - width;
+      const maxTop = overlayHostBounds.bottom - overlayHostBounds.top - height;
+
+      if (bounds.left > maxLeft || bounds.top > maxTop) {
+        const left = Math.max(0, Math.min(bounds.left, maxLeft));
+        const top = Math.max(0, Math.min(bounds.top, maxTop));
+
+        Object.assign(this.$.overlay.style, {
+          left: `${left}px`,
+          top: `${top}px`,
+        });
       }
     }
   };

--- a/packages/dialog/src/vaadin-dialog-styles.js
+++ b/packages/dialog/src/vaadin-dialog-styles.js
@@ -74,7 +74,7 @@ export const dialogOverlay = css`
     min-width: 12em; /* matches the default <vaadin-text-field> width */
   }
 
-  :host([has-bounds-set]) [part='overlay'] {
+  :host([has-bounds-set]:not([keep-in-viewport])) [part='overlay'] {
     max-width: none;
   }
 

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -115,6 +115,7 @@ class Dialog extends DialogDraggableMixin(
         with-backdrop="[[!modeless]]"
         resizable$="[[resizable]]"
         draggable$="[[draggable]]"
+        keep-in-viewport="[[keepInViewport]]"
         restore-focus-on-close
         focus-trap
       ></vaadin-dialog-overlay>

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -1,5 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, click, esc, fixtureSync, listenOnce, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { setViewport } from '@vaadin/test-runner-commands';
+import {
+  aTimeout,
+  click,
+  esc,
+  fixtureSync,
+  listenOnce,
+  nextFrame,
+  nextRender,
+  nextUpdate,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-dialog.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -371,6 +381,214 @@ describe('vaadin-dialog', () => {
       await nextRender();
 
       expect(getComputedStyle(overlay.$.overlay).height).to.equal(originalHeight);
+    });
+  });
+
+  describe('keepInViewport', () => {
+    let dialog, overlayHost, overlay;
+    let windowWidth, windowHeight;
+
+    before(() => {
+      windowWidth = window.innerWidth;
+      windowHeight = window.innerHeight;
+    });
+
+    beforeEach(async () => {
+      await setViewport({ width: 1000, height: 800 });
+
+      dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+      dialog.width = 400;
+      dialog.height = 300;
+      dialog.keepInViewport = true;
+      await nextRender();
+      overlayHost = dialog.$.overlay;
+      overlay = dialog.$.overlay.$.overlay;
+    });
+
+    afterEach(async () => {
+      dialog.opened = false;
+      await nextRender();
+    });
+
+    after(async () => {
+      await setViewport({ width: windowWidth, height: windowHeight });
+    });
+
+    it('should reflect keepInViewport attribute', async () => {
+      expect(dialog.hasAttribute('keep-in-viewport')).to.be.true;
+      dialog.keepInViewport = false;
+      await nextUpdate(dialog);
+      expect(dialog.hasAttribute('keep-in-viewport')).to.be.false;
+    });
+
+    it('should forward keep-in-viewport attribute to overlay', async () => {
+      expect(overlayHost.hasAttribute('keep-in-viewport')).to.be.true;
+      dialog.keepInViewport = false;
+      await nextUpdate(dialog);
+      expect(overlayHost.hasAttribute('keep-in-viewport')).to.be.false;
+    });
+
+    it('should constrain dialog width to viewport when has-bounds-set is applied', async () => {
+      // `has-bounds-set` is applied when the dialog is resized by the user, which removes the max-width constraint
+      overlayHost.setAttribute('has-bounds-set', '');
+      dialog.width = 1200;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      const overlayWidth = overlay.getBoundingClientRect().width;
+      expect(overlayWidth).to.be.at.most(window.innerWidth);
+    });
+
+    it('should constrain dialog height to viewport', async () => {
+      dialog.height = 1000;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      const overlayHeight = overlay.getBoundingClientRect().height;
+      expect(overlayHeight).to.be.at.most(window.innerHeight);
+    });
+
+    it('should adjust dialog to the left when it is opened', async () => {
+      dialog.left = 700;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.right).to.be.at.most(hostBounds.right);
+    });
+
+    it('should adjust dialog to the top when it is opened', async () => {
+      dialog.top = 600;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.bottom).to.be.at.most(hostBounds.bottom);
+    });
+
+    it('should adjust dialog position to the left when dialog is resized programmatically', async () => {
+      dialog.left = 400;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      dialog.width = 700;
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.right).to.be.at.most(hostBounds.right);
+    });
+
+    it('should adjust dialog position to the top when dialog is resized programmatically', async () => {
+      dialog.top = 400;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      dialog.height = 700;
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.bottom).to.be.at.most(hostBounds.bottom);
+    });
+
+    it('should adjust dialog position to the left when dialog is moved programmatically', async () => {
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      dialog.left = 800;
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.right).to.be.at.most(hostBounds.right);
+    });
+
+    it('should adjust dialog position to the top when dialog is moved programmatically', async () => {
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      dialog.top = 700;
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.bottom).to.be.at.most(hostBounds.bottom);
+    });
+
+    it('should adjust dialog position to the left when window is resized', async () => {
+      dialog.left = 400;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      await setViewport({ width: 600, height: 600 });
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.right).to.be.at.most(hostBounds.right);
+    });
+
+    it('should adjust dialog position to the top when window is resized', async () => {
+      dialog.top = 400;
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      await setViewport({ width: 600, height: 600 });
+      await nextRender();
+      await nextFrame();
+
+      const hostBounds = overlayHost.getBoundingClientRect();
+      const overlayBounds = overlay.getBoundingClientRect();
+
+      expect(overlayBounds.bottom).to.be.at.most(hostBounds.bottom);
+    });
+
+    it('should not adjust position when dialog is center positioned and window is resized', async () => {
+      dialog.opened = true;
+      await nextRender();
+      await nextFrame();
+
+      const initialOverlayBounds = overlay.getBoundingClientRect();
+      let overlayPosition = getComputedStyle(overlay).position;
+
+      // Sanity check: it's a centered dialog
+      expect(overlayPosition).not.to.equal('absolute');
+
+      await setViewport({ width: 600, height: 600 });
+      await nextRender();
+      await nextFrame();
+
+      const overlayBounds = overlay.getBoundingClientRect();
+      overlayPosition = getComputedStyle(overlay).position;
+
+      // Still a centered dialog, adjusts position to the left to stay centered
+      expect(overlayPosition).not.to.equal('absolute');
+      expect(overlayBounds.left).to.be.lessThan(initialOverlayBounds.left);
     });
   });
 });

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -737,13 +737,6 @@ describe('draggable', () => {
       const draggedBounds = container.getBoundingClientRect();
       expect(Math.floor(draggedBounds.left)).to.lessThan(0);
     });
-
-    it('should reflect keepInViewport attribute', async () => {
-      expect(dialog.hasAttribute('keep-in-viewport')).to.be.true;
-      dialog.keepInViewport = false;
-      await nextUpdate(dialog);
-      expect(dialog.hasAttribute('keep-in-viewport')).to.be.false;
-    });
   });
 });
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #11199 to branch 24.10.

---

> ## Description
> 
> Enhances the dialog `keepInViewport` behavior to also keep the dialog fully visible within the viewport in these scenarios:
> 
> - User resizes viewport while dialog is opened
> - User resizes viewport before dialog is opened
> - Application sets position / size while dialog is opened
> - Application sets position / size before dialog is opened
> 
> Part of https://github.com/vaadin/flow-components/issues/8600
> 
> ## Type of change
> 
> - Feature