### PR TITLE
fix: contain scroller overflow-indicators within the scroller stacking context

### DIFF
--- a/packages/scroller/src/styles/vaadin-scroller-base-styles.js
+++ b/packages/scroller/src/styles/vaadin-scroller-base-styles.js
@@ -19,6 +19,7 @@ export const scrollerStyles = css`
     outline: none;
     box-sizing: border-box;
     padding: var(--vaadin-scroller-padding-block) var(--vaadin-scroller-padding-inline);
+    contain: paint;
   }
 
   :host([focus-ring]) {


### PR DESCRIPTION
The indicators are positioned and use a high z-index to show above the content within the scroller. But the scroller itself isn't positioned, so the indicators can end up showing above other positioned elements when they share the same positioning context.

Fixed by containing painting painting within the scroller.

Before:
<img width="519" height="733" alt="Screenshot 2026-05-07 at 13 49 23" src="https://github.com/user-attachments/assets/c96cfb2f-6226-4bae-8d62-1180f302b41e" />

After: 
<img width="516" height="731" alt="Screenshot 2026-05-07 at 13 55 05" src="https://github.com/user-attachments/assets/9da6af99-0e83-404d-be5e-2b3a27b9893b" />
