### PR TITLE
fix: only set z-index: 0 for MDL with layout containment

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -16,12 +16,15 @@ export const masterDetailLayoutStyles = css`
     max-width: 100%;
     max-height: 100%;
     position: relative; /* Keep the positioning context stable across all modes */
-    z-index: 0; /* Create a new stacking context, don't let "layout contained" detail element stack outside it */
     overflow: hidden;
   }
 
   :host([hidden]) {
     display: none !important;
+  }
+
+  :host(:not([containment='viewport'])) {
+    z-index: 0; /* Create a new stacking context */
   }
 
   :host([orientation='vertical']) {


### PR DESCRIPTION
## Description

Updating from V24 to V25.1.4 caused the AppLayout’s Navbar to overlap MDL that uses the viewport containment mode. V24 didn’t set z-index on MDL, but V25 sets it to 0. Aligned with `25.2` version to only use this for layout containment.

## Type of change

- Bugfix