### PR TITLE
feat: add noTabFocus property to skip popover in Tab order

### DIFF
--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -39,10 +39,10 @@ export class PopoverFocusController {
     const targetFocusable = this.__getTargetFocusable();
 
     if (targetFocusable && isElementFocused(targetFocusable)) {
+      event.preventDefault();
       if (host.noTabFocus) {
         this.__moveLogicalNext(event, targetFocusable);
       } else {
-        event.preventDefault();
         host.focus();
       }
       return;

--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -39,14 +39,20 @@ export class PopoverFocusController {
     const targetFocusable = this.__getTargetFocusable();
 
     if (targetFocusable && isElementFocused(targetFocusable)) {
-      event.preventDefault();
-      host.focus();
+      if (host.noTabFocus) {
+        this.__moveLogicalNext(event, targetFocusable);
+      } else {
+        event.preventDefault();
+        host.focus();
+      }
       return;
     }
 
     const lastPopoverFocusable = this.__getLastPopoverFocusable();
     if (isElementFocused(lastPopoverFocusable)) {
-      this.__moveLogicalNext(event, host);
+      // With noTabFocus the popover isn't in the logical list, so the target
+      // becomes the reference for "next after the popover".
+      this.__moveLogicalNext(event, host.noTabFocus ? targetFocusable : host);
       return;
     }
 
@@ -167,7 +173,7 @@ export class PopoverFocusController {
   /**
    * Scope focusables in *logical* tab order: the popover is moved from its DOM
    * position to right after the target focusable. The popover is left out of
-   * the list entirely when there is no target.
+   * the list entirely when there is no target, or when `noTabFocus` is set.
    * @private
    */
   __buildLogicalList(scopeFocusables = this.__getScopeFocusables()) {
@@ -175,7 +181,7 @@ export class PopoverFocusController {
     const targetFocusable = this.__getTargetFocusable();
     const logicalFocusables = scopeFocusables.filter((el) => el !== host);
 
-    if (targetFocusable && targetFocusable !== host) {
+    if (!host.noTabFocus && targetFocusable && targetFocusable !== host) {
       const targetIdx = logicalFocusables.indexOf(targetFocusable);
       if (targetIdx >= 0) {
         logicalFocusables.splice(targetIdx + 1, 0, host);

--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -112,6 +112,10 @@ export class PopoverFocusController {
         prevFocusable.focus();
       } else if (getActiveTrappingNode(host)) {
         this.__wrapToLogicalLast(event, logicalFocusables);
+      } else if (host.noTabFocus) {
+        // No redirect target and no trap: still block native Shift+Tab so the
+        // popover host can never receive Shift+Tab focus.
+        event.preventDefault();
       }
       return;
     }
@@ -195,28 +199,32 @@ export class PopoverFocusController {
     const host = this.host;
     const logicalFocusables = this.__buildLogicalList(scopeFocusables);
     const fromIdx = logicalFocusables.indexOf(from);
-    if (fromIdx < 0) {
-      return;
-    }
 
-    // The popover sits right after the target in the logical list, so it can
-    // be the logical next only when `from` is the target. Skip it: the popover
-    // is Tab-reachable only from its target (handled in __handleTab case 1).
-    let nextIdx = fromIdx + 1;
-    if (logicalFocusables[nextIdx] === host) {
-      nextIdx += 1;
-    }
+    let focusable;
+    if (fromIdx >= 0) {
+      // The popover sits right after the target in the logical list, so it can
+      // be the logical next only when `from` is the target. Skip it: the popover
+      // is Tab-reachable only from its target (handled in __handleTab case 1).
+      let nextIdx = fromIdx + 1;
+      if (logicalFocusables[nextIdx] === host) {
+        nextIdx += 1;
+      }
 
-    // Past the end inside a trap: wrap to the first element. The popover
-    // never sits at position 0 (it only follows a target), so list[0] is real.
-    let focusable = logicalFocusables[nextIdx];
-    if (!focusable && getActiveTrappingNode(host)) {
-      focusable = logicalFocusables[0];
+      // Past the end inside a trap: wrap to the first element. The popover
+      // never sits at position 0 (it only follows a target), so list[0] is real.
+      focusable = logicalFocusables[nextIdx];
+      if (!focusable && getActiveTrappingNode(host)) {
+        focusable = logicalFocusables[0];
+      }
     }
 
     if (focusable) {
       event.preventDefault();
       focusable.focus();
+    } else if (host.noTabFocus) {
+      // No redirect target found: still block native Tab so the popover host
+      // can never receive Tab focus when it is DOM-adjacent.
+      event.preventDefault();
     }
   }
 

--- a/packages/popover/src/vaadin-popover.d.ts
+++ b/packages/popover/src/vaadin-popover.d.ts
@@ -206,6 +206,19 @@ declare class Popover extends PopoverPositionMixin(PopoverTargetMixin(ThemePrope
   noCloseOnEsc: boolean;
 
   /**
+   * When true, pressing Tab on the target or a sibling element does not move
+   * focus into the popover's content (including any nested popovers), and
+   * Shift+Tab does not move focus into the popover's last focusable. Focus
+   * still moves out of the popover on Tab / Shift+Tab if it was placed
+   * inside programmatically.
+   *
+   * Has no effect on modal popovers, which use their own focus trap.
+   *
+   * @attr {boolean} no-tab-focus
+   */
+  noTabFocus: boolean;
+
+  /**
    * Popover trigger mode, used to configure how the popover is opened or closed.
    * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
    *

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -399,6 +399,22 @@ class Popover extends PopoverPositionMixin(
       },
 
       /**
+       * When true, pressing Tab on the target or a sibling element does not move
+       * focus into the popover's content (including any nested popovers), and
+       * Shift+Tab does not move focus into the popover's last focusable. Focus
+       * still moves out of the popover on Tab / Shift+Tab if it was placed
+       * inside programmatically.
+       *
+       * Has no effect on modal popovers, which use their own focus trap.
+       *
+       * @attr {boolean} no-tab-focus
+       */
+      noTabFocus: {
+        type: Boolean,
+        value: false,
+      },
+
+      /**
        * Popover trigger mode, used to configure how the popover is opened or closed.
        * Could be set to multiple by providing an array, e.g. `trigger = ['hover', 'focus']`.
        *

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -599,5 +599,70 @@ describe('a11y', () => {
         });
       });
     });
+
+    describe('noTabFocus', () => {
+      let input, overlayInput;
+
+      beforeEach(async () => {
+        // Place popover after target so DOM = [target, popover, input]
+        target.parentElement.insertBefore(target, popover);
+
+        input = document.createElement('input');
+        target.parentElement.appendChild(input);
+
+        overlayInput = popover.querySelector('input');
+
+        popover.trigger = [];
+        popover.noTabFocus = true;
+        popover.opened = true;
+        await oneEvent(overlay, 'vaadin-overlay-open');
+      });
+
+      it('should focus next element after target on target Tab', async () => {
+        target.focus();
+
+        await sendKeys({ press: 'Tab' });
+
+        expect(getDeepActiveElement()).to.equal(input);
+      });
+
+      it('should focus target on next element Shift Tab', async () => {
+        input.focus();
+
+        await sendKeys({ press: 'Shift+Tab' });
+
+        expect(getDeepActiveElement()).to.equal(target);
+      });
+
+      it('should focus next element after target on last overlay child Tab', async () => {
+        overlayInput.focus();
+
+        await sendKeys({ press: 'Tab' });
+
+        expect(getDeepActiveElement()).to.equal(input);
+      });
+
+      it('should focus target on popover host Shift Tab', async () => {
+        popover.focus();
+
+        await sendKeys({ press: 'Shift+Tab' });
+
+        expect(getDeepActiveElement()).to.equal(target);
+      });
+
+      it('should not affect modal popover behavior', async () => {
+        popover.opened = false;
+        await nextUpdate(popover);
+        popover.modal = true;
+        popover.opened = true;
+        await oneEvent(overlay, 'vaadin-overlay-open');
+
+        target.focus();
+        await sendKeys({ press: 'Tab' });
+
+        // Modal popover uses overlay focus trap; noTabFocus has no effect.
+        expect(getDeepActiveElement()).to.equal(popover);
+      });
+    });
   });
 });

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -604,7 +604,7 @@ describe('a11y', () => {
       let input, overlayInput;
 
       beforeEach(async () => {
-        // Place popover after target so DOM = [target, popover, input]
+        // DOM = [target, popover, input]
         target.parentElement.insertBefore(target, popover);
 
         input = document.createElement('input');
@@ -664,58 +664,77 @@ describe('a11y', () => {
         expect(getDeepActiveElement()).to.equal(popover);
       });
 
-      it('should not focus popover on target Tab when popover is last in DOM', async () => {
-        // Remove the input so DOM = [target, popover] — popover is the last focusable.
-        input.remove();
+      describe('popover last in DOM', () => {
+        beforeEach(() => {
+          // DOM = [target, popover]
+          input.remove();
+        });
 
-        target.focus();
-        await sendKeys({ press: 'Tab' });
+        it('should not focus popover on target Tab', async () => {
+          target.focus();
+          await sendKeys({ press: 'Tab' });
 
-        // Focus must not land on the popover; nothing else to Tab to, so it stays on target.
-        expect(getDeepActiveElement()).to.equal(target);
+          // Nothing to Tab to past the popover, so focus stays on target.
+          expect(getDeepActiveElement()).to.equal(target);
+        });
       });
 
-      it('should not focus popover on target Shift Tab when popover is before target and focus trigger', async () => {
-        // Rearrange to DOM = [beforeInput, popover, target, input].
-        const beforeInput = document.createElement('input');
-        target.parentElement.insertBefore(popover, target); // move popover before target
-        target.parentElement.insertBefore(beforeInput, popover);
+      describe('sibling between target and popover', () => {
+        beforeEach(() => {
+          // DOM = [target, input, popover] — native Tab from input would land on the popover.
+          target.parentElement.appendChild(popover);
+        });
 
-        popover.opened = false;
-        popover.trigger = ['focus'];
-        await nextUpdate(popover);
+        it('should not focus popover on sibling Tab', async () => {
+          input.focus();
+          await sendKeys({ press: 'Tab' });
 
-        target.focus();
-        await oneEvent(overlay, 'vaadin-overlay-open');
-
-        await sendKeys({ press: 'Shift+Tab' });
-        await nextRender();
-
-        expect(getDeepActiveElement()).to.equal(beforeInput);
+          expect(getDeepActiveElement()).to.equal(input);
+        });
       });
 
-      it('should not focus popover on sibling Tab when popover is last in DOM', async () => {
-        // Rearrange to DOM = [target, input, popover] — popover is the last focusable,
-        // and native Tab from input would land on the popover host.
-        target.parentElement.appendChild(popover);
+      describe('popover before target, focus trigger', () => {
+        let beforeInput;
 
-        input.focus();
-        await sendKeys({ press: 'Tab' });
+        beforeEach(async () => {
+          // DOM = [beforeInput, popover, target, input]
+          beforeInput = document.createElement('input');
+          target.parentElement.insertBefore(popover, target);
+          target.parentElement.insertBefore(beforeInput, popover);
 
-        expect(getDeepActiveElement()).to.equal(input);
+          popover.opened = false;
+          popover.trigger = ['focus'];
+          await nextUpdate(popover);
+
+          target.focus();
+          await oneEvent(overlay, 'vaadin-overlay-open');
+        });
+
+        it('should not focus popover on target Shift Tab', async () => {
+          await sendKeys({ press: 'Shift+Tab' });
+          await nextRender();
+
+          expect(getDeepActiveElement()).to.equal(beforeInput);
+        });
       });
 
-      it('should not focus popover on sibling Shift Tab when popover is first in DOM', async () => {
-        // Rearrange to DOM = [popover, firstInput, target, input]. Shift+Tab
-        // from firstInput must not reach the popover host (DOM-prev).
-        const firstInput = document.createElement('input');
-        target.parentElement.insertBefore(popover, target);
-        target.parentElement.insertBefore(firstInput, target);
+      describe('popover first in DOM', () => {
+        let firstInput;
 
-        firstInput.focus();
-        await sendKeys({ press: 'Shift+Tab' });
+        beforeEach(() => {
+          // DOM = [popover, firstInput, target, input] — native Shift+Tab
+          // from firstInput would land on the popover host.
+          firstInput = document.createElement('input');
+          target.parentElement.insertBefore(popover, target);
+          target.parentElement.insertBefore(firstInput, target);
+        });
 
-        expect(getDeepActiveElement()).to.equal(firstInput);
+        it('should not focus popover on sibling Shift Tab', async () => {
+          firstInput.focus();
+          await sendKeys({ press: 'Shift+Tab' });
+
+          expect(getDeepActiveElement()).to.equal(firstInput);
+        });
       });
     });
   });

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -663,6 +663,36 @@ describe('a11y', () => {
         // Modal popover uses overlay focus trap; noTabFocus has no effect.
         expect(getDeepActiveElement()).to.equal(popover);
       });
+
+      it('should not focus popover on target Tab when popover is last in DOM', async () => {
+        // Remove the input so DOM = [target, popover] — popover is the last focusable.
+        input.remove();
+
+        target.focus();
+        await sendKeys({ press: 'Tab' });
+
+        // Focus must not land on the popover; nothing else to Tab to, so it stays on target.
+        expect(getDeepActiveElement()).to.equal(target);
+      });
+
+      it('should not focus popover on target Shift Tab when popover is before target and focus trigger', async () => {
+        // Rearrange to DOM = [beforeInput, popover, target, input].
+        const beforeInput = document.createElement('input');
+        target.parentElement.insertBefore(popover, target); // move popover before target
+        target.parentElement.insertBefore(beforeInput, popover);
+
+        popover.opened = false;
+        popover.trigger = ['focus'];
+        await nextUpdate(popover);
+
+        target.focus();
+        await oneEvent(overlay, 'vaadin-overlay-open');
+
+        await sendKeys({ press: 'Shift+Tab' });
+        await nextRender();
+
+        expect(getDeepActiveElement()).to.equal(beforeInput);
+      });
     });
   });
 });

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -693,6 +693,30 @@ describe('a11y', () => {
 
         expect(getDeepActiveElement()).to.equal(beforeInput);
       });
+
+      it('should not focus popover on sibling Tab when popover is last in DOM', async () => {
+        // Rearrange to DOM = [target, input, popover] — popover is the last focusable,
+        // and native Tab from input would land on the popover host.
+        target.parentElement.appendChild(popover);
+
+        input.focus();
+        await sendKeys({ press: 'Tab' });
+
+        expect(getDeepActiveElement()).to.equal(input);
+      });
+
+      it('should not focus popover on sibling Shift Tab when popover is first in DOM', async () => {
+        // Rearrange to DOM = [popover, firstInput, target, input]. Shift+Tab
+        // from firstInput must not reach the popover host (DOM-prev).
+        const firstInput = document.createElement('input');
+        target.parentElement.insertBefore(popover, target);
+        target.parentElement.insertBefore(firstInput, target);
+
+        firstInput.focus();
+        await sendKeys({ press: 'Shift+Tab' });
+
+        expect(getDeepActiveElement()).to.equal(firstInput);
+      });
     });
   });
 });

--- a/packages/popover/test/typings/popover.types.ts
+++ b/packages/popover/test/typings/popover.types.ts
@@ -37,6 +37,7 @@ assertType<boolean>(popover.modal);
 assertType<boolean>(popover.withBackdrop);
 assertType<boolean>(popover.noCloseOnEsc);
 assertType<boolean>(popover.noCloseOnOutsideClick);
+assertType<boolean>(popover.noTabFocus);
 assertType<number>(popover.focusDelay);
 assertType<number>(popover.hideDelay);
 assertType<number>(popover.hoverDelay);


### PR DESCRIPTION
Depends on #11535
Depends on #11557

## Summary
- New boolean property `noTabFocus` on `vaadin-popover` (attribute: `no-tab-focus`, default `false`). When true, the popover is not reachable via Tab from its target or surroundings — Tab on the target moves to the next sibling focusable instead of into the popover, and Shift+Tab from the element after the popover goes straight to the target.
- Focus placed inside the popover programmatically (e.g. via a custom ArrowDown handler on the target) still navigates out on Tab / Shift+Tab using the existing logic.
- Tab skipping also covers the popover's content, including any **nested popovers** — a consequence of `__getScopeFocusables` filtering out all light-DOM descendants.
- No effect on modal popovers, which use the overlay's own focus trap.

Implementation lands in the `PopoverFocusController` introduced by #11535. The related non-`noTabFocus` Shift+Tab loop fix is extracted into #11557 so this PR is scoped to the feature itself.

## Test plan
- [x] `yarn test --group popover` — new `noTabFocus` cases + all existing
- [x] `yarn test:it` — integration suite (dialog-popover trap cases)
- [x] `yarn lint:js` and `yarn lint:types`
- [x] Typings test coverage in `packages/popover/test/typings/popover.types.ts`

Closes https://github.com/vaadin/web-components/issues/11423

🤖 Generated with [Claude Code](https://claude.com/claude-code)