### PR TITLE
docs: extend @fires JSDoc descriptions for list-box events

### DIFF
--- a/packages/list-box/src/vaadin-list-box.d.ts
+++ b/packages/list-box/src/vaadin-list-box.d.ts
@@ -13,12 +13,12 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
 export type ListBoxItemsChangedEvent = CustomEvent<{ value: Element[] }>;
 
 /**
- * Fired when the `selected` property changes.
+ * Fired when the `selected` property changes. Not fired in multiple selection mode.
  */
 export type ListBoxSelectedChangedEvent = CustomEvent<{ value: number }>;
 
 /**
- * Fired when the `selectedValues` property changes.
+ * Fired when the `selectedValues` property changes. Not fired in single selection mode.
  */
 export type ListBoxSelectedValuesChangedEvent = CustomEvent<{ value: number[] }>;
 
@@ -61,8 +61,8 @@ export interface ListBoxEventMap extends HTMLElementEventMap, ListBoxCustomEvent
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
- * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
- * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes. Not fired in multiple selection mode.
+ * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes. Not fired in single selection mode.
  */
 declare class ListBox extends MultiSelectListMixin(ThemableMixin(ElementMixin(HTMLElement))) {
   focused: Element | null;

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -42,8 +42,8 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
- * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
- * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes. Not fired in multiple selection mode.
+ * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes. Not fired in single selection mode.
  *
  * @customElement vaadin-list-box
  * @extends HTMLElement


### PR DESCRIPTION
## Summary

- Restore the selection-mode caveats on `selected-changed` and `selected-values-changed` `@fires` lines for `<vaadin-list-box>` and `<vaadin-tabs>` (e.g. "Not fired in multiple selection mode").

## Why

CEM reads `@fires` lines on the class JSDoc but not standalone `@event` blocks. The selection-mode caveats lived in orphan blocks in `a11y-base/list-mixin.js` and `list-box/vaadin-multi-select-list-mixin.js`, so they were lost in CEM output.

The standalone `@event` blocks are intentionally left in place — they'll be removed in a follow-up sweep once the migration from Polymer Analyzer to CEM is fully complete.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn release:cem` — confirm `packages/list-box/custom-elements.json` and `packages/tabs/custom-elements.json` show the updated descriptions
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)