### PR TITLE
fix: iOS safe area insets for app-layout and master-detail-layout

### DIFF
--- a/dev/app-layout.html
+++ b/dev/app-layout.html
@@ -8,6 +8,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <!-- possible content values: default, black or black-translucent -->
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <!-- This is needed for iOS trigger @media (display-mode: standalone) when launched from the home screen -->
+    <link rel="manifest" href="assets/manifest.webmanifest">
     <title>App Layout</title>
     <script type="module" src="./common.js"></script>
 

--- a/dev/assets/manifest.webmanifest
+++ b/dev/assets/manifest.webmanifest
@@ -1,0 +1,3 @@
+{
+  "display": "standalone"
+}

--- a/dev/aura.html
+++ b/dev/aura.html
@@ -6,6 +6,8 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <!-- This is needed for iOS trigger @media (display-mode: standalone) when launched from the home screen -->
+    <link rel="manifest" href="assets/manifest.webmanifest">
     <title>Aura</title>
     <link rel="stylesheet" href="../packages/aura/aura.css" />
     <link rel="stylesheet" href="./aura/aura-view.css" />

--- a/dev/aura/aura-extras.css
+++ b/dev/aura/aura-extras.css
@@ -1,7 +1,19 @@
 html {
-  height: 100dvh;
+  height: 100%;
   --vaadin-user-color: var(--aura-accent-color);
   /* TODO how to use a different surface level in dark mode? */
+}
+
+/* 100% doesn't cover the entire screen on standalone iOS mode (home screen app) */
+/* 100vh would work on iOS 18 but not on iOS 17 (too tall in Safari, correct in standalone mode) */
+/* 100lvh is too tall in Safari. 100svh is too short in standalone apps. */
+/* 100dvh doesn't seem to work on first render when launched from home screen (initially like 100svh, then changes to 100lvh when you try to scroll the view) */
+/* So, we use 100% for the regular case (Safari and other browsers), and 100lvh for iOS home screen apps */
+/* TODO this needs be in Flow bootstrap page styles */
+@media all and (display-mode: standalone) {
+  html {
+    height: 100lvh;
+  }
 }
 
 body {

--- a/dev/aura/aura-view.css
+++ b/dev/aura/aura-view.css
@@ -3,7 +3,6 @@
   flex-direction: column;
   box-sizing: border-box;
   margin-block: calc(var(--safe-area-inset-top) * -1) calc(var(--safe-area-inset-bottom) * -1);
-  padding-block: var(--safe-area-inset-top) var(--safe-area-inset-bottom);
   height: calc(100% + var(--safe-area-inset-top) + var(--safe-area-inset-bottom));
 }
 
@@ -11,8 +10,8 @@
   flex: 1;
 }
 
