### PR TITLE
docs: add accessibility guidelines to the guidelines folder

### DIFF
--- a/guidelines/00-overview.md
+++ b/guidelines/00-overview.md
@@ -31,4 +31,5 @@ For repository-level commands (install, start, lint, test) see `CLAUDE.md`.
 | 08  | [DOM](08-dom.md)                                 | Designing a component's DOM surface — parts, attributes, slots.            |
 | 09  | [Events](09-events.md)                           | Dispatching and documenting component events.                              |
 | 10  | [Theming](10-theming.md)                         | Authoring base styles and integrating with Lumo and Aura.                  |
-| 11  | [Checklist](11-checklist.md)                     | Final scan before submitting a new component.                              |
+| 11  | [Accessibility](11-a11y.md)                      | Implementing accessible roles, labels, focus, and keyboard support.        |
+| 12  | [Checklist](12-checklist.md)                     | Final scan before submitting a new component.                              |

--- a/guidelines/05-common-packages.md
+++ b/guidelines/05-common-packages.md
@@ -43,7 +43,7 @@ fit together.
 | `FocusTrapController`        | Traps Tab and Shift+Tab inside a modal region.                                                                  |
 | `FocusRestorationController` | Saves the previously-focused element on overlay open and restores it on close.                                  |
 | `FieldAriaController`        | Wires `aria-labelledby` / `aria-describedby` / `aria-required` on form fields. Used internally by `FieldMixin`. |
-| `announce()`                 | Writes a message to a global polite or alert live region for transient AT announcements.                        |
+| `announce()`                 | Writes a text to a live region (`polite`, `alert`, or `assertive` mode) to trigger screen reader announcements. |
 
 ## `@vaadin/field-base`
 

--- a/guidelines/05-common-packages.md
+++ b/guidelines/05-common-packages.md
@@ -26,18 +26,24 @@ Core utilities used by every component.
 
 ## `@vaadin/a11y-base`
 
-Accessibility primitives.
+Accessibility primitives. See [Accessibility](11-a11y.md) for how these
+fit together.
 
-| Export                   | Purpose                                                                           |
-| ------------------------ | --------------------------------------------------------------------------------- |
-| `ActiveMixin`            | Toggles the `active` attribute on pointer-down / activation key.                  |
-| `DelegateFocusMixin`     | Forwards focus from the host to an internal slotted focusable element.            |
-| `DisabledMixin`          | Provides `disabled` property and `aria-disabled` attribute logic.                 |
-| `FocusMixin`             | Sets `focused` and `focus-ring` attributes (the latter only for keyboard focus).  |
-| `KeyboardMixin`          | Centralizes keydown handling; subclasses override `_onKeyDown`.                   |
-| `KeyboardDirectionMixin` | Keyboard navigation across child items (vertical or horizontal).                  |
-| `ListMixin`              | Builds on `KeyboardDirectionMixin` to add item selection and `selected` index.    |
-| `TabindexMixin`          | Manages `tabindex`; sets `-1` when `disabled`, restores prior value when enabled. |
+| Export                       | Purpose                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| `ActiveMixin`                | Toggles the `active` attribute on pointer-down / activation key.                  |
+| `DelegateFocusMixin`         | Forwards focus from the host to an internal slotted focusable element.            |
+| `DisabledMixin`              | Provides `disabled` property and `aria-disabled` attribute logic.                 |
+| `FocusMixin`                 | Sets `focused` and `focus-ring` attributes (the latter only for keyboard focus).  |
+| `KeyboardMixin`              | Centralizes keydown handling; subclasses override `_onKeyDown`.                   |
+| `KeyboardDirectionMixin`     | Keyboard navigation across child items (vertical or horizontal).                  |
+| `ListMixin`                  | Builds on `KeyboardDirectionMixin` to add item selection and `selected` index.    |
+| `TabindexMixin`              | Manages `tabindex`; sets `-1` when `disabled`, restores prior value when enabled. |
+| `AriaModalController`        | Sets `aria-hidden` on siblings outside an open modal so AT users can't reach background content. |
+| `FocusTrapController`        | Traps Tab and Shift+Tab inside a modal region.                                    |
+| `FocusRestorationController` | Saves the previously-focused element on overlay open and restores it on close.    |
+| `FieldAriaController`        | Wires `aria-labelledby` / `aria-describedby` / `aria-invalid` / `aria-required` on form fields. Used internally by `FieldMixin`. |
+| `announce()`                 | Writes a message to a global polite or alert live region for transient AT announcements. |
 
 ## `@vaadin/field-base`
 

