### PR TITLE
refactor: update CheckboxMixin to use single dynamic observer

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -124,7 +124,7 @@ export const CheckboxMixin = (superclass) =>
       );
       this.addController(new LabelledInputController(this.inputElement, this._labelController));
 
-      this._createMethodObserver('_checkedChanged(checked)');
+      this._createPropertyObserver('checked', '_checkedChanged');
     }
 
     /**
@@ -236,12 +236,10 @@ export const CheckboxMixin = (superclass) =>
     }
 
     /** @private */
-    _checkedChanged(checked) {
-      if (checked || this.__oldChecked) {
+    _checkedChanged(checked, oldChecked) {
+      if (checked || oldChecked) {
         this._requestValidation();
       }
-
-      this.__oldChecked = checked;
     }
 
     /**


### PR DESCRIPTION
## Description

Using `_createPropertyObserver` makes more sense as a single property observer has access to old value.

## Type of change

- Refactor