### PR TITLE
refactor: remove tooltip slot from menu-bar submenu

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -56,13 +56,14 @@ class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(Li
   }
 
   /** @protected */
-  ready() {
-    super.ready();
-
-    // The slotted `<vaadin-tooltip>` lives on the parent `<vaadin-menu-bar>`.
-    // Its tooltip controller instance is shared across sub-menus to reuse
-    // the same tooltip element for items at every nesting level.
+  firstUpdated(props) {
+    // Tooltip lives on the parent `<vaadin-menu-bar>`. Reuse its controller
+    // so the same tooltip element serves items at every nesting level.
+    // Assigned before `super.firstUpdated()` so `ContextMenuMixin` skips
+    // creating its own controller (we don't render a tooltip slot).
     this._tooltipController = this.parentElement._tooltipController;
+
+    super.firstUpdated(props);
   }
 
   /**
@@ -96,8 +97,6 @@ class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(Li
         <slot name="overlay"></slot>
         <slot name="submenu" slot="submenu"></slot>
       </vaadin-menu-bar-overlay>
-
-      <slot name="tooltip"></slot>
     `;
   }
 


### PR DESCRIPTION
The `<vaadin-menu-bar>` already hosts the slotted `<vaadin-tooltip>` and exposes its tooltip controller to nested submenus. The submenu's own `<slot name="tooltip">` had no slotted content, and the `ContextMenuTooltipController` instance that `ContextMenuMixin` created for it was unused — kept alive only so its slot lookup wouldn't crash.

Drop the unused slot from the submenu's shadow render. Move the parent-controller assignment from `ready()` to `firstUpdated()` so it runs before `ContextMenuMixin.firstUpdated()` — that mixin only creates its own tooltip controller when none is inherited, so the early assignment prevents it from looking up a slot that no longer exists.

---

🤖 Generated with Claude Code