### PR TITLE
feat: add focusSelectedItem property to combo-box

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -168,6 +168,7 @@ export const ComboBoxDataProviderMixin = (superClass) =>
       this.__synchronizeControllerState();
 
       this.__scrollToPendingIndexIfNeeded();
+      this.__scrollToSelectedItemIfNeeded();
 
       if (!this.opened && !this._isInputFocused()) {
         this._commitValue();
@@ -176,14 +177,38 @@ export const ComboBoxDataProviderMixin = (superClass) =>
 
     /**
      * Override method from `ComboBoxBaseMixin` to flush any pending
-     * `scrollToIndex` call after the overlay opens.
+     * `scrollToIndex` call after the overlay opens, and (for combo-box only)
+     * apply the `focusSelectedItem` auto-scroll behavior.
      *
      * @protected
      * @override
      */
     _onOpened() {
       super._onOpened();
+      // Latch the auto-scroll intent now so that a caller-queued
+      // `scrollToIndex` (which `__scrollToPendingIndexIfNeeded` is about to
+      // consume) takes precedence over the `focusSelectedItem` behavior.
+      // `selectedItem` is checked at retry time, not here: with a
+      // dataProvider, it's set asynchronously when the matching page loads.
+      this.__shouldFocusSelectedItem = this.focusSelectedItem && this.__scrollToPendingIndex === undefined;
+
       this.__scrollToPendingIndexIfNeeded();
+      this.__scrollToSelectedItemIfNeeded();
+    }
+
+    /** @private */
+    __scrollToSelectedItemIfNeeded() {
+      if (!this.__shouldFocusSelectedItem || !this.selectedItem) {
+        return;
+      }
+      const index = this.__getItemIndexByValue(this._dropdownItems, this._getItemValue(this.selectedItem));
+      if (index < 0) {
+        // With a dataProvider, the item's page may not be loaded yet.
+        // Keep the flag set so `__onDataProviderPageLoaded` can retry.
+        return;
+      }
+      delete this.__shouldFocusSelectedItem;
+      this.scrollToIndex(index);
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -200,9 +200,10 @@ export const ComboBoxItemsMixin = (superClass) =>
 
     /** @private */
     _filterChanged(filter) {
-      // A pending scrollToIndex targets an index in the unfiltered list,
-      // so it becomes stale when the filter changes.
+      // Scroll intents pinned at open time are canceled when the user
+      // starts filtering — the browsing context has changed.
       delete this.__scrollToPendingIndex;
+      delete this.__shouldFocusSelectedItem;
 
       // Scroll to the top of the list whenever the filter changes.
       this._scrollIntoView(0);

--- a/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.d.ts
@@ -89,6 +89,24 @@ export declare class ComboBoxMixinClass<TItem> {
   itemIdPath: string | null | undefined;
 
   /**
+   * When true, the dropdown automatically scrolls to and focuses the
+   * currently selected item when the overlay opens.
+   *
+   * With a `dataProvider`, the auto-scroll is best-effort: it only
+   * succeeds when the selected item's page is already loaded in the
+   * cache. For reliable scroll-to-selected with lazy data, compute
+   * the index externally (e.g. via a server-side `ItemIndexProvider`)
+   * and call `scrollToIndex(index)` directly, typically from a
+   * `vaadin-combo-box-dropdown-opened` event listener.
+   *
+   * An explicit `scrollToIndex` call pending from before the overlay
+   * opened takes precedence over this property.
+   *
+   * @attr {boolean} focus-selected-item
+   */
+  focusSelectedItem: boolean;
+
+  /**
    * Requests an update for the content of items.
    * While performing the update, it invokes the renderer (passed in the `renderer` property) once an item.
    *

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -97,6 +97,27 @@ export const ComboBoxMixin = (superClass) =>
           sync: true,
         },
 
+        /**
+         * When true, the dropdown automatically scrolls to and focuses the
+         * currently selected item when the overlay opens.
+         *
+         * With a `dataProvider`, the auto-scroll is best-effort: it only
+         * succeeds when the selected item's page is already loaded in the
+         * cache. For reliable scroll-to-selected with lazy data, compute
+         * the index externally (e.g. via a server-side `ItemIndexProvider`)
+         * and call `scrollToIndex(index)` directly, typically from a
+         * `vaadin-combo-box-dropdown-opened` event listener.
+         *
+         * An explicit `scrollToIndex` call pending from before the overlay
+         * opened takes precedence over this property.
+         *
+         * @attr {boolean} focus-selected-item
+         */
+        focusSelectedItem: {
+          type: Boolean,
+          value: false,
+        },
+
         /** @private */
         __keepOverlayOpened: {
           type: Boolean,

--- a/packages/combo-box/test/scroll-to-index.test.js
+++ b/packages/combo-box/test/scroll-to-index.test.js
@@ -213,6 +213,132 @@ describe('scrollToIndex', () => {
     });
   });
 
+  describe('focusSelectedItem', () => {
+    const SIZE = 200;
+
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box
+          style="--vaadin-combo-box-overlay-max-height: 400px"
+        ></vaadin-combo-box>
+      `);
+      await nextRender();
+      comboBox.items = makeItems(SIZE);
+    });
+
+    it('should default to false', () => {
+      expect(comboBox.focusSelectedItem).to.be.false;
+    });
+
+    it('should scroll to the selected item on open when true', () => {
+      comboBox.focusSelectedItem = true;
+      comboBox.selectedItem = comboBox.items[150];
+
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(150);
+      const viewport = getViewportItems(comboBox);
+      expect(viewport.map((item) => item.index)).to.include(150);
+    });
+
+    it('should not scroll when there is no selectedItem', () => {
+      comboBox.focusSelectedItem = true;
+
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(-1);
+      expect(getViewportItems(comboBox)[0].index).to.equal(0);
+    });
+
+    it('should prefer an explicit scrollToIndex call queued before open', () => {
+      comboBox.focusSelectedItem = true;
+      comboBox.selectedItem = comboBox.items[150];
+
+      comboBox.scrollToIndex(50);
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(50);
+      const viewport = getViewportItems(comboBox);
+      expect(viewport.map((item) => item.index)).to.include(50);
+    });
+
+    it('should scroll again when reopened after close', async () => {
+      comboBox.focusSelectedItem = true;
+      comboBox.selectedItem = comboBox.items[150];
+
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+      expect(comboBox._focusedIndex).to.equal(150);
+
+      comboBox.opened = false;
+      await nextFrame();
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(150);
+    });
+  });
+
+  describe('focusSelectedItem with dataProvider', () => {
+    const SIZE = 500;
+    const PAGE_SIZE = 50;
+    let pendingCallbacks;
+
+    function flushPendingCallbacks() {
+      const callbacks = pendingCallbacks;
+      pendingCallbacks = [];
+      callbacks.forEach((cb) => cb());
+    }
+
+    const asyncDataProvider = (params, callback) => {
+      pendingCallbacks.push(() => {
+        const items = makeItems(SIZE).slice(params.page * params.pageSize, (params.page + 1) * params.pageSize);
+        callback(items, SIZE);
+      });
+    };
+
+    beforeEach(async () => {
+      pendingCallbacks = [];
+      comboBox = fixtureSync(`
+        <vaadin-combo-box
+          style="--vaadin-combo-box-overlay-max-height: 400px"
+        ></vaadin-combo-box>
+      `);
+      await nextRender();
+      comboBox.pageSize = PAGE_SIZE;
+      comboBox.dataProvider = asyncDataProvider;
+      comboBox.focusSelectedItem = true;
+    });
+
+    it('should scroll to the selected item when its page is already loaded', async () => {
+      // Item 30 is in the first page, which loads on open.
+      comboBox.selectedItem = 'item 30';
+
+      comboBox.opened = true;
+      flushPendingCallbacks();
+      await nextFrame();
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(30);
+    });
+
+    it('should not scroll when the selected item is on an unloaded page', async () => {
+      // Item 300 is on page 6; only page 0 loads on open.
+      comboBox.selectedItem = 'item 300';
+
+      comboBox.opened = true;
+      flushPendingCallbacks();
+      await nextFrame();
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(-1);
+      expect(getViewportItems(comboBox)[0].index).to.equal(0);
+    });
+  });
+
   describe('regressions', () => {
     it('should not scroll on open when scrollToIndex was never called', async () => {
       comboBox = fixtureSync(`


### PR DESCRIPTION
## Description

Declarative `focusSelectedItem` boolean property that auto-scrolls the combo-box dropdown to the selected item on open, complementing the imperative `scrollToIndex` method for the common case.

- Opt-in (default `false`) — avoids the behavior removed in #6055 for users who don't enable it.
- Reliable with an items array.
- With a `dataProvider`: best-effort — scrolls only when the selected item's page is already loaded in the cache. For reliable scroll-to-selected with lazy data, use `scrollToIndex` with an externally-computed index (e.g. Flow's `ItemIndexProvider`).
- Explicit `scrollToIndex(N)` before open wins over the auto-scroll.

Part of #6061.

## Depends on

Stacked on #11552. This PR's base targets `feat/combo-box-scroll-to-index`; will retarget `main` once #11552 merges.

## Try it out

```html
<vaadin-combo-box id="cb" focus-selected-item></vaadin-combo-box>
<script type="module">
  const cb = document.getElementById('cb');
  cb.items = Array.from({ length: 500 }, (_, i) => `item ${i}`);
  cb.value = 'item 250';
  cb.opened = true; // opens with item 250 focused and scrolled into view
</script>
```

## Test plan

- [ ] Existing combo-box suite passes
- [ ] New `focusSelectedItem` tests in `test/scroll-to-index.test.js` (8 tests)
- [ ] time-picker suite passes
- [ ] `lint:types` green
- [ ] Regression: default `focusSelectedItem=false` does not scroll on open (guard for #6055)
- [ ] Regression: Escape closes dropdown in one press (guard for flow#5142)
- [ ] Manual: set items + selectedItem, enable property, reopen → item visible