### PR TITLE
perf: lazily capture scroll state in virtual index offset adjustment

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -861,32 +861,43 @@ export class IronListAdapter {
       const threshold = OFFSET_ADJUST_MIN_THRESHOLD;
       const maxShift = 100;
 
-      const fvi = this.adjustedFirstVisibleIndex;
-      const fviOffsetBefore = this.__getIndexScrollOffset(fvi);
+      // Lazily capture scroll state before the first offset change,
+      // so it can be restored afterwards.
+      let fvi, fviOffsetBefore;
+      const captureScrollState = () => {
+        fvi = this.adjustedFirstVisibleIndex;
+        fviOffsetBefore = this.__getIndexScrollOffset(fvi);
+      };
 
       // Near start
       if (this._scrollTop === 0) {
-        this._vidxOffset = 0;
-        if (oldOffset !== this._vidxOffset) {
+        if (oldOffset !== 0) {
+          captureScrollState();
+          this._vidxOffset = 0;
           super.scrollToIndex(0);
         }
       } else if (this.firstVisibleIndex < threshold && this._vidxOffset > 0) {
+        captureScrollState();
         this._vidxOffset -= Math.min(this._vidxOffset, maxShift);
         super.scrollToIndex(this.firstVisibleIndex + (oldOffset - this._vidxOffset));
       }
 
       // Near end
       if (this._scrollTop >= this._maxScrollTop && this._maxScrollTop > 0) {
-        this._vidxOffset = maxOffset;
-        if (oldOffset !== this._vidxOffset) {
+        if (oldOffset !== maxOffset) {
+          captureScrollState();
+          this._vidxOffset = maxOffset;
           super.scrollToIndex(this._virtualCount - 1);
         }
       } else if (this.firstVisibleIndex > this._virtualCount - threshold && this._vidxOffset < maxOffset) {
+        captureScrollState();
         this._vidxOffset += Math.min(maxOffset - this._vidxOffset, maxShift);
         super.scrollToIndex(this.firstVisibleIndex - (this._vidxOffset - oldOffset));
       }
 
-      this.__restoreScrollOffset(fvi, fviOffsetBefore);
+      if (fvi !== undefined) {
+        this.__restoreScrollOffset(fvi, fviOffsetBefore);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Lazily capture scroll state in virtual index offset adjustment

This is a follow-up performance improvement to https://github.com/vaadin/web-components/pull/11256

Before:

https://github.com/user-attachments/assets/59941596-e4ef-482e-aea7-c8fe84410f8e

After:

https://github.com/user-attachments/assets/ee8df529-2f8b-4658-9372-72f282e9ae8c

## Type of change

Performance