### PR TITLE
fix: fix detail visibility and outgoing size in master-detail-layout

### DIFF
--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -147,14 +147,14 @@ Animation parameters are driven by CSS custom properties, read once per transiti
 - `--_transition-duration` — defaults to `0s`, enabled via `@media (prefers-reduced-motion: no-preference)`: 200ms for split mode, 300ms for overlay mode. Replace transitions in split mode use 0ms (no slide, just instant swap).
 - `--_transition-easing` — cubic-bezier easing
 
-CSS handles resting states via `translate` and `visibility` on `#detail`: offscreen and hidden by default, on-screen and visible when `has-detail` is set. RTL is supported via `--_rtl-multiplier`.
+CSS handles resting states via `translate` and `opacity` on `#detail`: offscreen and transparent by default, on-screen and opaque when `has-detail` is set. RTL is supported via `--_rtl-multiplier`.
 
 ### Transition types
 
 - **Add**: DOM is updated first (new element inserted, `has-detail` set), then the detail slides in from off-screen. In split mode, also fades from opacity 0 → 1.
 - **Remove**: the detail slides out to off-screen first (in split mode, also fades to opacity 0), then the DOM is updated (element removed, `has-detail` cleared) on `animation.finished`. The `fill: 'forwards'` on the animation keeps the detail offscreen between animation end and the deferred layout recalculation (see below).
 - **Replace** (overlay): old content is reassigned to `slot="detail-outgoing"` (stays in light DOM so styles continue to apply), then old slides out while new slides in simultaneously
-- **Replace** (split): old content moves to outgoing slot. The outgoing slides out with fade on top (`z-index: 1`), revealing the incoming at full opacity underneath.
+- **Replace** (split): 0ms duration (instant swap). Old content moves to outgoing slot, new content appears immediately.
 
 The `noAnimation` property (reflected as `no-animation` attribute) skips all animations. Animations are also disabled when `--_transition-duration` resolves to `0s`.
 
@@ -196,9 +196,20 @@ All animations use `fill: 'forwards'` to keep the final keyframe applied after t
 
 For `replace` interruptions, the captured state is applied to the outgoing element (since the interrupted content moves from the detail slot to the outgoing slot).
 
+### Z-index layering
+
+```
+z-index: 1 — #detail-placeholder
+z-index: 2 — #backdrop
+z-index: 3 — #outgoing (always position: absolute)
+z-index: 4 — #detail
+```
+
+`#detail` above `#outgoing` is correct: split-mode replace has 0ms duration (no frames painted, z-order irrelevant), and overlay-mode replace has the incoming sliding over the outgoing.
+
 ### Outgoing container
 
-The `#outgoing` shadow DOM element with `<slot name="detail-outgoing">` enables replace animations. Old content is moved to this slot (light DOM reassignment preserves user styles), animated out, then removed on completion. The outgoing has `z-index: 1` to paint on top of the incoming during the transition.
+The `#outgoing` shadow DOM element with `<slot name="detail-outgoing">` enables replace animations. Old content is moved to this slot (light DOM reassignment preserves user styles), animated out, then removed on completion. During replace, the outgoing width is frozen to `__detailCachedSize` so it retains the previous detail's dimensions even when the new detail has a different intrinsic size.
 
 ## Test Patterns
 

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -56,11 +56,14 @@ export const masterDetailLayoutStyles = css`
   }
 
   #detail-placeholder {
-    visibility: hidden;
+    z-index: 1;
+    opacity: 0;
+    pointer-events: none;
   }
 
   :host([has-detail-placeholder]:not([has-detail], [overlay])) #detail-placeholder {
-    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   #master {
@@ -86,7 +89,7 @@ export const masterDetailLayoutStyles = css`
   #backdrop {
     position: absolute;
     inset: 0;
-    z-index: 1;
+    z-index: 2;
     opacity: 0;
     pointer-events: none;
     background: var(--vaadin-overlay-backdrop-background, rgba(0, 0, 0, 0.2));
