### PR TITLE
fix: add border radius inheritance to content part styles

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -48,6 +48,8 @@ const widgetStyles = css`
     flex: 1;
     overflow: hidden;
     min-height: 1em;
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
   }
 
   [part~='resize-button'] {


### PR DESCRIPTION
Prevent the content from rendering outside the rounded widget.

Before:

<img width="519" height="317" alt="Screenshot 2026-04-02 at 10 35 23" src="https://github.com/user-attachments/assets/106d49a3-10bb-4e00-aeb7-872af177e08d" />

After:

<img width="517" height="316" alt="Screenshot 2026-04-02 at 10 35 43" src="https://github.com/user-attachments/assets/fe83f330-5d11-4ec6-90d6-f071e3d3f6fc" />
