### PR TITLE
fix: round notification transform to nearest pixel

### DIFF
--- a/packages/notification/src/styles/vaadin-notification-container-base-styles.js
+++ b/packages/notification/src/styles/vaadin-notification-container-base-styles.js
@@ -104,7 +104,7 @@ export const notificationContainerStyles = css`
 
   [region-group] > [region$='center'] {
     left: 50%;
-    translate: -50%;
+    translate: round(-50%, 1px);
   }
 
   [region-group] > [region$='end'] {


### PR DESCRIPTION
Forgot to address the horizontal transform for the top/bottom centered position in #11257