### PR TITLE
fix: prevent detail element cleanup on interrupted replace transitions

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -140,6 +140,11 @@ export const masterDetailLayoutStyles = css`
   #detailOutgoing {
     position: absolute;
     z-index: 3;
+    display: none;
+  }
+
+  :host([transition='replace']) #detailOutgoing {
+    display: block;
   }
 
   /* Detail transition: off-screen by default, on-screen when has-detail */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -203,12 +203,6 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       },
 
       /** @private */
-      __replacing: {
-        type: Boolean,
-        sync: true,
-      },
-
-      /** @private */
       __detailCachedSize: {
         type: String,
         observer: '__detailCachedSizeChanged',
@@ -232,7 +226,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
       <div id="master" part="master" ?inert="${isLayoutContained}">
         <slot @slotchange="${this.__onSlotChange}"></slot>
       </div>
-      <div id="detailOutgoing" inert ?hidden="${!this.__replacing}">
+      <div id="detailOutgoing" inert>
         <slot name="detail-outgoing"></slot>
       </div>
       <div
@@ -599,8 +593,13 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
   /** @private */
   async __replaceTransition(updateSlot) {
+    const oldDetail = this.__slottedDetail;
+    if (oldDetail) {
+      oldDetail.slot = 'detail-outgoing';
+    }
+
     try {
-      this.__snapshotDetailOutgoing();
+      this.$.detailOutgoing.style.width = this.__detailCachedSize;
 
       await updateSlot();
 
@@ -610,7 +609,9 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
         animateOut(this.$.detailOutgoing, ['fade', 'slide'], progress),
       ]);
     } finally {
-      this.__clearDetailOutgoing();
+      if (oldDetail) {
+        oldDetail.remove();
+      }
     }
   }
 
@@ -623,32 +624,6 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     ]);
 
     await updateSlot();
-  }
-
-  /**
-   * Moves the current detail content to the outgoing slot so it can
-   * slide out while the new content slides in. Keeps the element in
-   * light DOM so light DOM styles continue to apply.
-   * @private
-   */
-  __snapshotDetailOutgoing() {
-    const currentDetail = this.__slottedDetail;
-    if (!currentDetail) {
-      return;
-    }
-    currentDetail.setAttribute('slot', 'detail-outgoing');
-    this.$.detailOutgoing.style.width = this.__detailCachedSize;
-    this.__replacing = true;
-  }
-
-  /**
-   * Clears the outgoing container after the replace transition completes.
-   * @private
-   */
-  __clearDetailOutgoing() {
-    this.querySelectorAll('[slot="detail-outgoing"]').forEach((el) => el.remove());
-    this.$.detailOutgoing.style.width = '';
-    this.__replacing = false;
   }
 
   /** @private */

--- a/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
+++ b/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
@@ -74,7 +74,6 @@ snapshots["vaadin-master-detail-layout shadow default"] =
   </slot>
 </div>
 <div
-  hidden=""
   id="detailOutgoing"
   inert=""
 >

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
@@ -365,7 +365,7 @@ describe('Transitions', () => {
 
       // During replace, old content should be in the outgoing slot
       const detailOutgoing = layout.shadowRoot.querySelector('#detailOutgoing');
-      expect(detailOutgoing.hasAttribute('hidden')).to.be.false;
+      expect(detailOutgoing.checkVisibility()).to.be.true;
       expect(detail.getAttribute('slot')).to.equal('detail-outgoing');
 
       // New content should be in the detail slot
@@ -375,12 +375,30 @@ describe('Transitions', () => {
       await replacePromise;
 
       // After transition, outgoing should be cleared and old element removed
-      expect(detailOutgoing.hasAttribute('hidden')).to.be.true;
+      expect(detailOutgoing.checkVisibility()).to.be.false;
       expect(layout.querySelector('[slot="detail-outgoing"]')).to.be.null;
     });
 
+    it('should not remove new outgoing detail when replace interrupts replace', async () => {
+      const detail1 = document.createElement('detail-content');
+      await layout._setDetail(detail1);
+
+      const detail2 = document.createElement('detail-content');
+      // Start first replace but don't await
+      layout._setDetail(detail2);
+      await nextFrame();
+
+      const detail3 = document.createElement('detail-content');
+      // Interrupt with second replace — detail2 becomes the new outgoing
+      layout._setDetail(detail3);
+      await nextFrame();
+
+      expect(layout.contains(detail1)).to.be.false;
+      expect(layout.querySelector('[slot="detail-outgoing"]')).to.equal(detail2);
+    });
+
     it('should preserve outgoing width when replacing with a differently sized detail', async () => {
-      let detailContent, replacePromise;
+      let detailContent;
 
       detailContent = document.createElement('detail-content');
       detailContent.style.width = '200px';
@@ -389,17 +407,38 @@ describe('Transitions', () => {
 
       detailContent = document.createElement('detail-content');
       detailContent.style.width = '400px';
-      replacePromise = layout._setDetail(detailContent);
+      const replacePromise = layout._setDetail(detailContent);
+      await onceResized(layout);
       expect(layout.$.detailOutgoing.style.width).to.equal('201px'); // 1px border
       await replacePromise;
-      expect(layout.$.detailOutgoing.style.width).to.equal('');
 
       detailContent = document.createElement('detail-content');
       detailContent.style.width = '200px';
-      replacePromise = layout._setDetail(detailContent);
+      layout._setDetail(detailContent);
+      await onceResized(layout);
       expect(layout.$.detailOutgoing.style.width).to.equal('401px'); // 1px border
-      await replacePromise;
-      expect(layout.$.detailOutgoing.style.width).to.equal('');
+    });
+
+    it('should preserve outgoing width when replace interrupts replace', async () => {
+      let detailContent;
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '200px';
+      await layout._setDetail(detailContent);
+      await onceResized(layout);
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '400px';
+      // Start replace transition but don't await — interrupt with another replace
+      layout._setDetail(detailContent);
+      await onceResized(layout);
+      expect(layout.$.detailOutgoing.style.width).to.equal('201px'); // 1px border
+
+      detailContent = document.createElement('detail-content');
+      detailContent.style.width = '200px';
+      layout._setDetail(detailContent);
+      await onceResized(layout);
+      expect(layout.$.detailOutgoing.style.width).to.equal('401px'); // 1px border
     });
 
     it('should adjust detail size after replacing with a differently sized detail', async () => {

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-master-detail-layout.js';
 import './helpers/master-content.js';
@@ -386,12 +386,12 @@ describe('Transitions', () => {
       const detail2 = document.createElement('detail-content');
       // Start first replace but don't await
       layout._setDetail(detail2);
-      await nextFrame();
+      await aTimeout(0);
 
       const detail3 = document.createElement('detail-content');
       // Interrupt with second replace — detail2 becomes the new outgoing
       layout._setDetail(detail3);
-      await nextFrame();
+      await aTimeout(0);
 
       expect(layout.contains(detail1)).to.be.false;
       expect(layout.querySelector('[slot="detail-outgoing"]')).to.equal(detail2);


### PR DESCRIPTION
## Summary
- Inline `__snapshotDetailOutgoing` and `__clearDetailOutgoing` into `__replaceTransition` to directly manage the outgoing detail element lifecycle
- Replace `__replacing` reactive property and `hidden` attribute with CSS-only visibility toggle (`display: none` / `:host([transition='replace']) display: block`)
- Fix interrupted replace transitions: when detail1→detail2 is interrupted by detail2→detail3, the previous cleanup logic would incorrectly remove detail2 from the outgoing slot and clear the width set on the detail outgoing element.

## Test plan
- [x] `yarn test --group master-detail-layout --glob="transitions*"` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)