### PR TITLE
refactor: extract menu-bar tooltip handling into controller

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -15,7 +15,7 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
-import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
+import { MenuBarTooltipController } from './vaadin-menu-bar-tooltip-controller.js';
 
 /**
  * Custom Lit directive for rendering item components
@@ -206,7 +206,6 @@ export const MenuBarMixin = (superClass) =>
     constructor() {
       super();
       this.__boundOnContextMenuKeydown = this.__onContextMenuKeydown.bind(this);
-      this.__boundOnTooltipMouseLeave = this.__onTooltipOverlayMouseLeave.bind(this);
     }
 
     /**
@@ -262,6 +261,12 @@ export const MenuBarMixin = (superClass) =>
       return Array.from(this.querySelectorAll('vaadin-menu-bar-button'));
     }
 
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this._tooltipController.attachTo(null);
+    }
+
     /** @private */
     get _hasOverflow() {
       return this._overflow && !this._overflow.hasAttribute('hidden');
@@ -311,11 +316,10 @@ export const MenuBarMixin = (superClass) =>
         },
       });
 
-      this._tooltipController = new TooltipController(this);
-      this._tooltipController.setManual(true);
+      this._tooltipController = new MenuBarTooltipController(this);
 
-      this.addEventListener('mousedown', () => this._hideTooltip(true));
-      this.addEventListener('mouseleave', () => this._hideTooltip());
+      this.addEventListener('mousedown', () => this._tooltipController.close(true));
+      this.addEventListener('mouseleave', () => this._tooltipController.close());
 
       this.addController(this._tooltipController);
       this.addController(this._subMenuController);
