### PR TITLE
feat(breadcrumbs-item): add DisabledMixin and FocusMixin

### DIFF
--- a/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
+++ b/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
@@ -16,6 +16,14 @@ export const breadcrumbsItemStyles = css`
     display: none !important;
   }
 
+  :host([disabled]) {
+    pointer-events: none;
+  }
+
+  [part='link']:focus-visible {
+    outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+  }
+
   :host::after {
     content: '';
     display: inline-block;

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.d.ts
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.d.ts
@@ -3,6 +3,8 @@
  * Copyright (c) 2026 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 
 /**
@@ -23,11 +25,14 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
  * Attribute    | Description
  * -------------|-------------
  * `current`    | Set by the parent `<vaadin-breadcrumbs>` on the last item when it has no `path`.
+ * `disabled`   | Set when the item is disabled.
+ * `focus-ring` | Set when the item is focused by the keyboard.
+ * `focused`    | Set when the item is focused.
  * `has-prefix` | Set when the item has content in the prefix slot
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
-declare class BreadcrumbsItem extends ElementMixin(HTMLElement) {
+declare class BreadcrumbsItem extends FocusMixin(DisabledMixin(ElementMixin(HTMLElement))) {
   /**
    * The path to navigate to. When set, the item renders as a link
    * (`<a part="link">`); when unset, it renders as a non-link

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -4,6 +4,8 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement, nothing } from 'lit';
+import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -64,6 +66,9 @@ class PrefixSlotController extends SlotController {
  * Attribute    | Description
  * -------------|-------------
  * `current`    | Set by the parent `<vaadin-breadcrumbs>` on the last item when it has no `path`.
+ * `disabled`   | Set when the item is disabled.
+ * `focus-ring` | Set when the item is focused by the keyboard.
+ * `focused`    | Set when the item is focused.
  * `has-prefix` | Set when the item has content in the prefix slot
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
@@ -71,9 +76,13 @@ class PrefixSlotController extends SlotController {
  * @customElement vaadin-breadcrumbs-item
  * @extends HTMLElement
  */
-class BreadcrumbsItem extends ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
+class BreadcrumbsItem extends FocusMixin(DisabledMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-breadcrumbs-item';
+  }
+
+  static get shadowRootOptions() {
+    return { ...LitElement.shadowRootOptions, delegatesFocus: true };
   }
 
   static get properties() {

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
@@ -140,7 +141,11 @@ class BreadcrumbsItem extends FocusMixin(DisabledMixin(ElementMixin(PolylitMixin
             </span>
           `
         : html`
-            <a href="${this.path}" part="link">
+            <a
+              href="${ifDefined(this.disabled ? null : this.path)}"
+              tabindex="${this.disabled ? '-1' : '0'}"
+              part="link"
+            >
               <slot name="prefix"></slot>
               <span part="label">
                 <slot></slot>

--- a/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
+++ b/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
@@ -88,3 +88,13 @@ snapshots["vaadin-breadcrumbs-item shadow current path"] =
 `;
 /* end snapshot vaadin-breadcrumbs-item shadow current path */
 
+snapshots["vaadin-breadcrumbs-item host disabled"] = 
+`<vaadin-breadcrumbs-item
+  aria-disabled="true"
+  disabled=""
+  role="listitem"
+>
+</vaadin-breadcrumbs-item>
+`;
+/* end snapshot vaadin-breadcrumbs-item host disabled */
+

