### PR TITLE
chore: mark internal focus/blur events with @internal JSDoc

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -12,8 +12,7 @@ const ignoredMembers = ['slotName', 'id'];
 
 // Events to exclude from CEM output:
 // - eventName: false positive from dynamic dispatchEvent calls (e.g., `new CustomEvent(eventName, ...)`)
-// - focus, blur: native events picked up by CEM without @fires annotations, not part of the public API
-const ignoredEvents = ['eventName', 'focus', 'blur'];
+const ignoredEvents = ['eventName'];
 
 const ignoredStaticMembers = [
   'is',

--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -152,6 +152,7 @@ export const DelegateFocusMixin = dedupeMixin(
        */
       _onFocus(event) {
         event.stopPropagation();
+        /** @internal to not document it in CEM */
         this.dispatchEvent(new Event('focus'));
       }
 
@@ -164,6 +165,7 @@ export const DelegateFocusMixin = dedupeMixin(
        */
       _onBlur(event) {
         event.stopPropagation();
+        /** @internal to not document it in CEM */
         this.dispatchEvent(new Event('blur'));
       }
 


### PR DESCRIPTION
## Summary

`DelegateFocusMixin` re-dispatches `focus` and `blur` events on the host element so consumers placing the focusable element in light DOM can listen via the host. These are native (non-bubbling) DOM events, not custom public API events — they are part of the standard `HTMLElement` event surface and should not be advertised separately in `custom-elements.json`, web-types, or React wrappers.

This PR moves the deny-listing from the global `ignoredEvents` array in `custom-elements-manifest.config.js` into source-level `/** @internal to not document it in CEM */` JSDoc on the two dispatch sites in `packages/a11y-base/src/delegate-focus-mixin.js`. The CEM analyzer's `eventsVisitor` already honors `@internal` / `@ignore` tags via `hasIgnoreJSDoc`.

Same approach as #11561 (dashboard `item-*-changed`) and #11577 (crud-edit `edit`) — keeps the deny list minimal and colocates the "internal" marker with the dispatch site.

## Test plan

- [ ] `yarn release:cem` — no `focus` or `blur` event appears in any per-package `custom-elements.json`
- [ ] `yarn lint` and `yarn lint:types` pass
- [ ] `yarn test --group a11y-base` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)