### PR TITLE
feat: migrate Lumo colors to CSS light-dark() and color-scheme

### DIFF
--- a/packages/vaadin-lumo-styles/src/global/color-scheme.css
+++ b/packages/vaadin-lumo-styles/src/global/color-scheme.css
@@ -12,9 +12,95 @@
 
 :host([theme~='dark']),
 [theme~='dark'] {
-  color: var(--lumo-body-text-color);
-  background-color: var(--lumo-base-color);
   color-scheme: dark;
+
+  /* Dark fallbacks for backwards compatibility: ensures users who only overrode
+     the light value of a variable still get a proper dark value. Without these,
+     a light-only override (e.g. html { --lumo-base-color: pink }) would apply
+     to both modes since color.css uses light-dark() on :where(:root). */
+
+  /* Base (background) */
+  --lumo-base-color: hsl(214, 35%, 21%);
+
+  /* Tint */
+  --lumo-tint-5pct: hsla(214, 65%, 85%, 0.06);
+  --lumo-tint-10pct: hsla(214, 60%, 80%, 0.14);
+  --lumo-tint-20pct: hsla(214, 64%, 82%, 0.23);
+  --lumo-tint-30pct: hsla(214, 69%, 84%, 0.32);
+  --lumo-tint-40pct: hsla(214, 73%, 86%, 0.41);
+  --lumo-tint-50pct: hsla(214, 78%, 88%, 0.5);
+  --lumo-tint-60pct: hsla(214, 82%, 90%, 0.58);
+  --lumo-tint-70pct: hsla(214, 87%, 92%, 0.69);
+  --lumo-tint-80pct: hsla(214, 91%, 94%, 0.8);
+  --lumo-tint-90pct: hsla(214, 96%, 96%, 0.9);
+  --lumo-tint: hsl(214, 100%, 98%);
+
+  /* Shade */
+  --lumo-shade-5pct: hsla(214, 0%, 0%, 0.07);
+  --lumo-shade-10pct: hsla(214, 4%, 2%, 0.15);
+  --lumo-shade-20pct: hsla(214, 8%, 4%, 0.23);
+  --lumo-shade-30pct: hsla(214, 12%, 6%, 0.32);
+  --lumo-shade-40pct: hsla(214, 16%, 8%, 0.41);
+  --lumo-shade-50pct: hsla(214, 20%, 10%, 0.5);
+  --lumo-shade-60pct: hsla(214, 24%, 12%, 0.6);
+  --lumo-shade-70pct: hsla(214, 28%, 13%, 0.7);
+  --lumo-shade-80pct: hsla(214, 32%, 13%, 0.8);
+  --lumo-shade-90pct: hsla(214, 33%, 13%, 0.9);
+  --lumo-shade: hsl(214, 33%, 13%);
+
+  /* Contrast */
+  --lumo-contrast-5pct: var(--lumo-tint-5pct);
+  --lumo-contrast-10pct: var(--lumo-tint-10pct);
+  --lumo-contrast-20pct: var(--lumo-tint-20pct);
+  --lumo-contrast-30pct: var(--lumo-tint-30pct);
+  --lumo-contrast-40pct: var(--lumo-tint-40pct);
+  --lumo-contrast-50pct: var(--lumo-tint-50pct);
+  --lumo-contrast-60pct: var(--lumo-tint-60pct);
+  --lumo-contrast-70pct: var(--lumo-tint-70pct);
+  --lumo-contrast-80pct: var(--lumo-tint-80pct);
+  --lumo-contrast-90pct: var(--lumo-tint-90pct);
+  --lumo-contrast: var(--lumo-tint);
+
+  /* Text */
+  --lumo-header-text-color: var(--lumo-contrast);
+  --lumo-body-text-color: var(--lumo-contrast-90pct);
+  --lumo-secondary-text-color: var(--lumo-contrast-70pct);
+  --lumo-tertiary-text-color: var(--lumo-contrast-50pct);
+  --lumo-disabled-text-color: var(--lumo-contrast-30pct);
+
+  /* Primary */
+  --lumo-primary-color: hsl(214, 90%, 48%);
+  --lumo-primary-color-50pct: hsla(214, 90%, 70%, 0.69);
+  --lumo-primary-color-10pct: hsla(214, 90%, 55%, 0.13);
+  --lumo-primary-text-color: hsl(214, 90%, 77%);
+  --lumo-primary-contrast-color: #fff;
+
+  /* Error */
+  --lumo-error-color: hsl(3, 79%, 49%);
+  --lumo-error-color-50pct: hsla(3, 75%, 62%, 0.5);
+  --lumo-error-color-10pct: hsla(3, 75%, 62%, 0.14);
+  --lumo-error-text-color: hsl(3, 100%, 80%);
+
+  /* Success */
+  --lumo-success-color: hsl(145, 72%, 30%);
+  --lumo-success-color-50pct: hsla(145, 92%, 51%, 0.5);
+  --lumo-success-color-10pct: hsla(145, 92%, 51%, 0.1);
+  --lumo-success-text-color: hsl(145, 85%, 46%);
+
+  /* Warning */
+  --lumo-warning-color: hsl(43, 100%, 48%);
+  --lumo-warning-color-10pct: hsla(40, 100%, 50%, 0.2);
+  --lumo-warning-text-color: hsl(45, 100%, 60%);
+  --lumo-warning-contrast-color: var(--lumo-shade-90pct);
+
+  /* User colors */
+  --vaadin-user-color-0: #ff66c7;
+  --vaadin-user-color-1: #9d8aff;
+  --vaadin-user-color-2: #8aff66;
+  --vaadin-user-color-3: #ffbd66;
+  --vaadin-user-color-4: #dc6bff;
+  --vaadin-user-color-5: #66fffa;
+  --vaadin-user-color-6: #e6ff66;
 
   /* Re-set registered <color> properties so they recompute in dark context.
      These are registered via CSS.registerProperty() in component-base/style-props.js
@@ -26,6 +112,9 @@
   --vaadin-border-color: var(--lumo-contrast-30pct);
   --vaadin-border-color-secondary: var(--lumo-contrast-10pct);
   --vaadin-background-color: var(--lumo-base-color);
+
+  color: var(--lumo-body-text-color);
+  background-color: var(--lumo-base-color);
 }
 
 :host([theme~='light-dark']),

--- a/packages/vaadin-lumo-styles/src/global/color-scheme.css
+++ b/packages/vaadin-lumo-styles/src/global/color-scheme.css
@@ -15,6 +15,17 @@
   color: var(--lumo-body-text-color);
   background-color: var(--lumo-base-color);
   color-scheme: dark;
+
+  /* Re-set registered <color> properties so they recompute in dark context.
+     These are registered via CSS.registerProperty() in component-base/style-props.js
+     and their values get resolved at definition time, so they won't update
+     by just changing color-scheme on a subtree. */
+  --vaadin-text-color: var(--lumo-body-text-color);
+  --vaadin-text-color-secondary: var(--lumo-secondary-text-color);
+  --vaadin-text-color-disabled: var(--lumo-disabled-text-color);
+  --vaadin-border-color: var(--lumo-contrast-30pct);
+  --vaadin-border-color-secondary: var(--lumo-contrast-10pct);
+  --vaadin-background-color: var(--lumo-base-color);
 }
 
 :host([theme~='light-dark']),
