### PR TITLE
feat: make disabled menu items accessible with feature flag

### DIFF
--- a/dev/context-menu.html
+++ b/dev/context-menu.html
@@ -8,6 +8,11 @@
     <script type="module" src="./common.js"></script>
 
     <script type="module">
+      window.Vaadin ??= {};
+      window.Vaadin.featureFlags ??= {};
+      window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+    </script>
+    <script type="module">
       import '@vaadin/context-menu';
       import '@vaadin/radio-group';
 

--- a/dev/menu-bar.html
+++ b/dev/menu-bar.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Menu bar</title>
     <script type="module" src="./common.js"></script>
+    <script type="module">
+      window.Vaadin ??= {};
+      window.Vaadin.featureFlags ??= {};
+      window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+    </script>
   </head>
 
   <body>

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -336,6 +336,22 @@ export const ListMixin = (superClass) =>
     }
 
     /**
+     * Override method inherited from `KeyboardDirectionMixin` to allow
+     * focusing disabled items that are configured so.
+     *
+     * @param {Element} item
+     * @protected
+     * @override
+     */
+    _isItemFocusable(item) {
+      if (item.disabled && item.__shouldAllowFocusWhenDisabled) {
+        return item.__shouldAllowFocusWhenDisabled();
+      }
+
+      return super._isItemFocusable(item);
+    }
+
+    /**
      * Fired when the selection is changed.
      * Not fired when used in `multiple` selection mode.
      *

--- a/packages/button/src/vaadin-button.d.ts
+++ b/packages/button/src/vaadin-button.d.ts
@@ -55,16 +55,14 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  */
 declare class Button extends ButtonMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   /**
-   * When disabled, the button is rendered as "dimmed" and prevents all
-   * user interactions (mouse and keyboard).
+   * When disabled, the button is rendered as "dimmed".
    *
-   * Since disabled buttons are not focusable and cannot react to hover
-   * events by default, it can cause accessibility issues by making them
-   * entirely invisible to assistive technologies, and prevents the use
-   * of Tooltips to explain why the action is not available. This can be
-   * addressed by enabling the feature flag `accessibleDisabledButtons`,
+   * By default, disabled buttons are not focusable and don't react to hover.
+   * As a result, they are hidden from assistive technologies, and it's not
+   * possible to show a tooltip to explain why they are disabled. This can
+   * be addressed by enabling the feature flag `accessibleDisabledButtons`,
    * which makes disabled buttons focusable and hoverable, while still
-   * preventing them from being triggered:
+   * preventing them from being activated:
    *
    * ```js
    * // Set before any button is attached to the DOM.

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -77,16 +77,14 @@ class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInj
   static get properties() {
     return {
       /**
-       * When disabled, the button is rendered as "dimmed" and prevents all
-       * user interactions (mouse and keyboard).
+       * When disabled, the button is rendered as "dimmed".
        *
-       * Since disabled buttons are not focusable and cannot react to hover
-       * events by default, it can cause accessibility issues by making them
-       * entirely invisible to assistive technologies, and prevents the use
-       * of Tooltips to explain why the action is not available. This can be
-       * addressed by enabling the feature flag `accessibleDisabledButtons`,
+       * By default, disabled buttons are not focusable and don't react to hover.
+       * As a result, they are hidden from assistive technologies, and it's not
+       * possible to show a tooltip to explain why they are disabled. This can
+       * be addressed by enabling the feature flag `accessibleDisabledButtons`,
        * which makes disabled buttons focusable and hoverable, while still
-       * preventing them from being triggered:
+       * preventing them from being activated:
        *
        * ```js
        * // Set before any button is attached to the DOM.

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -47,6 +47,11 @@ class ContextMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(Lumo
 
     this.setAttribute('role', 'menuitem');
   }
+
+  /** @override */
+  __shouldAllowFocusWhenDisabled() {
+    return window.Vaadin.featureFlags.accessibleDisabledMenuItems;
+  }
 }
 
 defineCustomElement(ContextMenuItem);

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -108,16 +108,14 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenu
  *
  * #### Disabled menu items
  *
