### PR TITLE
test: disable dashboard transitions in visual tests

### DIFF
--- a/packages/dashboard/test/visual/aura/dashboard.test.ts
+++ b/packages/dashboard/test/visual/aura/dashboard.test.ts
@@ -1,6 +1,7 @@
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../not-animated-styles.js';
 import '@vaadin/aura/aura.css';
 import '../../../vaadin-dashboard.js';
 import { html, render } from 'lit';

--- a/packages/dashboard/test/visual/not-animated-styles.js
+++ b/packages/dashboard/test/visual/not-animated-styles.js
@@ -1,0 +1,12 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+registerStyles(
+  'vaadin-dashboard-widget, vaadin-dashboard-section',
+  css`
+    :host,
+    [part='content'],
+    [part$='-button'] {
+      transition: none !important;
+    }
+  `,
+);


### PR DESCRIPTION
## Summary

- Adds `packages/dashboard/test/visual/not-animated-styles.js` to disable transitions on `vaadin-dashboard-widget` / `vaadin-dashboard-section` in visual tests.
- Imports it from the aura visual test file (the only theme that currently defines transitions on these parts).

The aura theme applies a 200ms `filter`/`opacity` transition on `[part='content']` when a widget enters resize/move mode, plus 120ms color transitions on the action buttons. The `resize mode` and `move mode` tests only `await nextFrame()` (~16ms) before taking the screenshot, so they were captured mid-transition. Disabling transitions makes those screenshots deterministic.

## Test plan

- [ ] `yarn test:aura --group dashboard` passes (and `resize mode` / `move mode` screenshots are stable across runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)