### PR TITLE
docs: align copyright years between paired .js and .d.ts files

### DIFF
--- a/packages/avatar/src/styles/vaadin-avatar-base-styles.js
+++ b/packages/avatar/src/styles/vaadin-avatar-base-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * Copyright (c) 2020 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/component-base/src/styles/style-props.js';

--- a/packages/checkbox/src/vaadin-checkbox-mixin.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2021 - 2026 Vaadin Ltd.
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.d.ts
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * Copyright (c) 2018 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/date-picker/src/vaadin-date-picker-helper.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-helper.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * Copyright (c) 2016 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { DatePickerDate } from './vaadin-date-picker-mixin.js';

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2018 - 2026 Vaadin Ltd.
+ * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/details/src/collapsible-mixin.d.ts
+++ b/packages/details/src/collapsible-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/details/src/vaadin-details-base-mixin.js
+++ b/packages/details/src/vaadin-details-base-mixin.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { DelegateFocusMixin } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';

--- a/packages/icon/src/vaadin-icon-mixin.d.ts
+++ b/packages/icon/src/vaadin-icon-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/icon/src/vaadin-iconset-mixin.d.ts
+++ b/packages/icon/src/vaadin-iconset-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';

--- a/packages/menu-bar/src/styles/vaadin-menu-bar-overlay-base-styles.js
+++ b/packages/menu-bar/src/styles/vaadin-menu-bar-overlay-base-styles.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2016 - 2026 Vaadin Ltd.
+ * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { menuOverlayStyles } from '@vaadin/context-menu/src/styles/vaadin-menu-overlay-base-styles.js';

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.d.ts
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2018 - 2026 Vaadin Ltd.
+ * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { ComboBoxDefaultItem, ComboBoxItemMixinClass } from '@vaadin/combo-box/src/vaadin-combo-box-item-mixin.js';

--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.d.ts
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.d.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2019 - 2026 Vaadin Ltd.
+ * Copyright (c) 2022 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';


### PR DESCRIPTION
## Summary

Aligns mismatched copyright start years between paired `.js` / `.d.ts` files (and one helper `.d.ts` with a clearly bogus year). For each pair, the canonical year was determined from the parent component file (e.g. `vaadin-checkbox.js` for `vaadin-checkbox-mixin.*`), so the side carrying the wrong year is the one updated.

| File | Before | After | Source of truth |
|---|---|---|---|
| `date-picker/src/vaadin-date-picker-helper.d.ts` | 2000 | 2016 | `vaadin-date-picker.js` |
| `checkbox/src/vaadin-checkbox-mixin.d.ts` | 2021 | 2017 | `vaadin-checkbox.js` |
| `icon/src/vaadin-icon-mixin.d.ts` | 2017 | 2021 | `vaadin-icon.js` |
| `icon/src/vaadin-iconset-mixin.d.ts` | 2017 | 2021 | `vaadin-iconset.js` |
| `details/src/vaadin-details-base-mixin.js` | 2017 | 2019 | `vaadin-details.js` |
| `details/src/collapsible-mixin.d.ts` | 2017 | 2019 | `vaadin-details.js` |
| `date-time-picker/src/vaadin-date-time-picker-mixin.d.ts` | 2018 | 2019 | `vaadin-date-time-picker.js` |
| `confirm-dialog/src/vaadin-confirm-dialog-mixin.d.ts` | 2017 | 2018 | `vaadin-confirm-dialog.js` |
| `tabsheet/src/vaadin-tabsheet-mixin.d.ts` | 2019 | 2022 | `vaadin-tabsheet.js` |
| `multi-select-combo-box/src/vaadin-multi-select-combo-box-item.d.ts` | 2018 | 2021 | `vaadin-multi-select-combo-box.js` |
| `avatar/src/styles/vaadin-avatar-base-styles.js` | 2017 | 2020 | `vaadin-avatar.js` |
| `menu-bar/src/styles/vaadin-menu-bar-overlay-base-styles.js` | 2016 | 2019 | `vaadin-menu-bar.js` |

Comment-only changes; no runtime or API impact.

## Test plan

- [ ] CI passes (lint + types)