### PR TITLE
refactor: move duplicated Lumo CSS to checkable field mixin

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/src/components/checkbox.css
@@ -7,19 +7,7 @@
   :host {
     color: var(--vaadin-checkbox-label-color, var(--lumo-body-text-color));
     font-size: var(--vaadin-checkbox-label-font-size, var(--lumo-font-size-m));
-    font-family: var(--lumo-font-family);
-    line-height: var(--lumo-line-height-s);
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-tap-highlight-color: transparent;
-    -webkit-user-select: none;
-    user-select: none;
-    cursor: default;
-    outline: none;
     --_checkbox-size: var(--vaadin-checkbox-size, calc(var(--lumo-size-m) / 2));
-    --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
-    --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
-    --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
     --_invalid-background: var(--vaadin-input-field-invalid-background, var(--lumo-error-color-10pct));
     --_disabled-checkmark-color: var(--vaadin-checkbox-disabled-checkmark-color, var(--lumo-contrast-30pct));
   }
@@ -47,14 +35,8 @@
 
   [part='checkbox'] {
     --_input-size: var(--_checkbox-size);
-    margin: var(--lumo-space-xs);
-    position: relative;
     border-radius: var(--vaadin-checkbox-border-radius, var(--lumo-border-radius-s));
     background: var(--vaadin-checkbox-background, var(--lumo-contrast-20pct));
-    transition:
-      transform 0.2s cubic-bezier(0.12, 0.32, 0.54, 2),
-      background-color 0.15s;
-    cursor: var(--lumo-clickable-cursor);
     /* Default field border color */
     --_input-border-color: var(--vaadin-input-field-border-color, var(--lumo-contrast-50pct));
   }
@@ -67,21 +49,6 @@
   :host([indeterminate]) [part='checkbox'],
   :host([checked]) [part='checkbox'] {
     background-color: var(--_selection-color);
-  }
-
-  /* Used for activation "halo" */
-  [part='checkbox']::before {
-    pointer-events: none;
-    color: transparent;
-    width: 100%;
-    height: 100%;
-    border-radius: inherit;
-    background-color: inherit;
-    transform: scale(1.4);
-    opacity: 0;
-    transition:
-      transform 0.1s,
-      opacity 0.8s;
   }
 
   /* Checkmark */

--- a/packages/vaadin-lumo-styles/src/components/radio-button.css
+++ b/packages/vaadin-lumo-styles/src/components/radio-button.css
@@ -7,19 +7,7 @@
   :host {
     color: var(--vaadin-radio-button-label-color, var(--lumo-body-text-color));
     font-size: var(--vaadin-radio-button-label-font-size, var(--lumo-font-size-m));
-    font-family: var(--lumo-font-family);
-    line-height: var(--lumo-line-height-s);
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-tap-highlight-color: transparent;
-    -webkit-user-select: none;
-    user-select: none;
-    cursor: default;
-    outline: none;
     --_radio-button-size: var(--vaadin-radio-button-size, calc(var(--lumo-size-m) / 2));
-    --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
-    --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
-    --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
   }
 
   :host([has-label]) ::slotted(label) {
@@ -31,33 +19,11 @@
 
   [part='radio'] {
     --_input-size: var(--_radio-button-size);
-    margin: var(--lumo-space-xs);
-    position: relative;
     border-radius: 50%;
     background: var(--vaadin-radio-button-background, var(--lumo-contrast-20pct));
-    transition:
-      transform 0.2s cubic-bezier(0.12, 0.32, 0.54, 2),
-      background-color 0.15s;
     will-change: transform;
-    cursor: var(--lumo-clickable-cursor);
     /* Default field border color */
     --_input-border-color: var(--vaadin-input-field-border-color, var(--lumo-contrast-50pct));
-  }
-
-  /* Used for activation "halo" */
-  [part='radio']::before {
-    pointer-events: none;
-    color: transparent;
-    width: 100%;
-    height: 100%;
-    border-radius: inherit;
-    background-color: inherit;
-    transform: scale(1.4);
-    opacity: 0;
-    transition:
-      transform 0.1s,
-      opacity 0.8s;
-    will-change: transform, opacity;
   }
 
   /* Used for the dot */

--- a/packages/vaadin-lumo-styles/src/mixins/checkable-field.css
+++ b/packages/vaadin-lumo-styles/src/mixins/checkable-field.css
@@ -6,6 +6,18 @@
 @media lumo_mixins_checkable-field {
   :host {
     display: inline-block;
+    font-family: var(--lumo-font-family);
+    line-height: var(--lumo-line-height-s);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: default;
+    outline: none;
+    --_focus-ring-color: var(--vaadin-focus-ring-color, var(--lumo-primary-color-50pct));
+    --_focus-ring-width: var(--vaadin-focus-ring-width, 2px);
+    --_selection-color: var(--vaadin-selection-color, var(--lumo-primary-color));
   }
 
   :host([hidden]) {
@@ -44,15 +56,33 @@
     height: var(--_input-size, 1em);
     --_input-border-width: var(--vaadin-input-field-border-width, 0);
     --_input-border-color: var(--vaadin-input-field-border-color, transparent);
+    margin: var(--lumo-space-xs);
+    position: relative;
     box-shadow: inset 0 0 0 var(--_input-border-width, 0) var(--_input-border-color);
+    transition:
+      transform 0.2s cubic-bezier(0.12, 0.32, 0.54, 2),
+      background-color 0.15s;
+    cursor: var(--lumo-clickable-cursor);
   }
 
+  /* Used for activation "halo" */
   [part='checkbox']::before,
   [part='radio']::before {
     display: block;
     content: '\202F';
     line-height: var(--_input-size, 1em);
     contain: paint;
+    pointer-events: none;
+    color: transparent;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    background-color: inherit;
+    transform: scale(1.4);
+    opacity: 0;
+    transition:
+      transform 0.1s,
+      opacity 0.8s;
   }
 
   /* visually hidden */


### PR DESCRIPTION
## Description

Moved duplicated code blocks for checkbox / radio-button Lumo CSS to their common checkable-field mixin.
These styles were also duplicated in the toggle-switch prototype, which will be using the same mixin.

## Type of change

- Refactor