### PR TITLE
docs: add missing @fires for dashboard-item-before-remove in .d.ts

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -227,6 +227,7 @@ export interface DashboardI18n {
  *
  * @fires {CustomEvent} dashboard-item-moved - Fired when an item was moved
  * @fires {CustomEvent} dashboard-item-resized - Fired when an item was resized
+ * @fires {CustomEvent} dashboard-item-before-remove - Fired before an item is removed. Calling preventDefault() on the event will cancel the removal.
  * @fires {CustomEvent} dashboard-item-removed - Fired when an item was removed
  * @fires {CustomEvent} dashboard-item-selected-changed - Fired when an item selected state changed
  * @fires {CustomEvent} dashboard-item-move-mode-changed - Fired when an item move mode changed


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/vaadin/web-components/pull/10623

- Added missing `@fires {CustomEvent} dashboard-item-before-remove` JSDoc annotation to `vaadin-dashboard.d.ts` to match the `.js` file

## Test plan
- [ ] Verify TypeScript compilation passes with `yarn lint:types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)