### PR TITLE
refactor: centralize rAF-based DOM writes into a shared queue

### DIFF
--- a/packages/component-base/src/dom-read-write.js
+++ b/packages/component-base/src/dom-read-write.js
@@ -20,13 +20,12 @@ function matchesFilter(entry, element, id) {
 }
 
 /**
- * Flushes pending DOM write callbacks, executing and removing them from the queue.
- * When called without arguments, flushes all pending writes. When called with
- * an element, only flushes writes for that element. The `id` option further
- * narrows the match to a specific write within the element.
+ * Flushes pending DOM read and write callbacks, executing and removing them
+ * from the queues. Reads are executed before writes. When called without
+ * arguments, flushes all pending tasks. When called with an element, only
+ * flushes tasks scheduled for that element.
  *
- * @param {HTMLElement} [element] - If provided, only flush writes scheduled for this element.
- * @param {{ id: string }} [options] - If provided, only flush writes with a matching id.
+ * @param {HTMLElement} [element] - If provided, only flush tasks scheduled for this element.
  */
 export function flush(element) {
   const readTasks = [];
@@ -52,10 +51,11 @@ export function flush(element) {
 }
 
 /**
- * Cancels pending DOM write callbacks, removing them from the queue without executing.
- * When called with an element, only cancels writes for that element.
+ * Cancels pending DOM read and write callbacks, removing them from the queues
+ * without executing. When called with an element, only cancels tasks scheduled
+ * for that element.
  *
- * @param {HTMLElement} [element] - If provided, only cancel writes scheduled for this element.
+ * @param {HTMLElement} [element] - If provided, only cancel tasks scheduled for this element.
  */
 export function cancel(element) {
   readTaskQueue = readTaskQueue.filter((entry) => !matchesFilter(entry, element));
@@ -63,11 +63,11 @@ export function cancel(element) {
 }
 
 /**
- * Schedules a DOM write callback to be executed in the next animation frame.
- * If a write with the same element and id already exists, it is replaced.
+ * Schedules DOM read and/or write callbacks for the given element. Reads are
+ * batched and executed before writes to avoid layout thrashing.
  *
- * @param {HTMLElement} element - The element associated with this write.
- * @param {{ read?: Function, write?: Function }} callbacks - The read and write callbacks to schedule.
+ * @param {HTMLElement} element - The element associated with these tasks.
+ * @param {{ read?: Function, write?: Function }} callbacks - The read and/or write callbacks to schedule.
  */
 export function schedule(element, { read, write }) {
   if (read) {

--- a/packages/component-base/src/dom-read-write.js
+++ b/packages/component-base/src/dom-read-write.js
@@ -3,7 +3,8 @@
  * Copyright (c) 2025 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-let writeQueue = [];
+let readTaskQueue = [];
+let writeTaskQueue = [];
 
 function matchesFilter(entry, element, id) {
   if (!element) {
@@ -27,32 +28,38 @@ function matchesFilter(entry, element, id) {
  * @param {HTMLElement} [element] - If provided, only flush writes scheduled for this element.
  * @param {{ id: string }} [options] - If provided, only flush writes with a matching id.
  */
-export function flushWrites(element, options = {}) {
-  const { id } = options;
+export function flush(element) {
+  const readTasks = [];
+  const writeTasks = [];
 
-  const entries = [];
-  writeQueue = writeQueue.filter((entry) => {
-    if (matchesFilter(entry, element, id)) {
-      entries.push(entry);
+  writeTaskQueue = writeTaskQueue.filter((entry) => {
+    if (matchesFilter(entry, element)) {
+      writeTasks.push(entry);
       return false;
     }
     return true;
   });
 
-  entries.forEach(({ callback }) => callback());
+  readTaskQueue = readTaskQueue.filter((entry) => {
+    if (matchesFilter(entry, element)) {
+      readTasks.push(entry);
+      return false;
+    }
+    return true;
+  });
+
+  [...readTasks, ...writeTasks].forEach(({ callback }) => callback());
 }
 
 /**
  * Cancels pending DOM write callbacks, removing them from the queue without executing.
- * When called with an element, only cancels writes for that element. The `id` option
- * further narrows the match to a specific write within the element.
+ * When called with an element, only cancels writes for that element.
  *
  * @param {HTMLElement} [element] - If provided, only cancel writes scheduled for this element.
- * @param {{ id: string }} [options] - If provided, only cancel writes with a matching id.
  */
-export function cancelWrites(element, options = {}) {
-  const { id } = options;
-  writeQueue = writeQueue.filter((entry) => !matchesFilter(entry, element, id));
+export function cancel(element) {
+  readTaskQueue = readTaskQueue.filter((entry) => !matchesFilter(entry, element));
+  writeTaskQueue = writeTaskQueue.filter((entry) => !matchesFilter(entry, element));
 }
 
 /**
@@ -60,16 +67,18 @@ export function cancelWrites(element, options = {}) {
  * If a write with the same element and id already exists, it is replaced.
  *
  * @param {HTMLElement} element - The element associated with this write.
- * @param {Function} callback - The callback to execute.
- * @param {{ id: string }} [options] - Optional id to deduplicate writes.
+ * @param {{ read?: Function, write?: Function }} callbacks - The read and write callbacks to schedule.
  */
-export function scheduleWrite(element, callback, options = {}) {
-  const { id } = options;
-  cancelWrites(element, { id });
+export function schedule(element, { read, write }) {
+  if (read) {
+    readTaskQueue.push({ element, callback: read });
+  }
 
-  writeQueue.push({ element, id, callback });
+  if (write) {
+    writeTaskQueue.push({ element, callback: write });
+  }
 
-  if (writeQueue.length <= 1) {
-    requestAnimationFrame(() => flushWrites());
+  if (readTaskQueue.length >= 1 || writeTaskQueue.length >= 1) {
+    setTimeout(() => flush());
   }
 }

--- a/packages/component-base/src/dom-task-scheduler.js
+++ b/packages/component-base/src/dom-task-scheduler.js
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright (c) 2025 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+let writeQueue = [];
+
+function matchesFilter(entry, element, id) {
+  if (!element) {
+    return true;
+  }
+  if (element && entry.element !== element) {
+    return false;
+  }
+  if (id && entry.id !== id) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Flushes pending DOM write callbacks, executing and removing them from the queue.
+ * When called without arguments, flushes all pending writes. When called with
+ * an element, only flushes writes for that element. The `id` option further
+ * narrows the match to a specific write within the element.
+ *
+ * @param {HTMLElement} [element] - If provided, only flush writes scheduled for this element.
+ * @param {{ id: string }} [options] - If provided, only flush writes with a matching id.
+ */
+export function flushWrites(element, options = {}) {
+  const { id } = options;
+
+  const entries = [];
+  writeQueue = writeQueue.filter((entry) => {
+    if (matchesFilter(entry, element, id)) {
+      entries.push(entry);
+      return false;
+    }
+    return true;
+  });
+
+  entries.forEach(({ callback }) => callback());
+}
+
+/**
+ * Cancels pending DOM write callbacks, removing them from the queue without executing.
+ * When called with an element, only cancels writes for that element. The `id` option
+ * further narrows the match to a specific write within the element.
+ *
+ * @param {HTMLElement} [element] - If provided, only cancel writes scheduled for this element.
+ * @param {{ id: string }} [options] - If provided, only cancel writes with a matching id.
+ */
+export function cancelWrites(element, options = {}) {
+  const { id } = options;
+  writeQueue = writeQueue.filter((entry) => !matchesFilter(entry, element, id));
+}
+
+/**
+ * Schedules a DOM write callback to be executed in the next animation frame.
+ * If a write with the same element and id already exists, it is replaced.
+ *
+ * @param {HTMLElement} element - The element associated with this write.
+ * @param {Function} callback - The callback to execute.
+ * @param {{ id: string }} [options] - Optional id to deduplicate writes.
+ */
+export function scheduleWrite(element, callback, options = {}) {
+  const { id } = options;
+  cancelWrites(element, { id });
+
+  writeQueue.push({ element, id, callback });
+
+  if (writeQueue.length <= 1) {
+    requestAnimationFrame(() => flushWrites());
+  }
+}

--- a/packages/component-base/src/overflow-controller.js
+++ b/packages/component-base/src/overflow-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import * as DOMTaskScheduler from './dom-task-scheduler.js';
+import * as DOMReadWrite from './dom-read-write.js';
 
 /**
  * A controller that detects if content inside the element overflows its scrolling viewport,
@@ -93,14 +93,19 @@ export class OverflowController {
 
   /** @private */
   __updateState({ sync }) {
-    const state = this.__readState();
+    let state;
 
-    DOMTaskScheduler.scheduleWrite(this, () => {
-      this.__writeState(state);
+    DOMReadWrite.schedule(this, {
+      read: () => {
+        state = this.__readState();
+      },
+      write: () => {
+        this.__writeState(state);
+      },
     });
 
     if (sync) {
-      DOMTaskScheduler.flushWrites(this);
+      DOMReadWrite.flush(this);
     }
   }
 

--- a/packages/component-base/src/overflow-controller.js
+++ b/packages/component-base/src/overflow-controller.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import * as DOMTaskScheduler from './dom-task-scheduler.js';
 
 /**
  * A controller that detects if content inside the element overflows its scrolling viewport,
@@ -92,13 +93,14 @@ export class OverflowController {
 
   /** @private */
   __updateState({ sync }) {
-    cancelAnimationFrame(this.__resizeRaf);
-
     const state = this.__readState();
-    if (sync) {
+
+    DOMTaskScheduler.scheduleWrite(this, () => {
       this.__writeState(state);
-    } else {
-      this.__resizeRaf = requestAnimationFrame(() => this.__writeState(state));
+    });
+
+    if (sync) {
+      DOMTaskScheduler.flushWrites(this);
     }
   }
 

--- a/packages/component-base/test/dom-task-scheduler.test.js
+++ b/packages/component-base/test/dom-task-scheduler.test.js
@@ -1,9 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import { cancelWrites, flushWrites, scheduleWrite } from '../src/dom-task-scheduler.js';
+import { cancel, flush, schedule } from '../src/dom-read-write.js';
 
-describe('dom-task-scheduler', () => {
+describe('dom-read-write', () => {
   let element;
 
   beforeEach(() => {
@@ -11,179 +11,181 @@ describe('dom-task-scheduler', () => {
   });
 
   afterEach(() => {
-    // Clean up any pending writes
-    cancelWrites();
+    // Clean up any pending tasks
+    cancel();
   });
 
-  describe('scheduleWrite', () => {
-    it('should execute callback on next animation frame', async () => {
-      const spy = sinon.spy();
-      scheduleWrite(element, spy);
-      expect(spy).to.not.be.called;
+  describe('schedule', () => {
+    it('should execute read and write callbacks on next microtask', async () => {
+      const readSpy = sinon.spy();
+      const writeSpy = sinon.spy();
+      schedule(element, { read: readSpy, write: writeSpy });
+      expect(readSpy).to.not.be.called;
+      expect(writeSpy).to.not.be.called;
 
       await nextFrame();
-      expect(spy).to.be.calledOnce;
+      expect(readSpy).to.be.calledOnce;
+      expect(writeSpy).to.be.calledOnce;
     });
 
-    it('should replace a previous write for the same element', async () => {
-      const spy1 = sinon.spy();
-      const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(element, spy2);
+    it('should execute read before write', async () => {
+      const calls = [];
+      schedule(element, {
+        read: () => calls.push('read'),
+        write: () => calls.push('write'),
+      });
 
       await nextFrame();
-      expect(spy1).to.not.be.called;
-      expect(spy2).to.be.calledOnce;
+      expect(calls).to.eql(['read', 'write']);
     });
 
-    it('should replace a previous write for the same element and id', async () => {
-      const spy1 = sinon.spy();
-      const spy2 = sinon.spy();
-      scheduleWrite(element, spy1, { id: 'resize' });
-      scheduleWrite(element, spy2, { id: 'resize' });
+    it('should schedule only a read callback', async () => {
+      const readSpy = sinon.spy();
+      schedule(element, { read: readSpy });
 
       await nextFrame();
-      expect(spy1).to.not.be.called;
-      expect(spy2).to.be.calledOnce;
+      expect(readSpy).to.be.calledOnce;
     });
 
-    it('should keep writes with different ids for the same element', async () => {
-      const spy1 = sinon.spy();
-      const spy2 = sinon.spy();
-      scheduleWrite(element, spy1, { id: 'resize' });
-      scheduleWrite(element, spy2, { id: 'scroll' });
+    it('should schedule only a write callback', async () => {
+      const writeSpy = sinon.spy();
+      schedule(element, { write: writeSpy });
 
       await nextFrame();
-      expect(spy1).to.be.calledOnce;
-      expect(spy2).to.be.calledOnce;
+      expect(writeSpy).to.be.calledOnce;
     });
 
-    it('should keep writes for different elements', async () => {
+    it('should keep tasks for different elements', async () => {
       const other = document.createElement('div');
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(other, spy2);
+      schedule(element, { write: spy1 });
+      schedule(other, { write: spy2 });
 
       await nextFrame();
       expect(spy1).to.be.calledOnce;
       expect(spy2).to.be.calledOnce;
     });
 
-    it('should execute callbacks in scheduling order', async () => {
+    it('should execute reads before writes across elements', async () => {
       const other = document.createElement('div');
       const calls = [];
-      scheduleWrite(element, () => calls.push('first'));
-      scheduleWrite(other, () => calls.push('second'));
+      schedule(element, {
+        read: () => calls.push('read-1'),
+        write: () => calls.push('write-1'),
+      });
+      schedule(other, {
+        read: () => calls.push('read-2'),
+        write: () => calls.push('write-2'),
+      });
 
       await nextFrame();
-      expect(calls).to.eql(['first', 'second']);
+      expect(calls).to.eql(['read-1', 'read-2', 'write-1', 'write-2']);
     });
   });
 
-  describe('flushWrites', () => {
-    it('should flush all pending writes when called without arguments', () => {
+  describe('flush', () => {
+    it('should flush all pending tasks when called without arguments', () => {
       const other = document.createElement('div');
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(other, spy2);
+      schedule(element, { write: spy1 });
+      schedule(other, { write: spy2 });
 
-      flushWrites();
+      flush();
       expect(spy1).to.be.calledOnce;
       expect(spy2).to.be.calledOnce;
     });
 
-    it('should flush only writes for the given element', () => {
+    it('should flush only tasks for the given element', () => {
       const other = document.createElement('div');
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(other, spy2);
+      schedule(element, { write: spy1 });
+      schedule(other, { write: spy2 });
 
-      flushWrites(element);
+      flush(element);
       expect(spy1).to.be.calledOnce;
       expect(spy2).to.not.be.called;
     });
 
-    it('should flush only writes matching the given element and id', () => {
-      const spy1 = sinon.spy();
-      const spy2 = sinon.spy();
-      scheduleWrite(element, spy1, { id: 'resize' });
-      scheduleWrite(element, spy2, { id: 'scroll' });
-
-      flushWrites(element, { id: 'resize' });
-      expect(spy1).to.be.calledOnce;
-      expect(spy2).to.not.be.called;
-    });
-
-    it('should not execute flushed writes again on next frame', async () => {
+    it('should not execute flushed tasks again on next frame', async () => {
       const spy = sinon.spy();
-      scheduleWrite(element, spy);
+      schedule(element, { write: spy });
 
-      flushWrites(element);
+      flush(element);
       expect(spy).to.be.calledOnce;
 
       await nextFrame();
       expect(spy).to.be.calledOnce;
     });
 
-    it('should still execute remaining writes on next frame', async () => {
+    it('should still execute remaining tasks on next frame', async () => {
       const other = document.createElement('div');
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(other, spy2);
+      schedule(element, { write: spy1 });
+      schedule(other, { write: spy2 });
 
-      flushWrites(element);
+      flush(element);
       expect(spy1).to.be.calledOnce;
       expect(spy2).to.not.be.called;
 
       await nextFrame();
       expect(spy2).to.be.calledOnce;
     });
+
+    it('should execute read before write when flushing', () => {
+      const calls = [];
+      schedule(element, {
+        read: () => calls.push('read'),
+        write: () => calls.push('write'),
+      });
+
+      flush(element);
+      expect(calls).to.eql(['read', 'write']);
+    });
   });
 
-  describe('cancelWrites', () => {
-    it('should cancel all pending writes when called without arguments', async () => {
+  describe('cancel', () => {
+    it('should cancel all pending tasks when called without arguments', async () => {
       const other = document.createElement('div');
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(other, spy2);
+      schedule(element, { write: spy1 });
+      schedule(other, { write: spy2 });
 
-      cancelWrites();
+      cancel();
 
       await nextFrame();
       expect(spy1).to.not.be.called;
       expect(spy2).to.not.be.called;
     });
 
-    it('should cancel only writes for the given element', async () => {
+    it('should cancel only tasks for the given element', async () => {
       const other = document.createElement('div');
       const spy1 = sinon.spy();
       const spy2 = sinon.spy();
-      scheduleWrite(element, spy1);
-      scheduleWrite(other, spy2);
+      schedule(element, { write: spy1 });
+      schedule(other, { write: spy2 });
 
-      cancelWrites(element);
+      cancel(element);
 
       await nextFrame();
       expect(spy1).to.not.be.called;
       expect(spy2).to.be.calledOnce;
     });
 
-    it('should cancel only writes matching the given element and id', async () => {
-      const spy1 = sinon.spy();
-      const spy2 = sinon.spy();
-      scheduleWrite(element, spy1, { id: 'resize' });
-      scheduleWrite(element, spy2, { id: 'scroll' });
+    it('should cancel both read and write for the given element', async () => {
+      const readSpy = sinon.spy();
+      const writeSpy = sinon.spy();
+      schedule(element, { read: readSpy, write: writeSpy });
 
-      cancelWrites(element, { id: 'resize' });
+      cancel(element);
 
       await nextFrame();
-      expect(spy1).to.not.be.called;
-      expect(spy2).to.be.calledOnce;
+      expect(readSpy).to.not.be.called;
+      expect(writeSpy).to.not.be.called;
     });
   });
 });

--- a/packages/component-base/test/dom-task-scheduler.test.js
+++ b/packages/component-base/test/dom-task-scheduler.test.js
@@ -1,0 +1,189 @@
+import { expect } from '@vaadin/chai-plugins';
+import { nextFrame } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { cancelWrites, flushWrites, scheduleWrite } from '../src/dom-task-scheduler.js';
+
+describe('dom-task-scheduler', () => {
+  let element;
+
+  beforeEach(() => {
+    element = document.createElement('div');
+  });
+
+  afterEach(() => {
+    // Clean up any pending writes
+    cancelWrites();
+  });
+
+  describe('scheduleWrite', () => {
+    it('should execute callback on next animation frame', async () => {
+      const spy = sinon.spy();
+      scheduleWrite(element, spy);
+      expect(spy).to.not.be.called;
+
+      await nextFrame();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should replace a previous write for the same element', async () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(element, spy2);
+
+      await nextFrame();
+      expect(spy1).to.not.be.called;
+      expect(spy2).to.be.calledOnce;
+    });
+
+    it('should replace a previous write for the same element and id', async () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1, { id: 'resize' });
+      scheduleWrite(element, spy2, { id: 'resize' });
+
+      await nextFrame();
+      expect(spy1).to.not.be.called;
+      expect(spy2).to.be.calledOnce;
+    });
+
+    it('should keep writes with different ids for the same element', async () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1, { id: 'resize' });
+      scheduleWrite(element, spy2, { id: 'scroll' });
+
+      await nextFrame();
+      expect(spy1).to.be.calledOnce;
+      expect(spy2).to.be.calledOnce;
+    });
+
+    it('should keep writes for different elements', async () => {
+      const other = document.createElement('div');
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(other, spy2);
+
+      await nextFrame();
+      expect(spy1).to.be.calledOnce;
+      expect(spy2).to.be.calledOnce;
+    });
+
+    it('should execute callbacks in scheduling order', async () => {
+      const other = document.createElement('div');
+      const calls = [];
+      scheduleWrite(element, () => calls.push('first'));
+      scheduleWrite(other, () => calls.push('second'));
+
+      await nextFrame();
+      expect(calls).to.eql(['first', 'second']);
+    });
+  });
+
+  describe('flushWrites', () => {
+    it('should flush all pending writes when called without arguments', () => {
+      const other = document.createElement('div');
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(other, spy2);
+
+      flushWrites();
+      expect(spy1).to.be.calledOnce;
+      expect(spy2).to.be.calledOnce;
+    });
+
+    it('should flush only writes for the given element', () => {
+      const other = document.createElement('div');
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(other, spy2);
+
+      flushWrites(element);
+      expect(spy1).to.be.calledOnce;
+      expect(spy2).to.not.be.called;
+    });
+
+    it('should flush only writes matching the given element and id', () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1, { id: 'resize' });
+      scheduleWrite(element, spy2, { id: 'scroll' });
+
+      flushWrites(element, { id: 'resize' });
+      expect(spy1).to.be.calledOnce;
+      expect(spy2).to.not.be.called;
+    });
+
+    it('should not execute flushed writes again on next frame', async () => {
+      const spy = sinon.spy();
+      scheduleWrite(element, spy);
+
+      flushWrites(element);
+      expect(spy).to.be.calledOnce;
+
+      await nextFrame();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should still execute remaining writes on next frame', async () => {
+      const other = document.createElement('div');
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(other, spy2);
+
+      flushWrites(element);
+      expect(spy1).to.be.calledOnce;
+      expect(spy2).to.not.be.called;
+
+      await nextFrame();
+      expect(spy2).to.be.calledOnce;
+    });
+  });
+
+  describe('cancelWrites', () => {
+    it('should cancel all pending writes when called without arguments', async () => {
+      const other = document.createElement('div');
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(other, spy2);
+
+      cancelWrites();
+
+      await nextFrame();
+      expect(spy1).to.not.be.called;
+      expect(spy2).to.not.be.called;
+    });
+
+    it('should cancel only writes for the given element', async () => {
+      const other = document.createElement('div');
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1);
+      scheduleWrite(other, spy2);
+
+      cancelWrites(element);
+
+      await nextFrame();
+      expect(spy1).to.not.be.called;
+      expect(spy2).to.be.calledOnce;
+    });
+
+    it('should cancel only writes matching the given element and id', async () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      scheduleWrite(element, spy1, { id: 'resize' });
+      scheduleWrite(element, spy2, { id: 'scroll' });
+
+      cancelWrites(element, { id: 'resize' });
+
+      await nextFrame();
+      expect(spy1).to.not.be.called;
+      expect(spy2).to.be.calledOnce;
+    });
+  });
+});

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -6,7 +6,7 @@
 import { html, LitElement, nothing } from 'lit';
 import { getFocusableElements, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
-import * as DOMTaskScheduler from '@vaadin/component-base/src/dom-task-scheduler.js';
+import * as DOMReadWrite from '@vaadin/component-base/src/dom-read-write.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -255,7 +255,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   disconnectedCallback() {
     super.disconnectedCallback();
     this.__resizeObserver.disconnect();
-    DOMTaskScheduler.cancelWrites(this);
+    DOMReadWrite.cancel(this);
     cancelAnimations(this);
   }
 
@@ -327,15 +327,17 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    * @private
    */
   __onResize() {
-    const state = this.__readLayoutState();
+    let state;
 
-    DOMTaskScheduler.scheduleWrite(
-      this,
-      () => {
+    DOMReadWrite.schedule(this, {
+      read: () => {
+        state = this.__readLayoutState();
+      },
+
+      write: () => {
         this.__writeLayoutState(state);
       },
-      { id: 'onResize' },
-    );
+    });
   }
 
   /**
@@ -434,9 +436,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
     // Cancel any previously scheduled DOM writes to prevent them from
     // potentially overriding the layout state with stale measurements.
-    invalidatedLayouts.forEach((layout) => {
-      DOMTaskScheduler.cancelWrites(layout, { id: 'onResize' });
-    });
+    invalidatedLayouts.forEach((layout) => DOMReadWrite.cancel(layout));
 
     // Write
     invalidatedLayouts.forEach((layout) => {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -6,6 +6,7 @@
 import { html, LitElement, nothing } from 'lit';
 import { getFocusableElements, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import * as DOMTaskScheduler from '@vaadin/component-base/src/dom-task-scheduler.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -254,7 +255,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   disconnectedCallback() {
     super.disconnectedCallback();
     this.__resizeObserver.disconnect();
-    cancelAnimationFrame(this.__resizeRaf);
+    DOMTaskScheduler.cancelWrites(this);
     cancelAnimations(this);
   }
 
@@ -327,8 +328,14 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    */
   __onResize() {
     const state = this.__readLayoutState();
-    cancelAnimationFrame(this.__resizeRaf);
-    this.__resizeRaf = requestAnimationFrame(() => this.__writeLayoutState(state));
+
+    DOMTaskScheduler.scheduleWrite(
+      this,
+      () => {
+        this.__writeLayoutState(state);
+      },
+      { id: 'onResize' },
+    );
   }
 
   /**
@@ -423,11 +430,13 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    * synchronous DOM reads and writes.
    */
   recalculateLayout() {
-    // Cancel any pending ResizeObserver rAF to prevent it from potentially
-    // overriding the layout state with stale measurements.
-    cancelAnimationFrame(this.__resizeRaf);
-
     const invalidatedLayouts = [...this.__ancestorLayouts.filter((layout) => layout.__isDetailAutoSized), this];
+
+    // Cancel any previously scheduled DOM writes to prevent them from
+    // potentially overriding the layout state with stale measurements.
+    invalidatedLayouts.forEach((layout) => {
+      DOMTaskScheduler.cancelWrites(layout, { id: 'onResize' });
+    });
 
     // Write
     invalidatedLayouts.forEach((layout) => {


### PR DESCRIPTION
## Summary
- Introduces a `DOMTaskScheduler` module (`component-base/src/dom-task-scheduler.js`) with `scheduleWrite`, `flushWrites`, and `cancelWrites` — a shared rAF-based DOM write queue with element/id-based filtering.
- Migrates `OverflowController` and `MasterDetailLayout` from per-instance `requestAnimationFrame`/`cancelAnimationFrame` to the new scheduler.


## Test plan
- [ ] Verify master-detail layout works in side-by-side and overlay modes
- [ ] Verify nested master-detail layouts coordinate correctly on resize
- [ ] Verify overflow detection still works for components using `OverflowController` (e.g., tabs, menu-bar)
- [ ] Run `yarn test --group master-detail-layout`
- [ ] Run `yarn test --group tabs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)