### PR TITLE
chore: resolve missing inherited members and fix CEM type overrides

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -301,10 +301,16 @@ function copyMissingItems(target, source, key) {
       target[key].push({ ...item });
       existingMap.set(item.name, item);
       changed = true;
-    } else if (!existing.type?.text && item.type?.text) {
-      // Fill in missing type from parent
-      existing.type = { ...item.type };
-      changed = true;
+    } else {
+      // Fill in missing type or description from parent
+      if (!existing.type?.text && item.type?.text) {
+        existing.type = { ...item.type };
+        changed = true;
+      }
+      if (!existing.description && item.description) {
+        existing.description = item.description;
+        changed = true;
+      }
     }
   }
   return changed;


### PR DESCRIPTION
## Description

The CEM analyzer only follows inheritedFrom one level deep, so members inherited through 2+ levels of mixins or superclasses are dropped from class declarations (e.g., TextField.label via FieldMixin → LabelMixin).

Add a multi-pass resolution step that copies missing members and attributes from mixin and superclass declarations to class declarations.

## Type of change

- Internal change

## Note

Can be tested by running `yarn release:cem` - in this PR there will be `label` property in the `custom-elements.json` for `vaadin-text-field` component, and in `main` branch it's missing from there:

```
{
  "kind": "field",
  "name": "label",
  "privacy": "public",
  "type": {
    "text": "string"
  },
  "description": "The label text for the input node.\nWhen no light dom defined via [slot=label], this value will be used.",
  "attribute": "label",
  "inheritedFrom": {
    "name": "FieldMixin",
    "package": "@vaadin/field-base/src/field-mixin.js"
  }
},
```

UPD: added a second commit that fixes a problem with type for `i18n` properties incorrectly set to `Object`.