### PR TITLE
docs: add missing @fires JSDoc for combo-box dropdown events

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box.d.ts
+++ b/packages/combo-box/src/vaadin-combo-box.d.ts
@@ -225,6 +225,8 @@ export interface ComboBoxEventMap<TItem> extends HTMLElementEventMap {
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
+ * @fires {CustomEvent} vaadin-combo-box-dropdown-opened - Fired after the `vaadin-combo-box-overlay` opens.
+ * @fires {CustomEvent} vaadin-combo-box-dropdown-closed - Fired after the `vaadin-combo-box-overlay` closes.
  */
 declare class ComboBox<TItem = ComboBoxDefaultItem> extends HTMLElement {
   addEventListener<K extends keyof ComboBoxEventMap<TItem>>(

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -157,6 +157,8 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
+ * @fires {CustomEvent} vaadin-combo-box-dropdown-opened - Fired after the `vaadin-combo-box-overlay` opens.
+ * @fires {CustomEvent} vaadin-combo-box-dropdown-closed - Fired after the `vaadin-combo-box-overlay` closes.
  *
  * @customElement vaadin-combo-box
  * @extends HTMLElement


### PR DESCRIPTION
## Summary

- Add `@fires` lines for `vaadin-combo-box-dropdown-opened` and `vaadin-combo-box-dropdown-closed` to the class JSDoc on `<vaadin-combo-box>`.

## Why

These two events were missing from CEM output entirely because they only existed as standalone `@event` blocks in `vaadin-combo-box-mixin.js`, which CEM doesn't read. Adding them to the class-level `@fires` list surfaces them in the generated `custom-elements.json` and downstream web-types.

The standalone `@event` blocks are intentionally left in place — they'll be removed in a follow-up sweep once the migration from Polymer Analyzer to CEM is fully complete. The other events flagged for combo-box and date-picker in the regression list (`selected-item-changed`, `value-changed`, `opened-changed`) already had equivalent or better wording on their existing `@fires` lines, so they don't need to change here.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn release:cem` — confirm `packages/combo-box/custom-elements.json` lists the two new events
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)