### PR TITLE
test: replace grid sorter unit tests with snapshots

### DIFF
--- a/packages/grid/test/dom/__snapshots__/grid-sorter.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid-sorter.test.snap.js
@@ -1,0 +1,46 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["vaadin-grid-sorter host default"] = 
+`<vaadin-grid-sorter>
+</vaadin-grid-sorter>
+`;
+/* end snapshot vaadin-grid-sorter host default */
+
+snapshots["vaadin-grid-sorter host direction asc"] = 
+`<vaadin-grid-sorter direction="asc">
+</vaadin-grid-sorter>
+`;
+/* end snapshot vaadin-grid-sorter host direction asc */
+
+snapshots["vaadin-grid-sorter host direction desc"] = 
+`<vaadin-grid-sorter direction="desc">
+</vaadin-grid-sorter>
+`;
+/* end snapshot vaadin-grid-sorter host direction desc */
+
+snapshots["vaadin-grid-sorter shadow default"] = 
+`<div part="content">
+  <slot>
+  </slot>
+</div>
+<div part="indicators">
+  <span part="order">
+  </span>
+</div>
+`;
+/* end snapshot vaadin-grid-sorter shadow default */
+
+snapshots["vaadin-grid-sorter shadow order"] = 
+`<div part="content">
+  <slot>
+  </slot>
+</div>
+<div part="indicators">
+  <span part="order">
+    2
+  </span>
+</div>
+`;
+/* end snapshot vaadin-grid-sorter shadow order */
+

--- a/packages/grid/test/dom/grid-sorter.test.js
+++ b/packages/grid/test/dom/grid-sorter.test.js
@@ -1,0 +1,42 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
+import '../../src/vaadin-grid-sorter.js';
+
+describe('vaadin-grid-sorter', () => {
+  let sorter;
+
+  beforeEach(async () => {
+    sorter = fixtureSync('<vaadin-grid-sorter></vaadin-grid-sorter>');
+    await nextUpdate(sorter);
+  });
+
+  describe('host', () => {
+    it('default', async () => {
+      await expect(sorter).dom.to.equalSnapshot();
+    });
+
+    it('direction asc', async () => {
+      sorter.direction = 'asc';
+      await nextUpdate(sorter);
+      await expect(sorter).dom.to.equalSnapshot();
+    });
+
+    it('direction desc', async () => {
+      sorter.direction = 'desc';
+      await nextUpdate(sorter);
+      await expect(sorter).dom.to.equalSnapshot();
+    });
+  });
+
+  describe('shadow', () => {
+    it('default', async () => {
+      await expect(sorter).shadowDom.to.equalSnapshot();
+    });
+
+    it('order', async () => {
+      sorter._order = 1;
+      await nextUpdate(sorter);
+      await expect(sorter).shadowDom.to.equalSnapshot();
+    });
+  });
+});

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -16,7 +16,7 @@ import {
 
 describe('sorting', () => {
   describe('sorter', () => {
-    let sorter, title, button, orderIndicator;
+    let sorter, title, button;
 
     beforeEach(async () => {
       sorter = fixtureSync(`
@@ -27,7 +27,6 @@ describe('sorting', () => {
       button = sorter.querySelector('button');
       title = sorter.querySelector('.title');
       await nextFrame();
-      orderIndicator = sorter.shadowRoot.querySelector('[part="order"]');
     });
 
     it('should have default direction', () => {
@@ -78,22 +77,6 @@ describe('sorting', () => {
 
       const shiftClickEvent = shiftClickSpy.args[0][0];
       expect(shiftClickEvent.detail.shiftClick).to.be.true;
-    });
-
-    it('should show order indicator', () => {
-      expect(orderIndicator.innerText).to.equal('');
-      sorter._order = 0;
-      expect(orderIndicator.innerText).to.equal('1');
-      sorter._order = 4;
-      expect(orderIndicator.innerText).to.equal('5');
-    });
-
-    it('should show direction indicator', () => {
-      expect(sorter.getAttribute('direction')).to.equal(null);
-      sorter.direction = 'asc';
-      expect(sorter.getAttribute('direction')).to.equal('asc');
-      sorter.direction = 'desc';
-      expect(sorter.getAttribute('direction')).to.equal('desc');
     });
 
     it('should prevent default on click', () => {


### PR DESCRIPTION
## Description

Replaced 2 tests that cover DOM with snapshots to align with testing guidelines.

## Type of change

- Test