### PR TITLE
test: add DOM snapshot tests for card component

### DIFF
--- a/packages/card/test/dom/__snapshots__/card.test.snap.js
+++ b/packages/card/test/dom/__snapshots__/card.test.snap.js
@@ -1,0 +1,180 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-card host default"] = 
+`<vaadin-card role="region">
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host default */
+
+snapshots["vaadin-card host card-title"] = 
+`<vaadin-card
+  _t=""
+  aria-labelledby="card-title-0"
+  role="region"
+>
+  <div
+    aria-level="2"
+    card-string-title=""
+    id="card-title-0"
+    role="heading"
+    slot="title"
+  >
+    Title
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host card-title */
+
+snapshots["vaadin-card host media"] = 
+`<vaadin-card
+  _m=""
+  role="region"
+>
+  <img slot="media">
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host media */
+
+snapshots["vaadin-card host header"] = 
+`<vaadin-card
+  _h=""
+  role="region"
+>
+  <div slot="header">
+    Header
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host header */
+
+snapshots["vaadin-card host title"] = 
+`<vaadin-card
+  _t=""
+  role="region"
+>
+  <div slot="title">
+    Title
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host title */
+
+snapshots["vaadin-card host subtitle"] = 
+`<vaadin-card
+  _st=""
+  role="region"
+>
+  <div slot="subtitle">
+    Subtitle
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host subtitle */
+
+snapshots["vaadin-card host title and header"] = 
+`<vaadin-card
+  _h=""
+  role="region"
+>
+  <div slot="title">
+    Title
+  </div>
+  <div slot="header">
+    Header
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host title and header */
+
+snapshots["vaadin-card host subtitle and header"] = 
+`<vaadin-card
+  _h=""
+  role="region"
+>
+  <div slot="subtitle">
+    Subtitle
+  </div>
+  <div slot="header">
+    Header
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host subtitle and header */
+
+snapshots["vaadin-card host header-prefix"] = 
+`<vaadin-card
+  _hp=""
+  role="region"
+>
+  <div slot="header-prefix">
+    Prefix
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host header-prefix */
+
+snapshots["vaadin-card host header-suffix"] = 
+`<vaadin-card
+  _hs=""
+  role="region"
+>
+  <div slot="header-suffix">
+    Suffix
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host header-suffix */
+
+snapshots["vaadin-card host content"] = 
+`<vaadin-card
+  _c=""
+  role="region"
+>
+  <div>
+    Content
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host content */
+
+snapshots["vaadin-card host footer"] = 
+`<vaadin-card
+  _f=""
+  role="region"
+>
+  <div slot="footer">
+    Footer
+  </div>
+</vaadin-card>
+`;
+/* end snapshot vaadin-card host footer */
+
+snapshots["vaadin-card shadow default"] = 
+`<div part="media">
+  <slot name="media">
+  </slot>
+</div>
+<div part="header">
+  <slot name="header-prefix">
+  </slot>
+  <slot name="header">
+    <slot name="title">
+    </slot>
+    <slot name="subtitle">
+    </slot>
+  </slot>
+  <slot name="header-suffix">
+  </slot>
+</div>
+<div part="content">
+  <slot>
+  </slot>
+</div>
+<div part="footer">
+  <slot name="footer">
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-card shadow default */
+

--- a/packages/card/test/dom/card.test.ts
+++ b/packages/card/test/dom/card.test.ts
@@ -1,0 +1,127 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
+import '../../src/vaadin-card.js';
+import type { Card } from '../../src/vaadin-card.js';
+
+describe('vaadin-card', () => {
+  let card: Card;
+
+  beforeEach(async () => {
+    card = fixtureSync('<vaadin-card></vaadin-card>');
+    await nextUpdate(card);
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('card-title', async () => {
+      card.cardTitle = 'Title';
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('media', async () => {
+      const img = document.createElement('img');
+      img.setAttribute('slot', 'media');
+      card.appendChild(img);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('header', async () => {
+      const header = document.createElement('div');
+      header.setAttribute('slot', 'header');
+      header.textContent = 'Header';
+      card.appendChild(header);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('title', async () => {
+      const title = document.createElement('div');
+      title.setAttribute('slot', 'title');
+      title.textContent = 'Title';
+      card.appendChild(title);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('subtitle', async () => {
+      const subtitle = document.createElement('div');
+      subtitle.setAttribute('slot', 'subtitle');
+      subtitle.textContent = 'Subtitle';
+      card.appendChild(subtitle);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('title and header', async () => {
+      const title = document.createElement('div');
+      title.setAttribute('slot', 'title');
+      title.textContent = 'Title';
+      card.appendChild(title);
+      const header = document.createElement('div');
+      header.setAttribute('slot', 'header');
+      header.textContent = 'Header';
+      card.appendChild(header);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('subtitle and header', async () => {
+      const subtitle = document.createElement('div');
+      subtitle.setAttribute('slot', 'subtitle');
+      subtitle.textContent = 'Subtitle';
+      card.appendChild(subtitle);
+      const header = document.createElement('div');
+      header.setAttribute('slot', 'header');
+      header.textContent = 'Header';
+      card.appendChild(header);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('header-prefix', async () => {
+      const prefix = document.createElement('div');
+      prefix.setAttribute('slot', 'header-prefix');
+      prefix.textContent = 'Prefix';
+      card.appendChild(prefix);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('header-suffix', async () => {
+      const suffix = document.createElement('div');
+      suffix.setAttribute('slot', 'header-suffix');
+      suffix.textContent = 'Suffix';
+      card.appendChild(suffix);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('content', async () => {
+      const content = document.createElement('div');
+      content.textContent = 'Content';
+      card.appendChild(content);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+
+    it('footer', async () => {
+      const footer = document.createElement('div');
+      footer.setAttribute('slot', 'footer');
+      footer.textContent = 'Footer';
+      card.appendChild(footer);
+      await nextUpdate(card);
+      await expect(card).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(card).shadowDom.to.equalSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add DOM snapshot tests for the card component
- Include snapshot file with expected DOM structure

## Test plan
- [x] `yarn test:snapshots --group card` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)