### PR TITLE
docs: add missing tag name to customElement JSDoc in badge

### DIFF
--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -65,7 +65,7 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @customElement
+ * @customElement vaadin-badge
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ThemableMixin


### PR DESCRIPTION
## Description

This is needed for CEM analyzer to resolve the correct tag name.

## Type of change

- Documentation