### PR TITLE
chore: update ESLint config to allow modern ES2020 operators

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,16 +120,6 @@ export default [
     plugins: { html },
   },
   {
-    files: ['packages/**/vaadin-*.js'],
-    rules: {
-      // Ban ES2020, ES2021 operators in source component files, as they aren't supported by Polymer analyzer
-      'es-x/no-optional-chaining': 'error',
-      'es-x/no-nullish-coalescing-operators': 'error',
-      'es-x/no-logical-assignment-operators': 'error',
-      'logical-assignment-operators': 'off',
-    },
-  },
-  {
     files: ['packages/*/src/**/*.js'],
     rules: {
       'no-restricted-syntax': [

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
@@ -102,7 +102,7 @@ export const GridProEditSelectMixin = (superClass) =>
           value: option,
         }));
 
-        this._overlayElement = this._overlayElement || this.shadowRoot.querySelector('vaadin-select-overlay');
+        this._overlayElement ||= this.shadowRoot.querySelector('vaadin-select-overlay');
         this._overlayElement.addEventListener('vaadin-overlay-outside-click', () => {
           this._grid._stopEdit();
         });

--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -145,8 +145,7 @@ export const ColumnAutoWidthMixin = (superClass) =>
         }
       });
 
-      this.__hasHadRenderedRowsForColumnWidthCalculation =
-        this.__hasHadRenderedRowsForColumnWidthCalculation || this._getRenderedRows().length > 0;
+      this.__hasHadRenderedRowsForColumnWidthCalculation ||= this._getRenderedRows().length > 0;
 
       this.__intrinsicWidthCache = new Map();
       // Cache the viewport rows to avoid unnecessary reflows while measuring the column widths

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -221,7 +221,7 @@ export class ColumnObserver {
   __onMutation() {
     // Detect if this is the initial call
     const initialCall = !this.__currentColumns;
-    this.__currentColumns = this.__currentColumns || [];
+    this.__currentColumns ||= [];
 
     // Detect added and removed columns or if the columns order has changed
     const columns = ColumnObserver.getColumns(this.__host);

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -337,7 +337,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
   /** @private */
   __initResizeObserver() {
-    this.__resizeObserver = this.__resizeObserver || new ResizeObserver(() => this.__onResize());
+    this.__resizeObserver ||= new ResizeObserver(() => this.__onResize());
     this.__resizeObserver.disconnect();
 
     [this, this.$.master, this.$.detail, this.__slottedMaster, this.__slottedDetail].forEach((node) => {
@@ -410,7 +410,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     // the slotted detail content to use as a fallback for the detail column size
     // while the detail content is rendered in an overlay.
     if ((hasDetail || hasDetailPlaceholder) && this.__isDetailAutoSized && detailSize > 0) {
-      this.__detailCachedSize = this.__detailCachedSize || `${Math.ceil(detailSize)}px`;
+      this.__detailCachedSize ||= `${Math.ceil(detailSize)}px`;
     } else {
       this.__detailCachedSize = null;
     }

--- a/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
@@ -26,7 +26,7 @@ export class MenuBarTooltipController extends SlotController {
    */
   initCustomNode(tooltipNode) {
     tooltipNode.manual = true;
-    tooltipNode.generator = tooltipNode.generator || (({ item }) => item && item.tooltip);
+    tooltipNode.generator ||= ({ item }) => item && item.tooltip;
   }
 
   /**

--- a/packages/upload/src/vaadin-upload-manager.js
+++ b/packages/upload/src/vaadin-upload-manager.js
@@ -4,8 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-window.Vaadin = window.Vaadin || {};
-window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};
+window.Vaadin ||= {};
+window.Vaadin.featureFlags ||= {};
 
 /**
  * A pure JavaScript class that manages file upload state and XHR requests.

--- a/packages/upload/test/dom/vaadin-upload-button.test.js
+++ b/packages/upload/test/dom/vaadin-upload-button.test.js
@@ -2,8 +2,8 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
 
-window.Vaadin = window.Vaadin || {};
-window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};
+window.Vaadin ||= {};
+window.Vaadin.featureFlags ||= {};
 window.Vaadin.featureFlags.modularUpload = true;
 
 import '../../src/vaadin-upload-button.js';

--- a/packages/upload/test/dom/vaadin-upload-file.test.js
+++ b/packages/upload/test/dom/vaadin-upload-file.test.js
@@ -1,8 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
 
-window.Vaadin = window.Vaadin || {};
-window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};
+window.Vaadin ||= {};
+window.Vaadin.featureFlags ||= {};
 window.Vaadin.featureFlags.modularUpload = true;
 
 import '../../src/vaadin-upload-file.js';

--- a/packages/vaadin-themable-mixin/vaadin-theme-detection-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-detection-mixin.js
@@ -23,7 +23,7 @@ export const ThemeDetectionMixin = (superClass) =>
 
       if (this.isConnected) {
         const root = findRoot(this);
-        root.__themeDetector = root.__themeDetector || new ThemeDetector(root);
+        root.__themeDetector ||= new ThemeDetector(root);
         this.__themeDetector = root.__themeDetector;
         this.__themeDetector.addEventListener('theme-changed', this.__applyDetectedTheme);
         this.__applyDetectedTheme();


### PR DESCRIPTION
## Description

Now when #11539 is merged, we have fully switched from Polymer Analyzer to CEM. Therefore, can now allow using modern ES2020 syntax like `??`, `?.`, `||=` etc in `vaadin-*.js` web component source files. Updated ESLitn config accordingly, also fixed errors for `logical-assignment-operators`.

I'll make follow-up PRs adding usage of optional chaining where it makes sense to keep this PR smaller.

## Type of change

- Internal change