### PR TITLE
fix: close expanded sub-menu when hovering a disabled item

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -407,6 +407,12 @@ export const ItemsMixin = (superClass) =>
           this._overlayElement.$.overlay.focus();
         }
       }
+
+      // Only reachable with `accessibleDisabledMenuItems` enabled (disabled
+      // items otherwise have `pointer-events: none` and never receive mouseover).
+      if (item && item.disabled) {
+        subMenu.close();
+      }
     }
 
     /** @protected */

--- a/packages/context-menu/test/accessible-disabled-menu-items.test.js
+++ b/packages/context-menu/test/accessible-disabled-menu-items.test.js
@@ -4,7 +4,7 @@ import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-context-menu.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
+import { activateItem, getMenuItems, getSubMenu, openMenu } from './helpers.js';
 
 describe('accessible disabled menu items', () => {
   let rootMenu, subMenu, target, items;
@@ -91,6 +91,26 @@ describe('accessible disabled menu items', () => {
     subMenu = getSubMenu(rootMenu);
     expect(subMenu.opened).to.be.false;
     expect(items[2].hasAttribute('expanded')).to.be.false;
+  });
+
+  it('should close expanded sibling sub-menu when hovering a disabled item', async () => {
+    rootMenu.close();
+    rootMenu.items = [
+      { text: 'Item 0', children: [{ text: 'SubItem 0' }] },
+      { text: 'Item 1', disabled: true },
+    ];
+    await nextRender();
+    await openMenu(target);
+    items = getMenuItems(rootMenu);
+
+    await openMenu(items[0]);
+    subMenu = getSubMenu(rootMenu);
+    expect(subMenu.opened).to.be.true;
+
+    activateItem(items[1]);
+    await nextRender();
+    expect(subMenu.opened).to.be.false;
+    expect(items[0].hasAttribute('expanded')).to.be.false;
   });
 
   it('should set --_vaadin-item-disabled-pointer-events on disabled item', () => {


### PR DESCRIPTION
## Description

When the `accessibleDisabledMenuItems` feature flag is enabled, disabled items get `pointer-events: auto` and start receiving mouseover events. The existing `__showSubMenu` mouseover handler ignored those events because of its `!item.disabled` guard, leaving any sibling's expanded sub-menu open while the cursor sat on a disabled item.

This change closes the sub-menu in that case so hovering a disabled item collapses the previously expanded sibling, matching the behavior for enabled items without children.

Follow-up to #11541 

## Type of change

- Bugfix