### PR TITLE
fix: declare TooltipController constructor signature in .d.ts

### DIFF
--- a/packages/component-base/src/tooltip-controller.d.ts
+++ b/packages/component-base/src/tooltip-controller.d.ts
@@ -23,6 +23,8 @@ type TooltipPosition =
  * A controller that manages the slotted tooltip element.
  */
 export class TooltipController extends SlotController {
+  constructor(host: HTMLElement);
+
   /**
    * An HTML element for linking with the tooltip overlay
    * via `aria-describedby` attribute used by screen readers.


### PR DESCRIPTION
<!-- Why this change was made. Focus on the problem and context. -->
`TooltipController.d.ts` did not declare its own constructor, so TS inherited the 2-4-arg signature from `SlotController`. The runtime constructor takes a single `host` argument (and internally calls `super(host, 'tooltip')`). Existing call sites pass one argument, e.g. `new TooltipController(this)`, which is correct at runtime but mistyped under stricter checking.

Surfaced while exploring `// @ts-check` on `vaadin-icon-mixin.js` (`proto/ts-check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)