### PR TITLE
refactor: do not use String shorthand syntax for properties

### DIFF
--- a/packages/crud/src/vaadin-crud-edit-column.js
+++ b/packages/crud/src/vaadin-crud-edit-column.js
@@ -56,8 +56,12 @@ class CrudEditColumn extends GridColumn {
         value: 0,
       },
 
-      /** The arial-label for the edit button */
-      ariaLabel: String,
+      /**
+       * The arial-label for the edit button
+       */
+      ariaLabel: {
+        type: String,
+      },
     };
   }
 

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -16,7 +16,9 @@ export const GridSorterMixin = (superClass) =>
         /**
          * JS Path of the property in the item used for sorting the data.
          */
-        path: String,
+        path: {
+          type: String,
+        },
 
         /**
          * How to sort the data.


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11273

Updated 2 more properties to use `{ type: String }` object syntax for properties so that they work with CEM Analyzer.

## Type of change

- Refactor