### PR TITLE
fix: remove disabled guard from button Lumo hover styles

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/button.css
+++ b/packages/vaadin-lumo-styles/src/components/button.css
@@ -115,7 +115,7 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
   /* Hover */
 
   @media (any-hover: hover) {
-    :host(:not([disabled]):hover)::before {
+    :host(:hover)::before {
       opacity: 0.02;
     }
   }
@@ -198,7 +198,7 @@ Note, to make it work, the form fields should have the same "::before" pseudo-el
   }
 
   @media (any-hover: hover) {
-    :host([theme~='primary']:not([disabled]):hover)::before {
+    :host([theme~='primary']:hover)::before {
       opacity: 0.05;
     }
   }


### PR DESCRIPTION
## Description

When the `accessibleDisabledButtons` feature flag was originally implemented, the `:not([disabled])` guard was left on the button Lumo hover styles, which prevented disabled-but-accessible buttons from showing hover feedback. This removes the guard so hover feedback is consistent with the focusable/hoverable behavior the flag enables. Disabled buttons without the flag have `pointer-events: none`, so `:hover` does not fire and the visual stays unchanged.

## Type of change

- Bugfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)