### PR TITLE
feat: add fixed row height support to dashboard

### DIFF
--- a/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.d.ts
+++ b/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.d.ts
@@ -10,4 +10,6 @@
  */
 import type { CSSResult } from 'lit';
 
+export const widgetFixedHeightDeclarations: CSSResult;
+
 export const dashboardLayoutStyles: CSSResult;

--- a/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
@@ -56,13 +56,13 @@ export const dashboardLayoutStyles = css`
 
     /* Default row min height */
     --_default-row-min-height: 12em;
-    /* Effective row min height. A fixed row height takes precedence so it acts as the track min as well */
+    /* Effective row min height. A fixed row height takes precedence so the parent track also collapses to it. */
     --_row-min-height: var(
       --vaadin-dashboard-row-height,
       var(--vaadin-dashboard-row-min-height, var(--_default-row-min-height))
     );
-    /* Effective row height for nested rows (e.g. inside sections). Fixed when --vaadin-dashboard-row-height is set, otherwise grows from min height */
-    --_row-height: var(--vaadin-dashboard-row-height, minmax(var(--_row-min-height, auto), auto));
+    /* Effective row height */
+    --_row-height: minmax(var(--_row-min-height, auto), auto);
 
     display: grid;
     overflow: hidden;
@@ -73,8 +73,7 @@ export const dashboardLayoutStyles = css`
       minmax(var(--_col-min-width), var(--_col-max-width))
     );
 
-    /* Always allow rows to grow so that sections can expand to wrap multiple sub-rows. Widgets are kept at the fixed row height via max-height (see ::slotted below and the widget host styles). */
-    grid-auto-rows: minmax(var(--_row-min-height, auto), auto);
+    grid-auto-rows: var(--_row-height);
   }
 
   ::slotted(*) {
@@ -88,11 +87,13 @@ export const dashboardLayoutStyles = css`
     grid-row: var(--_item-row);
   }
 
-  /* Cap the height when a fixed row height is set, so the track does not grow beyond it. When --vaadin-dashboard-row-height is unset, --_row-height resolves to a minmax() expression which is invalid in calc(), so max-height falls back to none. Sections are excluded so they can grow to wrap multiple sub-rows. */
+  /* Pin slotted children to the fixed row height when one is set, so the parent track does not grow beyond it. Split into min/max so an inline style.height cannot override the cap. When --vaadin-dashboard-row-height is unset the calc is invalid and both fall back to their initial values (auto / none). Sections are excluded so they can grow to wrap multiple sub-rows. */
   ::slotted(:not(vaadin-dashboard-section)) {
-    max-height: calc(
-      var(--vaadin-dashboard-widget-rowspan, 1) * var(--_row-height) + (var(--vaadin-dashboard-widget-rowspan, 1) - 1) *
-        var(--_gap)
+    --_widget-fixed-height: calc(
+      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
+        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
     );
+    min-height: var(--_widget-fixed-height);
+    max-height: var(--_widget-fixed-height);
   }
 `;

--- a/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
@@ -56,10 +56,13 @@ export const dashboardLayoutStyles = css`
 
     /* Default row min height */
     --_default-row-min-height: 12em;
-    /* Effective row min height */
-    --_row-min-height: var(--vaadin-dashboard-row-min-height, var(--_default-row-min-height));
-    /* Effective row height */
-    --_row-height: minmax(var(--_row-min-height, auto), auto);
+    /* Effective row min height. A fixed row height takes precedence so it acts as the track min as well */
+    --_row-min-height: var(
+      --vaadin-dashboard-row-height,
+      var(--vaadin-dashboard-row-min-height, var(--_default-row-min-height))
+    );
+    /* Effective row height for nested rows (e.g. inside sections). Fixed when --vaadin-dashboard-row-height is set, otherwise grows from min height */
+    --_row-height: var(--vaadin-dashboard-row-height, minmax(var(--_row-min-height, auto), auto));
 
     display: grid;
     overflow: hidden;
@@ -70,7 +73,8 @@ export const dashboardLayoutStyles = css`
       minmax(var(--_col-min-width), var(--_col-max-width))
     );
 
