### PR TITLE
docs: remove type JSDoc annotation for string enum properties

### DIFF
--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -46,7 +46,6 @@ export const ListMixin = (superClass) =>
          * Define how items are disposed in the dom.
          * Possible values are: `horizontal|vertical`.
          * It also changes navigation keys from left/right to up/down.
-         * @type {!ListOrientation}
          */
         orientation: {
           type: String,

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -31,7 +31,6 @@ export const AppLayoutMixin = (superclass) =>
          * - By default (`primary-section="navbar"`), the navbar takes the full available width and moves the drawer down.
          * - If `primary-section="drawer"` is set, then the drawer will move the navbar, taking the full available height.
          * @attr {navbar|drawer} primary-section
-         * @type {!PrimarySection}
          */
         primarySection: {
           type: String,

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -140,7 +140,6 @@ export const CrudMixin = (superClass) =>
          *   - `bottom` - form will open below the grid
          *   - `aside` - form will open on the grid side (_right_, if lft and _left_ if rtl)
          * @attr {bottom|aside} editor-position
-         * @type {!CrudEditorPosition}
          */
         editorPosition: {
           type: String,

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -57,7 +57,6 @@ export const GridProEditColumnMixin = (superClass) =>
          *
          * Editor type is set to `custom` when `editModeRenderer` is set.
          * @attr {text|checkbox|select|custom} editor-type
-         * @type {!GridProEditorType}
          */
         editorType: {
           type: String,

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -97,7 +97,6 @@ export const ColumnBaseMixin = (superClass) =>
          * Aligns the columns cell content horizontally.
          * Supported values: "start", "center" and "end".
          * @attr {start|center|end} text-align
-         * @type {GridColumnTextAlign | null | undefined}
          */
         textAlign: {
           type: String,

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -41,7 +41,6 @@ export const DragAndDropMixin = (superClass) =>
          * - `on-top-or-between`: The drop event can happen either on top of or between Grid rows.
          * - `on-grid`: The drop event will not happen on any specific row, it will show the drop target outline around the whole grid.
          * @attr {between|on-top|on-top-or-between|on-grid} drop-mode
-         * @type {GridDropMode | null | undefined}
          */
         dropMode: {
           type: String,

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -55,7 +55,6 @@ export const ScrollMixin = (superClass) =>
          * and thus not rendered.
          *
          * @attr {eager|lazy} column-rendering
-         * @type {!ColumnRendering}
          */
         columnRendering: {
           type: String,

--- a/packages/grid/src/vaadin-grid-sort-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-column-mixin.js
@@ -23,7 +23,6 @@ export const GridSortColumnMixin = (superClass) =>
          * How to sort the data.
          * Possible values are `asc` to use an ascending algorithm, `desc` to sort the data in
          * descending direction, or `null` for not sorting the data.
-         * @type {GridSorterDirection | undefined}
          */
         direction: {
           type: String,

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -22,7 +22,6 @@ export const GridSorterMixin = (superClass) =>
          * How to sort the data.
          * Possible values are `asc` to use an ascending algorithm, `desc` to sort the data in
          * descending direction, or `null` for not sorting the data.
-         * @type {GridSorterDirection | undefined}
          */
         direction: {
           type: String,

--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -147,7 +147,6 @@ export const NotificationMixin = (superClass) =>
         /**
          * Alignment of the notification in the viewport
          * Valid values are `top-stretch|top-start|top-center|top-end|middle|bottom-start|bottom-center|bottom-end|bottom-stretch`
-         * @type {!NotificationPosition}
          */
         position: {
           type: String,

--- a/packages/tabs/src/vaadin-tabs-mixin.js
+++ b/packages/tabs/src/vaadin-tabs-mixin.js
@@ -18,7 +18,6 @@ export const TabsMixin = (superClass) =>
       return {
         /**
          * Set tabs disposition. Possible values are `horizontal|vertical`
-         * @type {!TabsOrientation}
          */
         orientation: {
           value: 'horizontal',

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -147,7 +147,6 @@ export const UploadMixin = (superClass) =>
 
         /**
          * HTTP Method used to send the files. Only POST and PUT are allowed.
-         * @type {!UploadMethod}
          */
         method: {
           type: String,


### PR DESCRIPTION
## Description

Removed `@type` JSDoc annotation for string properties whose values are enums. These are currently not consistent:
- `orientation` property had the annotation in `vaadin-tabs` but not in `vaadin-split-layout`, 
- `position` property had the annotation in `vaadin-notification` but not in `vaadin-popover`.

Also, for API docs we generally don't use these as the script instead looks up for type definitions to resolve proper type.

The main problem with these is that CEM analyzer treats such properties as non-primitive types and therefore removes them from `attributes` in the output due to custom logic we have. It's better to have them listed as `string` instead.

## Type of change

- Documentation