@@ -367,12 +371,6 @@ export const MenuBarMixin = (superClass) =>
      */
     _getItems() {
       return this._buttons;
-    }
-
-    /** @protected */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-      this._hideTooltip(true);
     }
 
     /**
@@ -643,51 +641,6 @@ export const MenuBarMixin = (superClass) =>
       }
     }
 
-    /**
-     * @param {HTMLElement} button
-     * @protected
-     */
-    _showTooltip(button, isHover) {
-      // Check if there is a slotted vaadin-tooltip element.
-      const tooltip = this._tooltipController.node;
-      if (tooltip && tooltip.isConnected) {
-        // If the tooltip element doesn't have a generator assigned, use a default one
-        // that reads the `tooltip` property of an item.
-        if (tooltip.generator === undefined) {
-          tooltip.generator = ({ item }) => item && item.tooltip;
-        }
-
-        if (!tooltip._mouseLeaveListenerAdded) {
-          tooltip._overlayElement.addEventListener('mouseleave', this.__boundOnTooltipMouseLeave);
-          tooltip._mouseLeaveListenerAdded = true;
-        }
-
-        if (!this._subMenu.opened) {
-          this._tooltipController.setTarget(button);
-          this._tooltipController.setContext({ item: button.item });
-
-          // Trigger opening using the corresponding delay.
-          this._tooltipController.open({
-            hover: isHover,
-            focus: !isHover,
-          });
-        }
-      }
-    }
-
-    /** @protected */
-    _hideTooltip(immediate) {
-      this._tooltipController.setContext({ item: null });
-      this._tooltipController.close(immediate);
-    }
-
-    /** @private */
-    __onTooltipOverlayMouseLeave(event) {
-      if (event.relatedTarget !== this._tooltipController.target) {
-        this._hideTooltip();
-      }
-    }
-
     /** @protected */
     _setExpanded(button, expanded) {
       button.toggleAttribute('expanded', expanded);
@@ -715,24 +668,24 @@ export const MenuBarMixin = (superClass) =>
      * @protected
      * @override
      */
-    _focusItem(item, options, navigating) {
+    _focusItem(button, options, navigating) {
       const wasExpanded = navigating && this.focused === this._expandedButton;
       if (wasExpanded) {
         this._close();
       }
 
-      super._focusItem(item, options, navigating);
+      super._focusItem(button, options, navigating);
 
       this._buttons.forEach((btn) => {
-        this._setTabindex(btn, btn === item);
+        this._setTabindex(btn, btn === button);
       });
 
-      if (wasExpanded && item.item && item.item.children) {
-        this.__openSubMenu(item, true, { keepFocus: true });
-      } else if (item === this._overflow) {
-        this._hideTooltip();
+      this._tooltipController.attachTo(button);
+
+      if (wasExpanded && button.item && button.item.children) {
+        this.__openSubMenu(button, true, { keepFocus: true });
       } else {
-        this._showTooltip(item);
+        this._tooltipController.open({ trigger: 'focus' });
       }
     }
 
@@ -777,18 +730,19 @@ export const MenuBarMixin = (superClass) =>
      * @protected
      */
     _setFocused(focused) {
-      if (focused) {
-        const target = this.__getFocusTarget();
-        if (target) {
-          this._buttons.forEach((btn) => {
-            this._setTabindex(btn, btn === target);
-            if (btn === target && btn !== this._overflow && isKeyboardActive()) {
-              this._showTooltip(btn);
-            }
-          });
+      const target = focused ? this.__getFocusTarget() : null;
+      if (target) {
+        this._tooltipController.attachTo(target);
+
+        this._buttons.forEach((btn) => {
+          this._setTabindex(btn, btn === target);
+        });
+
+        if (isKeyboardActive()) {
+          this._tooltipController.open({ trigger: 'focus' });
         }
       } else {
-        this._hideTooltip();
+        this._tooltipController.close();
       }
     }
 
@@ -858,7 +812,7 @@ export const MenuBarMixin = (superClass) =>
         this._close(true);
       }
 
-      this._hideTooltip(true);
+      this._tooltipController.close(true);
     }
 
     /**
@@ -903,21 +857,16 @@ export const MenuBarMixin = (superClass) =>
       }
 
       const button = this._getButtonFromEvent(event);
-      if (!button) {
-        // Hide tooltip on mouseover to disabled button
-        this._hideTooltip();
-      } else if (button !== this._expandedButton) {
+      this._tooltipController.attachTo(button);
+
+      if (button && button !== this._expandedButton) {
         // Switch sub-menu when moving cursor over another button
         // with children, regardless of whether openOnHover is set.
         // If the button has no children, keep the sub-menu opened.
         if (button.item.children && (this.openOnHover || this._subMenu.opened)) {
           this.__openSubMenu(button, false);
-        }
-
-        if (button === this._overflow || (this.openOnHover && button.item.children)) {
-          this._hideTooltip();
         } else {
-          this._showTooltip(button, true);
+          this._tooltipController.open({ trigger: 'hover' });
         }
       }
     }
@@ -984,7 +933,7 @@ export const MenuBarMixin = (superClass) =>
       const overlay = subMenu._overlayElement;
       overlay.noVerticalOverlap = true;
 
-      this._hideTooltip(true);
+      this._tooltipController.close(true);
 
       this._expandedButton = button;
       this._setExpanded(button, true);

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -370,7 +370,7 @@ export const MenuBarMixin = (superClass) =>
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      this._tooltipController.attachTo(null);
+      this._tooltipController.setTarget(null);
     }
 
     /**
@@ -680,7 +680,7 @@ export const MenuBarMixin = (superClass) =>
         this._setTabindex(btn, btn === button);
       });
 
-      this._tooltipController.attachTo(button);
+      this._tooltipController.setTarget(button);
 
       if (wasExpanded && button.item && button.item.children) {
         this.__openSubMenu(button, true, { keepFocus: true });
@@ -732,7 +732,7 @@ export const MenuBarMixin = (superClass) =>
     _setFocused(focused) {
       const target = focused ? this.__getFocusTarget() : null;
       if (target) {
-        this._tooltipController.attachTo(target);
+        this._tooltipController.setTarget(target);
 
         this._buttons.forEach((btn) => {
           this._setTabindex(btn, btn === target);
@@ -857,7 +857,7 @@ export const MenuBarMixin = (superClass) =>
       }
 
       const button = this._getButtonFromEvent(event);
-      this._tooltipController.attachTo(button);
+      this._tooltipController.setTarget(button);
 
       if (button && button !== this._expandedButton) {
         // Switch sub-menu when moving cursor over another button

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -261,12 +261,6 @@ export const MenuBarMixin = (superClass) =>
       return Array.from(this.querySelectorAll('vaadin-menu-bar-button'));
     }
 
-    /** @protected */
-    disconnectedCallback() {
-      super.disconnectedCallback();
-      this._tooltipController.attachTo(null);
-    }
-
     /** @private */
     get _hasOverflow() {
       return this._overflow && !this._overflow.hasAttribute('hidden');
@@ -371,6 +365,12 @@ export const MenuBarMixin = (superClass) =>
      */
     _getItems() {
       return this._buttons;
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this._tooltipController.attachTo(null);
     }
 
     /**

--- a/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
@@ -5,16 +5,37 @@
  */
 import { SlotController } from '@vaadin/component-base/src/slot-controller';
 
+/**
+ * Controller for the tooltip slotted into a menu-bar. Configures the
+ * tooltip in manual mode and drives its target/context based on the
+ * currently hovered or focused button.
+ */
 export class MenuBarTooltipController extends SlotController {
   constructor(host) {
     super(host, 'tooltip');
   }
 
+  /**
+   * Initialize the slotted tooltip: switch it to manual mode and
+   * provide a default generator that reads the `tooltip` property
+   * of the menu-bar item.
+   *
+   * @param {HTMLElement} tooltipNode
+   * @protected
+   * @override
+   */
   initCustomNode(tooltipNode) {
     tooltipNode.manual = true;
     tooltipNode.generator = tooltipNode.generator || (({ item }) => item && item.tooltip);
   }
 
+  /**
+   * Attach the tooltip to the given button. When the button has no
+   * tooltip text (or is `null`), clears the target/context and closes
+   * the tooltip immediately.
+   *
+   * @param {HTMLElement | null} target
+   */
   attachTo(target) {
     const tooltipNode = this.node;
     if (!tooltipNode) {
@@ -32,6 +53,11 @@ export class MenuBarTooltipController extends SlotController {
     tooltipNode.context = { item: target.item };
   }
 
+  /**
+   * Schedule opening the tooltip. No-op when no target is attached.
+   *
+   * @param {{ trigger: 'hover' | 'focus' }} options
+   */
   open({ trigger }) {
     const tooltipNode = this.node;
     if (tooltipNode && tooltipNode.isConnected && tooltipNode.target) {
@@ -42,7 +68,12 @@ export class MenuBarTooltipController extends SlotController {
     }
   }
 
-  /** @protected */
+  /**
+   * Schedule closing the tooltip, respecting the configured hide delay
+   * unless `immediate` is true.
+   *
+   * @param {boolean} [immediate]
+   */
   close(immediate) {
     const tooltipNode = this.node;
     if (tooltipNode) {

--- a/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotController } from '@vaadin/component-base/src/slot-controller';
+
+export class MenuBarTooltipController extends SlotController {
+  constructor(host) {
+    super(host, 'tooltip');
+  }
+
+  initCustomNode(tooltipNode) {
+    tooltipNode.manual = true;
+    tooltipNode.generator = tooltipNode.generator || (({ item }) => item && item.tooltip);
+  }
+
+  attachTo(target) {
+    const tooltipNode = this.node;
+    if (!tooltipNode) {
+      return;
+    }
+
+    if (!target || !target.item || !target.item.tooltip) {
+      tooltipNode.target = null;
+      tooltipNode.context = { item: null };
+      tooltipNode._stateController.close(true);
+      return;
+    }
+
+    tooltipNode.target = target;
+    tooltipNode.context = { item: target.item };
+  }
+
+  open({ trigger }) {
+    const tooltipNode = this.node;
+    if (tooltipNode && tooltipNode.isConnected && tooltipNode.target) {
+      tooltipNode._stateController.open({
+        hover: trigger === 'hover',
+        focus: trigger === 'focus',
+      });
+    }
+  }
+
+  /** @protected */
+  close(immediate) {
+    const tooltipNode = this.node;
+    if (tooltipNode) {
+      tooltipNode._stateController.close(immediate);
+    }
+  }
+}

--- a/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
@@ -1,9 +1,9 @@
 /**
  * @license
- * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { SlotController } from '@vaadin/component-base/src/slot-controller';
+import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
 /**
  * Controller for the tooltip slotted into a menu-bar. Configures the
@@ -30,13 +30,13 @@ export class MenuBarTooltipController extends SlotController {
   }
 
   /**
-   * Attach the tooltip to the given button. When the button has no
+   * Set the tooltip target to the given button. When the button has no
    * tooltip text (or is `null`), clears the target/context and closes
    * the tooltip immediately.
    *
    * @param {HTMLElement | null} target
    */
-  attachTo(target) {
+  setTarget(target) {
     const tooltipNode = this.node;
     if (!tooltipNode) {
       return;

--- a/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
@@ -24,7 +24,7 @@ export class MenuBarTooltipController extends SlotController {
     if (!target || !target.item || !target.item.tooltip) {
       tooltipNode.target = null;
       tooltipNode.context = { item: null };
-      tooltipNode._stateController.close(true);
+      this.close(true);
       return;
     }
 

--- a/test/integration/menu-bar-tooltip.test.js
+++ b/test/integration/menu-bar-tooltip.test.js
@@ -100,7 +100,7 @@ describe('menu-bar with tooltip', () => {
     it('should show tooltip again on menu bar button mouseover', () => {
       mouseover(buttons[0]);
       mouseover(menuBar._container);
-      mouseover(buttons[1]);
+      mouseover(buttons[2]);
       expect(tooltip.opened).to.be.true;
     });
 
@@ -117,8 +117,8 @@ describe('menu-bar with tooltip', () => {
 
     it('should change tooltip context on another menu button mouseover', () => {
       mouseover(buttons[0]);
-      mouseover(buttons[1]);
-      expect(tooltip.context.item.text).to.equal('Share');
+      mouseover(buttons[2]);
+      expect(tooltip.context.item.text).to.equal('Move');
     });
 
     it('should hide tooltip on menu button mousedown', () => {
@@ -191,17 +191,11 @@ describe('menu-bar with tooltip', () => {
       expect(tooltip.opened).to.be.false;
     });
 
-    it('should not set tooltip properties if there is no tooltip', async () => {
-      const spyTarget = sinon.spy(menuBar._tooltipController, 'setTarget');
-      const spyContent = sinon.spy(menuBar._tooltipController, 'setContext');
-
+    it('should not throw when there is no tooltip', async () => {
       tooltip.remove();
       await nextRender();
 
-      mouseover(buttons[0]);
-
-      expect(spyTarget.called).to.be.false;
-      expect(spyContent.called).to.be.false;
+      expect(() => mouseover(buttons[0])).to.not.throw();
     });
 
     it('should not override a custom generator', () => {
@@ -235,9 +229,10 @@ describe('menu-bar with tooltip', () => {
       });
 
       it('should close tooltip on overflow button keyboard navigation', () => {
+        mouseover(buttons[0]);
+        expect(tooltip.opened).to.be.true;
         buttons[0].focus();
         arrowRight(buttons[0]);
-        expect(tooltip.opened).to.be.true;
         arrowRight(buttons[1]);
         expect(tooltip.opened).to.be.false;
       });

--- a/test/integration/menu-bar-tooltip.test.js
+++ b/test/integration/menu-bar-tooltip.test.js
@@ -204,6 +204,17 @@ describe('menu-bar with tooltip', () => {
       expect(tooltip.textContent).to.equal('Custom tooltip');
     });
 
+    // https://github.com/vaadin/web-components/issues/4781
+    it('should set aria-describedby on a menu button with tooltip', () => {
+      mouseover(buttons[0]);
+      expect(buttons[0].hasAttribute('aria-describedby')).to.be.true;
+    });
+
+    it('should not set aria-describedby on a menu button without tooltip', () => {
+      mouseover(buttons[1]);
+      expect(buttons[1].hasAttribute('aria-describedby')).to.be.false;
+    });
+
     describe('overflow button', () => {
       beforeEach(async () => {
         // Reduce the width by the width of the last visible button


### PR DESCRIPTION
## Description

Introduces `MenuBarTooltipController`, a dedicated controller that encapsulates the tooltip wiring previously spread across the menu-bar mixin (`_showTooltip`, `_hideTooltip`, the manual mouseleave listener, and `setTarget`/`setContext` calls).

The controller exposes a small API surface area — `setTarget`, `open`, `close` — and decides on its own whether the current button has a tooltip to show. As a result, the mixin no longer needs special-case branches for the overflow button or items without `tooltip` text, and only sets the tooltip target when a tooltip would actually be displayed.

Part of https://github.com/vaadin/web-components/issues/10415 and fixes https://github.com/vaadin/web-components/issues/4781 along the way

## Type of change

- Refactor