### PR TITLE
docs: remove orphan @event block for message-input submit

### DIFF
--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -165,10 +165,4 @@ export const MessageInputMixin = (superClass) =>
       }
       this._textArea.focus();
     }
-
-    /**
-     * Fired when a new message is submitted with `<vaadin-message-input>`, either
-     * by clicking the "send" button, or pressing the Enter key.
-     * @event submit
-     */
   };


### PR DESCRIPTION
## Summary

- Remove the orphan `@event submit` block from `vaadin-message-input-mixin.js`.

## Why

The class-level `@fires {CustomEvent} submit` line on `<vaadin-message-input>` already has the equivalent description. CEM only reads the class-level `@fires`, so the orphan block is dead.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)