### PR TITLE
refactor: make context-menu opened property sync

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -145,6 +145,12 @@ export const ContextMenuMixin = (superClass) =>
 
       this.__boundOnScroll = this.__onScroll.bind(this);
       window.addEventListener('scroll', this.__boundOnScroll, true);
+
+      // Restore opened state if overlay was opened when disconnecting
+      if (this.__restoreOpened) {
+        this._setOpened(true);
+        this.__restoreOpened = false;
+      }
     }
 
     /** @protected */
@@ -153,8 +159,9 @@ export const ContextMenuMixin = (superClass) =>
 
       window.removeEventListener('scroll', this.__boundOnScroll, true);
 
-      // Defer close so that DOM moves (disconnect followed by reconnect
-      // within the same task) do not close the overlay.
+      // Memorize opened state and defer close so that DOM moves (disconnect
+      // followed by reconnect within the same task) do not close the overlay.
+      this.__restoreOpened = this.opened;
       setTimeout(() => {
         if (!this.isConnected) {
           this.close();

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -36,6 +36,7 @@ export const ContextMenuMixin = (superClass) =>
           value: false,
           notify: true,
           readOnly: true,
+          sync: true,
         },
 
         /**
@@ -144,11 +145,6 @@ export const ContextMenuMixin = (superClass) =>
 
       this.__boundOnScroll = this.__onScroll.bind(this);
       window.addEventListener('scroll', this.__boundOnScroll, true);
-
-      // Restore opened state if overlay was opened when disconnecting
-      if (this.__restoreOpened) {
-        this._setOpened(true);
-      }
     }
 
     /** @protected */
@@ -157,9 +153,13 @@ export const ContextMenuMixin = (superClass) =>
 
       window.removeEventListener('scroll', this.__boundOnScroll, true);
 
-      // Close overlay and memorize opened state
-      this.__restoreOpened = this.opened;
-      this.close();
+      // Defer close so that DOM moves (disconnect followed by reconnect
+      // within the same task) do not close the overlay.
+      setTimeout(() => {
+        if (!this.isConnected) {
+          this.close();
+        }
+      });
     }
 
     /** @protected */

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -136,7 +136,7 @@ export const ContextMenuMixin = (superClass) =>
       this._boundOpen = this.open.bind(this);
       this._boundClose = this.close.bind(this);
       this._boundPreventDefault = this._preventDefault.bind(this);
-      this._boundOnGlobalContextMenu = this._onGlobalContextMenu.bind(this);
+      this.__onGlobalContextMenu = this.__onGlobalContextMenu.bind(this);
     }
 
     /** @protected */
@@ -145,6 +145,7 @@ export const ContextMenuMixin = (superClass) =>
 
       this.__boundOnScroll = this.__onScroll.bind(this);
       window.addEventListener('scroll', this.__boundOnScroll, true);
+      document.documentElement.addEventListener('contextmenu', this.__onGlobalContextMenu, true);
 
       // Restore opened state if overlay was opened when disconnecting
       if (this.__restoreOpened) {
@@ -158,6 +159,7 @@ export const ContextMenuMixin = (superClass) =>
       super.disconnectedCallback();
 
       window.removeEventListener('scroll', this.__boundOnScroll, true);
+      document.documentElement.removeEventListener('contextmenu', this.__onGlobalContextMenu, true);
 
       // Memorize opened state and defer close so that DOM moves (disconnect
       // followed by reconnect within the same task) do not close the overlay.
@@ -297,13 +299,7 @@ export const ContextMenuMixin = (superClass) =>
     }
 
     /** @private */
-    _openedChanged(opened, oldOpened) {
-      if (opened) {
-        document.documentElement.addEventListener('contextmenu', this._boundOnGlobalContextMenu, true);
-      } else if (oldOpened) {
-        document.documentElement.removeEventListener('contextmenu', this._boundOnGlobalContextMenu, true);
-      }
-
+    _openedChanged(opened) {
       this.__setListenOnUserSelect(opened);
     }
 
@@ -637,7 +633,10 @@ export const ContextMenuMixin = (superClass) =>
     }
 
     /** @private */
