### PR TITLE
refactor!: expose default i18n via static getter instead of mixin parameter

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -23,7 +23,7 @@ const DEFAULT_I18N = {
  * @mixes I18nMixin
  */
 export const AppLayoutMixin = (superclass) =>
-  class AppLayoutMixinClass extends I18nMixin(DEFAULT_I18N, superclass) {
+  class AppLayoutMixinClass extends I18nMixin(superclass) {
     static get properties() {
       return {
         /**
@@ -87,6 +87,10 @@ export const AppLayoutMixin = (superclass) =>
 
     static get observers() {
       return ['__i18nChanged(__effectiveI18n)'];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -30,7 +30,7 @@ const DEFAULT_I18N = {
  * @mixes ResizeMixin
  */
 export const AvatarGroupMixin = (superClass) =>
-  class AvatarGroupMixinClass extends I18nMixin(DEFAULT_I18N, ResizeMixin(superClass)) {
+  class AvatarGroupMixinClass extends I18nMixin(ResizeMixin(superClass)) {
     static get properties() {
       return {
         /**
@@ -99,6 +99,10 @@ export const AvatarGroupMixin = (superClass) =>
           sync: true,
         },
       };
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -17,7 +17,7 @@ const DEFAULT_I18N = {
  * @mixes FocusMixin
  */
 export const AvatarMixin = (superClass) =>
-  class AvatarMixinClass extends I18nMixin(DEFAULT_I18N, FocusMixin(superClass)) {
+  class AvatarMixinClass extends I18nMixin(FocusMixin(superClass)) {
     static get properties() {
       return {
         /**
@@ -88,6 +88,10 @@ export const AvatarMixin = (superClass) =>
         '__i18nChanged(__effectiveI18n)',
         '__tooltipChanged(__tooltipNode, name, abbr)',
       ];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/component-base/src/i18n-mixin.d.ts
+++ b/packages/component-base/src/i18n-mixin.d.ts
@@ -8,8 +8,7 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin that allows to set partial I18N properties.
  */
-export declare function I18nMixin<I, T extends Constructor<HTMLElement>>(
-  defaultI18n: I,
+export declare function I18nMixin<T extends Constructor<HTMLElement>, I = unknown>(
   superclass: T,
 ): Constructor<I18nMixinClass<I>> & T;
 

--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -35,9 +35,18 @@ function deepMerge(target, ...sources) {
 /**
  * A mixin that allows to set partial I18N properties.
  *
+ * Subclasses provide their default values by overriding the
+ * `defaultI18n` static getter:
+ *
+ * ```js
+ * static get defaultI18n() {
+ *   return { foo: 'Foo', bar: 'Bar' };
+ * }
+ * ```
+ *
  * @polymerMixin
  */
-export const I18nMixin = (defaultI18n, superClass) =>
+export const I18nMixin = (superClass) =>
   class I18nMixinClass extends superClass {
     static get properties() {
       return {
@@ -55,10 +64,20 @@ export const I18nMixin = (defaultI18n, superClass) =>
       };
     }
 
+    /**
+     * Default I18N values. Must be overridden by subclasses with actual defaults.
+     *
+     * @protected
+     * @return {Object}
+     */
+    static get defaultI18n() {
+      return {};
+    }
+
     constructor() {
       super();
 
-      this.i18n = deepMerge({}, defaultI18n);
+      this.i18n = deepMerge({}, this.constructor.defaultI18n);
     }
 
     /**
@@ -80,6 +99,6 @@ export const I18nMixin = (defaultI18n, superClass) =>
         return;
       }
       this.__customI18n = value;
-      this.__effectiveI18n = deepMerge({}, defaultI18n, this.__customI18n);
+      this.__effectiveI18n = deepMerge({}, this.constructor.defaultI18n, this.__customI18n);
     }
   };

--- a/packages/component-base/test/i18n-mixin.test.js
+++ b/packages/component-base/test/i18n-mixin.test.js
@@ -12,7 +12,11 @@ const DEFAULT_I18N = {
   qux: ['q', 'u', 'x'],
 };
 
-class I18nMixinLitElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElement)) {
+class I18nMixinLitElement extends I18nMixin(PolylitMixin(LitElement)) {
+  static get defaultI18n() {
+    return DEFAULT_I18N;
+  }
+
   static get is() {
     return 'i18n-mixin-lit-element';
   }
@@ -109,7 +113,11 @@ describe('I18nMixin', () => {
     expect(Object.prototype.hasOwnProperty.call(el, 'i18n')).to.be.true;
 
     // Now define the element — triggers upgrade
-    class LateElement extends I18nMixin(DEFAULT_I18N, PolylitMixin(LitElement)) {
+    class LateElement extends I18nMixin(PolylitMixin(LitElement)) {
+      static get defaultI18n() {
+        return DEFAULT_I18N;
+      }
+
       static get is() {
         return tagName;
       }

--- a/packages/component-base/test/typings/i18n-mixin/i18n-mixin.types.ts
+++ b/packages/component-base/test/typings/i18n-mixin/i18n-mixin.types.ts
@@ -10,7 +10,11 @@ const DEFAULT_I18N = {
   },
 };
 
-class TestElement extends I18nMixin(DEFAULT_I18N, HTMLElement) {}
+class TestElement extends I18nMixin<typeof HTMLElement, typeof DEFAULT_I18N>(HTMLElement) {
+  static get defaultI18n() {
+    return DEFAULT_I18N;
+  }
+}
 
 const element = new TestElement();
 

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -49,7 +49,7 @@ const DEFAULT_I18N = {
  * @mixes I18nMixin
  */
 export const CrudMixin = (superClass) =>
-  class extends I18nMixin(DEFAULT_I18N, superClass) {
+  class extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -302,6 +302,10 @@ export const CrudMixin = (superClass) =>
         '__deleteButtonPropsChanged(_deleteButton, __effectiveI18n, __isNew)',
         '__newButtonPropsChanged(_newButton, __effectiveI18n)',
       ];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/dashboard/src/vaadin-dashboard.d.ts
+++ b/packages/dashboard/src/vaadin-dashboard.d.ts
@@ -235,7 +235,7 @@ export interface DashboardI18n {
  * @fires {CustomEvent} dashboard-item-resize-mode-changed - Fired when an item resize mode changed
  */
 declare class Dashboard<TItem extends DashboardItem = DashboardItem> extends DashboardLayoutMixin(
-  I18nMixin({} as DashboardI18n, ElementMixin(ThemableMixin(HTMLElement))),
+  I18nMixin<typeof HTMLElement, DashboardI18n>(ElementMixin(ThemableMixin(HTMLElement))),
 ) {
   /**
    * An array containing the items of the dashboard

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -110,7 +110,7 @@ const DEFAULT_I18N = getDefaultI18n();
  * @mixes ThemableMixin
  */
 class Dashboard extends DashboardLayoutMixin(
-  I18nMixin(DEFAULT_I18N, ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
+  I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
     return 'vaadin-dashboard';
@@ -172,6 +172,10 @@ class Dashboard extends DashboardLayoutMixin(
 
   static get observers() {
     return ['__itemsOrRendererChanged(items, renderer, editable, __effectiveI18n)'];
+  }
+
+  static get defaultI18n() {
+    return DEFAULT_I18N;
   }
 
   /**

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -87,10 +87,7 @@ export const datePickerI18nDefaults = Object.freeze({
  * @param {function(new:HTMLElement)} subclass
  */
 export const DatePickerMixin = (subclass) =>
-  class DatePickerMixinClass extends I18nMixin(
-    datePickerI18nDefaults,
-    DelegateFocusMixin(InputConstraintsMixin(KeyboardMixin(subclass))),
-  ) {
+  class DatePickerMixinClass extends I18nMixin(DelegateFocusMixin(InputConstraintsMixin(KeyboardMixin(subclass)))) {
     static get properties() {
       return {
         /**
@@ -276,6 +273,10 @@ export const DatePickerMixin = (subclass) =>
         '__updateOverlayContentTheme(_overlayContent, _theme)',
         '__updateOverlayContentFullScreen(_overlayContent, _fullscreen)',
       ];
+    }
+
+    static get defaultI18n() {
+      return datePickerI18nDefaults;
     }
 
     static get constraints() {

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -49,7 +49,7 @@ class PickerSlotController extends SlotController {
  * @mixes FocusMixin
  */
 export const DateTimePickerMixin = (superClass) =>
-  class DateTimePickerMixinClass extends I18nMixin(DEFAULT_I18N, FieldMixin(FocusMixin(DisabledMixin(superClass)))) {
+  class DateTimePickerMixinClass extends I18nMixin(FieldMixin(FocusMixin(DisabledMixin(superClass)))) {
     static get properties() {
       return {
         /**
@@ -260,6 +260,10 @@ export const DateTimePickerMixin = (superClass) =>
         '__pickersChanged(__datePicker, __timePicker)',
         '__labelOrAccessibleNameChanged(label, accessibleName, __effectiveI18n, __datePicker, __timePicker)',
       ];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     constructor() {

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -26,7 +26,7 @@ const DEFAULT_I18N = {
  * @polymerMixin
  */
 export const LoginMixin = (superClass) =>
-  class LoginMixin extends I18nMixin(DEFAULT_I18N, superClass) {
+  class LoginMixin extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -100,6 +100,10 @@ export const LoginMixin = (superClass) =>
           value: false,
         },
       };
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -66,7 +66,6 @@ const DEFAULT_I18N = {
  */
 export const MenuBarMixin = (superClass) =>
   class MenuBarMixinClass extends I18nMixin(
-    DEFAULT_I18N,
     KeyboardDirectionMixin(ResizeMixin(FocusMixin(DisabledMixin(superClass)))),
   ) {
     static get properties() {
@@ -203,6 +202,10 @@ export const MenuBarMixin = (superClass) =>
           sync: true,
         },
       };
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -17,7 +17,7 @@ const DEFAULT_I18N = {
  * @mixes I18nMixin
  */
 export const MessageInputMixin = (superClass) =>
-  class MessageInputMixinClass extends I18nMixin(DEFAULT_I18N, superClass) {
+  class MessageInputMixinClass extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -58,6 +58,10 @@ export const MessageInputMixin = (superClass) =>
         '__buttonPropsChanged(_button, disabled, __effectiveI18n, value)',
         '__textAreaPropsChanged(_textArea, disabled, __effectiveI18n, value)',
       ];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -35,7 +35,6 @@ const DEFAULT_I18N = {
  */
 export const MultiSelectComboBoxMixin = (superClass) =>
   class MultiSelectComboBoxMixinClass extends I18nMixin(
-    DEFAULT_I18N,
     ComboBoxScrollToIndexMixin(
       ComboBoxDataProviderMixin(ComboBoxItemsMixin(InputControlMixin(ResizeMixin(superClass)))),
     ),
@@ -233,6 +232,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
         '__updateScroller(opened, _dropdownItems, _focusedIndex, _theme)',
         '__updateTopGroup(selectedItemsOnTop, selectedItems, opened)',
       ];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -100,7 +100,7 @@ const DEFAULT_I18N = {
  * @polymerMixin
  */
 export const RichTextEditorMixin = (superClass) =>
-  class RichTextEditorMixinClass extends I18nMixin(DEFAULT_I18N, superClass) {
+  class RichTextEditorMixinClass extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -243,6 +243,10 @@ export const RichTextEditorMixin = (superClass) =>
 
     static get observers() {
       return ['_valueChanged(value, _editor)', '_disabledChanged(disabled, readonly, _editor)'];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/side-nav/src/vaadin-side-nav-children-mixin.js
+++ b/packages/side-nav/src/vaadin-side-nav-children-mixin.js
@@ -39,7 +39,7 @@ class ChildrenController extends SlotController {
  * @polymerMixin
  */
 export const SideNavChildrenMixin = (superClass) =>
-  class SideNavChildrenMixin extends I18nMixin(DEFAULT_I18N, superClass) {
+  class SideNavChildrenMixin extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -51,6 +51,10 @@ export const SideNavChildrenMixin = (superClass) =>
           value: 0,
         },
       };
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     constructor() {

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -30,10 +30,7 @@ const MAX_ALLOWED_TIME = '23:59:59.999';
  * @mixes PatternMixin
  */
 export const TimePickerMixin = (superClass) =>
-  class TimePickerMixinClass extends I18nMixin(
-    timePickerI18nDefaults,
-    PatternMixin(ComboBoxBaseMixin(InputControlMixin(superClass))),
-  ) {
+  class TimePickerMixinClass extends I18nMixin(PatternMixin(ComboBoxBaseMixin(InputControlMixin(superClass)))) {
     static get properties() {
       return {
         /**
@@ -121,6 +118,10 @@ export const TimePickerMixin = (superClass) =>
         '__updateAriaAttributes(_dropdownItems, opened, inputElement)',
         '__updateDropdownItems(__effectiveI18n, min, max, step)',
       ];
+    }
+
+    static get defaultI18n() {
+      return timePickerI18nDefaults;
     }
 
     static get constraints() {

--- a/packages/upload/src/vaadin-upload-file-list-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.js
@@ -47,7 +47,7 @@ const DEFAULT_I18N = {
  * @mixes I18nMixin
  */
 export const UploadFileListMixin = (superClass) =>
-  class UploadFileListMixin extends I18nMixin(DEFAULT_I18N, superClass) {
+  class UploadFileListMixin extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -84,6 +84,10 @@ export const UploadFileListMixin = (superClass) =>
 
     static get observers() {
       return ['__updateItems(items, __effectiveI18n, disabled, _theme)'];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -109,7 +109,7 @@ class DropLabelController extends SlotController {
  * @polymerMixin
  */
 export const UploadMixin = (superClass) =>
-  class UploadMixin extends I18nMixin(DEFAULT_I18N, superClass) {
+  class UploadMixin extends I18nMixin(superClass) {
     static get properties() {
       return {
         /**
@@ -373,6 +373,10 @@ export const UploadMixin = (superClass) =>
         '__updateFileList(_fileList, files, __effectiveI18n, disabled, _theme)',
         '__updateMaxFilesReached(maxFiles, files)',
       ];
+    }
+
+    static get defaultI18n() {
+      return DEFAULT_I18N;
     }
 
     /**


### PR DESCRIPTION
## Summary

Changes `I18nMixin` from a two-argument call `I18nMixin(defaultI18n, superClass)` to a single-argument call `I18nMixin(superClass)`. Each consumer class declares its defaults via a `static get defaultI18n()` getter that returns its existing `DEFAULT_I18N` (or `*I18nDefaults`) const.

## Why

The CEM analyzer's class-extends recursion follows the **first argument** of every mixin call. The previous two-argument pattern hid the real mixin chain inside the **second argument**:

```js
extends I18nMixin(DEFAULT_I18N, FocusMixin(superClass))
//                ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^
//                recursed into  never visited
//                (plain object, recursion stops)
```

so the inner chain was dropped from `custom-elements.json`. The single-argument form puts the chain back in the first-argument position where the analyzer can see it:

```js
extends I18nMixin(FocusMixin(superClass))
//                ^^^^^^^^^^^^^^^^^^^^^^
//                recursed normally
```

This recovers 18 mixin references on 7 declarations (`AvatarMixin`, `AvatarGroupMixin`, `DatePickerMixin`, `DateTimePickerMixin`, `MenuBarMixin`, `MultiSelectComboBoxMixin`, `TimePickerMixin`) that previously only `mixesPlugin` could reconstruct from `@mixes` JSDoc tags.

## Empirical verification

With the new `I18nMixin` signature **and `mixesPlugin` disabled**, the analyzer alone produces the same `mixins` arrays the plugin was filling in:

| Mixin | Mixins captured |
|---|---|
| `AvatarMixin` | `I18nMixin`, `FocusMixin` |
| `AvatarGroupMixin` | `I18nMixin`, `ResizeMixin` |
| `DatePickerMixin` | `I18nMixin`, `DelegateFocusMixin`, `InputConstraintsMixin`, `KeyboardMixin` |
| `DateTimePickerMixin` | `I18nMixin`, `FieldMixin`, `FocusMixin`, `DisabledMixin` |
| `MenuBarMixin` | `I18nMixin`, `KeyboardDirectionMixin`, `ResizeMixin`, `FocusMixin`, `DisabledMixin` |
| `MultiSelectComboBoxMixin` | `I18nMixin`, `ComboBoxScrollToIndexMixin`, `ComboBoxDataProviderMixin`, `ComboBoxItemsMixin`, `InputControlMixin`, `ResizeMixin` |
| `TimePickerMixin` | `I18nMixin`, `PatternMixin`, `ComboBoxBaseMixin`, `InputControlMixin` |

`mixesPlugin` is left enabled in this PR (now a no-op for these mixins); it can be retired in a follow-up cleanup.

## Files changed

21 files, +117/-31:
- `packages/component-base/src/i18n-mixin.{js,d.ts}` — new signature, fallback `static get defaultI18n() { return {}; }`
- 16 consumer mixins (`avatar`, `avatar-group`, `app-layout`, `crud`, `dashboard`, `date-picker`, `date-time-picker`, `login`, `menu-bar`, `message-input`, `multi-select-combo-box`, `rich-text-editor`, `side-nav-children`, `time-picker`, `upload`, `upload-file-list`) — call `I18nMixin(X(s))` instead of `I18nMixin(DEFAULT, X(s))`, add `static get defaultI18n() { return DEFAULT_I18N; }` after `static get observers()` (or `static get properties()` if observers aren't present)
- `packages/component-base/test/i18n-mixin.test.js` and `test/typings/i18n-mixin/i18n-mixin.types.ts` — updated to new API
- `packages/dashboard/src/vaadin-dashboard.d.ts` — explicit type-arg `I18nMixin<typeof HTMLElement, DashboardI18n>(...)`

## Breaking change

The `I18nMixin` export from `@vaadin/component-base/src/i18n-mixin.js` no longer accepts `defaultI18n` as the first parameter. External callers using the two-argument form must migrate to the static-getter pattern.

> [!WARNING]
> Migration:
>
> ```diff
> -class FooMixinClass extends I18nMixin(DEFAULT_I18N, BarMixin(superClass)) {
> -  // ...
> -}
> +class FooMixinClass extends I18nMixin(BarMixin(superClass)) {
> +  static get defaultI18n() {
> +    return DEFAULT_I18N;
> +  }
> +  // ...
> +}
> ```

## Test plan

- [x] `yarn lint:js` and `yarn lint:types` pass
- [x] `yarn test --group component-base --glob="i18n-mixin*"` — 8/8 passed
- [x] All 16 consumer-package test groups pass: avatar (49), avatar-group (60), date-picker (412), time-picker (210), date-time-picker (249), dashboard (334), menu-bar (188), MSCB (262), upload (473), login (67), rich-text-editor (192), message-input (23), app-layout (89), side-nav (83), crud (278). 0 failures.
- [x] CEM analyzer captures the full mixin chain on the 7 affected declarations without `mixesPlugin` (table above)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)