### PR TITLE
chore: exclude focus and blur events from CEM output

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -10,9 +10,10 @@ const ignoredAttributeTypes = ['object', 'unknown', 'Array'];
 // (e.g., `this._controller.slotName = 'sr-label'` misinterpreted as a class field)
 const ignoredMembers = ['slotName', 'id'];
 
-// Events incorrectly picked up by CEM from dynamic dispatchEvent calls
-// (e.g., `new CustomEvent(eventName, ...)` where eventName is a variable)
-const ignoredEvents = ['eventName'];
+// Events to exclude from CEM output:
+// - eventName: false positive from dynamic dispatchEvent calls (e.g., `new CustomEvent(eventName, ...)`)
+// - focus, blur: native events picked up by CEM without @fires annotations, not part of the public API
+const ignoredEvents = ['eventName', 'focus', 'blur'];
 
 const ignoredStaticMembers = [
   'is',


### PR DESCRIPTION
## Summary

- Exclude `focus` and `blur` native events from CEM output by adding them to the `ignoredEvents` deny list
- These events are picked up by CEM from internal `dispatchEvent` calls without `@fires` annotations and are not part of the component public API

## Test plan

- [ ] Run `yarn release:cem` and verify no errors
- [ ] Verify no `focus` or `blur` events remain in any `custom-elements.json` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)