-    grid-auto-rows: var(--_row-height);
+    /* Always allow rows to grow so that sections can expand to wrap multiple sub-rows. Widgets are kept at the fixed row height via max-height (see ::slotted below and the widget host styles). */
+    grid-auto-rows: minmax(var(--_row-min-height, auto), auto);
   }
 
   ::slotted(*) {
@@ -82,5 +86,13 @@ export const dashboardLayoutStyles = css`
     /* The grid-row value applied to children */
     --_item-row: span var(--vaadin-dashboard-widget-rowspan, 1);
     grid-row: var(--_item-row);
+  }
+
+  /* Cap the height when a fixed row height is set, so the track does not grow beyond it. When --vaadin-dashboard-row-height is unset, --_row-height resolves to a minmax() expression which is invalid in calc(), so max-height falls back to none. Sections are excluded so they can grow to wrap multiple sub-rows. */
+  ::slotted(:not(vaadin-dashboard-section)) {
+    max-height: calc(
+      var(--vaadin-dashboard-widget-rowspan, 1) * var(--_row-height) + (var(--vaadin-dashboard-widget-rowspan, 1) - 1) *
+        var(--_gap)
+    );
   }
 `;

--- a/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
@@ -9,7 +9,28 @@
  * license.
  */
 import '@vaadin/component-base/src/styles/style-props.js';
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+
+/**
+ * Declarations that pin the host or slotted element to the fixed
+ * `--vaadin-dashboard-row-height` (scaled by `--vaadin-dashboard-widget-rowspan` and the
+ * inter-row `--_gap`). Imported by the widget host and the section's slotted rule
+ * because the calc must live on each capped element so `var(--vaadin-dashboard-widget-rowspan)`
+ * resolves against that element's own context.
+ *
+ * When `--vaadin-dashboard-row-height` is unset the calc is invalid, so the variable is
+ * the guaranteed-invalid value and both `min-height` and `max-height` fall back to their
+ * initial values (`auto` / `none`) — no cap, and inline heights work normally outside
+ * the feature.
+ */
+export const widgetFixedHeightDeclarations = unsafeCSS`
+    --_widget-fixed-height: calc(
+      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
+        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
+    );
+    min-height: var(--_widget-fixed-height);
+    max-height: var(--_widget-fixed-height);
+`;
 
 export const dashboardLayoutStyles = css`
   :host {
@@ -57,10 +78,8 @@ export const dashboardLayoutStyles = css`
     /* Default row min height */
     --_default-row-min-height: 12em;
     /* Effective row min height. A fixed row height takes precedence so the parent track also collapses to it. */
-    --_row-min-height: var(
-      --vaadin-dashboard-row-height,
-      var(--vaadin-dashboard-row-min-height, var(--_default-row-min-height))
-    );
+    /* prettier-ignore */
+    --_row-min-height: var(--vaadin-dashboard-row-height, var(--vaadin-dashboard-row-min-height, var(--_default-row-min-height)));
     /* Effective row height */
     --_row-height: minmax(var(--_row-min-height, auto), auto);
 
@@ -87,13 +106,8 @@ export const dashboardLayoutStyles = css`
     grid-row: var(--_item-row);
   }
 
-  /* Pin slotted children to the fixed row height when one is set, so the parent track does not grow beyond it. Split into min/max so an inline style.height cannot override the cap. When --vaadin-dashboard-row-height is unset the calc is invalid and both fall back to their initial values (auto / none). Sections are excluded so they can grow to wrap multiple sub-rows. */
+  /* Pin slotted children to the fixed row height when one is set. Sections are excluded so they can grow to wrap multiple sub-rows. */
   ::slotted(:not(vaadin-dashboard-section)) {
-    --_widget-fixed-height: calc(
-      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
-        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
-    );
-    min-height: var(--_widget-fixed-height);
-    max-height: var(--_widget-fixed-height);
+    ${widgetFixedHeightDeclarations};
   }
 `;

--- a/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-layout-base-styles.js
@@ -18,18 +18,20 @@ import { css, unsafeCSS } from 'lit';
  * because the calc must live on each capped element so `var(--vaadin-dashboard-widget-rowspan)`
  * resolves against that element's own context.
  *
- * When `--vaadin-dashboard-row-height` is unset the calc is invalid, so the variable is
- * the guaranteed-invalid value and both `min-height` and `max-height` fall back to their
- * initial values (`auto` / `none`) — no cap, and inline heights work normally outside
- * the feature.
+ * The cap is `!important` so an inline `min-height`/`max-height` on a widget can't widen
+ * the cell beyond the row height. When `--vaadin-dashboard-row-height` is unset the calc
+ * is invalid, the property becomes invalid at computed value time and falls back to its
+ * initial value (`auto` for `min-height`, `none` for `max-height`) — these initial values
+ * are still applied with `!important`, so an inline `min-height`/`max-height` on a widget
+ * is a no-op even when no fixed row height is configured. See the variable's docs.
  */
 export const widgetFixedHeightDeclarations = unsafeCSS`
     --_widget-fixed-height: calc(
       var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
         (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
     );
-    min-height: var(--_widget-fixed-height);
-    max-height: var(--_widget-fixed-height);
+    min-height: var(--_widget-fixed-height) !important;
+    max-height: var(--_widget-fixed-height) !important;
 `;
 
 export const dashboardLayoutStyles = css`

--- a/packages/dashboard/src/styles/vaadin-dashboard-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-section-base-styles.js
@@ -10,6 +10,7 @@
  */
 import '@vaadin/component-base/src/styles/style-props.js';
 import { css } from 'lit';
+import { widgetFixedHeightDeclarations } from './vaadin-dashboard-layout-base-styles.js';
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-widget-section-base-styles.js';
 
 const sectionStyles = css`
@@ -42,14 +43,9 @@ const sectionStyles = css`
     grid-row: var(--_item-row);
   }
 
-  /* Mirror the layout's cap so non-widget children inside a section also stay pinned to the fixed row height. The calc must live on each slotted element so it picks up that element's --vaadin-dashboard-widget-rowspan. Sections nested inside a section are excluded so they can still grow. */
+  /* Mirror the layout's cap so non-widget children inside a section also stay pinned to the fixed row height. Sections nested inside a section are excluded so they can still grow. */
   ::slotted(:not(vaadin-dashboard-section)) {
-    --_widget-fixed-height: calc(
-      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
-        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
-    );
-    min-height: var(--_widget-fixed-height);
-    max-height: var(--_widget-fixed-height);
+    ${widgetFixedHeightDeclarations};
   }
 
   header {

--- a/packages/dashboard/src/styles/vaadin-dashboard-section-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-section-base-styles.js
@@ -42,6 +42,16 @@ const sectionStyles = css`
     grid-row: var(--_item-row);
   }
 
