### PR TITLE
docs: add @prop JSDoc annotation for label property in vaadin-item

### DIFF
--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -60,6 +60,7 @@ import { ItemMixin } from './vaadin-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @prop {string} label - String that can be set to visually represent the selected item in `vaadin-select`.
  * @customElement vaadin-item
  * @extends HTMLElement
  * @mixes ItemMixin


### PR DESCRIPTION
## Description

CEM ignores constructor declarations for properties that Polymer Analyzer understands:

https://github.com/vaadin/web-components/blob/958c4a86c07783057a6e9af82efb60fb05ef1eda/packages/item/src/vaadin-item.js#L97-L101

Adding `@prop`to the class JSDoc block makes CEM pick it up as a public field:

```
{
  "type": {
    "text": "string"
  },
  "description": "String that can be set to visually represent the selected item in `vaadin-select`.",
  "name": "label",
  "kind": "field",
  "privacy": "public"
},
```

Note: in `vaadin-item.d.ts` the property is already declared, so we don't need to add `@prop` there.

## Type of change

- Documentation