### PR TITLE
docs: add missing date-time-picker unparsable-change event type

### DIFF
--- a/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.d.ts
@@ -17,6 +17,11 @@ export type DateTimePickerChangeEvent = Event & {
 };
 
 /**
+ * Fired when the user commits an unparsable value change and there is no change event.
+ */
+export type DateTimePickerUnparsableChangeEvent = CustomEvent;
+
+/**
  * Fired when the `invalid` property changes.
  */
 export type DateTimePickerInvalidChangedEvent = CustomEvent<{ value: boolean }>;
@@ -33,6 +38,8 @@ export type DateTimePickerValidatedEvent = CustomEvent<{ valid: boolean }>;
 
 export interface DateTimePickerCustomEventMap {
   'invalid-changed': DateTimePickerInvalidChangedEvent;
+
+  'unparsable-change': DateTimePickerUnparsableChangeEvent;
 
   'value-changed': DateTimePickerValueChangedEvent;
 


### PR DESCRIPTION
## Description

Same as https://github.com/vaadin/web-components/pull/11300 but for `vaadin-date-time-picker`

This fixes a finding from CEM migration research: DTP has `@fires` for the `unparsable-change` event, but no `.ts` type.

## Type of change

- Docs