### PR TITLE
docs(guidelines): use static get experimental() in the design chapter

### DIFF
--- a/guidelines/02-design.md
+++ b/guidelines/02-design.md
@@ -137,10 +137,20 @@ new implementation would have to redo. See
 
 Every new component enters the library behind a feature flag and
 graduates to stable only after its API has been validated in real use.
-The class declares `static experimental = true`; applications opt in via
-`window.Vaadin.featureFlags.{camelName}Component = true`. Breaking
-changes to an experimental API do not require a deprecation cycle — the
-flag is the contract that says "not yet stable."
+The class declares a `static get experimental()` getter — returning
+either `true` (the framework derives the flag name `{camelName}Component`
+from the tag) or an explicit flag-name string when the auto-derived
+name doesn't fit:
+
+```js
+static get experimental() {
+  return true;
+}
+```
+
+Applications opt in via `window.Vaadin.featureFlags.{camelName}Component = true`.
+Breaking changes to an experimental API do not require a deprecation
+cycle — the flag is the contract that says "not yet stable."
 
 ## Behavior principles
 


### PR DESCRIPTION
## Summary

`02-design.md § Ship new components as experimental` showed `static experimental = true`, but every actual experimental component in the repo (slider, breadcrumbs, master-detail-layout, badge, range-slider) uses the getter form: `static get experimental() { … }`.

Update the chapter to match, and note that the return value can be either `true` (the framework derives the flag name `{camelName}Component` from the tag) or an explicit flag-name string when the auto-derived name doesn't fit.

## Test plan

- [ ] Render `02-design.md` in the GitHub PR view — confirm code block renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)