--- a/guidelines/05-common-packages.md
+++ b/guidelines/05-common-packages.md
@@ -29,21 +29,21 @@ Core utilities used by every component.
 Accessibility primitives. See [Accessibility](11-a11y.md) for how these
 fit together.
 
-| Export                       | Purpose                                                                           |
-| ---------------------------- | --------------------------------------------------------------------------------- |
-| `ActiveMixin`                | Toggles the `active` attribute on pointer-down / activation key.                  |
-| `DelegateFocusMixin`         | Forwards focus from the host to an internal slotted focusable element.            |
-| `DisabledMixin`              | Provides `disabled` property and `aria-disabled` attribute logic.                 |
-| `FocusMixin`                 | Sets `focused` and `focus-ring` attributes (the latter only for keyboard focus).  |
-| `KeyboardMixin`              | Centralizes keydown handling; subclasses override `_onKeyDown`.                   |
-| `KeyboardDirectionMixin`     | Keyboard navigation across child items (vertical or horizontal).                  |
-| `ListMixin`                  | Builds on `KeyboardDirectionMixin` to add item selection and `selected` index.    |
-| `TabindexMixin`              | Manages `tabindex`; sets `-1` when `disabled`, restores prior value when enabled. |
-| `AriaModalController`        | Sets `aria-hidden` on siblings outside an open modal so AT users can't reach background content. |
-| `FocusTrapController`        | Traps Tab and Shift+Tab inside a modal region.                                    |
-| `FocusRestorationController` | Saves the previously-focused element on overlay open and restores it on close.    |
-| `FieldAriaController`        | Wires `aria-labelledby` / `aria-describedby` / `aria-invalid` / `aria-required` on form fields. Used internally by `FieldMixin`. |
-| `announce()`                 | Writes a message to a global polite or alert live region for transient AT announcements. |
+| Export                       | Purpose                                                                                                         |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `ActiveMixin`                | Toggles the `active` attribute on pointer-down / activation key.                                                |
+| `DelegateFocusMixin`         | Forwards focus from the host to an internal slotted focusable element.                                          |
+| `DisabledMixin`              | Provides `disabled` property and `aria-disabled` attribute logic.                                               |
+| `FocusMixin`                 | Sets `focused` and `focus-ring` attributes (the latter only for keyboard focus).                                |
+| `KeyboardMixin`              | Centralizes keydown handling; subclasses override `_onKeyDown`.                                                 |
+| `KeyboardDirectionMixin`     | Keyboard navigation across child items (vertical or horizontal).                                                |
+| `ListMixin`                  | Builds on `KeyboardDirectionMixin` to add item selection and `selected` index.                                  |
+| `TabindexMixin`              | Manages `tabindex`; sets `-1` when `disabled`, restores prior value when enabled.                               |
+| `AriaModalController`        | Sets `aria-hidden` on siblings outside an open modal so AT users can't reach background content.                |
+| `FocusTrapController`        | Traps Tab and Shift+Tab inside a modal region.                                                                  |
+| `FocusRestorationController` | Saves the previously-focused element on overlay open and restores it on close.                                  |
+| `FieldAriaController`        | Wires `aria-labelledby` / `aria-describedby` / `aria-required` on form fields. Used internally by `FieldMixin`. |
+| `announce()`                 | Writes a message to a global polite or alert live region for transient AT announcements.                        |
 
 ## `@vaadin/field-base`
 

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -110,6 +110,10 @@ order. Don't use `tabindex` values greater than `0`, and don't move
 focus around with JavaScript except to send it to a clearly indicated
 target (e.g. the first focusable child of an opened overlay).
 
