### PR TITLE
chore: migrate colors.html Aura dev controls to Lit

### DIFF
--- a/dev/aura/aura-color-control.js
+++ b/dev/aura/aura-color-control.js
@@ -1,96 +1,75 @@
-import { AuraControl } from './aura-abstract-control.js';
+import { html } from 'lit';
 import { normalizeHex, parseLightDark, resolveEffectiveScheme, toHex } from './aura-color-utils.js';
+import { AuraLitControl } from './aura-lit-control.js';
 
-class AuraColorControl extends AuraControl {
+class AuraColorControl extends AuraLitControl {
   static get is() {
     return 'aura-color-control';
   }
 
-  static get observedAttributes() {
-    return ['property', 'label'];
-  }
-
-  #input;
-  #output;
-  #labelEl;
-  #resetBtn;
-  #prop = '--accent-color';
+  static properties = {
+    property: { type: String },
+    value: { type: String, state: true },
+  };
 
   constructor() {
     super();
-    this.initControl({
-      label: 'Color',
-      content: '<input type="color" /><output>#000000</output>',
-    });
-    this.#input = this.querySelector('input[type="color"]');
-    this.#output = this.querySelector('output');
-    this.#labelEl = this.labelElement;
-    this.#resetBtn = this.resetButton;
-  }
-
-  attributeChangedCallback(name, _old, val) {
-    if (name === 'property') {
-      this.#prop = (val && val.trim()) || '--accent-color';
-      if (this.isConnected) this.#initialize();
-    }
-    if (name === 'label') {
-      this.#labelEl.textContent = val || 'Color';
-    }
+    this.property = '--accent-color';
+    this.value = '#000000';
   }
 
   connectedCallback() {
-    if (this.hasAttribute('label')) {
-      this.#labelEl.textContent = this.getAttribute('label');
-    } else {
-      this.#labelEl.textContent = `${this.#prop.replace(/^--/u, '')} color`;
-    }
+    super.connectedCallback();
     if (this.hasAttribute('property')) {
-      this.#prop = this.getAttribute('property').trim();
+      this.property = this.getAttribute('property').trim() || '--accent-color';
+    }
+    if (!this.label) {
+      this.label = `${this.property.replace(/^--/u, '')} color`;
     }
     this.#initialize();
-
-    // User change → set var + persist
-    this.#input.addEventListener('input', () => {
-      const hex = normalizeHex(this.#input.value) || '#000000';
-      this.#setUI(hex);
-      this.#setVar(hex); // set only on user action
-      this.#persist(hex);
-      this.#emit(hex);
-    });
-
-    // Reset → clear storage, remove inline var, UI from computed (no override)
-    this.#resetBtn.addEventListener('click', () => {
-      localStorage.removeItem(this.#storageKey());
-      document.documentElement.style.removeProperty(this.#prop);
-      const computedHex = this.#getComputedHex() || '#000000';
-      this.#setUI(computedHex);
-      this.#emit(computedHex, { source: 'reset' });
-    });
   }
 
-  // ----- Init: storage OR computed ----------------------------------------
+  updated(changed) {
+    if (changed.has('property') && changed.get('property') !== undefined && this.isConnected) {
+      this.#initialize();
+    }
+  }
+
+  renderContent() {
+    return html`
+      <input type="color" .value=${this.value} @input=${this.#onInput} />
+      <output>${this.value}</output>
+    `;
+  }
+
+  onReset() {
+    localStorage.removeItem(this.#storageKey());
+    document.documentElement.style.removeProperty(this.property);
+    const computedHex = this.#getComputedHex() || '#000000';
+    this.value = normalizeHex(computedHex) || '#000000';
+    this.#emit(this.value, { source: 'reset' });
+  }
+
+  #onInput(event) {
+    const hex = normalizeHex(event.target.value) || '#000000';
+    this.value = hex;
+    this.#setVar(hex);
+    this.#persist(hex);
+    this.#emit(hex);
+  }
+
   #initialize() {
-    // From storage → set var + UI
     const stored = localStorage.getItem(this.#storageKey());
     if (stored) {
       const hex = toHex(stored) || this.#getComputedHex() || '#000000';
-      this.#setUI(hex);
-      this.#setVar(hex); // set because it came from storage
-      this.#persist(hex); // normalize storage to hex
-      this.#emit(hex, { source: 'storage' });
+      this.value = normalizeHex(hex) || '#000000';
+      this.#setVar(this.value);
+      this.#persist(this.value);
+      this.#emit(this.value, { source: 'storage' });
       return;
     }
-
-    // From computed CSS → UI only
     const hex = this.#getComputedHex() || '#000000';
-    this.#setUI(hex);
-  }
-
-  // ----- UI helpers --------------------------------------------------------
-  #setUI(hex) {
-    const norm = normalizeHex(hex) || '#000000';
-    this.#input.value = norm;
-    this.#output.textContent = norm;
+    this.value = normalizeHex(hex) || '#000000';
   }
 
   #persist(hex) {
