### PR TITLE
docs: generalize upload file event descriptions

### DIFF
--- a/packages/upload/src/vaadin-upload-file.d.ts
+++ b/packages/upload/src/vaadin-upload-file.d.ts
@@ -9,17 +9,17 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
 export type { UploadFileI18n } from './vaadin-upload-file-mixin.js';
 
 /**
- * Fired when the retry button is pressed.
+ * Fired when the retry button is pressed to request retrying the upload of this file.
  */
 export type UploadFileRetryEvent = CustomEvent<{ file: File }>;
 
 /**
- * Fired when the start button is pressed.
+ * Fired when the start button is pressed to request starting the upload of this file.
  */
 export type UploadFileStartEvent = CustomEvent<{ file: File }>;
 
 /**
- * Fired when the abort button is pressed.
+ * Fired when the abort button is pressed to request aborting the upload of this file.
  */
 export type UploadFileAbortEvent = CustomEvent<{ file: File }>;
 
@@ -97,9 +97,9 @@ export interface UploadFileEventMap extends HTMLElementEventMap, UploadFileCusto
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @fires {CustomEvent} file-abort - Fired when the abort button is pressed. Listened by `vaadin-upload`, which aborts the upload in progress and removes the file from the list.
- * @fires {CustomEvent} file-retry - Fired when the retry button is pressed. Listened by `vaadin-upload`, which starts a new upload of this file.
- * @fires {CustomEvent} file-start - Fired when the start button is pressed. Listened by `vaadin-upload`, which starts a new upload of this file.
+ * @fires {CustomEvent} file-abort - Fired when the abort button is pressed to request aborting the upload of this file.
+ * @fires {CustomEvent} file-retry - Fired when the retry button is pressed to request retrying the upload of this file.
+ * @fires {CustomEvent} file-start - Fired when the start button is pressed to request starting the upload of this file.
  */
 declare class UploadFile extends UploadFileMixin(ThemableMixin(HTMLElement)) {
   addEventListener<K extends keyof UploadFileEventMap>(

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -77,9 +77,9 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
- * @fires {CustomEvent} file-abort - Fired when the abort button is pressed. Listened by `vaadin-upload`, which aborts the upload in progress and removes the file from the list.
- * @fires {CustomEvent} file-retry - Fired when the retry button is pressed. Listened by `vaadin-upload`, which starts a new upload of this file.
- * @fires {CustomEvent} file-start - Fired when the start button is pressed. Listened by `vaadin-upload`, which starts a new upload of this file.
+ * @fires {CustomEvent} file-abort - Fired when the abort button is pressed to request aborting the upload of this file.
+ * @fires {CustomEvent} file-retry - Fired when the retry button is pressed to request retrying the upload of this file.
+ * @fires {CustomEvent} file-start - Fired when the start button is pressed to request starting the upload of this file.
  *
  * @customElement vaadin-upload-file
  * @extends HTMLElement
@@ -159,8 +159,8 @@ class UploadFile extends UploadFileMixin(ThemableMixin(PolylitMixin(LumoInjectio
   }
 
   /**
-   * Fired when the retry button is pressed. It is listened by `vaadin-upload`
-   * which will start a new upload process of this file.
+   * Fired when the retry button is pressed to request retrying the upload
+   * of this file.
    *
    * @event file-retry
    * @param {Object} detail
@@ -168,8 +168,8 @@ class UploadFile extends UploadFileMixin(ThemableMixin(PolylitMixin(LumoInjectio
    */
 
   /**
-   * Fired when the start button is pressed. It is listened by `vaadin-upload`
-   * which will start a new upload process of this file.
+   * Fired when the start button is pressed to request starting the upload
+   * of this file.
    *
    * @event file-start
    * @param {Object} detail
@@ -177,8 +177,8 @@ class UploadFile extends UploadFileMixin(ThemableMixin(PolylitMixin(LumoInjectio
    */
 
   /**
-   * Fired when abort button is pressed. It is listened by `vaadin-upload` which
-   * will abort the upload in progress, and then remove the file from the list.
+   * Fired when the abort button is pressed to request aborting the upload
+   * of this file.
    *
    * @event file-abort
    * @param {Object} detail


### PR DESCRIPTION
## Summary

Follow-up to #11604, addressing [this review comment](https://github.com/vaadin/web-components/pull/11604#discussion_r3161528799).

The `file-abort`, `file-retry`, and `file-start` events on `<vaadin-upload-file>` are listened to by **both** `<vaadin-upload>` and `<vaadin-upload-file-list>` (which forwards the call to its linked `UploadManager`). The previous descriptions only mentioned `<vaadin-upload>`, which is incomplete.

This PR generalizes the descriptions to focus on the request intent rather than naming a specific listener. For example:

- Before: _Fired when the abort button is pressed. Listened by `vaadin-upload`, which aborts the upload in progress and removes the file from the list._
- After: _Fired when the abort button is pressed to request aborting the upload of this file._

All four documentation surfaces are updated in lockstep:
- `@fires` (one-line class-level) in `vaadin-upload-file.js`
- `@event` (multi-line) JSDoc blocks in `vaadin-upload-file.js`
- `@fires` in `vaadin-upload-file.d.ts`
- Short `UploadFile{Retry,Start,Abort}Event` type alias descriptions in `vaadin-upload-file.d.ts`

## Test plan

- [ ] `yarn lint` and `yarn lint:types` pass
- [ ] CEM output for `<vaadin-upload-file>` shows the generalized descriptions for `file-abort`, `file-retry`, `file-start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)