### PR TITLE
fix: isolate MDL detail stacking context from ancestor overlays

### DIFF
--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -158,6 +158,8 @@ z-index: 4 — #detail
 
 `#detail` above `#detailOutgoing` works correctly: split-mode replace is instant so z-order doesn't matter, and overlay-mode replace has the incoming sliding over the outgoing.
 
+The host sets `isolation: isolate` so these internal z-indices stay contained in MDL's own stacking context — otherwise `#detail` (z-4) would compete with an ancestor's overlays (e.g. `vaadin-app-layout`'s backdrop at z-2). The exception is `overlay-containment='page'`, where the detail uses `position: fixed` and must escape MDL's stacking context to layer above the page.
+
 ## Testing
 
 - **`onceResized(layout)`** (`test/helpers.js`): `nextResize()` + `nextRender()` — waits for ResizeObserver + rAF write phase

--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -21,7 +21,7 @@ export const masterDetailLayoutStyles = css`
   }
 
   :host:not([overlay-containment='page']) {
-    z-index: 0;
+    isolation: isolate;
   }
 
   :host([dir='rtl']) {


### PR DESCRIPTION
When `vaadin-master-detail-layout` is nested inside `vaadin-app-layout` and both are in overlay mode, the MDL detail panel renders above the app-layout's drawer backdrop. The backdrop becomes click-through behind the detail panel, so users cannot dismiss the drawer by clicking the visible part of it.

The root cause is a stacking conflict: MDL's `#detail` uses `z-index: 4` for its own internal layering (above its placeholder, backdrop, and outgoing-detail wrapper), and that z-index applies in the nearest ancestor stacking context — the app-layout's stacking context, where the drawer backdrop sits at `z-index: 2`.

Applying `isolation: isolate` on the MDL host contains the internal z-indices in MDL's own stacking context. MDL as a whole then stacks at its default level in the parent, and ancestor overlays (app-layout backdrop, dialogs, etc.) layer above it as expected. The `overlay-containment='page'` mode is excluded — there, the detail uses `position: fixed` and must escape MDL's stacking context to layer above the page.

Fixes #11762

---

🤖 Generated with Claude Code