### PR TITLE
fix: remove unnecessary mouse cursor override from avatar

### DIFF
--- a/packages/avatar/src/styles/vaadin-avatar-base-styles.js
+++ b/packages/avatar/src/styles/vaadin-avatar-base-styles.js
@@ -12,7 +12,6 @@ export const avatarStyles = css`
     display: inline-block;
     flex: none;
     border-radius: 50%;
-    cursor: default;
     color: var(--vaadin-avatar-text-color, var(--vaadin-text-color-secondary));
     overflow: hidden;
     --_size: var(--vaadin-avatar-size, calc(1lh + var(--vaadin-padding-block-container) * 2));


### PR DESCRIPTION
The mouse cursor is the default cursor without this declaration. If it is overridden, the cursor will change unexpectedly in cases like when an avatar is rendered within a Select item. See https://vaadin.com/docs/latest/components/select#custom-item-presentation for an example (switch to the Aura theme).

https://github.com/user-attachments/assets/5926bb36-a5c7-4cbc-b76b-a99b9baa202d

