### PR TITLE
test: try to stabilize thumbnails tests, extract common helpers

### DIFF
--- a/packages/upload/test/visual/aura/upload-file-list-thumbnails.test.js
+++ b/packages/upload/test/visual/aura/upload-file-list-thumbnails.test.js
@@ -1,58 +1,41 @@
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/aura/aura.css';
 import '../../../vaadin-upload-file-list.js';
+import { freezeLoaderAnimation, waitForRendered } from '../common.js';
 
 // Enable the feature flag so the theme propagates to upload-file children
 window.Vaadin ??= {};
 window.Vaadin.featureFlags ??= {};
 window.Vaadin.featureFlags.modularUpload = true;
 
-/**
- * Wait for the file list to render its children and for the children
- * to complete their Lit update cycle and receive external theme styles.
- */
-async function waitForRendered() {
-  await nextFrame();
-  await nextFrame();
-}
-
-/**
- * Freeze the loader animation on all upload-file elements inside the given element
- * so that visual diff screenshots are deterministic.
- */
-function freezeLoaderAnimation(container) {
-  container.querySelectorAll('vaadin-upload-file').forEach((file) => {
-    const style = document.createElement('style');
-    style.textContent = '[part="loader"] { animation: none !important; opacity: 1 !important; }';
-    file.shadowRoot.appendChild(style);
-  });
-}
-
 describe('upload-file-list-thumbnails', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.padding = '10px';
     div.style.width = '500px';
+    element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
+    await nextRender();
   });
 
   describe('states', () => {
-    beforeEach(async () => {
-      element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
+    it('complete', async () => {
       element.items = [
         { name: 'image.png', progress: 100, complete: true },
         { name: 'document.pdf', progress: 100, complete: true },
       ];
       await waitForRendered();
-    });
-
-    it('complete', async () => {
       await visualDiff(div, 'complete');
     });
 
     it('complete-thumbnail', async () => {
+      element.items = [
+        { name: 'image.png', progress: 100, complete: true },
+        { name: 'document.pdf', progress: 100, complete: true },
+      ];
+      await waitForRendered();
       // Simulate a thumbnail on the first file
       const file = element.querySelector('vaadin-upload-file');
       file.__thumbnail =
@@ -83,7 +66,6 @@ describe('upload-file-list-thumbnails', () => {
 
   describe('overflow', () => {
     it('wrapping', async () => {
-      element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
       element.items = [
         { name: 'image.png', progress: 100, complete: true },
         { name: 'document.pdf', progress: 100, complete: true },

--- a/packages/upload/test/visual/base/upload-file-list-thumbnails.test.js
+++ b/packages/upload/test/visual/base/upload-file-list-thumbnails.test.js
@@ -1,57 +1,40 @@
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../src/vaadin-upload-file-list.js';
+import { freezeLoaderAnimation, waitForRendered } from '../common.js';
 
 // Enable the feature flag so the theme propagates to upload-file children
 window.Vaadin ??= {};
 window.Vaadin.featureFlags ??= {};
 window.Vaadin.featureFlags.modularUpload = true;
 
-/**
- * Wait for the file list to render its children and for the children
- * to complete their Lit update cycle and receive external theme styles.
- */
-async function waitForRendered() {
-  await nextFrame();
-  await nextFrame();
-}
-
-/**
- * Freeze the loader animation on all upload-file elements inside the given element
- * so that visual diff screenshots are deterministic.
- */
-function freezeLoaderAnimation(container) {
-  container.querySelectorAll('vaadin-upload-file').forEach((file) => {
-    const style = document.createElement('style');
-    style.textContent = '[part="loader"] { animation: none !important; opacity: 1 !important; }';
-    file.shadowRoot.appendChild(style);
-  });
-}
-
 describe('upload-file-list-thumbnails', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.padding = '10px';
     div.style.width = '500px';
+    element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
+    await nextRender();
   });
 
   describe('states', () => {
-    beforeEach(async () => {
-      element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
+    it('complete', async () => {
       element.items = [
         { name: 'image.png', progress: 100, complete: true },
         { name: 'document.pdf', progress: 100, complete: true },
       ];
       await waitForRendered();
-    });
-
-    it('complete', async () => {
       await visualDiff(div, 'complete');
     });
 
     it('complete-thumbnail', async () => {
+      element.items = [
+        { name: 'image.png', progress: 100, complete: true },
+        { name: 'document.pdf', progress: 100, complete: true },
+      ];
+      await waitForRendered();
       // Simulate a thumbnail on the first file
       const file = element.querySelector('vaadin-upload-file');
       file.__thumbnail =
@@ -82,7 +65,6 @@ describe('upload-file-list-thumbnails', () => {
 
   describe('overflow', () => {
     it('wrapping', async () => {
-      element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
       element.items = [
         { name: 'image.png', progress: 100, complete: true },
         { name: 'document.pdf', progress: 100, complete: true },

--- a/packages/upload/test/visual/common.js
+++ b/packages/upload/test/visual/common.js
@@ -1,0 +1,22 @@
+import { nextFrame, nextRender } from '@vaadin/testing-helpers';
+
+/**
+ * Freeze the loader animation on all upload-file elements inside the given element
+ * so that visual diff screenshots are deterministic.
+ */
+export function freezeLoaderAnimation(container) {
+  container.querySelectorAll('vaadin-upload-file').forEach((file) => {
+    const style = document.createElement('style');
+    style.textContent = '[part="loader"] { animation: none !important; opacity: 1 !important; }';
+    file.shadowRoot.appendChild(style);
+  });
+}
+
+/**
+ * Wait for the file list to render its children and for the children
+ * to complete their Lit update cycle and receive external theme styles.
+ */
+export async function waitForRendered() {
+  await nextRender();
+  await nextFrame();
+}

--- a/packages/upload/test/visual/lumo/upload-file-list-thumbnails.test.js
+++ b/packages/upload/test/visual/lumo/upload-file-list-thumbnails.test.js
@@ -1,59 +1,42 @@
-import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/src/props/index.css';
 import '@vaadin/vaadin-lumo-styles/components/upload.css';
 import '../../../vaadin-upload-file-list.js';
+import { freezeLoaderAnimation, waitForRendered } from '../common.js';
 
 // Enable the feature flag so the theme propagates to upload-file children
 window.Vaadin ??= {};
 window.Vaadin.featureFlags ??= {};
 window.Vaadin.featureFlags.modularUpload = true;
 
-/**
- * Wait for the file list to render its children and for the children
- * to complete their Lit update cycle and receive external theme styles.
- */
-async function waitForRendered() {
-  await nextFrame();
-  await nextFrame();
-}
-
-/**
- * Freeze the loader animation on all upload-file elements inside the given element
- * so that visual diff screenshots are deterministic.
- */
-function freezeLoaderAnimation(container) {
-  container.querySelectorAll('vaadin-upload-file').forEach((file) => {
-    const style = document.createElement('style');
-    style.textContent = '[part="loader"] { animation: none !important; opacity: 1 !important; }';
-    file.shadowRoot.appendChild(style);
-  });
-}
-
 describe('upload-file-list-thumbnails', () => {
   let div, element;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     div = document.createElement('div');
     div.style.padding = '10px';
     div.style.width = '500px';
+    element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
+    await nextRender();
   });
 
   describe('states', () => {
-    beforeEach(async () => {
-      element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
+    it('complete', async () => {
       element.items = [
         { name: 'image.png', progress: 100, complete: true },
         { name: 'document.pdf', progress: 100, complete: true },
       ];
       await waitForRendered();
-    });
-
-    it('complete', async () => {
       await visualDiff(div, 'complete');
     });
 
     it('complete-thumbnail', async () => {
+      element.items = [
+        { name: 'image.png', progress: 100, complete: true },
+        { name: 'document.pdf', progress: 100, complete: true },
+      ];
+      await waitForRendered();
       // Simulate a thumbnail on the first file
       const file = element.querySelector('vaadin-upload-file');
       file.__thumbnail =
@@ -84,7 +67,6 @@ describe('upload-file-list-thumbnails', () => {
 
   describe('overflow', () => {
     it('wrapping', async () => {
-      element = fixtureSync('<vaadin-upload-file-list theme="thumbnails"></vaadin-upload-file-list>', div);
       element.items = [
         { name: 'image.png', progress: 100, complete: true },
         { name: 'document.pdf', progress: 100, complete: true },


### PR DESCRIPTION
## Description

We are getting some occasional screenshot failures with both Lumo and Aura e.g. the `uploading` state:

<img width="520" height="60" alt="uploading-diff" src="https://github.com/user-attachments/assets/3483ff5b-8776-4d8c-ba86-560337c06508" />

<img width="520" height="58" alt="uploading-diff" src="https://github.com/user-attachments/assets/8bfc4544-68f4-426b-9c31-65300a1995f3" />

Updated visual tests to try to stabilize them using `nextRender()` helper, also improved test structure a bit.

## Type of change

- Test