- * When disabled, menu items are rendered as "dimmed" and prevent all
- * user interactions (mouse and keyboard).
+ * When disabled, menu items are rendered as "dimmed".
  *
- * Since disabled items are not focusable and cannot react to hover
- * events by default, it can cause accessibility issues by making them
- * entirely invisible to assistive technologies, and prevents the use
- * of Tooltips to explain why the action is not available. This can be
- * addressed by enabling the feature flag `accessibleDisabledMenuItems`,
+ * By default, disabled items are not focusable and don't react to hover.
+ * As a result, they are hidden from assistive technologies, and it's not
+ * possible to show a tooltip to explain why they are disabled. This can
+ * be addressed by enabling the feature flag `accessibleDisabledMenuItems`,
  * which makes disabled items focusable and hoverable, while still
- * preventing them from being triggered:
+ * preventing them from being activated:
  *
  * ```js
  * // Set before any context menu is attached to the DOM.

--- a/packages/context-menu/src/vaadin-context-menu.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu.d.ts
@@ -106,6 +106,24 @@ export interface ContextMenuEventMap<TItem extends ContextMenuItem = ContextMenu
  *
  * **NOTE:** when the `items` array is defined, the renderer cannot be used.
  *
+ * #### Disabled menu items
+ *
+ * When disabled, menu items are rendered as "dimmed" and prevent all
+ * user interactions (mouse and keyboard).
+ *
+ * Since disabled items are not focusable and cannot react to hover
+ * events by default, it can cause accessibility issues by making them
+ * entirely invisible to assistive technologies, and prevents the use
+ * of Tooltips to explain why the action is not available. This can be
+ * addressed by enabling the feature flag `accessibleDisabledMenuItems`,
+ * which makes disabled items focusable and hoverable, while still
+ * preventing them from being triggered:
+ *
+ * ```js
+ * // Set before any context menu is attached to the DOM.
+ * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+ * ```
+ *
  * ### Rendering
  *
  * The content of the menu can be populated by using the renderer callback function.

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -56,16 +56,14 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * #### Disabled menu items
  *
- * When disabled, menu items are rendered as "dimmed" and prevent all
- * user interactions (mouse and keyboard).
+ * When disabled, menu items are rendered as "dimmed".
  *
- * Since disabled items are not focusable and cannot react to hover
- * events by default, it can cause accessibility issues by making them
- * entirely invisible to assistive technologies, and prevents the use
- * of Tooltips to explain why the action is not available. This can be
- * addressed by enabling the feature flag `accessibleDisabledMenuItems`,
+ * By default, disabled items are not focusable and don't react to hover.
+ * As a result, they are hidden from assistive technologies, and it's not
+ * possible to show a tooltip to explain why they are disabled. This can
+ * be addressed by enabling the feature flag `accessibleDisabledMenuItems`,
  * which makes disabled items focusable and hoverable, while still
- * preventing them from being triggered:
+ * preventing them from being activated:
  *
  * ```js
  * // Set before any context menu is attached to the DOM.

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -54,6 +54,24 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * **NOTE:** when the `items` array is defined, the renderer cannot be used.
  *
