### PR TITLE
docs: use @type instead of @return for i18n getter JSDoc

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -111,7 +111,7 @@ export const AppLayoutMixin = (superclass) =>
      *   drawer: 'Drawer'
      * }
      * ```
-     * @return {!AppLayoutI18n}
+     * @type {!AppLayoutI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -127,7 +127,7 @@ export const AvatarGroupMixin = (superClass) =>
      *   left: '{user} left'
      * }
      * ```
-     * @return {!AvatarGroupI18n}
+     * @type {!AvatarGroupI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -102,7 +102,7 @@ export const AvatarMixin = (superClass) =>
      *   anonymous: 'anonymous'
      * }
      * ```
-     * @return {!AvatarI18n}
+     * @type {!AvatarI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -79,22 +79,12 @@ export const I18nMixin = (defaultI18n, superClass) =>
      * Should be overridden by subclasses to provide a custom JSDoc with the
      * default I18N properties.
      *
-     * @returns {Object}
+     * @type {Object}
      */
     get i18n() {
       return this.__customI18n;
     }
 
-    /**
-     * The object used to localize this component. To change the default
-     * localization, replace this with an object that provides all properties, or
-     * just the individual properties you want to change.
-     *
-     * Should be overridden by subclasses to provide a custom JSDoc with the
-     * default I18N properties.
-     *
-     * @param {Object} value
-     */
     set i18n(value) {
       if (value === this.__customI18n) {
         return;

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -335,7 +335,7 @@ export const CrudMixin = (superClass) =>
      *   }
      * }
      * ```
-     * @return {!CrudI18n}
+     * @type {!CrudI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -196,7 +196,7 @@ class Dashboard extends DashboardLayoutMixin(
    *   moveBackward: 'Move Backward',
    * }
    * ```
-   * @return {!DashboardI18n}
+   * @type {!DashboardI18n}
    */
   get i18n() {
     return super.i18n;

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -369,7 +369,7 @@ export const DatePickerMixin = (subclass) =>
      *   }
      * }
      * ```
-     * @return {!DatePickerI18n}
+     * @type {!DatePickerI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -151,7 +151,7 @@ export const LoginMixin = (superClass) =>
      *   additionalInformation: 'In case you need to provide some additional info for the user.'
      * }
      * ```
-     * @return {!LoginI18n}
+     * @type {!LoginI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -190,7 +190,7 @@ export const MenuBarMixin = (superClass) =>
      *   moreOptions: 'More options'
      * }
      * ```
-     * @return {!MenuBarI18n}
+     * @type {!MenuBarI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -76,7 +76,7 @@ export const MessageInputMixin = (superClass) =>
      *   message: 'Message'
      * }
      * ```
-     * @return {!MessageInputI18n}
+     * @type {!MessageInputI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -239,7 +239,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      *   total: '{count} items selected',
      * }
      * ```
-     * @return {!MultiSelectComboBoxI18n}
+     * @type {!MultiSelectComboBoxI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -256,7 +256,7 @@ export const RichTextEditorMixin = (superClass) =>
      * The properties are used e.g. as the tooltips for the editor toolbar
      * buttons.
      *
-     * @return {!RichTextEditorI18n}
+     * @type {!RichTextEditorI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/side-nav/src/vaadin-side-nav-children-mixin.js
+++ b/packages/side-nav/src/vaadin-side-nav-children-mixin.js
@@ -70,7 +70,7 @@ export const SideNavChildrenMixin = (superClass) =>
      *   toggle: 'Toggle child items'
      * }
      * ```
-     * @return {!SideNavI18n}
+     * @type {!SideNavI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -177,7 +177,7 @@ export const TimePickerMixin = (superClass) =>
      * NOTE: `formatTime` and `parseTime` must be implemented in a
      * compatible manner to ensure the component works properly.
      *
-     * @return {!TimePickerI18n}
+     * @type {!TimePickerI18n}
      */
     get i18n() {
       return super.i18n;

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -443,7 +443,7 @@ export const UploadMixin = (superClass) =>
      *   }
      * }
      * ```
-     * @return {!UploadI18n}
+     * @type {!UploadI18n}
      */
     get i18n() {
       return super.i18n;


### PR DESCRIPTION
## Description

The CEM analyzer treats `@return` on getters as method-style output (return/parameters), causing i18n members to lack type and privacy fields. Using `@type` produces the correct field-style CEM output.

Note: some components like `vaadin-date-time-picker` already use `@type` syntax so they are not updated.

## Type of change

- Documentation