### PR TITLE
refactor: simplify Lumo custom field small variant selectors

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/custom-field.css
+++ b/packages/vaadin-lumo-styles/src/components/custom-field.css
@@ -87,11 +87,11 @@
     --lumo-text-field-size: var(--lumo-size-s);
   }
 
-  :host([theme~='small'][has-label]) [part='label'] {
+  :host([theme~='small']) [part='label'] {
     font-size: var(--lumo-font-size-xs);
   }
 
-  :host([theme~='small'][has-label]) [part='error-message'] {
+  :host([theme~='small']) [part='error-message'] {
     font-size: var(--lumo-font-size-xxs);
   }
 


### PR DESCRIPTION
## Description

Aligned CSS with `field-base` mixin (not used in custom field). This fixes a small problem where `font-size` for the error message would be unexpectedly set only when `has-label` attribute is present - I think it's just an oversight.

## Type of change

- Refactor