### PR TITLE
docs: update side-nav-item JSDoc to use vaadin-badge component

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -50,7 +50,7 @@ export type SideNavItemEventMap = HTMLElementEventMap & SideNavItemCustomEventMa
  * <vaadin-side-nav-item>
  *   <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
  *   Item
- *   <span theme="badge primary" slot="suffix">Suffix</span>
+ *   <vaadin-badge slot="suffix">Suffix</vaadin-badge>
  * </vaadin-side-nav-item>
  * ```
  *

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -48,7 +48,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * <vaadin-side-nav-item>
  *   <vaadin-icon icon="vaadin:chart" slot="prefix"></vaadin-icon>
  *   Item
- *   <span theme="badge primary" slot="suffix">Suffix</span>
+ *   <vaadin-badge slot="suffix">Suffix</vaadin-badge>
  * </vaadin-side-nav-item>
  * ```
  *


### PR DESCRIPTION
## Description

Replaced Lumo-specific `<span theme="badge primary">` in JSDoc with the new `vaadin-badge` component.

## Type of change

- Documentation