### PR TITLE
docs: remove orphan @event blocks for menu-bar and context-menu

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -337,14 +337,6 @@ class ContextMenu extends ContextMenuMixin(ElementMixin(ThemePropertyMixin(Polyl
 
     return ['top-start', 'top-end', 'top', 'start-bottom', 'end-bottom'].includes(position) ? 'bottom' : 'top';
   }
-
-  /**
-   * Fired when an item is selected when the context menu is populated using the `items` API.
-   *
-   * @event item-selected
-   * @param {Object} detail
-   * @param {Object} detail.value the selected menu item
-   */
 }
 
 defineCustomElement(ContextMenu);

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -95,14 +95,6 @@ class MenuBar extends MenuBarMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoI
       <slot name="tooltip"></slot>
     `;
   }
-
-  /**
-   * Fired when either a submenu item or menu bar button without nested children is clicked.
-   *
-   * @event item-selected
-   * @param {Object} detail
-   * @param {Object} detail.value the selected menu bar item
-   */
 }
 
 defineCustomElement(MenuBar);


### PR DESCRIPTION
## Summary

- Remove the orphan `@event item-selected` JSDoc blocks from `vaadin-menu-bar.js` and `vaadin-context-menu.js`.

## Why

Both files already have class-level `@fires {CustomEvent} item-selected` lines with equivalent or better wording. CEM only reads the class-level `@fires`, so the orphan blocks are dead duplicates.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)