+For slotted children, the effective tab order follows the placement of
+`<slot>` elements in the shadow template, not the light-DOM order of
+the children themselves. Arrange slots so visual and tab order match.
+
 In RTL contexts the layout mirrors visually, but the DOM stays the
 same — so tab order automatically mirrors with the layout. There is no
 RTL-specific focus logic to write.

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -17,9 +17,8 @@ De-facto screen reader support (ARIA features that are actually supported) takes
 
 ### Default `role`
 
-Set the host's default role in `firstUpdated()` (or `ready()` for
-PolylitMixin-using components) only if the application hasn't already
-supplied one — this keeps the role overridable.
+Set the host's default role in `ready()` only if the application
+hasn't already supplied one — this keeps the role overridable.
 
 ```js
 ready() {
@@ -85,14 +84,14 @@ attributes automatically:
 
 Components that render a heading-like element expose a property for
 the application to set its level (announced as `aria-level` on the
-heading). Typically, a property name should include `headingLevel`.
+heading). The property name conventionally includes `HeadingLevel`
+(e.g. `headingLevel`, `titleHeadingLevel`, `rootHeadingLevel`).
 
 ### `aria-hidden` on internal shadow-DOM elements
 
-Internal buttons and decorations whose action is reachable via the
-keyboard differently are hidden from assistive technology to avoid
-duplicate or redundant announcements. Apply `aria-hidden="true"` on
-the rendering element inside the shadow template:
+Hide internal buttons from screen readers using `aria-hidden="true"`
+when the same action is reachable via the keyboard differently — this
+avoids duplicate or redundant announcements.
 
 | Element                     | Why hidden                                              |
 | --------------------------- | ------------------------------------------------------- |
@@ -171,8 +170,8 @@ forces the `focus-ring` attribute on the host:
   showing the ring (when programmatic focus shouldn't look
   keyboard-driven, e.g. focusing a field after dismissing a non-modal
   overlay by pointer).
-- `element.focus({ focusVisible: true })` — same as the default, used
-  for clarity in code that explicitly handles keyboard interactions.
+- `element.focus({ focusVisible: true })` — same as the default; pass
+  explicitly to document that the call site is keyboard-driven.
 
 `KeyboardDirectionMixin` calls `focus({ focusVisible: true })` when the
 user navigates with arrow keys; `FocusTrapController` does the same for

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -53,9 +53,12 @@ property pair on the host that the framework forwards inward:
 Form fields inherit this pair from `FieldMixin` automatically — see
 [ARIA wiring for form fields](#aria-wiring-for-form-fields) below.
 
+Users should only set one or the other — `accessibleName` overrides
+the `aria-labelledby` set by `accessibleNameRef`.
+
 When the host element itself is the focusable target, prefer setting
 standard `aria-label` or `aria-labelledby` on the host rather than
-introducing an `accessibleName` property.
+introducing `accessibleName` / `accessibleNameRef` properties.
 
 ### Customizable labels
 

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -264,11 +264,6 @@ Modal overlays (`vaadin-dialog`, `vaadin-confirm-dialog`,
 directly to mark the surrounding content as inert for assistive
 technology.
 
-For non-overlay modal patterns (e.g. a side drawer that becomes modal
-at narrow widths in `vaadin-app-layout`), use `AriaModalController` to
-set `aria-hidden` on the siblings outside the modal region — the role
-that `aria-modal="true"` plays for overlays.
-
 ### Trapping focus
 
 `FocusTrapController` traps Tab and Shift+Tab inside the modal region

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -51,9 +51,8 @@ property pair on the host that the framework forwards inward:
 
 Form fields inherit this pair from `FieldMixin` automatically — see
 [ARIA wiring for form fields](#aria-wiring-for-form-fields) below.
-
-Users should only set one or the other — `accessibleName` overrides
-the `aria-labelledby` set by `accessibleNameRef`.
+Users should only set either `accessibleName` or `accessibleNameRef`,
+not both.
 
 When the host element itself is the focusable target, prefer setting
 standard `aria-label` or `aria-labelledby` on the host rather than

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -70,7 +70,6 @@ attributes automatically:
 
 - `aria-labelledby` — the label slot
 - `aria-describedby` — helper-text and error-message slots
-- `aria-invalid` — the `invalid` property
 - `aria-required` — the `required` property
 - `aria-label` — the `accessibleName` property
 

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -11,6 +11,8 @@ tested against the assistive-technology combinations below.
 - VoiceOver + Safari on macOS
 - VoiceOver + Safari on iOS
 
+De-facto screen reader support (ARIA features that are actually supported) takes priority over solutions that are technically WCAG conformant, but don't actually work in all supported AT /browser combinations.
+
 ## ARIA attributes
 
 ### Default `role`

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -237,10 +237,7 @@ static get styles() {
 For transient messages — selection feedback, validation outcomes,
 filter results — use the `announce()` utility from
 `@vaadin/a11y-base/src/announce.js`. It writes to a single global live
-region and supports two modes:
-
-- `polite` (default) — `aria-live="polite"`.
-- `alert` — `role="alert"` (interruptive).
+region and supports passing `polite`, `alert`, and `assertive` modes.
 
 ```js
 import { announce } from '@vaadin/a11y-base/src/announce.js';

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -94,12 +94,12 @@ keyboard differently are hidden from assistive technology to avoid
 duplicate or redundant announcements. Apply `aria-hidden="true"` on
 the rendering element inside the shadow template:
 
