### PR TITLE
docs: extend @fires JSDoc description for login event

### DIFF
--- a/packages/login/src/vaadin-login-form.d.ts
+++ b/packages/login/src/vaadin-login-form.d.ts
@@ -83,7 +83,7 @@ export interface LoginFormEventMap extends HTMLElementEventMap, LoginFormCustomE
  * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
  * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
- * @fires {CustomEvent} login - Fired when a user submits the login.
+ * @fires {CustomEvent} login - Fired when a user submits the login form. The event detail contains `username` and `password`.
  */
 declare class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(HTMLElement))) {
   addEventListener<K extends keyof LoginFormEventMap>(

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -63,7 +63,7 @@ import { LoginFormMixin } from './vaadin-login-form-mixin.js';
  * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
  * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
- * @fires {CustomEvent} login - Fired when a user submits the login.
+ * @fires {CustomEvent} login - Fired when a user submits the login form. The event detail contains `username` and `password`.
  *
  * @customElement vaadin-login-form
  * @extends HTMLElement

--- a/packages/login/src/vaadin-login-overlay.d.ts
+++ b/packages/login/src/vaadin-login-overlay.d.ts
@@ -107,7 +107,7 @@ export interface LoginOverlayEventMap extends HTMLElementEventMap, LoginOverlayC
  * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
  * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
- * @fires {CustomEvent} login - Fired when a user submits the login.
+ * @fires {CustomEvent} login - Fired when a user submits the login form. The event detail contains `username` and `password`.
  * @fires {CustomEvent} closed - Fired when the overlay is closed.
  */
 declare class LoginOverlay extends LoginFormMixin(LoginOverlayMixin(ElementMixin(ThemableMixin(HTMLElement)))) {

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -71,7 +71,7 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  * @fires {CustomEvent} disabled-changed - Fired when the `disabled` property changes.
  * @fires {CustomEvent} error-changed - Fired when the `error` property changes.
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
- * @fires {CustomEvent} login - Fired when a user submits the login.
+ * @fires {CustomEvent} login - Fired when a user submits the login form. The event detail contains `username` and `password`.
  * @fires {CustomEvent} closed - Fired when the overlay is closed.
  *
  * @customElement vaadin-login-overlay


### PR DESCRIPTION
## Summary

- Restore the `username`/`password` detail payload hint on the `login` `@fires` line for both `<vaadin-login-form>` and `<vaadin-login-overlay>`.

## Why

CEM reads `@fires` lines on the class JSDoc but not standalone `@event` blocks. The detail payload hint lived in an orphan block in `vaadin-login-mixin.js`, so it was lost in CEM output.

The standalone `@event` block is intentionally left in place — it'll be removed in a follow-up sweep once the migration from Polymer Analyzer to CEM is fully complete.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn release:cem` — confirm `packages/login/custom-elements.json` shows the updated description on both `LoginForm` and `LoginOverlay`
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)