### PR TITLE
refactor: reduce breadcrumbs gap in Lumo to match base styles

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/breadcrumbs.css
+++ b/packages/vaadin-lumo-styles/src/components/breadcrumbs.css
@@ -12,6 +12,6 @@
   }
 
   [part='list'] {
-    gap: var(--lumo-space-s);
+    gap: var(--lumo-space-xs);
   }
 }


### PR DESCRIPTION
## Description

Base styles currently use `gap: 0.25em`. Let's update Lumo accordingly to `--lumo-space-xs` - I believe that's the expected result at least based on current screenshots. This way we don't have to update screenshots in https://github.com/vaadin/web-components/pull/11767.

## Type of change

- Refactor