-.aura-view > * {
-  --vaadin-scroller-padding-inline: var(--vaadin-padding-l);
+.aura-view > vaadin-scroller {
+  --vaadin-scroller-padding-inline: max(var(--vaadin-padding-l) - var(--safe-area-inset-left), 0px);
 }
 
 .aura-view:not(:has(header, .aura-view-header)) > vaadin-scroller {
@@ -25,7 +24,8 @@
 
 .aura-view > :is(header, footer),
 :is(.aura-view-header, .aura-view-footer) {
-  padding: var(--vaadin-padding-m);
+  padding-block: var(--vaadin-padding-m);
+  padding-inline: max(var(--vaadin-padding-m) - var(--safe-area-inset-left), 0px);
   display: flex;
   align-items: center;
   gap: var(--vaadin-gap-xs);
@@ -43,6 +43,7 @@
 .aura-view[slot='drawer'] > header,
 .aura-view-header[slot='drawer'] {
   margin-top: calc(var(--safe-area-inset-top) * -1);
+  padding-inline-end: var(--vaadin-padding-m);
 }
 
 .aura-view[slot='navbar'] > :is(header, footer),
@@ -92,4 +93,10 @@ vaadin-app-layout:is([drawer-opened]:not([overlay]), :has(> [slot='navbar'] vaad
   & + :is(h1, h2, h3, h4, h5, h6, .aura-view-heading) {
     padding-inline-start: var(--vaadin-padding-s);
   }
+}
+
+/* This is really brittle/hacky. Might benefit from some explicit classname/selector that app-layout can detect. */
+vaadin-app-layout:has(> .aura-surface-solid)::part(content),
+vaadin-app-layout:has(> * > .aura-surface-solid)::part(content) {
+  background: var(--aura-surface-color-solid) padding-box;
 }

--- a/dev/rollup.config.js
+++ b/dev/rollup.config.js
@@ -43,7 +43,7 @@ export default {
     }),
     terser(),
     copy([
-      { src: 'assets/**/*.svg', dest: 'assets' },
+      { src: 'assets/**/*', dest: 'assets' },
       { src: 'charts/demo-data/*.json', dest: 'charts/demo-data' },
     ]),
   ],

--- a/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
+++ b/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
@@ -55,6 +55,10 @@ export const appLayoutStyles = css`
     padding-inline: var(--safe-area-inset-inline-start) var(--safe-area-inset-inline-end);
   }
 
+  :host([drawer-opened]:not([overlay])) [part~='content'] {
+    padding-inline-start: 0;
+  }
+
   @media (pointer: coarse) and (max-width: 800px) and (min-height: 500px) {
     :host {
       --vaadin-app-layout-touch-optimized: true;

--- a/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
+++ b/packages/app-layout/src/styles/vaadin-app-layout-base-styles.js
@@ -18,18 +18,9 @@ export const appLayoutStyles = css`
     --vaadin-app-layout-navbar-offset-top: var(--_vaadin-app-layout-navbar-offset-size);
     --vaadin-app-layout-navbar-offset-bottom: var(--_vaadin-app-layout-navbar-offset-size-bottom);
     --vaadin-app-layout-drawer-offset-left: 0px;
-    padding-top: max(var(--vaadin-app-layout-navbar-offset-top), var(--safe-area-inset-top));
-    padding-bottom: max(var(--vaadin-app-layout-navbar-offset-bottom), var(--safe-area-inset-bottom));
-  }
-
-  :host(:dir(ltr)) {
-    padding-left: max(var(--vaadin-app-layout-drawer-offset-left), var(--safe-area-inset-left));
-    padding-right: var(--safe-area-inset-right);
-  }
-
-  :host(:dir(rtl)) {
-    padding-left: var(--safe-area-inset-left);
-    padding-right: max(var(--vaadin-app-layout-drawer-offset-left), var(--safe-area-inset-right));
+    padding-top: var(--vaadin-app-layout-navbar-offset-top);
+    padding-bottom: var(--vaadin-app-layout-navbar-offset-bottom);
+    padding-inline-start: var(--vaadin-app-layout-drawer-offset-left);
   }
 
   :host([hidden]),
@@ -58,6 +49,10 @@ export const appLayoutStyles = css`
   [part~='content'] {
     height: 100%;
     transition: inherit;
+    box-sizing: border-box;
+    padding-top: max(0px, var(--safe-area-inset-top) - var(--vaadin-app-layout-navbar-offset-top));
+    padding-bottom: max(0px, var(--safe-area-inset-bottom) - var(--vaadin-app-layout-navbar-offset-bottom));
+    padding-inline: var(--safe-area-inset-inline-start) var(--safe-area-inset-inline-end);
   }
 
   @media (pointer: coarse) and (max-width: 800px) and (min-height: 500px) {
@@ -122,6 +117,7 @@ export const appLayoutStyles = css`
     width: var(--_vaadin-app-layout-drawer-width);
     box-sizing: border-box;
     padding-block: var(--safe-area-inset-top) var(--safe-area-inset-bottom);
+    padding-inline-start: var(--safe-area-inset-inline-start);
     outline: none;
     /* The drawer should be inaccessible by the tabbing navigation when it is closed. */
     visibility: hidden;
@@ -130,15 +126,8 @@ export const appLayoutStyles = css`
     background: var(--vaadin-app-layout-drawer-background, transparent);
   }
 
-  [part='drawer']:dir(ltr) {
-    padding-left: var(--safe-area-inset-left);
-  }
-
-  [part='drawer']:dir(rtl) {
-    padding-right: var(--safe-area-inset-right);
-  }
-
-  :host([has-navbar]:not([overlay])) [part='drawer'] {
+  :host([has-navbar]:not([overlay])) [part='drawer'],
+  :host([has-navbar]) [part='content'] {
     --safe-area-inset-top: 0px;
   }
 

--- a/packages/aura/src/components/app-layout.css
+++ b/packages/aura/src/components/app-layout.css
@@ -19,9 +19,9 @@
 
 vaadin-app-layout {
   --_app-layout-radius: clamp(0px, var(--aura-app-layout-radius), var(--aura-app-layout-inset) * 100);
-  padding-bottom: var(--aura-app-layout-inset);
+  padding-top: max(var(--aura-app-layout-inset), var(--vaadin-app-layout-navbar-offset-top));
+  padding-bottom: max(var(--aura-app-layout-inset), var(--vaadin-app-layout-navbar-offset-bottom));
   padding-inline-end: var(--aura-app-layout-inset);
-  padding-top: max(var(--aura-app-layout-inset), var(--_vaadin-app-layout-navbar-offset-size));
 }
 
 vaadin-app-layout[overlay]::part(drawer) {
@@ -55,6 +55,7 @@ vaadin-app-layout > vaadin-scroller[slot='drawer'] {
   --vaadin-scroller-padding-inline: var(--vaadin-padding-m);
   --vaadin-scroller-padding-block: var(--vaadin-padding-s);
   scrollbar-width: thin;
+  padding-inline-start: max(0px, var(--vaadin-padding-m) - var(--safe-area-inset-inline-start));
 }
 
 vaadin-app-layout::part(content) {
@@ -69,43 +70,6 @@ vaadin-app-layout::part(content) {
   border: var(--aura-app-layout-border-width) solid var(--vaadin-border-color-secondary);
   border-block-width: min(var(--aura-app-layout-inset), var(--aura-app-layout-border-width));
   border-inline-width: min(var(--aura-app-layout-inset), var(--aura-app-layout-border-width));
-}
-
-vaadin-app-layout > vaadin-master-detail-layout:nth-child(1 of :not([slot])):nth-last-child(1 of :not([slot])) {
-  margin-inline: calc(var(--safe-area-inset-left) * -1) calc(var(--safe-area-inset-right) * -1);
-  padding-inline: var(--safe-area-inset-left) var(--safe-area-inset-right);
-  max-width: calc(100% + var(--safe-area-inset-left) + var(--safe-area-inset-right));
-  margin-block: calc(var(--safe-area-inset-top) * -1) calc(var(--safe-area-inset-bottom) * -1);
-  padding-block: var(--safe-area-inset-top) var(--safe-area-inset-bottom);
-  height: calc(100% + var(--safe-area-inset-top) + var(--safe-area-inset-bottom));
-  max-height: calc(100% + var(--safe-area-inset-top) + var(--safe-area-inset-bottom));
-
-  &::part(detail) {
-    padding-top: var(--safe-area-inset-top);
-    padding-bottom: var(--safe-area-inset-bottom);
-  }
-
-  &:dir(ltr)::part(detail) {
-    padding-right: var(--safe-area-inset-right);
-  }
-
-  &:dir(rtl)::part(detail) {
-    padding-left: var(--safe-area-inset-left);
-  }
-
-  & > vaadin-master-detail-layout,
-  &:not([overlay])::part(detail) {
-    border-start-end-radius: var(--_app-layout-radius);
-    border-end-end-radius: var(--_app-layout-radius);
-  }
-
-  &::part(backdrop) {
-    border-radius: calc(var(--_app-layout-radius) - var(--aura-app-layout-border-width));
-  }
-
-  &:is([overlay][has-detail]) {
-    border-color: light-dark(var(--vaadin-border-color), var(--vaadin-border-color-secondary));
-  }
 }
 
 vaadin-app-layout[has-drawer][drawer-opened]:not([overlay])::part(content) {

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -119,6 +119,13 @@ addGlobalStyles(
         --safe-area-inset-right: env(safe-area-inset-right, 0px);
         --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
         --safe-area-inset-left: env(safe-area-inset-left, 0px);
+        --safe-area-inset-inline-start: var(--safe-area-inset-left);
+        --safe-area-inset-inline-end: var(--safe-area-inset-right);
+
+        &:dir(rtl) {
+          --safe-area-inset-inline-start: var(--safe-area-inset-right);
+          --safe-area-inset-inline-end: var(--safe-area-inset-left);
+        }
       }
 
       @supports not (color: hsl(0 0 0)) {

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -17,8 +17,11 @@ export const masterDetailLayoutStyles = css`
     box-sizing: border-box;
     height: 100%;
     position: relative;
-    z-index: 0;
     overflow: clip;
+  }
+
+  :host:not([overlay-containment='viewport']) {
+    z-index: 0;
   }
 
   :host([dir='rtl']) {
@@ -41,7 +44,7 @@ export const masterDetailLayoutStyles = css`
   /* CSS grid template */
 
   :host {
-    --_master-size: 30rem;
+    --_master-size: min(100%, 30rem);
     --_master-extra: 0px;
     --_detail-size: var(--_detail-cached-size);
     --_detail-extra: 0px;
@@ -240,6 +243,20 @@ export const masterDetailLayoutStyles = css`
 
   :host([has-detail][overlay][overlay-containment='page']) :is(#detail, #detailOutgoing, #backdrop) {
     position: fixed;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-right: env(safe-area-inset-right);
+    --safe-area-inset-top: 0px;
+    --safe-area-inset-bottom: 0px;
+    --safe-area-inset-left: 0px;
+    --safe-area-inset-right: 0px;
+    --safe-area-inset-inline-start: 0px;
+    --safe-area-inset-inline-end: 0px;
+  }
+
+  :host([dir='rtl'][has-detail][overlay][overlay-containment='viewport']) :is(#detail, #detailOutgoing, #backdrop) {
+    padding-right: 0;
+    padding-left: env(safe-area-inset-left);
   }
 
   /* Transitions */

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -20,7 +20,7 @@ export const masterDetailLayoutStyles = css`
     overflow: clip;
   }
 
-  :host:not([overlay-containment='viewport']) {
+  :host:not([overlay-containment='page']) {
     z-index: 0;
   }
 
@@ -254,7 +254,7 @@ export const masterDetailLayoutStyles = css`
     --safe-area-inset-inline-end: 0px;
   }
 
