### PR TITLE
chore: use default accent color for all components in aura dev page

### DIFF
--- a/dev/aura/aura-extras.css
+++ b/dev/aura/aura-extras.css
@@ -4,11 +4,6 @@ html {
   /* TODO how to use a different surface level in dark mode? */
 }
 
-:is(vaadin-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-side-nav, vaadin-tabs) {
-  --aura-accent-color-light: var(--aura-neutral-light);
-  --aura-accent-color-dark: var(--aura-neutral-dark);
-}
-
 body {
   margin: 0;
   height: 100%;


### PR DESCRIPTION
This makes the demo look the same as the default that you get in a standard, un-customized Vaadin project.