@@ -22,4 +33,12 @@
   color: var(--lumo-body-text-color);
   background-color: var(--lumo-base-color);
   color-scheme: light dark;
+
+  /* Re-set registered <color> properties so they recompute based on system preference */
+  --vaadin-text-color: var(--lumo-body-text-color);
+  --vaadin-text-color-secondary: var(--lumo-secondary-text-color);
+  --vaadin-text-color-disabled: var(--lumo-disabled-text-color);
+  --vaadin-border-color: var(--lumo-contrast-30pct);
+  --vaadin-border-color-secondary: var(--lumo-contrast-10pct);
+  --vaadin-background-color: var(--lumo-base-color);
 }

--- a/packages/vaadin-lumo-styles/src/global/color-scheme.css
+++ b/packages/vaadin-lumo-styles/src/global/color-scheme.css
@@ -12,90 +12,14 @@
 
 :host([theme~='dark']),
 [theme~='dark'] {
-  /* Base (background) */
-  --lumo-base-color: hsl(214, 35%, 21%);
-
-  /* Tint */
-  --lumo-tint-5pct: hsla(214, 65%, 85%, 0.06);
-  --lumo-tint-10pct: hsla(214, 60%, 80%, 0.14);
-  --lumo-tint-20pct: hsla(214, 64%, 82%, 0.23);
-  --lumo-tint-30pct: hsla(214, 69%, 84%, 0.32);
-  --lumo-tint-40pct: hsla(214, 73%, 86%, 0.41);
-  --lumo-tint-50pct: hsla(214, 78%, 88%, 0.5);
-  --lumo-tint-60pct: hsla(214, 82%, 90%, 0.58);
-  --lumo-tint-70pct: hsla(214, 87%, 92%, 0.69);
-  --lumo-tint-80pct: hsla(214, 91%, 94%, 0.8);
-  --lumo-tint-90pct: hsla(214, 96%, 96%, 0.9);
-  --lumo-tint: hsl(214, 100%, 98%);
-
-  /* Shade */
-  --lumo-shade-5pct: hsla(214, 0%, 0%, 0.07);
-  --lumo-shade-10pct: hsla(214, 4%, 2%, 0.15);
-  --lumo-shade-20pct: hsla(214, 8%, 4%, 0.23);
-  --lumo-shade-30pct: hsla(214, 12%, 6%, 0.32);
-  --lumo-shade-40pct: hsla(214, 16%, 8%, 0.41);
-  --lumo-shade-50pct: hsla(214, 20%, 10%, 0.5);
-  --lumo-shade-60pct: hsla(214, 24%, 12%, 0.6);
-  --lumo-shade-70pct: hsla(214, 28%, 13%, 0.7);
-  --lumo-shade-80pct: hsla(214, 32%, 13%, 0.8);
-  --lumo-shade-90pct: hsla(214, 33%, 13%, 0.9);
-  --lumo-shade: hsl(214, 33%, 13%);
-
-  /* Contrast */
-  --lumo-contrast-5pct: var(--lumo-tint-5pct);
-  --lumo-contrast-10pct: var(--lumo-tint-10pct);
-  --lumo-contrast-20pct: var(--lumo-tint-20pct);
-  --lumo-contrast-30pct: var(--lumo-tint-30pct);
-  --lumo-contrast-40pct: var(--lumo-tint-40pct);
-  --lumo-contrast-50pct: var(--lumo-tint-50pct);
-  --lumo-contrast-60pct: var(--lumo-tint-60pct);
-  --lumo-contrast-70pct: var(--lumo-tint-70pct);
-  --lumo-contrast-80pct: var(--lumo-tint-80pct);
-  --lumo-contrast-90pct: var(--lumo-tint-90pct);
-  --lumo-contrast: var(--lumo-tint);
-
-  /* Text */
-  --lumo-header-text-color: var(--lumo-contrast);
-  --lumo-body-text-color: var(--lumo-contrast-90pct);
-  --lumo-secondary-text-color: var(--lumo-contrast-70pct);
-  --lumo-tertiary-text-color: var(--lumo-contrast-50pct);
-  --lumo-disabled-text-color: var(--lumo-contrast-30pct);
-
-  /* Primary */
-  --lumo-primary-color: hsl(214, 90%, 48%);
-  --lumo-primary-color-50pct: hsla(214, 90%, 70%, 0.69);
-  --lumo-primary-color-10pct: hsla(214, 90%, 55%, 0.13);
-  --lumo-primary-text-color: hsl(214, 90%, 77%);
-  --lumo-primary-contrast-color: #fff;
-
-  /* Error */
-  --lumo-error-color: hsl(3, 79%, 49%);
-  --lumo-error-color-50pct: hsla(3, 75%, 62%, 0.5);
-  --lumo-error-color-10pct: hsla(3, 75%, 62%, 0.14);
-  --lumo-error-text-color: hsl(3, 100%, 80%);
-
-  /* Success */
-  --lumo-success-color: hsl(145, 72%, 30%);
-  --lumo-success-color-50pct: hsla(145, 92%, 51%, 0.5);
-  --lumo-success-color-10pct: hsla(145, 92%, 51%, 0.1);
-  --lumo-success-text-color: hsl(145, 85%, 46%);
-
-  /* Warning */
-  --lumo-warning-color: hsl(43, 100%, 48%);
-  --lumo-warning-color-10pct: hsla(40, 100%, 50%, 0.2);
-  --lumo-warning-text-color: hsl(45, 100%, 60%);
-  --lumo-warning-contrast-color: var(--lumo-shade-90pct);
-
-  /* User colors */
-  --vaadin-user-color-0: #ff66c7;
-  --vaadin-user-color-1: #9d8aff;
-  --vaadin-user-color-2: #8aff66;
-  --vaadin-user-color-3: #ffbd66;
-  --vaadin-user-color-4: #dc6bff;
-  --vaadin-user-color-5: #66fffa;
-  --vaadin-user-color-6: #e6ff66;
-
   color: var(--lumo-body-text-color);
   background-color: var(--lumo-base-color);
   color-scheme: dark;
+}
+
+:host([theme~='light-dark']),
+[theme~='light-dark'] {
+  color: var(--lumo-body-text-color);
+  background-color: var(--lumo-base-color);
+  color-scheme: light dark;
 }

