### PR TITLE
refactor: update Lumo checkbox to use field error message mixin

### DIFF
--- a/packages/vaadin-lumo-styles/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/components/checkbox.css
@@ -4,6 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 @import '../src/mixins/checkable-field.css';
+@import '../src/mixins/field-error-message.css';
 @import '../src/mixins/field-helper.css';
 @import '../src/mixins/field-required.css';
 @import '../src/components/checkbox.css';
@@ -15,5 +16,6 @@
     lumo_mixins_checkable-field,
     lumo_mixins_field-helper,
     lumo_mixins_field-required,
+    lumo_mixins_field-error-message,
     lumo_components_checkbox;
 }

--- a/packages/vaadin-lumo-styles/src/components/checkbox.css
+++ b/packages/vaadin-lumo-styles/src/components/checkbox.css
@@ -220,13 +220,7 @@
 
   /* Error message */
   [part='error-message'] {
-    font-size: var(--vaadin-input-field-error-font-size, var(--lumo-font-size-xs));
-    line-height: var(--lumo-line-height-xs);
-    font-weight: var(--vaadin-input-field-error-font-weight, 400);
-    color: var(--vaadin-input-field-error-color, var(--lumo-error-text-color));
-    will-change: max-height;
-    transition: 0.4s max-height;
-    max-height: 5em;
+    margin: 0;
     padding-inline-start: var(--lumo-space-xs);
   }
 
@@ -240,16 +234,14 @@
     display: none;
   }
 
-  :host([has-error-message]) [part='error-message']::after,
+  :host([has-error-message]) [part='error-message']::before {
+    display: none;
+  }
+
   :host([has-helper]) [part='helper-text']::after {
     content: '';
     display: block;
     height: 0.4em;
-  }
-
-  :host(:not([invalid])) [part='error-message'] {
-    max-height: 0;
-    overflow: hidden;
   }
 
   /* Helper */


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11752

Updated Lumo CSS for checkbox to use error message mixin, removed duplicated styles (preserved some overrides).

## Type of change

- Refactor