### PR TITLE
docs: drop Polymer Analyzer mixin JSDoc annotations from guidelines

### DIFF
--- a/guidelines/06-documenting.md
+++ b/guidelines/06-documenting.md
@@ -28,8 +28,6 @@ also reads JSDoc — that's why `@attr` exists, see below.
 | ------------------------- | ------------------- | ------------------------------------------------------------------------------------------------ |
 | `@customElement {tag}`    | Class JSDoc         | CEM doesn't pick up `defineCustomElement()`; this tells it the element's tag name.               |
 | `@extends HTMLElement`    | Class JSDoc         | Hides LitElement's API from CEM output.                                                          |
-| `@mixes {Name}`           | Class / mixin JSDoc | Tracked by CEM via the `mixesPlugin` configured in `custom-elements-manifest.config.js`.         |
-| `@polymerMixin`           | Mixin declaration   | Marks `(superClass) => class extends superClass …` as a mixin so CEM treats it as one.           |
 | `@attr {type} dash-name`  | Property JSDoc      | Maps a camelCase property to its kebab-case attribute (used by `vscode-lit-plugin`).             |
 | `@fires {Event} name`     | Class JSDoc         | Documents an event so it appears in `custom-elements.json` and `web-types.json`.                 |
 | `@prop`                   | Class body          | Documents properties **not** declared in `static get properties()`.                              |
@@ -80,9 +78,6 @@ Use this canonical shape (every public component already follows it):
  *
  * @customElement vaadin-{name}
  * @extends HTMLElement
- * @mixes {Name}Mixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 ```
 

--- a/guidelines/13-checklist.md
+++ b/guidelines/13-checklist.md
@@ -77,8 +77,7 @@ Author tests following the conventions in [Testing](12-testing.md).
 
 - [ ] Class JSDoc covers the styling tables (parts, state attributes,
       custom CSS properties).
-- [ ] Class JSDoc has `@customElement`, `@extends HTMLElement`, `@mixes`,
-      `@fires`.
+- [ ] Class JSDoc has `@customElement`, `@extends HTMLElement`, `@fires`.
 - [ ] Non-`notify` events have `@fires` lines on the class JSDoc.
 - [ ] `README.md` follows the same shape as a sibling package.
 


### PR DESCRIPTION
The migration to Custom Elements Manifest (CEM) removed the need for both
JSDoc tags. The `@polymerMixin` tag was used by Polymer Analyzer to mark
mixin factory functions; CEM identifies mixins from the class declaration
directly. The `@mixes` tag was tracked via a custom `mixesPlugin`, which
is being removed in #11711 once the I18nMixin refactor (#11710) lands.

Drop both from the guidelines so new components don't pick up tags that
no tool reads.

Related to #11710, #11711

---

🤖 Generated with Claude Code