### PR TITLE
refactor: update Lumo checkbox to use field helper mixin

### DIFF
--- a/packages/vaadin-lumo-styles/components/checkbox-group.css
+++ b/packages/vaadin-lumo-styles/components/checkbox-group.css
@@ -5,6 +5,7 @@
  */
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/group-field.css';
@@ -20,5 +21,6 @@
     lumo_mixins_field-required,
     lumo_mixins_field-error-message,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_components_checkbox-group;
 }

--- a/packages/vaadin-lumo-styles/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/components/checkbox.css
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @import '../src/mixins/checkable-field.css';
+@import '../src/mixins/field-helper.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/checkbox.css';
 
@@ -12,6 +13,7 @@
   --_lumo-vaadin-checkbox-inject: 1;
   --_lumo-vaadin-checkbox-inject-modules:
     lumo_mixins_checkable-field,
+    lumo_mixins_field-helper,
     lumo_mixins_field-required,
     lumo_components_checkbox;
 }

--- a/packages/vaadin-lumo-styles/components/combo-box.css
+++ b/packages/vaadin-lumo-styles/components/combo-box.css
@@ -9,6 +9,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/loader.css';
@@ -29,6 +30,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_combo-box;
 

--- a/packages/vaadin-lumo-styles/components/custom-field.css
+++ b/packages/vaadin-lumo-styles/components/custom-field.css
@@ -5,6 +5,7 @@
  */
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/custom-field.css';
@@ -17,5 +18,6 @@
     lumo_mixins_field-required,
     lumo_mixins_field-error-message,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_components_custom-field;
 }

--- a/packages/vaadin-lumo-styles/components/date-picker.css
+++ b/packages/vaadin-lumo-styles/components/date-picker.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/menu-overlay-core.css';
@@ -29,6 +30,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_date-picker;
 

--- a/packages/vaadin-lumo-styles/components/date-time-picker.css
+++ b/packages/vaadin-lumo-styles/components/date-time-picker.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/custom-field.css';
@@ -23,6 +24,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_custom-field,
     lumo_components_date-time-picker;

--- a/packages/vaadin-lumo-styles/components/email-field.css
+++ b/packages/vaadin-lumo-styles/components/email-field.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/email-field.css';
@@ -21,6 +22,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_email-field;
 }

--- a/packages/vaadin-lumo-styles/components/integer-field.css
+++ b/packages/vaadin-lumo-styles/components/integer-field.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/number-field.css';
@@ -21,6 +22,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_number-field;
 }

--- a/packages/vaadin-lumo-styles/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/components/multi-select-combo-box.css
@@ -9,6 +9,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/loader.css';
@@ -57,6 +58,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_multi-select-combo-box;
 }

--- a/packages/vaadin-lumo-styles/components/number-field.css
+++ b/packages/vaadin-lumo-styles/components/number-field.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/number-field.css';
@@ -21,6 +22,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_number-field;
 }

--- a/packages/vaadin-lumo-styles/components/password-field.css
+++ b/packages/vaadin-lumo-styles/components/password-field.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/button.css';
@@ -23,6 +24,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_password-field;
 

--- a/packages/vaadin-lumo-styles/components/radio-group.css
+++ b/packages/vaadin-lumo-styles/components/radio-group.css
@@ -5,6 +5,7 @@
  */
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/group-field.css';
@@ -20,5 +21,6 @@
     lumo_mixins_field-required,
     lumo_mixins_field-error-message,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_components_radio-group;
 }

--- a/packages/vaadin-lumo-styles/components/range-slider.css
+++ b/packages/vaadin-lumo-styles/components/range-slider.css
@@ -5,6 +5,7 @@
  */
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/overlay.css';
@@ -20,6 +21,7 @@
     lumo_mixins_field-required,
     lumo_mixins_field-error-message,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_slider,
     lumo_components_range-slider;
 

--- a/packages/vaadin-lumo-styles/components/select.css
+++ b/packages/vaadin-lumo-styles/components/select.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/menu-overlay-core.css';
@@ -28,6 +29,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_select;
 

--- a/packages/vaadin-lumo-styles/components/slider.css
+++ b/packages/vaadin-lumo-styles/components/slider.css
@@ -5,6 +5,7 @@
  */
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/overlay.css';
@@ -20,6 +21,7 @@
     lumo_mixins_field-required,
     lumo_mixins_field-error-message,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_slider,
     lumo_components_slider;
 

