### PR TITLE
chore: default member privacy to public in CEM config

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -240,10 +240,13 @@ export default {
                 .filter((member) => !member.name.startsWith('_'))
                 .filter((member) => !(member.static && ignoredStaticMembers.includes(member.name)))
                 .map((member) => {
-                  if (member.kind === 'field' && member.attribute) {
-                    return { ...member, attribute: camelToDash(member.attribute) };
+                  // Default privacy to 'public' for members that passed the filter
+                  // (e.g., inherited members from mixins may lack an explicit privacy)
+                  const normalized = member.privacy ? member : { ...member, privacy: 'public' };
+                  if (normalized.kind === 'field' && normalized.attribute) {
+                    return { ...normalized, attribute: camelToDash(normalized.attribute) };
                   }
-                  return member;
+                  return normalized;
                 })
                 .sort(sortName);
             }


### PR DESCRIPTION
## Description

Members inherited from mixins like I18nMixin may lack an explicit privacy field, causing them to be excluded from web-types properties. Normalize privacy to 'public' for members that pass the filter.

Note: this will be needed for updating `buildWebTypes.js` script to use CEM instead of Polymer Analyzer.

## Type of change

- Internal change