### PR TITLE
fix: handle display:contents detail wrappers in MasterDetailLayout

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -236,6 +236,12 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     `;
   }
 
+  constructor() {
+    super();
+    /** @type {WeakSet<Element>} Elements added to the DOM by `_setDetail()` */
+    this.__managedDetails = new WeakSet();
+  }
+
   /** @protected */
   connectedCallback() {
     super.connectedCallback();
@@ -312,12 +318,37 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     const detailPlaceholder = this.querySelector(':scope > [slot="detail-placeholder"]');
 
     const hadDetail = this.hasAttribute('has-detail');
-    const hasDetail = detailContent != null && detailContent.checkVisibility();
+    const hasDetail = detailContent != null && this.__isDetailVisible(detailContent);
     const hasDetailPlaceholder = !!detailPlaceholder;
     const hasOverflow = (hasDetail || hasDetailPlaceholder) && this.__checkOverflow();
 
     const focusTarget = !hadDetail && hasDetail && hasOverflow ? getFocusableElements(detailContent)[0] : null;
     return { hadDetail, hasDetail, hasDetailPlaceholder, hasOverflow, focusTarget };
+  }
+
+  /**
+   * Checks whether a detail element is visible. Handles `display: contents`
+   * elements (used by framework wrappers like React) which don't generate a
+   * CSS box and therefore return `false` from `checkVisibility()`.
+   *
+   * Note: dynamically adding children to a `display: contents` wrapper does
+   * not trigger the ResizeObserver (no box to observe). Framework wrappers
+   * must call `_startTransition`/`_setDetail` directly to manage transitions.
+   *
+   * @param {Element} element
+   * @return {boolean}
+   * @private
+   */
+  __isDetailVisible(element) {
+    if (element.checkVisibility()) {
+      return true;
+    }
+    // display:contents elements have no box, so checkVisibility returns false.
+    // Treat them as visible when they contain at least one visible child.
+    if (getComputedStyle(element).display === 'contents') {
+      return [...element.children].some((child) => child.checkVisibility());
+    }
+    return false;
   }
 
   /**
@@ -402,11 +433,16 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     }
 
     const updateSlot = () => {
-      // Remove old content
-      this.querySelectorAll('[slot="detail"]').forEach((oldElement) => oldElement.remove());
+      // Remove old content (only elements owned by _setDetail)
+      this.querySelectorAll('[slot="detail"]').forEach((oldElement) => {
+        if (this.__managedDetails.has(oldElement)) {
+          oldElement.remove();
+        }
+      });
       // Add new content
       if (element) {
         element.setAttribute('slot', 'detail');
+        this.__managedDetails.add(element);
         this.appendChild(element);
       }
     };
@@ -693,10 +729,19 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
   /**
    * Clears the outgoing container after the replace transition completes.
+   * Elements owned by `_setDetail` (tracked in `__managedDetails`) are removed.
+   * Externally managed elements (e.g. framework wrappers) are re-slotted to
+   * a hidden slot so the framework retains DOM ownership.
    * @private
    */
   __clearOutgoing() {
-    this.querySelectorAll('[slot="detail-outgoing"]').forEach((el) => el.remove());
+    this.querySelectorAll('[slot="detail-outgoing"]').forEach((el) => {
+      if (this.__managedDetails.has(el)) {
+        el.remove();
+      } else {
+        el.setAttribute('slot', 'detail-hidden');
+      }
+    });
     this.__replacing = false;
   }
 

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -75,6 +75,50 @@ describe('vaadin-master-detail-layout', () => {
       await onceResized(layout);
       expect(master.offsetWidth).to.equal(layout.offsetWidth);
     });
+
+    describe('display: contents wrapper', () => {
+      it('should set has-detail when detail uses display: contents with visible children', async () => {
+        layout.querySelector('[slot="detail"]').remove();
+        await onceResized(layout);
+        expect(layout.hasAttribute('has-detail')).to.be.false;
+
+        const wrapper = document.createElement('div');
+        wrapper.setAttribute('slot', 'detail');
+        wrapper.style.display = 'contents';
+        wrapper.innerHTML = '<div>Detail inside contents wrapper</div>';
+        layout.appendChild(wrapper);
+        await onceResized(layout);
+
+        expect(layout.hasAttribute('has-detail')).to.be.true;
+      });
+
+      it('should not set has-detail when detail uses display: contents with no children', async () => {
+        layout.querySelector('[slot="detail"]').remove();
+        await onceResized(layout);
+
+        const wrapper = document.createElement('div');
+        wrapper.setAttribute('slot', 'detail');
+        wrapper.style.display = 'contents';
+        layout.appendChild(wrapper);
+        await onceResized(layout);
+
+        expect(layout.hasAttribute('has-detail')).to.be.false;
+      });
+
+      it('should not set has-detail when detail uses display: contents with hidden children', async () => {
+        layout.querySelector('[slot="detail"]').remove();
+        await onceResized(layout);
+
+        const wrapper = document.createElement('div');
+        wrapper.setAttribute('slot', 'detail');
+        wrapper.style.display = 'contents';
+        wrapper.innerHTML = '<div hidden>Hidden detail</div>';
+        layout.appendChild(wrapper);
+        await onceResized(layout);
+
+        expect(layout.hasAttribute('has-detail')).to.be.false;
+      });
+    });
   });
 
   describe('expand', () => {

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -404,6 +404,77 @@ describe('Transitions', () => {
     });
   });
 
+  describe('external detail management', () => {
+    it('should not remove externally managed detail elements on _setDetail', async () => {
+      // Simulate a framework wrapper: element slotted to "detail" but NOT via _setDetail
+      const externalWrapper = document.createElement('div');
+      externalWrapper.setAttribute('slot', 'detail');
+      externalWrapper.style.display = 'contents';
+      layout.appendChild(externalWrapper);
+      await onceResized(layout);
+
+      // Use _setDetail to add a managed element
+      const managedDetail = document.createElement('detail-content');
+      await layout._setDetail(managedDetail);
+
+      // The externally managed wrapper should still be in the DOM
+      expect(externalWrapper.isConnected).to.be.true;
+      // The managed detail should also be in the DOM
+      expect(managedDetail.isConnected).to.be.true;
+    });
+
+    it('should remove only managed elements when replacing via _setDetail', async () => {
+      // Add a managed detail
+      const detail1 = document.createElement('detail-content');
+      await layout._setDetail(detail1);
+
+      // Replace with another managed detail
+      const detail2 = document.createElement('detail-content');
+      await layout._setDetail(detail2);
+
+      // Old managed element should be removed
+      expect(detail1.isConnected).to.be.false;
+      // New managed element should be present
+      expect(detail2.isConnected).to.be.true;
+    });
+
+    it('should re-slot externally managed outgoing elements to detail-hidden', async () => {
+      // Set up a framework-style wrapper in the detail slot
+      const externalWrapper = document.createElement('div');
+      externalWrapper.setAttribute('slot', 'detail');
+      externalWrapper.style.display = 'contents';
+      externalWrapper.innerHTML = '<div>Content</div>';
+      layout.appendChild(externalWrapper);
+      await onceResized(layout);
+
+      // Simulate a replace transition: move wrapper to outgoing, then clear
+      externalWrapper.setAttribute('slot', 'detail-outgoing');
+      layout.__replacing = true;
+
+      // Trigger __clearOutgoing indirectly via __endTransition
+      layout.__clearOutgoing();
+
+      // External element should be re-slotted to detail-hidden, not removed
+      expect(externalWrapper.isConnected).to.be.true;
+      expect(externalWrapper.getAttribute('slot')).to.equal('detail-hidden');
+    });
+
+    it('should remove managed outgoing elements on clear', async () => {
+      // Add a managed detail via _setDetail
+      const managedDetail = document.createElement('detail-content');
+      await layout._setDetail(managedDetail);
+
+      // Simulate outgoing: move to outgoing slot
+      managedDetail.setAttribute('slot', 'detail-outgoing');
+      layout.__replacing = true;
+
+      layout.__clearOutgoing();
+
+      // Managed element should be removed from DOM
+      expect(managedDetail.isConnected).to.be.false;
+    });
+  });
+
   describe('replace transition', () => {
     it('should move old content to outgoing container during replace', async () => {
       // Add initial detail


### PR DESCRIPTION
## Summary
- Handle `display: contents` detail wrappers (used by React) that return `false` from `checkVisibility()` — fall back to checking children visibility
- Use a private `WeakSet` to track elements owned by `_setDetail()`
- Re-slot externally managed elements to `detail-hidden` instead of removing them, so framework wrappers retain DOM ownership

## Test plan
- [x] Added tests for `display: contents` wrapper visibility detection (visible children, no children, hidden children)
- [x] Added tests for external detail management (framework wrappers not removed by `_setDetail`, managed elements properly cleaned up, outgoing re-slotting)
- [x] All 96 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)