### PR TITLE
test: stabilize grid-sorter visual tests by disabling indicator color transition

### DIFF
--- a/packages/grid/test/visual/aura/grid.test.js
+++ b/packages/grid/test/visual/aura/grid.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/aura/aura.css';
+import '../not-animated-styles.js';
 import '../../../vaadin-grid.js';
 import { flushGrid } from '../../helpers.js';
 import { users } from '../users.js';

--- a/packages/grid/test/visual/base/grid.test.js
+++ b/packages/grid/test/visual/base/grid.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../not-animated-styles.js';
 import '../../../src/vaadin-grid.js';
 import '../../../src/vaadin-grid-column-group.js';
 import '../../../src/vaadin-grid-selection-column.js';

--- a/packages/grid/test/visual/lumo/grid.test.js
+++ b/packages/grid/test/visual/lumo/grid.test.js
@@ -5,6 +5,7 @@ import '@vaadin/vaadin-lumo-styles/components/grid.css';
 import '@vaadin/vaadin-lumo-styles/components/grid-selection-column.css';
 import '@vaadin/vaadin-lumo-styles/components/grid-sort-column.css';
 import '@vaadin/vaadin-lumo-styles/components/grid-tree-column.css';
+import '../not-animated-styles.js';
 import '../../../vaadin-grid.js';
 import '../../../vaadin-grid-column-group.js';
 import '../../../vaadin-grid-selection-column.js';

--- a/packages/grid/test/visual/not-animated-styles.js
+++ b/packages/grid/test/visual/not-animated-styles.js
@@ -1,0 +1,16 @@
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+// Aura defines `transition: color 120ms` on
+// vaadin-grid-sorter::part(indicators)
+// (packages/aura/src/components/grid.css:14-16). The sort visual tests
+// click sorters to toggle direction, which flips the indicator colour
+// and races the screenshot. Suppress the transition so captures land
+// at the fully-applied colour deterministically.
+registerStyles(
+  'vaadin-grid-sorter',
+  css`
+    [part='indicators'] {
+      transition: none !important;
+    }
+  `,
+);


### PR DESCRIPTION
## Summary

Aura defines `transition: color 120ms` on `vaadin-grid-sorter::part(indicators)` (`packages/aura/src/components/grid.css:14-16`). Whenever a sorter's `direction` flips (none → asc → desc → none), the indicator colour ramps over 120 ms. Tests that programmatically click sorters and capture immediately could land mid-ramp under different Playwright versions. Lumo and base have no comparable transition.

## Changes

- New `packages/grid/test/visual/not-animated-styles.js` registering `[part='indicators'] { transition: none !important }` for `vaadin-grid-sorter`.
- Imported from all three themes' `grid.test.js` (aura, lumo, base).

`!important` is required because Aura is adopted into `adoptedStyleSheets` after `registerStyles`, and both rules sit at specificity 0,1,0.

## Baseline impact

**Zero baselines shifted across all 4 configs (aura default, aura dark, lumo, base).** This is purely defensive coverage:

- The Aura grid visual test (`packages/grid/test/visual/aura/grid.test.js`) doesn't exercise sorting — only `basic`, `column-borders`, `no-row-borders`, `selected-row`. None of these flip a sorter direction.
- Lumo and base grid tests share `grid.common.js` which does include sorting tests, but they use Lumo / base styling — neither has a sorter colour transition (Lumo's `vaadin-lumo-styles/src/components/grid-sorter.css` and base's `vaadin-grid-sorter-base-styles.js` define no transition).

The fix protects against a future test that adds sort interactions to the Aura grid visual test (or against a future Aura theme update that adds more transitions to the sorter).

## Test plan

- [x] Two consecutive 4-config sweeps in Docker leave all grid baselines byte-identical to main.
- [x] `yarn test:{aura,aura:dark,lumo,base} --group grid` — all pass.
- [ ] CI visual-tests workflow stays green.

Same cascade-order pattern as #11587/#11588/#11591/#11595/#11598/#11599/#11600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)