### PR TITLE
test: update side-nav DOM and visual tests to not use badge

### DIFF
--- a/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
+++ b/packages/side-nav/test/dom/__snapshots__/side-nav-item.test.snap.js
@@ -12,10 +12,7 @@ snapshots["vaadin-side-nav-item item default"] =
   >
   </vaadin-icon>
   Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
+  <span slot="suffix">
     2
   </span>
   <vaadin-side-nav-item
@@ -46,10 +43,7 @@ snapshots["vaadin-side-nav-item item expanded"] =
   >
   </vaadin-icon>
   Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
+  <span slot="suffix">
     2
   </span>
   <vaadin-side-nav-item
@@ -81,10 +75,7 @@ snapshots["vaadin-side-nav-item item disabled"] =
   >
   </vaadin-icon>
   Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
+  <span slot="suffix">
     2
   </span>
   <vaadin-side-nav-item
@@ -120,10 +111,7 @@ snapshots["vaadin-side-nav-item item current"] =
   >
   </vaadin-icon>
   Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
+  <span slot="suffix">
     2
   </span>
   <vaadin-side-nav-item
@@ -153,10 +141,7 @@ snapshots["vaadin-side-nav-item item path"] =
   >
   </vaadin-icon>
   Item
-  <span
-    slot="suffix"
-    theme="badge primary"
-  >
+  <span slot="suffix">
     2
   </span>
   <vaadin-side-nav-item

--- a/packages/side-nav/test/dom/side-nav-item.test.js
+++ b/packages/side-nav/test/dom/side-nav-item.test.js
@@ -22,7 +22,7 @@ describe('vaadin-side-nav-item', () => {
         <vaadin-side-nav-item>
           <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
           Item
-          <span theme="badge primary" slot="suffix">2</span>
+          <span slot="suffix">2</span>
           <vaadin-side-nav-item slot="children">Child item 1</vaadin-side-nav-item>
           <vaadin-side-nav-item slot="children">Child item 2</vaadin-side-nav-item>
         </vaadin-side-nav-item>

--- a/packages/side-nav/test/visual/lumo/side-nav.test.js
+++ b/packages/side-nav/test/visual/lumo/side-nav.test.js
@@ -102,12 +102,12 @@ describe('side-nav', () => {
                 <vaadin-side-nav-item>
                   <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
                   Item 1
-                  <span theme="badge primary" slot="suffix">2</span>
+                  <span slot="suffix">2</span>
                 </vaadin-side-nav-item>
                 <vaadin-side-nav-item>
                   <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
                   Item 2
-                  <span theme="badge primary" slot="suffix">3</span>
+                  <span slot="suffix">3</span>
                 </vaadin-side-nav-item>
               </vaadin-side-nav>
             `,
@@ -153,22 +153,22 @@ describe('side-nav', () => {
                 <vaadin-side-nav-item>
                   <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
                   Item 1
-                  <span theme="badge primary" slot="suffix">2</span>
+                  <span slot="suffix">2</span>
                   <vaadin-side-nav-item slot="children">
                     <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
                     Child item 1
-                    <span theme="badge primary" slot="suffix">12</span>
+                    <span slot="suffix">12</span>
                   </vaadin-side-nav-item>
                   <vaadin-side-nav-item slot="children">
                     <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
                     Child item 2
-                    <span theme="badge primary" slot="suffix">13</span>
+                    <span slot="suffix">13</span>
                   </vaadin-side-nav-item>
                 </vaadin-side-nav-item>
                 <vaadin-side-nav-item>
                   <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
                   Item 2
-                  <span theme="badge primary" slot="suffix">3</span>
+                 <span slot="suffix">3</span>
                 </vaadin-side-nav-item>
               </vaadin-side-nav>
             `,


### PR DESCRIPTION
## Description

Replaced `theme="badge"` usage in DOM and visual tests with regular `span` elements.
Note: CSS for the badge wasn't actually imported in Lumo, so there are no screenshot updates.

## Type of change

- Test