### PR TITLE
fix: prevent detail flash on close with fill forwards and rAF cancel

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -650,7 +650,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    * @private
    */
   __animate(element, keyframes, options) {
-    const animation = element.animate(keyframes, options);
+    const animation = element.animate(keyframes, { ...options, fill: 'forwards' });
 
     this.__activeAnimations = this.__activeAnimations || [];
     this.__activeAnimations.push(animation);
@@ -670,6 +670,10 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     }
     this.removeAttribute('transition');
     this.__clearOutgoing();
+    // Cancel any pending ResizeObserver rAF that captured stale state
+    // during the animation — _finishTransition already applied the
+    // correct post-transition state synchronously.
+    cancelAnimationFrame(this.__resizeRaf);
     if (this.__transitionResolve) {
       this.__transitionResolve();
       this.__transitionResolve = null;


### PR DESCRIPTION
## Summary

Two fixes to eliminate a one-frame flash when closing the detail panel:

- **`fill: 'forwards'` on Web Animations** — keeps the final keyframe applied after the animation finishes, preventing the CSS resting state (`translate: none` from `has-detail`) from showing between animation end and the `finished` Promise resolution. The fill effect is cleaned up when `__endTransition` cancels the animation, which happens after the callback has already cleared `has-detail`.

- **`cancelAnimationFrame(this.__resizeRaf)` in `__endTransition`** — during the closing animation, `ResizeObserver` can fire and capture stale layout state (`hasDetail: true`) into a deferred `requestAnimationFrame`. When the animation finishes, the callback correctly clears `has-detail`, but the stale rAF would re-apply it on the next frame. Cancelling it in `__endTransition` prevents the stale state from overwriting the correct post-transition state.

Both fixes are needed: `fill: 'forwards'` bridges the synchronous gap between animation end and Promise resolution, while the rAF cancel prevents the asynchronous ResizeObserver race.

## Test plan

- [x] `yarn test --group master-detail-layout` — all tests pass
- [ ] Manual: rapidly open/close overlay detail, verify no backdrop/detail flash on close

🤖 Generated with [Claude Code](https://claude.com/claude-code)