### PR TITLE
refactor: don't animate detail opacity in overlay mode

### DIFF
--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -134,9 +134,11 @@ CSS drives the resting states: `#detail` is translated off-screen and transparen
 
 ### Transition types
 
-- **Add**: update DOM first, then fade + slide detail in from off-screen
-- **Remove**: fade + slide detail out first, then update DOM
+- **Add**: update DOM first, then animate detail in from off-screen
+- **Remove**: animate detail out first, then update DOM
 - **Replace**: move old content to `slot="detail-outgoing"`, update DOM, then animate new in + old out simultaneously. Split-mode replace runs at 0ms (instant swap).
+
+Split mode animates detail with `slide` + `fade`. Overlay mode animates detail with `slide` only and runs the backdrop's `fade` in parallel — fading the detail would let the backdrop bleed through the panel.
 
 The `noAnimation` property (reflected as `no-animation` attribute) skips all animations.
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -611,12 +611,16 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   async __addTransition(updateSlot) {
     await updateSlot();
 
-    const isOverlay = this.hasAttribute('overlay');
     const progress = getCurrentAnimationProgress(this.$.detail);
-    await Promise.all([
-      animateIn(this.$.detail, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
-      animateIn(this.$.backdrop, ['fade'], isOverlay ? progress : 1),
-    ]);
+
+    if (this.hasAttribute('overlay')) {
+      await Promise.all([
+        animateIn(this.$.detail, ['slide'], progress),
+        animateIn(this.$.backdrop, ['fade'], progress),
+      ]);
+    } else {
+      await animateIn(this.$.detail, ['slide', 'fade'], progress);
+    }
   }
 
   /** @private */
@@ -633,9 +637,10 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
       const isOverlay = this.hasAttribute('overlay');
       const progress = getCurrentAnimationProgress(this.$.detail);
+
       await Promise.all([
-        animateIn(this.$.detail, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
-        animateOut(this.$.detailOutgoing, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
+        animateIn(this.$.detail, isOverlay ? ['slide'] : ['slide', 'fade'], progress),
+        animateOut(this.$.detailOutgoing, isOverlay ? ['slide'] : ['slide', 'fade'], progress),
       ]);
     } finally {
       // Skip removal if the slot was reassigned during the transition.
@@ -648,12 +653,16 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
   /** @private */
   async __removeTransition(updateSlot) {
-    const isOverlay = this.hasAttribute('overlay');
     const progress = getCurrentAnimationProgress(this.$.detail);
-    await Promise.all([
-      animateOut(this.$.detail, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
-      animateOut(this.$.backdrop, ['fade'], isOverlay ? progress : 1),
-    ]);
+
+    if (this.hasAttribute('overlay')) {
+      await Promise.all([
+        animateOut(this.$.detail, ['slide'], progress),
+        animateOut(this.$.backdrop, ['fade'], progress),
+      ]);
+    } else {
+      await animateOut(this.$.detail, ['slide', 'fade'], progress);
+    }
 
     await updateSlot();
   }

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -613,7 +613,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
     const progress = getCurrentAnimationProgress(this.$.detail);
     await Promise.all([
-      animateIn(this.$.detail, ['fade', 'slide'], progress),
+      animateIn(this.$.detail, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
       animateIn(this.$.backdrop, ['fade'], this.hasAttribute('overlay') ? progress : 1),
     ]);
   }
@@ -632,8 +632,8 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
       const progress = getCurrentAnimationProgress(this.$.detail);
       await Promise.all([
-        animateIn(this.$.detail, ['fade', 'slide'], progress),
-        animateOut(this.$.detailOutgoing, ['fade', 'slide'], progress),
+        animateIn(this.$.detail, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
+        animateOut(this.$.detailOutgoing, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
       ]);
     } finally {
       // Skip removal if the slot was reassigned during the transition.
@@ -648,7 +648,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   async __removeTransition(updateSlot) {
     const progress = getCurrentAnimationProgress(this.$.detail);
     await Promise.all([
-      animateOut(this.$.detail, ['fade', 'slide'], progress),
+      animateOut(this.$.detail, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
       animateOut(this.$.backdrop, ['fade'], this.hasAttribute('overlay') ? progress : 1),
     ]);
 

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -611,10 +611,11 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   async __addTransition(updateSlot) {
     await updateSlot();
 
+    const isOverlay = this.hasAttribute('overlay');
     const progress = getCurrentAnimationProgress(this.$.detail);
     await Promise.all([
-      animateIn(this.$.detail, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
-      animateIn(this.$.backdrop, ['fade'], this.hasAttribute('overlay') ? progress : 1),
+      animateIn(this.$.detail, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
+      animateIn(this.$.backdrop, ['fade'], isOverlay ? progress : 1),
     ]);
   }
 
@@ -630,10 +631,11 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
       await updateSlot();
 
+      const isOverlay = this.hasAttribute('overlay');
       const progress = getCurrentAnimationProgress(this.$.detail);
       await Promise.all([
-        animateIn(this.$.detail, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
-        animateOut(this.$.detailOutgoing, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
+        animateIn(this.$.detail, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
+        animateOut(this.$.detailOutgoing, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
       ]);
     } finally {
       // Skip removal if the slot was reassigned during the transition.
@@ -646,10 +648,11 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
   /** @private */
   async __removeTransition(updateSlot) {
+    const isOverlay = this.hasAttribute('overlay');
     const progress = getCurrentAnimationProgress(this.$.detail);
     await Promise.all([
-      animateOut(this.$.detail, this.hasAttribute('overlay') ? ['slide'] : ['fade', 'slide'], progress),
-      animateOut(this.$.backdrop, ['fade'], this.hasAttribute('overlay') ? progress : 1),
+      animateOut(this.$.detail, isOverlay ? ['slide'] : ['fade', 'slide'], progress),
+      animateOut(this.$.backdrop, ['fade'], isOverlay ? progress : 1),
     ]);
 
     await updateSlot();


### PR DESCRIPTION
Don't animate detail opacity when MDL is in overlay mode. This makes the animation similar to app-layout drawer.