### PR TITLE
docs: add custom CSS properties to avatar-group JSDoc

### DIFF
--- a/packages/avatar-group/src/vaadin-avatar-group.d.ts
+++ b/packages/avatar-group/src/vaadin-avatar-group.d.ts
@@ -38,6 +38,13 @@ export { AvatarGroupI18n, AvatarGroupItem, AvatarI18n };
  * `overlay`   | The overflow avatar menu overlay
  * `content`   | The overflow avatar menu overlay content
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-avatar-group-gap`      |
+ * | `--vaadin-avatar-group-overlap`  |
+ *
  * See the [`<vaadin-avatar>`](#/elements/vaadin-avatar) documentation for the available
  * state attributes and stylable shadow parts of avatar elements.
  *

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -45,6 +45,13 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  * `overlay`   | The overflow avatar menu overlay
  * `content`   | The overflow avatar menu overlay content
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-avatar-group-gap`      |
+ * | `--vaadin-avatar-group-overlap`  |
+ *
  * See the [`<vaadin-avatar>`](#/elements/vaadin-avatar) documentation for the available
  * state attributes and stylable shadow parts of avatar elements.
  *


### PR DESCRIPTION
## Summary
- Add custom CSS properties table (`--vaadin-avatar-group-gap`, `--vaadin-avatar-group-overlap`) to `vaadin-avatar-group` JSDoc in both `.js` and `.d.ts` files

## Test plan
- [ ] Verify the JSDoc renders correctly in IDE tooltips
- [ ] Verify the API docs page shows the new table

🤖 Generated with [Claude Code](https://claude.com/claude-code)