### PR TITLE
refactor!: avoid forced style recalculations on app-layout resize

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -161,8 +161,7 @@ export const AppLayoutMixin = (superclass) =>
 
       this.$.drawer.addEventListener('transitionend', () => {
         this.__isDrawerAnimating = false;
-        this.__resizeObserver.unobserve(this.$.drawer);
-        this.__resizeObserver.observe(this.$.drawer);
+        this.__scheduleResize(this.$.drawer);
       });
     }
 
@@ -177,21 +176,22 @@ export const AppLayoutMixin = (superclass) =>
 
     /** @private */
     __onNavbarSlotChange() {
-      this.__resizeObserver.unobserve(this);
-      this.__resizeObserver.observe(this);
+      this.__scheduleResize(this.$.navbarTop);
+      this.__scheduleResize(this.$.navbarBottom);
       this.toggleAttribute('has-navbar', !!this.querySelector('[slot="navbar"]'));
     }
 
     /** @private */
     __onDrawerSlotChange() {
+      this.__scheduleResize(this.$.drawer);
       this.__updateDrawerSize();
-      this.__resizeObserver.unobserve(this);
-      this.__resizeObserver.observe(this);
       this.toggleAttribute('has-drawer', !!this.querySelector('[slot="drawer"]'));
     }
 
     /** @private */
     __onResize(entries) {
+      cancelAnimationFrame(this.__resizeRaf);
+
       const isHostResized = entries.some(({ target }) => target === this);
 
       const drawerRect = this.$.drawer.getBoundingClientRect();
@@ -203,7 +203,7 @@ export const AppLayoutMixin = (superclass) =>
 
       const isDrawerAnimating = this.__isDrawerAnimating;
 
-      requestAnimationFrame(() => {
+      this.__resizeRaf = requestAnimationFrame(() => {
         if (isHostResized) {
           this._blockAnimationUntilAfterNextRender();
           this.__setOverlayMode(overlayMode);
@@ -508,6 +508,18 @@ export const AppLayoutMixin = (superclass) =>
           this.removeAttribute('no-anim');
         });
       });
+    }
+
+    /**
+     * Forces the ResizeObserver to re-report the size of the given element,
+     * scheduling a new {@link __onResize} callback even if the size hasn't changed.
+     *
+     * @param {Element} element
+     * @private
+     */
+    __scheduleResize(element) {
+      this.__resizeObserver.unobserve(element);
+      this.__resizeObserver.observe(element);
     }
 
     /**

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -120,7 +120,6 @@ export const AppLayoutMixin = (superclass) =>
     constructor() {
       super();
       // TODO(jouni): might want to debounce
-      this.__boundResizeListener = this._resize.bind(this);
       this.__drawerToggleClickListener = this._drawerToggleClick.bind(this);
       this.__onDrawerKeyDown = this.__onDrawerKeyDown.bind(this);
       this.__closeOverlayDrawerListener = this.__closeOverlayDrawer.bind(this);
@@ -138,34 +137,14 @@ export const AppLayoutMixin = (superclass) =>
     connectedCallback() {
       super.connectedCallback();
 
-      this._blockAnimationUntilAfterNextRender();
+      this.__resizeObserver = new ResizeObserver((entries) => this.__onResize(entries));
+      [this, this.$.navbarTop, this.$.navbarBottom, this.$.drawer].forEach((node) => {
+        if (node) {
+          this.__resizeObserver.observe(node);
+        }
+      });
 
-      window.addEventListener('resize', this.__boundResizeListener);
       this.addEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
-
-      requestAnimationFrame(() => {
-        this._updateOffsetSize();
-      });
-
-      this._updateTouchOptimizedMode();
-      this._updateDrawerSize();
-      this._updateOverlayMode();
-
-      this._navbarSizeObserver = new ResizeObserver(() => {
-        requestAnimationFrame(() => {
-          // Prevent updating offset size multiple times
-          // during the drawer open / close transition.
-          if (this.__isDrawerAnimating) {
-            this.__updateOffsetSizePending = true;
-          } else {
-            this._updateOffsetSize();
-          }
-        });
-      });
-      this._navbarSizeObserver.observe(this.$.navbarTop);
-      this._navbarSizeObserver.observe(this.$.navbarBottom);
-      this._navbarSizeObserver.observe(this.$.drawer);
-
       window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
       window.addEventListener('keydown', this.__onDrawerKeyDown);
     }
@@ -181,25 +160,16 @@ export const AppLayoutMixin = (superclass) =>
       });
 
       this.$.drawer.addEventListener('transitionend', () => {
-        // Update offset size after drawer animation.
-        if (this.__updateOffsetSizePending) {
-          this.__updateOffsetSizePending = false;
-          this._updateOffsetSize();
-        }
-
-        // Delay resetting the flag until animation frame
-        // to avoid updating offset size again on resize.
-        requestAnimationFrame(() => {
-          this.__isDrawerAnimating = false;
-        });
+        this.__isDrawerAnimating = false;
+        this.__resizeObserver.unobserve(this.$.drawer);
+        this.__resizeObserver.observe(this.$.drawer);
       });
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-
-      window.removeEventListener('resize', this.__boundResizeListener);
+      this.__resizeObserver.disconnect();
       this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
       window.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);
       window.removeEventListener('keydown', this.__onDrawerKeyDown);
@@ -207,14 +177,47 @@ export const AppLayoutMixin = (superclass) =>
 
     /** @private */
     __onNavbarSlotChange() {
-      this._updateTouchOptimizedMode();
+      this.__resizeObserver.unobserve(this);
+      this.__resizeObserver.observe(this);
       this.toggleAttribute('has-navbar', !!this.querySelector('[slot="navbar"]'));
     }
 
     /** @private */
     __onDrawerSlotChange() {
-      this._updateDrawerSize();
+      this.__updateDrawerSize();
+      this.__resizeObserver.unobserve(this);
+      this.__resizeObserver.observe(this);
       this.toggleAttribute('has-drawer', !!this.querySelector('[slot="drawer"]'));
+    }
+
+    /** @private */
+    __onResize(entries) {
+      const isHostResized = entries.some(({ target }) => target === this);
+
+      const drawerRect = this.$.drawer.getBoundingClientRect();
+      const navbarRect = this.$.navbarTop.getBoundingClientRect();
+      const navbarBottomRect = this.$.navbarBottom.getBoundingClientRect();
+
+      const overlayMode = this._getCustomPropertyValue('--vaadin-app-layout-drawer-overlay') === 'true';
+      const touchOptimized = this._getCustomPropertyValue('--vaadin-app-layout-touch-optimized') === 'true';
+
+      const isDrawerAnimating = this.__isDrawerAnimating;
+
+      requestAnimationFrame(() => {
+        if (isHostResized) {
+          this._blockAnimationUntilAfterNextRender();
+          this.__setOverlayMode(overlayMode);
+          this.__setTouchOptimized(touchOptimized);
+        }
+
+        if (!isDrawerAnimating) {
+          this.__setOffsetSize({
+            drawerRect,
+            navbarRect,
+            navbarBottomRect,
+          });
+        }
+      });
     }
 
     /**
@@ -306,48 +309,27 @@ export const AppLayoutMixin = (superclass) =>
       }
     }
 
-    /** @protected */
-    _updateDrawerSize() {
+    /** @private */
+    __updateDrawerSize() {
       const childCount = this.querySelectorAll('[slot=drawer]').length;
-      const drawer = this.$.drawer;
-
       if (childCount === 0) {
-        drawer.setAttribute('hidden', '');
+        this.$.drawer.setAttribute('hidden', '');
         this.style.setProperty('--_vaadin-app-layout-drawer-width', 0);
       } else {
-        drawer.removeAttribute('hidden');
+        this.$.drawer.removeAttribute('hidden');
         this.style.removeProperty('--_vaadin-app-layout-drawer-width');
       }
-      this._updateOffsetSize();
     }
 
     /** @private */
-    _resize() {
-      this._blockAnimationUntilAfterNextRender();
-      this._updateTouchOptimizedMode();
-      this._updateOverlayMode();
-    }
-
-    /** @protected */
-    _updateOffsetSize() {
-      const navbar = this.$.navbarTop;
-      const navbarRect = navbar.getBoundingClientRect();
-
-      const navbarBottom = this.$.navbarBottom;
-      const navbarBottomRect = navbarBottom.getBoundingClientRect();
-
-      const drawer = this.$.drawer;
-      const drawerRect = drawer.getBoundingClientRect();
-
+    __setOffsetSize({ drawerRect, navbarRect, navbarBottomRect }) {
+      this.style.setProperty('--_vaadin-app-layout-drawer-offset-size', `${drawerRect.width}px`);
       this.style.setProperty('--_vaadin-app-layout-navbar-offset-size', `${navbarRect.height}px`);
       this.style.setProperty('--_vaadin-app-layout-navbar-offset-size-bottom', `${navbarBottomRect.height}px`);
-      this.style.setProperty('--_vaadin-app-layout-drawer-offset-size', `${drawerRect.width}px`);
     }
 
-    /** @protected */
-    _updateOverlayMode() {
-      const overlay = this._getCustomPropertyValue('--vaadin-app-layout-drawer-overlay') === 'true';
-
+    /** @private */
+    __setOverlayMode(overlay) {
       if (!this.overlay && overlay) {
         // Changed from not overlay to overlay
         this._drawerStateSaved = this.drawerOpened;
@@ -487,12 +469,9 @@ export const AppLayoutMixin = (superclass) =>
       return (customPropertyValue || '').trim().toLowerCase();
     }
 
-    /** @protected */
-    _updateTouchOptimizedMode() {
-      const touchOptimized = this._getCustomPropertyValue('--vaadin-app-layout-touch-optimized') === 'true';
-
+    /** @private */
+    __setTouchOptimized(touchOptimized) {
       const navbarItems = this.querySelectorAll('[slot*="navbar"]');
-
       if (navbarItems.length > 0) {
         Array.from(navbarItems).forEach((navbar) => {
           if (navbar.getAttribute('slot').indexOf('touch-optimized') > -1) {
@@ -518,8 +497,6 @@ export const AppLayoutMixin = (superclass) =>
       } else {
         this.$.navbarBottom.removeAttribute('hidden');
       }
-
-      this._updateOffsetSize();
     }
 
     /** @protected */

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -138,11 +138,10 @@ export const AppLayoutMixin = (superclass) =>
       super.connectedCallback();
 
       this.__resizeObserver = new ResizeObserver((entries) => this.__onResize(entries));
-      [this, this.$.navbarTop, this.$.navbarBottom, this.$.drawer].forEach((node) => {
-        if (node) {
-          this.__resizeObserver.observe(node);
-        }
-      });
+      this.__resizeObserver.observe(this);
+      this.__resizeObserver.observe(this.$.drawer);
+      this.__resizeObserver.observe(this.$.navbarTop);
+      this.__resizeObserver.observe(this.$.navbarBottom);
 
       this.addEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
       window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -192,13 +192,14 @@ export const AppLayoutMixin = (superclass) =>
       cancelAnimationFrame(this.__resizeRaf);
 
       const isHostResized = entries.some(({ target }) => target === this);
-
-      const drawerRect = this.$.drawer.getBoundingClientRect();
-      const navbarRect = this.$.navbarTop.getBoundingClientRect();
-      const navbarBottomRect = this.$.navbarBottom.getBoundingClientRect();
+      const isNavbarResized = entries.some(({ target }) => [this.$.navbarTop, this.$.navbarBottom].includes(target));
 
       const overlayMode = this._getCustomPropertyValue('--vaadin-app-layout-drawer-overlay') === 'true';
       const touchOptimized = this._getCustomPropertyValue('--vaadin-app-layout-touch-optimized') === 'true';
+
+      const drawerRect = this.$.drawer.getBoundingClientRect();
+      const navbarTopRect = this.$.navbarTop.getBoundingClientRect();
+      const navbarBottomRect = this.$.navbarBottom.getBoundingClientRect();
 
       const isDrawerAnimating = this.__isDrawerAnimating;
 
@@ -206,13 +207,16 @@ export const AppLayoutMixin = (superclass) =>
         if (isHostResized) {
           this._blockAnimationUntilAfterNextRender();
           this.__setOverlayMode(overlayMode);
+        }
+
+        if (isHostResized || isNavbarResized) {
           this.__setTouchOptimized(touchOptimized);
         }
 
         if (!isDrawerAnimating) {
           this.__setOffsetSize({
             drawerRect,
-            navbarRect,
+            navbarTopRect,
             navbarBottomRect,
           });
         }
@@ -321,9 +325,9 @@ export const AppLayoutMixin = (superclass) =>
     }
 
     /** @private */
-    __setOffsetSize({ drawerRect, navbarRect, navbarBottomRect }) {
+    __setOffsetSize({ drawerRect, navbarTopRect, navbarBottomRect }) {
       this.style.setProperty('--_vaadin-app-layout-drawer-offset-size', `${drawerRect.width}px`);
-      this.style.setProperty('--_vaadin-app-layout-navbar-offset-size', `${navbarRect.height}px`);
+      this.style.setProperty('--_vaadin-app-layout-navbar-offset-size', `${navbarTopRect.height}px`);
       this.style.setProperty('--_vaadin-app-layout-navbar-offset-size-bottom', `${navbarBottomRect.height}px`);
     }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
-  aTimeout,
   esc,
   fixtureSync,
   makeSoloTouchEvent,
@@ -75,7 +74,8 @@ describe('vaadin-app-layout', () => {
         const toggle = document.createElement('vaadin-drawer-toggle');
         toggle.setAttribute('slot', 'navbar touch-optimized');
         layout.appendChild(toggle);
-        await aTimeout(0);
+        await nextResize(layout);
+        await nextFrame();
         expect(toggle.getAttribute('slot')).to.equal('navbar');
       });
 
@@ -83,7 +83,8 @@ describe('vaadin-app-layout', () => {
         const toggle = document.createElement('vaadin-drawer-toggle');
         toggle.setAttribute('slot', 'navbar');
         layout.appendChild(toggle);
-        await aTimeout(0);
+        await nextResize(layout);
+        await nextFrame();
         expect(toggle.offsetHeight).to.be.greaterThan(0);
       });
 
@@ -94,11 +95,13 @@ describe('vaadin-app-layout', () => {
         navbarContent.setAttribute('slot', 'navbar');
         layout.appendChild(navbarContent);
         await nextResize(layout);
+        await nextFrame();
         const initialOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-top'));
         expect(initialOffset).to.be.greaterThan(0);
         // Increase navbar content size and measure increase
         navbarContent.style.height = '200px';
         await nextResize(layout);
+        await nextFrame();
         const updatedOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-top'));
         expect(updatedOffset).to.equal(initialOffset + 100);
       });
@@ -113,7 +116,8 @@ describe('vaadin-app-layout', () => {
         const toggle = document.createElement('vaadin-drawer-toggle');
         toggle.setAttribute('slot', 'navbar touch-optimized');
         layout.appendChild(toggle);
-        await aTimeout(0);
+        await nextResize(layout);
+        await nextFrame();
         expect(toggle.getAttribute('slot')).to.equal('navbar-bottom');
       });
 
@@ -121,24 +125,9 @@ describe('vaadin-app-layout', () => {
         const toggle = document.createElement('vaadin-drawer-toggle');
         toggle.setAttribute('slot', 'navbar touch-optimized');
         layout.appendChild(toggle);
-        await aTimeout(0);
+        await nextResize(layout);
+        await nextFrame();
         expect(toggle.offsetHeight).to.be.greaterThan(0);
-      });
-
-      it('should not show empty navbar-bottom on resize', () => {
-        expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
-        window.dispatchEvent(new Event('resize'));
-        expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
-      });
-
-      it('should remove hidden attribute on non-empty navbar-bottom on resize', () => {
-        const header = document.createElement('h1');
-        header.textContent = 'Header';
-        header.setAttribute('slot', 'navbar touch-optimized');
-        layout.appendChild(header);
-        expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.true;
-        window.dispatchEvent(new Event('resize'));
-        expect(layout.$.navbarBottom.hasAttribute('hidden')).to.be.false;
       });
 
       it('should update content offset when navbar height changes', async () => {
@@ -148,11 +137,16 @@ describe('vaadin-app-layout', () => {
         navbarContent.setAttribute('slot', 'navbar touch-optimized');
         layout.appendChild(navbarContent);
         await nextResize(layout);
+        await nextFrame();
+        // Wait for second cycle after node is moved to navbar-bottom
+        await nextResize(layout.$.navbarBottom);
+        await nextFrame();
         const initialOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-bottom'));
         expect(initialOffset).to.be.greaterThan(0);
         // Increase navbar content size and measure increase
         navbarContent.style.height = '200px';
-        await nextResize(layout);
+        await nextResize(layout.$.navbarBottom);
+        await nextFrame();
         const updatedOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-bottom'));
         expect(updatedOffset).to.equal(initialOffset + 100);
       });
@@ -232,12 +226,14 @@ describe('vaadin-app-layout', () => {
         const section = layout.querySelector('[slot="drawer"]');
         const initialPadding = getComputedStyle(layout).paddingInlineStart;
         section.parentNode.removeChild(section);
+        await nextResize(layout);
         await nextFrame();
 
         expect(drawer.hasAttribute('hidden')).to.be.true;
         expect(getComputedStyle(layout).paddingInlineStart).to.be.equal('0px');
 
         layout.appendChild(section);
+        await nextResize(layout);
         await nextFrame();
 
         expect(drawer.hasAttribute('hidden')).to.be.false;
@@ -279,7 +275,7 @@ describe('vaadin-app-layout', () => {
 
         layout.style.setProperty('--vaadin-app-layout-transition-duration', '100ms');
 
-        const spy = sinon.spy(layout, '_updateOffsetSize');
+        const spy = sinon.spy(layout, '__setOffsetSize');
         toggle.click();
         await oneEvent(drawer, 'transitionend');
 
@@ -355,17 +351,17 @@ describe('vaadin-app-layout', () => {
         // Force it to desktop layout
         layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'false');
         layout.drawerOpened = true;
-        layout._updateOverlayMode();
+        layout.__setOverlayMode(false);
 
         // Force it to mobile layout
         layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'true');
-        layout._updateOverlayMode();
+        layout.__setOverlayMode(true);
 
         expect(layout.drawerOpened).to.be.false;
 
         // Force it to desktop layout
         layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'false');
-        layout._updateOverlayMode();
+        layout.__setOverlayMode(false);
         expect(layout.drawerOpened).to.be.true;
       });
 
@@ -480,7 +476,7 @@ describe('vaadin-app-layout', () => {
 
           // Force it to desktop layout
           layout.style.setProperty('--vaadin-app-layout-drawer-overlay', 'false');
-          layout._updateOverlayMode();
+          layout.__setOverlayMode(false);
           await nextRender();
 
           expect(drawer.hasAttribute('tabindex')).to.be.false;

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -139,13 +139,13 @@ describe('vaadin-app-layout', () => {
         await nextResize(layout);
         await nextFrame();
         // Wait for second cycle after node is moved to navbar-bottom
-        await nextResize(layout.$.navbarBottom);
+        await nextResize(layout);
         await nextFrame();
         const initialOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-bottom'));
         expect(initialOffset).to.be.greaterThan(0);
         // Increase navbar content size and measure increase
         navbarContent.style.height = '200px';
-        await nextResize(layout.$.navbarBottom);
+        await nextResize(layout);
         await nextFrame();
         const updatedOffset = parseInt(getComputedStyle(layout).getPropertyValue('padding-bottom'));
         expect(updatedOffset).to.equal(initialOffset + 100);

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -65,6 +65,20 @@ describe('vaadin-app-layout', () => {
       layout = fixtureSync('<vaadin-app-layout></vaadin-app-layout>');
     });
 
+    it('should toggle navbar container visibility when slot content changes', async () => {
+      const item = document.createElement('div');
+      item.setAttribute('slot', 'navbar');
+      layout.appendChild(item);
+      await nextResize(layout);
+      await nextFrame();
+      expect(layout.$.navbarTop.hasAttribute('hidden')).to.be.false;
+
+      item.remove();
+      await nextResize(layout);
+      await nextFrame();
+      expect(layout.$.navbarTop.hasAttribute('hidden')).to.be.true;
+    });
+
     describe('default', () => {
       beforeEach(() => {
         layout.style.setProperty('--vaadin-app-layout-touch-optimized', 'false');

--- a/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
@@ -6,7 +6,7 @@ snapshots["vaadin-app-layout host default"] =
   no-anim=""
   overlay=""
   primary-section="navbar"
-  style="--_vaadin-app-layout-navbar-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px; --_vaadin-app-layout-drawer-offset-size: 0px; --_vaadin-app-layout-drawer-width: 0;"
+  style="--_vaadin-app-layout-drawer-offset-size: 320px; --_vaadin-app-layout-navbar-offset-size: 16px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
 >
 </vaadin-app-layout>
 `;
@@ -17,7 +17,7 @@ snapshots["vaadin-app-layout host with drawer"] =
   has-drawer=""
   overlay=""
   primary-section="navbar"
-  style="--_vaadin-app-layout-navbar-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px; --_vaadin-app-layout-drawer-offset-size: 320px;"
+  style="--_vaadin-app-layout-drawer-offset-size: 320px; --_vaadin-app-layout-navbar-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
 >
   <div slot="drawer">
     Drawer Content
@@ -31,7 +31,7 @@ snapshots["vaadin-app-layout host with navbar"] =
   has-navbar=""
   overlay=""
   primary-section="navbar"
-  style="--_vaadin-app-layout-navbar-offset-size: 34px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px; --_vaadin-app-layout-drawer-offset-size: 0px; --_vaadin-app-layout-drawer-width: 0;"
+  style="--_vaadin-app-layout-drawer-offset-size: 320px; --_vaadin-app-layout-navbar-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
 >
   <div slot="navbar">
     Navbar Content

--- a/packages/app-layout/test/dom/app-layout.test.js
+++ b/packages/app-layout/test/dom/app-layout.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import '../../src/vaadin-app-layout.js';
 import '../../vaadin-drawer-toggle.js';
 
@@ -8,8 +8,10 @@ describe('vaadin-app-layout', () => {
   let layout;
 
   describe('host', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       layout = fixtureSync('<vaadin-app-layout></vaadin-app-layout>');
+      await nextResize(layout);
+      await nextFrame();
     });
 
     it('default', async () => {
@@ -21,7 +23,8 @@ describe('vaadin-app-layout', () => {
       drawer.setAttribute('slot', 'drawer');
       drawer.textContent = 'Drawer Content';
       layout.appendChild(drawer);
-      await nextRender();
+      await nextResize(layout);
+      await nextFrame();
       await expect(layout).dom.to.equalSnapshot();
     });
 
@@ -30,7 +33,8 @@ describe('vaadin-app-layout', () => {
       navbar.setAttribute('slot', 'navbar');
       navbar.textContent = 'Navbar Content';
       layout.appendChild(navbar);
-      await nextRender();
+      await nextResize(layout);
+      await nextFrame();
       await expect(layout).dom.to.equalSnapshot();
     });
   });
@@ -48,7 +52,8 @@ describe('vaadin-app-layout', () => {
           <main>Page Content</main>
         </vaadin-app-layout>
       `);
-      await nextRender();
+      await nextResize(layout);
+      await nextFrame();
     });
 
     describe('desktop layout', () => {

--- a/packages/app-layout/test/dom/app-layout.test.js
+++ b/packages/app-layout/test/dom/app-layout.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import '../../src/vaadin-app-layout.js';
 import '../../vaadin-drawer-toggle.js';
 
@@ -25,6 +25,7 @@ describe('vaadin-app-layout', () => {
       layout.appendChild(drawer);
       await nextResize(layout);
       await nextFrame();
+      await aTimeout(0);
       await expect(layout).dom.to.equalSnapshot();
     });
 
@@ -35,6 +36,7 @@ describe('vaadin-app-layout', () => {
       layout.appendChild(navbar);
       await nextResize(layout);
       await nextFrame();
+      await aTimeout(0);
       await expect(layout).dom.to.equalSnapshot();
     });
   });

--- a/packages/app-layout/test/keyboard-desktop.test.js
+++ b/packages/app-layout/test/keyboard-desktop.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import '../src/vaadin-app-layout.js';
 import '../src/vaadin-drawer-toggle.js';
 import { tab } from './helpers.js';
@@ -28,6 +28,7 @@ describe('desktop navigation', () => {
       </div>
     `);
     [layout, outerInput] = wrapper.children;
+    await nextResize(wrapper);
     await nextRender();
     toggle = layout.querySelector('[slot=navbar]');
     drawerInput = layout.querySelector('[slot=drawer] > input');

--- a/packages/app-layout/test/keyboard-mobile.test.js
+++ b/packages/app-layout/test/keyboard-mobile.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { setViewport } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextResize } from '@vaadin/testing-helpers';
 import '../src/vaadin-app-layout.js';
 import '../src/vaadin-drawer-toggle.js';
 import { esc, shiftTab, tab } from './helpers.js';
@@ -29,6 +29,7 @@ describe('mobile navigation', () => {
       </div>
     `);
     [layout, outerInput] = wrapper.children;
+    await nextResize(wrapper);
     await nextRender();
     toggle = layout.querySelector('[slot=navbar]');
     drawer = layout.shadowRoot.querySelector('[part=drawer]');

--- a/packages/app-layout/test/visual/aura/app-layout.test.js
+++ b/packages/app-layout/test/visual/aura/app-layout.test.js
@@ -1,3 +1,4 @@
+import { nextFrame, nextResize } from '@vaadin/testing-helpers';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/aura/aura.css';
@@ -35,13 +36,15 @@ describe('app-layout', () => {
 
   it('overlay', async () => {
     element.style.setProperty('--vaadin-app-layout-drawer-overlay', 'true');
-    window.dispatchEvent(new Event('resize'));
+    await nextResize(element);
+    await nextFrame();
     await visualDiff(div, 'overlay');
   });
 
   it('overlay-opened', async () => {
     element.style.setProperty('--vaadin-app-layout-drawer-overlay', 'true');
-    window.dispatchEvent(new Event('resize'));
+    await nextResize(element);
+    await nextFrame();
     element.drawerOpened = true;
     await visualDiff(div, 'overlay-opened');
   });

--- a/packages/app-layout/test/visual/base/app-layout.test.js
+++ b/packages/app-layout/test/visual/base/app-layout.test.js
@@ -1,4 +1,4 @@
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../src/vaadin-app-layout.js';
 import '../../../src/vaadin-drawer-toggle.js';
@@ -45,14 +45,16 @@ describe('app-layout', () => {
       it('overlay', async () => {
         // See https://github.com/vaadin/vaadin-app-layout/issues/183
         element.style.setProperty('--vaadin-app-layout-drawer-overlay', ' true');
-        window.dispatchEvent(new Event('resize'));
+        await nextResize(element);
+        await nextFrame();
         await visualDiff(div, `${dir}-overlay`);
       });
 
       it('primary-drawer-overlay-opened', async () => {
         element.primarySection = 'drawer';
         element.style.setProperty('--vaadin-app-layout-drawer-overlay', ' true');
-        window.dispatchEvent(new Event('resize'));
+        await nextResize(element);
+        await nextFrame();
         element.drawerOpened = true;
         await visualDiff(div, `${dir}-primary-drawer-overlay-opened`);
       });

--- a/packages/app-layout/test/visual/lumo/app-layout.test.js
+++ b/packages/app-layout/test/visual/lumo/app-layout.test.js
@@ -1,3 +1,4 @@
+import { nextFrame, nextResize } from '@vaadin/testing-helpers';
 import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/src/props/index.css';
@@ -48,14 +49,16 @@ describe('app-layout', () => {
       it('overlay', async () => {
         // See https://github.com/vaadin/vaadin-app-layout/issues/183
         element.style.setProperty('--vaadin-app-layout-drawer-overlay', ' true');
-        window.dispatchEvent(new Event('resize'));
+        await nextResize(element);
+        await nextFrame();
         await visualDiff(div, `${dir}-overlay`);
       });
 
       it('primary-drawer-overlay-opened', async () => {
         element.primarySection = 'drawer';
         element.style.setProperty('--vaadin-app-layout-drawer-overlay', ' true');
-        window.dispatchEvent(new Event('resize'));
+        await nextResize(element);
+        await nextFrame();
         element.drawerOpened = true;
         await visualDiff(div, `${dir}-primary-drawer-overlay-opened`);
       });


### PR DESCRIPTION
## Description

The PR consolidates a window resize listener and a separate `ResizeObserver` into a single `ResizeObserver` that reads values in the observer callback while DOM updates are deferred to `requestAnimationFrame`. This helps avoid forced style recalculations on app layout resize.

| Before | After |
|--------|------|
| <img width="1512" height="1910" alt="Screenshot 2026-04-16 at 15 25 55" src="https://github.com/user-attachments/assets/3b52706e-b6f5-498a-b451-2d63ee72e7a6" /> | <img width="1512" height="1910" alt="Screenshot 2026-04-16 at 15 27 14" src="https://github.com/user-attachments/assets/a3637f31-ba5e-46ec-8052-f6ff49b438f9" /> |

The screenshots show resizing the Starpass app before and after with 4x CPU throttle.

> [!WARNING]
> There is a small risk of this being a breaking change, as it it alters the timing of when attributes are set.

## Type of change

- Refactoring