### PR TITLE
fix: walk slot boundaries to find focused virtualizer row

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -515,25 +515,19 @@ export class IronListAdapter {
 
   /** @private */
   __getFocusedElement(visibleElements = this.__getVisibleElements()) {
-    // Case 1: focus is inside the shadow tree (e.g. a focusable cell with
-    // tabindex). The shadow root's activeElement is the focused descendant,
-    // and Node.contains finds it via tree containment.
-    const result = visibleElements.find(
-      (element) =>
-        element.contains(this.elementsContainer.getRootNode().activeElement) ||
-        element.contains(this.scrollTarget.getRootNode().activeElement),
-    );
-    if (result) {
-      return result;
-    }
-    // Case 2: focus is on light-DOM content slotted across the shadow boundary
-    // (e.g. an `<input>` inside a `vaadin-grid-cell-content`). The shadow
-    // root's activeElement is null because the focused element is outside the
-    // shadow tree, and Node.contains doesn't traverse slot projection.
-    // Walk up from document.activeElement, crossing slot boundaries via
-    // assignedSlot, to locate the projected-into virtualizer row.
-    const visible = new Set(visibleElements);
+    // `document.activeElement` retargets to the outermost shadow host when
+    // focus lives in a nested shadow tree. Walk down through any nested
+    // shadow roots' `activeElement` to reach the actual focused node.
     let node = document.activeElement;
+    while (node?.shadowRoot?.activeElement) {
+      node = node.shadowRoot.activeElement;
+    }
+    // Walk up the flattened tree via `assignedSlot`/`parentNode`/`host`
+    // until a visible row is reached. This handles both focus inside the
+    // row's tree and focus on light-DOM content slotted across a shadow
+    // boundary into a row (e.g. an `<input>` inside a
+    // `vaadin-grid-cell-content`).
+    const visible = new Set(visibleElements);
     while (node) {
       if (visible.has(node)) {
         return node;

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -516,25 +516,18 @@ export class IronListAdapter {
   /** @private */
   __getFocusedElement(visibleElements = this.__getVisibleElements()) {
     // `document.activeElement` retargets to the outermost shadow host when
-    // focus lives in a nested shadow tree. Walk down through any nested
-    // shadow roots' `activeElement` to reach the actual focused node.
+    // focus lives in a nested shadow tree. Descend through nested shadow
+    // roots' `activeElement`s to reach the real focused node, then walk up
+    // the flattened tree (via `assignedSlot`/`parentNode`/`host`) until a
+    // visible row is reached.
     let node = document.activeElement;
     while (node?.shadowRoot?.activeElement) {
       node = node.shadowRoot.activeElement;
     }
-    // Walk up the flattened tree via `assignedSlot`/`parentNode`/`host`
-    // until a visible row is reached. This handles both focus inside the
-    // row's tree and focus on light-DOM content slotted across a shadow
-    // boundary into a row (e.g. an `<input>` inside a
-    // `vaadin-grid-cell-content`).
-    const visible = new Set(visibleElements);
-    while (node) {
-      if (visible.has(node)) {
-        return node;
-      }
+    while (node && !visibleElements.includes(node)) {
       node = node.assignedSlot || node.parentNode || node.host;
     }
-    return undefined;
+    return node;
   }
 
   /** @private */

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -515,11 +515,32 @@ export class IronListAdapter {
 
   /** @private */
   __getFocusedElement(visibleElements = this.__getVisibleElements()) {
-    return visibleElements.find(
+    // Case 1: focus is inside the shadow tree (e.g. a focusable cell with
+    // tabindex). The shadow root's activeElement is the focused descendant,
+    // and Node.contains finds it via tree containment.
+    const result = visibleElements.find(
       (element) =>
         element.contains(this.elementsContainer.getRootNode().activeElement) ||
         element.contains(this.scrollTarget.getRootNode().activeElement),
     );
+    if (result) {
+      return result;
+    }
+    // Case 2: focus is on light-DOM content slotted across the shadow boundary
+    // (e.g. an `<input>` inside a `vaadin-grid-cell-content`). The shadow
+    // root's activeElement is null because the focused element is outside the
+    // shadow tree, and Node.contains doesn't traverse slot projection.
+    // Walk up from document.activeElement, crossing slot boundaries via
+    // assignedSlot, to locate the projected-into virtualizer row.
+    const visible = new Set(visibleElements);
+    let node = document.activeElement;
+    while (node) {
+      if (visible.has(node)) {
+        return node;
+      }
+      node = node.assignedSlot || node.parentNode || node.host;
+    }
+    return undefined;
   }
 
   /** @private */

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -204,11 +204,10 @@ describe('reorder elements', () => {
   });
 
   // Regression tests for vaadin/web-components#11639. When the virtualizer
-  // lives inside a shadow root, `document.activeElement` is the shadow host
-  // (open shadow roots hide their focused descendant from the outside). The
-  // focused row must therefore be located via the shadow root's
-  // `activeElement` or by walking the flattened ancestors of
-  // `document.activeElement` via `assignedSlot` for slotted content.
+  // lives inside a shadow root, the focused row must be located via the
+  // shadow root's `activeElement` (focus inside the shadow tree) or by
+  // walking the flattened ancestors via `assignedSlot` from the scroll
+  // target's root activeElement (focus on slotted light-DOM content).
   describe('focused element detection in shadow tree', () => {
     beforeEach(() => {
       // Remove default scroll target
@@ -268,6 +267,30 @@ describe('reorder elements', () => {
     });
 
     it('should not detach a row whose slotted content has focus on reorder', async () => {
+      // The row that will include the focused cell (should not get detached)
+      const rowContainingFocus = elementsContainer.children[4];
+      // Focus the slotted cell content on the row
+      rowContainingFocus.querySelector('slot').assignedNodes()[0].focus();
+
+      // Scroll and collect the detached elements
+      const detachedElements = await scrollRecycle();
+      // Expect the row containing focus to not have been detached
+      expect(detachedElements).not.to.include(rowContainingFocus);
+    });
+
+    // When the entire virtualizer host is itself nested inside another
+    // shadow root, `document.activeElement` retargets to the outermost
+    // host. The scroll target's root activeElement remains the actual
+    // slotted focused element and must be used as the walk's starting
+    // point.
+    it('should not detach a row whose slotted content has focus when wrapped in an outer shadow', async () => {
+      // Move the virtualizer host into an outer shadow root, keeping the
+      // slotted cell contents (currently in `scrollTarget`'s light DOM)
+      // wrapped inside the outer shadow as well.
+      const outerHost = fixtureSync('<div></div>');
+      const outerShadow = outerHost.attachShadow({ mode: 'open' });
+      outerShadow.appendChild(scrollTarget);
+
       // The row that will include the focused cell (should not get detached)
       const rowContainingFocus = elementsContainer.children[4];
       // Focus the slotted cell content on the row

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -202,4 +202,72 @@ describe('reorder elements', () => {
       expect(scrollTarget.scrollTop).to.equal(scrollTop);
     });
   });
+
+  // Regression test for vaadin/web-components#11639. When focusable content
+  // is slotted across a shadow boundary into a virtualizer row (the pattern
+  // vaadin-grid uses with `<vaadin-grid-cell-content>`), the row's shadow
+  // root has `activeElement === null`, so the original `Node.contains`-based
+  // lookup returned `undefined` for the focused row. Iron-list's reorder
+  // then anchored on the wrong element and shuffled the row containing
+  // focus around — which also triggered a silent focus drop in Firefox 148+
+  // during slot reprojection. The fix walks `document.activeElement`'s
+  // flattened ancestors via `assignedSlot` so the correct row is anchored.
+  describe('focused element detection across slot boundary', () => {
+    let host;
+    let slottedVirtualizer;
+    let slottedElementsContainer;
+
+    beforeEach(() => {
+      clock.restore();
+
+      host = fixtureSync('<div style="height: 100px;"></div>');
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      shadowRoot.innerHTML = `
+        <style>:host { display: block; height: 100%; }</style>
+        <div id="scrollTarget" style="height: 100%; overflow: auto;">
+          <div id="container"></div>
+        </div>
+      `;
+
+      let nextSlotId = 0;
+      slottedVirtualizer = new Virtualizer({
+        createElements: (count) =>
+          Array.from(Array(count)).map(() => {
+            const row = document.createElement('div');
+            const slotName = `cell-${nextSlotId}`;
+            nextSlotId += 1;
+            const slot = document.createElement('slot');
+            slot.name = slotName;
+            row.appendChild(slot);
+
+            const cellContent = document.createElement('div');
+            cellContent.slot = slotName;
+            cellContent.tabIndex = 0;
+            host.appendChild(cellContent);
+
+            row.__cellContent = cellContent;
+            return row;
+          }),
+        updateElement: (row, index) => {
+          row.index = index;
+          row.id = `row-${index}`;
+        },
+        scrollTarget: shadowRoot.getElementById('scrollTarget'),
+        scrollContainer: shadowRoot.getElementById('container'),
+        reorderElements: true,
+      });
+      slottedVirtualizer.size = 100;
+      slottedElementsContainer = shadowRoot.getElementById('container');
+    });
+
+    it('should find the row whose slotted content has focus', () => {
+      const row = slottedElementsContainer.children[1];
+      // Focus the light-DOM content slotted into the row. The shadow root's
+      // `activeElement` is null because the focused element is outside the
+      // shadow tree.
+      row.__cellContent.focus();
+      expect(host.shadowRoot.activeElement).to.be.null;
+      expect(slottedVirtualizer.__adapter.__getFocusedElement()).to.equal(row);
+    });
+  });
 });

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -203,25 +203,20 @@ describe('reorder elements', () => {
     });
   });
 
-  // Regression test for vaadin/web-components#11639. When focusable content
-  // is slotted across a shadow boundary into a virtualizer row (the pattern
-  // vaadin-grid uses with `<vaadin-grid-cell-content>`), the row's shadow
-  // root has `activeElement === null`, so the original `Node.contains`-based
-  // lookup returned `undefined` for the focused row. Iron-list's reorder
-  // then anchored on the wrong element and shuffled the row containing
-  // focus around — which also triggered a silent focus drop in Firefox 148+
-  // during slot reprojection. The fix walks `document.activeElement`'s
-  // flattened ancestors via `assignedSlot` so the correct row is anchored.
-  describe('focused element detection across slot boundary', () => {
-    let host;
-    let slottedVirtualizer;
-    let slottedElementsContainer;
-
+  // Regression tests for vaadin/web-components#11639. When the virtualizer
+  // lives inside a shadow root, `document.activeElement` is the shadow host
+  // (open shadow roots hide their focused descendant from the outside). The
+  // focused row must therefore be located via the shadow root's
+  // `activeElement` or by walking the flattened ancestors of
+  // `document.activeElement` via `assignedSlot` for slotted content.
+  describe('focused element detection in shadow tree', () => {
     beforeEach(() => {
+      // Remove default scroll target
+      scrollTarget.remove();
       clock.restore();
 
-      host = fixtureSync('<div style="height: 100px;"></div>');
-      const shadowRoot = host.attachShadow({ mode: 'open' });
+      scrollTarget = fixtureSync('<div style="height: 100px;"></div>');
+      const shadowRoot = scrollTarget.attachShadow({ mode: 'open' });
       shadowRoot.innerHTML = `
         <style>:host { display: block; height: 100%; }</style>
         <div id="scrollTarget" style="height: 100%; overflow: auto;">
@@ -229,45 +224,59 @@ describe('reorder elements', () => {
         </div>
       `;
 
-      let nextSlotId = 0;
-      slottedVirtualizer = new Virtualizer({
+      virtualizer = new Virtualizer({
         createElements: (count) =>
           Array.from(Array(count)).map(() => {
             const row = document.createElement('div');
-            const slotName = `cell-${nextSlotId}`;
-            nextSlotId += 1;
             const slot = document.createElement('slot');
-            slot.name = slotName;
+            slot.name = `cell-${scrollTarget.children.length}`;
             row.appendChild(slot);
 
             const cellContent = document.createElement('div');
-            cellContent.slot = slotName;
+            cellContent.slot = slot.name;
             cellContent.tabIndex = 0;
-            host.appendChild(cellContent);
+            scrollTarget.appendChild(cellContent);
 
-            row.__cellContent = cellContent;
             return row;
           }),
         updateElement: (row, index) => {
           row.index = index;
           row.id = `row-${index}`;
+          const cellContent = row.querySelector('slot').assignedNodes()[0];
+          cellContent.textContent = index;
         },
         scrollTarget: shadowRoot.getElementById('scrollTarget'),
         scrollContainer: shadowRoot.getElementById('container'),
         reorderElements: true,
       });
-      slottedVirtualizer.size = 100;
-      slottedElementsContainer = shadowRoot.getElementById('container');
+      virtualizer.size = 100;
+      elementsContainer = shadowRoot.getElementById('container');
     });
 
-    it('should find the row whose slotted content has focus', () => {
-      const row = slottedElementsContainer.children[1];
-      // Focus the light-DOM content slotted into the row. The shadow root's
-      // `activeElement` is null because the focused element is outside the
-      // shadow tree.
-      row.__cellContent.focus();
-      expect(host.shadowRoot.activeElement).to.be.null;
-      expect(slottedVirtualizer.__adapter.__getFocusedElement()).to.equal(row);
+    it('should not detach a focused row on reorder', async () => {
+      // The row that will receive focus (should not get detached)
+      const rowContainingFocus = elementsContainer.children[4];
+      // Focus the row directly. The row lives inside the shadow tree, so
+      // `document.activeElement` resolves to the shadow host, not the row.
+      rowContainingFocus.tabIndex = 0;
+      rowContainingFocus.focus();
+
+      // Scroll and collect the detached elements
+      const detachedElements = await scrollRecycle();
+      // Expect the focused row to not have been detached
+      expect(detachedElements).not.to.include(rowContainingFocus);
+    });
+
+    it('should not detach a row whose slotted content has focus on reorder', async () => {
+      // The row that will include the focused cell (should not get detached)
+      const rowContainingFocus = elementsContainer.children[4];
+      // Focus the slotted cell content on the row
+      rowContainingFocus.querySelector('slot').assignedNodes()[0].focus();
+
+      // Scroll and collect the detached elements
+      const detachedElements = await scrollRecycle();
+      // Expect the row containing focus to not have been detached
+      expect(detachedElements).not.to.include(rowContainingFocus);
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11639

`__getFocusedElement` checked `shadowRoot.activeElement` and used `Node.contains` to find the focused row among visible elements. When focusable content is slotted across the shadow boundary into a row (the pattern vaadin-grid uses with `<vaadin-grid-cell-content>`), the shadow root's `activeElement` is null because the focused element lives outside the shadow tree, and `Node.contains` does not traverse slot projection — so the lookup returned `undefined` for the focused row.

## Type of change

- Bugfix