### PR TITLE
chore: extract Aura font list into shared aura-fonts.js

### DIFF
--- a/dev/aura/aura-font-family-control.js
+++ b/dev/aura/aura-font-family-control.js
@@ -1,5 +1,6 @@
 import '@vaadin/select';
 import { AuraControl } from './aura-abstract-control.js';
+import { AURA_GOOGLE_FONTS } from './aura-fonts.js';
 
 class AuraFontFamilyControl extends AuraControl {
   static get is() {
@@ -20,53 +21,11 @@ class AuraFontFamilyControl extends AuraControl {
   #opts = [
     { label: 'Instrument Sans (local)', value: "'Instrument Sans', var(--aura-font-family-system)", default: true },
     { label: 'System (local)', value: 'var(--aura-font-family-system)' },
-    {
-      label: 'Inter',
-      value: "'Inter', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap',
-    },
-    {
-      label: 'Roboto',
-      value: "'Roboto', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=Roboto:wght@100..900&display=swap',
-    },
-    {
-      label: 'Public Sans',
-      value: "'Public Sans', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=Public+Sans:wght@100..900&display=swap',
-    },
-    {
-      label: 'Geist',
-      value: "'Geist', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap',
-    },
-    {
-      label: 'Manrope',
-      value: "'Manrope', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap',
-    },
-    {
-      label: 'Atkinson Hyperlegible Next',
-      value: "'Atkinson Hyperlegible Next', var(--aura-font-family-system)",
-      importUrl:
-        'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;500;600;700&display=swap',
-    },
-    {
-      label: 'Geist Mono',
-      value: "'Geist Mono', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap',
-    },
-    {
-      label: 'Jetbrains Mono',
-      value: "'JetBrains Mono', var(--aura-font-family-system)",
-      importUrl: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100..800&display=swap',
-    },
-    {
-      label: 'Atkinson Hyperlegible Mono',
-      value: "'Atkinson Hyperlegible Mono', var(--aura-font-family-system)",
-      importUrl:
-        'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Mono:wght@400;500;600;700&display=swap',
-    },
+    ...AURA_GOOGLE_FONTS.map(({ family, importUrl }) => ({
+      label: family,
+      value: `'${family}', var(--aura-font-family-system)`,
+      importUrl,
+    })),
   ];
 
   constructor() {

--- a/dev/aura/aura-fonts.js
+++ b/dev/aura/aura-fonts.js
@@ -1,0 +1,47 @@
+/**
+ * Google Fonts that the Aura dev playground can opt into.
+ */
+export const AURA_GOOGLE_FONTS = [
+  {
+    family: 'Inter',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap',
+  },
+  {
+    family: 'Roboto',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Roboto:wght@100..900&display=swap',
+  },
+  {
+    family: 'Public Sans',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Public+Sans:wght@100..900&display=swap',
+  },
+  {
+    family: 'Geist',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap',
+  },
+  {
+    family: 'Manrope',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap',
+  },
+  {
+    family: 'Atkinson Hyperlegible Next',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;500;600;700&display=swap',
+  },
+  {
+    family: 'Geist Mono',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap',
+  },
+  {
+    family: 'JetBrains Mono',
+    importUrl: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100..800&display=swap',
+  },
+  {
+    family: 'Atkinson Hyperlegible Mono',
+    importUrl: 'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Mono:wght@400;500;600;700&display=swap',
+  },
+];
+
+/**
+ * Lookup map keyed by CSS font-family name → Google Fonts import URL.
+ * Used by aura-theme-editor's export CSS logic to emit @import rules.
+ */
+export const FONT_FAMILY_IMPORTS = Object.fromEntries(AURA_GOOGLE_FONTS.map((font) => [font.family, font.importUrl]));

--- a/dev/aura/aura-theme-editor.js
+++ b/dev/aura/aura-theme-editor.js
@@ -11,6 +11,7 @@ import '@vaadin/text-area';
 import { html, nothing, render } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 import { toHex } from './aura-color-utils.js';
+import { FONT_FAMILY_IMPORTS } from './aura-fonts.js';
 import { DEFAULT_PRESET_ID, getThemeEditorPresetById, THEME_EDITOR_PRESETS } from './aura-theme-editor-presets.js';
 
 const EXTRA_RULES_STORAGE_KEY = 'aura-theme-editor:extra-rules';
@@ -25,20 +26,6 @@ const DEFAULT_PRESET = {
     glow: '#dbe6ff',
   },
 };
-const FONT_FAMILY_IMPORTS = {
-  Inter: 'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap',
-  Roboto: 'https://fonts.googleapis.com/css2?family=Roboto:wght@100..900&display=swap',
-  'Public Sans': 'https://fonts.googleapis.com/css2?family=Public+Sans:wght@100..900&display=swap',
-  Geist: 'https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap',
-  Manrope: 'https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap',
-  'Atkinson Hyperlegible Next':
-    'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Next:wght@400;500;600;700&display=swap',
-  'Geist Mono': 'https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap',
-  'JetBrains Mono': 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@100..800&display=swap',
-  'Atkinson Hyperlegible Mono':
-    'https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Mono:wght@400;500;600;700&display=swap',
-};
-
 const ACCENT_COLOR_LIGHT_PRESETS = [
   { value: '#3266e4', name: 'Default', default: true },
   { value: '#222222', name: 'Neutral' },


### PR DESCRIPTION
Move the Google Fonts catalog out of `dev/aura/aura-theme-editor.js` (`FONT_FAMILY_IMPORTS`) and `dev/aura/aura-font-family-control.js` (`#opts`) into a single `dev/aura/aura-fonts.js`, with `AURA_GOOGLE_FONTS` as the source of truth and `FONT_FAMILY_IMPORTS` derived from it via `Object.fromEntries`.

The font-family control's two "local" entries (Instrument Sans and System) stay inline; only the nine Google Fonts (Inter, Roboto, Public Sans, Geist, Manrope, Atkinson Hyperlegible Next, Geist Mono, JetBrains Mono, Atkinson Hyperlegible Mono) move out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)