### PR TITLE
fix: rich-text-editor toolbar-button color with mixed color schemes

### DIFF
--- a/packages/aura/src/components/rich-text-editor.css
+++ b/packages/aura/src/components/rich-text-editor.css
@@ -6,7 +6,6 @@
   --vaadin-rich-text-editor-toolbar-button-background: transparent;
   --vaadin-rich-text-editor-toolbar-button-border-radius: calc(var(--vaadin-radius-m) - 2px);
   --vaadin-rich-text-editor-toolbar-button-padding: var(--vaadin-padding-xs);
-  --vaadin-rich-text-editor-toolbar-button-text-color: var(--vaadin-text-color-secondary);
 }
 
 vaadin-rich-text-editor {
@@ -47,6 +46,7 @@ vaadin-rich-text-editor::part(toolbar-button) {
     scale 180ms;
   outline-offset: calc(var(--vaadin-focus-ring-width) * -1);
   position: relative;
+  color: var(--vaadin-rich-text-editor-toolbar-button-text-color, var(--vaadin-text-color-secondary));
 }
 
 vaadin-rich-text-editor::part(toolbar-button-pressed) {


### PR DESCRIPTION
When using mixed color schemes in Aura, the Rich Text Editor toolbar button color was incorrect when the editor is focused.

Before: 
<img width="729" height="504" alt="Screenshot 2026-03-06 at 9 55 52" src="https://github.com/user-attachments/assets/8437efa3-e8e6-45c7-abed-eb8d3c0f86d4" />

After:
<img width="746" height="386" alt="Screenshot 2026-03-06 at 9 56 30" src="https://github.com/user-attachments/assets/9cb4895f-99da-498a-b12d-b807a1800fa7" />
