### PR TITLE
chore: preserve -webkit- prefixes in dev page CSS for Safari 17

### DIFF
--- a/patches/@web+rollup-plugin-html+2.3.0.patch
+++ b/patches/@web+rollup-plugin-html+2.3.0.patch
@@ -1,13 +1,17 @@
 diff --git a/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js b/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js
-index 7fdc0bf..ec95119 100644
+index 7fdc0bf..69439d9 100644
 --- a/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js
 +++ b/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js
-@@ -73,7 +73,7 @@ async function emitAssets(inputs, options) {
+@@ -73,8 +73,11 @@ async function emitAssets(inputs, options) {
                      let updatedCssSource = false;
                      const { code } = await (0, lightningcss_1.transform)({
                          filename: basename,
 -                        code: asset.content,
 +                        code: source,
                          minify: false,
++                        // Without targets, lightningcss strips vendor prefixes
++                        // such as -webkit-backdrop-filter that Safari 17 still needs.
++                        targets: { safari: 17 << 16 },
                          visitor: {
                              Url: url => {
+                                 // Support foo.svg#bar


### PR DESCRIPTION
`@web/rollup-plugin-html` runs `lightningcss.transform()` on CSS assets when bundling URL references (e.g. font files in `aura.css`). Without `targets`, lightningcss assumes evergreen browsers and strips vendor prefixes — including `-webkit-backdrop-filter`, which Safari 17 still requires. As a result, overlay backdrop blur silently broke on Safari 17 in the built dev pages.

Extend the existing patch to pass `targets: { safari: 17 << 16 }` so the prefix is preserved.

See https://lightningcss.dev/transpilation.html#browser-targets

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)