### PR TITLE
chore: upgrade lerna dev dependency to 9.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "glob": "^13.0.0",
     "globals": "^16.5.0",
     "husky": "^9.1.4",
-    "lerna": "9.0.5",
+    "lerna": "9.0.6",
     "lint-staged": "^16.2.7",
     "npm-run-all": "^4.1.5",
     "patch-package": "^8.0.1",

--- a/patches/lerna+9.0.6.patch
+++ b/patches/lerna+9.0.6.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/lerna/dist/index.js b/node_modules/lerna/dist/index.js
-index 4c494bc..7dbaeb4 100644
+index 2d421c7..dfc1ab8 100644
 --- a/node_modules/lerna/dist/index.js
 +++ b/node_modules/lerna/dist/index.js
-@@ -9914,7 +9914,7 @@ var require_src2 = __commonJS({
+@@ -10446,7 +10446,7 @@ var require_src3 = __commonJS({
            forceGitTag,
            overrideMessage
          };

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,79 +813,6 @@
   resolved "https://registry.yarnpkg.com/@keyv/serialize/-/serialize-1.1.0.tgz#08f5d89096110fdcf778e5337362e1cd5afad70a"
   integrity sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==
 
-"@lerna/create@9.0.5":
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-9.0.5.tgz#8f88793ad4c404ea08a764f6139164154c8a0cfe"
-  integrity sha512-Gwd6ooSqXMdkdhiCGvHAfLRstj7W3ttr72WQB3Jf9HPP1A6mWtw0O80D0X+T/2hakqfe7lNLuKrEid4f7C0qbg==
-  dependencies:
-    "@npmcli/arborist" "9.1.6"
-    "@npmcli/package-json" "7.0.2"
-    "@npmcli/run-script" "10.0.3"
-    "@nx/devkit" ">=21.5.2 < 23.0.0"
-    "@octokit/plugin-enterprise-rest" "6.0.1"
-    "@octokit/rest" "20.1.2"
-    aproba "2.0.0"
-    byte-size "8.1.1"
-    chalk "4.1.0"
-    cmd-shim "6.0.3"
-    color-support "1.1.3"
-    columnify "1.6.0"
-    console-control-strings "^1.1.0"
-    conventional-changelog-core "5.0.1"
-    conventional-recommended-bump "7.0.1"
-    cosmiconfig "9.0.0"
-    dedent "1.5.3"
-    execa "5.0.0"
-    fs-extra "^11.2.0"
-    get-stream "6.0.0"
-    git-url-parse "14.0.0"
-    glob-parent "6.0.2"
-    has-unicode "2.0.1"
-    ini "^1.3.8"
-    init-package-json "8.2.2"
-    inquirer "12.9.6"
-    is-ci "3.0.1"
-    is-stream "2.0.0"
-    js-yaml "4.1.1"
-    libnpmpublish "11.1.2"
-    load-json-file "6.2.0"
-    make-dir "4.0.0"
-    make-fetch-happen "15.0.2"
-    minimatch "3.1.4"
-    multimatch "5.0.0"
-    npm-package-arg "13.0.1"
-    npm-packlist "10.0.3"
-    npm-registry-fetch "19.1.0"
-    nx ">=21.5.3 < 23.0.0"
-    p-map "4.0.0"
-    p-map-series "2.1.0"
-    p-queue "6.6.2"
-    p-reduce "^2.1.0"
-    pacote "21.0.1"
-    pify "5.0.0"
-    read-cmd-shim "4.0.0"
-    resolve-from "5.0.0"
-    rimraf "^6.1.2"
-    semver "7.7.2"
-    set-blocking "^2.0.0"
-    signal-exit "3.0.7"
-    slash "^3.0.0"
-    ssri "12.0.0"
-    string-width "^4.2.3"
-    tar "7.5.8"
-    temp-dir "1.0.0"
-    through "2.3.8"
-    tinyglobby "0.2.12"
-    upath "2.0.1"
-    uuid "^11.1.0"
-    validate-npm-package-license "3.0.4"
-    validate-npm-package-name "6.0.2"
-    wide-align "1.1.5"
-    write-file-atomic "5.0.1"
-    write-pkg "4.0.0"
-    yargs "17.7.2"
-    yargs-parser "21.1.1"
-
 "@lit-labs/ssr-dom-shim@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz#a28799c463177d1a0b0e5cefdc173da5ac859eb4"
@@ -3382,15 +3309,15 @@ chromium-bidi@2.1.2:
     mitt "^3.0.1"
     zod "^3.24.1"
 
+ci-info@4.3.1, ci-info@^4.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.3.1.tgz#355ad571920810b5623e11d40232f443f16f1daa"
+  integrity sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==
+
 ci-info@^3.2.0, ci-info@^3.7.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
-
-ci-info@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.3.0.tgz#c39b1013f8fdbd28cd78e62318357d02da160cd7"
-  integrity sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==
 
 clean-css@~5.3.2:
   version "5.3.3"
@@ -6650,12 +6577,11 @@ lerc@^3.0.0:
   resolved "https://registry.yarnpkg.com/lerc/-/lerc-3.0.0.tgz#36f36fbd4ba46f0abf4833799fff2e7d6865f5cb"
   integrity sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==
 
-lerna@9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-9.0.5.tgz#b60a4f190c1495de00cffba021fc8d49a6398e30"
-  integrity sha512-LtwZu2wINHlKpjRCxrEdK3QopyeUpFuUS4v6uzLYdg/uxnAKqDHrGY/mDPxdxDR3YAXJzpWXBdz49AHNIKZaSg==
+lerna@9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-9.0.6.tgz#24e77a8e1159173ee37f287260545e02b16d5ef6"
+  integrity sha512-ylCTTq8QOa2oRBDhQhy8UIFob6wJZTdREjXTtMJzoB9eWk8qbI0qyIAYmFClu0NVN3mTZ2UKN1HFgTpg4hCdmQ==
   dependencies:
-    "@lerna/create" "9.0.5"
     "@npmcli/arborist" "9.1.6"
     "@npmcli/package-json" "7.0.2"
     "@npmcli/run-script" "10.0.3"
@@ -6665,6 +6591,7 @@ lerna@9.0.5:
     aproba "2.0.0"
     byte-size "8.1.1"
     chalk "4.1.0"
+    ci-info "4.3.1"
     cmd-shim "6.0.3"
     color-support "1.1.3"
     columnify "1.6.0"
@@ -6718,7 +6645,7 @@ lerna@9.0.5:
     slash "3.0.0"
     ssri "12.0.0"
     string-width "^4.2.3"
-    tar "7.5.8"
+    tar "7.5.11"
     temp-dir "1.0.0"
     through "2.3.8"
     tinyglobby "0.2.12"
@@ -8109,7 +8036,7 @@ p-queue@6.6.2:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
 
-p-reduce@2.1.0, p-reduce@^2.0.0, p-reduce@^2.1.0:
+p-reduce@2.1.0, p-reduce@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
   integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
@@ -10224,18 +10151,7 @@ tar-stream@~2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@7.5.8:
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.8.tgz#6bbdfdb487914803d401bab6a2abb100aaa253d5"
-  integrity sha512-SYkBtK99u0yXa+IWL0JRzzcl7RxNpvX/U08Z+8DKnysfno7M+uExnTZH8K+VGgShf2qFPKtbNr9QBl8n7WBP6Q==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
-tar@^7.4.3, tar@^7.5.2:
+tar@7.5.11, tar@^7.4.3, tar@^7.5.2:
   version "7.5.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.11.tgz#1250fae45d98806b36d703b30973fa8e0a6d8868"
   integrity sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==


### PR DESCRIPTION
## Description

Upgraded `lerna` to latest version v9.0.6 to pick up a transitive dependency bump with a npm audit fix.

## Type of change

- Internal change