### PR TITLE
chore: remove redundant @type JSDoc annotations from properties

### DIFF
--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -21,7 +21,6 @@ export const AccordionMixin = (superClass) =>
          * The index of currently opened panel. First panel is opened by
          * default. Only one panel can be opened at the same time.
          * Setting null or undefined closes all the accordion panels.
-         * @type {number}
          */
         opened: {
           type: Number,

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -48,7 +48,6 @@ export const AppLayoutMixin = (superclass) =>
          * - `true`, for desktop size views
          * - `false`, for mobile size views
          * @attr {boolean} drawer-opened
-         * @type {boolean}
          */
         drawerOpened: {
           type: Boolean,
@@ -62,7 +61,6 @@ export const AppLayoutMixin = (superclass) =>
         /**
          * Drawer is an overlay on top of the content
          * Controlled via CSS using `--vaadin-app-layout-drawer-overlay: true|false`;
-         * @type {boolean}
          */
         overlay: {
           type: Boolean,
@@ -79,7 +77,6 @@ export const AppLayoutMixin = (superclass) =>
          * - The default is `vaadin-router-location-changed` dispatched by Vaadin Router
          *
          * @attr {string} close-drawer-on
-         * @type {string}
          */
         closeDrawerOn: {
           type: String,

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -222,7 +222,6 @@ export const ChartMixin = (superClass) =>
 
         /**
          * Represents the title of the chart.
-         * @type {string}
          */
         title: {
           type: String,
@@ -276,7 +275,6 @@ export const ChartMixin = (superClass) =>
         /**
          * Specifies the message displayed on a chart without displayable data.
          * @attr {string} empty-text
-         * @type {string}
          */
         emptyText: {
           type: String,

--- a/packages/charts/src/vaadin-chart-series-mixin.js
+++ b/packages/charts/src/vaadin-chart-series-mixin.js
@@ -71,7 +71,6 @@ export const ChartSeriesMixin = (superClass) =>
 
         /**
          * The name of the series as shown in the legend, tooltip etc.
-         * @type {string}
          */
         title: {
           type: String,

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -34,7 +34,6 @@ export const CheckboxMixin = (superclass) =>
          *
          * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Indeterminate_state_checkboxes
          *
-         * @type {boolean}
          */
         indeterminate: {
           type: Boolean,
@@ -46,7 +45,6 @@ export const CheckboxMixin = (superclass) =>
         /**
          * The name of the checkbox.
          *
-         * @type {string}
          */
         name: {
           type: String,

--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -26,7 +26,6 @@ export const ComboBoxBaseMixin = (superClass) =>
       return {
         /**
          * True if the dropdown is open, false otherwise.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -48,7 +47,6 @@ export const ComboBoxBaseMixin = (superClass) =>
 
         /**
          * When present, it specifies that the field is read-only.
-         * @type {boolean}
          */
         readonly: {
           type: Boolean,
@@ -57,7 +55,6 @@ export const ComboBoxBaseMixin = (superClass) =>
         },
 
         /**
-         * @type {number}
          * @protected
          */
         _focusedIndex: {

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -16,7 +16,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
         /**
          * Number of items fetched at a time from the dataprovider.
          * @attr {number} page-size
-         * @type {number}
          */
         pageSize: {
           type: Number,
@@ -27,7 +26,6 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
         /**
          * Total number of items.
-         * @type {number | undefined}
          */
         size: {
           type: Number,

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -68,7 +68,6 @@ export const ComboBoxItemsMixin = (superClass) =>
 
         /**
          * Filtering string the user has typed into the input field.
-         * @type {string}
          */
         filter: {
           type: String,
@@ -94,7 +93,6 @@ export const ComboBoxItemsMixin = (superClass) =>
          * The item label is also used for matching items when processing user
          * input, i.e., for filtering and selecting items.
          * @attr {string} item-label-path
-         * @type {string}
          */
         itemLabelPath: {
           type: String,
@@ -111,7 +109,6 @@ export const ComboBoxItemsMixin = (superClass) =>
          * The item value is used in the `value` property of the combo box,
          * to provide the form value.
          * @attr {string} item-value-path
-         * @type {string}
          */
         itemValuePath: {
           type: String,

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -49,7 +49,6 @@ export const ComboBoxMixin = (superClass) =>
          * Also, when `value` is set programmatically, the input value will be set
          * to reflect that value.
          * @attr {boolean} allow-custom-value
-         * @type {boolean}
          */
         allowCustomValue: {
           type: Boolean,
@@ -58,7 +57,6 @@ export const ComboBoxMixin = (superClass) =>
 
         /**
          * When set to `true`, "loading" attribute is added to host and the overlay element.
-         * @type {boolean}
          */
         loading: {
           type: Boolean,

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -31,7 +31,6 @@ export const ConfirmDialogMixin = (superClass) =>
 
         /**
          * True if the dialog is visible and available for interaction.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -43,7 +42,6 @@ export const ConfirmDialogMixin = (superClass) =>
 
         /**
          * Set the confirmation dialog title.
-         * @type {string}
          */
         header: {
           type: String,
@@ -62,7 +60,6 @@ export const ConfirmDialogMixin = (superClass) =>
          * Text displayed on confirm-button.
          * This only affects the default button, custom slotted buttons will not be altered.
          * @attr {string} confirm-text
-         * @type {string}
          */
         confirmText: {
           type: String,
@@ -73,7 +70,6 @@ export const ConfirmDialogMixin = (superClass) =>
          * Theme for a confirm-button.
          * This only affects the default button, custom slotted buttons will not be altered.
          * @attr {string} confirm-theme
-         * @type {string}
          */
         confirmTheme: {
           type: String,
@@ -83,7 +79,6 @@ export const ConfirmDialogMixin = (superClass) =>
         /**
          * Set to true to disable closing dialog on Escape press
          * @attr {boolean} no-close-on-esc
-         * @type {boolean}
          */
         noCloseOnEsc: {
           type: Boolean,
@@ -93,7 +88,6 @@ export const ConfirmDialogMixin = (superClass) =>
         /**
          * Whether to show reject button or not.
          * @attr {boolean} reject-button-visible
-         * @type {boolean}
          */
         rejectButtonVisible: {
           type: Boolean,
@@ -105,7 +99,6 @@ export const ConfirmDialogMixin = (superClass) =>
          * Text displayed on reject-button.
          * This only affects the default button, custom slotted buttons will not be altered.
          * @attr {string} reject-text
-         * @type {string}
          */
         rejectText: {
           type: String,
@@ -116,7 +109,6 @@ export const ConfirmDialogMixin = (superClass) =>
          * Theme for a reject-button.
          * This only affects the default button, custom slotted buttons will not be altered.
          * @attr {string} reject-theme
-         * @type {string}
          */
         rejectTheme: {
           type: String,
@@ -126,7 +118,6 @@ export const ConfirmDialogMixin = (superClass) =>
         /**
          * Whether to show cancel button or not.
          * @attr {boolean} cancel-button-visible
-         * @type {boolean}
          */
         cancelButtonVisible: {
           type: Boolean,
@@ -138,7 +129,6 @@ export const ConfirmDialogMixin = (superClass) =>
          * Text displayed on cancel-button.
          * This only affects the default button, custom slotted buttons will not be altered.
          * @attr {string} cancel-text
-         * @type {string}
          */
         cancelText: {
           type: String,
@@ -149,7 +139,6 @@ export const ConfirmDialogMixin = (superClass) =>
          * Theme for a cancel-button.
          * This only affects the default button, custom slotted buttons will not be altered.
          * @attr {string} cancel-theme
-         * @type {string}
          */
         cancelTheme: {
           type: String,

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -27,7 +27,6 @@ export const ContextMenuMixin = (superClass) =>
 
         /**
          * True if the overlay is currently displayed.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -41,7 +40,6 @@ export const ContextMenuMixin = (superClass) =>
         /**
          * Event name to listen for opening the context menu.
          * @attr {string} open-on
-         * @type {string}
          */
         openOn: {
           type: String,
@@ -67,7 +65,6 @@ export const ContextMenuMixin = (superClass) =>
         /**
          * Event name to listen for closing the context menu.
          * @attr {string} close-on
-         * @type {string}
          */
         closeOn: {
           type: String,

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -154,7 +154,6 @@ export const CrudMixin = (superClass) =>
          * Enables user to click on row to edit it.
          * Note: When enabled, auto-generated grid won't show the edit column.
          * @attr {boolean} edit-on-click
-         * @type {boolean}
          */
         editOnClick: {
           type: Boolean,
@@ -267,7 +266,6 @@ export const CrudMixin = (superClass) =>
         __isNew: Boolean,
 
         /**
-         * @type {boolean}
          * @protected
          */
         _fullscreen: {
@@ -277,7 +275,6 @@ export const CrudMixin = (superClass) =>
         },
 
         /**
-         * @type {string}
          * @protected
          */
         _fullscreenMediaQuery: {

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -24,7 +24,6 @@ export const DashboardLayoutMixin = (superClass) =>
          * Whether the dashboard layout is dense.
          *
          * @attr {boolean} dense-layout
-         * @type {boolean}
          */
         denseLayout: {
           type: Boolean,

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -119,7 +119,6 @@ export const DatePickerMixin = (subclass) =>
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
          *
-         * @type {string}
          */
         value: {
           type: String,
@@ -169,7 +168,6 @@ export const DatePickerMixin = (subclass) =>
         },
 
         /**
-         * @type {boolean}
          * @protected
          */
         _fullscreen: {
@@ -179,7 +177,6 @@ export const DatePickerMixin = (subclass) =>
         },
 
         /**
-         * @type {string}
          * @protected
          */
         _fullscreenMediaQuery: {

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -66,7 +66,6 @@ export const DateTimePickerMixin = (superClass) =>
          * - Minute precision `"YYYY-MM-DDThh:mm"` (default)
          * - Second precision `"YYYY-MM-DDThh:mm:ss"`
          * - Millisecond precision `"YYYY-MM-DDThh:mm:ss.fff"`
-         * @type {string}
          */
         value: {
           type: String,
@@ -201,7 +200,6 @@ export const DateTimePickerMixin = (superClass) =>
 
         /**
          * Set to true to make this element read-only.
-         * @type {boolean}
          */
         readonly: {
           type: Boolean,
@@ -212,7 +210,6 @@ export const DateTimePickerMixin = (superClass) =>
 
         /**
          * Specify that this control should have input focus when the page loads.
-         * @type {boolean}
          */
         autofocus: {
           type: Boolean,

--- a/packages/details/src/collapsible-mixin.js
+++ b/packages/details/src/collapsible-mixin.js
@@ -17,7 +17,6 @@ export const CollapsibleMixin = (superClass) =>
       return {
         /**
          * If true, the collapsible content is visible.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -13,7 +13,6 @@ export const DialogBaseMixin = (superClass) =>
       return {
         /**
          * True if the dialog is visible and available for interaction.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -26,7 +25,6 @@ export const DialogBaseMixin = (superClass) =>
         /**
          * Set to true to disable closing dialog on outside click
          * @attr {boolean} no-close-on-outside-click
-         * @type {boolean}
          */
         noCloseOnOutsideClick: {
           type: Boolean,
@@ -36,7 +34,6 @@ export const DialogBaseMixin = (superClass) =>
         /**
          * Set to true to disable closing dialog on Escape press
          * @attr {boolean} no-close-on-esc
-         * @type {boolean}
          */
         noCloseOnEsc: {
           type: Boolean,
@@ -45,7 +42,6 @@ export const DialogBaseMixin = (superClass) =>
 
         /**
          * Set to true to remove backdrop and allow click events on background elements.
-         * @type {boolean}
          */
         modeless: {
           type: Boolean,
@@ -55,7 +51,6 @@ export const DialogBaseMixin = (superClass) =>
         /**
          * Set to true to disable focus trapping.
          * @attr {boolean} no-focus-trap
-         * @type {boolean}
          */
         noFocusTrap: {
           type: Boolean,
@@ -101,7 +96,6 @@ export const DialogBaseMixin = (superClass) =>
          * dialog will also adjust any programmatically configured size and position
          * so that it stays within the viewport.
          * @attr {boolean} keep-in-viewport
-         * @type {boolean}
          */
         keepInViewport: {
           type: Boolean,

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -23,7 +23,6 @@ export const DialogDraggableMixin = (superClass) =>
          * but still have its children non-draggable (by default), mark it with
          * "`draggable-leaf-only`" class name.
          *
-         * @type {boolean}
          */
         draggable: {
           type: Boolean,

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -13,7 +13,6 @@ export const DialogResizableMixin = (superClass) =>
       return {
         /**
          * Set to true to enable resizing the dialog by dragging the corners and edges.
-         * @type {boolean}
          */
         resizable: {
           type: Boolean,

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -21,7 +21,6 @@ export const CheckedMixin = (superclass) =>
       return {
         /**
          * True if the element is checked.
-         * @type {boolean}
          */
         checked: {
           type: Boolean,

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -68,7 +68,6 @@ export const GridProEditColumnMixin = (superClass) =>
         /**
          * Path of the property used for the value of the editor component.
          * @attr {string} editor-value-path
-         * @type {string}
          */
         editorValuePath: {
           type: String,

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -39,7 +39,6 @@ export const ColumnBaseMixin = (superClass) =>
         /**
          * When true, the column is frozen. When a column inside of a column group is frozen,
          * all of the sibling columns inside the group will get frozen also.
-         * @type {boolean}
          */
         frozen: {
           type: Boolean,
@@ -55,7 +54,6 @@ export const ColumnBaseMixin = (superClass) =>
          *
          * Column can not be set as `frozen` and `frozenToEnd` at the same time.
          * @attr {boolean} frozen-to-end
-         * @type {boolean}
          */
         frozenToEnd: {
           type: Boolean,
@@ -71,7 +69,6 @@ export const ColumnBaseMixin = (superClass) =>
          * while navigating to help user identify the current row as uniquely as possible.
          *
          * @attr {boolean} row-header
-         * @type {boolean}
          */
         rowHeader: {
           type: Boolean,
@@ -128,7 +125,6 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * @type {boolean}
          * @protected
          */
         _lastFrozen: {
@@ -138,7 +134,6 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * @type {boolean}
          * @protected
          */
         _bodyContentHidden: {
@@ -148,7 +143,6 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * @type {boolean}
          * @protected
          */
         _firstFrozenToEnd: {
@@ -847,7 +841,6 @@ export const GridColumnMixin = (superClass) =>
         /**
          * Flex grow ratio for the cell widths. When set to 0, cell width is fixed.
          * @attr {number} flex-grow
-         * @type {number}
          */
         flexGrow: {
           type: Number,
@@ -914,7 +907,6 @@ export const GridColumnMixin = (superClass) =>
          *
          * The column width may still grow larger when `flexGrow` is not 0.
          * @attr {boolean} auto-width
-         * @type {boolean}
          */
         autoWidth: {
           type: Boolean,

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -17,7 +17,6 @@ export const ColumnReorderingMixin = (superClass) =>
         /**
          * Set to true to allow column reordering.
          * @attr {boolean} column-reordering-allowed
-         * @type {boolean}
          */
         columnReorderingAllowed: {
           type: Boolean,

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -18,7 +18,6 @@ export const DataProviderMixin = (superClass) =>
         /**
          * The number of root-level items in the grid.
          * @attr {number} size
-         * @type {number}
          */
         size: {
           type: Number,
@@ -38,7 +37,6 @@ export const DataProviderMixin = (superClass) =>
         /**
          * Number of items fetched at a time from the dataprovider.
          * @attr {number} page-size
-         * @type {number}
          */
         pageSize: {
           type: Number,

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -82,7 +82,6 @@ export const KeyboardNavigationMixin = (superClass) =>
          * the grid from receiving focus, allowing the user to switch focus to
          * controls in adjacent cells, rather than focussing the outer cell
          * itself.
-         * @type {boolean}
          * @private
          */
         interacting: {

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -134,7 +134,6 @@ export const GridMixin = (superClass) =>
          * Effectively, this disables the grid's virtual scrolling so that all the rows are rendered in the DOM at once.
          * If the grid has a large number of items, using the feature is discouraged to avoid performance issues.
          * @attr {boolean} all-rows-visible
-         * @type {boolean}
          */
         allRowsVisible: {
           type: Boolean,

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -42,7 +42,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         /**
          * Flex grow ratio for the cell widths. When set to 0, cell width is fixed.
          * @attr {number} flex-grow
-         * @type {number}
          */
         flexGrow: {
           type: Number,
@@ -53,7 +52,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         /**
          * When true, all the items are selected.
          * @attr {boolean} select-all
-         * @type {boolean}
          */
         selectAll: {
           type: Boolean,
@@ -65,7 +63,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         /**
          * When true, the active item gets automatically selected.
          * @attr {boolean} auto-select
-         * @type {boolean}
          */
         autoSelect: {
           type: Boolean,
@@ -76,7 +73,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         /**
          * When true, rows can be selected by dragging over the selection column.
          * @attr {boolean} drag-select
-         * @type {boolean}
          */
         dragSelect: {
           type: Boolean,

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -16,7 +16,6 @@ export const SortMixin = (superClass) =>
         /**
          * When `true`, all `<vaadin-grid-sorter>` are applied for sorting.
          * @attr {boolean} multi-sort
-         * @type {boolean}
          */
         multiSort: {
           type: Boolean,
@@ -48,7 +47,6 @@ export const SortMixin = (superClass) =>
          * `multiSort` property. If `multiSortOnShiftClick` is true, the multiSort property is effectively ignored.
          *
          * @attr {boolean} multi-sort-on-shift-click
-         * @type {boolean}
          */
         multiSortOnShiftClick: {
           type: Boolean,

--- a/packages/grid/src/vaadin-grid-tree-toggle-mixin.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle-mixin.js
@@ -15,7 +15,6 @@ export const GridTreeToggleMixin = (superClass) =>
         /**
          * Current level of the tree represented with a horizontal offset
          * of the toggle button.
-         * @type {number}
          */
         level: {
           type: Number,
@@ -26,7 +25,6 @@ export const GridTreeToggleMixin = (superClass) =>
 
         /**
          * Hides the toggle icon and disables toggling a tree sublevel.
-         * @type {boolean}
          */
         leaf: {
           type: Boolean,
@@ -36,7 +34,6 @@ export const GridTreeToggleMixin = (superClass) =>
 
         /**
          * Sublevel toggle state.
-         * @type {boolean}
          */
         expanded: {
           type: Boolean,

--- a/packages/icon/src/vaadin-icon-mixin.js
+++ b/packages/icon/src/vaadin-icon-mixin.js
@@ -30,7 +30,6 @@ export const IconMixin = (superClass) =>
          * See also [`name`](#/elements/vaadin-iconset#property-name) property of `vaadin-iconset`.
          *
          * @attr {string} icon
-         * @type {string}
          */
         icon: {
           type: String,
@@ -55,7 +54,6 @@ export const IconMixin = (superClass) =>
          * - a string in the format `data:image/svg+xml,<svg>...</svg>`. You may need to use the `encodeURIComponent`
          *   function for the SVG content passed
          *
-         * @type {string}
          */
         src: {
           type: String,
@@ -66,7 +64,6 @@ export const IconMixin = (superClass) =>
          * The symbol identifier that references an ID of an element contained in the SVG element assigned to the
          * `src` property
          *
-         * @type {string}
          */
         symbol: {
           type: String,
@@ -79,7 +76,6 @@ export const IconMixin = (superClass) =>
          * Example: "fa-solid fa-user"
          *
          * @attr {string} icon-class
-         * @type {string}
          */
         iconClass: {
           type: String,
@@ -92,7 +88,6 @@ export const IconMixin = (superClass) =>
          *
          * Example: "e001"
          *
-         * @type {string}
          */
         char: {
           type: String,
@@ -104,7 +99,6 @@ export const IconMixin = (superClass) =>
          *
          * Example: "home".
          *
-         * @type {string}
          */
         ligature: {
           type: String,
@@ -115,7 +109,6 @@ export const IconMixin = (superClass) =>
          * The font family to use for the font icon.
          *
          * @attr {string} font-family
-         * @type {string}
          */
         fontFamily: {
           type: String,

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -23,7 +23,6 @@ export const ItemMixin = (superClass) =>
          * Used for mixin detection because `instanceof` does not work with mixins.
          * e.g. in VaadinListMixin it filters items by using the
          * `element._hasVaadinItemMixin` condition.
-         * @type {boolean}
          */
         _hasVaadinItemMixin: {
           value: true,
@@ -31,7 +30,6 @@ export const ItemMixin = (superClass) =>
 
         /**
          * If true, the item is in selected state.
-         * @type {boolean}
          */
         selected: {
           type: Boolean,

--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -31,7 +31,6 @@ class LoginFormWrapper extends ThemableMixin(PolylitMixin(LumoInjectionMixin(Lit
       /**
        * If set, the error message is shown. The message is hidden by default.
        * When set, it changes the disabled state of the submit button.
-       * @type {boolean}
        */
       error: {
         type: Boolean,

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -56,7 +56,6 @@ export const LoginMixin = (superClass) =>
          * If set, disable the "Log in" button and prevent user from submitting login form.
          * It is re-enabled automatically, when error is set to true, allowing form resubmission
          * after user makes changes.
-         * @type {boolean}
          */
         disabled: {
           type: Boolean,
@@ -67,7 +66,6 @@ export const LoginMixin = (superClass) =>
         /**
          * If set, the error message is shown. The message is hidden by default.
          * When set, it changes the disabled state of the submit button.
-         * @type {boolean}
          */
         error: {
           type: Boolean,
@@ -78,7 +76,6 @@ export const LoginMixin = (superClass) =>
 
         /**
          * Whether to hide the forgot password button. The button is visible by default.
-         * @type {boolean}
          * @attr {boolean} no-forgot-password
          */
         noForgotPassword: {
@@ -88,7 +85,6 @@ export const LoginMixin = (superClass) =>
 
         /**
          * If set, the user name field automatically receives focus when the component is attached to the document.
-         * @type {boolean}
          * @attr {boolean} no-autofocus
          */
         noAutofocus: {

--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -14,7 +14,6 @@ export const LoginOverlayMixin = (superClass) =>
       return {
         /**
          * Defines the application description
-         * @type {string}
          */
         description: {
           type: String,
@@ -24,7 +23,6 @@ export const LoginOverlayMixin = (superClass) =>
 
         /**
          * True if the overlay is currently displayed.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -35,7 +33,6 @@ export const LoginOverlayMixin = (superClass) =>
 
         /**
          * Defines the application title
-         * @type {string}
          */
         title: {
           type: String,

--- a/packages/markdown/src/vaadin-markdown.js
+++ b/packages/markdown/src/vaadin-markdown.js
@@ -57,7 +57,6 @@ class Markdown extends SlotStylesMixin(ElementMixin(ThemableMixin(PolylitMixin(L
       /**
        * The Markdown content.
        *
-       * @type {string}
        */
       content: {
         type: String,

--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -31,7 +31,6 @@ export const MessageInputMixin = (superClass) =>
 
         /**
          * Set to true to disable this element.
-         * @type {boolean}
          */
         disabled: {
           type: Boolean,

--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -52,7 +52,6 @@ export const MessageListMixin = (superClass) =>
 
         /**
          * When set to `true`, the message text is parsed as Markdown.
-         * @type {boolean}
          */
         markdown: {
           type: Boolean,
@@ -63,7 +62,6 @@ export const MessageListMixin = (superClass) =>
         /**
          * When set to `true`, new messages are announced to assistive technologies using ARIA live regions.
          * @attr {boolean} announce-messages
-         * @type {boolean}
          */
         announceMessages: {
           type: Boolean,

--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -20,7 +20,6 @@ export const NotificationContainerMixin = (superClass) =>
       return {
         /**
          * True when the container is opened
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -127,7 +126,6 @@ export const NotificationMixin = (superClass) =>
         /**
          * The duration in milliseconds to show the notification.
          * Set to `0` or a negative number to disable the notification auto-closing.
-         * @type {number}
          */
         duration: {
           type: Number,
@@ -137,7 +135,6 @@ export const NotificationMixin = (superClass) =>
 
         /**
          * True if the notification is currently displayed.
-         * @type {boolean}
          */
         opened: {
           type: Boolean,

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -44,7 +44,6 @@ export const NumberFieldMixin = (superClass) =>
 
         /**
          * Specifies the allowed number intervals of the field.
-         * @type {number}
          */
         step: {
           type: Number,

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -62,7 +62,6 @@ export const OverlayMixin = (superClass) =>
         /**
          * When true the overlay won't disable the main content, showing
          * it doesn't change the functionality of the user interface.
-         * @type {boolean}
          */
         modeless: {
           type: Boolean,
@@ -75,7 +74,6 @@ export const OverlayMixin = (superClass) =>
         /**
          * When set to true, the overlay is hidden. This also closes the overlay
          * immediately in case there is a closing animation in progress.
-         * @type {boolean}
          */
         hidden: {
           type: Boolean,
@@ -86,7 +84,6 @@ export const OverlayMixin = (superClass) =>
 
         /**
          * When true the overlay has backdrop on top of content when opened.
-         * @type {boolean}
          */
         withBackdrop: {
           type: Boolean,

--- a/packages/progress-bar/src/vaadin-progress-mixin.js
+++ b/packages/progress-bar/src/vaadin-progress-mixin.js
@@ -21,7 +21,6 @@ export const ProgressMixin = (superClass) =>
 
         /**
          * Minimum bound of the progress bar.
-         * @type {number}
          */
         min: {
           type: Number,
@@ -31,7 +30,6 @@ export const ProgressMixin = (superClass) =>
 
         /**
          * Maximum bound of the progress bar.
-         * @type {number}
          */
         max: {
           type: Number,
@@ -42,7 +40,6 @@ export const ProgressMixin = (superClass) =>
         /**
          * Indeterminate state of the progress bar.
          * This property takes precedence over other state properties (min, max, value).
-         * @type {boolean}
          */
         indeterminate: {
           type: Boolean,

--- a/packages/radio-group/src/vaadin-radio-button-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-button-mixin.js
@@ -30,7 +30,6 @@ export const RadioButtonMixin = (superclass) =>
         /**
          * The name of the radio button.
          *
-         * @type {string}
          */
         name: {
           type: String,

--- a/packages/radio-group/src/vaadin-radio-group-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-group-mixin.js
@@ -36,7 +36,6 @@ export const RadioGroupMixin = (superclass) =>
         /**
          * The value of the radio group.
          *
-         * @type {string}
          */
         value: {
           type: String,
@@ -52,7 +51,6 @@ export const RadioGroupMixin = (superclass) =>
          * While the `disabled` property disables all radio buttons inside the group,
          * the `readonly` property disables only unchecked ones.
          *
-         * @type {boolean}
          */
         readonly: {
           type: Boolean,
@@ -63,7 +61,6 @@ export const RadioGroupMixin = (superclass) =>
         },
 
         /**
-         * @type {string}
          * @private
          */
         _fieldName: {

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -116,7 +116,6 @@ export const RichTextEditorMixin = (superClass) =>
          * ```
          *
          * See also https://github.com/quilljs/delta for detailed documentation.
-         * @type {string}
          */
         value: {
           type: String,
@@ -136,7 +135,6 @@ export const RichTextEditorMixin = (superClass) =>
 
         /**
          * When true, the user can not modify, nor copy the editor content.
-         * @type {boolean}
          */
         disabled: {
           type: Boolean,
@@ -146,7 +144,6 @@ export const RichTextEditorMixin = (superClass) =>
 
         /**
          * When true, the user can not modify the editor content, but can copy it.
-         * @type {boolean}
          */
         readonly: {
           type: Boolean,

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -53,7 +53,6 @@ export const SelectBaseMixin = (superClass) =>
 
         /**
          * Set when the select is open
-         * @type {boolean}
          */
         opened: {
           type: Boolean,
@@ -86,7 +85,6 @@ export const SelectBaseMixin = (superClass) =>
          * Hint: If you do not want to select any item by default, you can either set all
          * the values of inner vaadin-items, or set the vaadin-select value to
          * an inexistent value in the items list.
-         * @type {string}
          */
         value: {
           type: String,
@@ -116,7 +114,6 @@ export const SelectBaseMixin = (superClass) =>
 
         /**
          * When present, it specifies that the element is read-only.
-         * @type {boolean}
          */
         readonly: {
           type: Boolean,

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -110,7 +110,6 @@ class SideNavItem extends SideNavChildrenMixin(
       /**
        * Whether to show the child items or not
        *
-       * @type {boolean}
        */
       expanded: {
         type: Boolean,
@@ -129,7 +128,6 @@ class SideNavItem extends SideNavChildrenMixin(
        * Note that this only affects matching of the URLs path, not the base
        * origin or query parameters.
        *
-       * @type {boolean}
        * @attr {boolean} match-nested
        */
       matchNested: {
@@ -149,7 +147,6 @@ class SideNavItem extends SideNavChildrenMixin(
        * The state is updated when the item is added to the DOM or when the browser
        * navigates to a new page.
        *
-       * @type {boolean}
        */
       current: {
         type: Boolean,
@@ -169,7 +166,6 @@ class SideNavItem extends SideNavChildrenMixin(
        * page reload. This only works with supported routers, such as the one
        * provided in Vaadin apps, or when using the side nav `onNavigate` hook.
        *
-       * @type {boolean}
        * @attr {boolean} router-ignore
        */
       routerIgnore: {

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -89,7 +89,6 @@ class SideNav extends SideNavChildrenMixin(
       /**
        * Whether the side nav is collapsible. When enabled, the toggle icon is shown.
        *
-       * @type {boolean}
        */
       collapsible: {
         type: Boolean,
@@ -100,7 +99,6 @@ class SideNav extends SideNavChildrenMixin(
       /**
        * Whether the side nav is collapsed. When collapsed, the items are hidden.
        *
-       * @type {boolean}
        */
       collapsed: {
         type: Boolean,

--- a/packages/split-layout/src/vaadin-split-layout-mixin.js
+++ b/packages/split-layout/src/vaadin-split-layout-mixin.js
@@ -14,7 +14,6 @@ export const SplitLayoutMixin = (superClass) =>
       return {
         /**
          * The split layout's orientation. Possible values are: `horizontal|vertical`.
-         * @type {string}
          */
         orientation: {
           type: String,

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -43,7 +43,6 @@ export const TimePickerMixin = (superClass) =>
          * - `hh:mm` (default)
          * - `hh:mm:ss`
          * - `hh:mm:ss.fff`
-         * @type {string}
          */
         value: {
           type: String,
@@ -59,7 +58,6 @@ export const TimePickerMixin = (superClass) =>
          * - `hh:mm`
          * - `hh:mm:ss`
          * - `hh:mm:ss.fff`
-         * @type {string}
          */
         min: {
           type: String,
@@ -74,7 +72,6 @@ export const TimePickerMixin = (superClass) =>
          * - `hh:mm`
          * - `hh:mm:ss`
          * - `hh:mm:ss.fff`
-         * @type {string}
          */
         max: {
           type: String,

--- a/packages/upload/src/vaadin-upload-button.js
+++ b/packages/upload/src/vaadin-upload-button.js
@@ -101,7 +101,6 @@ class UploadButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(L
 
       /**
        * Capture attribute for mobile file input.
-       * @type {string}
        */
       capture: {
         type: String,
@@ -109,7 +108,6 @@ class UploadButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(L
 
       /**
        * True when max files has been reached on the manager.
-       * @type {boolean}
        */
       maxFilesReached: {
         type: Boolean,

--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -81,7 +81,6 @@ class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
       /**
        * Whether the drop zone is disabled.
        * Returns true if either explicitly disabled, manager is disabled, or no manager is set.
-       * @type {boolean}
        */
       disabled: {
         type: Boolean,
@@ -90,7 +89,6 @@ class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
 
       /**
        * True when max files has been reached on the manager.
-       * @type {boolean}
        * @readonly
        */
       maxFilesReached: {

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -114,7 +114,6 @@ export const UploadMixin = (superClass) =>
       return {
         /**
          * If true, the user cannot interact with this element.
-         * @type {boolean}
          */
         disabled: {
           type: Boolean,
@@ -129,7 +128,6 @@ export const UploadMixin = (superClass) =>
          * it false means that drop is enabled even in touch-devices, and true
          * disables drop in all devices.
          *
-         * @type {boolean}
          * @default true in touch-devices, false otherwise.
          */
         nodrop: {
@@ -141,7 +139,6 @@ export const UploadMixin = (superClass) =>
         /**
          * The server URL. The default value is an empty string, which means that
          * _window.location_ will be used.
-         * @type {string}
          */
         target: {
           type: String,
@@ -173,7 +170,6 @@ export const UploadMixin = (superClass) =>
         /**
          * Max time in milliseconds for the entire upload process, if exceeded the
          * request will be aborted. Zero means that there is no timeout.
-         * @type {number}
          */
         timeout: {
           type: Number,
@@ -221,7 +217,6 @@ export const UploadMixin = (superClass) =>
          * Limit of files to upload, by default it is unlimited. If the value is
          * set to one, native file browser will prevent selecting multiple files.
          * @attr {number} max-files
-         * @type {number}
          */
         maxFiles: {
           type: Number,
@@ -232,7 +227,6 @@ export const UploadMixin = (superClass) =>
         /**
          * Specifies if the maximum number of files have been uploaded
          * @attr {boolean} max-files-reached
-         * @type {boolean}
          */
         maxFilesReached: {
           type: Boolean,
@@ -249,7 +243,6 @@ export const UploadMixin = (superClass) =>
          * Notice that MIME types are widely supported, while file extensions
          * are only implemented in certain browsers, so avoid using it.
          * Example: accept="video/*,image/tiff" or accept=".pdf,audio/mp3"
-         * @type {string}
          */
         accept: {
           type: String,
@@ -262,7 +255,6 @@ export const UploadMixin = (superClass) =>
          * sending the request. Obviously you need to do the same validation in
          * the server-side and be sure that they are aligned.
          * @attr {number} max-file-size
-         * @type {number}
          */
         maxFileSize: {
           type: Number,
@@ -284,7 +276,6 @@ export const UploadMixin = (superClass) =>
          * Specifies the 'name' property at Content-Disposition for multipart uploads.
          * This property is ignored when uploadFormat is 'raw'.
          * @attr {string} form-data-name
-         * @type {string}
          */
         formDataName: {
           type: String,
@@ -295,7 +286,6 @@ export const UploadMixin = (superClass) =>
          * Prevents upload(s) from immediately uploading upon adding file(s).
          * When set, you must manually trigger uploads using the `uploadFiles` method
          * @attr {boolean} no-auto
-         * @type {boolean}
          */
         noAuto: {
           type: Boolean,
@@ -305,7 +295,6 @@ export const UploadMixin = (superClass) =>
         /**
          * Set the withCredentials flag on the request.
          * @attr {boolean} with-credentials
-         * @type {boolean}
          */
         withCredentials: {
           type: Boolean,
@@ -317,7 +306,6 @@ export const UploadMixin = (superClass) =>
          * - 'raw': Send file as raw binary data with the file's MIME type as Content-Type (default)
          * - 'multipart': Send file using multipart/form-data encoding
          * @attr {string} upload-format
-         * @type {string}
          */
         uploadFormat: {
           type: String,
@@ -330,7 +318,6 @@ export const UploadMixin = (superClass) =>
          * uploading large numbers of files. Files exceeding this limit will be queued
          * and uploaded as active uploads complete.
          * @attr {number} max-concurrent-uploads
-         * @type {number}
          */
         maxConcurrentUploads: {
           type: Number,


### PR DESCRIPTION
## Description

These JSDoc annotations are redundant because the CEM analyzer infers types from `type: Boolean` / `type: String` / `type: Number` in the property config. Verified that CEM and web-types output is identical after removal.

## Type of change

- Internal change

## Note

Polymer Analyzer also uses property types, and many string / boolean properties work without `@type`.
IIRC, we added it back in the day because it was needed for `polymer-modulizer` to generate `.d.ts` files.

I'm going to remove `@type` for some other properties where it's actually relevant for CEM in a separate PR.
This will be particularly relevant for properties like `primarySection` that have `@type {!PrimarySection}`.