### PR TITLE
refactor!: remove no longer used grid-pro notify events

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -60,7 +60,6 @@ export const GridProEditColumnMixin = (superClass) =>
          */
         editorType: {
           type: String,
-          notify: true, // FIXME(web-padawan): needed by Flow counterpart
           value: 'text',
         },
 

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -28,7 +28,6 @@ export const InlineEditingMixin = (superClass) =>
          */
         enterNextRow: {
           type: Boolean,
-          notify: true, // FIXME(yuriy-fix): needed by Flow counterpart
         },
 
         /**
@@ -41,7 +40,6 @@ export const InlineEditingMixin = (superClass) =>
          */
         singleCellEdit: {
           type: Boolean,
-          notify: true, // FIXME(yuriy-fix): needed by Flow counterpart
         },
 
         /**


### PR DESCRIPTION
## Description

These events are no longer used by Flow component and excluded in React wrappers:

- https://github.com/vaadin/flow-components/pull/9187
- https://github.com/vaadin/react-components/pull/377

Also, these events are undocumented: no `@fires` annotation, no TS types.
There is no point in keeping them (they are basically useless), so let's remove them.

## Type of change

- Breaking change