### PR TITLE
chore: improve active grid item styles in Aura dev page

### DIFF
--- a/dev/aura/aura-extras.css
+++ b/dev/aura/aura-extras.css
@@ -67,5 +67,13 @@ vaadin-card[theme~='footer-end']::part(footer) {
 }
 
 vaadin-grid::part(active-nav-item) {
-  --vaadin-grid-row-highlight-background-color: var(--aura-accent-surface);
+  --_highlight-color: light-dark(
+    oklch(from var(--aura-accent-color-light) min(0.9, l) c h / max(0.05, l / 4)),
+    oklch(from var(--aura-accent-color-dark) max(0.6, l) c h / max(0.2, l / 4))
+  );
+  --vaadin-grid-row-highlight-background-color: var(--_highlight-color);
+}
+
+vaadin-grid::part(active-nav-item first-column-cell) {
+  box-shadow: inset 3px 0 0 0 var(--aura-accent-color);
 }


### PR DESCRIPTION
Add a border (using box-shadow) on the first cell to make the active item more prominent. 

Use a different background color for the active item (copied from the Aura menu item styles), as the surface accent color can be transparent with a neutral accent color.