### PR TITLE
fix: start detail column offscreen regardless of expand mode

### DIFF
--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -47,14 +47,14 @@ In vertical mode, `grid-template-rows` replaces `grid-template-columns` using th
 - `Math.floor(masterSize + masterExtra + detailSize) <= Math.floor(hostSize)` (tracks fit; flooring prevents false overflow from sub-pixel track sizes)
 - `masterExtra >= detailSize` (master's extra space can absorb the detail)
 
-The `>=` (not `>`) is intentional: when `preserve-master-width` or `:not([has-detail])` is active, CSS `calc(100% - masterSize)` inflates the master extra track. With this inflation, `masterExtra >= detailSize` is equivalent to `hostSize >= masterSize + detailSize` — the correct no-overflow check. Strict `>` would miss the boundary case where they're equal.
+The `>=` (not `>`) is intentional: when `keep-detail-column-offscreen` or `:not([has-detail])` is active, CSS `calc(100% - masterSize)` inflates the master extra track. With this inflation, `masterExtra >= detailSize` is equivalent to `hostSize >= masterSize + detailSize` — the correct no-overflow check. Strict `>` would miss the boundary case where they're equal.
 
 ### Read/write separation
 
 Layout detection is split into two methods to avoid forced reflows:
 
 - **`__computeLayoutState()`** — pure reads: `checkVisibility()`, `getComputedStyle()`, `getFocusableElements()`. Called in the ResizeObserver callback where layout is already computed — no forced reflow.
-- **`__applyLayoutState(state)`** — pure writes: toggles `has-detail`, `overflow`, `preserve-master-width`; calls `requestUpdate()` for ARIA; focuses detail. No DOM/style reads.
+- **`__applyLayoutState(state)`** — pure writes: toggles `has-detail`, `overflow`, `keep-detail-column-offscreen`; calls `requestUpdate()` for ARIA; focuses detail. No DOM/style reads.
 
 ### ResizeObserver
 
@@ -85,18 +85,15 @@ When `overflow` AND `has-detail` are both set, the detail becomes an overlay:
 
 Setting `overlaySize` to `100%` makes the detail cover the full layout (replaces old "full" mode).
 
-## preserve-master-width
+## keep-detail-column-offscreen
 
 Prevents the master from jumping when the detail overlay first appears.
 
-**Problem**: When detail appears with overflow, the detail becomes absolute (out of grid flow). The master's `1fr` extra track expands since the detail's `1fr` is gone, causing a visual jump.
-
-**Solution**: Replace `1fr` with `calc(100% - masterSize)` to keep the master at full host width. Same rule applies when `has-detail` is not set. For `expand='detail'`, the same compensation is applied when no detail is present to prevent the detail tracks from reserving space.
+When no detail is present, master's extra track is set to `calc(100% - masterSize)`, pushing the detail column offscreen. This ensures that when a detail element appears, it starts offscreen and is then either moved into an overlay (if overflow, so no blink occurs and master area size is preserved) or revealed by removing the `calc()` override (if no overflow). The `keep-detail-column-offscreen` attribute keeps the same override active when detail first appears with overflow, until the overlay takes effect.
 
 ```css
-:host([expand='both']:is(:not([has-detail]), [preserve-master-width])),
-:host([expand='master']:is(:not([has-detail]), [preserve-master-width])),
-:host([expand='detail']:not([has-detail])) {
+:host(:not([has-detail])),
+:host([keep-detail-column-offscreen]) {
   --_master-column: var(--_master-size) calc(100% - var(--_master-size));
 }
 ```

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -69,9 +69,8 @@ export const masterDetailLayoutStyles = css`
     --_master-column: var(--_master-size) 1fr;
   }
 
-  :host([expand='both']:is(:not([has-detail]), [preserve-master-width])),
-  :host([expand='master']:is(:not([has-detail]), [preserve-master-width])),
-  :host([expand='detail']:not([has-detail])) {
+  :host(:not([has-detail])),
+  :host([keep-detail-column-offscreen]) {
     --_master-column: var(--_master-size) calc(100% - var(--_master-size));
   }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -288,12 +288,12 @@ class MasterDetailLayout extends SlotStylesMixin(ElementMixin(ThemableMixin(Poly
    * @private
    */
   __applyLayoutState({ hadDetail, hasDetail, hasOverflow, focusTarget }) {
-    // Set preserve-master-width when detail first appears with overflow
+    // Set keep-detail-column-offscreen when detail first appears with overflow
     // to prevent master width from jumping.
     if (!hadDetail && hasDetail && hasOverflow) {
-      this.setAttribute('preserve-master-width', '');
+      this.setAttribute('keep-detail-column-offscreen', '');
     } else if (!hasDetail || !hasOverflow) {
-      this.removeAttribute('preserve-master-width');
+      this.removeAttribute('keep-detail-column-offscreen');
     }
 
     this.toggleAttribute('has-detail', hasDetail);

--- a/packages/master-detail-layout/test/overflow.test.js
+++ b/packages/master-detail-layout/test/overflow.test.js
@@ -59,7 +59,7 @@ describe('overflow detection', () => {
         expect(layout.hasAttribute('overflow')).to.be.false;
       });
 
-      it('should remove overflow when masterSize decreases to fit while preserve-master-width is set', async () => {
+      it('should remove overflow when masterSize decreases to fit while keep-detail-column-offscreen is set', async () => {
         layout.style.width = '400px';
         await onceResized(layout);
 


### PR DESCRIPTION
The PR prevents master area jump when the detail appears as an overlay in `expand="detail"` mode. Previously, the jump prevention mechanism only covered `expand="both"` and `expand="master"`.