+ * #### Disabled menu items
+ *
+ * When disabled, menu items are rendered as "dimmed" and prevent all
+ * user interactions (mouse and keyboard).
+ *
+ * Since disabled items are not focusable and cannot react to hover
+ * events by default, it can cause accessibility issues by making them
+ * entirely invisible to assistive technologies, and prevents the use
+ * of Tooltips to explain why the action is not available. This can be
+ * addressed by enabling the feature flag `accessibleDisabledMenuItems`,
+ * which makes disabled items focusable and hoverable, while still
+ * preventing them from being triggered:
+ *
+ * ```js
+ * // Set before any context menu is attached to the DOM.
+ * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+ * ```
+ *
  * ### Rendering
  *
  * The content of the menu can be populated by using the renderer callback function.

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -54,6 +54,24 @@ export const ItemsMixin = (superClass) =>
          * ];
          * ```
          *
+         * #### Disabled menu items
+         *
+         * When disabled, menu items are rendered as "dimmed" and prevent all
+         * user interactions (mouse and keyboard).
+         *
+         * Since disabled items are not focusable and cannot react to hover
+         * events by default, it can cause accessibility issues by making them
+         * entirely invisible to assistive technologies, and prevents the use
+         * of Tooltips to explain why the action is not available. This can be
+         * addressed by enabling the feature flag `accessibleDisabledMenuItems`,
+         * which makes disabled items focusable and hoverable, while still
+         * preventing them from being triggered:
+         *
+         * ```js
+         * // Set before any context menu is attached to the DOM.
+         * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+         * ```
+         *
          * @type {!Array<!ContextMenuItem> | undefined}
          */
         items: {
@@ -374,7 +392,7 @@ export const ItemsMixin = (superClass) =>
       const subMenu = this._subMenu;
       const expandedItem = this._listBox.querySelector('[expanded]');
 
-      if (item && item !== expandedItem) {
+      if (item && item !== expandedItem && !item.disabled) {
         const { children } = item._item;
 
         // Check if the sub-menu was focused before closing it.

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -54,24 +54,6 @@ export const ItemsMixin = (superClass) =>
          * ];
          * ```
          *
