### PR TITLE
docs: extend @fires JSDoc descriptions for CRUD events

### DIFF
--- a/packages/crud/src/vaadin-crud.d.ts
+++ b/packages/crud/src/vaadin-crud.d.ts
@@ -178,14 +178,14 @@ export * from './vaadin-crud-mixin.js';
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
- * @fires {CustomEvent} edited-item-changed - Fired when `editedItem` property changes.
+ * @fires {CustomEvent} edited-item-changed - Fired when the `editedItem` property changes.
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} new - Fired when user wants to create a new item.
- * @fires {CustomEvent} edit - Fired when user wants to edit an existing item.
- * @fires {CustomEvent} delete - Fired when user wants to delete item.
- * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item.
- * @fires {CustomEvent} cancel - Fired when user discards edition.
+ * @fires {CustomEvent} edit - Fired when user wants to edit an existing item. If the default is prevented, a new item is not assigned to the form, but the dialog is still opened.
+ * @fires {CustomEvent} delete - Fired when user wants to delete item. If the default is prevented, no action is performed: the items array is not modified and the dialog is not closed.
+ * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item. If the default is prevented, no action is performed: the items array is not modified and the dialog is not closed.
+ * @fires {CustomEvent} cancel - Fired when user discards edition. If the default is prevented, no action is performed; the listener is responsible for closing the dialog and resetting the item and grid.
  */
 declare class Crud<Item = GridDefaultItem> extends HTMLElement {
   addEventListener<K extends keyof CrudEventMap<Item>>(

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -186,14 +186,14 @@ import { CrudMixin } from './vaadin-crud-mixin.js';
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} editor-opened-changed - Fired when the `editorOpened` property changes.
- * @fires {CustomEvent} edited-item-changed - Fired when `editedItem` property changes.
+ * @fires {CustomEvent} edited-item-changed - Fired when the `editedItem` property changes.
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} new - Fired when user wants to create a new item.
- * @fires {CustomEvent} edit - Fired when user wants to edit an existing item.
- * @fires {CustomEvent} delete - Fired when user wants to delete item.
- * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item.
- * @fires {CustomEvent} cancel - Fired when user discards edition.
+ * @fires {CustomEvent} edit - Fired when user wants to edit an existing item. If the default is prevented, a new item is not assigned to the form, but the dialog is still opened.
+ * @fires {CustomEvent} delete - Fired when user wants to delete item. If the default is prevented, no action is performed: the items array is not modified and the dialog is not closed.
+ * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item. If the default is prevented, no action is performed: the items array is not modified and the dialog is not closed.
+ * @fires {CustomEvent} cancel - Fired when user discards edition. If the default is prevented, no action is performed; the listener is responsible for closing the dialog and resetting the item and grid.
  *
  * @customElement vaadin-crud
  * @extends HTMLElement


### PR DESCRIPTION
## Summary

- Enrich the `@fires` lines for `cancel`, `delete`, `edit`, and `save` on `<vaadin-crud>` with the preventDefault semantics that previously only lived in the standalone `@event` JSDoc blocks.
- Add the missing "the" in `edited-item-changed` for consistency with the other property-changed events on the same element.

## Why

CEM reads `@fires` lines on the class JSDoc but not standalone `@event` blocks. The CRUD events lost their `preventDefault` semantics in CEM output because the long descriptions lived in orphan blocks.

The standalone `@event` blocks are intentionally left in place — they'll be removed in a follow-up sweep once the migration from Polymer Analyzer to CEM is fully complete.

The `<vaadin-confirm-dialog>` `confirm`/`cancel`/`reject` events are not touched here — their class-level `@fires` lines already match the baseline.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn release:cem` — confirm `packages/crud/custom-elements.json` shows the expanded descriptions
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)