### PR TITLE
chore: allow running visual tests in watch mode

### DIFF
--- a/scripts/run-docker-visual-tests.sh
+++ b/scripts/run-docker-visual-tests.sh
@@ -39,7 +39,7 @@ echo "  Command: yarn $*"
 
 # Run Docker:
 # - --rm: Remove container after exit
-# - -i: Enables input when --watch mode
+# - -i: Enables input in --watch mode
 # - -t: Enables colored and interactive output in --watch mode
 # - --ipc=host: Recommended for Chromium to avoid shared memory crashes
 # - -v $(pwd):/work: Mount repository source into container


### PR DESCRIPTION
## Description

The PR adds the necessary docker container CLI parameters to support running visual tests in `--watch` mode:

```bash
yarn test:base --watch
```
