### PR TITLE
feat: add collapseChips property to multi-select-combo-box

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.d.ts
@@ -79,6 +79,14 @@ export declare class MultiSelectComboBoxMixinClass<TItem> {
   autoExpandVertically: boolean;
 
   /**
+   * Set to true to collapse all selected items chips into the overflow
+   * chip when they don't all fit, instead of showing as many as possible.
+   * Has no effect when `autoExpandVertically` is true.
+   * @attr {boolean} collapse-chips
+   */
+  collapseChips: boolean;
+
+  /**
    * When true, the user can input a value that is not present in the items list.
    * @attr {boolean} allow-custom-value
    */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -64,6 +64,19 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         },
 
         /**
+         * Set to true to collapse all selected items chips into the overflow
+         * chip when they don't all fit, instead of showing as many as possible.
+         * Has no effect when `autoExpandVertically` is true.
+         * @attr {boolean} collapse-chips
+         */
+        collapseChips: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+          sync: true,
+        },
+
+        /**
          * A function used to generate CSS class names for dropdown
          * items and selected chips based on the item. The return
          * value should be the generated class name as a string, or
@@ -346,6 +359,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       const chipProps = [
         'autoExpandHorizontally',
         'autoExpandVertically',
+        'collapseChips',
         'disabled',
         'readonly',
         'clearButtonVisible',
@@ -926,7 +940,9 @@ export const MultiSelectComboBoxMixin = (superClass) =>
 
       const inputWidth = parseInt(getComputedStyle(this.inputElement).flexBasis);
 
-      if (this.autoExpandHorizontally) {
+      if (this.collapseChips) {
+        this._overflowItems = this.__updateChipsCollapsed(this.selectedItems, inputWidth);
+      } else if (this.autoExpandHorizontally) {
         this._overflowItems = this.__updateChipsHorizontalExpand(this.selectedItems, inputWidth);
       } else {
         this._overflowItems = this.__updateChipsDefault(this.selectedItems, inputWidth);
@@ -934,15 +950,35 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     }
 
     /** @private */