+  /* Mirror the layout's cap so non-widget children inside a section also stay pinned to the fixed row height. The calc must live on each slotted element so it picks up that element's --vaadin-dashboard-widget-rowspan. Sections nested inside a section are excluded so they can still grow. */
+  ::slotted(:not(vaadin-dashboard-section)) {
+    --_widget-fixed-height: calc(
+      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
+        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
+    );
+    min-height: var(--_widget-fixed-height);
+    max-height: var(--_widget-fixed-height);
+  }
+
   header {
     grid-column: var(--_section-column);
   }

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -10,6 +10,7 @@
  */
 import '@vaadin/component-base/src/styles/style-props.js';
 import { css } from 'lit';
+import { widgetFixedHeightDeclarations } from './vaadin-dashboard-layout-base-styles.js';
 import { dashboardWidgetAndSectionStyles } from './vaadin-dashboard-widget-section-base-styles.js';
 
 const widgetStyles = css`
@@ -24,13 +25,8 @@ const widgetStyles = css`
     box-shadow: var(--_widget-shadow);
     border: var(--_widget-border-width) solid var(--_widget-border-color);
 
-    /* Pin to the fixed row height when one is set, so the parent track does not grow beyond it. Split into min/max so an inline style.height cannot override the cap. When --vaadin-dashboard-row-height is unset the calc is invalid and both fall back to their initial values (auto / none). */
-    --_widget-fixed-height: calc(
-      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
-        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
-    );
-    min-height: var(--_widget-fixed-height);
-    max-height: var(--_widget-fixed-height);
+    /* Pin to the fixed row height when one is set. The widget host's own definition is needed so widgets nested inside sections in vaadin-dashboard-layout (where the layout-level cap doesn't reach) still get capped. */
+    ${widgetFixedHeightDeclarations};
   }
 
   :host([hidden]) {

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -23,6 +23,11 @@ const widgetStyles = css`
     border-radius: var(--_widget-border-radius);
     box-shadow: var(--_widget-shadow);
     border: var(--_widget-border-width) solid var(--_widget-border-color);
+    /* Cap the height when a fixed row height is set so the track does not grow beyond it. When --vaadin-dashboard-row-height is unset, --_row-height resolves to a minmax() expression which is invalid in calc(), so max-height falls back to none. */
+    max-height: calc(
+      var(--vaadin-dashboard-widget-rowspan, 1) * var(--_row-height) + (var(--vaadin-dashboard-widget-rowspan, 1) - 1) *
+        var(--_gap)
+    );
   }
 
   :host([hidden]) {

--- a/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
+++ b/packages/dashboard/src/styles/vaadin-dashboard-widget-base-styles.js
@@ -23,11 +23,14 @@ const widgetStyles = css`
     border-radius: var(--_widget-border-radius);
     box-shadow: var(--_widget-shadow);
     border: var(--_widget-border-width) solid var(--_widget-border-color);
-    /* Cap the height when a fixed row height is set so the track does not grow beyond it. When --vaadin-dashboard-row-height is unset, --_row-height resolves to a minmax() expression which is invalid in calc(), so max-height falls back to none. */
-    max-height: calc(
-      var(--vaadin-dashboard-widget-rowspan, 1) * var(--_row-height) + (var(--vaadin-dashboard-widget-rowspan, 1) - 1) *
-        var(--_gap)
+
+    /* Pin to the fixed row height when one is set, so the parent track does not grow beyond it. Split into min/max so an inline style.height cannot override the cap. When --vaadin-dashboard-row-height is unset the calc is invalid and both fall back to their initial values (auto / none). */
+    --_widget-fixed-height: calc(
+      var(--vaadin-dashboard-widget-rowspan, 1) * var(--vaadin-dashboard-row-height) +
+        (var(--vaadin-dashboard-widget-rowspan, 1) - 1) * var(--_gap)
     );
+    min-height: var(--_widget-fixed-height);
+    max-height: var(--_widget-fixed-height);
   }
 
   :host([hidden]) {

--- a/packages/dashboard/src/vaadin-dashboard-layout.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-layout.d.ts
@@ -34,6 +34,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the layout
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the layout
  * `--vaadin-dashboard-row-min-height` | minimum row height of the layout
+ * `--vaadin-dashboard-row-height`     | fixed row height of the layout. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the layout
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard-layout.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard-layout.d.ts
@@ -34,7 +34,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the layout
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the layout
  * `--vaadin-dashboard-row-min-height` | minimum row height of the layout
- * `--vaadin-dashboard-row-height`     | fixed row height of the layout. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
+ * `--vaadin-dashboard-row-height`     | fixed row height of the layout. Must be in length units. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the layout
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -39,7 +39,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the layout
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the layout
  * `--vaadin-dashboard-row-min-height` | minimum row height of the layout
- * `--vaadin-dashboard-row-height`     | fixed row height of the layout. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
+ * `--vaadin-dashboard-row-height`     | fixed row height of the layout. Must be in length units. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the layout
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -39,6 +39,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the layout
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the layout
  * `--vaadin-dashboard-row-min-height` | minimum row height of the layout
+ * `--vaadin-dashboard-row-height`     | fixed row height of the layout. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the layout
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -211,6 +211,7 @@ export interface DashboardI18n {
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the dashboard
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the dashboard
  * `--vaadin-dashboard-row-min-height` | minimum row height of the dashboard
+ * `--vaadin-dashboard-row-height`     | fixed row height of the dashboard. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the dashboard
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -211,7 +211,7 @@ export interface DashboardI18n {
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the dashboard
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the dashboard
  * `--vaadin-dashboard-row-min-height` | minimum row height of the dashboard
- * `--vaadin-dashboard-row-height`     | fixed row height of the dashboard. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
+ * `--vaadin-dashboard-row-height`     | fixed row height of the dashboard. Must be in length units. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the dashboard
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -79,6 +79,7 @@ const DEFAULT_I18N = getDefaultI18n();
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the dashboard
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the dashboard
  * `--vaadin-dashboard-row-min-height` | minimum row height of the dashboard
+ * `--vaadin-dashboard-row-height`     | fixed row height of the dashboard. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the dashboard
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -79,7 +79,7 @@ const DEFAULT_I18N = getDefaultI18n();
  * `--vaadin-dashboard-col-min-width`  | minimum column width of the dashboard
  * `--vaadin-dashboard-col-max-width`  | maximum column width of the dashboard
  * `--vaadin-dashboard-row-min-height` | minimum row height of the dashboard
- * `--vaadin-dashboard-row-height`     | fixed row height of the dashboard. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content, allowing widget content to use 100% height
+ * `--vaadin-dashboard-row-height`     | fixed row height of the dashboard. Must be in length units. Overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit content
  * `--vaadin-dashboard-col-max-count`  | maximum column count of the dashboard
  * `--vaadin-dashboard-gap`            | gap between child elements. Must be in length units (0 is not allowed, 0px is)
  * `--vaadin-dashboard-padding`        | space around the dashboard's outer edges. Must be in length units (0 is not allowed, 0px is)

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -18,6 +18,7 @@ import {
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
+  setRowHeight,
   setRowspan,
   setSpacing,
 } from './helpers.js';
@@ -216,6 +217,80 @@ describe('dashboard layout', () => {
       setMinimumRowHeight(dashboard, rowHeight);
       await nextResize(dashboard);
       expect(getRowHeights(dashboard)).to.eql([rowHeight, rowHeight]);
+    });
+  });
+
+  describe('fixed row height', () => {
+    const rowHeight = 100;
+
+    it('should set a fixed row height', async () => {
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(getRowHeights(dashboard)).to.eql([rowHeight]);
+    });
+
+    it('should not grow rows to fit larger content', async () => {
+      childElements[0].style.height = `${rowHeight * 2}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(getRowHeights(dashboard)).to.eql([rowHeight]);
+    });
+
+    it('should use fixed row height for all rows', async () => {
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+      expect(getRowHeights(dashboard)).to.eql([rowHeight, rowHeight]);
+    });
+
+    it('should override the minimum row height', async () => {
+      setMinimumRowHeight(dashboard, rowHeight * 3);
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(getRowHeights(dashboard)).to.eql([rowHeight]);
+    });
+
+    it('should allow widget content to use 100% height', async () => {
+      const content = document.createElement('div');
+      content.style.height = '100%';
+      content.id = 'content';
+      childElements[0].appendChild(content);
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(content.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should fit a multi-row child to its full rowspan including the gap', async () => {
+      // Use a non-zero gap so the cap calculation has to scale with rowspan AND
+      // include the gap between the spanned rows; otherwise the child gets capped
+      // to a single row's height.
+      const gap = 10;
+      setSpacing(dashboard, gap);
+      setRowspan(childElements[0], 2);
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(childElements[0].offsetHeight).to.eql(rowHeight * 2 + gap);
+    });
+
+    it('should fit a 3-row child to its full rowspan including all inter-row gaps', async () => {
+      // With rowspan = N > 2 the cap needs (N - 1) gap terms, not just one.
+      const gap = 10;
+      setSpacing(dashboard, gap);
+      setRowspan(childElements[0], 3);
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(childElements[0].offsetHeight).to.eql(rowHeight * 3 + gap * 2);
+    });
+
+    it('should not grow rows to fit larger content when gap is non-zero', async () => {
+      // The rowspan=1 cap must equal exactly the row-height, with no spurious gap added,
+      // otherwise tall child content can push the track to grow.
+      const gap = 10;
+      setSpacing(dashboard, gap);
+      childElements[0].style.height = `${rowHeight * 2}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(getRowHeights(dashboard)).to.eql([rowHeight]);
     });
   });
 
@@ -535,6 +610,25 @@ describe('dashboard layout', () => {
 
       expect(childElements[2].offsetHeight).to.eql(300);
       expect(childElements[3].offsetHeight).to.eql(300);
+    });
+
+    it('should use fixed row height for all section sub-rows', async () => {
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, 100);
+      await nextResize(dashboard);
+
+      expect(childElements[2].offsetHeight).to.eql(100);
+      expect(childElements[3].offsetHeight).to.eql(100);
+    });
+
+    it('should grow the section to fit all sub-rows with fixed row height', async () => {
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, 100);
+      await nextResize(dashboard);
+
+      // Section should be tall enough to contain its header and both sub-rows
+      // (rather than being constrained to a single fixed-height row).
+      expect(section.offsetHeight).to.be.greaterThan(200);
     });
 
     it('should not use minimum row height for section header row', async () => {

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -787,7 +787,7 @@ describe('dashboard layout', () => {
       // `height: var(--_widget-fixed-height) !important`, an invalid calc reduces to
       // `height: auto !important`, which silently overrides any inline height even
       // outside the fixed-row-height feature.
-      setMinimumRowHeight(dashboard, undefined);
+      setMinimumRowHeight(dashboard);
       const child = document.createElement('div');
       child.style.height = '200px';
       section.appendChild(child);

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -302,6 +302,23 @@ describe('dashboard layout', () => {
       await nextFrame();
       expect(childElements[0].offsetHeight).to.eql(rowHeight);
     });
+
+    it('should clamp an inline min-height that exceeds the fixed row height', async () => {
+      childElements[0].style.minHeight = `${rowHeight * 2}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(childElements[0].offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should clamp an inline max-height that exceeds the fixed row height', async () => {
+      // Without !important on the cap's max-height, an inline max-height higher than the
+      // cap wins by specificity and lets the child grow with its content past the cell.
+      childElements[0].style.maxHeight = `${rowHeight * 2}px`;
+      childElements[0].style.height = `${rowHeight * 2}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(childElements[0].offsetHeight).to.eql(rowHeight);
+    });
   });
 
   describe('column span', () => {

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -292,6 +292,16 @@ describe('dashboard layout', () => {
       await nextFrame();
       expect(getRowHeights(dashboard)).to.eql([rowHeight]);
     });
+
+    it('should not let an inline style.height shrink a child below the fixed row height', async () => {
+      // The cap pins children to row-height in both directions: a smaller inline
+      // style.height would otherwise leave empty space inside the cell. max-height
+      // alone only enforces the upper bound; min-height is needed for the lower.
+      childElements[0].style.height = `${rowHeight / 2}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextFrame();
+      expect(childElements[0].offsetHeight).to.eql(rowHeight);
+    });
   });
 
   describe('column span', () => {
@@ -629,6 +639,127 @@ describe('dashboard layout', () => {
       // Section should be tall enough to contain its header and both sub-rows
       // (rather than being constrained to a single fixed-height row).
       expect(section.offsetHeight).to.be.greaterThan(200);
+    });
+
+    it('should cap a widget nested inside a section to the fixed row height', async () => {
+      // The layout's ::slotted(:not(vaadin-dashboard-section)) rule excludes sections,
+      // so --_widget-fixed-height isn't set on the section. In vaadin-dashboard-layout
+      // the section is the direct slotted element (no display:contents wrapper above the
+      // widget to carry the variable through), so the widget host needs its own
+      // --_widget-fixed-height definition to keep the cap working for nested widgets.
+      const rowHeight = 100;
+      const widget = document.createElement('vaadin-dashboard-widget');
+      const tall = document.createElement('div');
+      tall.style.height = `${rowHeight * 2}px`;
+      widget.appendChild(tall);
+      section.appendChild(widget);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      expect(widget.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should cap a non-widget child nested inside a section to the fixed row height', async () => {
+      // Section's ::slotted(*) rule does not apply min/max-height, so non-widget
+      // children currently bypass the cap — tall content pushes the section's sub-row
+      // beyond the fixed row-height.
+      const rowHeight = 100;
+      const tall = document.createElement('div');
+      tall.style.height = `${rowHeight * 2}px`;
+      section.appendChild(tall);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      expect(tall.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should not let an inline style.height shrink a non-widget child inside a section below the fixed row height', async () => {
+      // The section's ::slotted cap pins children to row-height in both directions,
+      // mirroring the layout-side cap. max-height alone allows a smaller inline height
+      // to win and leaves empty space inside the cell — min-height is needed for the lower bound.
+      const rowHeight = 100;
+      const child = document.createElement('div');
+      child.style.height = `${rowHeight / 2}px`;
+      section.appendChild(child);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      expect(child.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should fit a multi-row non-widget child inside a section to its full rowspan including the gap', async () => {
+      // The section's cap calc must scale with --vaadin-dashboard-widget-rowspan and
+      // include (rowspan - 1) inter-row gaps. A constant `row-height + gap` clamps
+      // multi-row children to a single row's worth of height. Widget children are
+      // unaffected because the widget host's own cap wins via shadow-tree precedence,
+      // but non-widget children rely entirely on the section's ::slotted rule.
+      const gap = 10;
+      const rowHeight = 100;
+      setSpacing(dashboard, gap);
+      const child = document.createElement('div');
+      child.style.setProperty('--vaadin-dashboard-widget-rowspan', '2');
+      section.appendChild(child);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      expect(child.offsetHeight).to.eql(rowHeight * 2 + gap);
+    });
+
+    it('should fit a 3-row non-widget child inside a section including all inter-row gaps', async () => {
+      // With rowspan = N > 2 the section's cap needs (N - 1) gap terms, not just one.
+      const gap = 10;
+      const rowHeight = 100;
+      setSpacing(dashboard, gap);
+      const child = document.createElement('div');
+      child.style.setProperty('--vaadin-dashboard-widget-rowspan', '3');
+      section.appendChild(child);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      expect(child.offsetHeight).to.eql(rowHeight * 3 + gap * 2);
+    });
+
+    it('should not let a non-widget child inside a section grow the section sub-row when gap is non-zero', async () => {
+      // The rowspan=1 cap must equal exactly the row-height with no spurious gap added,
+      // otherwise tall content can push the section's sub-row beyond the fixed row-height.
+      const gap = 10;
+      const rowHeight = 100;
+      setSpacing(dashboard, gap);
+      const child = document.createElement('div');
+      child.style.height = `${rowHeight * 2}px`;
+      section.appendChild(child);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      expect(child.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should respect an inline style.height on a section child when no fixed row height is set', async () => {
+      // The section's cap must only apply when a fixed row-height is set. With
+      // `height: var(--_widget-fixed-height) !important`, an invalid calc reduces to
+      // `height: auto !important`, which silently overrides any inline height even
+      // outside the fixed-row-height feature.
+      setMinimumRowHeight(dashboard, undefined);
+      const child = document.createElement('div');
+      child.style.height = '200px';
+      section.appendChild(child);
+
+      dashboard.style.width = `${columnWidth}px`;
+      await nextResize(dashboard);
+
+      expect(child.offsetHeight).to.eql(200);
     });
 
     it('should not use minimum row height for section header row', async () => {

--- a/packages/dashboard/test/dashboard-layout.test.ts
+++ b/packages/dashboard/test/dashboard-layout.test.ts
@@ -746,6 +746,25 @@ describe('dashboard layout', () => {
       expect(child.offsetHeight).to.eql(rowHeight);
     });
 
+    it('should let a section nested inside another section grow with its own sub-rows', async () => {
+      // The section's ::slotted cap must exclude vaadin-dashboard-section, mirroring the
+      // layout's exclusion. Otherwise an inner section is clamped to one row's height
+      // and can't wrap its own children.
+      const rowHeight = 100;
+      const innerSection = document.createElement('vaadin-dashboard-section');
+      innerSection.appendChild(document.createElement('div'));
+      innerSection.appendChild(document.createElement('div'));
+      section.appendChild(innerSection);
+
+      dashboard.style.width = `${columnWidth}px`;
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      // Inner section should fit its header plus the two sub-rows; capping it to
+      // a single row's worth of height would leave it ≤ rowHeight.
+      expect(innerSection.offsetHeight).to.be.greaterThan(rowHeight);
+    });
+
     it('should respect an inline style.height on a section child when no fixed row height is set', async () => {
       // The section's cap must only apply when a fixed row-height is set. With
       // `height: var(--_widget-fixed-height) !important`, an invalid calc reduces to

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -295,7 +295,7 @@ describe('dashboard - widget resizing', () => {
     });
 
     it('should resize vertically if fixed row height is defined without minimum row height', async () => {
-      setMinimumRowHeight(dashboard, undefined);
+      setMinimumRowHeight(dashboard);
       setRowHeight(dashboard, rowHeight);
       dashboard.items = [{ id: 0 }, { id: 1 }, { id: 2 }];
       await nextFrame();

--- a/packages/dashboard/test/dashboard-widget-resizing.test.ts
+++ b/packages/dashboard/test/dashboard-widget-resizing.test.ts
@@ -16,6 +16,7 @@ import {
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
+  setRowHeight,
   setSpacing,
 } from './helpers.js';
 
@@ -290,6 +291,33 @@ describe('dashboard - widget resizing', () => {
       expectLayout(dashboard, [
         [0, 1],
         [2],
+      ]);
+    });
+
+    it('should resize vertically if fixed row height is defined without minimum row height', async () => {
+      setMinimumRowHeight(dashboard, undefined);
+      setRowHeight(dashboard, rowHeight);
+      dashboard.items = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      await nextFrame();
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [2],
+      ]);
+
+      fireResizeStart(getElementFromCell(dashboard, 0, 0)!);
+      await nextFrame();
+
+      fireResizeOver(getElementFromCell(dashboard, 1, 0)!, 'bottom');
+      await nextFrame();
+
+      fireResizeEnd(dashboard);
+      await nextFrame();
+
+      // prettier-ignore
+      expectLayout(dashboard, [
+        [0, 1],
+        [0, 2],
       ]);
     });
 

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -19,6 +19,7 @@ import {
   setMaximumColumnWidth,
   setMinimumColumnWidth,
   setMinimumRowHeight,
+  setRowHeight,
   setSpacing,
   updateComplete,
 } from './helpers.js';
@@ -265,6 +266,83 @@ describe('dashboard', () => {
       const widget = getElementFromCell(dashboard, 0, 0);
       expect(widget).to.have.property('widgetTitle', 'Item 0 title');
       expect(getElementFromCell(dashboard, 1, 0)).to.equal(widget);
+    });
+
+    it('should fit a multi-row widget to its full rowspan including the gap with fixed row height', async () => {
+      // Use a non-zero gap so the cap on the widget host has to include the gap
+      // between the spanned rows; otherwise the widget gets capped to N row heights
+      // without the (N - 1) gaps in between.
+      const gap = 10;
+      const rowHeight = 100;
+      setSpacing(dashboard, gap);
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ rowspan: 2, id: '0' }];
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      expect(widget.offsetHeight).to.eql(rowHeight * 2 + gap);
+    });
+
+    it('should not grow rows to fit larger widget content with fixed row height', async () => {
+      // The widget host's max-height cap must actually produce a length so that
+      // tall widget content cannot push the parent track beyond the fixed row height.
+      const rowHeight = 100;
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ id: '0' }];
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        const widget = document.createElement('vaadin-dashboard-widget');
+        widget.id = (model.item as TestDashboardItem).id;
+        const tall = document.createElement('div');
+        tall.style.height = `${rowHeight * 2}px`;
+        widget.appendChild(tall);
+        root.appendChild(widget);
+      };
+      setRowHeight(dashboard, rowHeight);
+      await updateComplete(dashboard);
+      await nextResize(dashboard);
+
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      expect(widget.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should fit a 3-row widget to its full rowspan including all inter-row gaps', async () => {
+      // With rowspan = N > 2 the widget cap needs (N - 1) gap terms, not just one.
+      const gap = 10;
+      const rowHeight = 100;
+      setSpacing(dashboard, gap);
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ rowspan: 3, id: '0' }];
+      setRowHeight(dashboard, rowHeight);
+      await nextResize(dashboard);
+
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      expect(widget.offsetHeight).to.eql(rowHeight * 3 + gap * 2);
+    });
+
+    it('should not grow rows to fit larger widget content when gap is non-zero', async () => {
+      // The rowspan=1 widget cap must equal exactly the row-height, with no spurious gap added.
+      const gap = 10;
+      const rowHeight = 100;
+      setSpacing(dashboard, gap);
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ id: '0' }];
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        const widget = document.createElement('vaadin-dashboard-widget');
+        widget.id = (model.item as TestDashboardItem).id;
+        const tall = document.createElement('div');
+        tall.style.height = `${rowHeight * 2}px`;
+        widget.appendChild(tall);
+        root.appendChild(widget);
+      };
+      setRowHeight(dashboard, rowHeight);
+      await updateComplete(dashboard);
+      await nextResize(dashboard);
+
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      expect(widget.offsetHeight).to.eql(rowHeight);
     });
   });
 

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -293,7 +293,7 @@ describe('dashboard', () => {
       dashboard.renderer = (root, _, model) => {
         root.textContent = '';
         const widget = document.createElement('vaadin-dashboard-widget');
-        widget.id = (model.item as TestDashboardItem).id;
+        widget.id = model.item.id;
         const tall = document.createElement('div');
         tall.style.height = `${rowHeight * 2}px`;
         widget.appendChild(tall);
@@ -317,7 +317,7 @@ describe('dashboard', () => {
       dashboard.renderer = (root, _, model) => {
         root.textContent = '';
         const widget = document.createElement('vaadin-dashboard-widget');
-        widget.id = (model.item as TestDashboardItem).id;
+        widget.id = model.item.id;
         widget.style.height = `${rowHeight * 2}px`;
         root.appendChild(widget);
       };
@@ -339,7 +339,7 @@ describe('dashboard', () => {
       dashboard.renderer = (root, _, model) => {
         root.textContent = '';
         const widget = document.createElement('vaadin-dashboard-widget');
-        widget.id = (model.item as TestDashboardItem).id;
+        widget.id = model.item.id;
         widget.style.height = `${rowHeight / 2}px`;
         root.appendChild(widget);
       };
@@ -361,7 +361,7 @@ describe('dashboard', () => {
       dashboard.renderer = (root, _, model) => {
         root.textContent = '';
         const widget = document.createElement('vaadin-dashboard-widget');
-        widget.id = (model.item as TestDashboardItem).id;
+        widget.id = model.item.id;
         widget.style.height = '200px';
         root.appendChild(widget);
       };
@@ -396,7 +396,7 @@ describe('dashboard', () => {
       dashboard.renderer = (root, _, model) => {
         root.textContent = '';
         const widget = document.createElement('vaadin-dashboard-widget');
-        widget.id = (model.item as TestDashboardItem).id;
+        widget.id = model.item.id;
         const tall = document.createElement('div');
         tall.style.height = `${rowHeight * 2}px`;
         widget.appendChild(tall);
@@ -422,7 +422,7 @@ describe('dashboard', () => {
       dashboard.renderer = (root, _, model) => {
         root.textContent = '';
         const widget = document.createElement('vaadin-dashboard-widget');
-        widget.id = (model.item as TestDashboardItem).id;
+        widget.id = model.item.id;
         const tall = document.createElement('div');
         tall.style.height = `${rowHeight * 2}px`;
         widget.appendChild(tall);

--- a/packages/dashboard/test/dashboard.test.ts
+++ b/packages/dashboard/test/dashboard.test.ts
@@ -307,6 +307,71 @@ describe('dashboard', () => {
       expect(widget.offsetHeight).to.eql(rowHeight);
     });
 
+    it('should not let an inline style.height on a widget override the fixed row height', async () => {
+      // The widget host's cap must clamp inline heights that exceed the fixed row height.
+      // A bare `height` declaration would lose to inline style; only `max-height` (paired
+      // with `min-height` so the row stays pinned for empty content too) clamps inline height.
+      const rowHeight = 100;
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ id: '0' }];
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        const widget = document.createElement('vaadin-dashboard-widget');
+        widget.id = (model.item as TestDashboardItem).id;
+        widget.style.height = `${rowHeight * 2}px`;
+        root.appendChild(widget);
+      };
+      setRowHeight(dashboard, rowHeight);
+      await updateComplete(dashboard);
+      await nextResize(dashboard);
+
+      const widget = getElementFromCell(dashboard, 0, 0)!;
+      expect(widget.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should not let an inline style.height shrink a widget below the fixed row height', async () => {
+      // The widget host cap pins to row-height in both directions: a smaller inline
+      // style.height would otherwise leave empty space inside the cell. max-height alone
+      // only enforces the upper bound; min-height is needed for the lower.
+      const rowHeight = 100;
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ id: '0' }];
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        const widget = document.createElement('vaadin-dashboard-widget');
+        widget.id = (model.item as TestDashboardItem).id;
+        widget.style.height = `${rowHeight / 2}px`;
+        root.appendChild(widget);
+      };
+      setRowHeight(dashboard, rowHeight);
+      await updateComplete(dashboard);
+      await nextResize(dashboard);
+
+      const widget = dashboard.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+      expect(widget.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should respect an inline style.height on a widget when no fixed row height is set', async () => {
+      // The widget cap must only apply when a fixed row-height is set. With
+      // `height: var(--_widget-fixed-height) !important`, an invalid calc reduces to
+      // `height: auto !important`, which silently overrides any inline height even
+      // outside the fixed-row-height feature.
+      dashboard.style.width = `${columnWidth}px`;
+      dashboard.items = [{ id: '0' }];
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        const widget = document.createElement('vaadin-dashboard-widget');
+        widget.id = (model.item as TestDashboardItem).id;
+        widget.style.height = '200px';
+        root.appendChild(widget);
+      };
+      await updateComplete(dashboard);
+      await nextResize(dashboard);
+
+      const widget = dashboard.querySelector('vaadin-dashboard-widget') as DashboardWidget;
+      expect(widget.offsetHeight).to.eql(200);
+    });
+
     it('should fit a 3-row widget to its full rowspan including all inter-row gaps', async () => {
       // With rowspan = N > 2 the widget cap needs (N - 1) gap terms, not just one.
       const gap = 10;
@@ -342,6 +407,32 @@ describe('dashboard', () => {
       await nextResize(dashboard);
 
       const widget = getElementFromCell(dashboard, 0, 0)!;
+      expect(widget.offsetHeight).to.eql(rowHeight);
+    });
+
+    it('should cap a widget nested inside a section to the fixed row height', async () => {
+      // The layout's ::slotted(...) rule excludes sections, so it never defines
+      // --_widget-fixed-height on a section, and widgets inside a section don't inherit
+      // it. The widget host therefore needs its own definition to keep the cap working
+      // for nested widgets — otherwise tall widget content pushes the section's sub-row.
+      const rowHeight = 100;
+      dashboard.style.width = `${columnWidth}px`;
+      const sectionItem: DashboardSectionItem<TestDashboardItem> = { items: [{ id: '0' }] };
+      dashboard.items = [sectionItem];
+      dashboard.renderer = (root, _, model) => {
+        root.textContent = '';
+        const widget = document.createElement('vaadin-dashboard-widget');
+        widget.id = (model.item as TestDashboardItem).id;
+        const tall = document.createElement('div');
+        tall.style.height = `${rowHeight * 2}px`;
+        widget.appendChild(tall);
+        root.appendChild(widget);
+      };
+      setRowHeight(dashboard, rowHeight);
+      await updateComplete(dashboard);
+      await nextResize(dashboard);
+
+      const widget = dashboard.querySelector('vaadin-dashboard-widget') as DashboardWidget;
       expect(widget.offsetHeight).to.eql(rowHeight);
     });
   });

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -138,6 +138,13 @@ export function setMinimumRowHeight(dashboard: HTMLElement, height?: number): vo
 }
 
 /**
+ * Sets the fixed row height of the dashboard.
+ */
+export function setRowHeight(dashboard: HTMLElement, height?: number): void {
+  dashboard.style.setProperty('--vaadin-dashboard-row-height', height !== undefined ? `${height}px` : null);
+}
+
+/**
  * Validates the given grid layout.
  *
  * This function iterates through a number matrix representing the IDs of

--- a/packages/dashboard/test/helpers.ts
+++ b/packages/dashboard/test/helpers.ts
@@ -141,7 +141,7 @@ export function setMinimumRowHeight(dashboard: HTMLElement, height?: number): vo
  * Sets the fixed row height of the dashboard.
  */
 export function setRowHeight(dashboard: HTMLElement, height?: number): void {
-  dashboard.style.setProperty('--vaadin-dashboard-row-height', height !== undefined ? `${height}px` : null);
+  dashboard.style.setProperty('--vaadin-dashboard-row-height', height === undefined ? null : `${height}px`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a new `--vaadin-dashboard-row-height` CSS custom property to `vaadin-dashboard` and `vaadin-dashboard-layout` that pins all rows to a fixed height
- When set, the property overrides `--vaadin-dashboard-row-min-height` and prevents rows from growing to fit their content, so widgets can use `100%` height for their inner content
- The cap is applied to the layout's slotted children, the section's slotted children, and the widget host itself, so it also works for widgets nested inside sections within `vaadin-dashboard-layout`
- Cap declarations are shared via `widgetFixedHeightDeclarations` to avoid duplication, and gracefully no-op (fall back to `auto` / `none`) when the property is unset

Part of https://github.com/vaadin/web-components/issues/10943

🤖 Generated with [Claude Code](https://claude.com/claude-code)