### PR TITLE
docs: mark edit event in vaadin-crud-edit as internal to exclude from CEM

### DIFF
--- a/packages/crud/src/vaadin-crud-edit.js
+++ b/packages/crud/src/vaadin-crud-edit.js
@@ -51,6 +51,7 @@ class CrudEdit extends Button {
   /** @private */
   __onClick(e) {
     const tr = e.target.parentElement.assignedSlot.parentElement.parentElement;
+    /** @internal to not document it in CEM */
     tr.dispatchEvent(
       new CustomEvent('edit', { detail: { item: tr._item, index: tr.index }, bubbles: true, composed: true }),
     );


### PR DESCRIPTION
## Summary

`<vaadin-crud-edit>` is a row-level icon button that dispatches an `edit` event on the surrounding `<vaadin-grid>` row. `<vaadin-crud>` listens for it, calls `stopPropagation()`, and re-dispatches its own public `edit` event with a different shape. The internal event is not part of the public API of `<vaadin-crud-edit>` itself — consumers should subscribe to `<vaadin-crud>`'s public `edit` event instead.

This PR annotates the dispatch site with `/** @internal to not document it in CEM */` so the CEM analyzer's `eventsVisitor` (which honors `@internal` and `@ignore` JSDoc tags via `hasIgnoreJSDoc`) skips it.

Same approach as #11561 (dashboard `item-*-changed` events) and #11565 (`dashboard-root-heading-level-changed`).

## Test plan

- [ ] `yarn release:cem` — `vaadin-crud-edit` has empty `events` array
- [ ] `yarn release:cem` — `vaadin-crud` still emits the public `edit` event unchanged
- [ ] `yarn lint` and `yarn lint:types` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)