### PR TITLE
test: add shadow DOM snapshots for context-menu and menu-bar

### DIFF
--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -171,3 +171,22 @@ snapshots["context-menu overlay"] =
 `;
 /* end snapshot context-menu overlay */
 
+snapshots["context-menu shadow"] = 
+`<slot id="slot">
+</slot>
+<vaadin-context-menu-overlay
+  exportparts="backdrop, overlay, content"
+  id="overlay"
+  popover="manual"
+>
+  <slot name="overlay">
+  </slot>
+  <slot
+    name="submenu"
+    slot="submenu"
+  >
+  </slot>
+</vaadin-context-menu-overlay>
+`;
+/* end snapshot context-menu shadow */
+

--- a/packages/context-menu/test/dom/context-menu.test.js
+++ b/packages/context-menu/test/dom/context-menu.test.js
@@ -90,4 +90,8 @@ describe('context-menu', () => {
   it('overlay', async () => {
     await expect(menu._overlayElement).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
+
+  it('shadow', async () => {
+    await expect(menu).shadowDom.to.equalSnapshot(SNAPSHOT_CONFIG);
+  });
 });

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -186,3 +186,20 @@ snapshots["menu-bar overlay"] =
 `;
 /* end snapshot menu-bar overlay */
 
+snapshots["menu-bar shadow"] = 
+`<div
+  part="container"
+  style=""
+>
+  <slot>
+  </slot>
+  <slot name="overflow">
+  </slot>
+</div>
+<slot name="submenu">
+</slot>
+<slot name="tooltip">
+</slot>
+`;
+/* end snapshot menu-bar shadow */
+

--- a/packages/menu-bar/test/dom/menu-bar.test.js
+++ b/packages/menu-bar/test/dom/menu-bar.test.js
@@ -50,4 +50,8 @@ describe('menu-bar', () => {
     await nextRender();
     await expect(menu._subMenu._overlayElement).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
   });
+
+  it('shadow', async () => {
+    await expect(menu).shadowDom.to.equalSnapshot();
+  });
 });


### PR DESCRIPTION
## Description

Adds shadow DOM snapshot tests for `vaadin-context-menu` and `vaadin-menu-bar`. Existing DOM snapshot tests only covered light DOM, so changes to the components' shadow DOM (e.g. adding/removing slots) went unnoticed in tests.

## Type of change

- Tests