### PR TITLE
chore: do not transform light-dark() styles in dev build CSS

### DIFF
--- a/patches/@web+rollup-plugin-html+2.3.0.patch
+++ b/patches/@web+rollup-plugin-html+2.3.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js b/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js
-index 7fdc0bf..69439d9 100644
+index 7fdc0bf..306ca65 100644
 --- a/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js
 +++ b/node_modules/@web/rollup-plugin-html/dist/output/emitAssets.js
-@@ -73,8 +73,11 @@ async function emitAssets(inputs, options) {
+@@ -73,8 +73,14 @@ async function emitAssets(inputs, options) {
                      let updatedCssSource = false;
                      const { code } = await (0, lightningcss_1.transform)({
                          filename: basename,
@@ -11,7 +11,10 @@ index 7fdc0bf..69439d9 100644
                          minify: false,
 +                        // Without targets, lightningcss strips vendor prefixes
 +                        // such as -webkit-backdrop-filter that Safari 17 still needs.
++                        // Exclude LightDark so light-dark() is left intact instead
++                        // of being polyfilled into broken --lightningcss-* placeholders.
 +                        targets: { safari: 17 << 16 },
++                        exclude: lightningcss_1.Features.LightDark,
                          visitor: {
                              Url: url => {
                                  // Support foo.svg#bar


### PR DESCRIPTION
Follow-up to #11685.

Targeting Safari 17 made lightningcss polyfill `light-dark()` into `var(--lightningcss-light, ...) var(--lightningcss-dark, ...)` pairs that reference undefined variables, breaking color values across the Aura theme on the deployed dev pages.

Exclude the `LightDark` feature so `light-dark()` passes through untouched while vendor prefixing still kicks in for `-webkit-backdrop-filter`.

See https://lightningcss.dev/transpilation.html#feature-flags

Follow-up to #11685

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)