### PR TITLE
fix: make scrollToColumn update cell position synchronously

### DIFF
--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -206,6 +206,8 @@ export const ScrollMixin = (superClass) =>
       }
 
       this._scrollHorizontallyToCell(column._headerCell);
+      // Update cell position synchronously
+      this.__updateHorizontalScrollPosition();
       // Synchronously update cells when using lazy column rendering
       this.__updateColumnsBodyContentHidden();
     }

--- a/packages/grid/test/scroll-to-column.test.js
+++ b/packages/grid/test/scroll-to-column.test.js
@@ -54,12 +54,11 @@ describe('scroll to column', () => {
       return false;
     }
 
-    const scrollLeft = grid.$.table.scrollLeft;
-    const clientWidth = grid.$.table.clientWidth;
-
-    return (
-      headerCell.offsetLeft + headerCell.offsetWidth >= scrollLeft && headerCell.offsetLeft <= scrollLeft + clientWidth
-    );
+    const bounds = headerCell.getBoundingClientRect();
+    const centerX = bounds.left + bounds.width / 2;
+    const centerY = bounds.top + bounds.height / 2;
+    const cellContent = document.elementFromPoint(centerX, centerY);
+    return headerCell.querySelector('slot').assignedElements().includes(cellContent);
   }
 
   describe('by index', () => {
@@ -216,14 +215,16 @@ describe('scroll to column', () => {
     });
 
     it('should not scroll for frozen column (always visible)', () => {
+      grid.scrollToColumn(9);
+      expect(isColumnInViewport(columns[9])).to.be.true;
+
       const initialScrollLeft = grid.$.table.scrollLeft;
       grid.scrollToColumn(columns[0]);
       expect(grid.$.table.scrollLeft).to.equal(initialScrollLeft);
     });
 
-    it('should scroll non-frozen column into view', async () => {
+    it('should scroll non-frozen column into view', () => {
       grid.scrollToColumn(9);
-      await nextFrame();
       expect(isColumnInViewport(columns[9])).to.be.true;
 
       // Scroll back to first non-frozen


### PR DESCRIPTION
## Description

Any scrolling in the grid needs to run `__updateHorizontalScrollPosition` to update positions of individual table elements so that the respective content actually becomes visible. Currently this is only run asynchronously after `scrollToColumn`, which means that scrolling to a column programmatically in a test can lead to follow up interactions (e.g. clicks) with cell contents failing (similar issue with checking cell visibility in the currently flaky [flow-components ITs](https://bender.vaadin.com/buildConfiguration/VaadinFlowComponents_WcFcNightlyValidation/839825?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildTestsSection=true)).

This change calls `__updateHorizontalScrollPosition` synchronously in `scrollToColumn`, so content can be interacted with right after scrolling.

## Type of change

- Bugfix
