### PR TITLE
docs: remove more unnecessary type JSDoc annotations

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -250,7 +250,6 @@ export const ChartMixin = (superClass) =>
 
         /**
          * Represents the subtitle of the chart.
-         * @type {string | undefined}
          */
         subtitle: {
           type: String,

--- a/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
@@ -26,8 +26,6 @@ export const CheckboxGroupMixin = (superclass) =>
          *
          * The array is immutable so toggling checkboxes always results in
          * creating a new array.
-         *
-         * @type {!Array<!string>}
          */
         value: {
           type: Array,

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -112,7 +112,6 @@ export const CrudMixin = (superClass) =>
 
         /**
          * An array containing the items which will be stamped to the column template instances.
-         * @type {Array<unknown> | undefined}
          */
         items: {
           type: Array,
@@ -123,7 +122,6 @@ export const CrudMixin = (superClass) =>
 
         /**
          * The item being edited in the dialog.
-         * @type {unknown}
          */
         editedItem: {
           type: Object,

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -117,7 +117,6 @@ class DashboardSection extends DashboardItemMixin(
        * The title of the section
        *
        * @attr {string} section-title
-       * @type {string | null | undefined}
        */
       sectionTitle: {
         type: String,

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -157,7 +157,6 @@ class DashboardWidget extends DashboardItemMixin(
        * The title of the widget.
        *
        * @attr {string} widget-title
-       * @type {string | null | undefined}
        */
       widgetTitle: {
         type: String,

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -118,7 +118,6 @@ export const DatePickerMixin = (subclass) =>
          * Supported date formats:
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
-         *
          */
         value: {
           type: String,
@@ -189,8 +188,6 @@ export const DatePickerMixin = (subclass) =>
          * Supported date formats:
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
-         *
-         * @type {string | undefined}
          */
         min: {
           type: String,
@@ -203,8 +200,6 @@ export const DatePickerMixin = (subclass) =>
          * Supported date formats:
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
-         *
-         * @type {string | undefined}
          */
         max: {
           type: String,

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -82,8 +82,6 @@ export const DateTimePickerMixin = (superClass) =>
          * - Minute precision `"YYYY-MM-DDThh:mm"`
          * - Second precision `"YYYY-MM-DDThh:mm:ss"`
          * - Millisecond precision `"YYYY-MM-DDThh:mm:ss.fff"`
-         *
-         * @type {string | undefined}
          */
         min: {
           type: String,
@@ -98,8 +96,6 @@ export const DateTimePickerMixin = (superClass) =>
          * - Minute precision `"YYYY-MM-DDThh:mm"`
          * - Second precision `"YYYY-MM-DDThh:mm:ss"`
          * - Millisecond precision `"YYYY-MM-DDThh:mm:ss.fff"`
-         *
-         * @type {string | undefined}
          */
         max: {
           type: String,

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -45,7 +45,6 @@ export const LoginMixin = (superClass) =>
         /**
          * If set, a synchronous POST call will be fired to the path defined.
          * The `login` event is also dispatched, so `event.preventDefault()` can be called to prevent the POST call.
-         * @type {string | null}
          */
         action: {
           type: String,

--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -48,8 +48,6 @@ export declare class SelectBaseMixinClass {
    *
    * Note: each item is rendered by default as the internal `<vaadin-select-item>` that is an extension of `<vaadin-item>`.
    * To render the item with a custom component, provide a tag name by the `component` property.
-   *
-   * @type {!Array<!SelectItem>}
    */
   items: SelectItem[] | null | undefined;
 

--- a/packages/upload/src/vaadin-upload-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-mixin.d.ts
@@ -273,7 +273,6 @@ export declare class UploadMixinClass {
    * }
    * ```
    *
-   * @type {!UploadI18n}
    * @default {English}
    */
   i18n: UploadI18n;


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11255

Removed a few more `@type` JSDoc annotations from property declarations which aren't needed. Unlike Polymer Analyzer, with CEM analyzer it's common to use `string` type rather than `string | null | undefined`.

Also removed 2 occurrences of `@type` incorrectly used in `.d.ts` files where they don't make sense.

## Type of change

- Documentation