### PR TITLE
docs: type chart options getter with @type instead of @return

### DIFF
--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -380,7 +380,9 @@ export const ChartMixin = (superClass) =>
     }
 
     /**
-     * @return {!Options}
+     * Highcharts configuration object derived from the chart's reactive
+     * properties, base config, and `additionalOptions`.
+     * @type {!Options}
      */
     get options() {
       const options = { ...this._baseConfig };


### PR DESCRIPTION
## Summary

The `<vaadin-chart>` `options` getter in `vaadin-chart-mixin.js` was annotated with `@return {!Options}`. CEM (Custom Elements Manifest) reads `@type` JSDoc on getters but ignores `@return`, so the getter surfaced in `custom-elements.json` and the generated `web-types.json` as a public field with an empty type and empty description.

This PR:
- Switches the JSDoc tag to `@type {!Options}`.
- Adds a brief description so the property has meaningful metadata.

## Test plan

- [ ] `yarn release:cem` — `vaadin-chart.options` member has `description` and `type.text === '!Options'` in `packages/charts/custom-elements.json`
- [ ] `yarn release:web-types` (after rebasing the CEM migration PR on top of this) — `vaadin-chart.options` has the description and type set in `packages/charts/web-types.json`
- [ ] `yarn lint` and `yarn lint:types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)