### PR TITLE
chore: drop Polymer Analyzer mixin JSDoc annotations from sources

### DIFF
--- a/packages/a11y-base/src/active-mixin.js
+++ b/packages/a11y-base/src/active-mixin.js
@@ -15,10 +15,6 @@ import { KeyboardMixin } from './keyboard-mixin.js';
  *
  * The attribute is removed as soon as the element is deactivated
  * by the pointer or by releasing the activation key.
- *
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes KeyboardMixin
  */
 export const ActiveMixin = (superclass) =>
   class ActiveMixinClass extends DisabledMixin(KeyboardMixin(superclass)) {

--- a/packages/a11y-base/src/delegate-focus-mixin.js
+++ b/packages/a11y-base/src/delegate-focus-mixin.js
@@ -9,10 +9,6 @@ import { TabindexMixin } from './tabindex-mixin.js';
 
 /**
  * A mixin to forward focus to an element in the light DOM.
- *
- * @polymerMixin
- * @mixes FocusMixin
- * @mixes TabindexMixin
  */
 const DelegateFocusMixinImplementation = (superclass) => {
   return class DelegateFocusMixinClass extends FocusMixin(TabindexMixin(superclass)) {

--- a/packages/a11y-base/src/disabled-mixin.js
+++ b/packages/a11y-base/src/disabled-mixin.js
@@ -7,8 +7,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide disabled property for field components.
- *
- * @polymerMixin
  */
 const DisabledMixinImplementation = (superclass) => {
   return class DisabledMixinClass extends superclass {

--- a/packages/a11y-base/src/focus-mixin.js
+++ b/packages/a11y-base/src/focus-mixin.js
@@ -8,8 +8,6 @@ import { isKeyboardActive } from './focus-utils.js';
 
 /**
  * A mixin to handle `focused` and `focus-ring` attributes based on focus.
- *
- * @polymerMixin
  */
 const FocusMixinImplementation = (superclass) => {
   return class FocusMixinClass extends superclass {

--- a/packages/a11y-base/src/keyboard-direction-mixin.js
+++ b/packages/a11y-base/src/keyboard-direction-mixin.js
@@ -8,9 +8,6 @@ import { KeyboardMixin } from './keyboard-mixin.js';
 
 /**
  * A mixin for navigating items with keyboard.
- *
- * @polymerMixin
- * @mixes KeyboardMixin
  */
 export const KeyboardDirectionMixin = (superclass) =>
   class KeyboardDirectionMixinClass extends KeyboardMixin(superclass) {

--- a/packages/a11y-base/src/keyboard-mixin.js
+++ b/packages/a11y-base/src/keyboard-mixin.js
@@ -9,8 +9,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
  * A mixin that manages keyboard handling.
  * The mixin subscribes to the keyboard events while an actual implementation
  * for the event handlers is left to the client (a component or another mixin).
- *
- * @polymerMixin
  */
 const KeyboardMixinImplementation = (superclass) => {
   return class KeyboardMixinClass extends superclass {

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -12,9 +12,6 @@ import { KeyboardDirectionMixin } from './keyboard-direction-mixin.js';
 
 /**
  * A mixin for list elements, facilitating navigation and selection of items.
- *
- * @polymerMixin
- * @mixes KeyboardDirectionMixin
  */
 export const ListMixin = (superClass) =>
   class ListMixinClass extends KeyboardDirectionMixin(superClass) {

--- a/packages/a11y-base/src/tabindex-mixin.js
+++ b/packages/a11y-base/src/tabindex-mixin.js
@@ -10,9 +10,6 @@ import { DisabledMixin } from './disabled-mixin.js';
  *
  * The attribute is set to -1 whenever the user disables the element
  * and restored with the last known value once the element is enabled.
- *
- * @polymerMixin
- * @mixes DisabledMixin
  */
 export const TabindexMixin = (superclass) =>
   class TabindexMixinClass extends DisabledMixin(superclass) {

--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -62,9 +62,6 @@ import { accordionHeading } from './styles/vaadin-accordion-heading-base-styles.
  *
  * @customElement vaadin-accordion-heading
  * @extends HTMLElement
- * @mixes ActiveMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  */
 class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -9,9 +9,6 @@ import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 
 /**
  * A mixin providing common accordion functionality.
- *
- * @polymerMixin
- * @mixes KeyboardDirectionMixin
  */
 export const AccordionMixin = (superClass) =>
   class AccordionMixinClass extends KeyboardDirectionMixin(superClass) {

--- a/packages/accordion/src/vaadin-accordion-panel-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-panel-mixin.js
@@ -11,11 +11,6 @@ import { SummaryController } from '@vaadin/details/src/summary-controller.js';
 
 /**
  * A mixin providing common accordion panel functionality.
- *
- * @polymerMixin
- * @mixes CollapsibleMixin
- * @mixes DelegateFocusMixin
- * @mixes DelegateStateMixin
  */
 export const AccordionPanelMixin = (superClass) =>
   class AccordionPanelMixinClass extends CollapsibleMixin(DelegateFocusMixin(DelegateStateMixin(superClass))) {

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -39,8 +39,6 @@ import { AccordionPanelMixin } from './vaadin-accordion-panel-mixin.js';
  *
  * @customElement vaadin-accordion-panel
  * @extends HTMLElement
- * @mixes AccordionPanelMixin
- * @mixes ThemableMixin
  */
 class AccordionPanel extends AccordionPanelMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -51,9 +51,6 @@ import { AccordionMixin } from './vaadin-accordion-mixin.js';
  *
  * @customElement vaadin-accordion
  * @extends HTMLElement
- * @mixes AccordionMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class Accordion extends AccordionMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -18,10 +18,6 @@ const DEFAULT_I18N = {
   drawer: 'Drawer',
 };
 
-/**
- * @polymerMixin
- * @mixes I18nMixin
- */
 export const AppLayoutMixin = (superclass) =>
   class AppLayoutMixinClass extends I18nMixin(superclass) {
     static get properties() {

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -129,9 +129,6 @@ import { AppLayoutMixin } from './vaadin-app-layout-mixin.js';
  *
  * @customElement vaadin-app-layout
  * @extends HTMLElement
- * @mixes AppLayoutMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class AppLayout extends AppLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -57,9 +57,6 @@ import { drawerToggle } from './styles/vaadin-drawer-toggle-base-styles.js';
  *
  * @customElement vaadin-drawer-toggle
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  */
 class DrawerToggle extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
@@ -17,9 +17,6 @@ import { avatarGroupMenuItemStyles } from './styles/vaadin-avatar-group-menu-ite
  *
  * @customElement vaadin-avatar-group-menu-item
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ItemMixin
- * @mixes ThemableMixin
  * @protected
  */
 class AvatarGroupMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.js
@@ -17,9 +17,6 @@ import { avatarGroupMenuStyles } from './styles/vaadin-avatar-group-menu-base-st
  *
  * @customElement vaadin-avatar-group-menu
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ListMixin
- * @mixes ThemableMixin
  * @protected
  */
 class AvatarGroupMenu extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/avatar-group/src/vaadin-avatar-group-mixin.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-mixin.js
@@ -24,10 +24,6 @@ const DEFAULT_I18N = {
 
 /**
  * A mixin providing common avatar group functionality.
- *
- * @polymerMixin
- * @mixes I18nMixin
- * @mixes ResizeMixin
  */
 export const AvatarGroupMixin = (superClass) =>
   class AvatarGroupMixinClass extends I18nMixin(ResizeMixin(superClass)) {

--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -18,10 +18,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @customElement vaadin-avatar-group-overlay
  * @extends HTMLElement
- * @mixes PositionMixin
- * @mixes OverlayMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 class AvatarGroupOverlay extends PositionMixin(

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -67,9 +67,6 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  *
  * @customElement vaadin-avatar-group
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes AvatarGroupMixin
- * @mixes ThemableMixin
  */
 class AvatarGroup extends AvatarGroupMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/avatar/src/vaadin-avatar-mixin.js
+++ b/packages/avatar/src/vaadin-avatar-mixin.js
@@ -12,9 +12,6 @@ const DEFAULT_I18N = {
 
 /**
  * A mixin providing common avatar functionality.
- *
- * @polymerMixin
- * @mixes FocusMixin
  */
 export const AvatarMixin = (superClass) =>
   class AvatarMixinClass extends I18nMixin(FocusMixin(superClass)) {

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -56,9 +56,6 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  *
  * @customElement vaadin-avatar
  * @extends HTMLElement
- * @mixes AvatarMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class Avatar extends AvatarMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -67,8 +67,6 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * @customElement vaadin-badge
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/board/src/vaadin-board-row-mixin.js
+++ b/packages/board/src/vaadin-board-row-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -17,10 +16,6 @@ const CLASSES = {
   LARGE: 'large',
 };
 
-/**
- * @polymerMixin
- * @mixes ResizeMixin
- */
 export const BoardRowMixin = (superClass) =>
   class BoardRowMixinClass extends ResizeMixin(superClass) {
     constructor() {

--- a/packages/board/src/vaadin-board-row.js
+++ b/packages/board/src/vaadin-board-row.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -50,8 +49,6 @@ import { BoardRowMixin } from './vaadin-board-row-mixin.js';
  *
  * @customElement vaadin-board-row
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes BoardRowMixin
  * @deprecated `<vaadin-board-row>` is deprecated and will be removed in Vaadin 26.
  * Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
  */

--- a/packages/board/src/vaadin-board.js
+++ b/packages/board/src/vaadin-board.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -37,7 +36,6 @@ import { BoardRow } from './vaadin-board-row.js';
  *
  * @customElement vaadin-board
  * @extends HTMLElement
- * @mixes ElementMixin
  * @deprecated `<vaadin-board>` is deprecated and will be removed in Vaadin 26.
  * Consider using `<vaadin-dashboard>` or `<vaadin-dashboard-layout>` as an alternative.
  */

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -70,7 +70,6 @@ class PrefixSlotController extends SlotController {
  *
  * @customElement vaadin-breadcrumbs-item
  * @extends HTMLElement
- * @mixes ElementMixin
  */
 class BreadcrumbsItem extends ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.js
@@ -17,7 +17,6 @@ import { breadcrumbsStyles } from './styles/vaadin-breadcrumbs-base-styles.js';
  *
  * @customElement vaadin-breadcrumbs
  * @extends HTMLElement
- * @mixes ElementMixin
  */
 class Breadcrumbs extends ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {

--- a/packages/button/src/vaadin-button-mixin.js
+++ b/packages/button/src/vaadin-button-mixin.js
@@ -11,11 +11,6 @@ const INTERACTION_EVENTS = ['mousedown', 'mouseup', 'click', 'dblclick', 'keypre
 
 /**
  * A mixin providing common button functionality.
- *
- * @polymerMixin
- * @mixes ActiveMixin
- * @mixes FocusMixin
- * @mixes TabindexMixin
  */
 export const ButtonMixin = (superClass) =>
   class ButtonMixinClass extends ActiveMixin(TabindexMixin(FocusMixin(superClass))) {

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -61,9 +61,6 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  *
  * @customElement vaadin-button
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class Button extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -63,8 +63,6 @@ import { cardStyles } from './styles/vaadin-card-base-styles.js';
  *
  * @customElement vaadin-card
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -103,10 +102,6 @@ KeyboardNavigation.prototype.onMouseUp = function (e) {
 // No data message should be empty by default
 Highcharts.setOptions({ lang: { noData: '' } });
 
-/**
- * @polymerMixin
- * @mixes ResizeMixin
- */
 export const ChartMixin = (superClass) =>
   class extends ResizeMixin(superClass) {
     static get properties() {

--- a/packages/charts/src/vaadin-chart-series-mixin.js
+++ b/packages/charts/src/vaadin-chart-series-mixin.js
@@ -4,15 +4,11 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
 import { deepMerge } from './helpers.js';
 
-/**
- * @polymerMixin
- */
 export const ChartSeriesMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/charts/src/vaadin-chart-series.js
+++ b/packages/charts/src/vaadin-chart-series.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -58,7 +57,6 @@ import { ChartSeriesMixin } from './vaadin-chart-series-mixin.js';
  *
  * @customElement vaadin-chart-series
  * @extends HTMLElement
- * @mixes ChartSeriesMixin
  */
 class ChartSeries extends ChartSeriesMixin(PolylitMixin(LitElement)) {
   static get is() {

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -152,9 +151,6 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  *
  * @customElement vaadin-chart
  * @extends HTMLElement
- * @mixes ChartMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class Chart extends ChartMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group-mixin.js
@@ -11,11 +11,6 @@ import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 
 /**
  * A mixin providing common checkbox-group functionality.
- *
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes FieldMixin
- * @mixes FocusMixin
  */
 export const CheckboxGroupMixin = (superclass) =>
   class CheckboxGroupMixinClass extends FieldMixin(FocusMixin(DisabledMixin(superclass))) {

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -78,9 +78,6 @@ import { CheckboxGroupMixin } from './vaadin-checkbox-group-mixin.js';
  *
  * @customElement vaadin-checkbox-group
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes CheckboxGroupMixin
  */
 class CheckboxGroup extends CheckboxGroupMixin(
   ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -13,13 +13,6 @@ import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-c
 
 /**
  * A mixin providing common checkbox functionality.
- *
- * @polymerMixin
- * @mixes ActiveMixin
- * @mixes CheckedMixin
- * @mixes DelegateFocusMixin
- * @mixes FieldMixin
- * @mixes SlotStylesMixin
  */
 export const CheckboxMixin = (superclass) =>
   class CheckboxMixinClass extends SlotStylesMixin(
@@ -33,7 +26,6 @@ export const CheckboxMixin = (superclass) =>
          * The state is reset once the user switches the checkbox by hand.
          *
          * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Indeterminate_state_checkboxes
-         *
          */
         indeterminate: {
           type: Boolean,
@@ -44,7 +36,6 @@ export const CheckboxMixin = (superclass) =>
 
         /**
          * The name of the checkbox.
-         *
          */
         name: {
           type: String,

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -76,9 +76,6 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  *
  * @customElement vaadin-checkbox
  * @extends HTMLElement
- * @mixes CheckboxMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -12,14 +12,6 @@ import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
 import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
-/**
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes FocusMixin
- * @mixes InputMixin
- * @mixes KeyboardMixin
- * @param {function(new:HTMLElement)} superClass
- */
 export const ComboBoxBaseMixin = (superClass) =>
   class ComboBoxMixinBaseClass extends KeyboardMixin(InputMixin(DisabledMixin(FocusMixin(superClass)))) {
     static get properties() {

--- a/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-data-provider-mixin.js
@@ -6,9 +6,6 @@
 import { DataProviderController } from '@vaadin/component-base/src/data-provider-controller/data-provider-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
-/**
- * @polymerMixin
- */
 export const ComboBoxDataProviderMixin = (superClass) =>
   class DataProviderMixin extends superClass {
     static get properties() {

--- a/packages/combo-box/src/vaadin-combo-box-item-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-item-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const ComboBoxItemMixin = (superClass) =>
   class ComboBoxItemMixinClass extends superClass {
     static get properties() {

--- a/packages/combo-box/src/vaadin-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-combo-box-item.js
@@ -35,9 +35,6 @@ import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @customElement vaadin-combo-box-item
- * @mixes ComboBoxItemMixin
- * @mixes ThemableMixin
- * @mixes DirMixin
  * @private
  */
 export class ComboBoxItem extends ComboBoxItemMixin(

--- a/packages/combo-box/src/vaadin-combo-box-items-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-items-mixin.js
@@ -35,10 +35,6 @@ function findItemIndex(items, callback) {
   });
 }
 
-/**
- * @polymerMixin
- * @mixes ComboBoxBaseMixin
- */
 export const ComboBoxItemsMixin = (superClass) =>
   class ComboBoxItemsMixinClass extends ComboBoxBaseMixin(superClass) {
     static get properties() {

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -16,12 +16,6 @@ function isValidValue(value) {
   return value !== undefined && value !== null;
 }
 
-/**
- * @polymerMixin
- * @mixes ComboBoxItemsMixin
- * @mixes ValidateMixin
- * @param {function(new:HTMLElement)} superClass
- */
 export const ComboBoxMixin = (superClass) =>
   class ComboBoxMixinClass extends ValidateMixin(ComboBoxItemsMixin(superClass)) {
     static get properties() {

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -6,10 +6,6 @@
 import { isElementFocusable } from '@vaadin/a11y-base/src/focus-utils.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes PositionMixin
- */
 export const ComboBoxOverlayMixin = (superClass) =>
   class ComboBoxOverlayMixin extends PositionMixin(superClass) {
     static get observers() {

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -19,10 +19,6 @@ import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
  *
  * @customElement vaadin-combo-box-overlay
  * @extends HTMLElement
- * @mixes ComboBoxOverlayMixin
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 export class ComboBoxOverlay extends ComboBoxOverlayMixin(

--- a/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
@@ -5,9 +5,6 @@
  */
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
-/**
- * @polymerMixin
- */
 export const ComboBoxScrollToIndexMixin = (superClass) =>
   class ScrollToIndexMixin extends superClass {
     static get observers() {

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -8,9 +8,6 @@ import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js'
 import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
-/**
- * @polymerMixin
- */
 export const ComboBoxScrollerMixin = (superClass) =>
   class ComboBoxScrollerMixin extends superClass {
     static get properties() {

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -14,7 +14,6 @@ import { ComboBoxScrollerMixin } from './vaadin-combo-box-scroller-mixin.js';
  *
  * @customElement vaadin-combo-box-scroller
  * @extends HTMLElement
- * @mixes ComboBoxScrollerMixin
  * @private
  */
 export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -163,13 +163,6 @@ import { ComboBoxScrollToIndexMixin } from './vaadin-combo-box-scroll-to-index-m
  *
  * @customElement vaadin-combo-box
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes InputControlMixin
- * @mixes PatternMixin
- * @mixes ComboBoxDataProviderMixin
- * @mixes ComboBoxMixin
- * @mixes ComboBoxScrollToIndexMixin
  */
 class ComboBox extends ComboBoxScrollToIndexMixin(
   ComboBoxDataProviderMixin(

--- a/packages/component-base/src/delegate-state-mixin.js
+++ b/packages/component-base/src/delegate-state-mixin.js
@@ -7,8 +7,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to delegate properties and attributes to a target element.
- *
- * @polymerMixin
  */
 const DelegateStateMixinImplementation = (superclass) => {
   return class DelegateStateMixinClass extends superclass {

--- a/packages/component-base/src/dir-mixin.js
+++ b/packages/component-base/src/dir-mixin.js
@@ -33,8 +33,6 @@ directionObserver.observe(document.documentElement, { attributes: true, attribut
 
 /**
  * A mixin to handle `dir` attribute based on the one set on the `<html>` element.
- *
- * @polymerMixin
  */
 export const DirMixin = (superClass) =>
   class VaadinDirMixin extends superClass {

--- a/packages/component-base/src/element-mixin.js
+++ b/packages/component-base/src/element-mixin.js
@@ -31,10 +31,6 @@ let statsJob;
 
 const registered = new Set();
 
-/**
- * @polymerMixin
- * @mixes DirMixin
- */
 export const ElementMixin = (superClass) =>
   class VaadinElementMixin extends DirMixin(superClass) {
     /** @protected */

--- a/packages/component-base/src/i18n-mixin.js
+++ b/packages/component-base/src/i18n-mixin.js
@@ -43,8 +43,6 @@ function deepMerge(target, ...sources) {
  *   return { foo: 'Foo', bar: 'Bar' };
  * }
  * ```
- *
- * @polymerMixin
  */
 export const I18nMixin = (superClass) =>
   class I18nMixinClass extends superClass {

--- a/packages/component-base/src/overlay-class-mixin.js
+++ b/packages/component-base/src/overlay-class-mixin.js
@@ -7,8 +7,6 @@
 /**
  * A mixin that forwards CSS class names to the internal overlay element
  * by setting the `overlayClass` property or `overlay-class` attribute.
- *
- * @polymerMixin
  */
 export const OverlayClassMixin = (superclass) =>
   class OverlayClassMixinClass extends superclass {

--- a/packages/component-base/src/resize-mixin.js
+++ b/packages/component-base/src/resize-mixin.js
@@ -26,8 +26,6 @@ const observer = new ResizeObserver((entries) => {
 
 /**
  * A mixin that uses a ResizeObserver to listen to host size changes.
- *
- * @polymerMixin
  */
 const ResizeMixinImplementation = (superclass) =>
   class ResizeMixinClass extends superclass {

--- a/packages/component-base/src/slot-styles-mixin.js
+++ b/packages/component-base/src/slot-styles-mixin.js
@@ -39,8 +39,6 @@ function insertStyles(styles, root) {
 /**
  * Mixin to insert styles into the outer scope to handle slotted components.
  * This is useful e.g. to hide native `<input type="number">` controls.
- *
- * @polymerMixin
  */
 const SlotStylesMixinImplementation = (superclass) =>
   class SlotStylesMixinClass extends superclass {

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-mixin.js
@@ -7,10 +7,6 @@ import { setAriaIDReference } from '@vaadin/a11y-base/src/aria-id-reference.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { DialogSizeMixin } from '@vaadin/dialog/src/vaadin-dialog-size-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes DialogSizeMixin
- */
 export const ConfirmDialogMixin = (superClass) =>
   class ConfirmDialogMixinClass extends DialogSizeMixin(superClass) {
     static get properties() {

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -17,9 +17,6 @@ import { confirmDialogOverlayStyles } from './styles/vaadin-confirm-dialog-overl
  *
  * @customElement vaadin-confirm-dialog-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -80,9 +80,6 @@ import { ConfirmDialogMixin } from './vaadin-confirm-dialog-mixin.js';
  *
  * @customElement vaadin-confirm-dialog
  * @extends HTMLElement
- * @mixes ConfirmDialogMixin
- * @mixes ElementMixin
- * @mixes ThemePropertyMixin
  */
 class ConfirmDialog extends ConfirmDialogMixin(ElementMixin(ThemePropertyMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -17,9 +17,6 @@ import { contextMenuItemStyles } from './styles/vaadin-context-menu-item-base-st
  *
  * @customElement vaadin-context-menu-item
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ItemMixin
- * @mixes ThemableMixin
  * @protected
  */
 class ContextMenuItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/context-menu/src/vaadin-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.js
@@ -17,9 +17,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @customElement vaadin-context-menu-list-box
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ListMixin
- * @mixes ThemableMixin
  * @protected
  */
 class ContextMenuListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -10,10 +10,6 @@ import { MediaQueryController } from '@vaadin/component-base/src/media-query-con
 import { ContextMenuTooltipController } from './vaadin-context-menu-tooltip-controller.js';
 import { ItemsMixin } from './vaadin-contextmenu-items-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes ItemsMixin
- */
 export const ContextMenuMixin = (superClass) =>
   class ContextMenuMixinClass extends ItemsMixin(superClass) {
     static get properties() {

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -18,10 +18,6 @@ import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
  *
  * @customElement vaadin-context-menu-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes MenuOverlayMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @protected
  */
 export class ContextMenuOverlay extends MenuOverlayMixin(

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -246,9 +246,6 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  *
  * @customElement vaadin-context-menu
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ContextMenuMixin
- * @mixes ThemePropertyMixin
  */
 class ContextMenu extends ContextMenuMixin(ElementMixin(ThemePropertyMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -6,9 +6,6 @@
 import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 
-/**
- * @polymerMixin
- */
 export const ItemsMixin = (superClass) =>
   class ItemsMixin extends superClass {
     static get properties() {

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -6,9 +6,6 @@
 import { OverlayFocusMixin } from '@vaadin/overlay/src/vaadin-overlay-focus-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
-/**
- * @polymerMixin
- */
 export const MenuOverlayMixin = (superClass) =>
   class MenuOverlayMixin extends OverlayFocusMixin(PositionMixin(superClass)) {
     static get properties() {

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -25,9 +24,6 @@ import { crudDialogOverlayStyles } from './styles/vaadin-crud-dialog-overlay-bas
  *
  * @customElement vaadin-crud-dialog
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/crud/src/vaadin-crud-form.js
+++ b/packages/crud/src/vaadin-crud-form.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -19,7 +18,6 @@ import { IncludedMixin } from './vaadin-crud-include-mixin.js';
  *
  * @customElement vaadin-crud-form
  * @extends FormLayout
- * @mixes IncludedMixin
  * @private
  */
 class CrudForm extends IncludedMixin(FormLayout) {

--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -13,9 +12,6 @@ import { IncludedMixin } from './vaadin-crud-include-mixin.js';
 
 /**
  * A mixin providing common crud-grid functionality.
- *
- * @polymerMixin
- * @mixes IncludedMixin
  */
 export const CrudGridMixin = (superClass) =>
   class extends IncludedMixin(superClass) {

--- a/packages/crud/src/vaadin-crud-grid.js
+++ b/packages/crud/src/vaadin-crud-grid.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -22,7 +21,6 @@ import { CrudGridMixin } from './vaadin-crud-grid-mixin.js';
  * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
  *
  * @extends Grid
- * @mixes CrudGridMixin
  * @private
  */
 class CrudGrid extends CrudGridMixin(Grid) {

--- a/packages/crud/src/vaadin-crud-include-mixin.js
+++ b/packages/crud/src/vaadin-crud-include-mixin.js
@@ -4,15 +4,11 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
 import { setProperty } from './vaadin-crud-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const IncludedMixin = (superClass) =>
   class IncludedMixin extends superClass {
     static get properties() {

--- a/packages/crud/src/vaadin-crud-mixin.js
+++ b/packages/crud/src/vaadin-crud-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -44,9 +43,6 @@ const DEFAULT_I18N = {
 
 /**
  * A mixin providing common crud functionality.
- *
- * @polymerMixin
- * @mixes I18nMixin
  */
 export const CrudMixin = (superClass) =>
   class extends I18nMixin(superClass) {

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -197,9 +196,6 @@ import { CrudMixin } from './vaadin-crud-mixin.js';
  *
  * @customElement vaadin-crud
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes CrudMixin
  */
 class Crud extends CrudMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -29,12 +29,6 @@ const defaultFormatValue = (inputValues) => {
   return inputValues.join('\t');
 };
 
-/**
- * @polymerMixin
- * @mixes FieldMixin
- * @mixes FocusMixin
- * @mixes KeyboardMixin
- */
 export const CustomFieldMixin = (superClass) =>
   class CustomFieldMixin extends FieldMixin(FocusMixin(KeyboardMixin(superClass))) {
     static get properties() {

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -77,9 +77,6 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  *
  * @customElement vaadin-custom-field
  * @extends HTMLElement
- * @mixes CustomFieldMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class CustomField extends CustomFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -23,9 +22,6 @@ import { dashboardButtonStyles } from './styles/vaadin-dashboard-button-base-sty
  *
  * @customElement vaadin-dashboard-button
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  * @protected
  */
 class DashboardButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/dashboard/src/vaadin-dashboard-item-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-item-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -40,9 +39,6 @@ export function getDefaultI18n() {
 
 /**
  * Shared functionality between widgets and sections
- *
- * @polymerMixin
- * @mixes ResizeMixin
  */
 export const DashboardItemMixin = (superClass) =>
   class DashboardItemMixinClass extends ResizeMixin(superClass) {

--- a/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -12,9 +11,6 @@ import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 
 /**
  * A mixin to enable the dashboard layout functionality
- *
- * @polymerMixin
- * @mixes ResizeMixin
  */
 export const DashboardLayoutMixin = (superClass) =>
   class DashboardLayoutMixinClass extends ResizeMixin(superClass) {

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -54,9 +53,6 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  *
  * @customElement vaadin-dashboard-layout
  * @extends HTMLElement
- * @mixes DashboardLayoutMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class DashboardLayout extends DashboardLayoutMixin(
   ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -67,9 +66,6 @@ import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
  *
  * @customElement vaadin-dashboard-section
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes DashboardItemMixin
  */
 class DashboardSection extends DashboardItemMixin(
   ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -101,9 +100,6 @@ import { DashboardSection } from './vaadin-dashboard-section.js';
  *
  * @customElement vaadin-dashboard-widget
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes DashboardItemMixin
  */
 class DashboardWidget extends DashboardItemMixin(
   ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -104,10 +103,6 @@ const DEFAULT_I18N = getDefaultI18n();
  *
  * @customElement vaadin-dashboard
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes DashboardLayoutMixin
- * @mixes I18nMixin
- * @mixes ThemableMixin
  */
 class Dashboard extends DashboardLayoutMixin(
   I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -78,14 +78,6 @@ export const datePickerI18nDefaults = Object.freeze({
   },
 });
 
-/**
- * @polymerMixin
- * @mixes DelegateFocusMixin
- * @mixes I18nMixin
- * @mixes InputConstraintsMixin
- * @mixes KeyboardMixin
- * @param {function(new:HTMLElement)} subclass
- */
 export const DatePickerMixin = (subclass) =>
   class DatePickerMixinClass extends I18nMixin(DelegateFocusMixin(InputConstraintsMixin(KeyboardMixin(subclass)))) {
     static get properties() {

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -10,9 +10,6 @@ import { MediaQueryController } from '@vaadin/component-base/src/media-query-con
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { dateAfterXMonths, dateAllowed, dateEquals, getClosestDate } from './vaadin-date-picker-helper.js';
 
-/**
- * @polymerMixin
- */
 export const DatePickerOverlayContentMixin = (superClass) =>
   class DatePickerOverlayContentMixin extends superClass {
     static get properties() {

--- a/packages/date-picker/src/vaadin-date-picker-overlay-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-mixin.js
@@ -7,11 +7,6 @@ import { isElementFocusable } from '@vaadin/a11y-base/src/focus-utils.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes OverlayMixin
- * @mixes PositionMixin
- */
 export const DatePickerOverlayMixin = (superClass) =>
   class DatePickerOverlayMixin extends PositionMixin(OverlayMixin(superClass)) {
     /**

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -18,9 +18,6 @@ import { DatePickerOverlayMixin } from './vaadin-date-picker-overlay-mixin.js';
  *
  * @customElement vaadin-date-picker-overlay
  * @extends HTMLElement
- * @mixes DatePickerOverlayMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 class DatePickerOverlay extends DatePickerOverlayMixin(

--- a/packages/date-picker/src/vaadin-date-picker-year.js
+++ b/packages/date-picker/src/vaadin-date-picker-year.js
@@ -15,7 +15,6 @@ import { datePickerYearStyles } from './styles/vaadin-date-picker-year-base-styl
  *
  * @customElement vaadin-date-picker-year
  * @extends HTMLElement
- * @mixes ThemableMixin
  * @private
  */
 export class DatePickerYear extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -152,10 +152,6 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  *
  * @customElement vaadin-date-picker
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes InputControlMixin
- * @mixes DatePickerMixin
  */
 class DatePicker extends DatePickerMixin(
   InputControlMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -7,10 +7,6 @@ import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { addListener } from '@vaadin/component-base/src/gestures.js';
 import { dateAllowed, dateEquals, getISOWeekNumber, normalizeDate } from './vaadin-date-picker-helper.js';
 
-/**
- * @polymerMixin
- * @mixes FocusMixin
- */
 export const MonthCalendarMixin = (superClass) =>
   class MonthCalendarMixinClass extends FocusMixin(superClass) {
     static get properties() {

--- a/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker-mixin.js
@@ -42,11 +42,6 @@ class PickerSlotController extends SlotController {
 
 /**
  * A mixin providing common date-time-picker functionality.
- *
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes FieldMixin
- * @mixes FocusMixin
  */
 export const DateTimePickerMixin = (superClass) =>
   class DateTimePickerMixinClass extends I18nMixin(FieldMixin(FocusMixin(DisabledMixin(superClass)))) {

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -114,9 +114,6 @@ import { DateTimePickerMixin } from './vaadin-date-time-picker-mixin.js';
  *
  * @customElement vaadin-date-time-picker
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes DateTimePickerMixin
  */
 class DateTimePicker extends DateTimePickerMixin(
   ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/details/src/collapsible-mixin.js
+++ b/packages/details/src/collapsible-mixin.js
@@ -8,8 +8,6 @@ import { ContentController } from './content-controller.js';
 /**
  * A mixin providing common functionality for making content collapsible,
  * used by `<vaadin-details>` and `<vaadin-accordion-panel>` elements.
- *
- * @polymerMixin
  */
 export const CollapsibleMixin = (superClass) =>
   class CollapsibleMixinClass extends superClass {

--- a/packages/details/src/vaadin-details-base-mixin.js
+++ b/packages/details/src/vaadin-details-base-mixin.js
@@ -9,12 +9,6 @@ import { TooltipController } from '@vaadin/component-base/src/tooltip-controller
 import { CollapsibleMixin } from './collapsible-mixin.js';
 import { SummaryController } from './summary-controller.js';
 
-/**
- * @polymerMixin
- * @mixes DelegateFocusMixin
- * @mixes DelegateStateMixin
- * @mixes CollapsibleMixin
- */
 export const DetailsBaseMixin = (superClass) =>
   class DetailsBaseMixin extends CollapsibleMixin(DelegateFocusMixin(DelegateStateMixin(superClass))) {
     static get properties() {

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -53,9 +53,6 @@ import { detailsSummary } from './styles/vaadin-details-summary-base-styles.js';
  *
  * @customElement vaadin-details-summary
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  */
 class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -49,9 +49,6 @@ import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
  *
  * @customElement vaadin-details
  * @extends HTMLElement
- * @mixes DetailsBaseMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class Details extends DetailsBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const DialogBaseMixin = (superClass) =>
   class DialogBaseMixin extends superClass {
     static get properties() {

--- a/packages/dialog/src/vaadin-dialog-draggable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-draggable-mixin.js
@@ -6,9 +6,6 @@
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { eventInWindow, getMouseOrFirstTouchEvent } from './vaadin-dialog-utils.js';
 
-/**
- * @polymerMixin
- */
 export const DialogDraggableMixin = (superClass) =>
   class VaadinDialogDraggableMixin extends superClass {
     static get properties() {
@@ -22,7 +19,6 @@ export const DialogDraggableMixin = (superClass) =>
          * If you want a child element to be draggable
          * but still have its children non-draggable (by default), mark it with
          * "`draggable-leaf-only`" class name.
-         *
          */
         draggable: {
           type: Boolean,

--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.js
@@ -7,10 +7,6 @@ import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { setOverlayStateAttribute } from '@vaadin/overlay/src/vaadin-overlay-utils.js';
 
-/**
- * @polymerMixin
- * @mixes OverlayMixin
- */
 export const DialogOverlayMixin = (superClass) =>
   class DialogOverlayMixin extends OverlayMixin(superClass) {
     static get properties() {

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -17,9 +17,6 @@ import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
  *
  * @customElement vaadin-dialog-overlay
  * @extends HTMLElement
- * @mixes DialogOverlayMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 export class DialogOverlay extends DialogOverlayMixin(

--- a/packages/dialog/src/vaadin-dialog-renderer-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-renderer-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const DialogRendererMixin = (superClass) =>
   class DialogRendererMixin extends superClass {
     static get properties() {

--- a/packages/dialog/src/vaadin-dialog-resizable-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-resizable-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { eventInWindow, getMouseOrFirstTouchEvent } from './vaadin-dialog-utils.js';
-/**
- * @polymerMixin
- */
 export const DialogResizableMixin = (superClass) =>
   class VaadinDialogResizableMixin extends superClass {
     static get properties() {

--- a/packages/dialog/src/vaadin-dialog-size-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-size-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const DialogSizeMixin = (superClass) =>
   class DialogSizeMixinClass extends superClass {
     static get properties() {

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -98,13 +98,6 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  *
  * @customElement vaadin-dialog
  * @extends HTMLElement
- * @mixes ThemePropertyMixin
- * @mixes ElementMixin
- * @mixes DialogBaseMixin
- * @mixes DialogDraggableMixin
- * @mixes DialogRendererMixin
- * @mixes DialogResizableMixin
- * @mixes DialogSizeMixin
  */
 class Dialog extends DialogSizeMixin(
   DialogDraggableMixin(

--- a/packages/field-base/src/checked-mixin.js
+++ b/packages/field-base/src/checked-mixin.js
@@ -9,11 +9,6 @@ import { InputMixin } from './input-mixin.js';
 
 /**
  * A mixin to manage the checked state.
- *
- * @polymerMixin
- * @mixes DelegateStateMixin
- * @mixes DisabledMixin
- * @mixes InputMixin
  */
 export const CheckedMixin = (superclass) =>
   class CheckedMixinClass extends DelegateStateMixin(DisabledMixin(InputMixin(superclass))) {

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -10,10 +10,6 @@ import { InputMixin } from './input-mixin.js';
 
 /**
  * A mixin that manages the clear button.
- *
- * @polymerMixin
- * @mixes InputMixin
- * @mixes KeyboardMixin
  */
 export const ClearButtonMixin = (superclass) =>
   class ClearButtonMixinClass extends InputMixin(KeyboardMixin(superclass)) {

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -11,10 +11,6 @@ import { ValidateMixin } from './validate-mixin.js';
 
 /**
  * A mixin to provide common field logic: label, error message and helper text.
- *
- * @polymerMixin
- * @mixes LabelMixin
- * @mixes ValidateMixin
  */
 export const FieldMixin = (superclass) =>
   class FieldMixinClass extends ValidateMixin(LabelMixin(superclass)) {

--- a/packages/field-base/src/input-constraints-mixin.js
+++ b/packages/field-base/src/input-constraints-mixin.js
@@ -10,11 +10,6 @@ import { ValidateMixin } from './validate-mixin.js';
 
 /**
  * A mixin to combine multiple input validation constraints.
- *
- * @polymerMixin
- * @mixes DelegateStateMixin
- * @mixes InputMixin
- * @mixes ValidateMixin
  */
 const InputConstraintsMixinImplementation = (superclass) => {
   return class InputConstraintsMixinClass extends DelegateStateMixin(ValidateMixin(InputMixin(superclass))) {

--- a/packages/field-base/src/input-control-mixin.js
+++ b/packages/field-base/src/input-control-mixin.js
@@ -14,14 +14,6 @@ import { InputConstraintsMixin } from './input-constraints-mixin.js';
 
 /**
  * A mixin to provide shared logic for the editable form input controls.
- *
- * @polymerMixin
- * @mixes DelegateFocusMixin
- * @mixes FieldMixin
- * @mixes InputConstraintsMixin
- * @mixes KeyboardMixin
- * @mixes ClearButtonMixin
- * @mixes SlotStylesMixin
  */
 export const InputControlMixin = (superclass) =>
   class InputControlMixinClass extends SlotStylesMixin(

--- a/packages/field-base/src/input-field-mixin.js
+++ b/packages/field-base/src/input-field-mixin.js
@@ -7,9 +7,6 @@ import { InputControlMixin } from './input-control-mixin.js';
 
 /**
  * A mixin to provide logic for vaadin-text-field and related components.
- *
- * @polymerMixin
- * @mixes InputControlMixin
  */
 export const InputFieldMixin = (superclass) =>
   class InputFieldMixinClass extends InputControlMixin(superclass) {

--- a/packages/field-base/src/input-mixin.js
+++ b/packages/field-base/src/input-mixin.js
@@ -8,8 +8,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 /**
  * A mixin to store the reference to an input element
  * and add input and change event listeners to it.
- *
- * @polymerMixin
  */
 const InputMixinImplementation = (superclass) => {
   return class InputMixinClass extends superclass {

--- a/packages/field-base/src/label-mixin.js
+++ b/packages/field-base/src/label-mixin.js
@@ -7,8 +7,6 @@ import { LabelController } from './label-controller.js';
 
 /**
  * A mixin to provide label via corresponding property or named slot.
- *
- * @polymerMixin
  */
 export const LabelMixin = (superclass) =>
   class LabelMixinClass extends superclass {

--- a/packages/field-base/src/pattern-mixin.js
+++ b/packages/field-base/src/pattern-mixin.js
@@ -7,9 +7,6 @@ import { InputConstraintsMixin } from './input-constraints-mixin.js';
 
 /**
  * A mixin to provide `pattern` property.
- *
- * @polymerMixin
- * @mixes InputConstraintsMixin
  */
 export const PatternMixin = (superclass) =>
   class PatternMixinClass extends InputConstraintsMixin(superclass) {

--- a/packages/field-base/src/validate-mixin.js
+++ b/packages/field-base/src/validate-mixin.js
@@ -7,8 +7,6 @@ import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
 /**
  * A mixin to provide required state and validation logic.
- *
- * @polymerMixin
  */
 const ValidateMixinImplementation = (superclass) =>
   class extends superclass {

--- a/packages/field-highlighter/src/vaadin-field-outline.js
+++ b/packages/field-highlighter/src/vaadin-field-outline.js
@@ -15,8 +15,6 @@ import { fieldOutlineStyles } from './styles/vaadin-field-outline-base-styles.js
  * An element used internally by `<vaadin-field-highlighter>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 export class FieldOutline extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {

--- a/packages/field-highlighter/src/vaadin-user-tag.js
+++ b/packages/field-highlighter/src/vaadin-user-tag.js
@@ -16,8 +16,6 @@ import { userTagStyles } from './styles/vaadin-user-tag-base-styles.js';
  *
  * @customElement vaadin-user-tag
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 export class UserTag extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {

--- a/packages/field-highlighter/src/vaadin-user-tags-overlay.js
+++ b/packages/field-highlighter/src/vaadin-user-tags-overlay.js
@@ -18,10 +18,6 @@ import { userTagsOverlayStyles } from './styles/vaadin-user-tags-overlay-base-st
  *
  * @customElement vaadin-user-tags-overlay
  * @extends HTMLElement
- * @mixes PositionMixin
- * @mixes OverlayMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 class UserTagsOverlay extends PositionMixin(

--- a/packages/form-layout/src/vaadin-form-item-mixin.js
+++ b/packages/form-layout/src/vaadin-form-item-mixin.js
@@ -7,9 +7,6 @@ import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { issueWarning } from '@vaadin/component-base/src/warnings.js';
 
-/**
- * @polymerMixin
- */
 export const FormItemMixin = (superClass) =>
   class extends superClass {
     constructor() {

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -88,8 +88,6 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  *
  * @customElement vaadin-form-item
  * @extends HTMLElement
- * @mixes FormItemMixin
- * @mixes ThemableMixin
  */
 class FormItem extends FormItemMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/form-layout/src/vaadin-form-layout-mixin.js
+++ b/packages/form-layout/src/vaadin-form-layout-mixin.js
@@ -8,10 +8,6 @@ import { AutoResponsiveLayout } from './layouts/auto-responsive-layout.js';
 import { ResponsiveStepsLayout } from './layouts/responsive-steps-layout.js';
 import { formLayoutSlotStyles } from './styles/vaadin-form-layout-base-styles.js';
 
-/**
- * @polymerMixin
- * @mixes SlotStylesMixin
- */
 export const FormLayoutMixin = (superClass) =>
   class extends SlotStylesMixin(superClass) {
     static get properties() {

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -200,9 +200,6 @@ import { FormLayoutMixin } from './vaadin-form-layout-mixin.js';
  *
  * @customElement vaadin-form-layout
  * @extends HTMLElement
- * @mixes FormLayoutMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class FormLayout extends FormLayoutMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/form-layout/src/vaadin-form-row.js
+++ b/packages/form-layout/src/vaadin-form-row.js
@@ -19,7 +19,6 @@ import { formRowStyles } from './styles/vaadin-form-row-base-styles.js';
  *
  * @customElement vaadin-form-row
  * @extends HTMLElement
- * @mixes ThemableMixin
  */
 class FormRow extends ThemableMixin(PolylitMixin(LitElement)) {
   static get is() {

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column-mixin.js
@@ -4,16 +4,12 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { get, set } from '@vaadin/component-base/src/path-utils.js';
 
-/**
- * @polymerMixin
- */
 export const GridProEditColumnMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-column.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -32,7 +31,6 @@ import { GridProEditColumnMixin } from './vaadin-grid-pro-edit-column-mixin.js';
  *
  * @customElement vaadin-grid-pro-edit-column
  * @extends GridColumn
- * @mixes GridProEditColumnMixin
  */
 class GridProEditColumn extends GridProEditColumnMixin(GridColumn) {
   static get is() {

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select-mixin.js
@@ -4,14 +4,10 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
 
-/**
- * @polymerMixin
- */
 export const GridProEditSelectMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-edit-select.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -17,7 +16,6 @@ import { GridProEditSelectMixin } from './vaadin-grid-pro-edit-select-mixin.js';
  *
  * @customElement vaadin-grid-pro-edit-select
  * @extends Select
- * @mixes GridProEditSelectMixin
  * @private
  */
 class GridProEditSelect extends GridProEditSelectMixin(Select) {

--- a/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
+++ b/packages/grid-pro/src/vaadin-grid-pro-inline-editing-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -13,9 +12,6 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { get, set } from '@vaadin/component-base/src/path-utils.js';
 import { iterateRowCells, updatePart } from '@vaadin/grid/src/vaadin-grid-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const InlineEditingMixin = (superClass) =>
   class InlineEditingMixin extends superClass {
     static get properties() {

--- a/packages/grid-pro/src/vaadin-grid-pro.js
+++ b/packages/grid-pro/src/vaadin-grid-pro.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -15,7 +14,6 @@ import { gridProStyles } from './styles/vaadin-grid-pro-base-styles.js';
 import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
 
 /**
- *
  * `<vaadin-grid-pro>` is a high quality data grid / data table Web Component with extended functionality.
  * It extends `<vaadin-grid>` and adds extra features on top of the basic ones.
  *
@@ -49,7 +47,6 @@ import { InlineEditingMixin } from './vaadin-grid-pro-inline-editing-mixin.js';
  *
  * @customElement vaadin-grid-pro
  * @extends Grid
- * @mixes InlineEditingMixin
  */
 class GridPro extends SlotStylesMixin(InlineEditingMixin(Grid)) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -5,9 +5,6 @@
  */
 import { findTreeToggleCell, iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const A11yMixin = (superClass) =>
   class A11yMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -20,9 +20,6 @@ export const isFocusable = (target) => {
   );
 };
 
-/**
- * @polymerMixin
- */
 export const ActiveItemMixin = (superClass) =>
   class ActiveItemMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-array-data-provider-mixin.js
@@ -5,9 +5,6 @@
  */
 import { createArrayDataProvider } from './array-data-provider.js';
 
-/**
- * @polymerMixin
- */
 export const ArrayDataProviderMixin = (superClass) =>
   class ArrayDataProviderMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -7,8 +7,6 @@ import { isElementHidden } from '@vaadin/a11y-base/src/focus-utils.js';
 
 /**
  * A mixin providing grid column auto-width functionality.
- *
- * @polymerMixin
  */
 export const ColumnAutoWidthMixin = (superClass) =>
   class extends superClass {

--- a/packages/grid/src/vaadin-grid-column-group-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-group-mixin.js
@@ -10,9 +10,6 @@ import { ColumnObserver, updateColumnOrders } from './vaadin-grid-helpers.js';
 
 /**
  * A mixin providing common vaadin-grid-column-group functionality.
- *
- * @polymerMixin
- * @mixes ColumnBaseMixin
  */
 export const GridColumnGroupMixin = (superClass) =>
   class extends ColumnBaseMixin(superClass) {

--- a/packages/grid/src/vaadin-grid-column-group.js
+++ b/packages/grid/src/vaadin-grid-column-group.js
@@ -40,7 +40,6 @@ export * from './vaadin-grid-column-group-mixin.js';
  *
  * @customElement vaadin-grid-column-group
  * @extends HTMLElement
- * @mixes GridColumnGroupMixin
  */
 class GridColumnGroup extends GridColumnGroupMixin(PolylitMixin(LitElement)) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -9,9 +9,6 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 import { updateCellState, updatePart } from './vaadin-grid-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const ColumnBaseMixin = (superClass) =>
   class ColumnBaseMixin extends superClass {
     static get properties() {
@@ -806,11 +803,6 @@ export const ColumnBaseMixin = (superClass) =>
     }
   };
 
-/**
- * @polymerMixin
- * @mixes ColumnBaseMixin
- * @mixes DirMixin
- */
 export const GridColumnMixin = (superClass) =>
   class extends ColumnBaseMixin(DirMixin(superClass)) {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -7,9 +7,6 @@ import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { addListener } from '@vaadin/component-base/src/gestures.js';
 import { getBodyRowCells, iterateChildren, updateColumnOrders } from './vaadin-grid-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const ColumnReorderingMixin = (superClass) =>
   class ColumnReorderingMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -5,9 +5,6 @@
  */
 import { addListener } from '@vaadin/component-base/src/gestures.js';
 
-/**
- * @polymerMixin
- */
 export const ColumnResizingMixin = (superClass) =>
   class ColumnResizingMixin extends superClass {
     /** @protected */

--- a/packages/grid/src/vaadin-grid-column.js
+++ b/packages/grid/src/vaadin-grid-column.js
@@ -17,7 +17,6 @@ import { GridColumnMixin } from './vaadin-grid-column-mixin.js';
  *
  * @customElement vaadin-grid-column
  * @extends HTMLElement
- * @mixes GridColumnMixin
  */
 class GridColumn extends GridColumnMixin(PolylitMixin(LitElement)) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-data-provider-mixin.js
+++ b/packages/grid/src/vaadin-grid-data-provider-mixin.js
@@ -8,9 +8,6 @@ import { DataProviderController } from '@vaadin/component-base/src/data-provider
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
 
-/**
- * @polymerMixin
- */
 export const DataProviderMixin = (superClass) =>
   class DataProviderMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -26,9 +26,6 @@ const DropLocation = {
   EMPTY: 'empty',
 };
 
-/**
- * @polymerMixin
- */
 export const DragAndDropMixin = (superClass) =>
   class DragAndDropMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -26,9 +26,6 @@ function arrayEquals(arr1, arr2) {
   return true;
 }
 
-/**
- * @polymerMixin
- */
 export const DynamicColumnsMixin = (superClass) =>
   class DynamicColumnsMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-event-context-mixin.js
+++ b/packages/grid/src/vaadin-grid-event-context-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const EventContextMixin = (superClass) =>
   class EventContextMixin extends superClass {
     /**

--- a/packages/grid/src/vaadin-grid-filter-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-column-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const GridFilterColumnMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-filter-column.js
+++ b/packages/grid/src/vaadin-grid-filter-column.js
@@ -23,7 +23,6 @@ import { GridFilterColumnMixin } from './vaadin-grid-filter-column-mixin.js';
  *
  * @customElement vaadin-grid-filter-column
  * @extends GridColumn
- * @mixes GridFilterColumnMixin
  */
 class GridFilterColumn extends GridFilterColumnMixin(GridColumn) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-filter-element-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-element-mixin.js
@@ -7,9 +7,6 @@ import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
-/**
- * @polymerMixin
- */
 export const GridFilterElementMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-filter-mixin.js
+++ b/packages/grid/src/vaadin-grid-filter-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const FilterMixin = (superClass) =>
   class FilterMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-filter.js
+++ b/packages/grid/src/vaadin-grid-filter.js
@@ -39,7 +39,6 @@ import { GridFilterElementMixin } from './vaadin-grid-filter-element-mixin.js';
  *
  * @customElement vaadin-grid-filter
  * @extends HTMLElement
- * @mixes GridFilterElementMixin
  */
 class GridFilter extends GridFilterElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
+++ b/packages/grid/src/vaadin-grid-keyboard-navigation-mixin.js
@@ -20,9 +20,6 @@ function isDetailsCell(element) {
   return element.matches('[part~="details-cell"]');
 }
 
-/**
- * @polymerMixin
- */
 export const KeyboardNavigationMixin = (superClass) =>
   class KeyboardNavigationMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -42,25 +42,6 @@ import { StylingMixin } from './vaadin-grid-styling-mixin.js';
 
 /**
  * A mixin providing common grid functionality.
- *
- * @polymerMixin
- * @mixes A11yMixin
- * @mixes ActiveItemMixin
- * @mixes ArrayDataProviderMixin
- * @mixes ColumnResizingMixin
- * @mixes DataProviderMixin
- * @mixes DynamicColumnsMixin
- * @mixes FilterMixin
- * @mixes RowDetailsMixin
- * @mixes ScrollMixin
- * @mixes SelectionMixin
- * @mixes SortMixin
- * @mixes KeyboardNavigationMixin
- * @mixes ColumnReorderingMixin
- * @mixes EventContextMixin
- * @mixes StylingMixin
- * @mixes DragAndDropMixin
- * @mixes ResizeMixin
  */
 export const GridMixin = (superClass) =>
   class extends ColumnAutoWidthMixin(

--- a/packages/grid/src/vaadin-grid-resize-mixin.js
+++ b/packages/grid/src/vaadin-grid-resize-mixin.js
@@ -6,8 +6,6 @@
 
 /**
  * A mixin to observe size changes of the grid and its main parts.
- *
- * @polymerMixin
  */
 export const ResizeMixin = (superClass) =>
   class extends superClass {

--- a/packages/grid/src/vaadin-grid-row-details-mixin.js
+++ b/packages/grid/src/vaadin-grid-row-details-mixin.js
@@ -5,9 +5,6 @@
  */
 import { updatePart } from './vaadin-grid-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const RowDetailsMixin = (superClass) =>
   class RowDetailsMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -13,9 +13,6 @@ const timeouts = {
   UPDATE_CONTENT_VISIBILITY: 100,
 };
 
-/**
- * @polymerMixin
- */
 export const ScrollMixin = (superClass) =>
   class ScrollMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -15,8 +15,6 @@ import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures
  * Web component-specific selection state updates must be implemented in the
  * `<vaadin-grid-selection-column>` itself, by overriding the protected methods
  * provided by this mixin.
- *
- * @polymerMixin
  */
 export const GridSelectionColumnBaseMixin = (superClass) =>
   class GridSelectionColumnBaseMixin extends superClass {

--- a/packages/grid/src/vaadin-grid-selection-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-mixin.js
@@ -5,10 +5,6 @@
  */
 import { GridSelectionColumnBaseMixin } from './vaadin-grid-selection-column-base-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes GridSelectionColumnBaseMixin
- */
 export const GridSelectionColumnMixin = (superClass) =>
   class extends GridSelectionColumnBaseMixin(superClass) {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-selection-column.js
+++ b/packages/grid/src/vaadin-grid-selection-column.js
@@ -34,7 +34,6 @@ import { GridSelectionColumnMixin } from './vaadin-grid-selection-column-mixin.j
  *
  * @customElement vaadin-grid-selection-column
  * @extends GridColumn
- * @mixes GridSelectionColumnMixin
  */
 class GridSelectionColumn extends GridSelectionColumnMixin(GridColumn) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const SelectionMixin = (superClass) =>
   class SelectionMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-sort-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-column-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const GridSortColumnMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-sort-column.js
+++ b/packages/grid/src/vaadin-grid-sort-column.js
@@ -25,7 +25,6 @@ import { GridSortColumnMixin } from './vaadin-grid-sort-column-mixin.js';
  *
  * @customElement vaadin-grid-sort-column
  * @extends GridColumn
- * @mixes GridSortColumnMixin
  */
 class GridSortColumn extends GridSortColumnMixin(GridColumn) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-sort-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-mixin.js
@@ -6,9 +6,6 @@
 
 let defaultMultiSortPriority = 'prepend';
 
-/**
- * @polymerMixin
- */
 export const SortMixin = (superClass) =>
   class SortMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -6,8 +6,6 @@
 
 /**
  * A mixin providing common sorter functionality.
- *
- * @polymerMixin
  */
 export const GridSorterMixin = (superClass) =>
   class GridSorterMixinClass extends superClass {

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -53,9 +53,6 @@ import { GridSorterMixin } from './vaadin-grid-sorter-mixin.js';
  *
  * @customElement vaadin-grid-sorter
  * @extends HTMLElement
- * @mixes GridSorterMixin
- * @mixes ThemableMixin
- * @mixes DirMixin
  */
 class GridSorter extends GridSorterMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-styling-mixin.js
+++ b/packages/grid/src/vaadin-grid-styling-mixin.js
@@ -5,9 +5,6 @@
  */
 import { iterateChildren, iterateRowCells, updatePart } from './vaadin-grid-helpers.js';
 
-/**
- * @polymerMixin
- */
 export const StylingMixin = (superClass) =>
   class StylingMixin extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-tree-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-tree-column-mixin.js
@@ -5,9 +5,6 @@
  */
 import { get } from '@vaadin/component-base/src/path-utils.js';
 
-/**
- * @polymerMixin
- */
 export const GridTreeColumnMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-tree-column.js
+++ b/packages/grid/src/vaadin-grid-tree-column.js
@@ -22,7 +22,6 @@ import { GridTreeColumnMixin } from './vaadin-grid-tree-column-mixin.js';
  * ```
  * @customElement vaadin-grid-tree-column
  * @extends GridColumn
- * @mixes GridTreeColumnMixin
  */
 class GridTreeColumn extends GridTreeColumnMixin(GridColumn) {
   static get is() {

--- a/packages/grid/src/vaadin-grid-tree-toggle-mixin.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle-mixin.js
@@ -5,9 +5,6 @@
  */
 import { isFocusable } from './vaadin-grid-active-item-mixin.js';
 
-/**
- * @polymerMixin
- */
 export const GridTreeToggleMixin = (superClass) =>
   class extends superClass {
     static get properties() {

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -61,9 +61,6 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  *
  * @customElement vaadin-grid-tree-toggle
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes DirMixin
- * @mixes GridTreeToggleMixin
  */
 class GridTreeToggle extends GridTreeToggleMixin(
   ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -267,8 +267,6 @@ import { GridMixin } from './vaadin-grid-mixin.js';
  *
  * @customElement vaadin-grid
  * @extends HTMLElement
- * @mixes GridMixin
- * @mixes ThemableMixin
  */
 class Grid extends GridMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout-mixin.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout-mixin.js
@@ -6,9 +6,6 @@
 import { isEmptyTextNode } from '@vaadin/component-base/src/dom-utils.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 
-/**
- * @polymerMixin
- */
 export const HorizontalLayoutMixin = (superClass) =>
   class extends superClass {
     /** @protected */

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -57,9 +57,6 @@ import { HorizontalLayoutMixin } from './vaadin-horizontal-layout-mixin.js';
  *
  * @customElement vaadin-horizontal-layout
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes HorizontalLayoutMixin
  */
 class HorizontalLayout extends HorizontalLayoutMixin(
   ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/icon/src/vaadin-icon-font-size-mixin.js
+++ b/packages/icon/src/vaadin-icon-font-size-mixin.js
@@ -15,8 +15,6 @@ const usesFontIconSizingFallback = needsFontIconSizingFallback();
  * recent versions, but there's an regression in Safari 26, which caused the same issue to happen when the icon is
  * attached to an element with shadow root.
  * The mixin does nothing if the browser supports CSS Container Query units for pseudo elements.
- *
- * @polymerMixin
  */
 export const IconFontSizeMixin = (superclass) =>
   !usesFontIconSizingFallback

--- a/packages/icon/src/vaadin-icon-mixin.js
+++ b/packages/icon/src/vaadin-icon-mixin.js
@@ -11,10 +11,6 @@ const srcCache = new Map();
 
 const Iconset = customElements.get('vaadin-iconset');
 
-/**
- * @polymerMixin
- * @mixes IconFontSizeMixin
- */
 export const IconMixin = (superClass) =>
   class extends IconFontSizeMixin(superClass) {
     static get properties() {
@@ -53,7 +49,6 @@ export const IconMixin = (superClass) =>
          *   inside the SVG referenced by the path. Note that the file needs to follow the same-origin policy.
          * - a string in the format `data:image/svg+xml,<svg>...</svg>`. You may need to use the `encodeURIComponent`
          *   function for the SVG content passed
-         *
          */
         src: {
           type: String,
@@ -63,7 +58,6 @@ export const IconMixin = (superClass) =>
         /**
          * The symbol identifier that references an ID of an element contained in the SVG element assigned to the
          * `src` property
-         *
          */
         symbol: {
           type: String,
@@ -87,7 +81,6 @@ export const IconMixin = (superClass) =>
          * A hexadecimal code point that specifies a glyph from an icon font.
          *
          * Example: "e001"
-         *
          */
         char: {
           type: String,
@@ -98,7 +91,6 @@ export const IconMixin = (superClass) =>
          * A ligature name that specifies an icon from an icon font with support for ligatures.
          *
          * Example: "home".
-         *
          */
         ligature: {
           type: String,

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -74,9 +74,6 @@ import { ensureSvgLiteral } from './vaadin-icon-svg.js';
  *
  * @customElement vaadin-icon
  * @extends HTMLElement
- * @mixes IconMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class Icon extends IconMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/icon/src/vaadin-iconset-mixin.js
+++ b/packages/icon/src/vaadin-iconset-mixin.js
@@ -31,9 +31,6 @@ function initIconsMap(iconset, name) {
   }, {});
 }
 
-/**
- * @polymerMixin
- */
 export const IconsetMixin = (superClass) =>
   class extends superClass {
     static get observedAttributes() {

--- a/packages/icon/src/vaadin-iconset.js
+++ b/packages/icon/src/vaadin-iconset.js
@@ -11,7 +11,6 @@ import { IconsetMixin } from './vaadin-iconset-mixin.js';
  *
  * @customElement vaadin-iconset
  * @extends HTMLElement
- * @mixes IconsetMixin
  */
 class Iconset extends IconsetMixin(HTMLElement) {
   static get is() {

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -14,8 +14,6 @@ import { inputContainerStyles } from './styles/vaadin-input-container-base-style
 /**
  * @customElement vaadin-input-container
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes DirMixin
  */
 export class InputContainer extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/item/src/vaadin-item-mixin.js
+++ b/packages/item/src/vaadin-item-mixin.js
@@ -10,10 +10,6 @@ import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
  * A mixin providing `focused`, `focus-ring`, `active`, `disabled` and `selected`.
  *
  * `focused`, `active` and `focus-ring` are set as only as attributes.
- *
- * @polymerMixin
- * @mixes ActiveMixin
- * @mixes FocusMixin
  */
 export const ItemMixin = (superClass) =>
   class VaadinItemMixin extends ActiveMixin(FocusMixin(superClass)) {

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -63,9 +63,6 @@ import { ItemMixin } from './vaadin-item-mixin.js';
  * @prop {string} label - String that can be set to visually represent the selected item in `vaadin-select`.
  * @customElement vaadin-item
  * @extends HTMLElement
- * @mixes ItemMixin
- * @mixes ThemableMixin
- * @mixes DirMixin
  */
 class Item extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -47,9 +47,6 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
  *
  * @customElement vaadin-list-box
  * @extends HTMLElement
- * @mixes MultiSelectListMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/list-box/src/vaadin-multi-select-list-mixin.js
+++ b/packages/list-box/src/vaadin-multi-select-list-mixin.js
@@ -7,9 +7,6 @@ import { ListMixin } from '@vaadin/a11y-base/src/list-mixin.js';
 
 /**
  * A mixin for `nav` elements, facilitating multiple selection of childNodes.
- *
- * @polymerMixin
- * @mixes ListMixin
  */
 export const MultiSelectListMixin = (superClass) =>
   class VaadinMultiSelectListMixin extends ListMixin(superClass) {

--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -11,10 +11,6 @@ function isCheckbox(field) {
   return (field.inputElement || field).type === 'checkbox';
 }
 
-/**
- * @polymerMixin
- * @mixes LoginMixin
- */
 export const LoginFormMixin = (superClass) =>
   class LoginFormMixin extends LoginMixin(superClass) {
     /** @protected */

--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -14,7 +14,6 @@ import { loginFormWrapperStyles } from './styles/vaadin-login-form-wrapper-base-
  * An element used internally by `<vaadin-login-form>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes ThemableMixin
  * @private
  */
 class LoginFormWrapper extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -67,9 +67,6 @@ import { LoginFormMixin } from './vaadin-login-form-mixin.js';
  *
  * @customElement vaadin-login-form
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes LoginFormMixin
  */
 class LoginForm extends LoginFormMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/login/src/vaadin-login-mixin.js
+++ b/packages/login/src/vaadin-login-mixin.js
@@ -21,10 +21,6 @@ const DEFAULT_I18N = {
   },
 };
 
-/**
- * @mixes LoginMixin
- * @polymerMixin
- */
 export const LoginMixin = (superClass) =>
   class LoginMixin extends I18nMixin(superClass) {
     static get properties() {

--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -5,9 +5,6 @@
  */
 import { TitleController } from './title-controller.js';
 
-/**
- * @polymerMixin
- */
 export const LoginOverlayMixin = (superClass) =>
   class LoginOverlayMixin extends superClass {
     static get properties() {

--- a/packages/login/src/vaadin-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-login-overlay-wrapper.js
@@ -16,9 +16,6 @@ import { loginOverlayWrapperStyles } from './styles/vaadin-login-overlay-wrapper
  * An element used internally by `<vaadin-login-overlay>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 class LoginOverlayWrapper extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -76,10 +76,6 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  *
  * @customElement vaadin-login-overlay
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes LoginFormMixin
- * @mixes LoginOverlayMixin
  */
 class LoginOverlay extends LoginFormMixin(LoginOverlayMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
   static get is() {

--- a/packages/map/src/vaadin-map-mixin.js
+++ b/packages/map/src/vaadin-map-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -14,11 +13,6 @@ import OpenLayersMap from 'ol/Map.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes ResizeMixin
- * @mixes FocusMixin
- */
 export const MapMixin = (superClass) =>
   class extends FocusMixin(ResizeMixin(superClass)) {
     constructor() {

--- a/packages/map/src/vaadin-map.d.ts
+++ b/packages/map/src/vaadin-map.d.ts
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -46,9 +45,6 @@ import { MapMixin } from './vaadin-map-mixin.js';
  * </script>
  * ```
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes MapMixin
  */
 declare class Map extends MapMixin(ThemableMixin(ElementMixin(HTMLElement))) {}
 

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -53,9 +52,6 @@ import { MapMixin } from './vaadin-map-mixin.js';
  *
  * @customElement vaadin-map
  * @extends HTMLElement
- * @mixes MapMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class Map extends MapMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/markdown/src/vaadin-markdown.js
+++ b/packages/markdown/src/vaadin-markdown.js
@@ -26,9 +26,6 @@ import { markdownSlotStyles } from './styles/vaadin-markdown-base-styles.js';
  *
  * @customElement vaadin-markdown
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes SlotStylesMixin
  */
 class Markdown extends SlotStylesMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {
@@ -56,7 +53,6 @@ class Markdown extends SlotStylesMixin(ElementMixin(ThemableMixin(PolylitMixin(L
     return {
       /**
        * The Markdown content.
-       *
        */
       content: {
         type: String,

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -90,8 +90,6 @@ import {
  *
  * @customElement vaadin-master-detail-layout
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElement))) {
   static get is() {

--- a/packages/menu-bar/src/vaadin-menu-bar-item.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.js
@@ -17,9 +17,6 @@ import { menuBarItemStyles } from './styles/vaadin-menu-bar-item-base-styles.js'
  *
  * @customElement vaadin-menu-bar-item
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ItemMixin
- * @mixes ThemableMixin
  * @protected
  */
 class MenuBarItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/menu-bar/src/vaadin-menu-bar-list-box.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-list-box.js
@@ -17,9 +17,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @customElement vaadin-menu-bar-list-box
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ListMixin
- * @mixes ThemableMixin
  * @protected
  */
 class MenuBarListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -56,14 +56,6 @@ const DEFAULT_I18N = {
   moreOptions: 'More options',
 };
 
-/**
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes FocusMixin
- * @mixes I18nMixin
- * @mixes KeyboardDirectionMixin
- * @mixes ResizeMixin
- */
 export const MenuBarMixin = (superClass) =>
   class MenuBarMixinClass extends I18nMixin(
     KeyboardDirectionMixin(ResizeMixin(FocusMixin(DisabledMixin(superClass)))),

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -18,10 +18,6 @@ import { menuBarOverlayStyles } from './styles/vaadin-menu-bar-overlay-base-styl
  *
  * @customElement vaadin-menu-bar-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes MenuOverlayMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @protected
  */
 export class MenuBarOverlay extends MenuOverlayMixin(

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -18,8 +18,6 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
  *
  * @customElement vaadin-menu-bar-submenu
  * @extends HTMLElement
- * @mixes ContextMenuMixin
- * @mixes ThemePropertyMixin
  * @protected
  */
 class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(LitElement))) {

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -69,9 +69,6 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  *
  * @customElement vaadin-menu-bar
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes MenuBarMixin
- * @mixes ThemableMixin
  */
 class MenuBar extends MenuBarMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/message-input/src/vaadin-message-input-button.js
+++ b/packages/message-input/src/vaadin-message-input-button.js
@@ -18,9 +18,6 @@ import { messageInputButtonStyles } from './styles/vaadin-message-input-button-s
  *
  * @customElement vaadin-message-input-button
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 class MessageInputButton extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/message-input/src/vaadin-message-input-mixin.js
+++ b/packages/message-input/src/vaadin-message-input-mixin.js
@@ -12,10 +12,6 @@ const DEFAULT_I18N = {
   message: 'Message',
 };
 
-/**
- * @polymerMixin
- * @mixes I18nMixin
- */
 export const MessageInputMixin = (superClass) =>
   class MessageInputMixinClass extends I18nMixin(superClass) {
     static get properties() {

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -49,9 +49,6 @@ import { MessageInputMixin } from './vaadin-message-input-mixin.js';
  *
  * @customElement vaadin-message-input
  * @extends HTMLElement
- * @mixes MessageInputMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class MessageInput extends MessageInputMixin(
   ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/message-list/src/vaadin-message-list-mixin.js
+++ b/packages/message-list/src/vaadin-message-list-mixin.js
@@ -9,10 +9,6 @@ import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction
 import { timeOut } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 
-/**
- * @polymerMixin
- * @mixes KeyboardDirectionMixin
- */
 export const MessageListMixin = (superClass) =>
   class MessageListMixinClass extends KeyboardDirectionMixin(superClass) {
     static get properties() {

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -49,10 +49,6 @@ import { MessageListMixin } from './vaadin-message-list-mixin.js';
  *
  * @customElement vaadin-message-list
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes MessageListMixin
- * @mixes SlotStylesMixin
  */
 class MessageList extends SlotStylesMixin(MessageListMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement))))) {
   static get is() {

--- a/packages/message-list/src/vaadin-message-mixin.js
+++ b/packages/message-list/src/vaadin-message-mixin.js
@@ -8,10 +8,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
-/**
- * @polymerMixin
- * @mixes FocusMixin
- */
 export const MessageMixin = (superClass) =>
   class MessageMixinClass extends FocusMixin(superClass) {
     static get properties() {

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -85,9 +85,6 @@ import { MessageMixin } from './vaadin-message-mixin.js';
  *
  * @customElement vaadin-message
  * @extends HTMLElement
- * @mixes MessageMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class Message extends MessageMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
@@ -35,9 +35,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @customElement vaadin-multi-select-combo-box-item
- * @mixes ComboBoxItemMixin
- * @mixes ThemableMixin
- * @mixes DirMixin
  * @private
  */
 export class MultiSelectComboBoxItem extends ComboBoxItemMixin(

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -24,15 +24,6 @@ const DEFAULT_I18N = {
   total: '{count} items selected',
 };
 
-/**
- * @polymerMixin
- * @mixes ComboBoxDataProviderMixin
- * @mixes ComboBoxItemsMixin
- * @mixes ComboBoxScrollToIndexMixin
- * @mixes I18nMixin
- * @mixes InputControlMixin
- * @mixes ResizeMixin
- */
 export const MultiSelectComboBoxMixin = (superClass) =>
   class MultiSelectComboBoxMixinClass extends I18nMixin(
     ComboBoxScrollToIndexMixin(

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -19,10 +19,6 @@ import { multiSelectComboBoxOverlayStyles } from './styles/vaadin-multi-select-c
  *
  * @customElement vaadin-multi-select-combo-box-overlay
  * @extends HTMLElement
- * @mixes ComboBoxOverlayMixin
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 class MultiSelectComboBoxOverlay extends ComboBoxOverlayMixin(

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -15,7 +15,6 @@ import { multiSelectComboBoxScrollerStyles } from './styles/vaadin-multi-select-
  *
  * @customElement vaadin-multi-select-combo-box-scroller
  * @extends HTMLElement
- * @mixes ComboBoxScrollerMixin
  * @private
  */
 export class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -98,9 +98,6 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  *
  * @customElement vaadin-multi-select-combo-box
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes MultiSelectComboBoxMixin
  */
 class MultiSelectComboBox extends MultiSelectComboBoxMixin(
   ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -11,8 +11,6 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 
 /**
  * A mixin providing common notification container functionality.
- *
- * @polymerMixin
  */
 export const NotificationContainerMixin = (superClass) =>
   class extends superClass {
@@ -103,10 +101,6 @@ export const NotificationContainerMixin = (superClass) =>
 
 /**
  * A mixin providing common notification functionality.
- *
- * @polymerMixin
- * @mixes OverlayClassMixin
- * @mixes ThemePropertyMixin
  */
 export const NotificationMixin = (superClass) =>
   class extends ThemePropertyMixin(OverlayClassMixin(superClass)) {

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -19,9 +19,6 @@ import { NotificationContainerMixin, NotificationMixin } from './vaadin-notifica
  *
  * @customElement vaadin-notification-container
  * @extends HTMLElement
- * @mixes NotificationContainerMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  * @private
  */
 class NotificationContainer extends NotificationContainerMixin(
@@ -60,7 +57,6 @@ class NotificationContainer extends NotificationContainerMixin(
  *
  * @customElement vaadin-notification-card
  * @extends HTMLElement
- * @mixes ThemableMixin
  * @private
  */
 class NotificationCard extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
@@ -139,8 +135,6 @@ class NotificationCard extends ThemableMixin(PolylitMixin(LumoInjectionMixin(Lit
  *
  * @customElement vaadin-notification
  * @extends HTMLElement
- * @mixes NotificationMixin
- * @mixes ElementMixin
  */
 class Notification extends NotificationMixin(ElementMixin(ThemableMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/number-field/src/vaadin-number-field-mixin.js
+++ b/packages/number-field/src/vaadin-number-field-mixin.js
@@ -20,9 +20,6 @@ const BAD_INPUT_STRING = 'NaN';
 
 /**
  * A mixin providing common number field functionality.
- *
- * @polymerMixin
- * @mixes InputFieldMixin
  */
 export const NumberFieldMixin = (superClass) =>
   class NumberFieldMixinClass extends InputFieldMixin(superClass) {

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -86,9 +86,6 @@ import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
  *
  * @customElement vaadin-number-field
  * @extends HTMLElement
- * @mixes NumberFieldMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class NumberField extends NumberFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -7,9 +7,6 @@ import { FocusRestorationController } from '@vaadin/a11y-base/src/focus-restorat
 import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller.js';
 import { getDeepActiveElement, isElementHidden, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 
-/**
- * @polymerMixin
- */
 export const OverlayFocusMixin = (superClass) =>
   class OverlayFocusMixin extends superClass {
     static get properties() {

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -8,11 +8,6 @@ import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
 import { setOverlayStateAttribute } from './vaadin-overlay-utils.js';
 
-/**
- * @polymerMixin
- * @mixes OverlayFocusMixin
- * @mixes OverlayStackMixin
- */
 export const OverlayMixin = (superClass) =>
   class OverlayMixin extends OverlayFocusMixin(OverlayStackMixin(superClass)) {
     static get properties() {

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -26,9 +26,6 @@ const targetResizeObserver = new ResizeObserver((entries) => {
   });
 });
 
-/**
- * @polymerMixin
- */
 export const PositionMixin = (superClass) =>
   class PositionMixin extends superClass {
     static get properties() {

--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -43,9 +43,6 @@ export const isLastOverlay = (overlay, filter = (_overlay) => true) => {
   return overlay === filteredOverlays.pop();
 };
 
-/**
- * @polymerMixin
- */
 export const OverlayStackMixin = (superClass) =>
   class OverlayStackMixin extends superClass {
     /**

--- a/packages/overlay/src/vaadin-overlay.js
+++ b/packages/overlay/src/vaadin-overlay.js
@@ -73,9 +73,6 @@ import { OverlayMixin } from './vaadin-overlay-mixin.js';
  *
  * @customElement vaadin-overlay
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes DirMixin
- * @mixes OverlayMixin
  */
 class Overlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/password-field/src/vaadin-password-field-button.js
+++ b/packages/password-field/src/vaadin-password-field-button.js
@@ -17,9 +17,6 @@ import { passwordFieldButton } from './styles/vaadin-password-field-button-base-
  *
  * @customElement vaadin-password-field-button
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes DirMixin
- * @mixes ThemableMixin
  * @private
  */
 class PasswordFieldButton extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/password-field/src/vaadin-password-field-mixin.js
+++ b/packages/password-field/src/vaadin-password-field-mixin.js
@@ -9,13 +9,6 @@ import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes FocusMixin
- * @mixes InputMixin
- * @mixes SlotStylesMixin
- */
 export const PasswordFieldMixin = (superClass) =>
   class PasswordFieldMixinClass extends SlotStylesMixin(DisabledMixin(FocusMixin(InputMixin(superClass)))) {
     static get properties() {

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -61,7 +61,6 @@ import { PasswordFieldMixin } from './vaadin-password-field-mixin.js';
  *
  * @customElement vaadin-password-field
  * @extends TextField
- * @mixes PasswordFieldMixin
  */
 export class PasswordField extends PasswordFieldMixin(TextField) {
   static get is() {

--- a/packages/popover/src/vaadin-popover-overlay-mixin.js
+++ b/packages/popover/src/vaadin-popover-overlay-mixin.js
@@ -8,10 +8,6 @@ import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin
 
 /**
  * A mixin providing common popover overlay functionality.
- *
- * @polymerMixin
- * @mixes PositionMixin
- * @mixes OverlayMixin
  */
 export const PopoverOverlayMixin = (superClass) =>
   class PopoverOverlayMixinClass extends PositionMixin(OverlayMixin(superClass)) {

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -18,9 +18,6 @@ import { PopoverOverlayMixin } from './vaadin-popover-overlay-mixin.js';
  *
  * @customElement vaadin-popover-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes PopoverOverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 class PopoverOverlay extends PopoverOverlayMixin(

--- a/packages/popover/src/vaadin-popover-position-mixin.js
+++ b/packages/popover/src/vaadin-popover-position-mixin.js
@@ -6,8 +6,6 @@
 
 /**
  * A mixin providing popover position functionality.
- *
- * @polymerMixin
  */
 export const PopoverPositionMixin = (superClass) =>
   class PopoverPositionMixinClass extends superClass {

--- a/packages/popover/src/vaadin-popover-target-mixin.js
+++ b/packages/popover/src/vaadin-popover-target-mixin.js
@@ -8,8 +8,6 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 
 /**
  * A mixin providing popover target functionality.
- *
- * @polymerMixin
  */
 export const PopoverTargetMixin = (superClass) =>
   class PopoverTargetMixinClass extends superClass {

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -209,10 +209,6 @@ const isLastOverlay = (overlay) => {
  *
  * @customElement vaadin-popover
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes PopoverPositionMixin
- * @mixes PopoverTargetMixin
- * @mixes ThemePropertyMixin
  */
 class Popover extends PopoverPositionMixin(
   PopoverTargetMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(LitElement)))),

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -53,9 +53,6 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  *
  * @customElement vaadin-progress-bar
  * @extends HTMLElement
- * @mixes ProgressMixin
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class ProgressBar extends ProgressMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/progress-bar/src/vaadin-progress-mixin.js
+++ b/packages/progress-bar/src/vaadin-progress-mixin.js
@@ -4,9 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-/**
- * @polymerMixin
- */
 export const ProgressMixin = (superClass) =>
   class VaadinProgressMixin extends superClass {
     static get properties() {

--- a/packages/radio-group/src/vaadin-radio-button-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-button-mixin.js
@@ -13,13 +13,6 @@ import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-c
 
 /**
  * A mixin providing common radio-button functionality.
- *
- * @polymerMixin
- * @mixes ActiveMixin
- * @mixes CheckedMixin
- * @mixes DelegateFocusMixin
- * @mixes LabelMixin
- * @mixes SlotStylesMixin
  */
 export const RadioButtonMixin = (superclass) =>
   class RadioButtonMixinClass extends SlotStylesMixin(
@@ -29,7 +22,6 @@ export const RadioButtonMixin = (superclass) =>
       return {
         /**
          * The name of the radio button.
-         *
          */
         name: {
           type: String,

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -65,9 +65,6 @@ import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
  *
  * @customElement vaadin-radio-button
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes RadioButtonMixin
  */
 class RadioButton extends RadioButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/radio-group/src/vaadin-radio-group-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-group-mixin.js
@@ -13,12 +13,6 @@ import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 
 /**
  * A mixin providing common radio-group functionality.
- *
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes FieldMixin
- * @mixes FocusMixin
- * @mixes KeyboardMixin
  */
 export const RadioGroupMixin = (superclass) =>
   class RadioGroupMixinClass extends FieldMixin(FocusMixin(DisabledMixin(KeyboardMixin(superclass)))) {
@@ -35,7 +29,6 @@ export const RadioGroupMixin = (superclass) =>
 
         /**
          * The value of the radio group.
-         *
          */
         value: {
           type: String,
@@ -50,7 +43,6 @@ export const RadioGroupMixin = (superclass) =>
          * The property works similarly to the `disabled` property.
          * While the `disabled` property disables all radio buttons inside the group,
          * the `readonly` property disables only unchecked ones.
-         *
          */
         readonly: {
           type: Boolean,

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -77,9 +77,6 @@ import { RadioGroupMixin } from './vaadin-radio-group-mixin.js';
  *
  * @customElement vaadin-radio-group
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes RadioGroupMixin
  */
 class RadioGroup extends RadioGroupMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -96,9 +95,6 @@ const DEFAULT_I18N = {
   remove: 'Remove',
 };
 
-/**
- * @polymerMixin
- */
 export const RichTextEditorMixin = (superClass) =>
   class RichTextEditorMixinClass extends I18nMixin(superClass) {
     static get properties() {

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -137,10 +136,6 @@ export { RichTextEditorPopup };
  *
  * @customElement vaadin-rich-text-editor-popup-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ThemableMixin
- * @mixes OverlayMixin
- * @mixes PositionMixin
  * @private
  */
 class RichTextEditorPopupOverlay extends PositionMixin(

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -4,7 +4,6 @@
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- *
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
@@ -118,9 +117,6 @@ import { RichTextEditorMixin } from './vaadin-rich-text-editor-mixin.js';
  *
  * @customElement vaadin-rich-text-editor
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes RichTextEditorMixin
- * @mixes ThemableMixin
  */
 class RichTextEditor extends RichTextEditorMixin(
   ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/scroller/src/vaadin-scroller-mixin.js
+++ b/packages/scroller/src/vaadin-scroller-mixin.js
@@ -5,10 +5,6 @@
  */
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes FocusMixin
- */
 export const ScrollerMixin = (superClass) =>
   class ScrollerMixinClass extends FocusMixin(superClass) {
     static get properties() {

--- a/packages/scroller/src/vaadin-scroller.js
+++ b/packages/scroller/src/vaadin-scroller.js
@@ -55,9 +55,6 @@ import { ScrollerMixin } from './vaadin-scroller-mixin.js';
  *
  * @customElement vaadin-scroller
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes ScrollerMixin
  */
 class Scroller extends ScrollerMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -14,13 +14,6 @@ import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { LabelController } from '@vaadin/field-base/src/label-controller.js';
 import { ButtonController } from './button-controller.js';
 
-/**
- * @polymerMixin
- * @mixes DelegateFocusMixin
- * @mixes DelegateStateMixin
- * @mixes FieldMixin
- * @mixes KeyboardMixin
- */
 export const SelectBaseMixin = (superClass) =>
   class SelectBaseMixin extends DelegateFocusMixin(DelegateStateMixin(KeyboardMixin(FieldMixin(superClass)))) {
     static get properties() {

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -17,9 +17,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @customElement vaadin-select-item
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ItemMixin
- * @mixes ThemableMixin
  * @protected
  */
 class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -17,9 +17,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * @customElement vaadin-select-list-box
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ListMixin
- * @mixes ThemableMixin
  * @protected
  */
 class SelectListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {

--- a/packages/select/src/vaadin-select-overlay-mixin.js
+++ b/packages/select/src/vaadin-select-overlay-mixin.js
@@ -7,12 +7,6 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes PositionMixin
- */
 export const SelectOverlayMixin = (superClass) =>
   class SelectOverlayMixin extends PositionMixin(OverlayMixin(DirMixin(superClass))) {
     static get observers() {

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -17,8 +17,6 @@ import { SelectOverlayMixin } from './vaadin-select-overlay-mixin.js';
  *
  * @customElement vaadin-select-overlay
  * @extends HTMLElement
- * @mixes SelectOverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 export class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -16,8 +16,6 @@ import { valueButton } from './styles/vaadin-select-value-button-base-styles.js'
  *
  * @customElement vaadin-select-value-button
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes ThemableMixin
  * @protected
  */
 class SelectValueButton extends ButtonMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -136,9 +136,6 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  *
  * @customElement vaadin-select
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes SelectBaseMixin
- * @mixes ThemableMixin
  */
 class Select extends SelectBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/side-nav/src/vaadin-side-nav-children-mixin.js
+++ b/packages/side-nav/src/vaadin-side-nav-children-mixin.js
@@ -35,9 +35,6 @@ class ChildrenController extends SlotController {
   }
 }
 
-/**
- * @polymerMixin
- */
 export const SideNavChildrenMixin = (superClass) =>
   class SideNavChildrenMixin extends I18nMixin(superClass) {
     static get properties() {

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -78,10 +78,6 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @customElement vaadin-side-nav-item
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes DisabledMixin
- * @mixes ElementMixin
- * @mixes SideNavChildrenMixin
  */
 class SideNavItem extends SideNavChildrenMixin(
   DisabledMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
@@ -111,7 +107,6 @@ class SideNavItem extends SideNavChildrenMixin(
 
       /**
        * Whether to show the child items or not
-       *
        */
       expanded: {
         type: Boolean,
@@ -148,7 +143,6 @@ class SideNavItem extends SideNavChildrenMixin(
        *
        * The state is updated when the item is added to the DOM or when the browser
        * navigates to a new page.
-       *
        */
       current: {
         type: Boolean,

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -69,9 +69,6 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @customElement vaadin-side-nav
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes SideNavChildrenMixin
  */
 class SideNav extends SideNavChildrenMixin(
   SlotStylesMixin(FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))))),
@@ -88,7 +85,6 @@ class SideNav extends SideNavChildrenMixin(
     return {
       /**
        * Whether the side nav is collapsible. When enabled, the toggle icon is shown.
-       *
        */
       collapsible: {
         type: Boolean,
@@ -98,7 +94,6 @@ class SideNav extends SideNavChildrenMixin(
 
       /**
        * Whether the side nav is collapsed. When collapsed, the items are hidden.
-       *
        */
       collapsed: {
         type: Boolean,

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -125,11 +125,6 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * @customElement vaadin-range-slider
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes FieldMixin
- * @mixes FocusMixin
- * @mixes SliderMixin
- * @mixes ThemableMixin
  */
 class RangeSlider extends FieldMixin(
   SliderMixin(FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))))),

--- a/packages/slider/src/vaadin-slider-bubble-overlay.js
+++ b/packages/slider/src/vaadin-slider-bubble-overlay.js
@@ -18,10 +18,6 @@ import { sliderBubbleOverlayStyles } from './styles/vaadin-slider-bubble-overlay
  *
  * @customElement vaadin-slider-bubble-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes PositionMixin
- * @mixes ThemableMixin
  * @private
  */
 class SliderBubbleOverlay extends PositionMixin(

--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -6,11 +6,6 @@
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { SlotStylesMixin } from '@vaadin/component-base/src/slot-styles-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes DisabledMixin
- * @mixes SlotStylesMixin
- */
 export const SliderMixin = (superClass) =>
   class SliderMixinClass extends SlotStylesMixin(DisabledMixin(superClass)) {
     static get properties() {

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -120,11 +120,6 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  *
  * @customElement vaadin-slider
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes FieldMixin
- * @mixes FocusMixin
- * @mixes SliderMixin
- * @mixes ThemableMixin
  */
 class Slider extends FieldMixin(
   SliderMixin(FocusMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))))),

--- a/packages/split-layout/src/vaadin-split-layout-mixin.js
+++ b/packages/split-layout/src/vaadin-split-layout-mixin.js
@@ -5,9 +5,6 @@
  */
 import { addListener } from '@vaadin/component-base/src/gestures.js';
 
-/**
- * @polymerMixin
- */
 export const SplitLayoutMixin = (superClass) =>
   class SplitLayoutMixin extends superClass {
     static get properties() {

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -162,9 +162,6 @@ import { SplitLayoutMixin } from './vaadin-split-layout-mixin.js';
  *
  * @customElement vaadin-split-layout
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes SplitLayoutMixin
- * @mixes ThemableMixin
  */
 class SplitLayout extends SplitLayoutMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -49,9 +49,6 @@ import { tabStyles } from './styles/vaadin-tab-base-styles.js';
  *
  * @customElement vaadin-tab
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ItemMixin
- * @mixes ThemableMixin
  */
 class Tab extends ItemMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/tabs/src/vaadin-tabs-mixin.js
+++ b/packages/tabs/src/vaadin-tabs-mixin.js
@@ -7,11 +7,6 @@ import { ListMixin } from '@vaadin/a11y-base/src/list-mixin.js';
 import { getNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 
-/**
- * @polymerMixin
- * @mixes ListMixin
- * @mixes ResizeMixin
- */
 export const TabsMixin = (superClass) =>
   class TabsMixinClass extends ResizeMixin(ListMixin(superClass)) {
     static get properties() {

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -62,9 +62,6 @@ import { TabsMixin } from './vaadin-tabs-mixin.js';
  *
  * @customElement vaadin-tabs
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes TabsMixin
- * @mixes ThemableMixin
  */
 class Tabs extends TabsMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/tabsheet/src/vaadin-tabsheet-mixin.js
+++ b/packages/tabsheet/src/vaadin-tabsheet-mixin.js
@@ -70,10 +70,6 @@ class TabsSlotController extends SlotController {
   }
 }
 
-/**
- * @polymerMixin
- * @mixes DelegateStateMixin
- */
 export const TabSheetMixin = (superClass) =>
   class extends DelegateStateMixin(superClass) {
     static get properties() {

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -68,9 +68,6 @@ import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
  *
  * @customElement vaadin-tabsheet
  * @extends HTMLElement
- * @mixes TabSheetMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class TabSheet extends TabSheetMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/text-area/src/vaadin-text-area-mixin.js
+++ b/packages/text-area/src/vaadin-text-area-mixin.js
@@ -10,10 +10,6 @@ import { TextAreaController } from '@vaadin/field-base/src/text-area-controller.
 
 /**
  * A mixin providing common text area functionality.
- *
- * @polymerMixin
- * @mixes InputFieldMixin
- * @mixes ResizeMixin
  */
 export const TextAreaMixin = (superClass) =>
   class TextAreaMixinClass extends ResizeMixin(InputFieldMixin(superClass)) {

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -85,9 +85,6 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  *
  * @customElement vaadin-text-area
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes TextAreaMixin
- * @mixes ThemableMixin
  */
 export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/text-field/src/vaadin-text-field-mixin.js
+++ b/packages/text-field/src/vaadin-text-field-mixin.js
@@ -9,9 +9,6 @@ import { LabelledInputController } from '@vaadin/field-base/src/labelled-input-c
 
 /**
  * A mixin providing common text field functionality.
- *
- * @polymerMixin
- * @mixes InputFieldMixin
  */
 export const TextFieldMixin = (superClass) =>
   class TextFieldMixinClass extends InputFieldMixin(superClass) {

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -84,9 +84,6 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  *
  * @customElement vaadin-text-field
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes TextFieldMixin
  */
 export class TextField extends TextFieldMixin(
   ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -35,9 +35,6 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @customElement vaadin-time-picker-item
- * @mixes ComboBoxItemMixin
- * @mixes ThemableMixin
- * @mixes DirMixin
  * @private
  */
 export class TimePickerItem extends ComboBoxItemMixin(

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -22,12 +22,6 @@ const MAX_ALLOWED_TIME = '23:59:59.999';
 
 /**
  * A mixin providing common time-picker functionality.
- *
- * @polymerMixin
- * @mixes ComboBoxBaseMixin
- * @mixes I18nMixin
- * @mixes InputControlMixin
- * @mixes PatternMixin
  */
 export const TimePickerMixin = (superClass) =>
   class TimePickerMixinClass extends I18nMixin(PatternMixin(ComboBoxBaseMixin(InputControlMixin(superClass)))) {

--- a/packages/time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.js
@@ -18,10 +18,6 @@ import { timePickerOverlayStyles } from './styles/vaadin-time-picker-overlay-bas
  * An element used internally by `<vaadin-time-picker>`. Not intended to be used separately.
  *
  * @extends HTMLElement
- * @mixes ComboBoxOverlayMixin
- * @mixes DirMixin
- * @mixes OverlayMixin
- * @mixes ThemableMixin
  * @private
  */
 export class TimePickerOverlay extends ComboBoxOverlayMixin(

--- a/packages/time-picker/src/vaadin-time-picker-scroller.js
+++ b/packages/time-picker/src/vaadin-time-picker-scroller.js
@@ -14,7 +14,6 @@ import { timePickerScrollerStyles } from './styles/vaadin-time-picker-scroller-b
  *
  * @customElement vaadin-time-picker-scroller
  * @extends HTMLElement
- * @mixes ComboBoxScrollerMixin
  * @private
  */
 export class TimePickerScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -105,9 +105,6 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  *
  * @customElement vaadin-time-picker
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes TimePickerMixin
  */
 class TimePicker extends TimePickerMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -216,10 +216,6 @@ class TooltipStateController {
 
 /**
  * A mixin providing common tooltip functionality.
- *
- * @polymerMixin
- * @mixes PopoverPositionMixin
- * @mixes PopoverTargetMixin
  */
 export const TooltipMixin = (superClass) =>
   class TooltipMixinClass extends PopoverPositionMixin(PopoverTargetMixin(superClass)) {

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -18,9 +18,6 @@ import { tooltipOverlayStyles } from './styles/vaadin-tooltip-overlay-base-style
  *
  * @customElement vaadin-tooltip-overlay
  * @extends HTMLElement
- * @mixes DirMixin
- * @mixes ThemableMixin
- * @mixes PopoverOverlayMixin
  * @private
  */
 class TooltipOverlay extends PopoverOverlayMixin(

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -75,9 +75,6 @@ import { TooltipMixin } from './vaadin-tooltip-mixin.js';
  *
  * @customElement vaadin-tooltip
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemePropertyMixin
- * @mixes TooltipMixin
  */
 class Tooltip extends TooltipMixin(ThemePropertyMixin(ElementMixin(PolylitMixin(LitElement)))) {
   static get is() {

--- a/packages/upload/src/vaadin-upload-button.js
+++ b/packages/upload/src/vaadin-upload-button.js
@@ -72,9 +72,6 @@ import { UploadManager } from './vaadin-upload-manager.js';
  *
  * @customElement vaadin-upload-button
  * @extends HTMLElement
- * @mixes ButtonMixin
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class UploadButton extends ButtonMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -49,8 +49,6 @@ import { UploadManager } from './vaadin-upload-manager.js';
  *
  * @customElement vaadin-upload-drop-zone
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
  */
 class UploadDropZone extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/upload/src/vaadin-upload-file-list-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.js
@@ -42,10 +42,6 @@ const DEFAULT_I18N = {
   },
 };
 
-/**
- * @polymerMixin
- * @mixes I18nMixin
- */
 export const UploadFileListMixin = (superClass) =>
   class UploadFileListMixin extends I18nMixin(superClass) {
     static get properties() {

--- a/packages/upload/src/vaadin-upload-file-list.js
+++ b/packages/upload/src/vaadin-upload-file-list.js
@@ -77,8 +77,6 @@ import { UploadFileListMixin } from './vaadin-upload-file-list-mixin.js';
  *
  * @customElement vaadin-upload-file-list
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes UploadFileListMixin
  */
 class UploadFileList extends UploadFileListMixin(ThemableMixin(PolylitMixin(LitElement))) {
   static get is() {

--- a/packages/upload/src/vaadin-upload-file-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-mixin.js
@@ -6,10 +6,6 @@
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
 
-/**
- * @polymerMixin
- * @mixes FocusMixin
- */
 export const UploadFileMixin = (superClass) =>
   class UploadFileMixin extends FocusMixin(superClass) {
     static get properties() {

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -83,8 +83,6 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
  *
  * @customElement vaadin-upload-file
  * @extends HTMLElement
- * @mixes UploadFileMixin
- * @mixes ThemableMixin
  */
 class UploadFile extends UploadFileMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -105,9 +105,6 @@ class DropLabelController extends SlotController {
   }
 }
 
-/**
- * @polymerMixin
- */
 export const UploadMixin = (superClass) =>
   class UploadMixin extends I18nMixin(superClass) {
     static get properties() {

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -104,9 +104,6 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  *
  * @customElement vaadin-upload
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
- * @mixes UploadMixin
  */
 class Upload extends UploadMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/vaadin-themable-mixin/lumo-injection-mixin.js
+++ b/packages/vaadin-themable-mixin/lumo-injection-mixin.js
@@ -28,8 +28,6 @@ export function findRoot(element) {
 
 /**
  * Mixin for internal use only. Do not use it in custom components.
- *
- * @polymerMixin
  */
 export const LumoInjectionMixin = (superClass) =>
   class LumoInjectionMixinClass extends superClass {

--- a/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-themable-mixin.js
@@ -298,10 +298,6 @@ function getThemes(tagName) {
   return themeRegistry.filter((theme) => theme.moduleId === defaultModuleName);
 }
 
-/**
- * @polymerMixin
- * @mixes ThemePropertyMixin
- */
 export const ThemableMixin = (superClass) =>
   class VaadinThemableMixin extends ThemePropertyMixin(superClass) {
     constructor() {

--- a/packages/vaadin-themable-mixin/vaadin-theme-detection-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-detection-mixin.js
@@ -6,8 +6,6 @@ import { ThemeDetector } from './src/theme-detector.js';
  * Automatically adds a `data-application-theme` attribute to the host
  * element with the name of the detected theme (`lumo` or `aura`), which
  * can be used in component styles to apply theme-specific styling.
- *
- * @polymerMixin
  */
 export const ThemeDetectionMixin = (superClass) =>
   class ThemeDetectionMixinClass extends superClass {

--- a/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
+++ b/packages/vaadin-themable-mixin/vaadin-theme-property-mixin.js
@@ -3,9 +3,6 @@
  * Copyright (c) 2017 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-/**
- * @polymerMixin
- */
 export const ThemePropertyMixin = (superClass) =>
   class VaadinThemePropertyMixin extends superClass {
     static get properties() {

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -46,8 +46,6 @@ import { verticalLayoutStyles } from './styles/vaadin-vertical-layout-base-style
  *
  * @customElement vaadin-vertical-layout
  * @extends HTMLElement
- * @mixes ThemableMixin
- * @mixes ElementMixin
  */
 class VerticalLayout extends ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -7,9 +7,6 @@ import { isChrome, isSafari } from '@vaadin/component-base/src/browser-utils.js'
 import { OverflowController } from '@vaadin/component-base/src/overflow-controller.js';
 import { Virtualizer } from '@vaadin/component-base/src/virtualizer.js';
 
-/**
- * @polymerMixin
- */
 export const VirtualListMixin = (superClass) =>
   class VirtualListMixinClass extends superClass {
     static get properties() {

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -57,9 +57,6 @@ import { VirtualListMixin } from './vaadin-virtual-list-mixin.js';
  *
  * @customElement vaadin-virtual-list
  * @extends HTMLElement
- * @mixes ElementMixin
- * @mixes ThemableMixin
- * @mixes VirtualListMixin
  */
 class VirtualList extends VirtualListMixin(ThemableMixin(ElementMixin(PolylitMixin(LitElement)))) {
   static get is() {


### PR DESCRIPTION
With the migration to Custom Elements Manifest (CEM) complete, the
`@mixes` and `@polymerMixin` JSDoc tags are no longer read by any tool —
CEM captures the mixin chain directly from the class declaration, and
the `mixesPlugin` shim was removed in #11711. Drop the orphaned
annotations from element and mixin source files, along with the
`@param {function(...)} superClass` blocks that only documented the
mixin factory signatures for Polymer Analyzer.

Mechanical change across 287 files. No runtime behavior, no public API,
no `.d.ts` impact. `yarn lint` and `yarn lint:types` pass.

Follow-up to #11710, #11711, #11712

---

🤖 Generated with Claude Code