### PR TITLE
refactor: align accordion-panel and details content part styles

### DIFF
--- a/packages/accordion/src/styles/vaadin-accordion-panel-base-styles.js
+++ b/packages/accordion/src/styles/vaadin-accordion-panel-base-styles.js
@@ -10,16 +10,13 @@ export const accordionPanel = css`
     display: block;
   }
 
-  :host([hidden]) {
+  :host([hidden]),
+  :host(:not([opened])) [part='content'] {
     display: none !important;
   }
 
   [part='content'] {
     box-sizing: border-box;
-  }
-
-  :host(:not([opened])) [part='content'] {
-    display: none !important;
   }
 
   :host([focus-ring]) {

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -64,16 +64,9 @@ class Details extends DetailsBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(L
         display: block;
       }
 
-      :host([hidden]) {
+      :host([hidden]),
+      :host(:not([opened])) [part='content'] {
         display: none !important;
-      }
-
-      [part='content'] {
-        display: none;
-      }
-
-      :host([opened]) [part='content'] {
-        display: block;
       }
     `;
   }


### PR DESCRIPTION
Align accordion-panel and details content part base styles, by forcing `display: none` when they are not opened.