### PR TITLE
fix: align controller .d.ts implements claims with runtime

### DIFF
--- a/packages/a11y-base/src/aria-modal-controller.d.ts
+++ b/packages/a11y-base/src/aria-modal-controller.d.ts
@@ -3,13 +3,12 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { ReactiveController } from 'lit';
 
 /**
  * A controller for handling modal state on the elements with `dialog` and `alertdialog` role.
  * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal
  */
-export class AriaModalController implements ReactiveController {
+export class AriaModalController {
   /**
    * The controller host element.
    */

--- a/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
+++ b/packages/component-base/src/data-provider-controller/data-provider-controller.d.ts
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import type { ReactiveController } from 'lit';
 import type { Cache } from './cache.js';
 import type { getFlatIndexByPath, getFlatIndexContext, getItemContext } from './helpers.js';
 
@@ -23,10 +22,7 @@ export type DataProvider<TItem, TDataProviderParams extends Record<string, unkno
 /**
  * A controller that stores and manages items loaded with a data provider.
  */
-export class DataProviderController<
-  TItem,
-  TDataProviderParams extends Record<string, unknown>,
-> implements ReactiveController {
+export class DataProviderController<TItem, TDataProviderParams extends Record<string, unknown>> extends EventTarget {
   /**
    * The controller host element.
    */
@@ -93,10 +89,6 @@ export class DataProviderController<
    * The total number of items, including items from expanded sub-caches.
    */
   get flatSize(): number;
-
-  hostConnected(): void;
-
-  hostDisconnected(): void;
 
   /**
    * Whether the root cache or any of its decendant caches have pending requests.

--- a/packages/field-base/src/labelled-input-controller.d.ts
+++ b/packages/field-base/src/labelled-input-controller.d.ts
@@ -4,8 +4,24 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import type { ReactiveController } from 'lit';
+import type { LabelController } from './label-controller.js';
 
 /**
  * A controller for linking a `<label>` element with an `<input>` element.
  */
-export class LabelledInputController implements ReactiveController {}
+export class LabelledInputController implements ReactiveController {
+  constructor(input: HTMLInputElement, labelController: LabelController);
+
+  /**
+   * The input element to link with the label.
+   */
+  input: HTMLInputElement;
+
+  /**
+   * Phantom optional method to satisfy the `ReactiveController` interface
+   * (TS2559: an interface with all-optional members needs at least one
+   * declared property in common). Not implemented at runtime; Lit's
+   * `addController` invokes it via optional chaining.
+   */
+  hostConnected?(): void;
+}

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -11,4 +11,12 @@ import type { ReactiveController } from 'lit';
  */
 export class VirtualKeyboardController implements ReactiveController {
   constructor(host: HTMLElement & { inputElement?: HTMLElement; opened: boolean });
+
+  /**
+   * Phantom optional method to satisfy the `ReactiveController` interface
+   * (TS2559: an interface with all-optional members needs at least one
+   * declared property in common). Not implemented at runtime; Lit's
+   * `addController` invokes it via optional chaining.
+   */
+  hostConnected?(): void;
 }


### PR DESCRIPTION
<!-- Why this change was made. Focus on the problem and context. -->
Four controllers had `.d.ts` declarations that didn't match runtime: bogus `implements ReactiveController` claims (the runtime classes never implement any of its methods) or method declarations for methods that don't exist. This is a class of drift exposed when enabling stricter type-checking.

## Per-file fix

- **`AriaModalController`** — not used as a controller (no `addController` call site). Removed the `implements ReactiveController` clause.
- **`DataProviderController`** — not used as a controller. Removed the `implements ReactiveController` clause and the bogus `hostConnected(): void` / `hostDisconnected(): void` declarations that don't exist at runtime. Added `extends EventTarget` to expose the `addEventListener` / `dispatchEvent` consumers actually use (combo-box-data-provider-mixin).
- **`VirtualKeyboardController`** — passed to `addController` from date-picker / time-picker, so must satisfy `ReactiveController`. Runtime has no host lifecycle methods. Declared an optional `hostConnected?(): void` to satisfy TS2559 without lying about implementation; Lit's `addController` invokes such methods via optional chaining.
- **`LabelledInputController`** — passed to `addController` from text-field / checkbox. Same fix as VirtualKeyboardController, plus the `.d.ts` was missing the `constructor(input, labelController)` declaration entirely and the `input` public field.

Related to #11662, #11664

🤖 Generated with [Claude Code](https://claude.com/claude-code)