### PR TITLE
chore: update card and side-nav dev pages to use badge

### DIFF
--- a/dev/card.html
+++ b/dev/card.html
@@ -6,11 +6,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Card</title>
     <script type="module" src="./common.js"></script>
-
     <script type="module">
-      import '@vaadin/card';
+      window.Vaadin ||= {};
+      window.Vaadin.featureFlags ||= {};
+      window.Vaadin.featureFlags.badgeComponent = true;
+    </script>
+    <script type="module">
       import '@vaadin/avatar';
+      import '@vaadin/badge';
       import '@vaadin/button';
+      import '@vaadin/card';
       import '@vaadin/checkbox';
       import '@vaadin/checkbox-group';
       import '@vaadin/icon';
@@ -325,7 +330,7 @@
           <h2>Lapland</h2>
         </div>
         <vaadin-avatar slot="header-prefix" abbr="L"></vaadin-avatar>
-        <span slot="header-suffix" theme="badge success">Arctic</span>
+        <vaadin-badge slot="header-suffix" theme="success">Arctic</vaadin-badge>
         <div slot="title">Lapland</div>
         <div slot="subtitle">The Exotic North</div>
         <vaadin-button slot="footer">Book Vacation</vaadin-button>

--- a/dev/side-nav.html
+++ b/dev/side-nav.html
@@ -7,6 +7,12 @@
     <title>Side Nav</title>
     <script type="module" src="./common.js"></script>
     <script type="module">
+      window.Vaadin ||= {};
+      window.Vaadin.featureFlags ||= {};
+      window.Vaadin.featureFlags.badgeComponent = true;
+    </script>
+    <script type="module">
+      import '@vaadin/badge';
       import '@vaadin/icon';
       import '@vaadin/icons';
       import '@vaadin/side-nav';
@@ -98,12 +104,12 @@
 
       <vaadin-side-nav-item path="/dev/side-nav.html">
         Side Nav
-        <span theme="badge" slot="suffix" aria-label="(2 new items)">1</span>
+        <vaadin-badge slot="suffix" number="1" theme="number-only">new items</vaadin-badge>
       </vaadin-side-nav-item>
 
       <vaadin-side-nav-item path="/dev" expanded>
         Dev pages
-        <span theme="badge" slot="suffix" aria-label="(2 new items)">99+</span>
+        <vaadin-badge slot="suffix" number="99" theme="number-only">new items</vaadin-badge>
 
         <vaadin-side-nav-item path="/dev/grid.html" slot="children">Grid</vaadin-side-nav-item>
         <vaadin-side-nav-item path="/dev/select.html" slot="children">Select</vaadin-side-nav-item>
@@ -120,7 +126,7 @@
           <vaadin-side-nav-item path="/dev/form-layout.html" slot="children"> Form Layout </vaadin-side-nav-item>
           <vaadin-side-nav-item path="/dev/master-detail-layout.html" slot="children">
             Master-Detail Layout
-            <span theme="badge" slot="suffix" aria-label="(2 new items)">2</span>
+             <vaadin-badge slot="suffix" number="2" theme="number-only">new items</vaadin-badge>
           </vaadin-side-nav-item>
           <vaadin-side-nav-item path="/dev/split-layout.html" slot="children"> Split Layout </vaadin-side-nav-item>
           <vaadin-side-nav-item path="/dev/horizontal-layout.html" slot="children">


### PR DESCRIPTION
## Description

Replaced Lumo specific `<span theme="badge">` with the new `vaadin-badge` component in dev pages.

## Type of change

- Internal change