### PR TITLE
docs: add missing type JSDoc to ItemMixin value property

### DIFF
--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -57,15 +57,13 @@ export const ItemMixin = (superClass) =>
     }
 
     /**
-     * @return {string}
+     * Submittable string value. The default value is the trimmed text content of the element.
+     * @type {string}
      */
     get value() {
       return this._value !== undefined ? this._value : this.textContent.trim();
     }
 
-    /**
-     * @param {string} value
-     */
     set value(value) {
       this._value = value;
     }


### PR DESCRIPTION
## Description

Fixed the following CEM Analyzer issue reported by Claude:

> `vaadin-item` missing `value` property description
> `ItemMixin.value` is a getter/setter pair without a JSDoc description. The old Polymer Analyzer inferred one, but CEM does not.
> **Fix:** Add a JSDoc `@type` or description comment to the `value` getter in `packages/item/src/vaadin-item-mixin.js:62`.

## Type of change

- Documentation