### PR TITLE
chore: fix incorrect type JSDoc annotations syntax

### DIFF
--- a/packages/component-base/src/slot-observer.js
+++ b/packages/component-base/src/slot-observer.js
@@ -9,13 +9,13 @@
  */
 export class SlotObserver {
   constructor(slot, callback, forceInitial) {
-    /** @type HTMLSlotElement */
+    /** @type {HTMLSlotElement} */
     this.slot = slot;
 
-    /** @type Function */
+    /** @type {Function} */
     this.callback = callback;
 
-    /** @type boolean */
+    /** @type {boolean} */
     this.forceInitial = forceInitial;
 
     /** @type {Node[]} */


### PR DESCRIPTION
## Description

Fixed `@type` annotations to use correct JSDoc.

## Type of change

- Internal change