### PR TITLE
fix: prevent dashboard from losing focus in Firefox

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -267,7 +267,7 @@ class Dashboard extends DashboardLayoutMixin(
     let wrappers = [...hostElement.children].filter((el) => el.localName === WRAPPER_LOCAL_NAME);
 
     const focusedWrapper = wrappers.find((wrapper) => wrapper.querySelector(':focus'));
-    const focusedElement = focusedWrapper && focusedWrapper.querySelector(':focus');
+    const focusedElement = focusedWrapper?.querySelector(':focus');
     const focusedWrapperWillBeRemoved = focusedWrapper && !this.__isActiveWrapper(focusedWrapper);
     const wrapperClosestToRemovedFocused =
       focusedWrapperWillBeRemoved && this.__getClosestActiveWrapper(focusedWrapper);

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -267,6 +267,7 @@ class Dashboard extends DashboardLayoutMixin(
     let wrappers = [...hostElement.children].filter((el) => el.localName === WRAPPER_LOCAL_NAME);
 
     const focusedWrapper = wrappers.find((wrapper) => wrapper.querySelector(':focus'));
+    const focusedElement = focusedWrapper && focusedWrapper.querySelector(':focus');
     const focusedWrapperWillBeRemoved = focusedWrapper && !this.__isActiveWrapper(focusedWrapper);
     const wrapperClosestToRemovedFocused =
       focusedWrapperWillBeRemoved && this.__getClosestActiveWrapper(focusedWrapper);
@@ -314,6 +315,10 @@ class Dashboard extends DashboardLayoutMixin(
       if (focusedWrapperWillBeRemoved) {
         // The wrapper containing the focused element was removed. Try to focus the element in the closest wrapper.
         this.__focusWrapperContent(wrapperClosestToRemovedFocused || this.querySelector(WRAPPER_LOCAL_NAME));
+      } else if (focusedElement && !focusedElement.matches(':focus')) {
+        // Firefox loses focus from a slotted element when the <slot> it was projected through is
+        // removed during the shadow re-render, even after re-projection through a different slot.
+        focusedElement.focus();
       }
 
       const focusedItem = this.querySelector(':focus');


### PR DESCRIPTION
Fixes https://github.com/vaadin/web-components/issues/11644

Firefox 148+ silently drops focus from a slotted element when the `<slot>` it was projected through is reassigned during the shadow-DOM re-render in `__renderItemWrappers`. No `blur` or `focusout` events fire — `document.activeElement` simply becomes `<body>` after the next frame.

```js
const dashboard = document.querySelector('vaadin-dashboard');
dashboard.querySelector('vaadin-dashboard-widget input').focus();
dashboard.items = [...dashboard.items];
// In Firefox 148+: document.activeElement === document.body
```

Cache the focused element before the re-render and re-focus it inside the existing `requestAnimationFrame` block when it lost focus and its wrapper was not removed.

The existing focus tests in \`packages/dashboard/test/dashboard.test.ts\` cover the regression scenarios. They pass on Firefox 144 (current CI) regardless of the fix and will start exercising it once CI moves to Firefox 148+ via the upcoming Playwright bump.

Reported upstream: https://bugzilla.mozilla.org/show_bug.cgi?id=2037008

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)