### PR TITLE
refactor: recalculate ancestor layouts after initializing deepest MDL 

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -248,6 +248,16 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   connectedCallback() {
     super.connectedCallback();
     this.__initResizeObserver();
+
+    if (!this.detailSize) {
+      this.__recalculateLayoutRaf = requestAnimationFrame(() => {
+        this.recalculateLayout();
+      });
+
+      this.__ancestorLayouts.forEach((layout) => {
+        cancelAnimationFrame(layout.__recalculateLayoutRaf);
+      });
+    }
   }
 
   /** @protected */
@@ -255,6 +265,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     super.disconnectedCallback();
     this.__resizeObserver.disconnect();
     cancelAnimationFrame(this.__resizeRaf);
+    cancelAnimationFrame(this.__recalculateLayoutRaf);
     cancelAnimations(this);
   }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -249,12 +249,13 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     super.connectedCallback();
     this.__initResizeObserver();
 
-    if (!this.detailSize) {
+    const ancestorLayouts = this.__ancestorLayouts;
+    if (ancestorLayouts.length > 0) {
       this.__recalculateLayoutRaf = requestAnimationFrame(() => {
         this.recalculateLayout();
       });
 
-      this.__ancestorLayouts.forEach((layout) => {
+      ancestorLayouts.forEach((layout) => {
         cancelAnimationFrame(layout.__recalculateLayoutRaf);
       });
     }
@@ -434,7 +435,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    * synchronous DOM reads and writes.
    */
   recalculateLayout() {
-    const invalidatedLayouts = [...this.__ancestorLayouts.filter((layout) => layout.__isDetailAutoSized), this];
+    const invalidatedLayouts = [...this.__ancestorLayouts, this];
 
     // Write
     invalidatedLayouts.forEach((layout) => {

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -251,12 +251,12 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
     const ancestorLayouts = this.__ancestorLayouts;
     if (ancestorLayouts.length > 0) {
-      this.__recalculateLayoutRaf = requestAnimationFrame(() => {
-        this.recalculateLayout();
+      ancestorLayouts.forEach((layout) => {
+        cancelAnimationFrame(layout.__initialRaf);
       });
 
-      ancestorLayouts.forEach((layout) => {
-        cancelAnimationFrame(layout.__recalculateLayoutRaf);
+      this.__initialRaf = requestAnimationFrame(() => {
+        this.recalculateLayout();
       });
     }
   }
@@ -266,7 +266,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     super.disconnectedCallback();
     this.__resizeObserver.disconnect();
     cancelAnimationFrame(this.__resizeRaf);
-    cancelAnimationFrame(this.__recalculateLayoutRaf);
+    cancelAnimationFrame(this.__initialRaf);
     cancelAnimations(this);
   }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -434,14 +434,14 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
    * synchronous DOM reads and writes.
    */
   recalculateLayout() {
-    // Cancel any pending ResizeObserver rAF to prevent it from potentially
-    // overriding the layout state with stale measurements.
-    cancelAnimationFrame(this.__resizeRaf);
-
     const invalidatedLayouts = [...this.__ancestorLayouts.filter((layout) => layout.__isDetailAutoSized), this];
 
     // Write
     invalidatedLayouts.forEach((layout) => {
+      // Cancel any pending ResizeObserver rAF to prevent it from potentially
+      // overriding the layout state with stale measurements.
+      cancelAnimationFrame(layout.__resizeRaf);
+
       layout.__detailCachedSize = null;
 
       if (layout.__isDetailAutoSized) {

--- a/packages/master-detail-layout/test/detail-auto-size.test.js
+++ b/packages/master-detail-layout/test/detail-auto-size.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { defineCE, fixtureSync } from '@vaadin/testing-helpers';
+import { defineCE, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-master-detail-layout.js';
 import { css, html, LitElement } from 'lit';
@@ -21,25 +21,17 @@ describe('detail auto size', () => {
 
     beforeEach(async () => {
       layout = fixtureSync(`
-        <vaadin-master-detail-layout>
+        <vaadin-master-detail-layout master-size="200px" detail-size="200px" orientation="horizontal">
           <div>Master</div>
           <div slot="detail">Detail</div>
         </vaadin-master-detail-layout>
       `);
-      await onceResized(layout);
       spy = sinon.spy(layout, 'recalculateLayout');
+      await onceResized(layout);
     });
 
-    it('should not be called when masterSize and detailSize are provided initially', async () => {
-      const newLayout = fixtureSync(`
-        <vaadin-master-detail-layout master-size="200px" detail-size="200px">
-          <div>Master</div>
-          <div slot="detail">Detail</div>
-        </vaadin-master-detail-layout>
-      `);
-      const newSpy = sinon.spy(newLayout, 'recalculateLayout');
-      await onceResized(newLayout);
-      expect(newSpy).to.not.be.called;
+    it('should not be called when masterSize, detailSize and orientation are provided initially', () => {
+      expect(spy).to.not.be.called;
     });
 
     it('should be called when masterSize is changed after initial render', () => {
@@ -52,18 +44,6 @@ describe('detail auto size', () => {
       layout.detailSize = '200px';
       layout.detailSize = '300px';
       expect(spy).to.be.calledOnce;
-    });
-
-    it('should not be called when orientation is provided initially', async () => {
-      const newLayout = fixtureSync(`
-        <vaadin-master-detail-layout orientation="vertical">
-          <div>Master</div>
-          <div slot="detail">Detail</div>
-        </vaadin-master-detail-layout>
-      `);
-      const newSpy = sinon.spy(newLayout, 'recalculateLayout');
-      await onceResized(newLayout);
-      expect(newSpy).to.not.be.called;
     });
 
     it('should be called when orientation is changed after initial render', () => {
@@ -133,7 +113,7 @@ describe('detail auto size', () => {
       },
     );
 
-    beforeEach(async () => {
+    beforeEach(() => {
       outer = fixtureSync(`
         <vaadin-master-detail-layout style="width: 1200px;" master-size="100px" expand="both">
           <div>Outer Master</div>
@@ -155,13 +135,20 @@ describe('detail auto size', () => {
       `);
       middle = outer.querySelector('vaadin-master-detail-layout');
       inner = middle.querySelector('[slot="detail"]').shadowRoot.querySelector('vaadin-master-detail-layout');
-
-      await onceResized(outer);
-      await onceResized(middle);
-      await onceResized(inner);
     });
 
-    it('should cache detail intrinsic size plus border at each level', () => {
+    it('should compute overlay state for all levels in a single animation frame', async () => {
+      outer.style.width = '200px';
+      await nextFrame();
+
+      expect(outer.hasAttribute('overlay')).to.be.true;
+      expect(middle.hasAttribute('overlay')).to.be.true;
+      expect(inner.hasAttribute('overlay')).to.be.true;
+    });
+
+    it('should compute detail sizes for all levels in a single animation frame', async () => {
+      await nextFrame();
+
       // Inner: 100px detail content + 1px border = 101px
       expect(getCachedSize(inner)).to.equal('101px');
       // Middle: inner layout min-content (100px master + 101px detail) + 1px border = 202px
@@ -172,12 +159,27 @@ describe('detail auto size', () => {
 
     it('should not cache detail size when detailSize is explicitly set', async () => {
       outer.detailSize = '300px';
-      await onceResized(outer);
+      await nextFrame();
       expect(getCachedSize(outer)).to.equal('');
     });
 
     describe('recalculateLayout', () => {
-      it('should update cached sizes on ancestors after detail content changes', () => {
+      let outerSpy, middleSpy, innerSpy;
+
+      beforeEach(async () => {
+        outerSpy = sinon.spy(outer, 'recalculateLayout');
+        middleSpy = sinon.spy(middle, 'recalculateLayout');
+        innerSpy = sinon.spy(inner, 'recalculateLayout');
+        await nextFrame();
+      });
+
+      it('should be called on deepest layout during initialization', () => {
+        expect(outerSpy).to.not.be.called;
+        expect(middleSpy).to.not.be.called;
+        expect(innerSpy).to.be.calledOnce;
+      });
+
+      it('should update cached sizes on ancestors', () => {
         inner.querySelector('[slot="detail"]').style.width = '200px';
         inner.recalculateLayout();
         expect(getCachedSize(inner)).to.equal('201px');
@@ -191,7 +193,7 @@ describe('detail auto size', () => {
         expect(getCachedSize(outer)).to.equal('303px');
       });
 
-      it('should toggle overlay on ancestors when detail content outgrows or fits available space', () => {
+      it('should update overlay state on ancestors', () => {
         // Grow inner detail so outer needs 100px + 1103px = 1203px > 1200px
         inner.querySelector('[slot="detail"]').style.width = '1000px';
         inner.recalculateLayout();

--- a/packages/master-detail-layout/test/detail-auto-size.test.js
+++ b/packages/master-detail-layout/test/detail-auto-size.test.js
@@ -137,16 +137,7 @@ describe('detail auto size', () => {
       inner = middle.querySelector('[slot="detail"]').shadowRoot.querySelector('vaadin-master-detail-layout');
     });
 
-    it('should compute overlay state for all levels in a single animation frame', async () => {
-      outer.style.width = '200px';
-      await nextFrame();
-
-      expect(outer.hasAttribute('overlay')).to.be.true;
-      expect(middle.hasAttribute('overlay')).to.be.true;
-      expect(inner.hasAttribute('overlay')).to.be.true;
-    });
-
-    it('should compute detail sizes for all levels in a single animation frame', async () => {
+    it('should cache detail intrinsic size plus border at each level', async () => {
       await nextFrame();
 
       // Inner: 100px detail content + 1px border = 101px
@@ -179,7 +170,7 @@ describe('detail auto size', () => {
         expect(innerSpy).to.be.calledOnce;
       });
 
-      it('should update cached sizes on ancestors', () => {
+      it('should update cached sizes on ancestors after detail content changes', () => {
         inner.querySelector('[slot="detail"]').style.width = '200px';
         inner.recalculateLayout();
         expect(getCachedSize(inner)).to.equal('201px');
@@ -193,7 +184,7 @@ describe('detail auto size', () => {
         expect(getCachedSize(outer)).to.equal('303px');
       });
 
-      it('should update overlay state on ancestors', () => {
+      it('should toggle overlay on ancestors when detail content outgrows or fits available space', () => {
         // Grow inner detail so outer needs 100px + 1103px = 1203px > 1200px
         inner.querySelector('[slot="detail"]').style.width = '1000px';
         inner.recalculateLayout();

--- a/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
+++ b/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
@@ -239,21 +239,23 @@ snapshots["vaadin-master-detail-layout nested layouts default"] =
   master-size="100px"
   orientation="horizontal"
   overlay-containment="layout"
-  style="--_master-size: 100px; --_detail-cached-size: 301px;"
+  overlay-size="100px"
+  style="--_master-size: 100px; --_overlay-size: 100px; --_detail-cached-size: 501px;"
 >
   <div>
     Master 0
   </div>
   <vaadin-master-detail-layout
-    detail-size="200px"
+    detail-size="400px"
     expand="master"
     has-detail=""
     has-master=""
     master-size="100px"
     orientation="horizontal"
     overlay-containment="layout"
+    overlay-size="100px"
     slot="detail"
-    style="--_master-size: 100px; --_detail-size: 200px;"
+    style="--_master-size: 100px; --_detail-size: 400px; --_overlay-size: 100px;"
   >
     <div>
       Master 1
@@ -262,13 +264,12 @@ snapshots["vaadin-master-detail-layout nested layouts default"] =
       expand="master"
       has-detail=""
       has-master=""
-      keep-detail-column-offscreen=""
       master-size="100px"
       orientation="horizontal"
-      overlay=""
       overlay-containment="layout"
+      overlay-size="100px"
       slot="detail"
-      style="--_master-size: 100px; --_detail-cached-size: 201px;"
+      style="--_master-size: 100px; --_overlay-size: 100px; --_detail-cached-size: 201px;"
     >
       <div>
         Master 2
@@ -278,10 +279,8 @@ snapshots["vaadin-master-detail-layout nested layouts default"] =
         expand="master"
         has-detail=""
         has-master=""
-        keep-detail-column-offscreen=""
         master-size="100px"
         orientation="horizontal"
-        overlay=""
         overlay-containment="layout"
         slot="detail"
         style="--_master-size: 100px; --_detail-size: 100px;"
@@ -309,13 +308,14 @@ snapshots["vaadin-master-detail-layout nested layouts overflow"] =
   orientation="horizontal"
   overlay=""
   overlay-containment="layout"
-  style="--_master-size: 100px; width: 200px; --_detail-cached-size: 301px;"
+  overlay-size="100px"
+  style="--_master-size: 100px; --_overlay-size: 100px; width: 200px; --_detail-cached-size: 501px;"
 >
   <div>
     Master 0
   </div>
   <vaadin-master-detail-layout
-    detail-size="200px"
+    detail-size="400px"
     expand="master"
     has-detail=""
     has-master=""
@@ -324,8 +324,9 @@ snapshots["vaadin-master-detail-layout nested layouts overflow"] =
     orientation="horizontal"
     overlay=""
     overlay-containment="layout"
+    overlay-size="100px"
     slot="detail"
-    style="--_master-size: 100px; --_detail-size: 200px;"
+    style="--_master-size: 100px; --_detail-size: 400px; --_overlay-size: 100px;"
   >
     <div>
       Master 1
@@ -339,8 +340,9 @@ snapshots["vaadin-master-detail-layout nested layouts overflow"] =
       orientation="horizontal"
       overlay=""
       overlay-containment="layout"
+      overlay-size="100px"
       slot="detail"
-      style="--_master-size: 100px; --_detail-cached-size: 201px;"
+      style="--_master-size: 100px; --_overlay-size: 100px; --_detail-cached-size: 201px;"
     >
       <div>
         Master 2
@@ -350,8 +352,10 @@ snapshots["vaadin-master-detail-layout nested layouts overflow"] =
         expand="master"
         has-detail=""
         has-master=""
+        keep-detail-column-offscreen=""
         master-size="100px"
         orientation="horizontal"
+        overlay=""
         overlay-containment="layout"
         slot="detail"
         style="--_master-size: 100px; --_detail-size: 100px;"

--- a/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
+++ b/packages/master-detail-layout/test/dom/__snapshots__/master-detail-layout.test.snap.js
@@ -231,3 +231,141 @@ snapshots["vaadin-master-detail-layout detail placeholder removed"] =
 `;
 /* end snapshot vaadin-master-detail-layout detail placeholder removed */
 
+snapshots["vaadin-master-detail-layout nested layouts default"] = 
+`<vaadin-master-detail-layout
+  expand="master"
+  has-detail=""
+  has-master=""
+  master-size="100px"
+  orientation="horizontal"
+  overlay-containment="layout"
+  style="--_master-size: 100px; --_detail-cached-size: 301px;"
+>
+  <div>
+    Master 0
+  </div>
+  <vaadin-master-detail-layout
+    detail-size="200px"
+    expand="master"
+    has-detail=""
+    has-master=""
+    master-size="100px"
+    orientation="horizontal"
+    overlay-containment="layout"
+    slot="detail"
+    style="--_master-size: 100px; --_detail-size: 200px;"
+  >
+    <div>
+      Master 1
+    </div>
+    <vaadin-master-detail-layout
+      expand="master"
+      has-detail=""
+      has-master=""
+      keep-detail-column-offscreen=""
+      master-size="100px"
+      orientation="horizontal"
+      overlay=""
+      overlay-containment="layout"
+      slot="detail"
+      style="--_master-size: 100px; --_detail-cached-size: 201px;"
+    >
+      <div>
+        Master 2
+      </div>
+      <vaadin-master-detail-layout
+        detail-size="100px"
+        expand="master"
+        has-detail=""
+        has-master=""
+        keep-detail-column-offscreen=""
+        master-size="100px"
+        orientation="horizontal"
+        overlay=""
+        overlay-containment="layout"
+        slot="detail"
+        style="--_master-size: 100px; --_detail-size: 100px;"
+      >
+        <div>
+          Master 3
+        </div>
+        <div slot="detail">
+          Detail
+        </div>
+      </vaadin-master-detail-layout>
+    </vaadin-master-detail-layout>
+  </vaadin-master-detail-layout>
+</vaadin-master-detail-layout>
+`;
+/* end snapshot vaadin-master-detail-layout nested layouts default */
+
+snapshots["vaadin-master-detail-layout nested layouts overflow"] = 
+`<vaadin-master-detail-layout
+  expand="master"
+  has-detail=""
+  has-master=""
+  keep-detail-column-offscreen=""
+  master-size="100px"
+  orientation="horizontal"
+  overlay=""
+  overlay-containment="layout"
+  style="--_master-size: 100px; width: 200px; --_detail-cached-size: 301px;"
+>
+  <div>
+    Master 0
+  </div>
+  <vaadin-master-detail-layout
+    detail-size="200px"
+    expand="master"
+    has-detail=""
+    has-master=""
+    keep-detail-column-offscreen=""
+    master-size="100px"
+    orientation="horizontal"
+    overlay=""
+    overlay-containment="layout"
+    slot="detail"
+    style="--_master-size: 100px; --_detail-size: 200px;"
+  >
+    <div>
+      Master 1
+    </div>
+    <vaadin-master-detail-layout
+      expand="master"
+      has-detail=""
+      has-master=""
+      keep-detail-column-offscreen=""
+      master-size="100px"
+      orientation="horizontal"
+      overlay=""
+      overlay-containment="layout"
+      slot="detail"
+      style="--_master-size: 100px; --_detail-cached-size: 201px;"
+    >
+      <div>
+        Master 2
+      </div>
+      <vaadin-master-detail-layout
+        detail-size="100px"
+        expand="master"
+        has-detail=""
+        has-master=""
+        master-size="100px"
+        orientation="horizontal"
+        overlay-containment="layout"
+        slot="detail"
+        style="--_master-size: 100px; --_detail-size: 100px;"
+      >
+        <div>
+          Master 3
+        </div>
+        <div slot="detail">
+          Detail
+        </div>
+      </vaadin-master-detail-layout>
+    </vaadin-master-detail-layout>
+  </vaadin-master-detail-layout>
+</vaadin-master-detail-layout>
+`;
+/* end snapshot vaadin-master-detail-layout nested layouts overflow */
+

--- a/packages/master-detail-layout/test/dom/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/dom/master-detail-layout.test.js
@@ -120,18 +120,30 @@ describe('vaadin-master-detail-layout', () => {
   describe('nested layouts', () => {
     beforeEach(() => {
       layout = fixtureSync(`
-        <vaadin-master-detail-layout master-size="100px">
+        <vaadin-master-detail-layout
+          master-size="100px"
+          overlay-size="100px"
+        >
           <div>Master 0</div>
-
-          <vaadin-master-detail-layout slot="detail" master-size="100px" detail-size="200px">
+          <vaadin-master-detail-layout
+            slot="detail"
+            master-size="100px"
+            detail-size="400px"
+            overlay-size="100px"
+          >
             <div>Master 1</div>
-
-            <vaadin-master-detail-layout slot="detail" master-size="100px">
+            <vaadin-master-detail-layout
+              slot="detail"
+              master-size="100px"
+              overlay-size="100px"
+            >
               <div>Master 2</div>
-
-              <vaadin-master-detail-layout slot="detail" master-size="100px" detail-size="100px">
+              <vaadin-master-detail-layout
+                slot="detail"
+                master-size="100px"
+                detail-size="100px"
+              >
                 <div>Master 3</div>
-
                 <div slot="detail">Detail</div>
               </vaadin-master-detail-layout>
             </vaadin-master-detail-layout>

--- a/packages/master-detail-layout/test/dom/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/dom/master-detail-layout.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../src/vaadin-master-detail-layout.js';
 import { onceResized } from '../helpers.js';
 
@@ -113,6 +113,41 @@ describe('vaadin-master-detail-layout', () => {
     it('removed', async () => {
       layout.querySelector('[slot="detail-placeholder"]').remove();
       await onceResized(layout);
+      await expect(layout).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('nested layouts', () => {
+    beforeEach(() => {
+      layout = fixtureSync(`
+        <vaadin-master-detail-layout master-size="100px">
+          <div>Master 0</div>
+
+          <vaadin-master-detail-layout slot="detail" master-size="100px" detail-size="200px">
+            <div>Master 1</div>
+
+            <vaadin-master-detail-layout slot="detail" master-size="100px">
+              <div>Master 2</div>
+
+              <vaadin-master-detail-layout slot="detail" master-size="100px" detail-size="100px">
+                <div>Master 3</div>
+
+                <div slot="detail">Detail</div>
+              </vaadin-master-detail-layout>
+            </vaadin-master-detail-layout>
+          </vaadin-master-detail-layout>
+        </vaadin-master-detail-layout>
+      `);
+    });
+
+    it('default', async () => {
+      await nextFrame();
+      await expect(layout).dom.to.equalSnapshot();
+    });
+
+    it('overflow', async () => {
+      layout.style.width = '200px';
+      await nextFrame();
       await expect(layout).dom.to.equalSnapshot();
     });
   });


### PR DESCRIPTION
The PR guarantees that all nested MDLs enter overlay mode synchronously during the initial render to avoid a brief flash of layouts not yet in the final state. 

This is achieved by calling `recalculateLayout` on the deepest MDL inside a `requestAnimationFrame` scheduled in `connectedCallback`. This callback updates all ancestor layouts within a single animation frame, starting from the outermost and switching them into overlays one by one. Otherwise, they switch into overlays through separate asynchronous resize observer callbacks, which causes the flash:

| Before | After |
|--------|------|
| <video src="https://github.com/user-attachments/assets/46b19c9f-e8b2-4eef-831c-010f5b08cec7"></video> | <video src="https://github.com/user-attachments/assets/0a476008-7efe-400e-ab33-c685cc90ef07"></video> |