@@ -125,19 +128,21 @@ export const masterDetailLayoutStyles = css`
       var(--vaadin-master-detail-layout-border-color, var(--vaadin-border-color-secondary));
   }
 
+  #outgoing {
+    position: absolute;
+    z-index: 3;
+  }
+
   /* Detail transition: off-screen by default, on-screen when has-detail */
   #detail {
     translate: var(--_detail-offscreen);
-    visibility: hidden;
+    opacity: 0;
+    z-index: 4;
   }
 
   :host([has-detail]) #detail {
     translate: none;
-    visibility: visible;
-  }
-
-  #outgoing:not([hidden]) {
-    z-index: 1;
+    opacity: 1;
   }
 
   :host([overlay]) {
@@ -150,7 +155,6 @@ export const masterDetailLayoutStyles = css`
 
   :host([has-detail][overlay]) :is(#detail, #outgoing) {
     position: absolute;
-    z-index: 2;
     background: var(--vaadin-master-detail-layout-detail-background, var(--vaadin-background-color));
     box-shadow: var(--vaadin-master-detail-layout-detail-shadow, 0 0 20px 0 rgba(0, 0, 0, 0.3));
     grid-column: none;

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -645,7 +645,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     if (transitionType === 'remove') {
       slide = this.__slide(this.$.detail, false, opts);
     } else if (transitionType === 'replace') {
-      // Outgoing slides out on top (z-index), revealing incoming underneath.
+      // Outgoing slides out while incoming is revealed underneath.
       // In overlay mode, the incoming also slides in simultaneously.
       slide = this.__slide(this.$.outgoing, false, opts);
       if (opts.overlay) {
@@ -771,8 +771,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   }
 
   /**
-   * Cancels in-progress animations, cleans up state, and resolves the
-   * pending transition promise.
+   * Cancels in-progress animations and cleans up transition state.
    * @private
    */
   __endTransition() {
@@ -796,6 +795,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       return;
     }
     currentDetail.setAttribute('slot', 'detail-outgoing');
+    this.$.outgoing.style.width = this.__detailCachedSize;
     this.__replacing = true;
   }
 
@@ -805,6 +805,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    */
   __clearOutgoing() {
     this.querySelectorAll('[slot="detail-outgoing"]').forEach((el) => el.remove());
+    this.$.outgoing.style.width = '';
     this.__replacing = false;
   }
 

--- a/packages/master-detail-layout/test/detail-auto-size.test.js
+++ b/packages/master-detail-layout/test/detail-auto-size.test.js
@@ -183,6 +183,12 @@ describe('detail auto size', () => {
         expect(getCachedSize(inner)).to.equal('201px');
         expect(getCachedSize(middle)).to.equal('302px');
         expect(getCachedSize(outer)).to.equal('403px');
+
+        inner.querySelector('[slot="detail"]').style.width = '100px';
+        inner.recalculateLayout();
+        expect(getCachedSize(inner)).to.equal('101px');
+        expect(getCachedSize(middle)).to.equal('202px');
+        expect(getCachedSize(outer)).to.equal('303px');
       });
 
       it('should toggle overlay on ancestors when detail content outgrows or fits available space', () => {

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -432,5 +432,47 @@ describe('Transitions', () => {
       expect(outgoing.hasAttribute('hidden')).to.be.true;
       expect(layout.querySelector('[slot="detail-outgoing"]')).to.be.null;
     });
+
+    it('should preserve outgoing width when replacing with a differently sized detail', async () => {
+      let detailContent, replacePromise;
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '200px';
+      await layout._setDetail(detailContent);
+      await onceResized(layout);
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '400px';
+      replacePromise = layout._setDetail(detailContent);
+      expect(layout.$.outgoing.style.width).to.equal('201px'); // 1px border
+      await replacePromise;
+      expect(layout.$.outgoing.style.width).to.equal('');
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '200px';
+      replacePromise = layout._setDetail(detailContent);
+      expect(layout.$.outgoing.style.width).to.equal('401px'); // 1px border
+      await replacePromise;
+      expect(layout.$.outgoing.style.width).to.equal('');
+    });
+
+    it('should adjust detail size after replacing with a differently sized detail', async () => {
+      let detailContent;
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '200px';
+      await layout._setDetail(detailContent);
+      expect(layout.$.detail.offsetWidth).to.be.equal(201); // 1px border
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '400px';
+      await layout._setDetail(detailContent);
+      expect(layout.$.detail.offsetWidth).to.be.equal(401); // 1px border
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '200px';
+      await layout._setDetail(detailContent);
+      expect(layout.$.detail.offsetWidth).to.be.equal(201); // 1px border
+    });
   });
 });

--- a/test/integration/master-detail-layout-form-layout.test.js
+++ b/test/integration/master-detail-layout-form-layout.test.js
@@ -1,0 +1,39 @@
+import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import '@vaadin/form-layout';
+import '@vaadin/master-detail-layout';
+import { assertFormLayoutGrid } from '@vaadin/form-layout/test/helpers.js';
+
+window.Vaadin ||= {};
+window.Vaadin.featureFlags ||= {};
+window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
+
+describe('form-layout in master-detail-layout', () => {
+  let mdl;
+
+  describe('detail auto size', () => {
+    beforeEach(async () => {
+      mdl = fixtureSync(`
+        <vaadin-master-detail-layout style="width: 800px;" master-size="300px">
+          <div>Master</div>
+        </vaadin-master-detail-layout>
+      `);
+      await nextFrame();
+      await nextResize(mdl);
+    });
+
+    it('should expand form layout to max columns', async () => {
+      const formLayout = document.createElement('vaadin-form-layout');
+      formLayout.autoResponsive = true;
+      formLayout.autoRows = true;
+      formLayout.maxColumns = 3;
+
+      for (let i = 0; i < 6; i++) {
+        formLayout.appendChild(document.createElement('input'));
+      }
+
+      await mdl._setDetail(formLayout);
+
+      assertFormLayoutGrid(formLayout, { columns: 3, rows: 2 });
+    });
+  });
+});


### PR DESCRIPTION
1. Replaces `visibility: hidden/visible` with `opacity: 0/1` on `#detail` and `#detail-placeholder` so form-layout can measure its intrinsic size on first open. Previously, it wouldn't expand to max columns because `isElementHidden` uses `checkVisibility({ visibilityProperty: true })` and treated the content as hidden
2. Preserves the outgoing container's width during replace transitions by setting it to the cached detail size in `__snapshotOutgoing`. Without this, replacing a detail with differently-sized content caused the outgoing element to resize mid-animation
3. Introduces explicit z-index stacking (placeholder z:1, backdrop z:2, outgoing z:3, detail z:4) instead of the previous visibility + conditional z-index scheme


🤖 Partially generated with [Claude Code](https://claude.com/claude-code)