-    _onGlobalContextMenu(e) {
+    __onGlobalContextMenu(e) {
+      if (!this.opened) {
+        return;
+      }
       if (!e.shiftKey) {
         const isTouchDevice = isAndroid || isIOS;
         if (!isTouchDevice) {

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -150,7 +150,6 @@ export const ContextMenuMixin = (superClass) =>
       // Restore opened state if overlay was opened when disconnecting
       if (this.__restoreOpened) {
         this._setOpened(true);
-        this.__restoreOpened = false;
       }
     }
 

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -374,9 +374,7 @@ export const ItemsMixin = (superClass) =>
 
       // Listen to the forwarded event from sub-menu.
       this.addEventListener('close-all-menus', () => {
-        // Call `close()` on the overlay to close synchronously,
-        // as we can't have `sync: true` on `opened` property.
-        this._overlayElement.close();
+        this.close();
       });
 
       // Listen to the forwarded event from sub-menu.

--- a/packages/context-menu/test/context.test.js
+++ b/packages/context-menu/test/context.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { aTimeout, fire, fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-context-menu.js';
 import '@vaadin/item/src/vaadin-item.js';
@@ -121,18 +121,19 @@ describe('context', () => {
     expect(menu.opened).to.be.true;
   });
 
-  it('should be closed after detached', () => {
+  it('should be closed after detached', async () => {
     fire(target, 'contextmenu');
     expect(menu.opened).to.be.true;
 
     const spy = sinon.spy(menu, 'close');
 
     menu.parentNode.removeChild(menu);
+    await aTimeout(0);
     expect(spy.calledOnce).to.be.true;
     expect(menu.opened).to.be.false;
   });
 
-  it('should not close when moved within the DOM', () => {
+  it('should not close when moved within the DOM', async () => {
     fire(target, 'contextmenu');
     expect(menu.opened).to.be.true;
 
@@ -140,6 +141,7 @@ describe('context', () => {
     document.body.appendChild(newParent);
 
     newParent.appendChild(menu);
+    await aTimeout(0);
     expect(menu.opened).to.be.true;
   });
 });

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -707,7 +707,7 @@ export const MenuBarMixin = (superClass) =>
 
       if (wasExpanded && button.item && button.item.children) {
         this.__openSubMenu(button, true, { keepFocus: true });
-      } else {
+      } else if (!this._subMenu.opened) {
         this._tooltipController.open({ trigger: 'focus' });
       }
     }
@@ -761,7 +761,7 @@ export const MenuBarMixin = (superClass) =>
           this._setTabindex(btn, btn === target);
         });
 
-        if (isKeyboardActive()) {
+        if (isKeyboardActive() && !this._expandedButton) {
           this._tooltipController.open({ trigger: 'focus' });
         }
       } else {

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -761,7 +761,7 @@ export const MenuBarMixin = (superClass) =>
           this._setTabindex(btn, btn === target);
         });
 
-        if (isKeyboardActive() && !this._expandedButton) {
+        if (!this._subMenu.opened && isKeyboardActive()) {
           this._tooltipController.open({ trigger: 'focus' });
         }
       } else {

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -102,10 +102,18 @@ class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(Li
   }
 
   /**
-   * Overriding the observer to not add global "contextmenu" listener.
+   * Overriding the observer to not toggle user-select on the host.
    * @override
    */
   _openedChanged() {
+    // Do nothing
+  }
+
+  /**
+   * Overriding the handler to not react to global "contextmenu" events.
+   * @override
+   */
+  __onGlobalContextMenu() {
     // Do nothing
   }
 


### PR DESCRIPTION
Make `<vaadin-context-menu>` `opened` property and `opened-changed` event propagate synchronously, matching `<vaadin-dialog>` and `<vaadin-select>`. Callers reacting to `opened-changed` no longer need a microtask to observe the new state.

This change surfaced a few issues that were fixed in the same PR:

- Disconnect memorizes `opened` and re-opens on reconnect, so DOM moves spanning multiple tasks no longer drop the overlay.
- Global `contextmenu` listener moved to connected/disconnected callbacks with an `opened` guard, instead of toggling in `_openedChanged`.
- `MenuBarSubmenu` overrides `__onGlobalContextMenu` directly, since the previous `_openedChanged` no-op no longer suppresses listener install.
- Menu-bar focus tooltip gated on sub-menu `opened` state instead of an async signal.

---

🤖 Generated with Claude Code