### PR TITLE
refactor: dispatch internal is-item-selectable-changed manually

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -109,10 +109,10 @@ export const SelectionMixin = (superClass) =>
     }
 
     /** @protected */
-    updated(changedProperties) {
-      super.updated(changedProperties);
+    updated(props) {
+      super.updated(props);
 
-      if (changedProperties.has('isItemSelectable')) {
+      if (props.has('isItemSelectable')) {
         /** @internal to not document it in CEM */
         this.dispatchEvent(new CustomEvent('is-item-selectable-changed'));
       }

--- a/packages/grid/src/vaadin-grid-selection-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-mixin.js
@@ -42,7 +42,6 @@ export const SelectionMixin = (superClass) =>
          */
         isItemSelectable: {
           type: Function,
-          notify: (() => true)(), // prevent Polymer analyzer from documenting a changed event
         },
 
         /**
@@ -106,6 +105,16 @@ export const SelectionMixin = (superClass) =>
     deselectItem(item) {
       if (this._isSelected(item)) {
         this.selectedItems = this.selectedItems.filter((i) => !this._itemsEqual(i, item));
+      }
+    }
+
+    /** @protected */
+    updated(changedProperties) {
+      super.updated(changedProperties);
+
+      if (changedProperties.has('isItemSelectable')) {
+        /** @internal to not document it in CEM */
+        this.dispatchEvent(new CustomEvent('is-item-selectable-changed'));
       }
     }
 


### PR DESCRIPTION
The grid's `isItemSelectable` property used a `notify: (() => true)()`
IIFE so that the auto-generated `is-item-selectable-changed` event would
fire at runtime but stay invisible to Polymer Analyzer (which only saw
the IIFE expression, not its `true` value). With the migration to CEM
the trick is no longer needed — CEM doesn't pick up `notify` at all.

Drop the `notify` hack and dispatch the event explicitly from a property
observer. The dispatch is annotated with `@internal` so CEM omits it
from the manifest. The only consumer (`vaadin-grid-selection-column-mixin`)
doesn't read `event.detail`, so the empty `CustomEvent` is sufficient.

Follow-up to #11539

---

🤖 Generated with Claude Code