### PR TITLE
fix: hide detail placeholder from screen readers and keyboard

### DIFF
--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -102,19 +102,7 @@ The attribute keeps this inflation active when detail first appears with overlay
 | `detail-placeholder` | `has-detail-placeholder` | Shown when no detail and not in overlay                      |
 | `detail-outgoing`    | (internal)               | Used during replace transitions, hosted on `#detailOutgoing` |
 
-Detail placeholder uses `visibility` (not `display`) so it always participates in grid sizing but is fully removed from interaction when hidden:
-
-```css
-#detailPlaceholder {
-  visibility: hidden;
-}
-
-:host([has-detail-placeholder]:not([has-detail], [overlay])) #detailPlaceholder {
-  visibility: visible;
-}
-```
-
-`visibility: hidden` covers all three concerns at once: hidden from the accessibility tree, removed from tab order, and ignores pointer events. The placeholder is included in overflow detection — without it, a layout with only a placeholder would never check for overflow and `keep-detail-column-offscreen` wouldn't apply.
+Detail placeholder uses `visibility` (not `display`) so it always participates in grid sizing but is fully removed from interaction: hidden from the accessibility tree, removed from tab order, and ignores pointer events. The placeholder is included in overflow detection — without it, a layout with only a placeholder would never check for overflow and `keep-detail-column-offscreen` wouldn't apply.
 
 `#detailOutgoing` is a shadow DOM wrapper with `<slot name="detail-outgoing">`. During replace, the outgoing detail element's slot is reassigned from `detail` to `detail-outgoing` (light DOM reassignment preserves user styles). Its width is frozen to the cached detail size so it retains the previous dimensions even when the new detail has a different intrinsic size. It's removed on completion.
 

--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -102,21 +102,19 @@ The attribute keeps this inflation active when detail first appears with overlay
 | `detail-placeholder` | `has-detail-placeholder` | Shown when no detail and not in overlay                      |
 | `detail-outgoing`    | (internal)               | Used during replace transitions, hosted on `#detailOutgoing` |
 
-Detail placeholder uses `opacity` + `pointer-events` (not `display`) so it always participates in grid sizing but can't intercept clicks when hidden:
+Detail placeholder uses `visibility` (not `display`) so it always participates in grid sizing but is fully removed from interaction when hidden:
 
 ```css
 #detailPlaceholder {
-  opacity: 0;
-  pointer-events: none;
+  visibility: hidden;
 }
 
 :host([has-detail-placeholder]:not([has-detail], [overlay])) #detailPlaceholder {
-  opacity: 1;
-  pointer-events: auto;
+  visibility: visible;
 }
 ```
 
-The placeholder is included in overflow detection. Without it, a layout with only a placeholder would never check for overflow and `keep-detail-column-offscreen` wouldn't apply.
+`visibility: hidden` covers all three concerns at once: hidden from the accessibility tree, removed from tab order, and ignores pointer events. The placeholder is included in overflow detection — without it, a layout with only a placeholder would never check for overflow and `keep-detail-column-offscreen` wouldn't apply.
 
 `#detailOutgoing` is a shadow DOM wrapper with `<slot name="detail-outgoing">`. During replace, the outgoing detail element's slot is reassigned from `detail` to `detail-outgoing` (light DOM reassignment preserves user styles). Its width is frozen to the cached detail size so it retains the previous dimensions even when the new detail has a different intrinsic size. It's removed on completion.
 

--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -102,7 +102,7 @@ The attribute keeps this inflation active when detail first appears with overlay
 | `detail-placeholder` | `has-detail-placeholder` | Shown when no detail and not in overlay                      |
 | `detail-outgoing`    | (internal)               | Used during replace transitions, hosted on `#detailOutgoing` |
 
