### PR TITLE
fix: allow setting i18n before upgrading element

### DIFF
--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -41,6 +41,12 @@ export const I18nMixin = (defaultI18n, superClass) =>
   class I18nMixinClass extends superClass {
     static get properties() {
       return {
+        // Even though the property is overridden by a custom getter/setter, it needs to be declared here to initialize
+        // __effectiveI18n properly if the i18n property is set before upgrading the element.
+        i18n: {
+          type: Object,
+        },
+
         /** @private */
         __effectiveI18n: {
           type: Object,
@@ -49,26 +55,10 @@ export const I18nMixin = (defaultI18n, superClass) =>
       };
     }
 
-    static get observedAttributes() {
-      return [...super.observedAttributes, 'i18n'];
-    }
-
     constructor() {
       super();
 
       this.i18n = deepMerge({}, defaultI18n);
-    }
-
-    /** @protected */
-    attributeChangedCallback(name, oldValue, newValue) {
-      super.attributeChangedCallback(name, oldValue, newValue);
-      if (name === 'i18n') {
-        try {
-          this.i18n = JSON.parse(newValue);
-        } catch (_) {
-          // Invalid JSON, ignore
-        }
-      }
     }
 
     /**

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -95,9 +95,31 @@ describe('I18nMixin', () => {
     expect(element.__effectiveI18n).to.deep.equal({ ...DEFAULT_I18N, foo: 'Updated Foo' });
   });
 
-  it('should ignore invalid JSON in i18n attribute', () => {
-    element.setAttribute('i18n', 'not valid json');
+  it('should initialize __effectiveI18n when i18n own property is set before upgrade', async () => {
+    // Simulate a scenario where a parent element sets i18n on a child
+    // before the child is upgraded (e.g. during custom element upgrade
+    // when parent's updated() propagates i18n to not-yet-upgraded children).
+    const tagName = 'i18n-mixin-late-define';
 
-    expect(element.i18n).to.deep.equal(DEFAULT_I18N);
+    // Create element in DOM before it's defined — it's a plain HTMLElement
+    const el = fixtureSync(`<${tagName}></${tagName}>`);
+
+    // Set i18n as a plain own data property (no setter exists yet)
+    el.i18n = { foo: 'Pre-upgrade' };
+    expect(Object.prototype.hasOwnProperty.call(el, 'i18n')).to.be.true;
+
+    // Now define the element — triggers upgrade
+    class LateElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElement)) {
+      static get is() {
+        return tagName;
+      }
+    }
+    customElements.define(tagName, LateElement);
+    await customElements.whenDefined(tagName);
+    await nextRender();
+
+    // After upgrade, __effectiveI18n should be initialized (not undefined).
+    expect(el.__effectiveI18n).to.not.be.undefined;
+    expect(el.__effectiveI18n).to.deep.equal({ ...DEFAULT_I18N, foo: 'Pre-upgrade' });
   });
 });


### PR DESCRIPTION
## Description

https://github.com/vaadin/web-components/pull/11178 caused a regression where setting `i18n` before upgrading an element results in `__effectiveI18n` not being calculated and the `i18n` setter not working properly afterwards. This is currently reproducable in the side nav dev page where rendering child items is broken because `__effectiveI18n` is undefined. It looks like the property needs to be declared to make Lit remove the data property during the upgrade, which otherwise shadows the custom setter.

This restores the `i18n` property declaration.

## Type of change

- Bugfix
