### PR TITLE
docs(guidelines): note readOnly property accessor convention

### DIFF
--- a/guidelines/04-coding-conventions.md
+++ b/guidelines/04-coding-conventions.md
@@ -200,6 +200,11 @@ Other notes:
   prefers this over Lit's `state: true`).
 - `notify: true` is provided by PolylitMixin and dispatches a
   `{property}-changed` `CustomEvent` — see [Events](09-events.md).
+- `readOnly: true` replaces the public setter with a no-op — even
+  `host.toggleAttribute(...)` won't update the property because the
+  reflected change still hits the no-op. PolylitMixin generates a
+  protected `_set{Name}(value)` accessor; use it from component code
+  and tests instead.
 
 For full Lit property options refer to the
 [Lit reactive properties guide](https://lit.dev/docs/components/properties/).

--- a/guidelines/04-coding-conventions.md
+++ b/guidelines/04-coding-conventions.md
@@ -203,8 +203,7 @@ Other notes:
 - `readOnly: true` replaces the public setter with a no-op — even
   `host.toggleAttribute(...)` won't update the property because the
   reflected change still hits the no-op. PolylitMixin generates a
-  protected `_set{Name}(value)` accessor; use it from component code
-  and tests instead.
+  protected `_set{Name}(value)` accessor; use it instead.
 
 For full Lit property options refer to the
 [Lit reactive properties guide](https://lit.dev/docs/components/properties/).


### PR DESCRIPTION
## Summary

PolylitMixin's `readOnly: true` replaces the public setter with a no-op, so even `host.toggleAttribute(...)` doesn't update the property — the reflected change still hits the no-op. Add a one-bullet note to `04-coding-conventions.md` documenting the generated `_set{Name}()` accessor as the intended way to drive read-only state from component code and tests.

Discovered while implementing parent-side `current` placement on breadcrumb-item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)