### PR TITLE
fix: round translate to nearest pixel

### DIFF
--- a/packages/notification/src/styles/vaadin-notification-container-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-container-base-styles.js
@@ -71,7 +71,7 @@ export const notificationContainerStyles = css`
     position: fixed;
     top: 50%;
     left: 50%;
-    translate: -50% -50%;
+    translate: round(-50%, 1px) round(-50%, 1px);
     max-width: calc(100% - var(--_padding) * 2);
   }
 


### PR DESCRIPTION
Avoid rendering notifications in the middle position at sub-pixel values.

Before (not noticeable on high-DPI screens):

<img width="463" height="130" alt="Screenshot 2026-03-06 at 9 22 52" src="https://github.com/user-attachments/assets/d8b227a5-f83f-4403-8a69-5d769e851978" />

After:

<img width="438" height="108" alt="Screenshot 2026-03-06 at 9 23 13" src="https://github.com/user-attachments/assets/422d6503-0a8b-4061-ad2a-22ed468374aa" />
