### PR TITLE
docs: add missing dashboard-layout root-heading-level-changed event type

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-layout.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-layout.d.ts
@@ -13,6 +13,17 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
 
 /**
+ * Fired when the `rootHeadingLevel` property changes.
+ */
+export type DashboardLayoutRootHeadingLevelChangedEvent = CustomEvent<{ value: number | null }>;
+
+export interface DashboardLayoutCustomEventMap {
+  'dashboard-root-heading-level-changed': DashboardLayoutRootHeadingLevelChangedEvent;
+}
+
+export interface DashboardLayoutEventMap extends HTMLElementEventMap, DashboardLayoutCustomEventMap {}
+
+/**
  * A responsive, grid-based dashboard layout component
  *
  * ```html
@@ -45,8 +56,22 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * `dense-layout` | Set when the dashboard is in dense mode.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
+ *
+ * @fires {CustomEvent} dashboard-root-heading-level-changed - Fired when the `rootHeadingLevel` property changes.
  */
-declare class DashboardLayout extends DashboardLayoutMixin(ElementMixin(ThemableMixin(HTMLElement))) {}
+declare class DashboardLayout extends DashboardLayoutMixin(ElementMixin(ThemableMixin(HTMLElement))) {
+  addEventListener<K extends keyof DashboardLayoutEventMap>(
+    type: K,
+    listener: (this: DashboardLayout, ev: DashboardLayoutEventMap[K]) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+
+  removeEventListener<K extends keyof DashboardLayoutEventMap>(
+    type: K,
+    listener: (this: DashboardLayout, ev: DashboardLayoutEventMap[K]) => void,
+    options?: EventListenerOptions | boolean,
+  ): void;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -51,6 +51,8 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @fires {CustomEvent} dashboard-root-heading-level-changed - Fired when the `rootHeadingLevel` property changes.
+ *
  * @customElement vaadin-dashboard-layout
  * @extends HTMLElement
  * @mixes DashboardLayoutMixin


### PR DESCRIPTION
## Description

Same as https://github.com/vaadin/web-components/pull/11553 but for `vaadin-dashboard-layout`.

The `dashboard-root-heading-level-changed` event has been fired from `<vaadin-dashboard-layout>` since #9249 but was never surfaced in its `.d.ts`. This adds `DashboardLayoutRootHeadingLevelChangedEvent`, `DashboardLayoutCustomEventMap`, `DashboardLayoutEventMap`, typed `addEventListener`/`removeEventListener` overloads, and the matching `@fires` JSDoc on both the `.js` and `.d.ts` class blocks.

## Type of change

- Docs

## Note

Generally, this event is mostly used internally for updating heading level on items / sections.
But dashboard exposes it as a public event, so IMO it makes sense to have it consistently.