### PR TITLE
fix: restore `stroke` value for `.highcharts-color-7`

### DIFF
--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -393,7 +393,7 @@ export const chartStyles = css`
 
   :where([styled-mode]) .highcharts-color-7 {
     fill: var(--_color-7);
-    color: var(--_color-7-label);
+    stroke: var(--_color-7);
   }
 
   :where([styled-mode]) .highcharts-color-8 {


### PR DESCRIPTION
## Description

In https://github.com/vaadin/web-components/pull/10205, the `stroke` value for the `.highcharts-color-7` was mistakenly removed instead of the `color` value.

Related to #9988