### PR TITLE
docs: add missing @fires and type for time-picker unparsable-change event

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker.d.ts
+++ b/packages/time-picker/src/vaadin-time-picker.d.ts
@@ -37,12 +37,19 @@ export type TimePickerValueChangedEvent = CustomEvent<{ value: string }>;
  */
 export type TimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
+/**
+ * Fired when the user commits an unparsable value change and there is no change event.
+ */
+export type TimePickerUnparsableChangeEvent = CustomEvent;
+
 export interface TimePickerCustomEventMap {
   'invalid-changed': TimePickerInvalidChangedEvent;
 
   'opened-changed': TimePickerOpenedChangedEvent;
 
   'value-changed': TimePickerValueChangedEvent;
+
+  'unparsable-change': TimePickerUnparsableChangeEvent;
 
   validated: TimePickerValidatedEvent;
 }
@@ -130,6 +137,7 @@ export interface TimePickerEventMap extends HTMLElementEventMap, TimePickerCusto
  * unparsable => unparsable | unparsable-change
  *
  * @fires {Event} change - Fired when the user commits a value change.
+ * @fires {Event} unparsable-change - Fired when the user commits an unparsable value change and there is no change event.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -97,6 +97,7 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  * unparsable => unparsable | unparsable-change
  *
  * @fires {Event} change - Fired when the user commits a value change.
+ * @fires {Event} unparsable-change - Fired when the user commits an unparsable value change and there is no change event.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.


### PR DESCRIPTION
## Summary
- Added `@fires {Event} unparsable-change` JSDoc annotation to `vaadin-time-picker.js` and `.d.ts` for CEM event discovery
- Added `TimePickerUnparsableChangeEvent` type and `'unparsable-change'` entry to `TimePickerCustomEventMap` in `.d.ts`

## Test plan
- [ ] Run `yarn release:cem` and verify `unparsable-change` event has a description in `custom-elements.json`
- [ ] Verify TypeScript compilation passes with `yarn lint:types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)