### PR TITLE
fix: mark internal filter-changed event as @internal in CEM

### DIFF
--- a/packages/grid/src/vaadin-grid-filter-element-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.js
@@ -68,6 +68,7 @@ export const GridFilterElementMixin = (superClass) =>
       textField.value = value;
 
       this._debouncerFilterChanged = Debouncer.debounce(this._debouncerFilterChanged, timeOut.after(200), () => {
+        /** @internal to not document it in CEM */
         this.dispatchEvent(new CustomEvent('filter-changed', { bubbles: true }));
       });
     }


### PR DESCRIPTION
## Summary

Fixes a regression introduced by web-components 25.2.0-alpha10: the React wrapper generator fails with `Property 'filter-changed' does not exist on type 'GridFilterEventMap'`.

The `filter-changed` event on `<vaadin-grid-filter>` is dispatched internally by `GridFilterElementMixin` so that the surrounding `<vaadin-grid>` can react to filter value changes. It is **not** part of the public API of `<vaadin-grid-filter>` and it does not declare a corresponding entry in its TypeScript `EventMap`. CEM picked the event up directly from the runtime dispatch site post-#11539, which is what broke the React generator.

The event is already filtered out in React wrappers by https://github.com/vaadin/react-components/pull/381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)