### PR TITLE
docs: add missing @fires annotations for message-input and context-menu

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -265,6 +265,8 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenu
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
  * @fires {CustomEvent} closed - Fired when the context menu is closed.
+ * @fires {CustomEvent} close-all-menus - Fired when all menus should close, e.g., after pressing Tab or on submenu close.
+ * @fires {CustomEvent} items-outside-click - Fired when a click happens outside any open sub-menus.
  */
 declare class ContextMenu<TItem extends ContextMenuItem = ContextMenuItem> extends HTMLElement {
   /**

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -213,6 +213,8 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} item-selected - Fired when an item is selected when the context menu is populated using the `items` API.
  * @fires {CustomEvent} closed - Fired when the context menu is closed.
+ * @fires {CustomEvent} close-all-menus - Fired when all menus should close, e.g., after pressing Tab or on submenu close.
+ * @fires {CustomEvent} items-outside-click - Fired when a click happens outside any open sub-menus.
  *
  * @customElement vaadin-context-menu
  * @extends HTMLElement

--- a/packages/message-input/src/vaadin-message-input.d.ts
+++ b/packages/message-input/src/vaadin-message-input.d.ts
@@ -51,6 +51,8 @@ export type MessageInputEventMap = HTMLElementEventMap & MessageInputCustomEvent
  * - `<vaadin-text-area>`
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @fires {CustomEvent} submit - Fired when a new message is submitted, either by clicking the "send" button, or pressing the Enter key.
  */
 declare class MessageInput extends MessageInputMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   addEventListener<K extends keyof MessageInputEventMap>(

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -45,6 +45,8 @@ import { MessageInputMixin } from './vaadin-message-input-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @fires {CustomEvent} submit - Fired when a new message is submitted, either by clicking the "send" button, or pressing the Enter key.
+ *
  * @customElement vaadin-message-input
  * @extends HTMLElement
  * @mixes MessageInputMixin


### PR DESCRIPTION
## Summary
- Added `@fires {CustomEvent} submit` to `vaadin-message-input.js` and `.d.ts`
- Added `@fires {CustomEvent} close-all-menus` and `@fires {CustomEvent} items-outside-click` to `vaadin-context-menu.js` and `.d.ts`

## Test plan
- [ ] Run `yarn release:cem` and verify events have descriptions in `custom-elements.json`
- [ ] Verify TypeScript compilation passes with `yarn lint:types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note

These events are present in corresponding TS event maps in `.d.ts` but are lacking JSDoc.