### PR TITLE
chore: support URL fragment navigation in aura dev page

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -29,25 +29,85 @@
       import '@vaadin/item';
 
       // Fake navigation: prevent navigation, update 'current' item manually
+      const appLayout = document.querySelector('vaadin-app-layout');
+
+      const findNavItemByViewName = (viewName) =>
+        Array.from(document.querySelectorAll('vaadin-side-nav-item[data-view-name]')).find(
+          (item) => item.dataset.viewName === viewName,
+        );
+
+      const getCurrentViewElement = () => Array.from(appLayout.children).find((el) => !el.hasAttribute('slot'));
+
+      const setCurrentItem = (currentItem) => {
+        document.querySelectorAll('vaadin-side-nav-item').forEach((item) => item.removeAttribute('current'));
+
+        if (currentItem) {
+          currentItem.setAttribute('current', '');
+        }
+      };
+
+      const showView = (viewName) => {
+        if (!viewName) {
+          return;
+        }
+
+        const currentView = getCurrentViewElement();
+        if (currentView?.localName !== viewName) {
+          currentView?.remove();
+          const view = document.createElement(viewName);
+          appLayout.append(view);
+        }
+      };
+
+      const navigateToItem = (item, updateHash = true) => {
+        if (!item) {
+          return;
+        }
+
+        setCurrentItem(item);
+
+        const { viewName } = item.dataset;
+        if (viewName) {
+          showView(viewName);
+
+          if (updateHash && decodeURIComponent(window.location.hash.slice(1)) !== viewName) {
+            window.location.hash = encodeURIComponent(viewName);
+          }
+        }
+      };
+
       document.querySelectorAll('vaadin-side-nav').forEach((nav) => {
         nav.addEventListener('click', (e) => {
           const item = e.target.closest('vaadin-side-nav-item');
           if (item) {
             e.preventDefault();
-            item
-              .closest('vaadin-side-nav')
-              .parentNode.querySelectorAll('vaadin-side-nav-item')
-              .forEach((item) => item.removeAttribute('current'));
-            item.setAttribute('current', '');
-
-            if (item.dataset.viewName) {
-              document.querySelector('vaadin-app-layout > :not([slot])').remove();
-              const view = document.createElement(item.dataset.viewName);
-              document.querySelector('vaadin-app-layout').append(view);
-            }
+            navigateToItem(item);
           }
         });
       });
+
+      window.addEventListener('hashchange', () => {
+        const viewName = decodeURIComponent(window.location.hash.slice(1));
+        const item = findNavItemByViewName(viewName);
+
+        if (item) {
+          navigateToItem(item, false);
+        }
+      });
+
+      const viewNameFromHash = decodeURIComponent(window.location.hash.slice(1));
+      const hashedItem = findNavItemByViewName(viewNameFromHash);
+
+      if (hashedItem) {
+        navigateToItem(hashedItem, false);
+      } else {
+        const currentViewName = getCurrentViewElement()?.localName;
+        const currentItem = findNavItemByViewName(currentViewName);
+
+        if (currentItem) {
+          navigateToItem(currentItem, false);
+        }
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
This makes it easier to test code changes that affect a certain view, when you don't have to manually navigate back to the view after the page reloads.

🤖 Implemented by Codex