### PR TITLE
docs: extend @fires JSDoc description for chart-redraw event

### DIFF
--- a/packages/charts/src/vaadin-chart.d.ts
+++ b/packages/charts/src/vaadin-chart.d.ts
@@ -120,7 +120,7 @@ export * from './vaadin-chart-mixin.js';
  * @fires {CustomEvent} chart-drilldown - Fired when drilldown point is clicked.
  * @fires {CustomEvent} chart-drillup - Fired when drilling up from a drilldown series.
  * @fires {CustomEvent} chart-drillupall - Fired after all the drilldown series has been drilled up.
- * @fires {CustomEvent} chart-redraw - Fired after the chart redraw.
+ * @fires {CustomEvent} chart-redraw - Fired when the chart is redrawn: after `Chart.configuration.redraw()`, or after an axis, series, or point is modified with the `redraw` option set to true.
  * @fires {CustomEvent} chart-selection - Fired when an area of the chart has been selected.
  * @fires {CustomEvent} chart-end-resize - Fired when the chart finishes resizing.
  * @fires {CustomEvent} series-after-animate - Fired when the series has finished its initial animation.

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -125,7 +125,7 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  * @fires {CustomEvent} chart-drilldown - Fired when drilldown point is clicked.
  * @fires {CustomEvent} chart-drillup - Fired when drilling up from a drilldown series.
  * @fires {CustomEvent} chart-drillupall - Fired after all the drilldown series has been drilled up.
- * @fires {CustomEvent} chart-redraw - Fired after the chart redraw.
+ * @fires {CustomEvent} chart-redraw - Fired when the chart is redrawn: after `Chart.configuration.redraw()`, or after an axis, series, or point is modified with the `redraw` option set to true.
  * @fires {CustomEvent} chart-selection - Fired when an area of the chart has been selected.
  * @fires {CustomEvent} chart-end-resize - Fired when the chart finishes resizing.
  * @fires {CustomEvent} series-after-animate - Fired when the series has finished its initial animation.


### PR DESCRIPTION
## Summary

- Enrich the `@fires` line for `chart-redraw` on the `<vaadin-chart>` class JSDoc with the trigger-condition detail (after `Chart.configuration.redraw()` or after a redraw-flagged modification) that previously only lived in the standalone `@event` block in `vaadin-chart-mixin.js`.

## Why

CEM reads `@fires` lines on the class JSDoc but not standalone `@event` blocks. The other 7 chart events flagged in the regression list already had equivalent or better wording on the `@fires` line, so `chart-redraw` is the only one that needs to change.

The standalone `@event` blocks are intentionally left in place — they'll be removed in a follow-up sweep once the migration from Polymer Analyzer to CEM is fully complete.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn release:cem` — confirm `packages/charts/custom-elements.json` shows the expanded description for `chart-redraw`
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)