-| Element                     | Why hidden                                                 |
-| --------------------------- | ---------------------------------------------------------- |
-| Clear button                | User clears with `Escape` from inside the field.           |
-| Toggle button               | User opens the dropdown with `Arrow Down` / `Arrow Up`.    |
-| Increase / decrease buttons | Number-field steps with `Arrow Up` / `Arrow Down`.         |
-| Required indicator          | The input itself carries `aria-required`.                  |
+| Element                     | Why hidden                                              |
+| --------------------------- | ------------------------------------------------------- |
+| Clear button                | User clears with `Escape` from inside the field.        |
+| Toggle button               | User opens the dropdown with `Arrow Down` / `Arrow Up`. |
+| Increase / decrease buttons | Number-field steps with `Arrow Up` / `Arrow Down`.      |
+| Required indicator          | The input itself carries `aria-required`.               |
 
 ## Focus
 

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -81,6 +81,12 @@ attributes automatically:
 - `aria-required` — the `required` property
 - `aria-label` — the `accessibleName` property
 
+### `aria-level` for headings
+
+Components that render a heading-like element expose a property for
+the application to set its level (announced as `aria-level` on the
+heading). Typically, a property name should include `headingLevel`.
+
 ### `aria-hidden` on internal shadow-DOM elements
 
 Internal buttons and decorations whose action is reachable via the

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -22,13 +22,16 @@ PolylitMixin-using components) only if the application hasn't already
 supplied one — this keeps the role overridable.
 
 ```js
-firstUpdated() {
-  super.firstUpdated();
+ready() {
+  super.ready();
   if (!this.hasAttribute('role')) {
     this.setAttribute('role', 'button');
   }
 }
 ```
+
+Prefer setting `role` on the host over adding semantic HTML elements
+in shadow DOM — e.g. `role="listitem"` rather than a nested `<li>`.
 
 ### Accessible names
 

