### PR TITLE
fix: narrow hidden to boolean on grid column classes

### DIFF
--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts
@@ -29,7 +29,9 @@ export * from './vaadin-grid-pro-edit-column-mixin.js';
  *    ...
  * ```
  */
-declare class GridProEditColumn<TItem = GridDefaultItem> extends HTMLElement {}
+declare class GridProEditColumn<TItem = GridDefaultItem> extends HTMLElement {
+  hidden: boolean;
+}
 
 interface GridProEditColumn<TItem = GridDefaultItem>
   extends GridProEditColumnMixinClass<TItem>, GridColumnMixin<TItem, GridColumn<TItem>>, GridColumn<TItem> {}

--- a/packages/grid/src/vaadin-grid-column-group.d.ts
+++ b/packages/grid/src/vaadin-grid-column-group.d.ts
@@ -36,7 +36,9 @@ export * from './vaadin-grid-column-group-mixin.js';
  * column2.renderer = (root, column, model) => { ... };
  * ```
  */
-declare class GridColumnGroup extends HTMLElement {}
+declare class GridColumnGroup extends HTMLElement {
+  hidden: boolean;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface GridColumnGroup<TItem = GridDefaultItem> extends GridColumnGroupMixin<TItem, GridColumnGroup<TItem>> {}

--- a/packages/grid/src/vaadin-grid-column.d.ts
+++ b/packages/grid/src/vaadin-grid-column.d.ts
@@ -22,9 +22,12 @@ export type GridHeaderFooterRenderer<TItem = GridDefaultItem> = GridMixinHeaderF
  * See [`<vaadin-grid>`](#/elements/vaadin-grid) documentation for instructions on how
  * to configure the `<vaadin-grid-column>`.
  */
-declare class GridColumn<TItem = GridDefaultItem> extends HTMLElement {}
+declare class GridColumn<TItem = GridDefaultItem> extends HTMLElement {
+  hidden: boolean;
+}
 
-interface GridColumn<TItem = GridDefaultItem> extends GridColumnMixin<TItem, GridColumn<TItem>>, HTMLElement {}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface GridColumn<TItem = GridDefaultItem> extends GridColumnMixin<TItem, GridColumn<TItem>> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/grid/src/vaadin-grid-filter-column.d.ts
+++ b/packages/grid/src/vaadin-grid-filter-column.d.ts
@@ -22,7 +22,9 @@ export * from './vaadin-grid-filter-column-mixin.js';
  *    ...
  * ```
  */
-declare class GridFilterColumn<TItem = GridDefaultItem> extends HTMLElement {}
+declare class GridFilterColumn<TItem = GridDefaultItem> extends HTMLElement {
+  hidden: boolean;
+}
 
 interface GridFilterColumn<TItem = GridDefaultItem>
   extends GridFilterColumnMixinClass, GridColumnMixin<TItem, GridColumn<TItem>>, GridColumn<TItem> {}

--- a/packages/grid/src/vaadin-grid-selection-column.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column.d.ts
@@ -37,7 +37,9 @@ export * from './vaadin-grid-selection-column-mixin.js';
  *
  * @fires {CustomEvent} select-all-changed - Fired when the `selectAll` property changes.
  */
-declare class GridSelectionColumn<TItem = GridDefaultItem> extends HTMLElement {}
+declare class GridSelectionColumn<TItem = GridDefaultItem> extends HTMLElement {
+  hidden: boolean;
+}
 
 interface GridSelectionColumn<TItem = GridDefaultItem>
   extends GridSelectionColumnMixinClass<TItem>, GridColumnMixin<TItem, GridColumn<TItem>>, GridColumn<TItem> {

--- a/packages/grid/src/vaadin-grid-sort-column.d.ts
+++ b/packages/grid/src/vaadin-grid-sort-column.d.ts
@@ -24,7 +24,9 @@ export * from './vaadin-grid-sort-column-mixin.js';
  *
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  */
-declare class GridSortColumn<TItem = GridDefaultItem> extends HTMLElement {}
+declare class GridSortColumn<TItem = GridDefaultItem> extends HTMLElement {
+  hidden: boolean;
+}
 
 interface GridSortColumn<TItem = GridDefaultItem>
   extends GridSortColumnMixinClass, GridColumnMixin<TItem, GridColumn<TItem>>, GridColumn<TItem> {

--- a/packages/grid/src/vaadin-grid-tree-column.d.ts
+++ b/packages/grid/src/vaadin-grid-tree-column.d.ts
@@ -20,7 +20,9 @@ import type { GridTreeColumnMixinClass } from './vaadin-grid-tree-column-mixin.j
  *    ...
  * ```
  */
-declare class GridTreeColumn<TItem = GridDefaultItem> extends HTMLElement {}
+declare class GridTreeColumn<TItem = GridDefaultItem> extends HTMLElement {
+  hidden: boolean;
+}
 
 interface GridTreeColumn<TItem = GridDefaultItem>
   extends GridTreeColumnMixinClass<TItem>, GridColumnMixin<TItem, GridColumn<TItem>>, GridColumn<TItem> {}


### PR DESCRIPTION
## Summary

- `HTMLElement.hidden` in the DOM lib is typed as `boolean | \"until-found\"` to reflect the HTML spec's `beforematch` feature.
- Grid column classes use a `declare class X extends HTMLElement {} / interface X extends ColumnMixin<...>, HTMLElement {}` declaration-merging pattern, which forces TS to reconcile `HTMLElement.hidden: boolean | \"until-found\"` with the mixin's `hidden: boolean`. TS 5.9 silently accepts the mismatch; newer TS (6.0) flags it as `TS2320: Interface 'X' cannot simultaneously extend types 'HTMLElement' and 'GridColumnMixin<...>'` and IDEs already surface it.
- Grid's column logic does not support `\"until-found\"` (none of our runtime code handles a string value — it's boolean-coerced throughout `vaadin-grid-column-mixin.js`), so `hidden` should remain `boolean`.
- Fix: add an explicit `hidden: boolean` class-body override on each column class. This is a legal class-property narrowing of the HTMLElement base, matches the mixin's declaration, and resolves the merge conflict without changing the public API.
- `OverlayMixin` has the same `hidden: boolean` narrowing but uses the single-inheritance mixin-function pattern (`OverlayMixin(HTMLElement)`), which TS treats as a legal class override — so it's unaffected by this issue.

Affected files:
- `packages/grid/src/vaadin-grid-column.d.ts`
- `packages/grid/src/vaadin-grid-column-group.d.ts`
- `packages/grid/src/vaadin-grid-filter-column.d.ts`
- `packages/grid/src/vaadin-grid-selection-column.d.ts`
- `packages/grid/src/vaadin-grid-sort-column.d.ts`
- `packages/grid/src/vaadin-grid-tree-column.d.ts`
- `packages/grid-pro/src/vaadin-grid-pro-edit-column.d.ts`

## Test plan

- [ ] `yarn lint:types` passes on TS 5.9 (current project compiler)
- [ ] Verified locally that the TS2320/TS2344 errors on these files are gone when running `tsc` under TypeScript 6.0
- [ ] `packages/grid/test/typings/grid.types.ts` still asserts `assertType<boolean>(narrowedColumn.hidden)` — passes unchanged (the class-body type is `boolean`, matching the assertion)
- [ ] IDE no longer reports TS2320 on the affected `.d.ts` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)