### PR TITLE
fix: add missing component-specific CSS custom properties in Aura overlay styles

### DIFF
--- a/packages/aura/aura.css
+++ b/packages/aura/aura.css
@@ -31,6 +31,7 @@
 @import './src/components/multi-select-combo-box.css';
 @import './src/components/notification.css';
 @import './src/components/overlay.css';
+@import './src/components/popover.css';
 @import './src/components/progress-bar.css';
 @import './src/components/rich-text-editor.css';
 @import './src/components/select.css';

--- a/packages/aura/src/components/dialog.css
+++ b/packages/aura/src/components/dialog.css
@@ -12,6 +12,9 @@ vaadin-confirm-dialog {
 vaadin-dialog::part(overlay),
 vaadin-confirm-dialog::part(overlay) {
   background: var(--vaadin-dialog-background, var(--vaadin-overlay-background, var(--aura-surface-color)));
+  box-shadow:
+    var(--aura-overlay-outline-shadow),
+    var(--vaadin-dialog-shadow, var(--vaadin-overlay-shadow, var(--aura-overlay-shadow)));
   --aura-surface-level: 2;
   --aura-surface-opacity: var(--aura-overlay-surface-opacity);
 

--- a/packages/aura/src/components/login.css
+++ b/packages/aura/src/components/login.css
@@ -26,6 +26,10 @@ vaadin-login-overlay {
 
   &::part(overlay) {
     --aura-surface-level: 2;
+    background: var(--vaadin-login-overlay-background, var(--vaadin-overlay-background, var(--aura-surface-color)));
+    box-shadow:
+      var(--aura-overlay-outline-shadow),
+      var(--vaadin-login-overlay-shadow, var(--vaadin-overlay-shadow, var(--aura-overlay-shadow)));
   }
 
   &::part(brand) {

--- a/packages/aura/src/components/notification.css
+++ b/packages/aura/src/components/notification.css
@@ -12,6 +12,7 @@ vaadin-notification-container {
 vaadin-notification-card::part(overlay) {
   --aura-surface-level: 3.5;
   background: var(--vaadin-notification-background, var(--aura-surface-color));
+  box-shadow: var(--aura-overlay-outline-shadow), var(--vaadin-notification-shadow, var(--aura-overlay-shadow));
 
   /* TODO probably should be in base styles */
   /* Keeps notifications on top of MDL view transitions */

--- a/packages/aura/src/components/popover.css
+++ b/packages/aura/src/components/popover.css
@@ -1,0 +1,10 @@
+vaadin-popover::part(overlay) {
+  background: var(--vaadin-popover-background, var(--vaadin-overlay-background, var(--aura-surface-color)));
+  box-shadow:
+    var(--aura-overlay-outline-shadow),
+    var(--vaadin-popover-shadow, var(--vaadin-overlay-shadow, var(--aura-overlay-shadow)));
+}
+
+vaadin-popover::part(arrow) {
+  background: var(--vaadin-popover-background, var(--vaadin-overlay-background, var(--aura-surface-color)));
+}

--- a/packages/aura/src/components/tooltip.css
+++ b/packages/aura/src/components/tooltip.css
@@ -8,5 +8,6 @@
 }
 
 :is(vaadin-tooltip, vaadin-slider-bubble)::part(overlay) {
+  background: var(--vaadin-tooltip-background, var(--vaadin-overlay-background, var(--aura-surface-color)));
   box-shadow: var(--aura-overlay-outline-shadow), var(--vaadin-tooltip-shadow, var(--aura-shadow-s));
 }


### PR DESCRIPTION
## Summary

Part of #11163

The global Aura `overlay.css` sets `background` and `box-shadow` on a bare `::part(overlay)` selector using only generic properties (`--vaadin-overlay-background`, `--vaadin-overlay-shadow`). This overrides the component base styles that contain component-specific fallback chains. As a result, setting component-specific CSS custom properties (e.g. `--vaadin-dialog-shadow`, `--vaadin-tooltip-background`) on the host element has no effect.

This PR adds the missing component-specific `background` and/or `box-shadow` declarations:

- **dialog.css** — add `box-shadow` with `--vaadin-dialog-shadow` fallback
- **notification.css** — add `box-shadow` with `--vaadin-notification-shadow` fallback
- **tooltip.css** — add `background` with `--vaadin-tooltip-background` fallback
- **login.css** — add `background` and `box-shadow` with `--vaadin-login-overlay-*` fallbacks
- **popover.css** (new) — add `background` and `box-shadow` with `--vaadin-popover-*` fallbacks
- **aura.css** — import `popover.css`

## Test plan

- [x] `yarn test:aura --group dialog` — 3 passed
- [x] `yarn test:aura --group confirm-dialog` — 4 passed
- [x] `yarn test:aura --group notification` — 17 passed
- [x] `yarn test:aura --group tooltip` — 2 passed
- [x] `yarn test:aura --group login` — 6 passed
- [x] `yarn test:aura --group popover` — 24 passed
- [x] `yarn test:aura:dark --group dialog` — 3 passed
- [x] `yarn test:aura:dark --group confirm-dialog` — 4 passed
- [x] `yarn test:aura:dark --group notification` — 17 passed
- [x] `yarn test:aura:dark --group tooltip` — 2 passed
- [x] `yarn test:aura:dark --group login` — 6 passed
- [x] `yarn test:aura:dark --group popover` — 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)