### PR TITLE
fix: avoid Rolldown cross-chunk binding bug in markdown-helpers

### DIFF
--- a/packages/markdown/src/markdown-helpers.js
+++ b/packages/markdown/src/markdown-helpers.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import DOMPurify from 'dompurify';
-import { marked } from 'marked';
+import { parse } from 'marked';
 
 /**
  * Synchronizes the attributes of a target element with those of a source element.
@@ -79,7 +79,7 @@ function synchronizeNodes(targetNode, sourceNode) {
  */
 export function renderMarkdownToElement(element, markdown) {
   const template = document.createElement('template');
-  template.innerHTML = DOMPurify.sanitize(marked.parse(markdown || ''), {
+  template.innerHTML = DOMPurify.sanitize(parse(markdown || ''), {
     CUSTOM_ELEMENT_HANDLING: {
       tagNameCheck: (_tagName) => true,
     },


### PR DESCRIPTION
Fixes #11429

## Summary

- Import `parse` directly from `marked` instead of accessing it via `marked.parse()`
- `parse` and `marked.parse` are the same function (`marked.parse === parse` is `true`)
- This avoids a Rolldown bug where the cross-chunk re-export of the `marked` object gets an incorrect binding when Vite 8 splits `markdown-helpers.js` into a separate chunk

## Test plan
- [x] Verified `parse === marked.parse` in the `marked` library
- [x] Hilla react-grid ITs pass with this fix applied (previously all failed with `TypeError: t is not a function`)