### PR TITLE
chore: remove redundant a11y-base dev dependency in RTE

### DIFF
--- a/packages/rich-text-editor/package.json
+++ b/packages/rich-text-editor/package.json
@@ -46,7 +46,6 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@vaadin/a11y-base": "25.1.0-beta2",
     "@vaadin/aura": "25.2.0-alpha10",
     "@vaadin/chai-plugins": "25.2.0-alpha10",
     "@vaadin/test-runner-commands": "25.2.0-alpha10",


### PR DESCRIPTION
## Description

This was previously fixed in https://github.com/vaadin/web-components/pull/11327 but the version got out of sync again. In fact, we don't need this in `devDependencies` because it's already in `dependencies` - let's just remove it.

## Type of change

- Internal change