### PR TITLE
docs: remove orphan @event blocks for dashboard

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -501,48 +501,6 @@ class Dashboard extends DashboardLayoutMixin(
       });
     }
   }
-
-  /**
-   * Fired when an item selected state changed
-   *
-   * @event dashboard-item-selected-changed
-   */
-
-  /**
-   * Fired when an item move mode changed
-   *
-   * @event dashboard-item-move-mode-changed
-   */
-
-  /**
-   * Fired when an item resize mode changed
-   *
-   * @event dashboard-item-resize-mode-changed
-   */
-
-  /**
-   * Fired when an item was moved
-   *
-   * @event dashboard-item-moved
-   */
-
-  /**
-   * Fired when an item was resized
-   *
-   * @event dashboard-item-resized
-   */
-
-  /**
-   * Fired before an item is removed
-   *
-   * @event dashboard-item-before-remove
-   */
-
-  /**
-   * Fired when an item was removed
-   *
-   * @event dashboard-item-removed
-   */
 }
 
 defineCustomElement(Dashboard);


### PR DESCRIPTION
## Summary

- Remove the seven orphan `@event` JSDoc blocks from `vaadin-dashboard.js`.

## Why

The class-level `@fires` lines already document all seven events with equivalent or better wording (the orphan `dashboard-item-before-remove` block was missing the `preventDefault()` note). CEM only reads the class-level `@fires`, so the orphan blocks are dead.

This is one of several follow-up PRs after the CEM migration, split per package to keep reviews scoped.

## Test plan
- [ ] `yarn release:cem` — confirm `packages/dashboard/custom-elements.json` still lists all seven events
- [ ] `yarn lint` passes
- [ ] `yarn lint:types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)