### PR TITLE
fix: invalidate overlay content size cache on positionTarget change

### DIFF
--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -145,6 +145,12 @@ export const PositionMixin = (superClass) =>
       if (props.has('positionTarget')) {
         const oldTarget = props.get('positionTarget');
 
+        // Invalidate the cached content size so the next `_updatePosition` call
+        // measures the overlay against the new target instead of carrying over
+        // a larger size from the previous one.
+        this.__oldContentWidth = undefined;
+        this.__oldContentHeight = undefined;
+
         // 1. When position target is removed, always reset position settings
         // 2. When position target is set, reset if overlay was opened before
         if ((!this.positionTarget && oldTarget) || (this.positionTarget && !oldTarget && !!this.__margins)) {

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -511,6 +511,28 @@ describe('position mixin', () => {
       expect(parent.hasAttribute('end-aligned')).to.be.true;
     });
 
+    it('should re-evaluate alignment when positionTarget changes after content shrinks', () => {
+      // Make the content wide enough to force a flip at a target position
+      // where the narrow content would still fit.
+      overlayContent.style.width = '200px';
+      const wideFlipThreshold = document.documentElement.clientWidth - 200 - margin;
+      target.style.left = `${wideFlipThreshold + 3}px`;
+      updatePosition();
+      expect(overlay.hasAttribute('end-aligned')).to.be.true;
+
+      // Shrink the content so the same target position fits without a flip.
+      overlayContent.style.width = '50px';
+
+      // Switch to a fresh target at the same position. The cached content
+      // size from the previous target must not carry over.
+      const newTarget = target.cloneNode(true);
+      target.parentElement.appendChild(newTarget);
+      overlay.positionTarget = newTarget;
+
+      expect(overlay.hasAttribute('start-aligned')).to.be.true;
+      expect(overlay.hasAttribute('end-aligned')).to.be.false;
+    });
+
     describe('no overlap', () => {
       beforeEach(() => {
         overlay.noHorizontalOverlap = true;


### PR DESCRIPTION
`PositionMixin` keeps the largest-ever measured content size in `__oldContentWidth` / `__oldContentHeight` (via `Math.max`) so a window-resize squeeze doesn't shrink the overlay below its current available space. The cache was never cleared when `positionTarget` changed, so an overlay that moves to a target with smaller content kept comparing against the previous, larger size and stayed flipped to the wrong side.

This shows up most visibly in components that reuse a single overlay across multiple targets — e.g. a context-menu tooltip that follows the hovered item and switches between a long-text item and a short-text one. After hovering the long item once, the tooltip stays end-aligned (flipped) on the short item even though it would fit on the default side.

## Changes

- Reset `__oldContentWidth` and `__oldContentHeight` whenever `positionTarget` changes, so the next `_updatePosition` measures the overlay against its current content rather than a stale maximum.
- Add a regression test in `position-mixin.test.js` that forces a flip with wide content, shrinks the content, switches to a fresh target, and asserts the alignment is re-evaluated against the new content size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)