### PR TITLE
fix: reset cell order according to order of columns in DOM

### DIFF
--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -338,6 +338,59 @@ export const ColumnReorderingMixin = (superClass) =>
     }
 
     /**
+     * Resets the visual column order so that cells in every row reflect the
+     * current DOM order of `<vaadin-grid-column>` elements: `_order` is
+     * recomputed from the DOM order and cells in header, footer, body and
+     * sizer rows are physically moved to match.
+     *
+     * Intended to be called by Vaadin Flow's `GridColumnOrderHelper` (via
+     * `executeJs`) to realign cell order with the column DOM order after an
+     * earlier drag reorder, even when the column DOM order itself has not
+     * changed (in which case the `_columnTree` observer does not fire and
+     * `_renderColumnTree` does not re-render the rows).
+     *
+     * @private
+     */
+    _resetColumnOrder() {
+      if (this._columnTree === undefined) {
+        return;
+      }
+
+      // Each `_columnTree[level]` array is already in DOM order. If every
+      // level's `_order` values are monotonically non-decreasing along that
+      // array, cells are already in sync with DOM order and no work is needed.
+      const alreadyInDomOrder = this._columnTree.every((level) =>
+        level.every((column, i) => i === 0 || column._order >= level[i - 1]._order),
+      );
+      if (alreadyInDomOrder) {
+        return;
+      }
+
+      this._updateOrders(this._columnTree);
+
+      // Physically reorder cells in all rows to match the updated column order.
+      [...this.$.header.children, ...this.$.footer.children, ...this.$.items.children, this.$.sizer].forEach((row) => {
+        const cells = getBodyRowCells(row);
+        const sortedCells = [...cells].sort((a, b) => a._column._order - b._column._order);
+        const referenceNode = row.__detailsCell || null;
+        sortedCells.forEach((cell) => {
+          // Only move cells that are already attached to the row — detached body
+          // cells belong to columns hidden by lazy column rendering, and their
+          // attachment state is owned by `__updateColumnsBodyContentHidden`.
+          if (cell.parentNode === row) {
+            row.insertBefore(cell, referenceNode);
+          }
+        });
+        if (row.__cells) {
+          row.__cells = sortedCells;
+        }
+      });
+
+      this._debounceUpdateFrozenColumn();
+      this._updateFirstAndLastColumn();
+    }
+
+    /**
      * @param {!GridColumn} column
      * @param {string} status
      * @protected

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -339,9 +339,7 @@ export const ColumnReorderingMixin = (superClass) =>
 
     /**
      * Resets the visual column order so that cells in every row reflect the
-     * current DOM order of `<vaadin-grid-column>` elements: `_order` is
-     * recomputed from the DOM order and cells in header, footer, body and
-     * sizer rows are physically moved to match.
+     * current DOM order of `<vaadin-grid-column>` elements.
      *
      * Intended to be called by Vaadin Flow's `GridColumnOrderHelper` (via
      * `executeJs`) to realign cell order with the column DOM order after an
@@ -366,28 +364,7 @@ export const ColumnReorderingMixin = (superClass) =>
         return;
       }
 
-      this._updateOrders(this._columnTree);
-
-      // Physically reorder cells in all rows to match the updated column order.
-      [...this.$.header.children, ...this.$.footer.children, ...this.$.items.children, this.$.sizer].forEach((row) => {
-        const cells = getBodyRowCells(row);
-        const sortedCells = [...cells].sort((a, b) => a._column._order - b._column._order);
-        const referenceNode = row.__detailsCell || null;
-        sortedCells.forEach((cell) => {
-          // Only move cells that are already attached to the row — detached body
-          // cells belong to columns hidden by lazy column rendering, and their
-          // attachment state is owned by `__updateColumnsBodyContentHidden`.
-          if (cell.parentNode === row) {
-            row.insertBefore(cell, referenceNode);
-          }
-        });
-        if (row.__cells) {
-          row.__cells = sortedCells;
-        }
-      });
-
-      this._debounceUpdateFrozenColumn();
-      this._updateFirstAndLastColumn();
+      this._columnTree = this._getColumnTree();
     }
 
     /**

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../all-imports.js';
@@ -435,6 +435,25 @@ describe('reordering simple grid', () => {
       expect(e.detail.columns.map((column) => column.getAttribute('index'))).to.eql(['2', '1', '3', '4']);
     });
 
+    it('should restore cell order to match column DOM order when _resetColumnOrder is called', () => {
+      // Drag the first column over the last column so cells are reordered to [2, 3, 4, 1]
+      dragOver(headerContent[0], headerContent[3]);
+      flushGrid(grid);
+      expectVisualOrder(grid, [2, 3, 4, 1]);
+
+      // Simulate the Flow component calling _resetColumnOrder to restore the order of cells
+      // to match the DOM order of the <vaadin-grid-column> elements, which hasn't changed.
+      grid._resetColumnOrder();
+      flushGrid(grid);
+      expectVisualOrder(grid, [1, 2, 3, 4]);
+    });
+
+    it('should skip DOM work in _resetColumnOrder when cells already match DOM order', () => {
+      const spy = sinon.spy(grid, '_debounceUpdateFrozenColumn');
+      grid._resetColumnOrder();
+      expect(spy.called).to.be.false;
+    });
+
     describe('focus button mode', () => {
       beforeEach(() => {
         grid = fixtureSync(`
@@ -765,6 +784,51 @@ describe('reordering simple grid', () => {
       dragOver(handle, cell);
       expect(grid.hasAttribute('reordering')).to.be.false;
     });
+  });
+});
+
+describe('reordering grid with lazy columns', () => {
+  let grid;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid style="width: 250px; height: 200px;" size="1" column-reordering-allowed>
+        ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+          .map((col) => `<vaadin-grid-column width="100px" flex-grow="0" header="${col}"></vaadin-grid-column>`)
+          .join('')}
+      </vaadin-grid>
+    `);
+
+    grid.querySelectorAll('vaadin-grid-column').forEach((col, idx) => {
+      col.renderer = (root) => {
+        root.textContent = `${idx + 1}`;
+      };
+    });
+
+    grid.columnRendering = 'lazy';
+    grid.dataProvider = infiniteDataProvider;
+    await nextResize(grid);
+    flushGrid(grid);
+  });
+
+  it('should not re-attach detached cells when _resetColumnOrder is called', () => {
+    const bodyRow = grid.$.items.children[0];
+    const initialCellCount = bodyRow.children.length;
+    // Sanity check: lazy rendering should produce fewer cells than total columns
+    expect(initialCellCount).to.be.lessThan(grid._columnTree[0].length);
+
+    // Reorder the first two columns (both inside the viewport)
+    const firstHeader = getVisualHeaderCellContent(grid, 0, 0);
+    const secondHeader = getVisualHeaderCellContent(grid, 0, 1);
+    dragOver(firstHeader, secondHeader);
+    flushGrid(grid);
+    expect(bodyRow.children.length).to.equal(initialCellCount);
+
+    // Simulate the Flow component calling _resetColumnOrder; it should not
+    // re-attach cells that are detached due to lazy column rendering.
+    grid._resetColumnOrder();
+    flushGrid(grid);
+    expect(bodyRow.children.length).to.equal(initialCellCount);
   });
 });
 

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { aTimeout, fixtureSync, nextFrame, nextResize } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../all-imports.js';
@@ -449,8 +449,9 @@ describe('reordering simple grid', () => {
     });
 
     it('should skip DOM work in _resetColumnOrder when cells already match DOM order', () => {
-      const spy = sinon.spy(grid, '_debounceUpdateFrozenColumn');
+      const spy = sinon.spy(grid, '_renderColumnTree');
       grid._resetColumnOrder();
+      flushGrid(grid);
       expect(spy.called).to.be.false;
     });
 
@@ -784,51 +785,6 @@ describe('reordering simple grid', () => {
       dragOver(handle, cell);
       expect(grid.hasAttribute('reordering')).to.be.false;
     });
-  });
-});
-
-describe('reordering grid with lazy columns', () => {
-  let grid;
-
-  beforeEach(async () => {
-    grid = fixtureSync(`
-      <vaadin-grid style="width: 250px; height: 200px;" size="1" column-reordering-allowed>
-        ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-          .map((col) => `<vaadin-grid-column width="100px" flex-grow="0" header="${col}"></vaadin-grid-column>`)
-          .join('')}
-      </vaadin-grid>
-    `);
-
-    grid.querySelectorAll('vaadin-grid-column').forEach((col, idx) => {
-      col.renderer = (root) => {
-        root.textContent = `${idx + 1}`;
-      };
-    });
-
-    grid.columnRendering = 'lazy';
-    grid.dataProvider = infiniteDataProvider;
-    await nextResize(grid);
-    flushGrid(grid);
-  });
-
-  it('should not re-attach detached cells when _resetColumnOrder is called', () => {
-    const bodyRow = grid.$.items.children[0];
-    const initialCellCount = bodyRow.children.length;
-    // Sanity check: lazy rendering should produce fewer cells than total columns
-    expect(initialCellCount).to.be.lessThan(grid._columnTree[0].length);
-
-    // Reorder the first two columns (both inside the viewport)
-    const firstHeader = getVisualHeaderCellContent(grid, 0, 0);
-    const secondHeader = getVisualHeaderCellContent(grid, 0, 1);
-    dragOver(firstHeader, secondHeader);
-    flushGrid(grid);
-    expect(bodyRow.children.length).to.equal(initialCellCount);
-
-    // Simulate the Flow component calling _resetColumnOrder; it should not
-    // re-attach cells that are detached due to lazy column rendering.
-    grid._resetColumnOrder();
-    flushGrid(grid);
-    expect(bodyRow.children.length).to.equal(initialCellCount);
   });
 });
 


### PR DESCRIPTION
## Description

Since https://github.com/vaadin/web-components/pull/10632 reordering columns per drag and drop physically reorders cells instead of applying an order through CSS. Note that this does not actually reorder the columns in the DOM, so it only establishes a new "visual order". When changing the order of columns in the DOM afterwards programmatically, `_renderColumnTree` will recreate rows with the correct cell order, and `_updateOrders` will reset the `_order` property to be in sync with the DOM order again.

When setting a column order in the Flow component, it will reorder columns in the DOM, which triggers the path above. However, if the order of columns in the DOM already match the new order, this path would not trigger. For that the Flow component additionally calls `_updateOrders`, which is not effective anymore as it only updates the `_order` prop, but doesn't reorder cells to reset the visual order. The use case is basically:
- User reorders columns
- Then clicks a button to restore initial column order
- DOM order doesn't actually change, cells are neither regenerated or reordered

In order to fix this, this adds a `_resetColumnOrder` method that the Flow component can use to force reset the visual order to the DOM order. The method force recreates the column tree, similar to what would happen when the column DOM order actually changes. The method also short-circuits when the visual and DOM order are already in sync. This works for the Flow component, as the mutation observer / column tree update debouncer run before the `executeJs` call, so the Flow component should be able to call this unconditionally without having to detect whether column order actually changed.

Part of https://github.com/vaadin/flow-components/issues/9119

## Type of change

- Bugfix
