### PR TITLE
refactor: use object syntax for property declarations to fix CEM types

### DIFF
--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -25,19 +25,25 @@ export const CrudGridMixin = (superClass) =>
          * Disable filtering in the generated columns.
          * @attr {boolean} no-filter
          */
-        noFilter: Boolean,
+        noFilter: {
+          type: Boolean,
+        },
 
         /**
          * Disable sorting in the generated columns.
          * @attr {boolean} no-sort
          */
-        noSort: Boolean,
+        noSort: {
+          type: Boolean,
+        },
 
         /**
          * Do not add headers to columns.
          * @attr {boolean} no-head
          */
-        noHead: Boolean,
+        noHead: {
+          type: Boolean,
+        },
 
         /**
          * Determines whether the edit column should be hidden.

--- a/packages/crud/src/vaadin-crud-include-mixin.js
+++ b/packages/crud/src/vaadin-crud-include-mixin.js
@@ -27,6 +27,7 @@ export const IncludedMixin = (superClass) =>
          * @type {string | RegExp}
          */
         exclude: {
+          type: String,
           value: '^_',
           observer: '__onExcludeChange',
           sync: true,
@@ -40,6 +41,7 @@ export const IncludedMixin = (superClass) =>
          * @type {string | !Array<string> | undefined}
          */
         include: {
+          type: String,
           observer: '__onIncludeChange',
           sync: true,
         },

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -180,19 +180,25 @@ export const CrudMixin = (superClass) =>
          * Disable filtering when grid is autoconfigured.
          * @attr {boolean} no-filter
          */
-        noFilter: Boolean,
+        noFilter: {
+          type: Boolean,
+        },
 
         /**
          * Disable sorting when grid is autoconfigured.
          * @attr {boolean} no-sort
          */
-        noSort: Boolean,
+        noSort: {
+          type: Boolean,
+        },
 
         /**
          * Remove grid headers when it is autoconfigured.
          * @attr {boolean} no-head
          */
-        noHead: Boolean,
+        noHead: {
+          type: Boolean,
+        },
 
         /**
          * A comma-separated list of fields to include in the generated grid and the generated editor.
@@ -203,7 +209,9 @@ export const CrudMixin = (superClass) =>
          *
          * Default is undefined meaning that all properties in the object should be mapped to fields.
          */
-        include: String,
+        include: {
+          type: String,
+        },
 
         /**
          * A comma-separated list of fields to be excluded from the generated grid and the generated editor.
@@ -212,7 +220,9 @@ export const CrudMixin = (superClass) =>
          *
          * Default is to exclude all private fields (those properties starting with underscore)
          */
-        exclude: String,
+        exclude: {
+          type: String,
+        },
 
         /**
          * Reflects the opened status of the editor.

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -42,7 +42,9 @@ export const CustomFieldMixin = (superClass) =>
         /**
          * The name of the control, which is submitted with the form data.
          */
-        name: String,
+        name: {
+          type: String,
+        },
 
         /**
          * The value of the field. When wrapping several inputs, it will contain `\t`

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -132,7 +132,9 @@ export const DatePickerMixin = (subclass) =>
          * The same date formats as for the `value` property are supported.
          * @attr {string} initial-position
          */
-        initialPosition: String,
+        initialPosition: {
+          type: String,
+        },
 
         /**
          * Set true to open the date selector overlay.

--- a/packages/dialog/src/vaadin-dialog-renderer-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-renderer-mixin.js
@@ -33,7 +33,9 @@ export const DialogRendererMixin = (superClass) =>
          * When `headerTitle` is set, the attribute `has-title` is set on the dialog.
          * @attr {string} header-title
          */
-        headerTitle: String,
+        headerTitle: {
+          type: String,
+        },
 
         /**
          * Custom function for rendering the dialog header.

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -95,7 +95,9 @@ class SideNavItem extends SideNavChildrenMixin(
       /**
        * The path to navigate to
        */
-      path: String,
+      path: {
+        type: String,
+      },
 
       /**
        * The list of alternative paths matching this item
@@ -158,7 +160,9 @@ class SideNavItem extends SideNavChildrenMixin(
       /**
        * The target of the link. Works only when `path` is set.
        */
-      target: String,
+      target: {
+        type: String,
+      },
 
       /**
        * Whether to exclude the item from client-side routing. When enabled,

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -328,7 +328,9 @@ export const UploadMixin = (superClass) =>
          * Pass-through to input's capture attribute. Allows user to trigger device inputs
          * such as camera or microphone immediately.
          */
-        capture: String,
+        capture: {
+          type: String,
+        },
 
         /** @private */
         _addButton: {


### PR DESCRIPTION
## Description

Shorthand Polymer property syntax (e.g., `prop: String`) causes the CEM analyzer to produce empty types. Convert all affected properties to object syntax (`prop: { type: String }`).

## Type of change

- Refactor