### PR TITLE
fix: use padding shorthand in Aura upload file custom property (#11226)

### DIFF
--- a/packages/aura/src/components/upload.css
+++ b/packages/aura/src/components/upload.css
@@ -9,7 +9,7 @@
   --vaadin-upload-file-warning-color: var(--aura-red);
   --vaadin-upload-file-done-color: var(--aura-green);
   --vaadin-upload-file-name-font-weight: var(--aura-font-weight-medium);
-  --vaadin-upload-file-padding: var(--vaadin-padding-s);
+  --vaadin-upload-file-padding: var(--vaadin-padding-m) var(--vaadin-padding-s);
   --vaadin-upload-file-gap: 0 var(--vaadin-gap-s);
   --vaadin-upload-file-button-border-width: 0;
   --vaadin-upload-file-status-font-size: var(--aura-font-size-s);
@@ -63,7 +63,6 @@ vaadin-upload:not([theme~='no-border']) > vaadin-upload-file-list:has(> ul > li)
 vaadin-upload-file {
   --vaadin-icon-visual-size: 0.75lh;
   border-radius: var(--vaadin-radius-m);
-  padding-block: var(--vaadin-padding-m);
   margin-inline: calc(var(--_divider-offset-start, 0) * -1) calc(var(--_divider-offset-end, 0) * -1);
 
   &:not([error])::part(done-icon) {


### PR DESCRIPTION
## Summary
- Backport of #11226 to the `25.0` branch
- Sets `--vaadin-upload-file-padding` to `var(--vaadin-padding-m) var(--vaadin-padding-s)` (shorthand with both block and inline values)
- Removes the now-redundant `padding-block: var(--vaadin-padding-m)` override from `vaadin-upload-file`

## Test plan
- [x] Aura visual tests for upload pass (6/6, no screenshot diffs)
- [x] Upload unit tests pass (162/162)

🤖 Generated with [Claude Code](https://claude.com/claude-code)