### PR TITLE
docs: add missing space to chart fires JSDoc annotation

### DIFF
--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -136,7 +136,7 @@ export * from './vaadin-chart-mixin.js';
  * @fires {CustomEvent} point-mouse-out - Fired when the mouse leaves the area close to the point.
  * @fires {CustomEvent} point-mouse-over - Fired when the mouse enters the area close to the point.
  * @fires {CustomEvent} point-remove - Fired when the point is removed from the series.
- * @fires {CustomEvent} point-select -Fired when the point is selected either programmatically or by clicking on the point.
+ * @fires {CustomEvent} point-select - Fired when the point is selected either programmatically or by clicking on the point.
  * @fires {CustomEvent} point-unselect - Fired when the point is unselected either programmatically or by clicking on the point.
  * @fires {CustomEvent} point-update - Fired when the point is updated programmatically through `.updateConfiguration()` method.
  * @fires {CustomEvent} point-drag-start - Fired when starting to drag a point.

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -141,7 +141,7 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  * @fires {CustomEvent} point-mouse-out - Fired when the mouse leaves the area close to the point.
  * @fires {CustomEvent} point-mouse-over - Fired when the mouse enters the area close to the point.
  * @fires {CustomEvent} point-remove - Fired when the point is removed from the series.
- * @fires {CustomEvent} point-select -Fired when the point is selected either programmatically or by clicking on the point.
+ * @fires {CustomEvent} point-select - Fired when the point is selected either programmatically or by clicking on the point.
  * @fires {CustomEvent} point-unselect - Fired when the point is unselected either programmatically or by clicking on the point.
  * @fires {CustomEvent} point-update - Fired when the point is updated programmatically through `.updateConfiguration()` method.
  * @fires {CustomEvent} point-drag-start - Fired when starting to drag a point.


### PR DESCRIPTION
## Description

Added missing space to fix the event description as currently it incorrectly includes a dash:

```
"description": "-Fired when the point is selected either programmatically or by clicking on the point."
```

## Type of change

- Documentation