### PR TITLE
docs: remove more types JSDoc for enum properties

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -177,7 +177,6 @@ export const ChartMixin = (superClass) =>
          * Defaults to `undefined`
          *
          * @attr {left|right|top|bottom} category-position
-         * @type {ChartCategoryPosition | undefined}
          */
         categoryPosition: {
           type: String,
@@ -202,7 +201,6 @@ export const ChartMixin = (superClass) =>
          * If "stack" property is not defined on the vaadin-chart-series elements, then series will be put into
          * the default stack.
          * @attr {normal|percent} stacking
-         * @type {ChartStacking | undefined}
          */
         stacking: {
           type: String,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11264

These properties also use `@type` causing CEM to produce output that is considered as non-primitive type and therefore would cause corresponding attributes to be filtered out from `web-types.json`. Let's remove them.

## Type of change

- Documentation