### PR TITLE
docs: remove orphan @event blocks for master-detail-layout

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -671,16 +671,6 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   get __slottedDetailPlaceholder() {
     return this.querySelector(':scope > [slot="detail-placeholder"]');
   }
-
-  /**
-   * @event backdrop-click
-   * Fired when the user clicks the backdrop in the overlay mode.
-   */
-
-  /**
-   * @event detail-escape-press
-   * Fired when the user presses Escape in the detail area.
-   */
 }
 
 defineCustomElement(MasterDetailLayout);


### PR DESCRIPTION
## Summary

- Remove the orphan `@event` JSDoc blocks for `backdrop-click` and `detail-escape-press` from `vaadin-master-detail-layout.js`.

## Why

The class-level `@fires` lines already have the correct descriptions, so the orphan blocks are pure duplicates that CEM doesn't read.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)