### PR TITLE
docs: add checkbox field-level CSS properties to JSDoc

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -86,20 +86,30 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-checkbox-background`         |
- * | `--vaadin-checkbox-border-color`       |
- * | `--vaadin-checkbox-border-radius`      |
- * | `--vaadin-checkbox-border-width`       |
- * | `--vaadin-checkbox-gap`                |
- * | `--vaadin-checkbox-label-color`        |
- * | `--vaadin-checkbox-label-font-size`    |
- * | `--vaadin-checkbox-label-font-weight`  |
- * | `--vaadin-checkbox-label-line-height`  |
- * | `--vaadin-checkbox-marker-color`       |
- * | `--vaadin-checkbox-marker-size`        |
- * | `--vaadin-checkbox-size`               |
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-checkbox-background`                   |
+ * | `--vaadin-checkbox-border-color`                 |
+ * | `--vaadin-checkbox-border-radius`                |
+ * | `--vaadin-checkbox-border-width`                 |
+ * | `--vaadin-checkbox-gap`                          |
+ * | `--vaadin-checkbox-label-color`                  |
+ * | `--vaadin-checkbox-label-font-size`              |
+ * | `--vaadin-checkbox-label-font-weight`            |
+ * | `--vaadin-checkbox-label-line-height`            |
+ * | `--vaadin-checkbox-marker-color`                 |
+ * | `--vaadin-checkbox-marker-size`                  |
+ * | `--vaadin-checkbox-size`                         |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -51,20 +51,30 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  *
  * The following custom CSS properties are available for styling:
  *
- * Custom CSS property                      |
- * :----------------------------------------|
- * | `--vaadin-checkbox-background`         |
- * | `--vaadin-checkbox-border-color`       |
- * | `--vaadin-checkbox-border-radius`      |
- * | `--vaadin-checkbox-border-width`       |
- * | `--vaadin-checkbox-gap`                |
- * | `--vaadin-checkbox-label-color`        |
- * | `--vaadin-checkbox-label-font-size`    |
- * | `--vaadin-checkbox-label-font-weight`  |
- * | `--vaadin-checkbox-label-line-height`  |
- * | `--vaadin-checkbox-marker-color`       |
- * | `--vaadin-checkbox-marker-size`        |
- * | `--vaadin-checkbox-size`               |
+ * Custom CSS property                                |
+ * :--------------------------------------------------|
+ * | `--vaadin-checkbox-background`                   |
+ * | `--vaadin-checkbox-border-color`                 |
+ * | `--vaadin-checkbox-border-radius`                |
+ * | `--vaadin-checkbox-border-width`                 |
+ * | `--vaadin-checkbox-gap`                          |
+ * | `--vaadin-checkbox-label-color`                  |
+ * | `--vaadin-checkbox-label-font-size`              |
+ * | `--vaadin-checkbox-label-font-weight`            |
+ * | `--vaadin-checkbox-label-line-height`            |
+ * | `--vaadin-checkbox-marker-color`                 |
+ * | `--vaadin-checkbox-marker-size`                  |
+ * | `--vaadin-checkbox-size`                         |
+ * | `--vaadin-input-field-error-color`               |
+ * | `--vaadin-input-field-error-font-size`           |
+ * | `--vaadin-input-field-error-font-weight`         |
+ * | `--vaadin-input-field-error-line-height`         |
+ * | `--vaadin-input-field-helper-color`              |
+ * | `--vaadin-input-field-helper-font-size`          |
+ * | `--vaadin-input-field-helper-font-weight`        |
+ * | `--vaadin-input-field-helper-line-height`        |
+ * | `--vaadin-input-field-required-indicator`        |
+ * | `--vaadin-input-field-required-indicator-color`  |
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *


### PR DESCRIPTION
Document the field-level custom CSS properties that checkbox inherits from the shared field base styles, but that were missing from its JSDoc table:

- `--vaadin-input-field-required-indicator`
- `--vaadin-input-field-required-indicator-color`
- `--vaadin-input-field-helper-color`, `-font-size`, `-font-weight`, `-line-height`
- `--vaadin-input-field-error-color`, `-font-size`, `-font-weight`, `-line-height`

These already apply to checkbox at runtime via `field-base-styles.js` / `checkable-base-styles.js`; this PR just surfaces them in the public API docs so they show up in the CEM manifest and at vaadin.com/api.

Part of #9617

🤖 Generated with [Claude Code](https://claude.com/claude-code)