### PR TITLE
fix: prevent removing outgoing detail when its slot is reassigned

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -621,7 +621,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
         animateOut(this.$.detailOutgoing, ['fade', 'slide'], progress),
       ]);
     } finally {
-      if (oldDetail) {
+      if (oldDetail && oldDetail.slot === 'detail-outgoing') {
         oldDetail.remove();
       }
     }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -621,6 +621,8 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
         animateOut(this.$.detailOutgoing, ['fade', 'slide'], progress),
       ]);
     } finally {
+      // Skip removal if the slot was reassigned during the transition.
+      // The React component does this to let React handle the removal.
       if (oldDetail && oldDetail.slot === 'detail-outgoing') {
         oldDetail.remove();
       }

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -176,12 +176,13 @@ describe('Transitions', () => {
       expect(layout.hasAttribute('transition')).to.be.false;
     });
 
+    // Reproduces how the React component handles transitions: it reassigns
+    // the outgoing detail's slot so that React can handle the removal.
     it('should not remove outgoing detail when it is reassigned to different slot', async () => {
       const detail = document.createElement('detail-content');
       await layout._setDetail(detail);
 
       await layout._startTransition('replace', () => {
-        // At this point, the old detail has been moved to 'detail-outgoing'
         const outgoing = layout.querySelector('[slot="detail-outgoing"]');
         expect(outgoing).to.equal(detail);
         outgoing.slot = 'detail-hidden';

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -176,6 +176,22 @@ describe('Transitions', () => {
       expect(layout.hasAttribute('transition')).to.be.false;
     });
 
+    it('should not remove outgoing detail when it is reassigned to different slot', async () => {
+      const detail = document.createElement('detail-content');
+      await layout._setDetail(detail);
+
+      await layout._startTransition('replace', () => {
+        // At this point, the old detail has been moved to 'detail-outgoing'
+        const outgoing = layout.querySelector('[slot="detail-outgoing"]');
+        expect(outgoing).to.equal(detail);
+        outgoing.slot = 'detail-hidden';
+      });
+
+      // The element should still be in the DOM since its slot was changed
+      expect(detail.isConnected).to.be.true;
+      expect(detail.slot).to.equal('detail-hidden');
+    });
+
     it('should resolve previous transition when interrupted', async () => {
       const callback1 = sinon.spy();
       const callback2 = sinon.spy();


### PR DESCRIPTION
## Summary

- Add a slot check in `__replaceTransition`'s `finally` block so the outgoing detail element is only removed when its slot is still `detail-outgoing`
- This allows `_startTransition` callers to reassign the outgoing element to a different slot (e.g. `detail-hidden`) to preserve it in the DOM
- Add a test verifying the element is not removed when its slot is reassigned during a manual replace transition

This fixes a JS error that occurred in the React component because the web component removed the outgoing detail element, which should have been removed by React instead – a regression that was introduced by #11437 .

```
Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at removeChild (react-dom-client.development.js:22205:22)
    at runWithFiberInDEV (react-dom-client.development.js:871:30)
    at commitDeletionEffectsOnFiber (react-dom-client.development.js:14321:17)
    at recursivelyTraverseMutationEffects (react-dom-client.development.js:14555:11)
    at commitMutationEffectsOnFiber (react-dom-client.development.js:14591:11)
    at recursivelyTraverseMutationEffects (react-dom-client.development.js:14576:11)
    at commitMutationEffectsOnFiber (react-dom-client.development.js:14821:11)
    at recursivelyTraverseMutationEffects (react-dom-client.development.js:14576:11)
    at commitMutationEffectsOnFiber (react-dom-client.development.js:14591:11)
    at recursivelyTraverseMutationEffects (react-dom-client.development.js:14576:11)
```