### PR TITLE
chore: remove visual tests workflow condition

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -3,7 +3,6 @@ name: Visual tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
The visual tests workflow automatically only runs in all branches that have the workflow. Configuring an explicit list of branches that it applies to is unnecessary.