--- a/packages/vaadin-lumo-styles/components/text-area.css
+++ b/packages/vaadin-lumo-styles/components/text-area.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/text-area.css';
@@ -21,6 +22,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_text-area;
 }

--- a/packages/vaadin-lumo-styles/components/text-field.css
+++ b/packages/vaadin-lumo-styles/components/text-field.css
@@ -7,6 +7,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import './input-container.css';
@@ -20,5 +21,6 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-above,
     lumo_mixins_field-base;
 }

--- a/packages/vaadin-lumo-styles/components/time-picker.css
+++ b/packages/vaadin-lumo-styles/components/time-picker.css
@@ -8,6 +8,7 @@
 @import '../src/mixins/field-button.css';
 @import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
+@import '../src/mixins/field-helper-above.css';
 @import '../src/mixins/field-label.css';
 @import '../src/mixins/field-required.css';
 @import '../src/mixins/menu-overlay-core.css';
@@ -27,6 +28,7 @@
     lumo_mixins_field-error-message,
     lumo_mixins_field-button,
     lumo_mixins_field-helper,
+    lumo_mixins_field-helper-above,
     lumo_mixins_field-base,
     lumo_components_time-picker;
 

--- a/packages/vaadin-lumo-styles/src/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/src/components/checkbox.css
@@ -169,8 +169,7 @@
     color: var(--_disabled-checkmark-color);
   }
 
-  :host([disabled]) [part='label'],
-  :host([disabled]) [part='helper-text'] {
+  :host([disabled]) [part='label'] {
     color: var(--lumo-disabled-text-color);
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }
@@ -288,18 +287,11 @@
 
   /* Helper */
   [part='helper-text'] {
-    display: block;
-    color: var(--vaadin-input-field-helper-color, var(--lumo-secondary-text-color));
-    font-size: var(--vaadin-input-field-helper-font-size, var(--lumo-font-size-xs));
-    line-height: var(--lumo-line-height-xs);
-    font-weight: var(--vaadin-input-field-helper-font-weight, 400);
-    margin-left: calc(var(--lumo-border-radius-m) / 4);
-    transition: color 0.2s;
     padding-inline-start: var(--lumo-space-xs);
   }
 
-  :host(:hover:not([readonly])) [part='helper-text'] {
-    color: var(--lumo-body-text-color);
+  :host([has-helper]) [part='helper-text']::before {
+    display: none;
   }
 
   :host([has-error-message]) ::slotted(label),

--- a/packages/vaadin-lumo-styles/src/mixins/field-helper-above.css
+++ b/packages/vaadin-lumo-styles/src/mixins/field-helper-above.css
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+@media lumo_mixins_field-helper-above {
+  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::before {
+    display: none;
+  }
+
+  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::after {
+    content: '';
+    display: block;
+    height: var(--_helper-spacing);
+  }
+
+  :host([has-helper][theme~='helper-above-field']) [part='label'] {
+    order: 0;
+    padding-bottom: var(--_helper-spacing);
+  }
+
+  :host([has-helper][theme~='helper-above-field']) [part='helper-text'] {
+    order: 1;
+  }
+
+  :host([has-helper][theme~='helper-above-field']) [part='label'] + * {
+    order: 2;
+  }
+
+  :host([has-helper][theme~='helper-above-field']) [part='error-message'] {
+    order: 3;
+  }
+}

--- a/packages/vaadin-lumo-styles/src/mixins/field-helper.css
+++ b/packages/vaadin-lumo-styles/src/mixins/field-helper.css
@@ -32,31 +32,4 @@
     color: var(--lumo-disabled-text-color);
     -webkit-text-fill-color: var(--lumo-disabled-text-color);
   }
-
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::before {
-    display: none;
-  }
-
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text']::after {
-    content: '';
-    display: block;
-    height: var(--_helper-spacing);
-  }
-
-  :host([has-helper][theme~='helper-above-field']) [part='label'] {
-    order: 0;
-    padding-bottom: var(--_helper-spacing);
-  }
-
-  :host([has-helper][theme~='helper-above-field']) [part='helper-text'] {
-    order: 1;
-  }
-
-  :host([has-helper][theme~='helper-above-field']) [part='label'] + * {
-    order: 2;
-  }
-
-  :host([has-helper][theme~='helper-above-field']) [part='error-message'] {
-    order: 3;
-  }
 }


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/11751

Updated checkbox component Lumo to use `field-helper` mixin, and preserved necessary overrides.
This reduces duplication of helper text styles - same approach will be used in the toggle switch.

## Type of change

- Refactor