### PR TITLE
docs: add field components base styles custom CSS properties to JSDoc

### DIFF
--- a/packages/email-field/src/vaadin-email-field.d.ts
+++ b/packages/email-field/src/vaadin-email-field.d.ts
@@ -78,6 +78,45 @@ export interface EmailFieldEventMap extends HTMLElementEventMap, EmailFieldCusto
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -46,6 +46,45 @@ import { emailFieldStyles } from './styles/vaadin-email-field-base-styles.js';
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.

--- a/packages/integer-field/src/vaadin-integer-field.d.ts
+++ b/packages/integer-field/src/vaadin-integer-field.d.ts
@@ -85,6 +85,45 @@ export interface IntegerFieldEventMap extends HTMLElementEventMap, IntegerFieldC
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Change events

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -45,6 +45,45 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
  * `focus-ring`         | Set when the element is keyboard focused
  * `readonly`           | Set when the element is readonly
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Change events

--- a/packages/number-field/src/vaadin-number-field.d.ts
+++ b/packages/number-field/src/vaadin-number-field.d.ts
@@ -89,6 +89,45 @@ export interface NumberFieldEventMap extends HTMLElementEventMap, NumberFieldCus
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Change events

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -56,6 +56,45 @@ import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * ### Change events

--- a/packages/password-field/src/vaadin-password-field.d.ts
+++ b/packages/password-field/src/vaadin-password-field.d.ts
@@ -81,6 +81,45 @@ export interface PasswordFieldEventMap extends HTMLElementEventMap, PasswordFiel
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -51,6 +51,45 @@ import { PasswordFieldMixin } from './vaadin-password-field-mixin.js';
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
  *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
+ *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.

--- a/packages/text-area/src/vaadin-text-area.d.ts
+++ b/packages/text-area/src/vaadin-text-area.d.ts
@@ -64,12 +64,6 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                | Description                | Default
- * -------------------------------|----------------------------|---------
- * `--vaadin-field-default-width` | Default width of the field | `12em`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -99,6 +93,45 @@ export interface TextAreaEventMap extends HTMLElementEventMap, TextAreaCustomEve
  * `readonly`           | Set when the element is readonly
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -39,12 +39,6 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                | Description                | Default
- * -------------------------------|----------------------------|---------
- * `--vaadin-field-default-width` | Default width of the field | `12em`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -74,6 +68,45 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  * `readonly`           | Set when the element is readonly
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-field/src/vaadin-text-field.d.ts
+++ b/packages/text-field/src/vaadin-text-field.d.ts
@@ -64,12 +64,6 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                | Description                | Default
- * -------------------------------|----------------------------|---------
- * `--vaadin-field-default-width` | Default width of the field | `12em`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -99,6 +93,45 @@ export interface TextFieldEventMap extends HTMLElementEventMap, TextFieldCustomE
  * `readonly`           | Set when the element is readonly
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -38,12 +38,6 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  *
  * ### Styling
  *
- * The following custom properties are available for styling:
- *
- * Custom property                | Description                | Default
- * -------------------------------|----------------------------|---------
- * `--vaadin-field-default-width` | Default width of the field | `12em`
- *
  * The following shadow DOM parts are available for styling:
  *
  * Part name            | Description
@@ -73,6 +67,45 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  * `readonly`           | Set when the element is readonly
  *
  * Note, the `input-prevented` state attribute is only supported when `allowedCharPattern` is set.
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-field-default-width`                   |
+ * | `--vaadin-input-field-background`                |
+ * | `--vaadin-input-field-border-color`              |
+ * | `--vaadin-input-field-border-radius`             |
+ * | `--vaadin-input-field-border-width`              |
+ * | `--vaadin-input-field-bottom-end-radius`         |
+ * | `--vaadin-input-field-bottom-start-radius`       |
+ * | `--vaadin-input-field-button-text-color`         |
+ * | `--vaadin-input-field-container-gap`             |
+ * | `--vaadin-input-field-disabled-background`       |
+ * | `--vaadin-input-field-disabled-text-color`       |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-gap`                       |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-label-color`               |
+ * | `--vaadin-input-field-label-font-size`           |
+ * | `--vaadin-input-field-label-font-weight`         |
+ * | `--vaadin-input-field-label-line-height`         |
+ * | `--vaadin-input-field-padding`                   |
+ * | `--vaadin-input-field-placeholder-color`         |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
+ * | `--vaadin-input-field-top-end-radius`            |
+ * | `--vaadin-input-field-top-start-radius`          |
+ * | `--vaadin-input-field-value-color`               |
+ * | `--vaadin-input-field-value-font-size`           |
+ * | `--vaadin-input-field-value-font-weight`         |
+ * | `--vaadin-input-field-value-line-height`         |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
## Description

Added custom CSS properties tables to JSDoc for the following components:

- `vaadin-email-field`
- `vaadin-integer-field`
- `vaadin-number-field`
- `vaadin-password-field`
- `vaadin-text-area`
- `vaadin-text-field`

## Type of change

- Documentation