-  :host([dir='rtl'][has-detail][overlay][overlay-containment='viewport']) :is(#detail, #detailOutgoing, #backdrop) {
+  :host([dir='rtl'][has-detail][overlay][overlay-containment='page']) :is(#detail, #detailOutgoing, #backdrop) {
     padding-right: 0;
     padding-left: env(safe-area-inset-left);
   }

--- a/packages/vaadin-lumo-styles/src/components/app-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/app-layout.css
@@ -14,7 +14,8 @@
     --vaadin-app-layout-touch-optimized: false;
     --vaadin-app-layout-navbar-offset-top: var(--_vaadin-app-layout-navbar-offset-size);
     --vaadin-app-layout-navbar-offset-bottom: var(--_vaadin-app-layout-navbar-offset-size-bottom);
-    padding-block: var(--vaadin-app-layout-navbar-offset-top) var(--vaadin-app-layout-navbar-offset-bottom);
+    padding-top: var(--vaadin-app-layout-navbar-offset-top);
+    padding-bottom: var(--vaadin-app-layout-navbar-offset-bottom);
     padding-inline-start: var(--vaadin-app-layout-navbar-offset-left);
   }
 
@@ -32,8 +33,8 @@
   }
 
   :host([overlay]) {
-    --vaadin-app-layout-drawer-offset-left: 0;
-    --vaadin-app-layout-navbar-offset-left: 0;
+    --vaadin-app-layout-drawer-offset-left: 0px;
+    --vaadin-app-layout-navbar-offset-left: 0px;
   }
 
   :host(:not([no-scroll])) [part~='content'] {
@@ -42,6 +43,19 @@
 
   [part~='content'] {
     height: 100%;
+    padding-top: max(0px, var(--safe-area-inset-top) - var(--vaadin-app-layout-navbar-offset-top));
+    padding-bottom: max(0px, var(--safe-area-inset-bottom) - var(--vaadin-app-layout-navbar-offset-bottom));
+    box-sizing: border-box;
+  }
+
+  :host(:dir(ltr)) [part~='content'] {
+    padding-left: var(--safe-area-inset-left);
+    padding-right: var(--safe-area-inset-right);
+  }
+
+  :host(:dir(rtl)) [part~='content'] {
+    padding-left: var(--safe-area-inset-left);
+    padding-right: var(--safe-area-inset-right);
   }
 
   @media (pointer: coarse) and (max-width: 800px) and (min-height: 500px) {
@@ -76,6 +90,7 @@
   [part~='navbar-bottom'] {
     top: auto;
     bottom: 0;
+    padding-top: 0;
     padding-bottom: var(--safe-area-inset-bottom);
     border-bottom: none;
     border-top: 1px solid var(--lumo-contrast-10pct);

--- a/packages/vaadin-lumo-styles/src/components/app-layout.css
+++ b/packages/vaadin-lumo-styles/src/components/app-layout.css
@@ -46,16 +46,11 @@
     padding-top: max(0px, var(--safe-area-inset-top) - var(--vaadin-app-layout-navbar-offset-top));
     padding-bottom: max(0px, var(--safe-area-inset-bottom) - var(--vaadin-app-layout-navbar-offset-bottom));
     box-sizing: border-box;
+    padding-inline: var(--safe-area-inset-inline-start) var(--safe-area-inset-inline-end);
   }
 
-  :host(:dir(ltr)) [part~='content'] {
-    padding-left: var(--safe-area-inset-left);
-    padding-right: var(--safe-area-inset-right);
-  }
-
-  :host(:dir(rtl)) [part~='content'] {
-    padding-left: var(--safe-area-inset-left);
-    padding-right: var(--safe-area-inset-right);
+  :host([drawer-opened]:not([overlay])) [part~='content'] {
+    padding-inline-start: 0;
   }
 
   @media (pointer: coarse) and (max-width: 800px) and (min-height: 500px) {


### PR DESCRIPTION
Refactor and cleanup styles related to iOS safe area insets for both App Layout and Master-Detail Layout, across base styles, Lumo, and Aura.