### PR TITLE
feat: add backdrop fade-in/out transition to master-detail-layout

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -74,7 +74,7 @@ export const masterDetailLayoutStyles = css`
     grid-row: detail-start / detail-end;
   }
 
-  [part~='backdrop'] {
+  #backdrop {
     position: absolute;
     inset: 0;
     z-index: 1;
@@ -142,7 +142,7 @@ export const masterDetailLayoutStyles = css`
     grid-row: none;
   }
 
-  :host([has-detail][overlay]) [part~='backdrop'] {
+  :host([has-detail][overlay]) #backdrop {
     opacity: 1;
     pointer-events: auto;
   }
@@ -159,8 +159,7 @@ export const masterDetailLayoutStyles = css`
     height: var(--_overlay-size, var(--_detail-size, min-content));
   }
 
-  :host([has-detail][overlay][overlay-containment='viewport']) :is(#detail, #outgoing),
-  :host([has-detail][overlay][overlay-containment='viewport']) [part~='backdrop'] {
+  :host([has-detail][overlay][overlay-containment='viewport']) :is(#detail, #outgoing, #backdrop) {
     position: fixed;
   }
 

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -78,7 +78,8 @@ export const masterDetailLayoutStyles = css`
     position: absolute;
     inset: 0;
     z-index: 1;
-    display: none;
+    opacity: 0;
+    pointer-events: none;
     background: var(--vaadin-overlay-backdrop-background, rgba(0, 0, 0, 0.2));
     forced-color-adjust: none;
   }
@@ -142,7 +143,8 @@ export const masterDetailLayoutStyles = css`
   }
 
   :host([has-detail][overlay]) [part~='backdrop'] {
-    display: block;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   :host([has-detail][overlay]:not([orientation='vertical'])) :is(#detail, #outgoing) {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -542,6 +542,16 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       } else {
         this.__slide(this.$.detail, true, opts).then(() => onFinish());
       }
+
+      // Fade backdrop in/out for overlay add/remove (not replace — backdrop stays visible)
+      if (opts.overlay && transitionType !== 'replace') {
+        const fadeIn = transitionType !== 'remove';
+        this.__animate(
+          this.shadowRoot.querySelector('[part~="backdrop"]'),
+          [{ opacity: fadeIn ? 0 : 1 }, { opacity: fadeIn ? 1 : 0 }],
+          { duration: opts.duration, easing: 'linear' },
+        );
+      }
     });
   }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -214,7 +214,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     const isLayoutContained = isOverlay && !isViewport;
 
     return html`
-      <div part="backdrop" @click="${this.__onBackdropClick}"></div>
+      <div id="backdrop" part="backdrop" @click="${this.__onBackdropClick}"></div>
       <div id="master" part="master" ?inert="${isLayoutContained}">
         <slot @slotchange="${this.__onSlotChange}"></slot>
       </div>
@@ -546,11 +546,10 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       // Fade backdrop in/out for overlay add/remove (not replace — backdrop stays visible)
       if (opts.overlay && transitionType !== 'replace') {
         const fadeIn = transitionType !== 'remove';
-        this.__animate(
-          this.shadowRoot.querySelector('[part~="backdrop"]'),
-          [{ opacity: fadeIn ? 0 : 1 }, { opacity: fadeIn ? 1 : 0 }],
-          { duration: opts.duration, easing: 'linear' },
-        );
+        this.__animate(this.$.backdrop, [{ opacity: fadeIn ? 0 : 1 }, { opacity: fadeIn ? 1 : 0 }], {
+          duration: opts.duration,
+          easing: 'linear',
+        });
       }
     });
   }

--- a/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
+++ b/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
@@ -115,7 +115,10 @@ snapshots["vaadin-master-detail-layout host no detail placeholder"] =
 /* end snapshot vaadin-master-detail-layout host no detail placeholder */
 
 snapshots["vaadin-master-detail-layout shadow default"] = 
-`<div part="backdrop">
+`<div
+  id="backdrop"
+  part="backdrop"
+>
 </div>
 <div
   id="master"


### PR DESCRIPTION
## Summary

- Animate the backdrop opacity alongside the detail panel slide when opening/closing the overlay
- Switch backdrop from `display: none/block` to `opacity: 0/1` + `pointer-events: none/auto` so the Web Animations API can fade it
- Use `linear` easing for a clean fade independent of the detail panel's cubic-bezier curve
- Backdrop fade only runs for overlay add/remove (not replace — backdrop stays visible)

## Test plan

- [x] `yarn test --group master-detail-layout` — all tests pass
- [x] `yarn test:snapshots --group master-detail-layout` — pass
- [x] `yarn lint:js` / `yarn lint:css` — pass
- [ ] `yarn test:base --group master-detail-layout` — visual tests (requires Docker)
- [ ] Manual: open/close overlay detail, verify backdrop fades smoothly
- [ ] Manual: click backdrop during fade-in, verify interruption works

🤖 Generated with [Claude Code](https://claude.com/claude-code)