### PR TITLE
test: pin item height in date-picker overlay-content fixture

### DIFF
--- a/packages/date-picker/test/overlay-content.test.js
+++ b/packages/date-picker/test/overlay-content.test.js
@@ -8,6 +8,9 @@ async function customizeFixture({ initialPosition, monthScrollerItems, monthScro
   const overlay = fixtureSync(`<vaadin-date-picker-overlay-content></vaadin-date-picker-overlay-content>`);
   await untilOverlayScrolled(overlay);
   const monthScroller = overlay._monthScroller;
+  // Pin item height to a clean integer pixel value so percentage-based buffer
+  // offsets resolve to whole pixels and revealDate position math stays exact.
+  monthScroller.style.setProperty('--vaadin-infinite-scroller-item-height', '270px');
   monthScroller.style.setProperty('--vaadin-infinite-scroller-buffer-offset', monthScrollerOffset);
   monthScroller.style.height = `${270 * monthScrollerItems}px`;
   overlay.i18n = getDefaultI18n();
@@ -426,8 +429,7 @@ describe('overlay', () => {
       it('should scroll when the month is below the visible area', () => {
         const position = monthScroller.position;
         overlay.revealDate(new Date(2021, 3, 1), false);
-        // FIXME: fails with base styles: "expected -51.04545454545455 to equal -51"
-        expect(monthScroller.position).to.be.closeTo(position + 1, 0.1);
+        expect(monthScroller.position).to.equal(position + 1);
       });
     });
 
@@ -456,8 +458,7 @@ describe('overlay', () => {
       it('should scroll when the month is below the visible area', () => {
         const position = monthScroller.position;
         overlay.revealDate(new Date(2021, 3, 1), false);
-        // FIXME: fails with base styles: "expected -51.45454545454545 to equal -51.4"
-        expect(monthScroller.position).to.be.closeTo(position + 0.6, 0.1 /* The bottom 10% offset is ensured by JS */);
+        expect(monthScroller.position).to.equal(position + 0.6 /* The bottom 10% offset is ensured by JS */);
       });
     });
   });


### PR DESCRIPTION
The `customizeFixture` helper in `overlay-content.test.js` set the month scroller height as `270 * monthScrollerItems` px, hardcoding the theme-specific Lumo item height. The actual `--vaadin-infinite-scroller-item-height` is theme-dependent (264 px in the current base styles, different in upcoming changes), so `revealDate` position math drifted and two assertions had to fall back on `closeTo(…, 0.1)` plus FIXME comments.

Pin the CSS variable to `270px` on the month scroller before it activates (i.e. before `_createPool` reads and caches `itemHeight`). With a clean integer item height, percentage-based buffer offsets resolve to whole pixels and the visible-area math is exact:

- `monthScrollerItems: 2`, no offset → `visibleItems = 2` → expected `position + 1`
- `monthScrollerItems: 3`, 10% offset → `bufferOffset = 81 px` exact → `visibleItems = 2.4` → expected `position + 0.6`

Drop the FIXMEs and tighten the two assertions from `closeTo(…, 0.1)` to `equal(…)` so any future drift fails loudly instead of being masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)