--- a/guidelines/11-a11y.md
+++ b/guidelines/11-a11y.md
@@ -1,0 +1,278 @@
+# Accessibility
+
+Vaadin web components target [WCAG 2.1 level AA](https://www.w3.org/WAI/WCAG21/quickref/)
+using semantic HTML and WAI-ARIA. Components are audited and
+tested against the assistive-technology combinations below.
+
+## Supported assistive-technology combinations
+
+- NVDA + Chrome / Firefox on Windows
+- JAWS + Chrome / Firefox on Windows
+- VoiceOver + Safari on macOS
+- VoiceOver + Safari on iOS
+
+## ARIA attributes
+
+### Default `role`
+
+Set the host's default role in `firstUpdated()` (or `ready()` for
+PolylitMixin-using components) only if the application hasn't already
+supplied one — this keeps the role overridable.
+
+```js
+firstUpdated() {
+  super.firstUpdated();
+  if (!this.hasAttribute('role')) {
+    this.setAttribute('role', 'button');
+  }
+}
+```
+
+### Accessible names
+
+Every focusable element, control, and landmark contributed by the
+component needs an accessible name. When the name comes from visible
+text (a button label, a tab caption), that's automatic. When it does
+not — icon-only controls, dismiss / overflow controls, landmark
+regions — the component must expose a way for the application to
+supply and localize the name.
+
+The standard pattern for composite components that delegate focus to
+an internal element (a field with an internal `<input>`, etc.) is a
+property pair on the host that the framework forwards inward:
+
+- `accessibleName` — sets `aria-label` on the internal element.
+- `accessibleNameRef` — references an external label by id, forwarded
+  as `aria-labelledby`.
+
+Form fields inherit this pair from `FieldMixin` automatically — see
+[ARIA wiring for form fields](#aria-wiring-for-form-fields) below.
+
+When the host element itself is the focusable target, prefer setting
+standard `aria-label` or `aria-labelledby` on the host rather than
+introducing an `accessibleName` property.
+
+### Customizable labels
+
+Built-in fallback strings the component renders itself ("More",
+"Clear selection", "Open menu", error messages, landmark labels) must
+be overridable so applications can localize and adapt them.
+
+The standard pattern is the `i18n` property exposed by `I18nMixin` —
+applications supply a partial object that's deep-merged with the
+component's defaults. See `I18nMixin` in
+[Common packages](05-common-packages.md).
+
+### ARIA wiring for form fields
+
+`FieldMixin` (with `FieldAriaController`) wires the field-internal ARIA
+attributes automatically:
+
+- `aria-labelledby` — the label slot
+- `aria-describedby` — helper-text and error-message slots
+- `aria-invalid` — the `invalid` property
+- `aria-required` — the `required` property
+- `aria-label` — the `accessibleName` property
+
+### `aria-hidden` on internal shadow-DOM elements
+
+Internal buttons and decorations whose action is reachable via the
+keyboard differently are hidden from assistive technology to avoid
+duplicate or redundant announcements. Apply `aria-hidden="true"` on
+the rendering element inside the shadow template:
+
+| Element                     | Why hidden                                                 |
+| --------------------------- | ---------------------------------------------------------- |
+| Clear button                | User clears with `Escape` from inside the field.           |
+| Toggle button               | User opens the dropdown with `Arrow Down` / `Arrow Up`.    |
+| Increase / decrease buttons | Number-field steps with `Arrow Up` / `Arrow Down`.         |
+| Required indicator          | The input itself carries `aria-required`.                  |
+
+## Focus
+
+### Focus order
+
+Keyboard tab order matches DOM order, and DOM order matches visual
+order. Don't use `tabindex` values greater than `0`, and don't move
+focus around with JavaScript except to send it to a clearly indicated
+target (e.g. the first focusable child of an opened overlay).
+
+In RTL contexts the layout mirrors visually, but the DOM stays the
+same — so tab order automatically mirrors with the layout. There is no
+RTL-specific focus logic to write.
+
+### Delegating focus
+
+Most components are composite — the host element isn't directly
+focusable; some inner element is. There are two ways to forward focus
+from the host to that inner element:
+
+- **Focusable slotted element.** When the focusable target is slotted
+  from the light DOM (typically a form field's `<input>` or
+  `<textarea>`), use `DelegateFocusMixin`. It exposes a `focusElement`
+  getter on the host and ensures `focus()` / `blur()` reach the
+  slotted target.
+- **Focusable element in shadow DOM.** When the focusable target lives
+  inside the host's own shadow tree, override `shadowRootOptions` to
+  enable native focus delegation:
+
+  ```js
+  static get shadowRootOptions() {
+    return { ...LitElement.shadowRootOptions, delegatesFocus: true };
+  }
+  ```
+
+  The browser then forwards `focus()` calls to the first focusable
+  element in the shadow tree and matches `:focus` / `:focus-visible`
+  on the host whenever any inner element has focus. Used by
+  `vaadin-side-nav` and `vaadin-accordion-heading`.
+
+### Focus styling
+
+Style keyboard focus through both `:focus-visible` and the `focus-ring`
+attribute that `FocusMixin` reflects. The combined selector handles
+the range of supported browsers and Vaadin's programmatic
+`focusVisible` flag (see below):
+
+```css
+:host(:is([focus-ring], :focus-visible)) {
+  outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+}
+```
+
+The `--vaadin-focus-ring-color` and `--vaadin-focus-ring-width` custom
+properties come from the theme — see [Theming](10-theming.md).
+
+### `focus({ focusVisible })`
+
+`FocusMixin` overrides `focus()` to accept a `focusVisible` option that
+forces the `focus-ring` attribute on the host:
+
+- `element.focus()` — focus-ring is set (the default for programmatic
+  focus).
+- `element.focus({ focusVisible: false })` — focus the element without
+  showing the ring (when programmatic focus shouldn't look
+  keyboard-driven, e.g. focusing a field after dismissing a non-modal
+  overlay by pointer).
+- `element.focus({ focusVisible: true })` — same as the default, used
+  for clarity in code that explicitly handles keyboard interactions.
+
+`KeyboardDirectionMixin` calls `focus({ focusVisible: true })` when the
+user navigates with arrow keys; `FocusTrapController` does the same for
+Tab inside a modal.
+
+## Keyboard navigation
+
+Two patterns coexist across Vaadin components:
+
+- **Roving tabindex** — only one child item is `tabindex="0"`; the rest
+  are `tabindex="-1"`. Arrow keys move focus between items, and the
+  component takes a single Tab stop overall. Used by `vaadin-list-box`,
+  `vaadin-tabs`, and similar list-like components.
+- **Tab navigation** — every child is independently focusable via Tab,
+  no roving. Used by `vaadin-accordion` and similar containers whose
+  children act as standalone interactive regions.
+
+`vaadin-menu-bar` supports both via a `tabNavigation` property that
+toggles between roving (the default) and Tab.
+
+The shared building blocks:
+
+- `KeyboardMixin` centralizes keydown handling; subclasses override
+  `_onKeyDown(event)`.
+- `KeyboardDirectionMixin` adds arrow-key navigation (Home / End,
+  vertical or horizontal). It flips Arrow Left / Right when
+  `dir="rtl"` is set, but only for horizontal navigation; vertical
+  (Up / Down) is unchanged. Components don't re-implement RTL keys
+  themselves.
+
+## Disabled state
+
+`DisabledMixin` reflects `disabled` on the host and propagates the
+`aria-disabled` attribute. `TabindexMixin` automatically sets
+`tabindex="-1"` when the host becomes disabled and restores the prior
+value when re-enabled.
+
+A disabled element stays in the accessibility tree but doesn't receive
+focus or react to hover — which means screen-reader users navigating by
+Tab can't reach it, and tooltips that would explain _why_ it's disabled
+never show. Two opt-in feature flags address this by keeping disabled
+buttons and menu items focusable and hoverable while still preventing
+activation:
+
+```js
+window.Vaadin.featureFlags.accessibleDisabledButtons = true;
+window.Vaadin.featureFlags.accessibleDisabledMenuItems = true;
+```
+
+Set them before the relevant components attach to the DOM. They're
+opt-in because the default matches platform conventions for native
+`<button disabled>`.
+
+## Screen readers
+
+### Screen-reader-only text
+
+Some components need a label that's announced by assistive technology
+but not visible — the inverse of `aria-hidden`. Use the
+`screenReaderOnly` CSS export from
+`@vaadin/a11y-base/src/styles/sr-only-styles.js`, which clips the
+element to 1×1 px while keeping it in the accessibility tree:
+
+```js
+import { screenReaderOnly } from '@vaadin/a11y-base/src/styles/sr-only-styles.js';
+
+static get styles() {
+  return [..., screenReaderOnly];
+}
+```
+
+```html
+<div class="sr-only">${labelText}</div>
+```
+
+### Live regions
+
+For transient messages — selection feedback, validation outcomes,
+filter results — use the `announce()` utility from
+`@vaadin/a11y-base/src/announce.js`. It writes to a single global live
+region and supports two modes:
+
+- `polite` (default) — `aria-live="polite"`.
+- `alert` — `role="alert"` (interruptive).
+
+```js
+import { announce } from '@vaadin/a11y-base/src/announce.js';
+
+announce('Item selected', { mode: 'polite' });
+```
+
+Some components also set `aria-live="polite"` on an internal element
+directly when announcements are tied to a specific region of their own
+shadow DOM rather than to the global live region.
+
+## Overlays
+
+### Modality
+
+Modal overlays (`vaadin-dialog`, `vaadin-confirm-dialog`,
+`vaadin-popover` in modal mode) set `aria-modal="true"` on the host
+directly to mark the surrounding content as inert for assistive
+technology.
+
+For non-overlay modal patterns (e.g. a side drawer that becomes modal
+at narrow widths in `vaadin-app-layout`), use `AriaModalController` to
+set `aria-hidden` on the siblings outside the modal region — the role
+that `aria-modal="true"` plays for overlays.
+
+### Trapping focus
+
+`FocusTrapController` traps Tab and Shift+Tab inside the modal region
+so users can't accidentally move focus into background content. Wired
+by `OverlayMixin`; component code doesn't set it up directly.
+
+### Restoring focus
+
+`FocusRestorationController` saves the previously-focused element when
+the overlay opens and returns focus to it on close. Also wired by
+`OverlayMixin`.

--- a/guidelines/12-checklist.md
+++ b/guidelines/12-checklist.md
@@ -6,6 +6,8 @@ not a substitute for reading [Component Structure](03-component-structure.md) an
 ## Design
 
 - [ ] API and behavior reviewed against [Design](02-design.md).
+- [ ] Roles, ARIA wiring, and keyboard navigation reviewed against
+      [Accessibility](11-a11y.md).
 
 ## Files
 

--- a/guidelines/12-checklist.md
+++ b/guidelines/12-checklist.md
@@ -31,8 +31,7 @@ not a substitute for reading [Component Structure](03-component-structure.md) an
 - [ ] `static get properties()` declares every reactive property with a
       JSDoc comment (and `@attr` for camelCase ones).
 - [ ] Defaults set via field initializers, not a `value:` property option.
-- [ ] `firstUpdated()` sets host attributes (e.g. `role`) and attaches
-      controllers.
+- [ ] `ready()` sets host attributes (e.g. `role`) and attaches controllers.
 - [ ] `updated(changed)` reacts to property changes (no Polymer observers).
 - [ ] `defineCustomElement(...)` called at the bottom of the source file.
 


### PR DESCRIPTION
## Summary

Adds `guidelines/11-a11y.md` covering ARIA attributes, focus (incl. delegation), keyboard navigation, disabled state, screen-reader content, and overlays. Extends `05-common-packages.md` with the a11y controllers and the `announce()` utility. Renames `11-checklist.md` → `12-checklist.md` and adds an Accessibility checklist item.

## Test plan

- [ ] Render each touched `guidelines/*.md` file in the GitHub PR view — confirm tables and code blocks render.
- [ ] Confirm cross-links resolve (`05-common-packages.md`, `10-theming.md`, in-file `#aria-wiring-for-form-fields`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)