### PR TITLE
fix: prevent Shift+Tab loop when popover is before target

### DIFF
--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -65,10 +65,12 @@ export class PopoverFocusController {
     const host = this.host;
     const targetFocusable = this.__getTargetFocusable();
 
-    // Just clear the flag so native Shift+Tab from the target doesn't reopen.
+    // Clear the flag so native Shift+Tab from the target doesn't reopen. Fall
+    // through to the redirect logic: when the popover is DOM-prev of the target,
+    // case 5 steers focus away from it instead of letting the browser land on
+    // the popover host or its content.
     if (targetFocusable && isElementFocused(targetFocusable) && host.__shouldRestoreFocus) {
       host.__shouldRestoreFocus = false;
-      return;
     }
 
     if (isElementFocused(host)) {

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -528,48 +528,75 @@ describe('a11y', () => {
       });
     });
 
-    describe('focus', () => {
-      let input;
+    describe('focus trigger', () => {
+      describe('popover after target', () => {
+        let input;
 
-      beforeEach(async () => {
-        // Place popover after target
-        target.parentElement.insertBefore(target, popover);
+        beforeEach(async () => {
+          // DOM = [target, popover, input]
+          target.parentElement.insertBefore(target, popover);
 
-        input = document.createElement('input');
-        target.parentElement.appendChild(input);
+          input = document.createElement('input');
+          target.parentElement.appendChild(input);
 
-        popover.trigger = ['focus'];
-        target.focus();
+          popover.trigger = ['focus'];
+          target.focus();
 
-        await oneEvent(overlay, 'vaadin-overlay-open');
+          await oneEvent(overlay, 'vaadin-overlay-open');
+        });
+
+        it('should focus the next element after target on last overlay child Tab', async () => {
+          // Move focus to the overlay
+          await sendKeys({ press: 'Tab' });
+
+          // Move focus to the input inside the overlay
+          await sendKeys({ press: 'Tab' });
+
+          // Move focus to the input after the overlay
+          await sendKeys({ press: 'Tab' });
+
+          const activeElement = getDeepActiveElement();
+          expect(activeElement).to.equal(input);
+        });
+
+        it('should focus the popover on focusable content Shift Tab', async () => {
+          // Move focus to the overlay
+          await sendKeys({ press: 'Tab' });
+
+          // Move focus to the input inside the overlay
+          await sendKeys({ press: 'Tab' });
+
+          // Move focus back to the popover
+          await sendKeys({ press: 'Shift+Tab' });
+
+          const activeElement = getDeepActiveElement();
+          expect(activeElement).to.equal(popover);
+        });
       });
 
-      it('should focus the next element after target on last overlay child Tab', async () => {
-        // Move focus to the overlay
-        await sendKeys({ press: 'Tab' });
+      describe('popover before target', () => {
+        let before;
 
-        // Move focus to the input inside the overlay
-        await sendKeys({ press: 'Tab' });
+        beforeEach(async () => {
+          // DOM = [before, popover, target, input]
+          before = document.createElement('input');
+          const input = document.createElement('input');
+          target.parentElement.insertBefore(popover, target);
+          target.parentElement.insertBefore(before, popover);
+          target.parentElement.appendChild(input);
 
-        // Move focus to the input after the overlay
-        await sendKeys({ press: 'Tab' });
+          popover.trigger = ['focus'];
+          target.focus();
+          await oneEvent(overlay, 'vaadin-overlay-open');
+        });
 
-        const activeElement = getDeepActiveElement();
-        expect(activeElement).to.equal(input);
-      });
+        it('should focus previous element on target Shift Tab without entering popover', async () => {
+          // Shift+Tab from target must not land on the popover (DOM-prev).
+          await sendKeys({ press: 'Shift+Tab' });
+          await nextRender();
 
-      it('should focus the popover on focusable content Shift Tab', async () => {
-        // Move focus to the overlay
-        await sendKeys({ press: 'Tab' });
-
-        // Move focus to the input inside the overlay
-        await sendKeys({ press: 'Tab' });
-
-        // Move focus back to the popover
-        await sendKeys({ press: 'Shift+Tab' });
-
-        const activeElement = getDeepActiveElement();
-        expect(activeElement).to.equal(popover);
+          expect(getDeepActiveElement()).to.equal(before);
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

- Fixes a pre-existing Shift+Tab loop when a popover sits before its target in DOM and is opened via focus/click trigger.
- Drops the early `return` in `__handleShiftTab` case 1 so case 5 (`scope DOM-prev is host`) can redirect focus away from the popover instead of letting the browser land on it.
- Groups the focus-trigger Tab order tests by DOM configuration: `describe('focus')` → `describe('focus trigger') > describe('popover after target')`, plus a new sibling `describe('popover before target')` covering the fixed scenario.

## Background

DOM = `[before, popover, target, after]`, focus trigger:

1. Tab from `before` focuses the target → popover opens → `__shouldRestoreFocus = true`.
2. Shift+Tab from target → case 1 clears the flag and returns without preventDefault.
3. Native Shift+Tab moves focus to the DOM-prev (the popover host).
4. focusin on the popover re-arms `__shouldRestoreFocus`.
5. Further Shift+Tab keystrokes cycle `target → popover content → popover host → target`, never reaching `before`.

With the early return removed, case 5 fires when the popover is DOM-prev of the target and redirects focus to the true logical previous (`before`). When the popover is elsewhere in the DOM, none of the later cases fire and native Shift+Tab still takes over — same observable behavior as before.

## Test plan

- [x] `yarn test --group popover --glob="a11y*"` — 66 passed
- [ ] Manual check in `dev/popover.html` after rearranging the popover to sit before the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)