--- a/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
+++ b/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
@@ -31,6 +31,35 @@ snapshots["vaadin-breadcrumbs-item host prefix path"] =
 `;
 /* end snapshot vaadin-breadcrumbs-item host prefix path */
 
+snapshots["vaadin-breadcrumbs-item host disabled"] = 
+`<vaadin-breadcrumbs-item
+  aria-disabled="true"
+  disabled=""
+  role="listitem"
+>
+</vaadin-breadcrumbs-item>
+`;
+/* end snapshot vaadin-breadcrumbs-item host disabled */
+
+snapshots["vaadin-breadcrumbs-item host focused"] = 
+`<vaadin-breadcrumbs-item
+  focused=""
+  role="listitem"
+>
+</vaadin-breadcrumbs-item>
+`;
+/* end snapshot vaadin-breadcrumbs-item host focused */
+
+snapshots["vaadin-breadcrumbs-item host focus-ring"] = 
+`<vaadin-breadcrumbs-item
+  focus-ring=""
+  focused=""
+  role="listitem"
+>
+</vaadin-breadcrumbs-item>
+`;
+/* end snapshot vaadin-breadcrumbs-item host focus-ring */
+
 snapshots["vaadin-breadcrumbs-item shadow default"] = 
 `<span part="nolink">
   <slot name="prefix">
@@ -90,16 +119,6 @@ snapshots["vaadin-breadcrumbs-item shadow current path"] =
 `;
 /* end snapshot vaadin-breadcrumbs-item shadow current path */
 
-snapshots["vaadin-breadcrumbs-item host disabled"] = 
-`<vaadin-breadcrumbs-item
-  aria-disabled="true"
-  disabled=""
-  role="listitem"
->
-</vaadin-breadcrumbs-item>
-`;
-/* end snapshot vaadin-breadcrumbs-item host disabled */
-
 snapshots["vaadin-breadcrumbs-item shadow disabled path"] = 
 `<a
   part="link"
@@ -114,23 +133,4 @@ snapshots["vaadin-breadcrumbs-item shadow disabled path"] =
 </a>
 `;
 /* end snapshot vaadin-breadcrumbs-item shadow disabled path */
-
-snapshots["vaadin-breadcrumbs-item host focused"] = 
-`<vaadin-breadcrumbs-item
-  focused=""
-  role="listitem"
->
-</vaadin-breadcrumbs-item>
-`;
-/* end snapshot vaadin-breadcrumbs-item host focused */
-
-snapshots["vaadin-breadcrumbs-item host focus-ring"] = 
-`<vaadin-breadcrumbs-item
-  focus-ring=""
-  focused=""
-  role="listitem"
->
-</vaadin-breadcrumbs-item>
-`;
-/* end snapshot vaadin-breadcrumbs-item host focus-ring */
 

--- a/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
+++ b/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
@@ -115,3 +115,22 @@ snapshots["vaadin-breadcrumbs-item shadow disabled path"] =
 `;
 /* end snapshot vaadin-breadcrumbs-item shadow disabled path */
 
+snapshots["vaadin-breadcrumbs-item host focused"] = 
+`<vaadin-breadcrumbs-item
+  focused=""
+  role="listitem"
+>
+</vaadin-breadcrumbs-item>
+`;
+/* end snapshot vaadin-breadcrumbs-item host focused */
+
+snapshots["vaadin-breadcrumbs-item host focus-ring"] = 
+`<vaadin-breadcrumbs-item
+  focus-ring=""
+  focused=""
+  role="listitem"
+>
+</vaadin-breadcrumbs-item>
+`;
+/* end snapshot vaadin-breadcrumbs-item host focus-ring */
+

--- a/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
+++ b/packages/breadcrumbs/test/dom/__snapshots__/breadcrumbs-item.test.snap.js
@@ -47,6 +47,7 @@ snapshots["vaadin-breadcrumbs-item shadow path"] =
 `<a
   href="/foo"
   part="link"
+  tabindex="0"
 >
   <slot name="prefix">
   </slot>
@@ -77,6 +78,7 @@ snapshots["vaadin-breadcrumbs-item shadow current path"] =
 `<a
   href="/foo"
   part="link"
+  tabindex="0"
 >
   <slot name="prefix">
   </slot>
