### PR TITLE
docs: correct guidelines on @fires for notify: true properties

### DIFF
--- a/guidelines/06-documenting.md
+++ b/guidelines/06-documenting.md
@@ -34,9 +34,10 @@ also reads JSDoc — that's why `@attr` exists, see below.
 | `@type`                   | Getters             | Documents the type of a getter (e.g. an `i18n` accessor).                                        |
 | `@private` / `@protected` | Class JSDoc         | Marks the whole element as internal — excluded from `custom-elements.json` and `web-types.json`. |
 
-`notify: true` on a property declaration auto-generates the matching
-`{property}-changed` event in CEM's output — no `@fires` is needed for
-those. See [Events](09-events.md).
+Every event a public component dispatches — including the
+`{property}-changed` events emitted by `notify: true` properties — needs
+its own `@fires` line on the class JSDoc. CEM does not infer events from
+`notify: true`. See [Events](09-events.md).
 
 ## Component class JSDoc
 

--- a/guidelines/09-events.md
+++ b/guidelines/09-events.md
@@ -25,8 +25,9 @@ Use `notify: true` only for properties the **component itself** mutates and
 that consumers might want to two-way-bind to. Do not fire change events for
 properties that only change in response to user code setting them.
 
-`notify: true` events are picked up by CEM automatically, so no `@fires`
-JSDoc is needed for them.
+CEM does not infer the auto-generated `{property}-changed` event from
+`notify: true` — add a matching `@fires` line on the class JSDoc so the
+event lands in `custom-elements.json` and the React wrappers.
 
 ## Field events
 
@@ -63,6 +64,7 @@ root boundaries, which can be problematic for low-level interaction events.
 
 ## Documenting events
 
-Events that aren't driven by `notify: true` need a `@fires {Event} name -
-…` line on the class JSDoc so CEM picks them up. See
-[Documenting](06-documenting.md) for the full set of JSDoc tags.
+Every event the component dispatches — `notify: true` change events
+included — needs a `@fires {Event} name - …` line on the class JSDoc so
+CEM picks it up. See [Documenting](06-documenting.md) for the full set
+of JSDoc tags.

--- a/guidelines/13-checklist.md
+++ b/guidelines/13-checklist.md
@@ -77,8 +77,8 @@ Author tests following the conventions in [Testing](12-testing.md).
 
 - [ ] Class JSDoc covers the styling tables (parts, state attributes,
       custom CSS properties).
-- [ ] Class JSDoc has `@customElement`, `@extends HTMLElement`, `@fires`.
-- [ ] Non-`notify` events have `@fires` lines on the class JSDoc.
+- [ ] Class JSDoc has `@customElement` and `@extends HTMLElement`.
+- [ ] Every public dispatched event has a `@fires` line on the class JSDoc.
 - [ ] `README.md` follows the same shape as a sibling package.
 
 ## Final validation


### PR DESCRIPTION
The guidelines claimed CEM auto-generates the matching `{property}-changed`
event from `notify: true` and therefore no `@fires` JSDoc is needed. Both
parts are wrong — CEM has no awareness of Polymer's `notify: true` and
reads events exclusively from `@fires` lines.

Verified empirically by removing the `@fires {CustomEvent} checked-changed`
line from `vaadin-checkbox.js` (the property is still `notify: true`) and
re-running `yarn release:cem` — the event disappeared from the generated
`custom-elements.json`. That's why every public component already lists a
`@fires` line for each notify property.

Update three guidelines that propagated the misconception:
- `guidelines/06-documenting.md` — replace the wrong note under the JSDoc
  tag table.
- `guidelines/09-events.md` — fix two paragraphs (the `notify: true`
  section and "Documenting events").
- `guidelines/13-checklist.md` — drop the misleading "Non-`notify`
  events" wording from the new-component checklist.

---

🤖 Generated with Claude Code