### PR TITLE
refactor: remove redundant replace grid-overlap rules in MDL

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -120,14 +120,6 @@ export const masterDetailLayoutStyles = css`
     translate: none;
   }
 
-  :host(:not([orientation='vertical'])[transition='replace']) :is(#detail, #outgoing) {
-    grid-row: 1 / -1;
-  }
-
-  :host([orientation='vertical'][transition='replace']) :is(#detail, #outgoing) {
-    grid-column: 1 / -1;
-  }
-
   #outgoing:not([hidden]) {
     z-index: 1;
   }


### PR DESCRIPTION
## Summary

- Remove replace-specific `grid-row: 1 / -1` and `grid-column: 1 / -1` rules from master-detail-layout base styles
- These were originally needed to force `#detail` and `#outgoing` into the same grid cell during replace transitions (without explicit placement on the non-positioned axis, the second element was auto-placed into an implicit track)
- The detail-placeholder changes (#11374) added explicit `grid-row: 1` / `grid-column: 1` to all detail elements in their base rules, making the replace-specific overrides redundant

## Test plan

- [x] `yarn test --group master-detail-layout` — all tests pass
- [x] `yarn lint:css` — pass
- [ ] Manual: verify replace transitions work in split and overlay mode (both orientations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)