### PR TITLE
fix: use navbar-offset-size-bottom to set `padding-bottom` in `app-layout` in Aura

### DIFF
--- a/packages/aura/src/components/app-layout.css
+++ b/packages/aura/src/components/app-layout.css
@@ -19,7 +19,7 @@
 
 vaadin-app-layout {
   --_app-layout-radius: clamp(0px, var(--aura-app-layout-radius), var(--aura-app-layout-inset) * 100);
-  padding-bottom: var(--aura-app-layout-inset);
+  padding-bottom: max(var(--_vaadin-app-layout-navbar-offset-size-bottom), var(--aura-app-layout-inset));
   padding-inline-end: var(--aura-app-layout-inset);
   padding-top: max(var(--aura-app-layout-inset), var(--_vaadin-app-layout-navbar-offset-size));
 }


### PR DESCRIPTION
## Description

As in Lumo and base style, use the calculated value from the `--_vaadin-app-layout-navbar-offset-size-bottom` CSS property to set the `padding-bottom` of the `app-layout` host element, to ensure that the content is not blocked by the bottom navbar in phone devices.

Fix https://github.com/vaadin/flow-components/issues/9038

## Type of change

- Bugfix
