### PR TITLE
fix: disable backdrop-filter when overlay opacity is 100%

### DIFF
--- a/packages/aura/src/components/overlay.css
+++ b/packages/aura/src/components/overlay.css
@@ -40,6 +40,12 @@
   font-weight: var(--aura-font-weight-regular);
   line-height: var(--aura-line-height-m);
   color: var(--vaadin-text-color);
+
+  @container style(--aura-overlay-surface-opacity: 1) {
+    html {
+      --aura-overlay-backdrop-filter: none;
+    }
+  }
 }
 
 vaadin-popover,


### PR DESCRIPTION
This can potentially improve performance, when the browser can skip computing the filter. I suppose that depends on the rendering optimizations.