@@ -97,4 +99,19 @@ snapshots["vaadin-breadcrumbs-item host disabled"] =
 </vaadin-breadcrumbs-item>
 `;
 /* end snapshot vaadin-breadcrumbs-item host disabled */
+
+snapshots["vaadin-breadcrumbs-item shadow disabled path"] = 
+`<a
+  part="link"
+  tabindex="-1"
+>
+  <slot name="prefix">
+  </slot>
+  <span part="label">
+    <slot>
+    </slot>
+  </span>
+</a>
+`;
+/* end snapshot vaadin-breadcrumbs-item shadow disabled path */
 

--- a/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
@@ -68,5 +68,12 @@ describe('vaadin-breadcrumbs-item', () => {
       await nextUpdate(item);
       await expect(item).shadowDom.to.equalSnapshot();
     });
+
+    it('disabled path', async () => {
+      item.path = '/foo';
+      item.disabled = true;
+      await nextUpdate(item);
+      await expect(item).shadowDom.to.equalSnapshot();
+    });
   });
 });

--- a/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../../src/vaadin-breadcrumbs-item.js';
 
@@ -41,6 +42,20 @@ describe('vaadin-breadcrumbs-item', () => {
     it('disabled', async () => {
       item.disabled = true;
       await nextUpdate(item);
+      await expect(item).dom.to.equalSnapshot();
+    });
+
+    it('focused', async () => {
+      item.path = '/foo';
+      await nextUpdate(item);
+      item.focus({ focusVisible: false });
+      await expect(item).dom.to.equalSnapshot();
+    });
+
+    it('focus-ring', async () => {
+      item.path = '/foo';
+      await nextUpdate(item);
+      await sendKeys({ press: 'Tab' });
       await expect(item).dom.to.equalSnapshot();
     });
   });

--- a/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/dom/breadcrumbs-item.test.js
@@ -37,6 +37,12 @@ describe('vaadin-breadcrumbs-item', () => {
       await nextRender();
       await expect(item).dom.to.equalSnapshot();
     });
+
+    it('disabled', async () => {
+      item.disabled = true;
+      await nextUpdate(item);
+      await expect(item).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/breadcrumbs/test/typings/breadcrumbs-item.types.ts
+++ b/packages/breadcrumbs/test/typings/breadcrumbs-item.types.ts
@@ -1,4 +1,6 @@
 import '../../vaadin-breadcrumbs-item.js';
+import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
+import type { FocusMixinClass } from '@vaadin/a11y-base/src/focus-mixin.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
@@ -6,3 +8,6 @@ const item = document.createElement('vaadin-breadcrumbs-item');
 
 assertType<string | null | undefined>(item.path);
 assertType<boolean>(item.current);
+assertType<boolean>(item.disabled);
+assertType<DisabledMixinClass>(item);
+assertType<FocusMixinClass>(item);

--- a/packages/breadcrumbs/test/typings/breadcrumbs-item.types.ts
+++ b/packages/breadcrumbs/test/typings/breadcrumbs-item.types.ts
@@ -6,8 +6,11 @@ const assertType = <TExpected>(actual: TExpected) => actual;
 
 const item = document.createElement('vaadin-breadcrumbs-item');
 
+// Properties
 assertType<string | null | undefined>(item.path);
 assertType<boolean>(item.current);
 assertType<boolean>(item.disabled);
+
+// Mixins
 assertType<DisabledMixinClass>(item);
 assertType<FocusMixinClass>(item);


### PR DESCRIPTION
`<vaadin-breadcrumbs-item>` now uses `DisabledMixin` and `FocusMixin` from `@vaadin/a11y-base`, plus `delegatesFocus: true` on its shadow root so focus delegates to the inner `<a>` when rendered.

- `disabled` (Boolean, reflected) — sets `aria-disabled`, suppresses pointer events via base styles, and makes `click()` a no-op.
- `focus-ring` and `focused` host attributes reflect keyboard and any focus, respectively.

Base styles add `:host([disabled]) { pointer-events: none }` and a `[part='link']:focus-visible` outline using the shared focus-ring custom properties.

DOM snapshot test covers the disabled `aria-disabled` reflection; typings tests assert the new mixin types.