@@ -100,21 +79,21 @@ class AuraColorControl extends AuraControl {
   #emit(hex, extra = {}) {
     this.dispatchEvent(
       new CustomEvent('value-change', {
-        detail: { property: this.#prop, value: normalizeHex(hex), ...extra },
+        detail: { property: this.property, value: normalizeHex(hex), ...extra },
       }),
     );
   }
 
   #setVar(hex) {
-    document.documentElement.style.setProperty(this.#prop, normalizeHex(hex));
+    document.documentElement.style.setProperty(this.property, normalizeHex(hex));
   }
 
   #storageKey() {
-    return `aura-color:${this.#prop}`;
+    return `aura-color:${this.property}`;
   }
 
   #getComputedHex() {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue(this.#prop).trim();
+    const raw = getComputedStyle(document.documentElement).getPropertyValue(this.property).trim();
     if (!raw) return null;
 
     const ld = parseLightDark(raw);

--- a/dev/aura/aura-color-control.js
+++ b/dev/aura/aura-color-control.js
@@ -12,9 +12,6 @@ class AuraColorControl extends AuraLitControl {
       property: {
         type: String,
       },
-      label: {
-        type: String,
-      },
       value: {
         type: String,
         state: true,

--- a/dev/aura/aura-color-control.js
+++ b/dev/aura/aura-color-control.js
@@ -7,30 +7,30 @@ class AuraColorControl extends AuraLitControl {
     return 'aura-color-control';
   }
 
-  static properties = {
-    property: { type: String },
-    value: { type: String, state: true },
-  };
+  static get properties() {
+    return {
+      property: {
+        type: String,
+      },
+      label: {
+        type: String,
+      },
+      value: {
+        type: String,
+        state: true,
+      },
+    };
+  }
 
   constructor() {
     super();
     this.property = '--accent-color';
+    this.label = `${this.property.replace(/^--/u, '')} color`;
     this.value = '#000000';
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    if (this.hasAttribute('property')) {
-      this.property = this.getAttribute('property').trim() || '--accent-color';
-    }
-    if (!this.label) {
-      this.label = `${this.property.replace(/^--/u, '')} color`;
-    }
-    this.#initialize();
-  }
-
-  updated(changed) {
-    if (changed.has('property') && changed.get('property') !== undefined && this.isConnected) {
+  willUpdate(props) {
+    if (props.has('property')) {
       this.#initialize();
     }
   }

--- a/dev/aura/aura-lit-control.js
+++ b/dev/aura/aura-lit-control.js
@@ -14,8 +14,6 @@ import { html, LitElement } from 'lit';
  *   - `label` / `isLocked` reactive properties (latter reflects to
  *     `data-locked` attribute).
  *   - `toggleLock()` method.
- *   - `labelElement` / `rowElement` / `resetButton` / `lockButton`
- *     getters that query the rendered light-DOM subtree.
  */
 export class AuraLitControl extends LitElement {
   static get properties() {
@@ -66,22 +64,6 @@ export class AuraLitControl extends LitElement {
   toggleLock() {
     this.isLocked = !this.isLocked;
     this.#persistLockState();
-  }
-
-  get labelElement() {
-    return this.querySelector(':scope > .control > .row > label');
-  }
-
-  get rowElement() {
-    return this.querySelector(':scope > .control > .row');
-  }
-
-  get resetButton() {
-    return this.querySelector(':scope > .control > .row > .reset');
-  }
-
-  get lockButton() {
-    return this.querySelector(':scope > .control > .row > .lock');
   }
 
   render() {

--- a/dev/aura/aura-lit-control.js
+++ b/dev/aura/aura-lit-control.js
@@ -1,0 +1,124 @@
+import '@vaadin/button';
+import { html, LitElement } from 'lit';
+
+/**
+ * Lit-based base class for Aura dev-page controls.
+ *
+ * Renders the shared label / reset / lock chrome in light DOM so the
+ * existing `dev/aura/aura-control.css` rules keep matching, and exposes
+ * two override hooks for subclasses:
+ *   - `renderContent()` — return the row-2 body for this control.
+ *   - `onReset()` — invoked when the reset button is clicked.
+ *
+ * Public surface preserved for cross-control consumers:
+ *   - `label` / `isLocked` reactive properties (latter reflects to
+ *     `data-locked` attribute).
+ *   - `toggleLock()` method.
+ *   - `labelElement` / `rowElement` / `resetButton` / `lockButton`
+ *     getters that query the rendered light-DOM subtree.
+ */
+export class AuraLitControl extends LitElement {
+  static properties = {
+    label: { type: String },
+    isLocked: { type: Boolean, reflect: true, attribute: 'data-locked' },
+  };
+
+  constructor() {
+    super();
+    this.label = '';
+    this.isLocked = false;
+    this.style.display = 'contents';
+    this.classList.add('aura-theme-control');
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.#restoreLockState();
+  }
+
+  /**
+   * Override in subclasses to render the row-2 body of the control.
+   * Default: empty.
+   */
+  renderContent() {
+    return html``;
+  }
+
+  /**
+   * Override in subclasses to handle the reset button click — for
+   * example, clear persisted state and remove the inline custom
+   * property from the document root. Default: no-op.
+   */
+  onReset() {}
+
+  toggleLock() {
+    this.isLocked = !this.isLocked;
+    this.#persistLockState();
+  }
+
+  get labelElement() {
+    return this.querySelector(':scope > .control > .row > label');
+  }
+
+  get rowElement() {
+    return this.querySelector(':scope > .control > .row');
+  }
+
+  get resetButton() {
+    return this.querySelector(':scope > .control > .row > .reset');
+  }
+
+  get lockButton() {
+    return this.querySelector(':scope > .control > .row > .lock');
+  }
+
+  render() {
+    const lockTitle = this.isLocked ? 'Unlock shuffle' : 'Lock shuffle';
+    return html`
+      <div class="control">
+        <div class="row">
+          <label>${this.label}</label>
+          <vaadin-button class="reset" theme="tertiary" aria-label="reset" @click=${this.#onResetClick}></vaadin-button>
+          <vaadin-button
+            class="lock"
+            theme="tertiary"
+            aria-label=${lockTitle}
+            title=${lockTitle}
+            aria-pressed=${String(this.isLocked)}
+            @click=${this.#onLockClick}
+          ></vaadin-button>
+        </div>
+        <div class="row">${this.renderContent()}</div>
+      </div>
+    `;
+  }
+
+  #onResetClick() {
+    this.onReset();
+  }
+
+  #onLockClick(event) {
+    event.preventDefault();
+    this.toggleLock();
+  }
+
+  #persistLockState() {
+    localStorage.setItem(this.#lockStorageKey(), this.isLocked ? '1' : '0');
+  }
+
+  #restoreLockState() {
+    const stored = localStorage.getItem(this.#lockStorageKey());
+    if (stored === '1' && !this.isLocked) {
+      this.isLocked = true;
+    }
+  }
+
+  #lockStorageKey() {
+    const identity = this.getAttribute('property') || this.id || this.localName;
+    return `aura-lock:${this.localName}:${identity}`;
+  }
+}

--- a/dev/aura/aura-lit-control.js
+++ b/dev/aura/aura-lit-control.js
@@ -18,10 +18,18 @@ import { html, LitElement } from 'lit';
  *     getters that query the rendered light-DOM subtree.
  */
 export class AuraLitControl extends LitElement {
-  static properties = {
-    label: { type: String },
-    isLocked: { type: Boolean, reflect: true, attribute: 'data-locked' },
-  };
+  static get properties() {
+    return {
+      label: {
+        type: String,
+      },
+      isLocked: {
+        type: Boolean,
+        reflect: true,
+        attribute: 'data-locked',
+      },
+    };
+  }
 
   constructor() {
     super();

--- a/dev/aura/aura-number-control.js
+++ b/dev/aura/aura-number-control.js
@@ -6,14 +6,33 @@ class AuraNumberControl extends AuraLitControl {
     return 'aura-number-control';
   }
 
-  static properties = {
-    property: { type: String },
-    min: { type: Number },
-    max: { type: Number },
-    step: { type: Number },
-    defaultValue: { type: Number, attribute: 'default' },
-    value: { type: Number, state: true },
-  };
+  static get properties() {
+    return {
+      property: {
+        type: String,
+      },
+      min: {
+        type: Number,
+      },
+      max: {
+        type: Number,
+      },
+      step: {
+        type: Number,
+      },
+      label: {
+        type: String,
+      },
+      defaultValue: {
+        type: Number,
+        attribute: 'default',
+      },
+      value: {
+        type: String,
+        state: true,
+      },
+    };
+  }
 
   #initialComputed = null;
 
@@ -28,15 +47,11 @@ class AuraNumberControl extends AuraLitControl {
 
   connectedCallback() {
     super.connectedCallback();
-    if (this.hasAttribute('property')) {
-      this.property = this.getAttribute('property').trim() || '--numeric';
-    }
+
     if (this.min > this.max) {
       [this.min, this.max] = [this.max, this.min];
     }
-    if (!this.label) {
-      this.label = this.property;
-    }
+
     this.#initializeValue();
   }
 

--- a/dev/aura/aura-number-control.js
+++ b/dev/aura/aura-number-control.js
@@ -1,173 +1,134 @@
-import { AuraControl } from './aura-abstract-control.js';
+import { html } from 'lit';
+import { AuraLitControl } from './aura-lit-control.js';
 
-class AuraNumberControl extends AuraControl {
+class AuraNumberControl extends AuraLitControl {
   static get is() {
     return 'aura-number-control';
   }
 
-  static get observedAttributes() {
-    return ['property', 'min', 'max', 'step', 'label'];
-  }
+  static properties = {
+    property: { type: String },
+    min: { type: Number },
+    max: { type: Number },
+    step: { type: Number },
+    defaultValue: { type: Number, attribute: 'default' },
+    value: { type: Number, state: true },
+  };
 
-  #labelEl;
-  #input;
-  #output;
-  #resetBtn;
-  #prop = '--numeric';
-  #min = 0;
-  #max = 100;
-  #step = 1;
-  #default;
   #initialComputed = null;
 
   constructor() {
     super();
-    this.initControl({
-      label: 'Numeric value',
-      content: '<input type="range" /><output>0</output>',
-    });
-    this.#labelEl = this.labelElement;
-    this.#input = this.querySelector('input[type="range"]');
-    this.#output = this.querySelector('output');
-    this.#resetBtn = this.resetButton;
-  }
-
-  attributeChangedCallback(name, _old, val) {
-    switch (name) {
-      case 'property':
-        this.#prop = val?.trim() || '--numeric';
-        break;
-      case 'min':
-        this.#min = this.#toNumber(val, 0);
-        break;
-      case 'max':
-        this.#max = this.#toNumber(val, 100);
-        break;
-      case 'step':
-        this.#step = this.#toNumber(val, 1);
-        break;
-      case 'default':
-        this.#default = this.#toNumber(val, -1);
-        break;
-      case 'label':
-        this.#labelEl.textContent = val || 'Numeric value';
-        break;
-      default:
-        break;
-    }
-    // if (this.isConnected) this.#configureAndInit();
+    this.property = '--numeric';
+    this.min = 0;
+    this.max = 100;
+    this.step = 1;
+    this.value = 0;
   }
 
   connectedCallback() {
-    // Defaults from attributes if present
-    if (this.hasAttribute('property')) this.#prop = this.getAttribute('property').trim();
-    if (this.hasAttribute('min')) this.#min = this.#toNumber(this.getAttribute('min'), this.#min);
-    if (this.hasAttribute('max')) this.#max = this.#toNumber(this.getAttribute('max'), this.#max);
-    if (this.hasAttribute('step')) this.#step = this.#toNumber(this.getAttribute('step'), this.#step);
-    if (this.hasAttribute('default')) this.#default = this.#toNumber(this.getAttribute('default'), this.#default);
-    if (this.hasAttribute('label')) {
-      this.#labelEl.textContent = this.getAttribute('label');
-    } else {
-      this.#labelEl.textContent = this.#prop;
+    super.connectedCallback();
+    if (this.hasAttribute('property')) {
+      this.property = this.getAttribute('property').trim() || '--numeric';
     }
-
-    this.#configureAndInit();
-
-    this.#input.addEventListener('input', () => {
-      const v = Number(this.#input.value);
-      this.#setValue(v);
-    });
-
-    this.#resetBtn.addEventListener('click', () => {
-      if (this.#initialComputed != null) {
-        this.#setValue(this.#initialComputed, { persist: null });
-      } else {
-        this.#initializeValue(); // recompute fallback
-      }
-    });
-  }
-
-  // ----- Internals -----
-
-  #configureAndInit() {
-    // Ensure min <= max; swap if needed
-    if (this.#min > this.#max) [this.#min, this.#max] = [this.#max, this.#min];
-    // Configure input element
-    this.#input.min = String(this.#min);
-    this.#input.max = String(this.#max);
-    this.#input.step = String(this.#step > 0 ? this.#step : 1);
-    this.#input.value = String(this.#default > 0 ? this.#default : undefined);
-    // Initialize value from storage or computed
+    if (this.min > this.max) {
+      [this.min, this.max] = [this.max, this.min];
+    }
+    if (!this.label) {
+      this.label = this.property;
+    }
     this.#initializeValue();
   }
 
-  #storageKey() {
-    return `aura-number:${this.#prop}`;
+  renderContent() {
+    return html`
+      <input
+        type="range"
+        min=${this.min}
+        max=${this.max}
+        step=${this.step > 0 ? this.step : 1}
+        .value=${String(this.value)}
+        @input=${this.#onInput}
+      />
+      <output>${this.value}</output>
+    `;
+  }
+
+  onReset() {
+    if (this.#initialComputed != null) {
+      this.#setValue(this.#initialComputed, { persist: 'clear' });
+    } else {
+      this.#initializeValue();
+    }
+  }
+
+  #onInput(event) {
+    this.#setValue(Number(event.target.value));
   }
 
   #initializeValue() {
-    // 1) Try localStorage
     const stored = localStorage.getItem(this.#storageKey());
     if (stored != null && stored !== '') {
       const num = this.#clamp(this.#snap(Number(stored)));
-      this.#initialComputed = this.#getComputedNumber(); // track for reset
+      this.#initialComputed = this.#getComputedNumber();
       this.#setValue(num, { persist: false });
       return;
     }
 
-    // 2) Fallback to computed style
     const computed = this.#getComputedNumber();
-    const initial = computed != null ? computed : this.#clamp(this.#snap((this.#min + this.#max) / 2));
+    const initial =
+      computed != null
+        ? computed
+        : Number.isFinite(this.defaultValue)
+          ? this.#clamp(this.#snap(this.defaultValue))
+          : this.#clamp(this.#snap((this.min + this.max) / 2));
     this.#initialComputed = computed ?? initial;
-    this.#setValue(initial, { persist: null });
+    this.#setValue(initial, { persist: 'clear' });
+  }
+
+  #setValue(v, opts = { persist: true }) {
+    const value = this.#clamp(this.#snap(Number(v)));
+    this.value = value;
+    document.documentElement.style.setProperty(this.property, String(value));
+    if (opts.persist === true) {
+      localStorage.setItem(this.#storageKey(), String(value));
+    } else if (opts.persist === 'clear') {
+      document.documentElement.style.removeProperty(this.property);
+      localStorage.removeItem(this.#storageKey());
+    }
+    this.dispatchEvent(new CustomEvent('value-change', { detail: { property: this.property, value } }));
+  }
+
+  #storageKey() {
+    return `aura-number:${this.property}`;
   }
 
   #getComputedNumber() {
-    // Read computed value for the property on :root and parseFloat
-    const raw = getComputedStyle(document.documentElement).getPropertyValue(this.#prop).trim();
+    const raw = getComputedStyle(document.documentElement).getPropertyValue(this.property).trim();
     if (!raw) return null;
     const n = parseFloat(raw);
     return Number.isFinite(n) ? this.#clamp(this.#snap(n)) : null;
   }
 
   #clamp(v) {
-    return Math.min(this.#max, Math.max(this.#min, v));
+    return Math.min(this.max, Math.max(this.min, v));
   }
 
   #snap(v) {
-    // Snap to the nearest multiple of step from min
-    const step = this.#step > 0 ? this.#step : 1;
-    const k = Math.round((v - this.#min) / step);
-    const snapped = this.#min + k * step;
-    // Avoid floating point noise
+    const step = this.step > 0 ? this.step : 1;
+    const k = Math.round((v - this.min) / step);
+    const snapped = this.min + k * step;
     const decimals = this.#decimals(step);
     return Number(snapped.toFixed(decimals));
   }
 
   #decimals(n) {
     const s = String(n);
-    if (s.includes('e-')) return parseInt(s.split('e-')[1], 10) || 0;
+    if (s.includes('e-')) {
+      return parseInt(s.split('e-')[1], 10) || 0;
+    }
     const i = s.indexOf('.');
     return i === -1 ? 0 : s.length - i - 1;
-  }
-
-  #toNumber(val, fallback) {
-    const n = Number(val);
-    return Number.isFinite(n) ? n : fallback;
-  }
-
-  #setValue(v, opts = { persist: true }) {
-    const value = this.#clamp(this.#snap(Number(v)));
-    this.#input.value = String(value);
-    this.#output.textContent = String(value);
-    document.documentElement.style.setProperty(this.#prop, String(value));
-    if (opts.persist) {
-      localStorage.setItem(this.#storageKey(), String(value));
-    } else if (opts.persist === null) {
-      document.documentElement.style.removeProperty(this.#prop);
-      localStorage.removeItem(this.#storageKey());
-    }
-    this.dispatchEvent(new CustomEvent('value-change', { detail: { property: this.#prop, value } }));
   }
 }
 

--- a/dev/aura/aura-number-control.js
+++ b/dev/aura/aura-number-control.js
@@ -20,9 +20,6 @@ class AuraNumberControl extends AuraLitControl {
       step: {
         type: Number,
       },
-      label: {
-        type: String,
-      },
       defaultValue: {
         type: Number,
         attribute: 'default',

--- a/dev/aura/aura-number-control.js
+++ b/dev/aura/aura-number-control.js
@@ -89,12 +89,11 @@ class AuraNumberControl extends AuraLitControl {
 
     const computed = this.#getComputedNumber();
     const initial =
-      computed != null
-        ? computed
-        : Number.isFinite(this.defaultValue)
-          ? this.#clamp(this.#snap(this.defaultValue))
-          : this.#clamp(this.#snap((this.min + this.max) / 2));
-    this.#initialComputed = computed ?? initial;
+      computed ??
+      (Number.isFinite(this.defaultValue)
+        ? this.#clamp(this.#snap(this.defaultValue))
+        : this.#clamp(this.#snap((this.min + this.max) / 2)));
+    this.#initialComputed = initial;
     this.#setValue(initial, { persist: 'clear' });
   }
 

--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -17,9 +17,6 @@ class AuraSchemeControl extends AuraLitControl {
       property: {
         type: String,
       },
-      label: {
-        type: String,
-      },
       value: {
         type: String,
         state: true,

--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -12,34 +12,32 @@ class AuraSchemeControl extends AuraLitControl {
     return 'aura-scheme-control';
   }
 
-  static properties = {
-    property: { type: String },
-    value: { type: String, state: true },
-  };
+  static get properties() {
+    return {
+      property: {
+        type: String,
+      },
+      label: {
+        type: String,
+      },
+      value: {
+        type: String,
+        state: true,
+      },
+    };
+  }
 
   constructor() {
     super();
     this.property = '--aura-color-scheme';
+    this.label = 'Color scheme';
     this.value = '';
   }
 
   connectedCallback() {
     super.connectedCallback();
-    if (this.hasAttribute('property')) {
-      this.property = this.getAttribute('property').trim() || '--aura-color-scheme';
-    }
-    if (!this.label) {
-      this.label = 'Color scheme';
-    }
-    this.#initialize();
 
-    // Demo-only: mirror to readout if present on the page.
-    const readout = document.getElementById('scheme-readout');
-    if (readout) {
-      this.addEventListener('value-change', (event) => {
-        readout.textContent = event.detail.value;
-      });
-    }
+    this.#initialize();
   }
 
   renderContent() {

--- a/dev/aura/aura-scheme-control.js
+++ b/dev/aura/aura-scheme-control.js
@@ -1,149 +1,113 @@
-import { AuraControl } from './aura-abstract-control.js';
+import { html } from 'lit';
+import { AuraLitControl } from './aura-lit-control.js';
 
-class AuraSchemeControl extends AuraControl {
+const SCHEME_OPTIONS = [
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Auto', value: 'light dark' },
+];
+
+class AuraSchemeControl extends AuraLitControl {
   static get is() {
     return 'aura-scheme-control';
   }
 
-  static get observedAttributes() {
-    return ['property', 'label'];
-  }
-
-  #prop = '--aura-color-scheme';
-  #group;
-  #reset;
-  #labelEl;
-  #values = ['light', 'dark', 'light dark']; // UI: Light, Dark, Auto
+  static properties = {
+    property: { type: String },
+    value: { type: String, state: true },
+  };
 
   constructor() {
     super();
-    this.initControl({
-      label: 'Color scheme',
-      content: '<div class="segmented" role="radiogroup"></div>',
-    });
-    this.#group = this.querySelector('[role="radiogroup"]');
-    this.#reset = this.resetButton;
-    this.#labelEl = this.labelElement;
-  }
-
-  attributeChangedCallback(name, _old, val) {
-    if (name === 'property') {
-      this.#prop = (val && val.trim()) || this.#prop;
-      if (this.isConnected) this.#initialize();
-    } else if (name === 'label') {
-      this.#labelEl.textContent = val || 'Color scheme';
-    }
+    this.property = '--aura-color-scheme';
+    this.value = '';
   }
 
   connectedCallback() {
-    if (this.hasAttribute('label')) {
-      this.#labelEl.textContent = this.getAttribute('label');
+    super.connectedCallback();
+    if (this.hasAttribute('property')) {
+      this.property = this.getAttribute('property').trim() || '--aura-color-scheme';
     }
-    this.#renderRadios();
+    if (!this.label) {
+      this.label = 'Color scheme';
+    }
     this.#initialize();
 
-    this.#group.addEventListener('change', (e) => {
-      const target = e.target;
-      if (target && target.name === this.#prop) {
-        const value = target.value;
-        this.#apply(value); // sets var + persists + event
-      }
-    });
-
-    this.#reset.addEventListener('click', () => this.#resetToComputed());
-
-    // Demo-only: mirror to readout
-    const ro = document.getElementById('scheme-readout');
-    this.addEventListener('value-change', (e) => {
-      if (ro) ro.textContent = e.detail.value;
-    });
+    // Demo-only: mirror to readout if present on the page.
+    const readout = document.getElementById('scheme-readout');
+    if (readout) {
+      this.addEventListener('value-change', (event) => {
+        readout.textContent = event.detail.value;
+      });
+    }
   }
 
-  // ----- UI setup -----
-  #renderRadios() {
-    // Clear and rebuild radios (Light / Dark / Auto)
-    this.#group.innerHTML = '';
-    const labels = ['Light', 'Dark', 'Auto'];
-    this.#values.forEach((val, idx) => {
-      const input = document.createElement('input');
-      input.type = 'radio';
-      input.name = this.#prop;
-      input.value = val; // "light", "dark", "light dark"
-      const label = document.createElement('label');
-      label.textContent = labels[idx];
-      label.appendChild(input);
-      this.#group.appendChild(label);
-    });
+  renderContent() {
+    return html`
+      <div class="segmented" role="radiogroup">
+        ${SCHEME_OPTIONS.map(
+          (opt) => html`
+            <label>
+              ${opt.label}
+              <input
+                type="radio"
+                name=${this.property}
+                .value=${opt.value}
+                .checked=${this.value === opt.value}
+                @change=${this.#onChange}
+              />
+            </label>
+          `,
+        )}
+      </div>
+    `;
   }
 
-  // ----- Init / Reset -----
-  #initialize() {
-    // 1) localStorage wins if present
-    const stored = localStorage.getItem(this.#storageKey());
-    if (stored && this.#isValid(stored)) {
-      this.#select(stored);
-      this.#setVar(stored); // ensure :root reflects stored
+  onReset() {
+    localStorage.removeItem(this.#storageKey());
+    document.documentElement.style.removeProperty(this.property);
+    const token = getComputedStyle(document.documentElement).getPropertyValue(this.property).trim();
+    const next = this.#isValid(token) ? token : 'normal';
+    this.value = next;
+    this.dispatchEvent(
+      new CustomEvent('value-change', {
+        detail: { property: this.property, value: next, source: 'reset' },
+      }),
+    );
+  }
+
+  #onChange(event) {
+    const next = event.target.value;
+    if (!this.#isValid(next)) {
       return;
     }
-
-    // 2) Else read from computed CSS on :root
-    const computed = getComputedStyle(document.documentElement).getPropertyValue(this.#prop).trim(); // "light" | "dark" | "light dark" | ""
-    const initial = this.#isValid(computed) ? computed : 'normal';
-    this.#select(initial);
-    // Don’t override stylesheet on load; only reflect the choice in UI.
-  }
-
-  #resetToComputed() {
-    // Clear storage and remove inline override
-    localStorage.removeItem(this.#storageKey());
-    document.documentElement.style.removeProperty(this.#prop);
-
-    // Re-read stylesheet-driven value; default to "light dark"
-    const token = getComputedStyle(document.documentElement).getPropertyValue(this.#prop).trim();
-    const value = this.#isValid(token) ? token : 'normal';
-
-    // Update UI (no persist, no inline set)
-    this.#select(value);
-
-    // Notify listeners we’re back to stylesheet value
+    this.value = next;
+    document.documentElement.style.setProperty(this.property, next);
+    localStorage.setItem(this.#storageKey(), next);
     this.dispatchEvent(
       new CustomEvent('value-change', {
-        detail: { property: this.#prop, value, source: 'reset' },
+        detail: { property: this.property, value: next },
       }),
     );
   }
 
-  // ----- Core apply -----
-  #apply(value) {
-    if (!this.#isValid(value)) return;
-    this.#setVar(value);
-    localStorage.setItem(this.#storageKey(), value);
-    this.dispatchEvent(
-      new CustomEvent('value-change', {
-        detail: { property: this.#prop, value },
-      }),
-    );
+  #initialize() {
+    const stored = localStorage.getItem(this.#storageKey());
+    if (stored && this.#isValid(stored)) {
+      this.value = stored;
+      document.documentElement.style.setProperty(this.property, stored);
+      return;
+    }
+    const computed = getComputedStyle(document.documentElement).getPropertyValue(this.property).trim();
+    this.value = this.#isValid(computed) ? computed : 'normal';
   }
 
-  #setVar(value) {
-    document.documentElement.style.setProperty(this.#prop, value);
-  }
-
-  // ----- Helpers -----
   #storageKey() {
-    return `aura:scheme:${this.#prop}`;
+    return `aura:scheme:${this.property}`;
   }
 
   #isValid(v) {
-    return this.#values.includes(String(v).trim());
-  }
-
-  #select(value) {
-    // Set the correct radio as checked
-    const inputs = this.#group.querySelectorAll(`input[name="${this.#prop}"]`);
-    inputs.forEach((i) => {
-      i.checked = i.value === value;
-    });
+    return SCHEME_OPTIONS.some((opt) => opt.value === String(v).trim());
   }
 }
 

--- a/dev/aura/aura-theme-editor.js
+++ b/dev/aura/aura-theme-editor.js
@@ -1,6 +1,5 @@
 import './aura-color-preset-control.js';
 import './aura-font-family-control.js';
-import './aura-number-control.js';
 import './aura-preset-thumbnail.js';
 import './aura-segmented-control.js';
 import './aura-theme-scheme-control.js';


### PR DESCRIPTION
Migrate the three Aura dev controls that are only used by `dev/aura/colors.html` (and never reached by the theme editor on `dev/aura.html`) from the legacy `AuraControl` base to a new LitElement base:

- `aura-color-control`
- `aura-number-control`
- `aura-scheme-control`

Also removed unused import from `aura-theme-editor.js` - the Customize panel uses `aura-segmented-control` for every numeric slider; the `aura-number-control` isn't used since f96228dba9 - see https://github.com/vaadin/web-components/pull/11402..

🤖 Generated with [Claude Code](https://claude.com/claude-code)