### PR TITLE
fix: allow pinch-zoom on grid by resetting touch-action (CP: 24.10)

### DIFF
--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -8,7 +8,7 @@ snapshots["vaadin-crud host default"] =
   </h3>
   <vaadin-crud-grid
     slot="grid"
-    style="touch-action: none;"
+    style=""
   >
     <vaadin-grid-column-group>
       <vaadin-grid-column>

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -64,7 +64,23 @@ export const ColumnReorderingMixin = (superClass) =>
     }
 
     /** @private */
+    _cancelReorderForMultiTouch(e) {
+      if (e.touches.length > 1) {
+        clearTimeout(this._startTouchReorderTimeout);
+        if (this._draggedColumn) {
+          this._onTrackEnd();
+        }
+        return true;
+      }
+      return false;
+    }
+
+    /** @private */
     _onTouchStart(e) {
+      if (this._cancelReorderForMultiTouch(e)) {
+        return;
+      }
+
       // Touch event, delay activation by 100ms
       this._startTouchReorderTimeout = setTimeout(() => {
         this._onTrackStart({
@@ -78,6 +94,10 @@ export const ColumnReorderingMixin = (superClass) =>
 
     /** @private */
     _onTouchMove(e) {
+      if (this._cancelReorderForMultiTouch(e)) {
+        return;
+      }
+
       if (this._draggedColumn) {
         e.preventDefault();
       }

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -16,8 +16,23 @@ export const ColumnResizingMixin = (superClass) =>
       const scroller = this.$.scroller;
       addListener(scroller, 'track', this._onHeaderTrack.bind(this));
 
-      // Disallow scrolling while resizing
-      scroller.addEventListener('touchmove', (e) => scroller.hasAttribute('column-resizing') && e.preventDefault());
+      // Cancel resizing on multi-touch (e.g. pinch-zoom)
+      scroller.addEventListener('touchstart', (e) => {
+        if (e.touches.length > 1) {
+          scroller.removeAttribute('column-resizing');
+        }
+      });
+
+      // Disallow scrolling while resizing, but allow multi-touch gestures
+      scroller.addEventListener('touchmove', (e) => {
+        if (e.touches.length > 1) {
+          scroller.removeAttribute('column-resizing');
+          return;
+        }
+        if (scroller.hasAttribute('column-resizing')) {
+          e.preventDefault();
+        }
+      });
 
       // Disable contextmenu on any resize separator.
       scroller.addEventListener(
@@ -36,6 +51,11 @@ export const ColumnResizingMixin = (superClass) =>
     _onHeaderTrack(e) {
       const handle = e.target;
       if (handle.getAttribute('part') === 'resize-handle') {
+        // Ignore track events after multi-touch cancelled resizing
+        if (e.detail.state !== 'start' && !this.$.scroller.hasAttribute('column-resizing')) {
+          return;
+        }
+
         const cell = handle.parentElement;
         let column = cell._column;
 

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -16,6 +16,7 @@ import {
 } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
+import { setTouchAction } from '@vaadin/component-base/src/gestures.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { processTemplates } from '@vaadin/component-base/src/templates.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -257,6 +258,9 @@ export const GridMixin = (superClass) =>
     /** @protected */
     ready() {
       super.ready();
+
+      setTouchAction(this, '');
+      setTouchAction(this.$.scroller, '');
 
       this.__virtualizer = new Virtualizer({
         createElements: this._createScrollerRows.bind(this),

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2025 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { addListener } from '@vaadin/component-base/src/gestures.js';
+import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures.js';
 
 /**
  * A mixin that provides basic functionality for the
@@ -118,6 +118,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       this.__onCellMouseDown = this.__onCellMouseDown.bind(this);
       this.__onGridInteraction = this.__onGridInteraction.bind(this);
       this.__onActiveItemChanged = this.__onActiveItemChanged.bind(this);
+      this.__onTouchStart = this.__onTouchStart.bind(this);
       this.__onSelectRowCheckboxChange = this.__onSelectRowCheckboxChange.bind(this);
       this.__onSelectAllCheckboxChange = this.__onSelectAllCheckboxChange.bind(this);
     }
@@ -130,6 +131,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         this._grid.addEventListener('keydown', this.__onGridInteraction, { capture: true });
         this._grid.addEventListener('mousedown', this.__onGridInteraction);
         this._grid.addEventListener('active-item-changed', this.__onActiveItemChanged);
+        this._grid.addEventListener('touchstart', this.__onTouchStart);
       }
     }
 
@@ -141,6 +143,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         this._grid.removeEventListener('keydown', this.__onGridInteraction, { capture: true });
         this._grid.removeEventListener('mousedown', this.__onGridInteraction);
         this._grid.removeEventListener('active-item-changed', this.__onActiveItemChanged);
+        this._grid.removeEventListener('touchstart', this.__onTouchStart);
       }
     }
 
@@ -178,6 +181,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         checkbox.addEventListener('change', this.__onSelectRowCheckboxChange);
         root.appendChild(checkbox);
         addListener(root, 'track', this.__onCellTrack);
+        setTouchAction(root, 'pinch-zoom');
         root.addEventListener('mousedown', this.__onCellMouseDown);
         root.addEventListener('click', this.__onCellClick);
       }
@@ -234,6 +238,10 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       this.__dragCurrentY = event.detail.y;
       this.__dragDy = event.detail.dy;
       if (event.detail.state === 'start') {
+        // Don't start drag-select during multi-touch (e.g. pinch-zoom)
+        if (this.__multiTouchActive) {
+          return;
+        }
         const renderedRows = this._grid._getRenderedRows();
         // Get the row where the drag started
         const dragStartRow = renderedRows.find((row) => row.contains(event.currentTarget.assignedSlot));
@@ -263,6 +271,18 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       if (this.dragSelect) {
         // Prevent text selection when starting to drag
         e.preventDefault();
+      }
+    }
+
+    /** @private */
+    __onTouchStart(e) {
+      if (e.touches.length > 1) {
+        this.__multiTouchActive = true;
+        // Cancel in-progress drag-select on multi-touch (e.g. pinch-zoom)
+        this.__dragStartIndex = undefined;
+        this.__dragStartItem = undefined;
+      } else {
+        this.__multiTouchActive = false;
       }
     }
 

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -13,6 +13,7 @@ import {
   getRowCells,
   getRows,
   infiniteDataProvider,
+  makeMultiTouchEvent,
   makeSoloTouchEvent,
 } from './helpers.js';
 
@@ -227,6 +228,68 @@ describe('reordering simple grid', () => {
       makeSoloTouchEvent('touchstart', { x: rect.left, y: rect.top }, headerContent[0]);
       makeSoloTouchEvent('touchend', { x: 0, y: 0 }, headerContent[0]);
       clock.tick(500);
+      expect(grid.hasAttribute('reordering')).to.be.false;
+    });
+  });
+
+  describe('multi-touch', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should not start reordering on multi-touch touchstart', () => {
+      const rect = headerContent[0].getBoundingClientRect();
+      makeMultiTouchEvent(
+        'touchstart',
+        [
+          { x: rect.left, y: rect.top },
+          { x: rect.left + 100, y: rect.top + 100 },
+        ],
+        headerContent[0],
+      );
+      clock.tick(500);
+      expect(grid.hasAttribute('reordering')).to.be.false;
+    });
+
+    it('should cancel pending reorder when second finger arrives', () => {
+      const rect = headerContent[0].getBoundingClientRect();
+      // First finger starts
+      makeSoloTouchEvent('touchstart', { x: rect.left, y: rect.top }, headerContent[0]);
+      // Second finger arrives before 100ms timeout
+      makeMultiTouchEvent(
+        'touchstart',
+        [
+          { x: rect.left, y: rect.top },
+          { x: rect.left + 100, y: rect.top + 100 },
+        ],
+        headerContent[0],
+      );
+      clock.tick(500);
+      expect(grid.hasAttribute('reordering')).to.be.false;
+    });
+
+    it('should cancel active reorder when multi-touch move detected', () => {
+      const rect = headerContent[0].getBoundingClientRect();
+      // Start reorder via touch
+      makeSoloTouchEvent('touchstart', { x: rect.left, y: rect.top }, headerContent[0]);
+      clock.tick(500);
+      expect(grid.hasAttribute('reordering')).to.be.true;
+
+      // Multi-touch move cancels the reorder
+      makeMultiTouchEvent(
+        'touchmove',
+        [
+          { x: rect.left + 10, y: rect.top },
+          { x: rect.left + 110, y: rect.top + 100 },
+        ],
+        headerContent[0],
+      );
       expect(grid.hasAttribute('reordering')).to.be.false;
     });
   });

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -10,6 +10,7 @@ import {
   getRowCells,
   getRows,
   infiniteDataProvider,
+  makeMultiTouchEvent,
 } from './helpers.js';
 
 function getElementFromPoint(context, x, y) {
@@ -224,6 +225,66 @@ describe('column resizing', () => {
     const event = new CustomEvent('mousedown', { bubbles: true, cancelable: true, composed: true });
     headerCells[0].dispatchEvent(event);
     expect(event.defaultPrevented).to.be.false;
+  });
+
+  describe('multi-touch during resize', () => {
+    it('should cancel resizing when second finger touches during resize', () => {
+      fire('track', { state: 'start' }, { node: handle });
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.true;
+
+      const rect = headerCells[0].getBoundingClientRect();
+      makeMultiTouchEvent(
+        'touchstart',
+        [
+          { x: rect.left, y: rect.top },
+          { x: rect.left + 100, y: rect.top + 100 },
+        ],
+        grid.$.scroller,
+      );
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.false;
+    });
+
+    it('should cancel resizing when multi-touch move detected during resize', () => {
+      fire('track', { state: 'start' }, { node: handle });
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.true;
+
+      const rect = headerCells[0].getBoundingClientRect();
+      makeMultiTouchEvent(
+        'touchmove',
+        [
+          { x: rect.left + 10, y: rect.top },
+          { x: rect.left + 110, y: rect.top + 100 },
+        ],
+        grid.$.scroller,
+      );
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.false;
+    });
+
+    it('should ignore track events after multi-touch cancellation', () => {
+      const options = { node: handle };
+      const rect = headerCells[0].getBoundingClientRect();
+
+      // Start resize
+      fire('track', { state: 'start' }, options);
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.true;
+      const widthAfterStart = headerCells[0].offsetWidth;
+
+      // Multi-touch cancels resize
+      makeMultiTouchEvent(
+        'touchstart',
+        [
+          { x: rect.left, y: rect.top },
+          { x: rect.left + 100, y: rect.top + 100 },
+        ],
+        grid.$.scroller,
+      );
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.false;
+
+      // Subsequent track event should be ignored (no column-resizing attribute re-set)
+      fire('track', { state: 'track', x: rect.left + 200, y: 0 }, options);
+      expect(grid.$.scroller.hasAttribute('column-resizing')).to.be.false;
+      expect(headerCells[0].offsetWidth).to.equal(widthAfterStart);
+    });
   });
 });
 

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-grid host default"] = 
-`<vaadin-grid style="touch-action: none;">
+`<vaadin-grid style="">
   <vaadin-grid-column path="name.first">
   </vaadin-grid-column>
   <vaadin-grid-column path="name.last">
@@ -40,7 +40,7 @@ snapshots["vaadin-grid host default"] =
 snapshots["vaadin-grid shadow default"] = 
 `<div
   id="scroller"
-  style="touch-action: none;"
+  style=""
 >
   <table
     aria-colcount="2"
@@ -264,7 +264,7 @@ snapshots["vaadin-grid shadow default"] =
 snapshots["vaadin-grid shadow selected"] = 
 `<div
   id="scroller"
-  style="touch-action: none;"
+  style=""
 >
   <table
     aria-colcount="2"
@@ -489,7 +489,7 @@ snapshots["vaadin-grid shadow selected"] =
 snapshots["vaadin-grid shadow details opened"] = 
 `<div
   id="scroller"
-  style="touch-action: none;"
+  style=""
 >
   <table
     aria-colcount="2"
@@ -714,7 +714,7 @@ snapshots["vaadin-grid shadow hidden column"] =
 `<div
   id="scroller"
   scrolling=""
-  style="touch-action: none;"
+  style=""
 >
   <table
     aria-colcount="2"
@@ -887,7 +887,7 @@ snapshots["vaadin-grid shadow hidden column selected"] =
 `<div
   id="scroller"
   scrolling=""
-  style="touch-action: none;"
+  style=""
 >
   <table
     aria-colcount="2"

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -273,6 +273,26 @@ export const makeSoloTouchEvent = (type, xy, node) => {
   return event;
 };
 
+export const makeMultiTouchEvent = (type, touchPoints, node) => {
+  const touches = touchPoints.map((point, index) => ({
+    identifier: index,
+    target: node,
+    clientX: point.x,
+    clientY: point.y,
+  }));
+  const touchEventInit = {
+    touches,
+    targetTouches: touches,
+    changedTouches: [touches[touches.length - 1]],
+  };
+  const event = new CustomEvent(type, { bubbles: true, cancelable: true });
+  Object.entries(touchEventInit).forEach(([key, value]) => {
+    event[key] = value;
+  });
+  node.dispatchEvent(event);
+  return event;
+};
+
 /**
  * Resolves once the function is invoked on the given object.
  */

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -15,6 +15,8 @@ import {
   getRowCells,
   getRows,
   infiniteDataProvider,
+  makeMultiTouchEvent,
+  makeSoloTouchEvent,
 } from './helpers.js';
 
 describe('selection', () => {
@@ -927,6 +929,115 @@ describe('multi selection column', () => {
       clock.tick(10);
 
       expect(grid.$.table.scrollTop).to.be.eq(prevScrollTop);
+    });
+
+    describe('multi-touch', () => {
+      it('should cancel drag-select when second finger touches during drag', () => {
+        const row0cell = getBodyCellContent(grid, 0, 0);
+        const row1cell = getBodyCellContent(grid, 1, 0);
+        const row2cell = getBodyCellContent(grid, 2, 0);
+        const row3cell = getBodyCellContent(grid, 3, 0);
+
+        // Start drag-select on row 0
+        fireTrackEvent(row0cell, row0cell, 'start');
+        clock.tick(10);
+
+        // Drag to row 1 to trigger selection
+        fireTrackEvent(row1cell, row0cell, 'track');
+        clock.tick(10);
+
+        // Rows 0-1 should be selected
+        expect(grid.selectedItems).to.include(grid.items[0]);
+        expect(grid.selectedItems).to.include(grid.items[1]);
+
+        // Second finger arrives (pinch-zoom gesture)
+        const rect = row2cell.getBoundingClientRect();
+        makeMultiTouchEvent(
+          'touchstart',
+          [
+            { x: rect.left, y: rect.top },
+            { x: rect.left + 100, y: rect.top + 100 },
+          ],
+          grid,
+        );
+
+        // Continue dragging to row 3
+        fireTrackEvent(row3cell, row0cell, 'track');
+        clock.tick(10);
+
+        // Row 3 should not be selected since drag was cancelled
+        expect(grid.selectedItems).to.not.include(grid.items[3]);
+      });
+
+      it('should not start drag-select when both fingers touch before drag starts', () => {
+        const row0cell = getBodyCellContent(grid, 0, 0);
+        const row1cell = getBodyCellContent(grid, 1, 0);
+        const row2cell = getBodyCellContent(grid, 2, 0);
+
+        // Both fingers arrive before any movement (simulating pinch-zoom start)
+        const rect = row0cell.getBoundingClientRect();
+        makeMultiTouchEvent(
+          'touchstart',
+          [
+            { x: rect.left, y: rect.top },
+            { x: rect.left + 100, y: rect.top + 100 },
+          ],
+          grid,
+        );
+
+        // Track gesture fires after 5px movement threshold
+        fireTrackEvent(row1cell, row0cell, 'start');
+        fireTrackEvent(row2cell, row0cell, 'track');
+        clock.tick(10);
+
+        // No rows should be selected
+        expect(grid.selectedItems).to.be.empty;
+      });
+
+      it('should not start drag-select when second finger arrives before drag starts', () => {
+        const row0cell = getBodyCellContent(grid, 0, 0);
+        const row1cell = getBodyCellContent(grid, 1, 0);
+        const row2cell = getBodyCellContent(grid, 2, 0);
+
+        // First finger touches
+        const rect = row0cell.getBoundingClientRect();
+        makeSoloTouchEvent('touchstart', { x: rect.left, y: rect.top }, grid);
+
+        // Second finger arrives (pinch gesture)
+        makeMultiTouchEvent(
+          'touchstart',
+          [
+            { x: rect.left, y: rect.top },
+            { x: rect.left + 100, y: rect.top + 100 },
+          ],
+          grid,
+        );
+
+        // Track gesture fires after 5px movement threshold
+        fireTrackEvent(row1cell, row0cell, 'start');
+        fireTrackEvent(row2cell, row0cell, 'track');
+        clock.tick(10);
+
+        // No rows should be selected
+        expect(grid.selectedItems).to.be.empty;
+      });
+
+      it('should not cancel drag-select on single touch', () => {
+        const row0cell = getBodyCellContent(grid, 0, 0);
+        const row1cell = getBodyCellContent(grid, 1, 0);
+
+        // Start drag-select
+        fireTrackEvent(row0cell, row0cell, 'start');
+        clock.tick(10);
+
+        // Drag to row 1
+        fireTrackEvent(row1cell, row0cell, 'track');
+        clock.tick(10);
+
+        // Both rows should be selected
+        expect(grid.selectedItems).to.include(grid.items[0]);
+        expect(grid.selectedItems).to.include(grid.items[1]);
+      });
     });
   });
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #11197 to branch 24.10.

---

> ## Summary
> 
> Fixes #11138
> 
> - Override the `touch-action: none` inline style set by Polymer gesture system's `track` recognizer on the grid host and scroller elements by calling `setTouchAction(this, '')` and `setTouchAction(this.$.scroller, '')` in `ready()`
> - Add unit tests to prevent regression (`touch-action` should not be `none` on host or scroller)
> - Update DOM snapshots to reflect the corrected style
> 
> ## Test plan
> 
> - [x] `yarn test:snapshots --group grid` — all 10 snapshot tests pass
> - [x] Verified new tests fail when the fix is removed (`expected 'none' to not equal 'none'`)
> - [ ] **Manual testing is advised** to verify pinch-zoom works correctly on affected devices (Windows Edge tablets, Android Chrome) since the touch interaction cannot be fully simulated in automated tests
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)