### PR TITLE
fix: declare correct controller constructor signatures in .d.ts

### DIFF
--- a/packages/a11y-base/src/aria-modal-controller.d.ts
+++ b/packages/a11y-base/src/aria-modal-controller.d.ts
@@ -21,7 +21,7 @@ export class AriaModalController implements ReactiveController {
    */
   callback: () => HTMLElement | HTMLElement[];
 
-  constructor(node: HTMLElement);
+  constructor(host: HTMLElement, callback?: () => HTMLElement | HTMLElement[]);
 
   /**
    * Make the controller host element modal by trapping focus inside it and hiding

--- a/packages/details/src/content-controller.d.ts
+++ b/packages/details/src/content-controller.d.ts
@@ -8,4 +8,6 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
 /**
  * A controller to manage the default content slot.
  */
-export class ContentController extends SlotChildObserveController {}
+export class ContentController extends SlotChildObserveController {
+  constructor(host: HTMLElement);
+}

--- a/packages/details/src/summary-controller.d.ts
+++ b/packages/details/src/summary-controller.d.ts
@@ -9,6 +9,8 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
  * A controller to manage the summary element.
  */
 export class SummaryController extends SlotChildObserveController {
+  constructor(host: HTMLElement, tagName: string);
+
   /**
    * String used for the summary.
    */

--- a/packages/field-base/src/error-controller.d.ts
+++ b/packages/field-base/src/error-controller.d.ts
@@ -9,6 +9,8 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
  * A controller that manages the error message node content.
  */
 export class ErrorController extends SlotChildObserveController {
+  constructor(host: HTMLElement);
+
   /**
    * String used for the error message text content.
    */

--- a/packages/field-base/src/helper-controller.d.ts
+++ b/packages/field-base/src/helper-controller.d.ts
@@ -9,6 +9,8 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
  * A controller that manages the helper node content.
  */
 export class HelperController extends SlotChildObserveController {
+  constructor(host: HTMLElement);
+
   /**
    * String used for the helper text.
    */

--- a/packages/field-base/src/input-controller.d.ts
+++ b/packages/field-base/src/input-controller.d.ts
@@ -8,4 +8,6 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 /**
  * A controller to create and initialize slotted `<input>` element.
  */
-export class InputController extends SlotController {}
+export class InputController extends SlotController {
+  constructor(host: HTMLElement, callback?: (node: HTMLInputElement) => void, options?: { uniqueIdPrefix?: string });
+}

--- a/packages/field-base/src/label-controller.d.ts
+++ b/packages/field-base/src/label-controller.d.ts
@@ -9,6 +9,8 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
  * A controller to manage the label element.
  */
 export class LabelController extends SlotChildObserveController {
+  constructor(host: HTMLElement);
+
   /**
    * String used for the label.
    */

--- a/packages/field-base/src/text-area-controller.d.ts
+++ b/packages/field-base/src/text-area-controller.d.ts
@@ -8,4 +8,6 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 /**
  * A controller to create and initialize slotted `<textarea>` element.
  */
-export class TextAreaController extends SlotController {}
+export class TextAreaController extends SlotController {
+  constructor(host: HTMLElement, callback?: (node: HTMLTextAreaElement) => void);
+}

--- a/packages/login/src/title-controller.d.ts
+++ b/packages/login/src/title-controller.d.ts
@@ -8,4 +8,6 @@ import { SlotChildObserveController } from '@vaadin/component-base/src/slot-chil
 /**
  * A controller to manage the title element.
  */
-export class TitleController extends SlotChildObserveController {}
+export class TitleController extends SlotChildObserveController {
+  constructor(host: HTMLElement);
+}

--- a/packages/select/src/button-controller.d.ts
+++ b/packages/select/src/button-controller.d.ts
@@ -8,4 +8,6 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 /**
  * A controller to manage the value button element.
  */
-export class ButtonController extends SlotController {}
+export class ButtonController extends SlotController {
+  constructor(host: HTMLElement);
+}


### PR DESCRIPTION
<!-- Why this change was made. Focus on the problem and context. -->
Each of these controllers overrides its base class constructor at runtime with a narrower signature (typically `constructor(host)`, forwarding to `super(host, slotName, ...)` internally), but the matching `.d.ts` did not declare its own constructor. TS therefore inherited the base's wider signature (e.g. `SlotController`'s 4 parameters), and call sites passing one argument were mistyped.

```ts
// Before — inherited 4 params from SlotController:
new ContentController(this);  // TS2554: Expected 2-4 arguments, but got 1
```

Same drift class as `TooltipController` (#11662). I audited every direct subclass of `SlotController` / `SlotChildObserveController`; all controllers needing a constructor declaration are fixed in one pass.

Also fixes `AriaModalController`, whose explicitly-declared constructor took one argument while the runtime takes two (`host`, `callback`).

10 controllers updated:
- `packages/a11y-base/src/aria-modal-controller.d.ts`
- `packages/details/src/content-controller.d.ts`
- `packages/details/src/summary-controller.d.ts`
- `packages/field-base/src/error-controller.d.ts`
- `packages/field-base/src/helper-controller.d.ts`
- `packages/field-base/src/input-controller.d.ts`
- `packages/field-base/src/label-controller.d.ts`
- `packages/field-base/src/text-area-controller.d.ts`
- `packages/login/src/title-controller.d.ts`
- `packages/select/src/button-controller.d.ts`

Surfaced while exploring `// @ts-check` on Lit-based mixins (`proto/ts-check`).

Related to #11662

🤖 Generated with [Claude Code](https://claude.com/claude-code)