### PR TITLE
fix: do not set radius on the content if title is provided

### DIFF
--- a/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
+++ b/packages/dialog/src/styles/vaadin-dialog-overlay-base-styles.js
@@ -141,7 +141,7 @@ const dialogResizableOverlay = css`
   }
 
   [part='header'],
-  :host(:not([has-title]):not([has-header])) [part='content'] {
+  :host(:not([has-title], [has-header])) [part='content'] {
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
   }


### PR DESCRIPTION
## Description

Fixes a problem where content of a dialog with title gets unexpected radius, see https://github.com/vaadin/docs/pull/5239#discussion_r2858752087.

## Type of change

- Bugfix