### PR TITLE
chore: use optional chaining in components sources

### DIFF
--- a/packages/a11y-base/src/aria-hidden.js
+++ b/packages/a11y-base/src/aria-hidden.js
@@ -27,7 +27,7 @@ let lockCount = 0;
  * @param {?Node} node
  * @return {boolean}
  */
-const isElement = (node) => node && node.nodeType === Node.ELEMENT_NODE;
+const isElement = (node) => node?.nodeType === Node.ELEMENT_NODE;
 
 /**
  * @param  {...unknown} args

--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -87,7 +87,7 @@ const DelegateFocusMixinImplementation = (superclass) => {
 
         // Set focus-ring attribute on programmatic focus by default
         // unless explicitly disabled by `{ focusVisible: false }`.
-        if (!(options && options.focusVisible === false)) {
+        if (options?.focusVisible !== false) {
           this.setAttribute('focus-ring', '');
         }
       }

--- a/packages/a11y-base/src/focus-mixin.js
+++ b/packages/a11y-base/src/focus-mixin.js
@@ -63,7 +63,7 @@ const FocusMixinImplementation = (superclass) => {
 
       // Set focus-ring attribute on programmatic focus by default
       // unless explicitly disabled by `{ focusVisible: false }`.
-      if (!(options && options.focusVisible === false)) {
+      if (options?.focusVisible !== false) {
         this.setAttribute('focus-ring', '');
       }
     }

--- a/packages/accordion/src/vaadin-accordion-panel-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-panel-mixin.js
@@ -125,7 +125,7 @@ export const AccordionPanelMixin = (superClass) =>
           node.setAttribute('aria-labelledby', focusElement.id);
         }
 
-        if (node && node.id) {
+        if (node?.id) {
           focusElement.setAttribute('aria-controls', node.id);
         } else {
           focusElement.removeAttribute('aria-controls');

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -440,7 +440,7 @@ export const AvatarGroupMixin = (superClass) =>
 
     /** @private */
     __i18nItemsChanged(effectiveI18n, items) {
-      if (effectiveI18n && effectiveI18n.activeUsers) {
+      if (effectiveI18n?.activeUsers) {
         const count = Array.isArray(items) ? items.length : 0;
         const field = count === 1 ? 'one' : 'many';
         if (effectiveI18n.activeUsers[field]) {

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -203,7 +203,7 @@ export const AvatarMixin = (superClass) =>
 
     /** @private */
     __i18nChanged(effectiveI18n) {
-      if (effectiveI18n && effectiveI18n.anonymous) {
+      if (effectiveI18n?.anonymous) {
         if (this.__oldAnonymous && this.__tooltipNode && this.__tooltipNode.text === this.__oldAnonymous) {
           this.__setTooltip();
         }

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -178,7 +178,7 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(Li
       this.removeChild(stringTitleElement);
     }
     const ariaLabelledby = this.getAttribute('aria-labelledby');
-    if (ariaLabelledby && ariaLabelledby.startsWith('card-title-')) {
+    if (ariaLabelledby?.startsWith('card-title-')) {
       this.removeAttribute('aria-labelledby');
     }
     if (this.cardTitle) {

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -85,8 +85,8 @@ KeyboardNavigation.prototype.onMouseUp = function (e) {
     const chart = this.chart;
     const target = e.composedPath()[0];
     if (!target || !chart.container.contains(target)) {
-      const curMod = this.modules && this.modules[this.currentModuleIx || 0];
-      if (curMod && curMod.terminate) {
+      const curMod = this.modules?.[this.currentModuleIx || 0];
+      if (curMod?.terminate) {
         curMod.terminate();
       }
       this.currentModuleIx = 0;
@@ -1426,7 +1426,7 @@ export const ChartMixin = (superClass) =>
           default:
             break;
         }
-        if (axes && axes[axisIndex]) {
+        if (axes?.[axisIndex]) {
           const axis = axes[axisIndex];
           const functionToCall = axis[functionName];
           if (functionToCall && typeof functionToCall === 'function') {

--- a/packages/charts/src/vaadin-chart-series-mixin.js
+++ b/packages/charts/src/vaadin-chart-series-mixin.js
@@ -284,7 +284,7 @@ export const ChartSeriesMixin = (superClass) =>
         return;
       }
 
-      if (series && series.yAxis) {
+      if (series?.yAxis) {
         series.yAxis.update({ [key]: value });
       }
     }

--- a/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
@@ -60,7 +60,7 @@ export const CheckboxGroupMixin = (superclass) =>
       this._tooltipController = new TooltipController(this);
       this._tooltipController.addEventListener('tooltip-changed', (event) => {
         const tooltip = event.detail.node;
-        if (tooltip && tooltip.isConnected) {
+        if (tooltip?.isConnected) {
           // Tooltip element has been added to the DOM
           const inputs = this.__checkboxes.map((checkbox) => checkbox.inputElement);
           this._tooltipController.setAriaTarget(inputs);
@@ -250,14 +250,14 @@ export const CheckboxGroupMixin = (superclass) =>
      */
     __valueChanged(value, oldValue) {
       // Setting initial value to empty array, skip validation
-      if (value && value.length === 0 && oldValue === undefined) {
+      if (value?.length === 0 && oldValue === undefined) {
         return;
       }
 
-      this.toggleAttribute('has-value', value && value.length > 0);
+      this.toggleAttribute('has-value', value?.length > 0);
 
       this.__checkboxes.forEach((checkbox) => {
-        checkbox.checked = value && value.includes(checkbox.value);
+        checkbox.checked = value?.includes(checkbox.value);
       });
 
       if (oldValue !== undefined) {

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -177,7 +177,7 @@ export const ComboBoxMixin = (superClass) =>
     _openedOrItemsChanged(opened, items, loading, keepOverlayOpened) {
       // Close the overlay if there are no items to display.
       // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = opened && (keepOverlayOpened || loading || !!(items && items.length));
+      this._overlayOpened = opened && (keepOverlayOpened || loading || !!items?.length);
     }
 
     /**

--- a/packages/component-base/src/data-provider-controller/helpers.js
+++ b/packages/component-base/src/data-provider-controller/helpers.js
@@ -105,7 +105,7 @@ export function getFlatIndexByPath(cache, [levelIndex, ...subIndexes], flatIndex
 
   const flatIndexOnLevel = cache.getFlatIndex(levelIndex);
   const subCache = cache.getSubCache(levelIndex);
-  if (subCache && subCache.flatSize > 0 && subIndexes.length) {
+  if (subCache?.flatSize > 0 && subIndexes.length) {
     return getFlatIndexByPath(subCache, subIndexes, flatIndex + flatIndexOnLevel + 1);
   }
   return flatIndex + flatIndexOnLevel;

--- a/packages/component-base/src/gestures.js
+++ b/packages/component-base/src/gestures.js
@@ -232,7 +232,7 @@ export function deepTargetFind(x, y) {
   // This code path is only taken when native ShadowDOM is used
   // if there is a shadowroot, it may have a node at x/y
   // if there is not a shadowroot, exit the loop
-  while (next && next.shadowRoot && !window.ShadyDOM) {
+  while (next?.shadowRoot && !window.ShadyDOM) {
     // If there is a node at x/y in the shadowroot, look deeper
     const oldNext = next;
     next = next.shadowRoot.elementFromPoint(x, y);
@@ -448,7 +448,7 @@ function _remove(node, evType, handler) {
     for (let i = 0, dep, gd; i < deps.length; i++) {
       dep = deps[i];
       gd = gobj[dep];
-      if (gd && gd[name]) {
+      if (gd?.[name]) {
         gd[name] = (gd[name] || 1) - 1;
         gd._count = (gd._count || 1) - 1;
         if (gd._count === 0) {
@@ -531,7 +531,7 @@ function _fire(target, type, detail) {
   // Forward `preventDefault` in a clean way
   if (ev.defaultPrevented) {
     const preventer = detail.preventer || detail.sourceEvent;
-    if (preventer && preventer.preventDefault) {
+    if (preventer?.preventDefault) {
       preventer.preventDefault();
     }
   }

--- a/packages/component-base/src/polylit-mixin.js
+++ b/packages/component-base/src/polylit-mixin.js
@@ -59,7 +59,7 @@ const PolylitMixinImplementation = (superclass) => {
         };
       }
 
-      if (options && options.reflectToAttribute) {
+      if (options?.reflectToAttribute) {
         options.reflect = true;
       }
 

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -223,7 +223,7 @@ export class SlotController extends EventTarget {
         });
       }
 
-      if (newNodes && newNodes.length > 0) {
+      if (newNodes?.length > 0) {
         if (this.multiple) {
           // Remove default node if exists
           if (this.defaultNode) {

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -160,7 +160,7 @@ export class TooltipController extends SlotController {
    */
   open(options) {
     const tooltipNode = this.node;
-    if (tooltipNode && tooltipNode.isConnected) {
+    if (tooltipNode?.isConnected) {
       tooltipNode._stateController.open(options);
     }
   }

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -365,7 +365,7 @@ export const ConfirmDialogMixin = (superClass) =>
 
     /** @private */
     __updateMessageNodes(nodes, message) {
-      if (nodes && nodes.length > 0) {
+      if (nodes?.length > 0) {
         const defaultNode = nodes.find((node) => node === this._messageController.defaultNode);
         if (defaultNode) {
           defaultNode.textContent = message;

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -283,7 +283,7 @@ class ContextMenu extends ContextMenuMixin(ElementMixin(ThemePropertyMixin(Polyl
         .modeless="${this._modeless}"
         .renderer="${this.items ? this.__itemsRenderer : this.renderer}"
         .position="${position}"
-        .positionTarget="${position ? context && context.target : this._positionTarget}"
+        .positionTarget="${position ? context?.target : this._positionTarget}"
         .horizontalAlign="${this.__computeHorizontalAlign(position)}"
         .verticalAlign="${this.__computeVerticalAlign(position)}"
         ?no-horizontal-overlap="${this.__computeNoHorizontalOverlap(position)}"

--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -120,7 +120,7 @@ register({
     ev.detail = { x, y, sourceEvent };
     target.dispatchEvent(ev);
     // Forward `preventDefault` in a clean way
-    if (ev.defaultPrevented && sourceEvent && sourceEvent.preventDefault) {
+    if (ev.defaultPrevented && sourceEvent?.preventDefault) {
       sourceEvent.preventDefault();
     }
   },

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -126,7 +126,7 @@ export const ItemsMixin = (superClass) =>
       // If parent item is not focused, do not focus submenu
       if (overlay.parentOverlay) {
         const parent = overlay.parentOverlay._contentRoot.querySelector('[expanded]');
-        if (parent && parent.hasAttribute('focused') && child) {
+        if (parent?.hasAttribute('focused') && child) {
           child.focus();
         } else {
           overlay.$.overlay.focus();
@@ -379,7 +379,7 @@ export const ItemsMixin = (superClass) =>
 
         // Check if the sub-menu was focused before closing it.
         const child = subMenu._overlayElement._contentRoot.firstElementChild;
-        const isSubmenuFocused = child && child.focused;
+        const isSubmenuFocused = child?.focused;
 
         // Mark previously expanded item as collapsed
         if (expandedItem) {
@@ -395,7 +395,7 @@ export const ItemsMixin = (superClass) =>
           return;
         }
 
-        if (children && children.length) {
+        if (children?.length) {
           // Open or update the submenu if the new item has children
           this.__updateExpanded(item, true);
           this.__openSubMenu(subMenu, item);
@@ -410,7 +410,7 @@ export const ItemsMixin = (superClass) =>
 
       // Only reachable with `accessibleDisabledMenuItems` enabled (disabled
       // items otherwise have `pointer-events: none` and never receive mouseover).
-      if (item && item.disabled) {
+      if (item?.disabled) {
         subMenu.close();
       }
     }

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -103,7 +103,7 @@ export const MenuOverlayMixin = (superClass) =>
 
       // Adjust constraints to ensure bottom-aligned applies to sub-menu.
       const parent = this.parentOverlay;
-      if (parent && parent.hasAttribute('bottom-aligned')) {
+      if (parent?.hasAttribute('bottom-aligned')) {
         const parentStyle = getComputedStyle(parent);
         yMax = yMax - parseFloat(parentStyle.bottom) - parseFloat(parentStyle.height);
       }

--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -62,7 +62,7 @@ export const CrudGridMixin = (superClass) =>
 
     /** @private */
     __onItemsChange(items) {
-      if ((!this.dataProvider || this.dataProvider === this._arrayDataProvider) && !this.include && items && items[0]) {
+      if ((!this.dataProvider || this.dataProvider === this._arrayDataProvider) && !this.include && items?.[0]) {
         this._configure(items[0]);
       }
     }

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -793,7 +793,7 @@ export const CrudMixin = (superClass) =>
     __createDataProviderProxy(dataProvider) {
       return (params, callback) => {
         const callbackProxy = (chunk, size) => {
-          if (chunk && chunk[0]) {
+          if (chunk?.[0]) {
             this.__model = chunk[0];
           }
 

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -278,7 +278,7 @@ export const CustomFieldMixin = (superClass) =>
     /** @private */
     __inputsChanged(inputs, oldInputs) {
       if (inputs.length === 0) {
-        if (oldInputs && oldInputs.length > 0) {
+        if (oldInputs?.length > 0) {
           this.__setValue();
         }
         return;

--- a/packages/dashboard/src/vaadin-dashboard-helpers.js
+++ b/packages/dashboard/src/vaadin-dashboard-helpers.js
@@ -52,7 +52,7 @@ export function getItemsArrayOfItem(item, items) {
  */
 export function getElementItem(element) {
   const wrapper = element.closest(WRAPPER_LOCAL_NAME);
-  return wrapper && wrapper.__item;
+  return wrapper?.__item;
 }
 
 /**

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -347,7 +347,7 @@ class Dashboard extends DashboardLayoutMixin(
 
   /** @private */
   __focusWrapperContent(wrapper) {
-    if (wrapper && wrapper.firstElementChild) {
+    if (wrapper?.firstElementChild) {
       wrapper.firstElementChild.focus();
     }
   }

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -290,14 +290,14 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     /** @private */
     __updateCancelButton(cancelButton, i18n) {
       if (cancelButton) {
-        cancelButton.textContent = i18n && i18n.cancel;
+        cancelButton.textContent = i18n?.cancel;
       }
     }
 
     /** @private */
     __updateTodayButton(todayButton, i18n, minDate, maxDate, isDateDisabled) {
       if (todayButton) {
-        todayButton.textContent = i18n && i18n.today;
+        todayButton.textContent = i18n?.today;
         todayButton.disabled = !this._isTodayAllowed(minDate, maxDate, isDateDisabled);
       }
     }
@@ -316,7 +316,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
       isDateDisabled,
       enteredDate,
     ) {
-      if (calendars && calendars.length) {
+      if (calendars?.length) {
         calendars.forEach((calendar) => {
           calendar.i18n = i18n;
           calendar.minDate = minDate;
@@ -339,7 +339,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     __updateYears(years, selectedDate, theme) {
-      if (years && years.length) {
+      if (years?.length) {
         years.forEach((year) => {
           year.selectedDate = selectedDate;
 

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -285,7 +285,7 @@ class DatePicker extends DatePickerMixin(
   _onVaadinOverlayClose(e) {
     // Prevent closing the overlay on label element click
     const event = e.detail.sourceEvent;
-    if (event && event.composedPath().includes(this) && !event.composedPath().includes(this._overlayElement)) {
+    if (event?.composedPath().includes(this) && !event.composedPath().includes(this._overlayElement)) {
       e.preventDefault();
     }
   }

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -244,7 +244,7 @@ export const MonthCalendarMixin = (superClass) =>
     /** @protected */
     __computeShowWeekSeparator(showWeekNumbers, i18n) {
       // Currently only supported for locales that start the week on Monday.
-      return showWeekNumbers && i18n && i18n.firstDayOfWeek === 1;
+      return showWeekNumbers && i18n?.firstDayOfWeek === 1;
     }
 
     /** @protected */

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -469,7 +469,7 @@ export const DateTimePickerMixin = (superClass) =>
       const targetI18n = {};
       props.forEach((prop) => {
         // eslint-disable-next-line no-prototype-builtins
-        if (i18n && i18n.hasOwnProperty(prop)) {
+        if (i18n?.hasOwnProperty(prop)) {
           targetI18n[prop] = i18n[prop];
         }
       });

--- a/packages/details/src/vaadin-details-base-mixin.js
+++ b/packages/details/src/vaadin-details-base-mixin.js
@@ -103,7 +103,7 @@ export const DetailsBaseMixin = (superClass) =>
       if (summary && contentElements) {
         const node = contentElements[0];
 
-        if (node && node.id) {
+        if (node?.id) {
           summary.setAttribute('aria-controls', node.id);
         } else {
           summary.removeAttribute('aria-controls');

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -200,7 +200,7 @@ export const FieldMixin = (superclass) =>
         // Otherwise assistive technologies would announce the error, even if we hide it.
         if (invalid) {
           const node = this._errorNode;
-          this._fieldAriaController.setErrorId(node && node.id);
+          this._fieldAriaController.setErrorId(node?.id);
         } else {
           this._fieldAriaController.setErrorId(null);
         }

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -38,7 +38,7 @@ export const LabelMixin = (superclass) =>
     /** @protected */
     get _labelId() {
       const node = this._labelNode;
-      return node && node.id;
+      return node?.id;
     }
 
     /** @protected */

--- a/packages/field-highlighter/src/vaadin-field-highlighter.js
+++ b/packages/field-highlighter/src/vaadin-field-highlighter.js
@@ -120,7 +120,7 @@ export class FieldHighlighterController {
   }
 
   removeUser(user) {
-    if (user && user.id !== undefined) {
+    if (user?.id !== undefined) {
       let index;
       for (let i = 0; i < this.users.length; i++) {
         if (this.users[i].id === user.id) {

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -248,11 +248,11 @@ export class UserTags extends PolylitMixin(LitElement) {
 
   applyTagsEnd({ added, removed }) {
     removed.forEach((tag) => {
-      if (tag && tag.parentNode === this) {
+      if (tag?.parentNode === this) {
         this.removeChild(tag);
       }
     });
-    added.forEach((tag) => tag && tag.classList.add('show'));
+    added.forEach((tag) => tag?.classList.add('show'));
   }
 
   setUsers(users) {

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
@@ -96,7 +96,7 @@ export const GridProEditSelectMixin = (superClass) =>
     }
 
     _optionsChanged(options) {
-      if (options && options.length) {
+      if (options?.length) {
         this.items = options.map((option) => ({
           label: option,
           value: option,

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -228,7 +228,7 @@ export const InlineEditingMixin = (superClass) =>
             return;
           }
 
-          if (edited && edited.cell === cell) {
+          if (edited?.cell === cell) {
             return;
           }
 
@@ -255,7 +255,7 @@ export const InlineEditingMixin = (superClass) =>
 
     /** @private */
     _isEditColumn(column) {
-      return column && column.localName.toLowerCase() === 'vaadin-grid-pro-edit-column';
+      return column?.localName.toLowerCase() === 'vaadin-grid-pro-edit-column';
     }
 
     /** @private */
@@ -301,7 +301,7 @@ export const InlineEditingMixin = (superClass) =>
           return;
         }
 
-        if (edited && edited.cell === cell && column._getEditorComponent(cell).contains(e.target)) {
+        if (edited?.cell === cell && column._getEditorComponent(cell).contains(e.target)) {
           return;
         }
 
@@ -461,7 +461,7 @@ export const InlineEditingMixin = (superClass) =>
 
       // Do not prevent Tab to allow native input blur and wait for it,
       // unless the keydown event is from the edit cell select overlay.
-      if (e.key === 'Tab' && editor && editor.contains(e.target)) {
+      if (e.key === 'Tab' && editor?.contains(e.target)) {
         const ignore = await new Promise((resolve) => {
           editor.addEventListener(
             'focusout',

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -54,7 +54,7 @@ export const A11yMixin = (superClass) =>
 
       // If no header and footer rows while the empty state is active, count as one column
       // Otherwise, use the number of body columns, if present
-      const columnsCount = emptyState ? 1 : (rowsCount && bodyColumns && bodyColumns.length) || 0;
+      const columnsCount = emptyState ? 1 : (rowsCount && bodyColumns?.length) || 0;
       this.$.table.setAttribute('aria-colcount', columnsCount);
 
       this.__a11yUpdateHeaderRows();
@@ -164,7 +164,7 @@ export const A11yMixin = (superClass) =>
         while (cellContent && cellContent.localName !== 'vaadin-grid-cell-content') {
           cellContent = cellContent.parentNode;
         }
-        if (cellContent && cellContent.assignedSlot) {
+        if (cellContent?.assignedSlot) {
           const cell = cellContent.assignedSlot.parentNode;
           cell.setAttribute(
             'aria-sort',

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -29,7 +29,7 @@ export const ColumnBaseMixin = (superClass) =>
             }
 
             const parent = this.parentNode;
-            if (parent && parent.localName === 'vaadin-grid-column-group') {
+            if (parent?.localName === 'vaadin-grid-column-group') {
               return parent.resizable || false;
             }
             return false;
@@ -563,7 +563,7 @@ export const ColumnBaseMixin = (superClass) =>
 
     /** @protected */
     _runRenderer(renderer, cell, model) {
-      const isVisibleBodyCell = model && model.item && !cell.parentElement.hidden;
+      const isVisibleBodyCell = model?.item && !cell.parentElement.hidden;
       const shouldRender = isVisibleBodyCell || renderer === this._headerRenderer || renderer === this._footerRenderer;
       if (!shouldRender) {
         return;

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -147,8 +147,8 @@ export const ColumnReorderingMixin = (superClass) =>
       }
 
       // Cancel reordering if there are draggable nodes on the event path following this element
-      const path = e.composedPath && e.composedPath();
-      if (path && path.slice(0, Math.max(0, path.indexOf(this))).some((node) => node.draggable)) {
+      const path = e.composedPath?.();
+      if (path?.slice(0, Math.max(0, path.indexOf(this))).some((node) => node.draggable)) {
         return;
       }
 
@@ -271,7 +271,7 @@ export const ColumnReorderingMixin = (superClass) =>
         }
         // Check if element is the cell of a focus button mode column
         const { parentElement } = element;
-        if (parentElement && parentElement._focusButton === element) {
+        if (parentElement?._focusButton === element) {
           return parentElement;
         }
       }

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -286,7 +286,7 @@ export const DragAndDropMixin = (superClass) =>
           }
         }
 
-        if (row && row.hasAttribute('drop-disabled')) {
+        if (row?.hasAttribute('drop-disabled')) {
           this._dropLocation = undefined;
           return;
         }

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -112,7 +112,7 @@ export const DynamicColumnsMixin = (superClass) =>
       this._observer = new ColumnObserver(this, (_addedColumns, removedColumns) => {
         const allRemovedCells = removedColumns.flatMap((c) => c._allCells);
         const filterNotConnected = (element) =>
-          allRemovedCells.filter((cell) => cell && cell._content.contains(element)).length;
+          allRemovedCells.filter((cell) => cell?._content.contains(element)).length;
 
         this.__removeSorters(this._sorters.filter(filterNotConnected));
         this.__removeFilters(this._filters.filter(filterNotConnected));

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -103,7 +103,7 @@ export const KeyboardNavigationMixin = (superClass) =>
       ['_itemsFocusable', '_footerFocusable', '_headerFocusable'].forEach((prop) => {
         const focusable = this[prop];
         if (value) {
-          const parent = focusable && focusable.parentElement;
+          const parent = focusable?.parentElement;
           if (isCell(focusable)) {
             // Cell itself focusable (default)
             this[prop] = parent;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -417,7 +417,7 @@ export const GridMixin = (superClass) =>
       const slot = document.createElement('slot');
       slot.setAttribute('name', slotName);
 
-      if (column && column._focusButtonMode) {
+      if (column?._focusButtonMode) {
         const div = document.createElement('div');
         div.setAttribute('role', 'button');
         div.setAttribute('tabindex', '-1');
@@ -871,7 +871,7 @@ export const GridMixin = (superClass) =>
     _showTooltip(event) {
       // Check if there is a slotted vaadin-tooltip element.
       const tooltip = this._tooltipController.node;
-      if (tooltip && tooltip.isConnected) {
+      if (tooltip?.isConnected) {
         const target = event.target;
 
         if (!this.__isCellFullyVisible(target)) {

--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -70,9 +70,9 @@ export const LoginOverlayMixin = (superClass) =>
       super.willUpdate(props);
 
       if (props.has('__effectiveI18n') || props.has('title') || props.has('description')) {
-        const header = this.__effectiveI18n && this.__effectiveI18n.header;
-        this.__effectiveTitle = header && header.title != null ? header.title : this.title;
-        this.__effectiveDescription = header && header.description != null ? header.description : this.description;
+        const header = this.__effectiveI18n?.header;
+        this.__effectiveTitle = header?.title != null ? header.title : this.title;
+        this.__effectiveDescription = header?.description != null ? header.description : this.description;
       }
     }
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -530,7 +530,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     }
 
     const updateSlot = async () => {
-      if (oldDetail && oldDetail.slot === 'detail') {
+      if (oldDetail?.slot === 'detail') {
         oldDetail.remove();
       }
 
@@ -640,7 +640,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     } finally {
       // Skip removal if the slot was reassigned during the transition.
       // The React component does this to let React handle the removal.
-      if (oldDetail && oldDetail.slot === 'detail-outgoing') {
+      if (oldDetail?.slot === 'detail-outgoing') {
         oldDetail.remove();
       }
     }

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -413,7 +413,7 @@ export const MenuBarMixin = (superClass) =>
     /** @private */
     __updateSubMenu() {
       const subMenu = this._subMenu;
-      if (subMenu && subMenu.opened) {
+      if (subMenu?.opened) {
         const button = subMenu._positionTarget;
 
         // Close sub-menu if the corresponding button is no longer in the DOM,
@@ -426,7 +426,7 @@ export const MenuBarMixin = (superClass) =>
 
     /** @private */
     __i18nChanged(effectiveI18n) {
-      if (effectiveI18n && effectiveI18n.moreOptions !== undefined) {
+      if (effectiveI18n?.moreOptions !== undefined) {
         if (effectiveI18n.moreOptions) {
           this._overflow.setAttribute('aria-label', effectiveI18n.moreOptions);
         } else {
@@ -568,7 +568,7 @@ export const MenuBarMixin = (superClass) =>
       let theme = hostTheme;
 
       // Item theme takes precedence over host theme even if it's empty, as long as it's not undefined or null
-      const itemTheme = item && item.theme;
+      const itemTheme = item?.theme;
       if (itemTheme != null) {
         theme = Array.isArray(itemTheme) ? itemTheme.join(' ') : itemTheme;
       }
@@ -602,7 +602,7 @@ export const MenuBarMixin = (superClass) =>
         html`
           ${items.map((item) => {
             const itemCopy = { ...item };
-            const hasChildren = Boolean(item && item.children);
+            const hasChildren = Boolean(item?.children);
 
             if (itemCopy.component) {
               const component = this.__getComponent(itemCopy);
@@ -921,7 +921,7 @@ export const MenuBarMixin = (superClass) =>
         }
       }
 
-      const items = item && item.children;
+      const items = item?.children;
       if (!items || items.length === 0) {
         this.__fireItemSelected(item);
         return;
@@ -998,7 +998,7 @@ export const MenuBarMixin = (superClass) =>
     /** @private */
     __deactivateButton(restoreFocus) {
       const button = this._expandedButton;
-      if (button && button.hasAttribute('expanded')) {
+      if (button?.hasAttribute('expanded')) {
         this._setExpanded(button, false);
         if (restoreFocus) {
           const focusOptions = { focusVisible: isKeyboardActive() };

--- a/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-tooltip-controller.js
@@ -26,7 +26,7 @@ export class MenuBarTooltipController extends SlotController {
    */
   initCustomNode(tooltipNode) {
     tooltipNode.manual = true;
-    tooltipNode.generator ||= ({ item }) => item && item.tooltip;
+    tooltipNode.generator ||= ({ item }) => item?.tooltip;
   }
 
   /**
@@ -60,7 +60,7 @@ export class MenuBarTooltipController extends SlotController {
    */
   open({ trigger }) {
     const tooltipNode = this.node;
-    if (tooltipNode && tooltipNode.isConnected && tooltipNode.target) {
+    if (tooltipNode?.isConnected && tooltipNode.target) {
       tooltipNode._stateController.open({
         hover: trigger === 'hover',
         focus: trigger === 'focus',

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -501,7 +501,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
     __openedOrItemsChanged(opened, items, loading, keepOverlayOpened) {
       // Close the overlay if there are no items to display.
       // See https://github.com/vaadin/vaadin-combo-box/pull/964
-      this._overlayOpened = opened && (keepOverlayOpened || loading || !!(items && items.length));
+      this._overlayOpened = opened && (keepOverlayOpened || loading || !!items?.length);
     }
 
     /**
@@ -714,7 +714,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         return;
       }
 
-      if (items && items.length && this._topGroup && this._topGroup.length) {
+      if (items?.length && this._topGroup?.length) {
         // Filter out items included to the top group.
         const filteredItems = items.filter((item) => this._findIndex(item, this._topGroup, this.itemIdPath) === -1);
 
@@ -815,7 +815,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       if (index !== -1) {
         const lastFilter = this._lastFilter;
         // Do not unselect when manually typing and committing an already selected item.
-        if (lastFilter && lastFilter.toLowerCase() === itemLabel.toLowerCase()) {
+        if (lastFilter?.toLowerCase() === itemLabel.toLowerCase()) {
           this.__clearInternalValue();
           return;
         }

--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -94,7 +94,7 @@ export const NotificationContainerMixin = (superClass) =>
       // Notifications are a separate overlay mechanism from vaadin-overlay, and
       // interacting with them should not close modal overlays
       const sourceEvent = event.detail.sourceEvent;
-      const isFromNotification = sourceEvent && sourceEvent.composedPath().indexOf(this) >= 0;
+      const isFromNotification = sourceEvent?.composedPath().indexOf(this) >= 0;
       if (isFromNotification) {
         event.preventDefault();
       }
@@ -216,16 +216,16 @@ export const NotificationMixin = (superClass) =>
       if (options && Number.isFinite(options.duration)) {
         notification.duration = options.duration;
       }
-      if (options && options.position) {
+      if (options?.position) {
         notification.position = options.position;
       }
-      if (options && options.assertive) {
+      if (options?.assertive) {
         notification.assertive = options.assertive;
       }
-      if (options && options.theme) {
+      if (options?.theme) {
         notification.setAttribute('theme', options.theme);
       }
-      if (options && options.className) {
+      if (options?.className) {
         notification.overlayClass = options.className;
       }
       notification.renderer = renderer;

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -22,7 +22,7 @@ export function observeMove(element, callback) {
 
   function cleanup() {
     timeout && clearTimeout(timeout);
-    io && io.disconnect();
+    io?.disconnect();
     io = null;
   }
 

--- a/packages/radio-group/src/vaadin-radio-group-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-group-mixin.js
@@ -79,7 +79,7 @@ export const RadioGroupMixin = (superclass) =>
       this._tooltipController = new TooltipController(this);
       this._tooltipController.addEventListener('tooltip-changed', (event) => {
         const tooltip = event.detail.node;
-        if (tooltip && tooltip.isConnected) {
+        if (tooltip?.isConnected) {
           // Tooltip element has been added to the DOM
           const inputs = this.__radioButtons.map((radio) => radio.inputElement);
           this._tooltipController.setAriaTarget(inputs);

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -766,7 +766,7 @@ export const RichTextEditorMixin = (superClass) =>
         const tabs = '\t'.repeat(level);
         // Add tabs to content
         const firstChild = element.firstChild;
-        if (firstChild && firstChild.nodeType === Node.TEXT_NODE) {
+        if (firstChild?.nodeType === Node.TEXT_NODE) {
           firstChild.textContent = tabs + firstChild.textContent;
         } else if (element.childNodes.length > 0) {
           const tabNode = document.createTextNode(tabs);

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -271,7 +271,7 @@ export const SelectBaseMixin = (superClass) =>
           'click',
           (e) => {
             const item = e.composedPath().find((el) => el._hasVaadinItemMixin);
-            this.__dispatchChangePending = Boolean(item && item.value !== undefined && item.value !== this.value);
+            this.__dispatchChangePending = Boolean(item?.value !== undefined && item.value !== this.value);
             this.opened = false;
           },
           true,

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -342,7 +342,7 @@ class SideNavItem extends SideNavChildrenMixin(
   /** @private */
   __expandParentItems() {
     const sideNav = this.closest('vaadin-side-nav');
-    if (sideNav && sideNav.noAutoExpand) {
+    if (sideNav?.noAutoExpand) {
       return;
     }
 

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -281,7 +281,7 @@ export const TimePickerMixin = (superClass) =>
     /** @private */
     _openedOrItemsChanged(opened, items) {
       // Close the overlay if there are no items to display.
-      this._overlayOpened = opened && !!(items && items.length);
+      this._overlayOpened = opened && !!items?.length;
     }
 
     /**
@@ -458,10 +458,10 @@ export const TimePickerMixin = (superClass) =>
      * @private
      */
     __getMsec(obj) {
-      let result = ((obj && obj.hours) || 0) * 60 * 60 * 1000;
-      result += ((obj && obj.minutes) || 0) * 60 * 1000;
-      result += ((obj && obj.seconds) || 0) * 1000;
-      result += (obj && parseInt(obj.milliseconds)) || 0;
+      let result = (obj?.hours || 0) * 60 * 60 * 1000;
+      result += (obj?.minutes || 0) * 60 * 1000;
+      result += (obj?.seconds || 0) * 1000;
+      result += parseInt(obj?.milliseconds) || 0;
 
       return result;
     }
@@ -471,10 +471,10 @@ export const TimePickerMixin = (superClass) =>
      * @private
      */
     __getSec(obj) {
-      let result = ((obj && obj.hours) || 0) * 60 * 60;
-      result += ((obj && obj.minutes) || 0) * 60;
-      result += (obj && obj.seconds) || 0;
-      result += (obj && obj.milliseconds / 1000) || 0;
+      let result = (obj?.hours || 0) * 60 * 60;
+      result += (obj?.minutes || 0) * 60;
+      result += obj?.seconds || 0;
+      result += (obj?.milliseconds || 0) / 1000;
 
       return result;
     }

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -719,7 +719,7 @@ export const TooltipMixin = (superClass) =>
 
     /** @private */
     __computeAriaTarget(ariaTarget, target) {
-      const isElementNode = (el) => el && el.nodeType === Node.ELEMENT_NODE;
+      const isElementNode = (el) => el?.nodeType === Node.ELEMENT_NODE;
       const isAriaTargetSet = Array.isArray(ariaTarget) ? ariaTarget.some(isElementNode) : ariaTarget;
       return ariaTarget === null || isAriaTargetSet ? ariaTarget : target;
     }

--- a/packages/upload/src/vaadin-upload-helpers.js
+++ b/packages/upload/src/vaadin-upload-helpers.js
@@ -33,7 +33,7 @@ export function getFilesFromDropEvent(dropEvent) {
     .filter((item) => !!item)
     .filter((item) => typeof item.webkitGetAsEntry === 'function')
     .map((item) => item.webkitGetAsEntry())
-    .some((entry) => !!entry && entry.isDirectory);
+    .some((entry) => !!entry?.isDirectory);
 
   if (!containsFolders) {
     return Promise.resolve(dropEvent.dataTransfer.files ? Array.from(dropEvent.dataTransfer.files) : []);


### PR DESCRIPTION
## Description

Follow-up to #11622. Replaces `obj && obj.x` patterns with `obj?.x` across component source files now that ES2020 syntax is permitted.

## Type of change

- Internal change