### PR TITLE
refactor: use shared field-required mixin in Lumo checkbox

### DIFF
--- a/packages/vaadin-lumo-styles/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/components/checkbox.css
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @import '../src/mixins/checkable-field.css';
+@import '../src/mixins/field-required.css';
 @import '../src/components/checkbox.css';
 
 :root,
@@ -11,5 +12,6 @@
   --_lumo-vaadin-checkbox-inject: 1;
   --_lumo-vaadin-checkbox-inject-modules:
     lumo_mixins_checkable-field,
+    lumo_mixins_field-required,
     lumo_components_checkbox;
 }

--- a/packages/vaadin-lumo-styles/src/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/src/components/checkbox.css
@@ -224,17 +224,6 @@
     left: var(--lumo-space-xs);
   }
 
-  :host([required]) [part='required-indicator']::after {
-    content: var(--vaadin-input-field-required-indicator, var(--lumo-required-field-indicator, '\2022'));
-    transition: opacity 0.2s;
-    color: var(
-      --vaadin-input-field-required-indicator-color,
-      var(--lumo-required-field-indicator-color, var(--lumo-primary-text-color))
-    );
-    width: 1em;
-    text-align: center;
-  }
-
   :host(:not([has-label])) [part='required-indicator'] {
     display: none;
   }
@@ -257,13 +246,6 @@
 
   :host([invalid][focus-ring]) {
     --_focus-ring-color: var(--lumo-error-color-50pct);
-  }
-
-  :host([invalid]) [part='required-indicator']::after {
-    color: var(
-      --vaadin-input-field-required-indicator-color,
-      var(--lumo-required-field-indicator-color, var(--lumo-error-text-color))
-    );
   }
 
   /* Error message */

--- a/packages/vaadin-lumo-styles/src/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/src/components/checkbox.css
@@ -224,6 +224,10 @@
     left: var(--lumo-space-xs);
   }
 
+  :host([required]) [part='required-indicator']::after {
+    position: static;
+  }
+
   :host(:not([has-label])) [part='required-indicator'] {
     display: none;
   }


### PR DESCRIPTION
The Lumo checkbox duplicated the required indicator content, color, and invalid-state color rules already provided by the shared `lumo_mixins_field-required` mixin. Added the mixin to the checkbox and drop the duplicated declarations, keeping only the checkbox-specific position overrides.

This is a finding from the `vaadin-toggle-switch` prototype (which duplicated corresponding CSS from checkbox).

---

🤖 Generated with Claude Code