### PR TITLE
chore: drop mixesPlugin from CEM analyzer config

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -62,87 +62,6 @@ function sortName(a, b) {
 }
 
 /**
- * Extracts @mixes JSDoc tag names from a node's JSDoc comments.
- * @param {object} node - A TypeScript AST node
- * @param {object} ts - The TypeScript module
- * @returns {string[]} - Array of mixin names
- */
-function getJsDocMixesTags(node, ts) {
-  return (node.jsDoc || [])
-    .flatMap((doc) => doc.tags || [])
-    .filter((tag) => ts.isJSDocUnknownTag(tag) && tag.tagName.text === 'mixes')
-    .map((tag) => tag.comment?.trim())
-    .filter(Boolean);
-}
-
-/**
- * Resolves a mixin name to a package reference by checking the module's imports.
- * @param {object} sourceFile - The TypeScript source file AST
- * @param {string} mixinName - The mixin name (e.g., "InputControlMixin")
- * @param {object} ts - The TypeScript module
- * @returns {{ name: string, package?: string, module?: string } | null}
- */
-function resolveMixinRef(sourceFile, mixinName, ts) {
-  for (const statement of sourceFile.statements) {
-    if (!ts.isImportDeclaration(statement)) continue;
-    const moduleSpecifier = statement.moduleSpecifier.text;
-    const importClause = statement.importClause;
-    if (!importClause) continue;
-
-    // Check named imports
-    const namedBindings = importClause.namedBindings;
-    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue;
-
-    const match = namedBindings.elements.find((el) => el.name.text === mixinName);
-    if (!match) continue;
-
-    if (moduleSpecifier.startsWith('.')) {
-      // Same-package import
-      return { name: mixinName, module: moduleSpecifier.replace(/^\.\//u, '') };
-    }
-    // Cross-package import
-    return { name: mixinName, package: moduleSpecifier };
-  }
-  return null;
-}
-
-/**
- * CEM plugin that augments mixin declarations with @mixes JSDoc tag references
- * that the analyzer couldn't capture from static analysis (e.g., when
- * I18nMixin wraps other mixins as: I18nMixin(defaultI18n, Chain(superClass))).
- */
-function mixesPlugin() {
-  return {
-    analyzePhase({ ts, node, moduleDoc }) {
-      // Only process mixin export declarations (const Mixin = (superClass) => class ...)
-      if (!ts.isVariableStatement(node)) return;
-
-      for (const decl of node.declarationList.declarations) {
-        const mixesNames = getJsDocMixesTags(node, ts);
-        if (mixesNames.length === 0) continue;
-
-        const mixinName = decl.name.text;
-        const mixinDecl = moduleDoc.declarations?.find((d) => d.name === mixinName && d.kind === 'mixin');
-        if (!mixinDecl) continue;
-
-        const existingMixinNames = new Set((mixinDecl.mixins || []).map((m) => m.name));
-        const sourceFile = node.getSourceFile();
-
-        for (const mixName of mixesNames) {
-          if (existingMixinNames.has(mixName)) continue;
-
-          const ref = resolveMixinRef(sourceFile, mixName, ts);
-          if (ref) {
-            mixinDecl.mixins ||= [];
-            mixinDecl.mixins.push(ref);
-          }
-        }
-      }
-    },
-  };
-}
-
-/**
  * CEM plugin that marks `readOnly: true` properties as `readonly` in custom-elements.json
  * to filter them out of Lit property bindings when generating web-types-lit.json files.
  */
@@ -270,7 +189,6 @@ export default {
   litelement: true,
   plugins: [
     classPrivacyPlugin(),
-    mixesPlugin(),
     readonlyPlugin(),
     {
       packageLinkPhase({ customElementsManifest }) {


### PR DESCRIPTION
## Summary

`mixesPlugin` existed to recover mixin references the CEM analyzer dropped when class-extends used the two-argument `I18nMixin(defaultI18n, …)` pattern (the analyzer recurses through the first argument; the chain sat in the second). With #11710 refactoring `I18nMixin` to take a single argument, the chain is now in the first-argument position and the analyzer captures it directly.

This PR removes:
- `mixesPlugin` and its helpers (`getJsDocMixesTags`, `resolveMixinRef`) from `custom-elements-manifest.config.js`
- the corresponding `@mixes` row from the JSDoc tag reference in `guidelines/06-documenting.md`

Net change: −83 lines.

## Verification

With `mixesPlugin` removed, all 7 previously-affected mixin declarations get the same `mixins` arrays the plugin used to fill in:

| Mixin | Mixins captured (analyzer alone) |
|---|---|
| `AvatarMixin` | `I18nMixin`, `FocusMixin` |
| `AvatarGroupMixin` | `I18nMixin`, `ResizeMixin` |
| `DatePickerMixin` | `I18nMixin`, `DelegateFocusMixin`, `InputConstraintsMixin`, `KeyboardMixin` |
| `DateTimePickerMixin` | `I18nMixin`, `FieldMixin`, `FocusMixin`, `DisabledMixin` |
| `MenuBarMixin` | `I18nMixin`, `KeyboardDirectionMixin`, `ResizeMixin`, `FocusMixin`, `DisabledMixin` |
| `MultiSelectComboBoxMixin` | `I18nMixin`, `ComboBoxScrollToIndexMixin`, `ComboBoxDataProviderMixin`, `ComboBoxItemsMixin`, `InputControlMixin`, `ResizeMixin` |
| `TimePickerMixin` | `I18nMixin`, `PatternMixin`, `ComboBoxBaseMixin`, `InputControlMixin` |

## Test plan

- [x] `yarn release:cem` produces 148 mixin declarations with 186 total mixin-references (matches the with-plugin baseline)
- [x] All 7 affected mixin declarations match the expected `mixins` arrays exactly
- [x] `yarn lint` and `yarn lint:types` pass

## Relation

Depends on #11710

🤖 Generated with [Claude Code](https://claude.com/claude-code)