--- a/packages/vaadin-lumo-styles/src/props/color.css
+++ b/packages/vaadin-lumo-styles/src/props/color.css
@@ -6,46 +6,46 @@
 :where(:root),
 :where(:host) {
   /* Base (background) */
-  --lumo-base-color: #fff;
+  --lumo-base-color: light-dark(#fff, hsl(214, 35%, 21%));
 
   /* Tint */
-  --lumo-tint-5pct: hsla(0, 0%, 100%, 0.3);
-  --lumo-tint-10pct: hsla(0, 0%, 100%, 0.37);
-  --lumo-tint-20pct: hsla(0, 0%, 100%, 0.44);
-  --lumo-tint-30pct: hsla(0, 0%, 100%, 0.5);
-  --lumo-tint-40pct: hsla(0, 0%, 100%, 0.57);
-  --lumo-tint-50pct: hsla(0, 0%, 100%, 0.64);
-  --lumo-tint-60pct: hsla(0, 0%, 100%, 0.7);
-  --lumo-tint-70pct: hsla(0, 0%, 100%, 0.77);
-  --lumo-tint-80pct: hsla(0, 0%, 100%, 0.84);
-  --lumo-tint-90pct: hsla(0, 0%, 100%, 0.9);
-  --lumo-tint: #fff;
+  --lumo-tint-5pct: light-dark(hsla(0, 0%, 100%, 0.3), hsla(214, 65%, 85%, 0.06));
+  --lumo-tint-10pct: light-dark(hsla(0, 0%, 100%, 0.37), hsla(214, 60%, 80%, 0.14));
+  --lumo-tint-20pct: light-dark(hsla(0, 0%, 100%, 0.44), hsla(214, 64%, 82%, 0.23));
+  --lumo-tint-30pct: light-dark(hsla(0, 0%, 100%, 0.5), hsla(214, 69%, 84%, 0.32));
+  --lumo-tint-40pct: light-dark(hsla(0, 0%, 100%, 0.57), hsla(214, 73%, 86%, 0.41));
+  --lumo-tint-50pct: light-dark(hsla(0, 0%, 100%, 0.64), hsla(214, 78%, 88%, 0.5));
+  --lumo-tint-60pct: light-dark(hsla(0, 0%, 100%, 0.7), hsla(214, 82%, 90%, 0.58));
+  --lumo-tint-70pct: light-dark(hsla(0, 0%, 100%, 0.77), hsla(214, 87%, 92%, 0.69));
+  --lumo-tint-80pct: light-dark(hsla(0, 0%, 100%, 0.84), hsla(214, 91%, 94%, 0.8));
+  --lumo-tint-90pct: light-dark(hsla(0, 0%, 100%, 0.9), hsla(214, 96%, 96%, 0.9));
+  --lumo-tint: light-dark(#fff, hsl(214, 100%, 98%));
 
   /* Shade */
-  --lumo-shade-5pct: hsla(214, 61%, 25%, 0.05);
-  --lumo-shade-10pct: hsla(214, 57%, 24%, 0.1);
-  --lumo-shade-20pct: hsla(214, 53%, 23%, 0.16);
-  --lumo-shade-30pct: hsla(214, 50%, 22%, 0.26);
-  --lumo-shade-40pct: hsla(214, 47%, 21%, 0.38);
-  --lumo-shade-50pct: hsla(214, 45%, 20%, 0.52);
-  --lumo-shade-60pct: hsla(214, 43%, 19%, 0.6);
-  --lumo-shade-70pct: hsla(214, 42%, 18%, 0.69);
-  --lumo-shade-80pct: hsla(214, 41%, 17%, 0.83);
-  --lumo-shade-90pct: hsla(214, 40%, 16%, 0.94);
-  --lumo-shade: hsl(214, 35%, 15%);
+  --lumo-shade-5pct: light-dark(hsla(214, 61%, 25%, 0.05), hsla(214, 0%, 0%, 0.07));
+  --lumo-shade-10pct: light-dark(hsla(214, 57%, 24%, 0.1), hsla(214, 4%, 2%, 0.15));
+  --lumo-shade-20pct: light-dark(hsla(214, 53%, 23%, 0.16), hsla(214, 8%, 4%, 0.23));
+  --lumo-shade-30pct: light-dark(hsla(214, 50%, 22%, 0.26), hsla(214, 12%, 6%, 0.32));
+  --lumo-shade-40pct: light-dark(hsla(214, 47%, 21%, 0.38), hsla(214, 16%, 8%, 0.41));
+  --lumo-shade-50pct: light-dark(hsla(214, 45%, 20%, 0.52), hsla(214, 20%, 10%, 0.5));
+  --lumo-shade-60pct: light-dark(hsla(214, 43%, 19%, 0.6), hsla(214, 24%, 12%, 0.6));
+  --lumo-shade-70pct: light-dark(hsla(214, 42%, 18%, 0.69), hsla(214, 28%, 13%, 0.7));
+  --lumo-shade-80pct: light-dark(hsla(214, 41%, 17%, 0.83), hsla(214, 32%, 13%, 0.8));
+  --lumo-shade-90pct: light-dark(hsla(214, 40%, 16%, 0.94), hsla(214, 33%, 13%, 0.9));
+  --lumo-shade: light-dark(hsl(214, 35%, 15%), hsl(214, 33%, 13%));
 
   /* Contrast */
-  --lumo-contrast-5pct: var(--lumo-shade-5pct);
-  --lumo-contrast-10pct: var(--lumo-shade-10pct);
-  --lumo-contrast-20pct: var(--lumo-shade-20pct);
-  --lumo-contrast-30pct: var(--lumo-shade-30pct);
-  --lumo-contrast-40pct: var(--lumo-shade-40pct);
-  --lumo-contrast-50pct: var(--lumo-shade-50pct);
-  --lumo-contrast-60pct: var(--lumo-shade-60pct);
-  --lumo-contrast-70pct: var(--lumo-shade-70pct);
-  --lumo-contrast-80pct: var(--lumo-shade-80pct);
-  --lumo-contrast-90pct: var(--lumo-shade-90pct);
-  --lumo-contrast: var(--lumo-shade);
+  --lumo-contrast-5pct: light-dark(var(--lumo-shade-5pct), var(--lumo-tint-5pct));
+  --lumo-contrast-10pct: light-dark(var(--lumo-shade-10pct), var(--lumo-tint-10pct));
+  --lumo-contrast-20pct: light-dark(var(--lumo-shade-20pct), var(--lumo-tint-20pct));
+  --lumo-contrast-30pct: light-dark(var(--lumo-shade-30pct), var(--lumo-tint-30pct));
+  --lumo-contrast-40pct: light-dark(var(--lumo-shade-40pct), var(--lumo-tint-40pct));
+  --lumo-contrast-50pct: light-dark(var(--lumo-shade-50pct), var(--lumo-tint-50pct));
+  --lumo-contrast-60pct: light-dark(var(--lumo-shade-60pct), var(--lumo-tint-60pct));
+  --lumo-contrast-70pct: light-dark(var(--lumo-shade-70pct), var(--lumo-tint-70pct));
+  --lumo-contrast-80pct: light-dark(var(--lumo-shade-80pct), var(--lumo-tint-80pct));
+  --lumo-contrast-90pct: light-dark(var(--lumo-shade-90pct), var(--lumo-tint-90pct));
+  --lumo-contrast: light-dark(var(--lumo-shade), var(--lumo-tint));
 
   /* Text */
   --lumo-header-text-color: var(--lumo-contrast);
@@ -55,40 +55,40 @@
   --lumo-disabled-text-color: var(--lumo-contrast-30pct);
 
   /* Primary */
-  --lumo-primary-color: hsl(214, 100%, 48%);
-  --lumo-primary-color-50pct: hsla(214, 100%, 49%, 0.76);
-  --lumo-primary-color-10pct: hsla(214, 100%, 60%, 0.13);
-  --lumo-primary-text-color: hsl(214, 100%, 43%);
+  --lumo-primary-color: light-dark(hsl(214, 100%, 48%), hsl(214, 90%, 48%));
+  --lumo-primary-color-50pct: light-dark(hsla(214, 100%, 49%, 0.76), hsla(214, 90%, 70%, 0.69));
+  --lumo-primary-color-10pct: light-dark(hsla(214, 100%, 60%, 0.13), hsla(214, 90%, 55%, 0.13));
+  --lumo-primary-text-color: light-dark(hsl(214, 100%, 43%), hsl(214, 90%, 77%));
   --lumo-primary-contrast-color: #fff;
 
   /* Error */
-  --lumo-error-color: hsl(3, 85%, 48%);
-  --lumo-error-color-50pct: hsla(3, 85%, 49%, 0.5);
-  --lumo-error-color-10pct: hsla(3, 85%, 49%, 0.1);
-  --lumo-error-text-color: hsl(3, 89%, 42%);
+  --lumo-error-color: light-dark(hsl(3, 85%, 48%), hsl(3, 79%, 49%));
+  --lumo-error-color-50pct: light-dark(hsla(3, 85%, 49%, 0.5), hsla(3, 75%, 62%, 0.5));
+  --lumo-error-color-10pct: light-dark(hsla(3, 85%, 49%, 0.1), hsla(3, 75%, 62%, 0.14));
+  --lumo-error-text-color: light-dark(hsl(3, 89%, 42%), hsl(3, 100%, 80%));
   --lumo-error-contrast-color: #fff;
 
   /* Success */
   --lumo-success-color: hsl(145, 72%, 30%);
-  --lumo-success-color-50pct: hsla(145, 72%, 31%, 0.5);
-  --lumo-success-color-10pct: hsla(145, 72%, 31%, 0.1);
-  --lumo-success-text-color: hsl(145, 85%, 25%);
+  --lumo-success-color-50pct: light-dark(hsla(145, 72%, 31%, 0.5), hsla(145, 92%, 51%, 0.5));
+  --lumo-success-color-10pct: light-dark(hsla(145, 72%, 31%, 0.1), hsla(145, 92%, 51%, 0.1));
+  --lumo-success-text-color: light-dark(hsl(145, 85%, 25%), hsl(145, 85%, 46%));
   --lumo-success-contrast-color: #fff;
 
   /* Warning */
-  --lumo-warning-color: hsl(48, 100%, 50%);
-  --lumo-warning-color-10pct: hsla(48, 100%, 50%, 0.25);
-  --lumo-warning-text-color: hsl(32, 100%, 30%);
+  --lumo-warning-color: light-dark(hsl(48, 100%, 50%), hsl(43, 100%, 48%));
+  --lumo-warning-color-10pct: light-dark(hsla(48, 100%, 50%, 0.25), hsla(40, 100%, 50%, 0.2));
+  --lumo-warning-text-color: light-dark(hsl(32, 100%, 30%), hsl(45, 100%, 60%));
   --lumo-warning-contrast-color: var(--lumo-shade-90pct);
 
   /* User colors */
-  --vaadin-user-color-0: #df0b92;
-  --vaadin-user-color-1: #650acc;
-  --vaadin-user-color-2: #097faa;
-  --vaadin-user-color-3: #ad6200;
-  --vaadin-user-color-4: #bf16f3;
-  --vaadin-user-color-5: #084391;
-  --vaadin-user-color-6: #078836;
+  --vaadin-user-color-0: light-dark(#df0b92, #ff66c7);
+  --vaadin-user-color-1: light-dark(#650acc, #9d8aff);
+  --vaadin-user-color-2: light-dark(#097faa, #8aff66);
+  --vaadin-user-color-3: light-dark(#ad6200, #ffbd66);
+  --vaadin-user-color-4: light-dark(#bf16f3, #dc6bff);
+  --vaadin-user-color-5: light-dark(#084391, #66fffa);
+  --vaadin-user-color-6: light-dark(#078836, #e6ff66);
 
   /* Base styles colors */
   --vaadin-text-color: var(--lumo-body-text-color);

--- a/packages/vaadin-lumo-styles/test/color-scheme.test.js
+++ b/packages/vaadin-lumo-styles/test/color-scheme.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
 // Ensure registered custom properties are available
-import '../../component-base/src/styles/style-props.js';
+import '@vaadin/component-base/src/styles/style-props.js';
 
 // Load Lumo CSS
 function loadCSS(href) {

--- a/packages/vaadin-lumo-styles/test/color-scheme.test.js
+++ b/packages/vaadin-lumo-styles/test/color-scheme.test.js
@@ -1,0 +1,138 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync } from '@vaadin/testing-helpers';
+// Ensure registered custom properties are available
+import '../../component-base/src/styles/style-props.js';
+
+// Load Lumo CSS
+function loadCSS(href) {
+  return new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    link.addEventListener('load', resolve);
+    link.addEventListener('error', reject);
+    document.head.appendChild(link);
+  });
+}
+
+function getColor(element, property) {
+  return getComputedStyle(element).getPropertyValue(property).trim();
+}
+
+const WHITE = 'rgb(255, 255, 255)';
+
+describe('color-scheme', () => {
+  before(async () => {
+    await loadCSS('/packages/vaadin-lumo-styles/src/props/index.css');
+    await loadCSS('/packages/vaadin-lumo-styles/src/global/index.css');
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute('theme');
+  });
+
+  describe('light mode (default)', () => {
+    it('should resolve --lumo-base-color to white', () => {
+      const el = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      expect(getColor(el, 'background-color')).to.equal(WHITE);
+    });
+
+    it('should resolve --lumo-contrast to a dark shade', () => {
+      const el = fixtureSync('<div style="color: var(--lumo-contrast)"></div>');
+      expect(getColor(el, 'color')).to.not.equal(WHITE);
+    });
+  });
+
+  describe('dark mode on document', () => {
+    beforeEach(() => {
+      document.documentElement.setAttribute('theme', 'dark');
+    });
+
+    it('should resolve --lumo-base-color to a dark color', () => {
+      const el = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      expect(getColor(el, 'background-color')).to.not.equal(WHITE);
+    });
+
+    it('should resolve --lumo-contrast to a light tint', () => {
+      const el = fixtureSync('<div style="background-color: var(--lumo-contrast)"></div>');
+      // In dark mode, contrast flips to tint (light values)
+      expect(getColor(el, 'background-color')).to.not.equal('rgba(0, 0, 0, 0)');
+    });
+  });
+
+  describe('dark mode on subtree', () => {
+    it('should resolve --lumo-base-color to a dark color on the subtree element', () => {
+      const container = fixtureSync(`
+        <div theme="dark">
+          <div id="inner" style="background-color: var(--lumo-base-color)"></div>
+        </div>
+      `);
+      const inner = container.querySelector('#inner');
+      expect(getColor(inner, 'background-color')).to.not.equal(WHITE);
+    });
+
+    it('should resolve --lumo-contrast to tint values on the subtree element', () => {
+      // Get light contrast value for comparison
+      const lightEl = fixtureSync('<div style="background-color: var(--lumo-contrast)"></div>');
+      const lightContrast = getColor(lightEl, 'background-color');
+
+      const container = fixtureSync(`
+        <div theme="dark">
+          <div id="inner" style="background-color: var(--lumo-contrast)"></div>
+        </div>
+      `);
+      const inner = container.querySelector('#inner');
+      const darkContrast = getColor(inner, 'background-color');
+
+      // Dark contrast (tint) should differ from light contrast (shade)
+      expect(darkContrast).to.not.equal(lightContrast);
+    });
+
+    it('should not affect elements outside the subtree', () => {
+      fixtureSync('<div theme="dark"></div>');
+      const outside = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      expect(getColor(outside, 'background-color')).to.equal(WHITE);
+    });
+  });
+
+  describe('registered custom properties in subtree dark mode', () => {
+    it('should update --vaadin-background-color in dark subtree', () => {
+      // Get light value
+      const lightEl = fixtureSync('<div></div>');
+      const lightBg = getColor(lightEl, '--vaadin-background-color');
+
+      // Get dark subtree value
+      const container = fixtureSync(`
+        <div theme="dark">
+          <div id="inner"></div>
+        </div>
+      `);
+      const inner = container.querySelector('#inner');
+      const darkBg = getColor(inner, '--vaadin-background-color');
+
+      expect(darkBg).to.not.equal(lightBg);
+    });
+
+    it('should update --vaadin-text-color in dark subtree', () => {
+      const lightEl = fixtureSync('<div></div>');
+      const lightText = getColor(lightEl, '--vaadin-text-color');
+
+      const container = fixtureSync(`
+        <div theme="dark">
+          <div id="inner"></div>
+        </div>
+      `);
+      const inner = container.querySelector('#inner');
+      const darkText = getColor(inner, '--vaadin-text-color');
+
+      expect(darkText).to.not.equal(lightText);
+    });
+  });
+
+  describe('light-dark mode', () => {
+    it('should set color-scheme to light dark', () => {
+      const el = fixtureSync('<div theme="light-dark"></div>');
+      expect(getColor(el, 'color-scheme')).to.equal('light dark');
+    });
+  });
+});

--- a/packages/vaadin-lumo-styles/test/color-scheme.test.js
+++ b/packages/vaadin-lumo-styles/test/color-scheme.test.js
@@ -129,6 +129,73 @@ describe('color-scheme', () => {
     });
   });
 
+  describe('backwards compatibility: light-only override', () => {
+    let style;
+
+    before(() => {
+      // Simulate a user overriding only the light value
+      style = document.createElement('style');
+      style.textContent = `
+        html {
+          --lumo-base-color: pink;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
+    after(() => {
+      style.remove();
+    });
+
+    it('should use the overridden value in light mode', () => {
+      const el = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      // Pink in computed style
+      expect(getColor(el, 'background-color')).to.not.equal(WHITE);
+    });
+
+    it('should use the dark fallback (not the light override) in dark mode', () => {
+      document.documentElement.setAttribute('theme', 'dark');
+      const el = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      const bg = getColor(el, 'background-color');
+      // Should NOT be pink — the dark fallback block should win
+      expect(bg).to.not.equal('rgb(255, 192, 203)');
+      // Should be the Lumo dark base color
+      expect(bg).to.not.equal(WHITE);
+    });
+  });
+
+  describe('backwards compatibility: light and dark override', () => {
+    let style;
+
+    before(() => {
+      style = document.createElement('style');
+      style.textContent = `
+        html {
+          --lumo-base-color: pink;
+        }
+        html[theme~='dark'] {
+          --lumo-base-color: darkslategray;
+        }
+      `;
+      document.head.appendChild(style);
+    });
+
+    after(() => {
+      style.remove();
+    });
+
+    it('should use the light override in light mode', () => {
+      const el = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      expect(getColor(el, 'background-color')).to.equal('rgb(255, 192, 203)');
+    });
+
+    it('should use the dark override in dark mode', () => {
+      document.documentElement.setAttribute('theme', 'dark');
+      const el = fixtureSync('<div style="background-color: var(--lumo-base-color)"></div>');
+      expect(getColor(el, 'background-color')).to.equal('rgb(47, 79, 79)');
+    });
+  });
+
   describe('light-dark mode', () => {
     it('should set color-scheme to light dark', () => {
       const el = fixtureSync('<div theme="light-dark"></div>');


### PR DESCRIPTION
Use the CSS light-dark() function for all color variables that differ between light and dark mode, replacing the previous approach of redefining 55 variables in a [theme~="dark"] selector block. The dark block now only sets color-scheme: dark, which triggers light-dark() to pick the dark values.

Also adds theme="light-dark" support (color-scheme: light dark) so the browser can follow the user's system preference automatically.
