### PR TITLE
fix: correct slider input event type to extend InputEvent

### DIFF
--- a/packages/slider/src/vaadin-range-slider.d.ts
+++ b/packages/slider/src/vaadin-range-slider.d.ts
@@ -19,7 +19,7 @@ export type RangeSliderChangeEvent = Event & {
 /**
  * Fired when the slider value changes during user interaction.
  */
-export type RangeSliderInputEvent = Event & {
+export type RangeSliderInputEvent = InputEvent & {
   target: RangeSlider;
 };
 

--- a/packages/slider/src/vaadin-slider.d.ts
+++ b/packages/slider/src/vaadin-slider.d.ts
@@ -19,7 +19,7 @@ export type SliderChangeEvent = Event & {
 /**
  * Fired when the slider value changes during user interaction.
  */
-export type SliderInputEvent = Event & {
+export type SliderInputEvent = InputEvent & {
   target: Slider;
 };
 


### PR DESCRIPTION
## Summary

- `SliderEventMap` / `RangeSliderEventMap` declare `input: Event & { target }`, but the extended `HTMLElementEventMap.input` is `InputEvent`. The narrower type drops `data`, `dataTransfer`, `inputType`, `isComposing`, and other `InputEvent` properties.
- TypeScript 5.9 silently accepts this, but newer compilers (TS 6.0) and modern IDEs flag it as TS2430: *Interface 'SliderEventMap' incorrectly extends interface 'HTMLElementEventMap'*.
- Fix: change `SliderInputEvent` / `RangeSliderInputEvent` to `InputEvent & { target }` so the event map remains a valid extension of `HTMLElementEventMap`.

## Test plan

- [ ] `yarn lint:types` passes
- [ ] IDE no longer reports TS2430 on `packages/slider/src/vaadin-slider.d.ts:49` or `vaadin-range-slider.d.ts:49`
- [ ] `slider.types.ts` / `range-slider.types.ts` typings tests still compile (they assert against `SliderInputEvent` / `RangeSliderInputEvent`, which remain assignable from the event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)