### PR TITLE
fix: reduce helper text opacity on disabled fields

### DIFF
--- a/packages/aura/src/components/input-container.css
+++ b/packages/aura/src/components/input-container.css
@@ -26,6 +26,10 @@ vaadin-message-input:not([readonly], [disabled]) {
   background-color: var(--vaadin-input-field-disabled-background, var(--vaadin-background-container));
 }
 
+[disabled]::part(helper-text) {
+  opacity: 0.5;
+}
+
 ::part(field-button) {
   transition: color 100ms;
   --vaadin-icon-visual-size: 90%;


### PR DESCRIPTION
All other parts of a disabled field are more muted. I forgot to tweak this originally, always meant to do it.