### PR TITLE
fix: place Lumo injected styles after element styles in cascade

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-utils.js
+++ b/packages/vaadin-themable-mixin/src/css-utils.js
@@ -22,7 +22,7 @@ function getEffectiveStyles(component) {
     return [...(lumoInjector.includeBaseStyles ? baseStyles : []), lumoStyleSheet, ...themeStyles];
   }
 
-  return [lumoStyleSheet, ...elementStyles].filter(Boolean);
+  return [...elementStyles, lumoStyleSheet].filter(Boolean);
 }
 
 /**

--- a/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
@@ -90,6 +90,54 @@ class TestCustomLumoInjectorTagName extends TestFoo {
 
 customElements.define(TestCustomLumoInjectorTagName.is, TestCustomLumoInjectorTagName);
 
+class TestQux extends LumoInjectionMixin(LitElement) {
+  static get is() {
+    return 'test-qux';
+  }
+
+  static get version() {
+    return '1.0.0';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+
+      [part='content'] {
+        transition: background-color 1ms linear;
+        color: black;
+        background-color: yellow;
+      }
+    `;
+  }
+
+  static get lumoInjector() {
+    return { ...super.lumoInjector, includeBaseStyles: true };
+  }
+
+  render() {
+    return html`<div part="content">Content</div>`;
+  }
+}
+
+customElements.define(TestQux.is, TestQux);
+
+const TEST_QUX_STYLES = `
+  html, :host {
+    --_lumo-test-qux-inject: 1;
+    --_lumo-test-qux-inject-modules: lumo_qux;
+  }
+
+  @media lumo_qux {
+    [part='content'] {
+      color: red;
+      background-color: green;
+    }
+  }
+`;
+
 const TEST_FOO_STYLES = `
   html, :host {
     --_lumo-test-foo-inject: 1;
@@ -648,6 +696,35 @@ describe('Lumo injection', () => {
       await contentTransition();
 
       assertThemeStyle();
+    });
+  });
+
+  describe('without ThemableMixin', () => {
+    beforeEach(async () => {
+      element = fixtureSync('<test-qux></test-qux>');
+      await nextRender();
+      content = element.shadowRoot.querySelector('[part="content"]');
+    });
+
+    afterEach(() => {
+      document.__lumoInjector?.disconnect();
+      document.__lumoInjector = undefined;
+      document.__cssPropertyObserver?.disconnect();
+      document.__cssPropertyObserver = undefined;
+    });
+
+    it('should apply injected styles after element static styles', async () => {
+      const style = document.createElement('style');
+      style.textContent = TEST_QUX_STYLES;
+      document.head.appendChild(style);
+
+      await contentTransition();
+      assertInjectedStyle();
+
+      style.remove();
+
+      await contentTransition();
+      assertBaseStyle();
     });
   });
 });


### PR DESCRIPTION
For components using `LumoInjectionMixin` without `ThemableMixin`, `getEffectiveStyles()` was returning `adoptedStyleSheets` in the wrong order — Lumo first, then the component's static styles. With equal-specificity rules, this made the component's base styles win over the Lumo override, opposite of the documented contract.

The function's own docstring states the intent:

> place the injected stylesheet after styles defined with `static styles` and before any custom theme styles

The `ThemableMixin` branch already does this correctly (`[baseStyles, lumo, themeStyles]`); the fallback branch did not.

## Reproduction

`<vaadin-breadcrumbs>` and `<vaadin-breadcrumbs-item>` are the only components today that use `LumoInjectionMixin` without `ThemableMixin`. With the current code, e.g. Lumo `[part='list'] { gap: var(--lumo-space-s) }` does not override the base `gap: 0.25em` defined in `vaadin-breadcrumbs-base-styles.js`. The fix restores the documented precedence.

## Changes

One-line swap in `packages/vaadin-themable-mixin/src/css-utils.js`:

```diff
-  return [lumoStyleSheet, ...elementStyles].filter(Boolean);
+  return [...elementStyles, lumoStyleSheet].filter(Boolean);
```

## Blast radius

Only breadcrumbs hits this branch today (every other Lumo-injected component inherits `ThemableMixin` and takes the `if` branch above). Full themable-mixin and breadcrumbs test suites pass unchanged.

---

🤖 Generated with Claude Code