### PR TITLE
docs: add i18n getter override and improve i18n JSDoc for upload

### DIFF
--- a/packages/upload/src/vaadin-upload-file-list-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.d.ts
@@ -69,6 +69,43 @@ export declare class UploadFileListMixinClass {
    * To change the default localization, replace this with an object
    * that provides all properties, or just the individual properties
    * you want to change.
+   *
+   * The object has the following JSON structure and default values:
+   * ```js
+   * {
+   *   file: {
+   *     retry: 'Retry',
+   *     start: 'Start',
+   *     remove: 'Remove'
+   *   },
+   *   error: {
+   *     tooManyFiles: 'Too Many Files.',
+   *     fileIsTooBig: 'File is Too Big.',
+   *     incorrectFileType: 'Incorrect File Type.'
+   *   },
+   *   uploading: {
+   *     status: {
+   *       connecting: 'Connecting...',
+   *       stalled: 'Stalled',
+   *       processing: 'Processing File...',
+   *       held: 'Queued'
+   *     },
+   *     remainingTime: {
+   *       prefix: 'remaining time: ',
+   *       unknown: 'unknown remaining time'
+   *     },
+   *     error: {
+   *       serverUnavailable: 'Upload failed, please try again later',
+   *       unexpectedServerError: 'Upload failed due to server error',
+   *       forbidden: 'Upload forbidden',
+   *       fileTooLarge: 'File is too large'
+   *     }
+   *   },
+   *   units: {
+   *     size: ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+   *   }
+   * }
+   * ```
    */
   i18n: UploadFileListI18n;
 }

--- a/packages/upload/src/vaadin-upload-file-list-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.js
@@ -86,6 +86,58 @@ export const UploadFileListMixin = (superClass) =>
       return ['__updateItems(items, __effectiveI18n, disabled, _theme)'];
     }
 
+    /**
+     * The object used to localize this component.
+     * To change the default localization, replace this with an object
+     * that provides all properties, or just the individual properties
+     * you want to change.
+     *
+     * The object has the following JSON structure and default values:
+     * ```js
+     * {
+     *   file: {
+     *     retry: 'Retry',
+     *     start: 'Start',
+     *     remove: 'Remove'
+     *   },
+     *   error: {
+     *     tooManyFiles: 'Too Many Files.',
+     *     fileIsTooBig: 'File is Too Big.',
+     *     incorrectFileType: 'Incorrect File Type.'
+     *   },
+     *   uploading: {
+     *     status: {
+     *       connecting: 'Connecting...',
+     *       stalled: 'Stalled',
+     *       processing: 'Processing File...',
+     *       held: 'Queued'
+     *     },
+     *     remainingTime: {
+     *       prefix: 'remaining time: ',
+     *       unknown: 'unknown remaining time'
+     *     },
+     *     error: {
+     *       serverUnavailable: 'Upload failed, please try again later',
+     *       unexpectedServerError: 'Upload failed due to server error',
+     *       forbidden: 'Upload forbidden',
+     *       fileTooLarge: 'File is too large'
+     *     }
+     *   },
+     *   units: {
+     *     size: ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+     *   }
+     * }
+     * ```
+     * @type {!UploadFileListI18n}
+     */
+    get i18n() {
+      return super.i18n;
+    }
+
+    set i18n(value) {
+      super.i18n = value;
+    }
+
     constructor() {
       super();
       this.__onManagerFilesChanged = this.__onManagerFilesChanged.bind(this);

--- a/packages/upload/src/vaadin-upload-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-mixin.d.ts
@@ -252,7 +252,8 @@ export declare class UploadMixinClass {
    *     error: {
    *       serverUnavailable: 'Upload failed, please try again later',
    *       unexpectedServerError: 'Upload failed due to server error',
-   *       forbidden: 'Upload forbidden'
+   *       forbidden: 'Upload forbidden',
+   *       fileTooLarge: 'File is too large'
    *     }
    *   },
    *   file: {

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -411,7 +411,8 @@ export const UploadMixin = (superClass) =>
      *     error: {
      *       serverUnavailable: 'Upload failed, please try again later',
      *       unexpectedServerError: 'Upload failed due to server error',
-     *       forbidden: 'Upload forbidden'
+     *       forbidden: 'Upload forbidden',
+     *       fileTooLarge: 'File is too large'
      *     }
      *   },
      *   file: {


### PR DESCRIPTION
## Summary

- Add i18n getter/setter with `@type {!UploadFileListI18n}` override to `UploadFileListMixin` so the CEM analyzer can resolve the specific type instead of generic `Object`
- Add full default i18n structure to JSDoc in both `.js` and `.d.ts` for `UploadFileListMixin`
- Add missing `fileTooLarge` to `UploadMixin` i18n JSDoc in both `.js` and `.d.ts`

## Test plan

- [ ] Run `yarn release:cem` and verify no errors
- [ ] Check `packages/upload/custom-elements.json` — `UploadFileListMixin` should have `i18n` member with description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note

The `i18n` override is fixing the API docs for `vaadin-upload-file-list` that currently have this:

<img width="731" height="286" alt="Screenshot 2026-03-20 at 10 30 56" src="https://github.com/user-attachments/assets/034556d7-f5b9-4368-8dbe-307270aaf241" />
