### PR TITLE
refactor: use nullish coalescing for slider constraints

### DIFF
--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -153,8 +153,8 @@ export const SliderMixin = (superClass) =>
     __updateValue(value, index, fullValue = this.__value) {
       const { min, max, step } = this.__getConstraints();
 
-      const minValue = fullValue[index - 1] !== undefined ? fullValue[index - 1] : min;
-      const maxValue = fullValue[index + 1] !== undefined ? fullValue[index + 1] : max;
+      const minValue = fullValue[index - 1] ?? min;
+      const maxValue = fullValue[index + 1] ?? max;
 
       const safeValue = Math.min(Math.max(value, minValue), maxValue);
 
@@ -184,9 +184,9 @@ export const SliderMixin = (superClass) =>
      */
     __getConstraints() {
       return {
-        min: this.min !== undefined ? this.min : 0,
-        max: this.max !== undefined ? this.max : 100,
-        step: this.step !== undefined ? this.step : 1,
+        min: this.min ?? 0,
+        max: this.max ?? 100,
+        step: this.step ?? 1,
       };
     }
 


### PR DESCRIPTION
## Summary
- Replace `x !== undefined ? x : default` ternaries in `__getConstraints` and `__updateValue` with the `??` operator.
- The verbose ternaries were introduced in #11092 to fix a bug where `0` was clobbered by `||` for `min`. Now that ESLint allows `??` in component source files (#11622), the same intent reads more clearly.

## Test plan
- [ ] `yarn lint:js` passes
- [ ] `yarn test --group slider` passes