### PR TITLE
fix: scope vaadin-item styles to overlay only

### DIFF
--- a/packages/aura/src/components/item-overlay.css
+++ b/packages/aura/src/components/item-overlay.css
@@ -15,7 +15,7 @@ vaadin-avatar-group-menu-item,
 vaadin-combo-box-item,
 vaadin-context-menu-item,
 vaadin-time-picker-item,
-vaadin-item,
+vaadin-item:where([role]),
 vaadin-menu-bar-item,
 vaadin-multi-select-combo-box-item,
 vaadin-select-item:where([role]) {


### PR DESCRIPTION
In Flow, Select renders `<vaadin-item>` elements instead of `<vaadin-select-item>` elements. 

When those items are rendered in the select overlay, they have the `role` attribute. That attribute is omitted when the selected item is rendered within `<vaadin-select-value-button>`.

This fix scopes the styles only to the items in the overlay, not the item in the select value button. This prevents unwanted hover styles on the item, for example.