### PR TITLE
chore: add dev page workaround to enable active styles on iOS

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -18,6 +18,9 @@
       window.Vaadin.featureFlags ||= {};
       window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
       window.Vaadin.featureFlags.badgeComponent = true;
+
+      // Enable :active styles on iOS
+      document.addEventListener('touchstart', () => {}, { passive: true });
     </script>
     <script type="module">
       import './aura/aura-theme-editor.js';

--- a/dev/common.js
+++ b/dev/common.js
@@ -1,6 +1,9 @@
 import { css, html, LitElement } from 'lit';
 import { addGlobalStyles } from '@vaadin/component-base/src/styles/add-global-styles.js';
 
+// Enable :active styles on iOS
+document.addEventListener('touchstart', () => {}, { passive: true });
+
 addGlobalStyles(
   'dev-common',
   css`


### PR DESCRIPTION
Without a touch listener on the page, iOS doesn't apply `:active` styles immediately upon pressing an element.

For example, the Aura theme for vaadin-side-nav-item uses the native `:active` style, and without this change that style isn't applied on iOS on the dev/test pages.