### PR TITLE
chore: upgrade TypeScript to ^6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "stylelint": "^17.4.0",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-vaadin": "^1.0.0-alpha.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "resolutions": {
     "playwright": "^1.56.0"

--- a/test/types/global.d.ts
+++ b/test/types/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,17 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["esnext", "es2021", "DOM", "DOM.Iterable"],
+    "types": ["mocha"],
     "noEmit": true,
     "strict": true,
     // WARNING: Avoid enabling the `skipLibCheck` option as it disables type checking
     // for the components' type declarations (e.g packages/button/src/vaadin-button.d.ts).
     "skipLibCheck": false,
     "skipDefaultLibCheck": true,
+    "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["packages/**/test"]
+  "include": ["packages/**/test", "test"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10472,10 +10472,15 @@ typescript-eslint@8.50.0:
     "@typescript-eslint/typescript-estree" "8.50.0"
     "@typescript-eslint/utils" "8.50.0"
 
-"typescript@>=3 < 6", typescript@^5.9.3:
+"typescript@>=3 < 6":
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 typescript@~5.4.2:
   version "5.4.5"


### PR DESCRIPTION
## Summary

Upgrade TypeScript from `^5.9.3` to `^6.0.3` and adjust `tsconfig.json` so `yarn lint:types` runs cleanly under the new compiler.

### `tsconfig.json` changes

- **`moduleResolution: node` → `bundler`.** `node` (alias for `node10`) is deprecated in TS 6.0 and scheduled for removal in TS 7.0. `bundler` is the modern, permissive option and fits this monorepo's `web-dev-server` / rollup workflow.
  - `nodenext` was considered but breaks against the third-party `ol` (OpenLayers) library, whose shipped `.d.ts` files use relative imports without `.js` extensions (102 × TS2835) and whose `package.json` has no `exports` field for subpath imports like `ol/Map`, `ol/View`, `ol/layer/Tile`, etc. (20 × TS2307). Silencing those would require `skipLibCheck: true`, which the existing tsconfig comment explicitly warns against because it also stops type-checking our own component `.d.ts` files — the mechanism that caught the slider and grid bugs in #11558 and #11560.
- **Add `"types": ["mocha"]`.** TS 6.0 no longer implicitly picks up `@types/mocha` globals in this workspace layout, which otherwise surfaces ~1.5k spurious `describe` / `it` / `beforeEach` / `afterEach` errors across every test file.
- **Add `"allowImportingTsExtensions": true`.** The two themable-mixin test entry points (`post-finalize-styles-lit.test.ts`, `post-finalize-styles-polymer.test.ts`) keep an explicit `.ts` extension on their shared common import because they are bundled in-browser by esbuild, where the extension is needed for URL resolution. Valid alongside the existing `noEmit: true`.
- **Add ambient `declare module '*.css';` at `test/types/global.d.ts` and include the whole `test` folder.** Visual tests side-effect-import theme CSS (`@vaadin/aura/aura.css`, `@vaadin/vaadin-lumo-styles/src/props/index.css`, etc.); without the ambient declaration these produce 15 × TS2882 errors. Including the top-level `test/` folder (instead of a dedicated `types/` dir) also unblocks writing integration tests under `test/integration/` in TypeScript without further tsconfig changes.

### Context / prior PRs

This closes out work spun off while investigating an IDE-reported TS2430 on the slider:

- #11558 fixed the slider `SliderInputEvent` / `RangeSliderInputEvent` so they extend `InputEvent` rather than `Event` (TS 6.0 flagged this as an incorrect interface extension).
- #11560 fixed a similar class of bug in the grid column `.d.ts` files, where `hidden: boolean` conflicted with `HTMLElement.hidden: boolean | "until-found"` under the column declaration-merging pattern.

With those merged, this upgrade is the final piece.

## Test plan

- [ ] `yarn lint:types` passes cleanly under TS 6.0.3
- [ ] `yarn lint:js` still runs (note: `typescript-eslint` 8.50 declares a peer range of `<6.0.0`; it installs with a warning. Monitor for runtime issues — an eslint/typescript-eslint bump may be a follow-up)
- [ ] Spot-check an IDE using the workspace TypeScript: previously-flagged errors on slider and grid `.d.ts` files are gone
- [ ] Component type-checking is preserved (verify `skipLibCheck` is still `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
