### PR TITLE
fix: avoid virtualizer losing scroll position on large size change

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -333,6 +333,19 @@ export class IronListAdapter {
     return element ? this.scrollTarget.getBoundingClientRect().top - element.getBoundingClientRect().top : undefined;
   }
 
+  /**
+   * Adjusts the scroll position to compensate for any offset change of a given index.
+   * @param {number} index - The index whose scroll offset to restore
+   * @param {number|undefined} offsetBefore - The scroll offset of the index before the change
+   * @private
+   */
+  __restoreScrollOffset(index, offsetBefore) {
+    const offsetAfter = this.__getIndexScrollOffset(index);
+    if (offsetBefore !== undefined && offsetAfter !== undefined) {
+      this._scrollTop += offsetBefore - offsetAfter;
+    }
+  }
+
   get size() {
     return this.__size;
   }
@@ -382,15 +395,7 @@ export class IronListAdapter {
       // and remove exceeding items when size is decreased.
       this.scrollToIndex(fvi);
 
-      const fviOffsetAfter = this.__getIndexScrollOffset(fvi);
-      if (fviOffsetBefore !== undefined && fviOffsetAfter !== undefined) {
-        this._scrollTop += fviOffsetBefore - fviOffsetAfter;
-      }
-
-      // Skip the next virtual index offset adjustment to prevent the async
-      // scroll event (caused by the scrollToIndex + _scrollTop change above) from
-      // disrupting the restored scroll position.
-      this.__skipNextVirtualIndexAdjust = true;
+      this.__restoreScrollOffset(fvi, fviOffsetBefore);
     }
 
     this.__preventElementUpdates = false;
@@ -856,6 +861,9 @@ export class IronListAdapter {
       const threshold = OFFSET_ADJUST_MIN_THRESHOLD;
       const maxShift = 100;
 
+      const fvi = this.adjustedFirstVisibleIndex;
+      const fviOffsetBefore = this.__getIndexScrollOffset(fvi);
+
       // Near start
       if (this._scrollTop === 0) {
         this._vidxOffset = 0;
@@ -877,6 +885,8 @@ export class IronListAdapter {
         this._vidxOffset += Math.min(maxOffset - this._vidxOffset, maxShift);
         super.scrollToIndex(this.firstVisibleIndex - (this._vidxOffset - oldOffset));
       }
+
+      this.__restoreScrollOffset(fvi, fviOffsetBefore);
     }
   }
 }

--- a/packages/component-base/test/virtualizer-unlimited-size.test.js
+++ b/packages/component-base/test/virtualizer-unlimited-size.test.js
@@ -41,6 +41,11 @@ describe('unlimited size', () => {
     return [...elementsContainer.children].reduce((max, el) => Math.max(max, el.index), 0);
   }
 
+  function getIndexScrollOffset(fvi) {
+    const element = elementsContainer.querySelector(`#item-${fvi}`);
+    return scrollTarget.getBoundingClientRect().top - element.getBoundingClientRect().top;
+  }
+
   it('should scroll to a large index', () => {
     const index = Math.floor(virtualizer.size / 2);
     virtualizer.scrollToIndex(index);
@@ -159,10 +164,18 @@ describe('unlimited size', () => {
       smallestIndex = Math.min(...Array.from(elementsContainer.children).map((el) => el.index));
 
       scrollTarget.scrollTop -= (elementHeight * elementCount) / 2;
+
+      // Scroll offset of the index before the scroll event
+      const scrollOffsetBefore = getIndexScrollOffset(smallestIndex);
       await oneEvent(scrollTarget, 'scroll');
 
       const item = elementsContainer.querySelector(`#item-${smallestIndex}`);
       expect(item).to.be.ok;
+
+      // Scroll offset of the same index after the scroll event
+      const scrollOffsetAfter = getIndexScrollOffset(smallestIndex);
+      // Expect the scroll offset to be approximately the same, meaning the scroll position is preserved relative to the item
+      expect(scrollOffsetAfter).to.be.closeTo(scrollOffsetBefore, 1);
     }
 
     const item = elementsContainer.querySelector('#item-0');


### PR DESCRIPTION
## Description

Properly restore the scroll position (not only the the first visible index, but also scroll offset) also on virtual index adjust.

Fixes https://github.com/vaadin/web-components/issues/7237

This will also enable a couple of virtualizer tests that are currently skipped

## Type of change

Bugfix