### PR TITLE
docs: add side-nav base styles custom CSS properties to JSDoc

### DIFF
--- a/packages/side-nav/src/vaadin-side-nav-item.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav-item.d.ts
@@ -74,6 +74,21 @@ export type SideNavItemEventMap = HTMLElementEventMap & SideNavItemCustomEventMa
  * `has-children` | Set when the element has child items.
  * `has-tooltip`  | Set when the element has a slotted tooltip.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                       |
+ * :-----------------------------------------|
+ * | `--vaadin-side-nav-item-background`     |
+ * | `--vaadin-side-nav-item-border-color`   |
+ * | `--vaadin-side-nav-item-border-radius`  |
+ * | `--vaadin-side-nav-item-border-width`   |
+ * | `--vaadin-side-nav-item-font-size`      |
+ * | `--vaadin-side-nav-item-font-weight`    |
+ * | `--vaadin-side-nav-item-gap`            |
+ * | `--vaadin-side-nav-item-line-height`    |
+ * | `--vaadin-side-nav-item-padding`        |
+ * | `--vaadin-side-nav-item-text-color`     |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -72,7 +72,6 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * `has-children` | Set when the element has child items.
  * `has-tooltip`  | Set when the element has a slotted tooltip.
  *
- *
  * The following custom CSS properties are available for styling:
  *
  * Custom CSS property                       |

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -72,6 +72,22 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * `has-children` | Set when the element has child items.
  * `has-tooltip`  | Set when the element has a slotted tooltip.
  *
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                       |
+ * :-----------------------------------------|
+ * | `--vaadin-side-nav-item-background`     |
+ * | `--vaadin-side-nav-item-border-color`   |
+ * | `--vaadin-side-nav-item-border-radius`  |
+ * | `--vaadin-side-nav-item-border-width`   |
+ * | `--vaadin-side-nav-item-font-size`      |
+ * | `--vaadin-side-nav-item-font-weight`    |
+ * | `--vaadin-side-nav-item-gap`            |
+ * | `--vaadin-side-nav-item-line-height`    |
+ * | `--vaadin-side-nav-item-padding`        |
+ * | `--vaadin-side-nav-item-text-color`     |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -78,6 +78,16 @@ export type NavigateEvent = {
  * `focus-ring` | Set when the label is focused using the keyboard.
  * `focused`    | Set when the label is focused.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                       |
+ * :-----------------------------------------|
+ * | `--vaadin-side-nav-child-indent`        |
+ * | `--vaadin-side-nav-label-color`         |
+ * | `--vaadin-side-nav-label-font-size`     |
+ * | `--vaadin-side-nav-label-font-weight`   |
+ * | `--vaadin-side-nav-label-line-height`   |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.

--- a/packages/side-nav/src/vaadin-side-nav.d.ts
+++ b/packages/side-nav/src/vaadin-side-nav.d.ts
@@ -83,6 +83,7 @@ export type NavigateEvent = {
  * Custom CSS property                       |
  * :-----------------------------------------|
  * | `--vaadin-side-nav-child-indent`        |
+ * | `--vaadin-side-nav-items-gap`           |
  * | `--vaadin-side-nav-label-color`         |
  * | `--vaadin-side-nav-label-font-size`     |
  * | `--vaadin-side-nav-label-font-weight`   |

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -68,6 +68,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * Custom CSS property                       |
  * :-----------------------------------------|
  * | `--vaadin-side-nav-child-indent`        |
+ * | `--vaadin-side-nav-items-gap`           |
  * | `--vaadin-side-nav-label-color`         |
  * | `--vaadin-side-nav-label-font-size`     |
  * | `--vaadin-side-nav-label-font-weight`   |

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -63,6 +63,16 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  * `focus-ring` | Set when the label is focused using the keyboard.
  * `focused`    | Set when the label is focused.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                       |
+ * :-----------------------------------------|
+ * | `--vaadin-side-nav-child-indent`        |
+ * | `--vaadin-side-nav-label-color`         |
+ * | `--vaadin-side-nav-label-font-size`     |
+ * | `--vaadin-side-nav-label-font-weight`   |
+ * | `--vaadin-side-nav-label-line-height`   |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.


### PR DESCRIPTION
## Description

Part of #9617

Added tables of custom CSS properties to `vaadin-side-nav` and `vaadin-side-nav-item`.
Note: side-nav reuses some item CSS properties for the label, I didn't duplicate those.

## Type of change

- Documentation