-    __updateChipsHorizontalExpand(items, inputWidth) {
-      // Add all chips to make the field fully expand
+    __renderAllChips(items, inputWidth) {
       const chips = items.map((item) => {
         const chip = this.__createChip(item);
         this.appendChild(chip);
         return chip;
       });
 
-      if (this.__getWrapperWidth() - this.$.chips.clientWidth >= inputWidth) {
+      const allChipsFit = this.__getWrapperWidth() - this.$.chips.clientWidth >= inputWidth;
+      return { chips, allChipsFit };
+    }
+
+    /** @private */
+    __updateChipsCollapsed(items, inputWidth) {
+      const { chips, allChipsFit } = this.__renderAllChips(items, inputWidth);
+
+      if (allChipsFit) {
+        return [];
+      }
+
+      // Not enough space: remove all chips, collapse everything to overflow
+      chips.forEach((chip) => chip.remove());
+      return items.slice();
+    }
+
+    /** @private */
+    __updateChipsHorizontalExpand(items, inputWidth) {
+      const { chips, allChipsFit } = this.__renderAllChips(items, inputWidth);
+
+      if (allChipsFit) {
         return [];
       }
 

--- a/packages/multi-select-combo-box/test/chips.test.js
+++ b/packages/multi-select-combo-box/test/chips.test.js
@@ -507,6 +507,109 @@ describe('chips', () => {
     });
   });
 
+  describe('collapseChips', () => {
+    let overflow;
+
+    beforeEach(async () => {
+      comboBox.collapseChips = true;
+      comboBox.style.width = '250px';
+      await nextResize(comboBox);
+      overflow = getChips(comboBox)[0];
+    });
+
+    it('should show all chips when they all fit', async () => {
+      comboBox.selectedItems = ['apple'];
+      await nextRender();
+      const chips = getChips(comboBox);
+      expect(chips.length).to.equal(2);
+      expect(getChipContent(chips[1])).to.equal('apple');
+      expect(overflow.hasAttribute('hidden')).to.be.true;
+    });
+
+    it('should collapse all chips to overflow when they do not fit', async () => {
+      comboBox.selectedItems = ['apple', 'banana', 'orange'];
+      await nextRender();
+      const chips = getChips(comboBox);
+      expect(chips.length).to.equal(1);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+      expect(overflow.label).to.equal('3');
+      expect(overflow.getAttribute('title')).to.equal('apple, banana, orange');
+    });
+
+    it('should collapse chips when setting collapseChips to true', async () => {
+      comboBox.collapseChips = false;
+      comboBox.selectedItems = ['apple', 'banana', 'orange'];
+      await nextRender();
+      // Default mode: at least one chip visible + overflow
+      expect(getChips(comboBox).length).to.equal(2);
+
+      comboBox.collapseChips = true;
+      await nextRender();
+      expect(getChips(comboBox).length).to.equal(1);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should revert to default overflow when setting collapseChips to false', async () => {
+      comboBox.selectedItems = ['apple', 'banana', 'orange'];
+      await nextRender();
+      expect(getChips(comboBox).length).to.equal(1);
+
+      comboBox.collapseChips = false;
+      await nextRender();
+      expect(getChips(comboBox).length).to.equal(2);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should show chips when component is resized wider', async () => {
+      comboBox.selectedItems = ['apple', 'banana', 'orange'];
+      await nextRender();
+      expect(getChips(comboBox).length).to.equal(1);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+
+      comboBox.style.width = '500px';
+      await nextResize(comboBox);
+      expect(getChips(comboBox).length).to.equal(4);
+      expect(overflow.hasAttribute('hidden')).to.be.true;
+    });
+
+    it('should collapse chips when component is resized narrower', async () => {
+      comboBox.style.width = '500px';
+      await nextResize(comboBox);
+      comboBox.selectedItems = ['apple', 'banana', 'orange'];
+      await nextRender();
+      expect(getChips(comboBox).length).to.equal(4);
+
+      comboBox.style.width = '250px';
+      await nextResize(comboBox);
+      expect(getChips(comboBox).length).to.equal(1);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+    });
+
+    it('should collapse single item that does not fit', async () => {
+      comboBox.style.width = '100px';
+      await nextResize(comboBox);
+      comboBox.selectedItems = ['orange'];
+      await nextRender();
+      const chips = getChips(comboBox);
+      expect(chips.length).to.equal(1);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+      expect(overflow.label).to.equal('1');
+    });
+
+    it('should expand field and collapse when used with autoExpandHorizontally', async () => {
+      comboBox.autoExpandHorizontally = true;
+      comboBox.style.width = '';
+      comboBox.style.maxWidth = '300px';
+      await nextResize(comboBox);
+      comboBox.selectedItems = ['apple', 'banana', 'lemon', 'orange'];
+      await nextRender();
+      const chips = getChips(comboBox);
+      expect(chips.length).to.equal(1);
+      expect(overflow.hasAttribute('hidden')).to.be.false;
+      expect(overflow.label).to.equal('4');
+    });
+  });
+
   describe('autoExpandHorizontally', () => {
     let overflow;
 

--- a/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
+++ b/packages/multi-select-combo-box/test/typings/multi-select-combo-box.types.ts
@@ -111,6 +111,7 @@ assertType<string | null | undefined>(narrowedComboBox.label);
 assertType<boolean>(narrowedComboBox.required);
 assertType<boolean>(narrowedComboBox.selectedItemsOnTop);
 assertType<boolean>(narrowedComboBox.autoExpandVertically);
+assertType<boolean>(narrowedComboBox.collapseChips);
 
 // Mixins
 assertType<ComboBoxBaseMixinClass>(narrowedComboBox);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/flow-components/issues/8533

Added `collapseChips` boolean property. When set to true, all selected item chips collapse into the overflow chip if they don't all fit, instead of showing as many as possible.

## Type of change

- Feature