### PR TITLE
docs: remove type JSDoc annotation for series markers property

### DIFF
--- a/packages/charts/src/vaadin-chart-series-mixin.js
+++ b/packages/charts/src/vaadin-chart-series-mixin.js
@@ -84,7 +84,6 @@ export const ChartSeriesMixin = (superClass) =>
          *  - `shown`: markers are always visible
          *  - `hidden`: markers are always hidden
          *  - `auto`: markers are visible for widespread data and hidden, when data is dense *(default)*
-         * @type {ChartSeriesMarkers | undefined}
          */
         markers: {
           type: String,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11274

This property also uses `@type` causing CEM to produce output that is considered as non-primitive type and therefore would cause corresponding attribute to be filtered out from `web-types.json`. Let's remove it so it would be marked as string.

## Type of change

- Documentation