### PR TITLE
fix: respect includeBaseStyles when ThemableMixin is absent

### DIFF
--- a/packages/vaadin-themable-mixin/src/css-utils.js
+++ b/packages/vaadin-themable-mixin/src/css-utils.js
@@ -23,7 +23,7 @@ function getEffectiveStyles(component) {
     return [...base, lumoStyleSheet, ...(themeStyles ?? [])];
   }
 
-  return [...elementStyles];
+  return elementStyles;
 }
 
 /**

--- a/packages/vaadin-themable-mixin/src/css-utils.js
+++ b/packages/vaadin-themable-mixin/src/css-utils.js
@@ -18,11 +18,12 @@ function getEffectiveStyles(component) {
   const { baseStyles, themeStyles, elementStyles, lumoInjector } = component.constructor;
   const lumoStyleSheet = component.__lumoStyleSheet;
 
-  if (lumoStyleSheet && (baseStyles || themeStyles)) {
-    return [...(lumoInjector.includeBaseStyles ? baseStyles : []), lumoStyleSheet, ...themeStyles];
+  if (lumoStyleSheet) {
+    const base = lumoInjector.includeBaseStyles ? (baseStyles ?? elementStyles) : [];
+    return [...base, lumoStyleSheet, ...(themeStyles ?? [])];
   }
 
-  return [...elementStyles, lumoStyleSheet].filter(Boolean);
+  return [...elementStyles];
 }
 
 /**

--- a/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
+++ b/packages/vaadin-themable-mixin/test/lumo-injection-mixin.test.js
@@ -124,6 +124,39 @@ class TestQux extends LumoInjectionMixin(LitElement) {
 
 customElements.define(TestQux.is, TestQux);
 
+class TestQuxNoBase extends LumoInjectionMixin(LitElement) {
+  static get is() {
+    return 'test-qux-no-base';
+  }
+
+  static get version() {
+    return '1.0.0';
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+      }
+
+      [part='content'] {
+        transition: background-color 1ms linear;
+        color: black;
+        background-color: yellow;
+        padding: 10px;
+      }
+    `;
+  }
+
+  // Uses LumoInjectionMixin's default lumoInjector: includeBaseStyles is false.
+
+  render() {
+    return html`<div part="content">Content</div>`;
+  }
+}
+
+customElements.define(TestQuxNoBase.is, TestQuxNoBase);
+
 const TEST_QUX_STYLES = `
   html, :host {
     --_lumo-test-qux-inject: 1;
@@ -132,6 +165,21 @@ const TEST_QUX_STYLES = `
 
   @media lumo_qux {
     [part='content'] {
+      color: red;
+      background-color: green;
+    }
+  }
+`;
+
+const TEST_QUX_NO_BASE_STYLES = `
+  html, :host {
+    --_lumo-test-qux-no-base-inject: 1;
+    --_lumo-test-qux-no-base-inject-modules: lumo_qux-no-base;
+  }
+
+  @media lumo_qux-no-base {
+    [part='content'] {
+      transition: background-color 1ms linear;
       color: red;
       background-color: green;
     }
@@ -725,6 +773,45 @@ describe('Lumo injection', () => {
 
       await contentTransition();
       assertBaseStyle();
+    });
+  });
+
+  describe('without ThemableMixin and includeBaseStyles=false', () => {
+    beforeEach(async () => {
+      element = fixtureSync('<test-qux-no-base></test-qux-no-base>');
+      await nextRender();
+      content = element.shadowRoot.querySelector('[part="content"]');
+    });
+
+    afterEach(() => {
+      document.__lumoInjector?.disconnect();
+      document.__lumoInjector = undefined;
+      document.__cssPropertyObserver?.disconnect();
+      document.__cssPropertyObserver = undefined;
+    });
+
+    it('should drop element static styles when injected styles are present', async () => {
+      // Before injection: element static styles apply.
+      assertBaseStyle();
+      expect(getComputedStyle(content).paddingTop).to.equal('10px');
+
+      const style = document.createElement('style');
+      style.textContent = TEST_QUX_NO_BASE_STYLES;
+      document.head.appendChild(style);
+
+      await contentTransition();
+
+      // After injection: only the Lumo stylesheet applies — padding from base styles is gone.
+      assertInjectedStyle();
+      expect(getComputedStyle(content).paddingTop).to.equal('0px');
+
+      style.remove();
+
+      await contentTransition();
+
+      // After removal: element static styles re-apply.
+      assertBaseStyle();
+      expect(getComputedStyle(content).paddingTop).to.equal('10px');
     });
   });
 });


### PR DESCRIPTION
`LumoInjectionMixin` documents `includeBaseStyles: false` as its default and instructs theme files to redeclare every primitive that the component's `static styles` provide. However, the option was silently ignored when a component used `LumoInjectionMixin` without `ThemableMixin`. In that case the element's `static get styles()` was always prepended to `adoptedStyleSheets` before the injected Lumo stylesheet, even when `includeBaseStyles: false`.

## Root cause

In `getEffectiveStyles()` (`packages/vaadin-themable-mixin/src/css-utils.js`), the branch that honors `includeBaseStyles` only fires when `baseStyles` or `themeStyles` is defined — which requires `ThemableMixin` in the chain. Without `ThemableMixin`, control falls through to a fallback that always returns `[...elementStyles, lumoStyleSheet]`.

```js
if (lumoStyleSheet && (baseStyles || themeStyles)) {
  return [...(lumoInjector.includeBaseStyles ? baseStyles : []), lumoStyleSheet, ...themeStyles];
}

// Fallback path — ignores includeBaseStyles
return [...elementStyles, lumoStyleSheet].filter(Boolean);
```

## Fix

Honor `includeBaseStyles` in the unified path. `baseStyles ?? elementStyles` lets the same code serve both ThemableMixin and non-ThemableMixin chains.

## Regression check

The only existing components that use `LumoInjectionMixin` without `ThemableMixin` are `vaadin-breadcrumbs` and `vaadin-breadcrumbs-item`, and both override `includeBaseStyles` to `true`. They take the first branch and continue to pick up `elementStyles` exactly as before.

## Test

Added `'without ThemableMixin and includeBaseStyles=false'` covering the bug: the test component sets `padding: 10px` in its `static styles`, the Lumo CSS does not, and the test asserts padding is `0px` after injection and `10px` again after removal. The test fails on `main` and passes with this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)