### PR TITLE
fix: honor hidden attribute on grid sorter and filter

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-filter-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-filter-base-styles.js
@@ -11,6 +11,10 @@ export const gridFilterStyles = css`
     max-width: 100%;
   }
 
+  :host([hidden]) {
+    display: none !important;
+  }
+
   ::slotted(*) {
     width: 100%;
     box-sizing: border-box;

--- a/packages/grid/src/styles/vaadin-grid-sorter-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-sorter-base-styles.js
@@ -18,6 +18,10 @@ export const gridSorterStyles = css`
     -webkit-tap-highlight-color: transparent;
   }
 
+  :host([hidden]) {
+    display: none !important;
+  }
+
   [part='content'] {
     flex: 1 1 auto;
     overflow: hidden;

--- a/packages/grid/test/filtering.test.js
+++ b/packages/grid/test/filtering.test.js
@@ -124,6 +124,11 @@ describe('filter', () => {
     filter.focus();
     expect(spy.calledOnce).to.be.true;
   });
+
+  it('should hide the filter when applying the hidden attribute', () => {
+    filter.hidden = true;
+    expect(getComputedStyle(filter).display).to.equal('none');
+  });
 });
 
 function gridFiltersFixture() {

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -101,6 +101,11 @@ describe('sorting', () => {
 
       expect(clickEvent.defaultPrevented).to.be.true;
     });
+
+    it('should hide the sorter when applying the hidden attribute', () => {
+      sorter.hidden = true;
+      expect(getComputedStyle(sorter).display).to.equal('none');
+    });
   });
 
   describe('DOM operations', () => {


### PR DESCRIPTION
## Summary
- `vaadin-grid-sorter` and `vaadin-grid-filter` were missing the standard `:host([hidden]) { display: none !important; }` rule, so setting `hidden` didn't actually hide them.
- Brings them in line with the DOM guideline that says to always include this rule, and matches what `vaadin-grid-tree-toggle` already does.