-         * #### Disabled menu items
-         *
-         * When disabled, menu items are rendered as "dimmed" and prevent all
-         * user interactions (mouse and keyboard).
-         *
-         * Since disabled items are not focusable and cannot react to hover
-         * events by default, it can cause accessibility issues by making them
-         * entirely invisible to assistive technologies, and prevents the use
-         * of Tooltips to explain why the action is not available. This can be
-         * addressed by enabling the feature flag `accessibleDisabledMenuItems`,
-         * which makes disabled items focusable and hoverable, while still
-         * preventing them from being triggered:
-         *
-         * ```js
-         * // Set before any context menu is attached to the DOM.
-         * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
-         * ```
-         *
          * @type {!Array<!ContextMenuItem> | undefined}
          */
         items: {

--- a/packages/context-menu/test/accessible-disabled-menu-items.test.js
+++ b/packages/context-menu/test/accessible-disabled-menu-items.test.js
@@ -19,13 +19,18 @@ describe('accessible disabled menu items', () => {
   });
 
   beforeEach(async () => {
+    // Firefox: when a previous test ends with focus on an overlay item
+    // that then gets removed during fixture teardown, element.focus()
+    // calls in the next test's overlay silently no-op (activeElement
+    // stays on <body>), breaking sendKeys-based arrow navigation.
+    // Adding a real focusable sibling outside the overlay helps work
+    // this around
     const wrapper = fixtureSync(`
       <div>
         <input id="first-global-focusable" />
         <vaadin-context-menu>
           <button id="target"></button>
         </vaadin-context-menu>
-        <input id="last-global-focusable" />
       </div>
     `);
     rootMenu = wrapper.querySelector('vaadin-context-menu');
@@ -103,7 +108,6 @@ describe('accessible disabled menu items (feature flag disabled)', () => {
         <vaadin-context-menu>
           <button id="target"></button>
         </vaadin-context-menu>
-        <input id="last-global-focusable" />
       </div>
     `);
     rootMenu = wrapper.querySelector('vaadin-context-menu');

--- a/packages/context-menu/test/accessible-disabled-menu-items.test.js
+++ b/packages/context-menu/test/accessible-disabled-menu-items.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-context-menu.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
@@ -18,11 +19,16 @@ describe('accessible disabled menu items', () => {
   });
 
   beforeEach(async () => {
-    rootMenu = fixtureSync(`
-      <vaadin-context-menu>
-        <button id="target"></button>
-      </vaadin-context-menu>
+    const wrapper = fixtureSync(`
+      <div>
+        <input id="first-global-focusable" />
+        <vaadin-context-menu>
+          <button id="target"></button>
+        </vaadin-context-menu>
+        <input id="last-global-focusable" />
+      </div>
     `);
+    rootMenu = wrapper.querySelector('vaadin-context-menu');
     rootMenu.openOn = isTouch ? 'click' : 'mouseover';
     target = rootMenu.firstElementChild;
     rootMenu.items = [
@@ -61,8 +67,10 @@ describe('accessible disabled menu items', () => {
   });
 
   it('should not select a disabled item on click', async () => {
+    const spy = sinon.spy();
+    rootMenu.addEventListener('item-selected', spy);
     await sendMouseToElement({ type: 'click', element: items[1] });
-    expect(items[1].selected).to.be.false;
+    expect(spy.called).to.be.false;
   });
 
   it('should not open sub-menu on disabled parent item hover', async () => {
@@ -89,11 +97,16 @@ describe('accessible disabled menu items (feature flag disabled)', () => {
   let rootMenu, target, items;
 
   beforeEach(async () => {
-    rootMenu = fixtureSync(`
-      <vaadin-context-menu>
-        <button id="target"></button>
-      </vaadin-context-menu>
+    const wrapper = fixtureSync(`
+      <div>
+        <input id="first-global-focusable" />
+        <vaadin-context-menu>
+          <button id="target"></button>
+        </vaadin-context-menu>
+        <input id="last-global-focusable" />
+      </div>
     `);
+    rootMenu = wrapper.querySelector('vaadin-context-menu');
     rootMenu.openOn = isTouch ? 'click' : 'mouseover';
     target = rootMenu.firstElementChild;
     rootMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', disabled: true }, { text: 'Item 2' }];

--- a/packages/context-menu/test/accessible-disabled-menu-items.test.js
+++ b/packages/context-menu/test/accessible-disabled-menu-items.test.js
@@ -1,0 +1,115 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '../src/vaadin-context-menu.js';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
+
+describe('accessible disabled menu items', () => {
+  let rootMenu, subMenu, target, items;
+
+  before(() => {
+    window.Vaadin.featureFlags ??= {};
+    window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+  });
+
+  after(() => {
+    window.Vaadin.featureFlags.accessibleDisabledMenuItems = false;
+  });
+
+  beforeEach(async () => {
+    rootMenu = fixtureSync(`
+      <vaadin-context-menu>
+        <button id="target"></button>
+      </vaadin-context-menu>
+    `);
+    rootMenu.openOn = isTouch ? 'click' : 'mouseover';
+    target = rootMenu.firstElementChild;
+    rootMenu.items = [
+      { text: 'Item 0' },
+      { text: 'Item 1', disabled: true },
+      { text: 'Item 2', disabled: true, children: [{ text: 'SubItem 0' }] },
+      { text: 'Item 3' },
+    ];
+    await nextRender();
+    await openMenu(target);
+    items = getMenuItems(rootMenu);
+  });
+
+  afterEach(async () => {
+    await resetMouse();
+  });
+
+  it('should allow programmatic focus on disabled item', () => {
+    items[1].focus();
+    expect(document.activeElement).to.equal(items[1]);
+  });
+
+  it('should include disabled items in arrow key navigation', async () => {
+    items[0].focus();
+    await sendKeys({ press: 'ArrowDown' });
+    expect(document.activeElement).to.equal(items[1]);
+
+    await sendKeys({ press: 'ArrowDown' });
+    expect(document.activeElement).to.equal(items[2]);
+
+    await sendKeys({ press: 'ArrowDown' });
+    expect(document.activeElement).to.equal(items[3]);
+
+    await sendKeys({ press: 'ArrowUp' });
+    expect(document.activeElement).to.equal(items[2]);
+  });
+
+  it('should not select a disabled item on click', async () => {
+    await sendMouseToElement({ type: 'click', element: items[1] });
+    expect(items[1].selected).to.be.false;
+  });
+
+  it('should not open sub-menu on disabled parent item hover', async () => {
+    await sendMouseToElement({ type: 'move', element: items[2] });
+    subMenu = getSubMenu(rootMenu);
+    expect(subMenu.opened).to.be.false;
+    expect(items[2].hasAttribute('expanded')).to.be.false;
+  });
+
+  it('should not open sub-menu on disabled parent item Enter', async () => {
+    items[2].focus();
+    await sendKeys({ press: 'Enter' });
+    subMenu = getSubMenu(rootMenu);
+    expect(subMenu.opened).to.be.false;
+    expect(items[2].hasAttribute('expanded')).to.be.false;
+  });
+
+  it('should set --_vaadin-item-disabled-pointer-events on disabled item', () => {
+    expect(items[1].style.getPropertyValue('--_vaadin-item-disabled-pointer-events')).to.equal('auto');
+  });
+});
+
+describe('accessible disabled menu items (feature flag disabled)', () => {
+  let rootMenu, target, items;
+
+  beforeEach(async () => {
+    rootMenu = fixtureSync(`
+      <vaadin-context-menu>
+        <button id="target"></button>
+      </vaadin-context-menu>
+    `);
+    rootMenu.openOn = isTouch ? 'click' : 'mouseover';
+    target = rootMenu.firstElementChild;
+    rootMenu.items = [{ text: 'Item 0' }, { text: 'Item 1', disabled: true }, { text: 'Item 2' }];
+    await nextRender();
+    await openMenu(target);
+    items = getMenuItems(rootMenu);
+  });
+
+  it('should not allow programmatic focus on disabled item', () => {
+    items[1].focus();
+    expect(document.activeElement).to.not.equal(items[1]);
+  });
+
+  it('should skip disabled items in arrow key navigation', async () => {
+    items[0].focus();
+    await sendKeys({ press: 'ArrowDown' });
+    expect(document.activeElement).to.equal(items[2]);
+  });
+});

--- a/packages/item/src/styles/vaadin-item-base-styles.js
+++ b/packages/item/src/styles/vaadin-item-base-styles.js
@@ -27,7 +27,7 @@ export const itemStyles = css`
   :host([disabled]) {
     cursor: var(--vaadin-disabled-cursor);
     opacity: 0.5;
-    pointer-events: none;
+    pointer-events: var(--_vaadin-item-disabled-pointer-events, none);
   }
 
   :host([hidden]) {

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -76,6 +76,10 @@ export const ItemMixin = (superClass) =>
       if (attrValue !== null) {
         this.value = attrValue;
       }
+
+      if (this.__shouldAllowFocusWhenDisabled()) {
+        this.style.setProperty('--_vaadin-item-disabled-pointer-events', 'auto');
+      }
     }
 
     /**
@@ -84,7 +88,7 @@ export const ItemMixin = (superClass) =>
      * @override
      */
     focus(options) {
-      if (this.disabled) {
+      if (this.disabled && !this.__shouldAllowFocusWhenDisabled()) {
         return;
       }
 
@@ -115,7 +119,9 @@ export const ItemMixin = (superClass) =>
 
       if (disabled) {
         this.selected = false;
-        this.blur();
+        if (!this.__shouldAllowFocusWhenDisabled()) {
+          this.blur();
+        }
       }
     }
 
@@ -141,5 +147,16 @@ export const ItemMixin = (superClass) =>
         // so that it doesn't fire the `click` event when the element is disabled.
         this.click();
       }
+    }
+
+    /**
+     * Returns whether the component should be focusable when disabled.
+     * Returns false by default.
+     *
+     * @private
+     * @return {boolean}
+     */
+    __shouldAllowFocusWhenDisabled() {
+      return false;
     }
   };

--- a/packages/menu-bar/src/vaadin-menu-bar-item.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.js
@@ -49,6 +49,11 @@ class MenuBarItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInje
     // because the role is removed when teleporting to button.
     this.setAttribute('role', 'menuitem');
   }
+
+  /** @override */
+  __shouldAllowFocusWhenDisabled() {
+    return window.Vaadin.featureFlags.accessibleDisabledMenuItems;
+  }
 }
 
 defineCustomElement(MenuBarItem);

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
@@ -101,35 +101,25 @@ export declare class MenuBarMixinClass<TItem extends MenuBarItem = MenuBarItem> 
    * ];
    * ```
    *
-   * #### Disabled buttons
+   * #### Disabled items
    *
-   * When disabled, menu bar buttons (root-level items) are rendered
-   * as "dimmed" and prevent all user interactions (mouse and keyboard).
+   * When disabled, menu bar items are rendered as "dimmed".
    *
-   * Since disabled buttons are not focusable and cannot react to hover
-   * events by default, it can cause accessibility issues by making them
-   * entirely invisible to assistive technologies, and prevents the use
-   * of Tooltips to explain why the action is not available. This can be
-   * addressed by enabling the feature flag `accessibleDisabledButtons`,
-   * which makes disabled buttons focusable and hoverable, while still
-   * preventing them from being triggered:
+   * By default, disabled items are not focusable and don't react to hover.
+   * As a result, they are hidden from assistive technologies, and it's not
+   * possible to show a tooltip to explain why they are disabled. This can be
+   * addressed by enabling several feature flags, which makes disabled items
+   * focusable and hoverable, while still preventing them from being activated:
    *
    * ```js
-   * // Set before any menu bar is attached to the DOM.
+   * // Allow focus and hover interactions with disabled menu bar root items (buttons)
    * window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-   * ```
    *
-   * #### Disabled sub-menu items
-   *
-   * Likewise, disabled sub-menu items are not focusable or hoverable
-   * by default. Enabling the feature flag `accessibleDisabledMenuItems`
-   * makes them focusable and hoverable, while still preventing them
-   * from being triggered:
-   *
-   * ```js
-   * // Set before any menu bar is attached to the DOM.
+   * // Allow focus and hover interactions with disabled menu bar sub-menu items
    * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
    * ```
+   *
+   * Both flags must be set before any menu bar is attached to the DOM.
    */
   items: TItem[];
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.d.ts
@@ -118,6 +118,18 @@ export declare class MenuBarMixinClass<TItem extends MenuBarItem = MenuBarItem> 
    * // Set before any menu bar is attached to the DOM.
    * window.Vaadin.featureFlags.accessibleDisabledButtons = true;
    * ```
+   *
+   * #### Disabled sub-menu items
+   *
+   * Likewise, disabled sub-menu items are not focusable or hoverable
+   * by default. Enabling the feature flag `accessibleDisabledMenuItems`
+   * makes them focusable and hoverable, while still preventing them
+   * from being triggered:
+   *
+   * ```js
+   * // Set before any menu bar is attached to the DOM.
+   * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+   * ```
    */
   items: TItem[];
 

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -123,35 +123,25 @@ export const MenuBarMixin = (superClass) =>
          * ];
          * ```
          *
-         * #### Disabled buttons
+         * #### Disabled items
          *
-         * When disabled, menu bar buttons (root-level items) are rendered
-         * as "dimmed" and prevent all user interactions (mouse and keyboard).
+         * When disabled, menu bar items are rendered as "dimmed".
          *
-         * Since disabled buttons are not focusable and cannot react to hover
-         * events by default, it can cause accessibility issues by making them
-         * entirely invisible to assistive technologies, and prevents the use
-         * of Tooltips to explain why the action is not available. This can be
-         * addressed by enabling the feature flag `accessibleDisabledButtons`,
-         * which makes disabled buttons focusable and hoverable, while still
-         * preventing them from being triggered:
+         * By default, disabled items are not focusable and don't react to hover.
+         * As a result, they are hidden from assistive technologies, and it's not
+         * possible to show a tooltip to explain why they are disabled. This can be
+         * addressed by enabling several feature flags, which makes disabled items
+         * focusable and hoverable, while still preventing them from being activated:
          *
          * ```js
-         * // Set before any menu bar is attached to the DOM.
+         * // Allow focus and hover interactions with disabled menu bar root items (buttons)
          * window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-         * ```
          *
-         * #### Disabled sub-menu items
-         *
-         * Likewise, disabled sub-menu items are not focusable or hoverable
-         * by default. Enabling the feature flag `accessibleDisabledMenuItems`
-         * makes them focusable and hoverable, while still preventing them
-         * from being triggered:
-         *
-         * ```js
-         * // Set before any menu bar is attached to the DOM.
+         * // Allow focus and hover interactions with disabled menu bar sub-menu items
          * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
          * ```
+         *
+         * Both flags must be set before any menu bar is attached to the DOM.
          *
          * @type {!Array<!MenuBarItem>}
          */

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -141,6 +141,18 @@ export const MenuBarMixin = (superClass) =>
          * window.Vaadin.featureFlags.accessibleDisabledButtons = true;
          * ```
          *
+         * #### Disabled sub-menu items
+         *
+         * Likewise, disabled sub-menu items are not focusable or hoverable
+         * by default. Enabling the feature flag `accessibleDisabledMenuItems`
+         * makes them focusable and hoverable, while still preventing them
+         * from being triggered:
+         *
+         * ```js
+         * // Set before any menu bar is attached to the DOM.
+         * window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+         * ```
+         *
          * @type {!Array<!MenuBarItem>}
          */
         items: {

--- a/packages/menu-bar/test/accessible-disabled-menu-items.test.js
+++ b/packages/menu-bar/test/accessible-disabled-menu-items.test.js
@@ -17,7 +17,14 @@ describe('accessible disabled menu items', () => {
   });
 
   beforeEach(async () => {
-    menuBar = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+    const wrapper = fixtureSync(`
+      <div>
+        <input id="first-global-focusable" />
+        <vaadin-menu-bar></vaadin-menu-bar>
+        <input id="last-global-focusable" />
+      </div>
+    `);
+    menuBar = wrapper.querySelector('vaadin-menu-bar');
     menuBar.items = [
       {
         text: 'Item 0',

--- a/packages/menu-bar/test/accessible-disabled-menu-items.test.js
+++ b/packages/menu-bar/test/accessible-disabled-menu-items.test.js
@@ -1,0 +1,81 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-menu-bar.js';
+
+describe('accessible disabled menu items', () => {
+  let menuBar, buttons, subMenu;
+
+  before(() => {
+    window.Vaadin.featureFlags ??= {};
+    window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+  });
+
+  after(() => {
+    window.Vaadin.featureFlags.accessibleDisabledMenuItems = false;
+  });
+
+  beforeEach(async () => {
+    menuBar = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+    menuBar.items = [
+      {
+        text: 'Item 0',
+        children: [{ text: 'SubItem 0' }, { text: 'SubItem 1', disabled: true }, { text: 'SubItem 2' }],
+      },
+    ];
+    await nextRender();
+    buttons = menuBar._buttons;
+    subMenu = menuBar._subMenu;
+  });
+
+  afterEach(async () => {
+    await resetMouse();
+  });
+
+  function getSubMenuItems() {
+    return [...subMenu.querySelectorAll('vaadin-menu-bar-item')];
+  }
+
+  it('should include disabled sub-menu item in arrow key navigation', async () => {
+    buttons[0].focus();
+    await sendKeys({ press: 'ArrowDown' });
+    await nextRender();
+
+    let items = getSubMenuItems();
+    expect(document.activeElement).to.equal(items[0]);
+
+    await sendKeys({ press: 'ArrowDown' });
+    items = getSubMenuItems();
+    expect(document.activeElement).to.equal(items[1]);
+    expect(items[1].disabled).to.be.true;
+
+    await sendKeys({ press: 'ArrowDown' });
+    items = getSubMenuItems();
+    expect(document.activeElement).to.equal(items[2]);
+  });
+
+  it('should allow programmatic focus on disabled sub-menu item', async () => {
+    buttons[0].focus();
+    await sendKeys({ press: 'ArrowDown' });
+    await nextRender();
+
+    const items = getSubMenuItems();
+    items[1].focus();
+    expect(document.activeElement).to.equal(items[1]);
+  });
+
+  it('should not select a disabled sub-menu item on click', async () => {
+    buttons[0].focus();
+    await sendKeys({ press: 'ArrowDown' });
+    await nextRender();
+
+    const spy = sinon.spy();
+    menuBar.addEventListener('item-selected', spy);
+
+    const items = getSubMenuItems();
+    await sendMouseToElement({ type: 'click', element: items[1] });
+
+    expect(spy.called).to.be.false;
+  });
+});

--- a/packages/menu-bar/test/accessible-disabled-menu-items.test.js
+++ b/packages/menu-bar/test/accessible-disabled-menu-items.test.js
@@ -17,14 +17,7 @@ describe('accessible disabled menu items', () => {
   });
 
   beforeEach(async () => {
-    const wrapper = fixtureSync(`
-      <div>
-        <input id="first-global-focusable" />
-        <vaadin-menu-bar></vaadin-menu-bar>
-        <input id="last-global-focusable" />
-      </div>
-    `);
-    menuBar = wrapper.querySelector('vaadin-menu-bar');
+    menuBar = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
     menuBar.items = [
       {
         text: 'Item 0',

--- a/packages/vaadin-lumo-styles/src/components/context-menu-list-box.css
+++ b/packages/vaadin-lumo-styles/src/components/context-menu-list-box.css
@@ -11,7 +11,6 @@
   /* Normal item */
   [part='items'] ::slotted([role='menuitem']) {
     -webkit-tap-highlight-color: var(--lumo-primary-color-10pct);
-    cursor: default;
     outline: none;
     border-radius: var(--lumo-border-radius-m);
     padding-left: calc(var(--lumo-border-radius-m) / 4);
@@ -20,8 +19,8 @@
 
   /* Hovered item */
   /* TODO a workaround until we have "focus-follows-mouse". After that, use the hover style for focus-ring as well */
-  [part='items'] ::slotted([role='menuitem']:hover:not([disabled])),
-  [part='items'] ::slotted([role='menuitem'][expanded]:not([disabled])) {
+  [part='items'] ::slotted([role='menuitem']:hover),
+  [part='items'] ::slotted([role='menuitem'][expanded]) {
     background-color: var(--lumo-primary-color-10pct);
   }
 
@@ -33,7 +32,7 @@
 
   /* Focused item */
   @media (pointer: coarse) {
-    [part='items'] ::slotted([role='menuitem']:hover:not([expanded]):not([disabled])) {
+    [part='items'] ::slotted([role='menuitem']:hover:not([expanded])) {
       background-color: transparent;
     }
   }

--- a/packages/vaadin-lumo-styles/src/components/item.css
+++ b/packages/vaadin-lumo-styles/src/components/item.css
@@ -65,18 +65,18 @@
   /* Disabled */
   :host([disabled]) {
     color: var(--lumo-disabled-text-color);
-    cursor: default;
-    pointer-events: none;
+    cursor: not-allowed;
+    pointer-events: var(--_vaadin-item-disabled-pointer-events, none);
   }
 
   /* TODO a workaround until we have "focus-follows-mouse". After that, use the hover style for focus-ring as well */
   @media (any-hover: hover) {
-    :host(:hover:not([disabled])) {
+    :host(:hover) {
       background-color: var(--lumo-primary-color-10pct);
     }
   }
 
-  :host([focus-ring]:not([disabled])) {
+  :host([focus-ring]) {
     box-shadow: inset 0 0 0 var(--_focus-ring-width) var(--_focus-ring-color);
   }
 


### PR DESCRIPTION
## Description

This is the first part of the work to improve accessibility of disabled menu items. It introduces a new feature flag `accessibleDisabledMenuItems` that makes disabled context-menu and menu-bar sub-menu items focusable and hoverable, while still preventing selection and sub-menu opening. Tooltip support for disabled menu items will be added in a follow-up PR.

```js
// Set before any context menu or menu bar is attached to the DOM.
window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
```

Part of https://github.com/vaadin/web-components/issues/10415

## Type of change

- Feature

🤖 Partially generated with [Claude Code](https://claude.com/claude-code)