### PR TITLE
test: skip baseline rewrite on sub-threshold drift in update mode

### DIFF
--- a/patches/@web+test-runner-visual-regression+0.10.0.patch
+++ b/patches/@web+test-runner-visual-regression+0.10.0.patch
@@ -1,3 +1,30 @@
+diff --git a/node_modules/@web/test-runner-visual-regression/dist/visualDiffCommand.js b/node_modules/@web/test-runner-visual-regression/dist/visualDiffCommand.js
+index 08b4d27..423aa5a 100644
+--- a/node_modules/@web/test-runner-visual-regression/dist/visualDiffCommand.js
++++ b/node_modules/@web/test-runner-visual-regression/dist/visualDiffCommand.js
+@@ -40,6 +40,22 @@ async function visualDiffCommand(options, image, name, { browser, testFile }) {
+         name: baselineName,
+     });
+     if (options.update) {
++        // Skip rewriting the baseline if the new image is already within the
++        // configured diff threshold. Sub-perceptual drift (1-LSB Chromium
++        // rasterizer rounding, anti-alias jitter on shadows / translucent
++        // layers) leaves the existing baseline untouched, avoiding 800+
++        // file rewrites on every browser bump.
++        if (baselineImage) {
++            const updateResult = await options.getImageDiff({
++                name,
++                baselineImage,
++                image,
++                options: options.diffOptions,
++            });
++            if (!updateResult.error && passesFailureThreshold(updateResult, options).passed) {
++                return { diffPercentage: updateResult.diffPercentage, passed: true };
++            }
++        }
+         await options.saveBaseline({
+             filePath: resolveImagePath(baseDir, baselineName),
+             baseDir,
 diff --git a/node_modules/@web/test-runner-visual-regression/index.d.ts b/node_modules/@web/test-runner-visual-regression/index.d.ts
 index f540538..5198ffa 100644
 --- a/node_modules/@web/test-runner-visual-regression/index.d.ts

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -312,6 +312,7 @@ const createVisualTestsConfig = (theme) => {
         getFailedName(args) {
           return getScreenshotFileName(args, 'failed');
         },
+        diffOptions: { threshold: 0.2 },
         failureThreshold: 0.05,
         failureThresholdType: 'percent',
         update: process.env.TEST_ENV === 'update',


### PR DESCRIPTION
## Summary

Make `yarn update:*` a no-op for the 1-LSB Chromium rasterizer drift that comes with every Playwright bump.

`@web/test-runner-visual-regression`'s update mode currently rewrites every baseline byte-for-byte without consulting `diffOptions` or `failureThreshold`. After a Playwright bump, that churns 800+ Aura screenshots — most of which only drifted by 1 LSB on translucent layers (box-shadows, page-bg gradients, dark overlays) and would have been absorbed in compare mode.

## Changes

- **`patches/@web+test-runner-visual-regression+0.10.0.patch`** — `visualDiffCommand.js` runs the same diff check in update mode and only rewrites the baseline if the new image exceeds the threshold.
- **`wtr-utils.js`** — `diffOptions: { threshold: 0.2 }` raises pixelmatch's per-pixel YIQ tolerance just enough to absorb 1-LSB shadow / anti-alias rounding while keeping real visual regressions far above the line.

## Effect on the current Playwright 1.57 bump

| `yarn update:aura` group | Before | After |
|---|---|---|
| `app-layout` (default + dark) | 30 PNGs rewritten | **0** |
| `button` (default + dark) | 6 PNGs rewritten | **0** |
| `rich-text-editor` (default + dark) | several PNGs rewritten | **0** |

Real regressions still get rebaselined: when a captured frame *does* exceed the threshold, the existing `saveBaseline` runs as before. First-time captures still save unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)