### PR TITLE
chore: bump ol from 10.6.0 to 10.6.1

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -39,7 +39,7 @@
     "@vaadin/component-base": "25.2.0-alpha10",
     "@vaadin/vaadin-themable-mixin": "25.2.0-alpha10",
     "lit": "^3.0.0",
-    "ol": "10.6.2"
+    "ol": "10.6.1"
   },
   "devDependencies": {
     "@vaadin/aura": "25.2.0-alpha10",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -39,7 +39,7 @@
     "@vaadin/component-base": "25.2.0-alpha10",
     "@vaadin/vaadin-themable-mixin": "25.2.0-alpha10",
     "lit": "^3.0.0",
-    "ol": "10.6.0"
+    "ol": "10.6.2"
   },
   "devDependencies": {
     "@vaadin/aura": "25.2.0-alpha10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7893,10 +7893,10 @@ object.values@^1.1.6, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-ol@10.6.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/ol/-/ol-10.6.0.tgz#cb703b951af0eeed316b2a361d3c7c04f89bf296"
-  integrity sha512-rNnSROaU1du+hFFvA+3AC6Y9NrJpsCJw65r0YtZaoyfKmpPkF7CZZhLLxrC4J3MRWKKEMT0JQkZ0wfc1+hiXjg==
+ol@10.6.1:
+  version "10.6.1"
+  resolved "https://registry.yarnpkg.com/ol/-/ol-10.6.1.tgz#950f3914b4eec978f087b36aa74ce1e18c41ab09"
+  integrity sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==
   dependencies:
     "@types/rbush" "4.0.0"
     earcut "^3.0.0"


### PR DESCRIPTION
Bumps `ol` dependency in `@vaadin/map` from 10.6.0 to 10.6.1

🤖 Generated with Claude Code