### PR TITLE
docs: add missing fires JSDoc annotations for upload file events

### DIFF
--- a/packages/upload/src/vaadin-upload-file.d.ts
+++ b/packages/upload/src/vaadin-upload-file.d.ts
@@ -97,9 +97,9 @@ export interface UploadFileEventMap extends HTMLElementEventMap, UploadFileCusto
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @fires {CustomEvent} file-abort - Fired when abort button is pressed.
- * @fires {CustomEvent} file-retry - Fired when retry button is pressed.
- * @fires {CustomEvent} file-start - Fired when start button is pressed.
+ * @fires {CustomEvent} file-abort - Fired when the abort button is pressed.
+ * @fires {CustomEvent} file-retry - Fired when the retry button is pressed.
+ * @fires {CustomEvent} file-start - Fired when the start button is pressed.
  */
 declare class UploadFile extends UploadFileMixin(ThemableMixin(HTMLElement)) {
   addEventListener<K extends keyof UploadFileEventMap>(

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -77,9 +77,9 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @fires {CustomEvent} file-abort - Fired when abort button is pressed.
- * @fires {CustomEvent} file-retry - Fired when retry button is pressed.
- * @fires {CustomEvent} file-start - Fired when start button is pressed.
+ * @fires {CustomEvent} file-abort - Fired when the abort button is pressed.
+ * @fires {CustomEvent} file-retry - Fired when the retry button is pressed.
+ * @fires {CustomEvent} file-start - Fired when the start button is pressed.
  *
  * @customElement vaadin-upload-file
  * @extends HTMLElement


### PR DESCRIPTION
## Description

These events are present in `.d.ts` event map and have `@event` annotations but lacking `@fires`. This PR fixes that.

## Type of change

- Documentation