### PR TITLE
refactor: use reflectToAttribute on upload sub-elements

### DIFF
--- a/packages/upload/src/vaadin-upload-button.js
+++ b/packages/upload/src/vaadin-upload-button.js
@@ -112,7 +112,7 @@ class UploadButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(L
       maxFilesReached: {
         type: Boolean,
         value: false,
-        reflect: true,
+        reflectToAttribute: true,
         attribute: 'max-files-reached',
       },
     };

--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -94,7 +94,7 @@ class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
       maxFilesReached: {
         type: Boolean,
         value: false,
-        reflect: true,
+        reflectToAttribute: true,
         attribute: 'max-files-reached',
       },
 
@@ -102,7 +102,7 @@ class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
       __dragover: {
         type: Boolean,
         value: false,
-        reflect: true,
+        reflectToAttribute: true,
         attribute: 'dragover',
       },
     };


### PR DESCRIPTION
## Summary
- Three properties in `vaadin-upload-drop-zone` and `vaadin-upload-button` declared `reflect: true` (Lit-style) instead of the canonical `reflectToAttribute: true` that PolylitMixin recognises and the rest of the codebase consistently uses.
- PolylitMixin normalises one to the other internally, so runtime behavior is unchanged.