-Detail placeholder uses `visibility` (not `display`) so it always participates in grid sizing but is fully removed from interaction: hidden from the accessibility tree, removed from tab order, and ignores pointer events. The placeholder is included in overflow detection — without it, a layout with only a placeholder would never check for overflow and `keep-detail-column-offscreen` wouldn't apply.
+`#detailPlaceholder` uses `visibility` (not `display`) so it always participates in grid sizing but is fully removed from interaction: hidden from the accessibility tree, removed from tab order, and ignores pointer events. The placeholder is included in overflow detection — without it, a layout with only a placeholder would never check for overflow and `keep-detail-column-offscreen` wouldn't apply.
 
 `#detailOutgoing` is a shadow DOM wrapper with `<slot name="detail-outgoing">`. During replace, the outgoing detail element's slot is reassigned from `detail` to `detail-outgoing` (light DOM reassignment preserves user styles). Its width is frozen to the cached detail size so it retains the previous dimensions even when the new detail has a different intrinsic size. It's removed on completion.
 

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -183,13 +183,11 @@ export const masterDetailLayoutStyles = css`
 
   #detailPlaceholder {
     z-index: 1;
-    opacity: 0;
-    pointer-events: none;
+    visibility: hidden;
   }
 
   :host([has-detail-placeholder]:not([has-detail], [overlay])) #detailPlaceholder {
-    opacity: 1;
-    pointer-events: auto;
+    visibility: visible;
   }
 
   :is(#detail, #detailPlaceholder, #detailOutgoing) {

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -72,25 +72,13 @@ describe('ARIA', () => {
       await onceResized(layout);
     });
 
-    it('should hide placeholder when detail is present in split mode', () => {
+    it('should toggle detail placeholder visibility based on detail presence', async () => {
       expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('hidden');
-    });
 
-    it('should show placeholder when detail is removed in split mode', async () => {
       layout.querySelector('[slot="detail"]').remove();
       await onceResized(layout);
+
       expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('visible');
-    });
-
-    it('should hide placeholder in overlay mode regardless of detail presence', async () => {
-      layout.style.width = '400px';
-      await onceResized(layout);
-      expect(layout.hasAttribute('overlay')).to.be.true;
-      expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('hidden');
-
-      layout.querySelector('[slot="detail"]').remove();
-      await onceResized(layout);
-      expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('hidden');
     });
   });
 });

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -60,4 +60,37 @@ describe('ARIA', () => {
     await onceResized(layout);
     expect(master.hasAttribute('inert')).to.be.false;
   });
+
+  describe('detail placeholder visibility', () => {
+    let placeholder;
+
+    beforeEach(async () => {
+      layout.style.width = '800px';
+      placeholder = document.createElement('div');
+      placeholder.setAttribute('slot', 'detail-placeholder');
+      layout.appendChild(placeholder);
+      await onceResized(layout);
+    });
+
+    it('should hide placeholder when detail is present in split mode', () => {
+      expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('hidden');
+    });
+
+    it('should show placeholder when detail is removed in split mode', async () => {
+      layout.querySelector('[slot="detail"]').remove();
+      await onceResized(layout);
+      expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('visible');
+    });
+
+    it('should hide placeholder in overlay mode regardless of detail presence', async () => {
+      layout.style.width = '400px';
+      await onceResized(layout);
+      expect(layout.hasAttribute('overlay')).to.be.true;
+      expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('hidden');
+
+      layout.querySelector('[slot="detail"]').remove();
+      await onceResized(layout);
+      expect(getComputedStyle(layout.$.detailPlaceholder).visibility).to.equal('hidden');
+    });
+  });
 });

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -61,7 +61,7 @@ describe('ARIA', () => {
     expect(master.hasAttribute('inert')).to.be.false;
   });
 
-  describe('detail placeholder visibility', () => {
+  describe('detail placeholder', () => {
     let placeholder;
 
     beforeEach(async () => {


### PR DESCRIPTION
The detail placeholder content was hidden visually with `opacity: 0` + `pointer-events: none`, but remained in the accessibility tree and the keyboard tab order. Screen reader users encountered the placeholder text even when the actual detail content was visible, and keyboard users could tab into focusable elements inside it.

Replacing `opacity` + `pointer-events` with `visibility: hidden` covers all three concerns at once — hidden from the accessibility tree, removed from tab order, and ignores pointer events. The placeholder still participates in grid layout (unlike `display: none`), which is required for `min-content` sizing and the overflow detection that drives `keep-detail-column-offscreen`.

Transitions are unaffected: the placeholder has no CSS transition declared, and detail animations target `#detail` (not `#detailPlaceholder`).

Fixes #11720

---

🤖 Generated with Claude Code