### PR TITLE
feat: add aura-button class to style anchors as buttons

### DIFF
--- a/dev/button.html
+++ b/dev/button.html
@@ -18,5 +18,12 @@
       Edit
       <vaadin-tooltip slot="tooltip" text="Click to edit"></vaadin-tooltip>
     </vaadin-button>
+
+    <div class="section">
+      <p class="heading">Anchors styled as buttons (Aura: <code>.aura-button</code>)</p>
+      <a class="aura-button" href="#">Default link</a>
+      <a class="aura-button" theme="primary" href="#">Primary link</a>
+      <a class="aura-button" theme="tertiary" href="#">Tertiary link</a>
+    </div>
   </body>
 </html>

--- a/dev/button.html
+++ b/dev/button.html
@@ -25,5 +25,12 @@
       <a class="aura-button" theme="primary" href="#">Primary link</a>
       <a class="aura-button" theme="tertiary" href="#">Tertiary link</a>
     </div>
+
+    <div class="section">
+      <p class="heading">Anchors styled as buttons (Lumo: <code>.lumo-button</code>)</p>
+      <a class="lumo-button" href="#">Default link</a>
+      <a class="lumo-button" theme="primary" href="#">Primary link</a>
+      <a class="lumo-button" theme="tertiary" href="#">Tertiary link</a>
+    </div>
   </body>
 </html>

--- a/packages/aura/src/components/button.css
+++ b/packages/aura/src/components/button.css
@@ -3,7 +3,50 @@
   --vaadin-button-shadow: var(--aura-shadow-xs);
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit) {
+/*
+Base styles for the .aura-button class, which lets a plain element (typically <a>)
+look like a vaadin-button. The corresponding rules for vaadin-button itself are
+applied inside its shadow root via the base button styles. See issue #1803.
+*/
+.aura-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  text-decoration: none;
+  gap: var(--vaadin-button-gap, 0 var(--vaadin-gap-s));
+  white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  cursor: var(--vaadin-clickable-cursor);
+  box-sizing: border-box;
+  flex-shrink: 0;
+  height: var(--vaadin-button-height, fit-content);
+  margin: var(--vaadin-button-margin, 0);
+  padding: var(--vaadin-button-padding, var(--vaadin-padding-block-container) var(--vaadin-padding-inline-container));
+  font-family: var(--vaadin-button-font-family, inherit);
+  font-size: var(--vaadin-button-font-size, inherit);
+  line-height: var(--vaadin-button-line-height, inherit);
+  font-weight: var(--vaadin-button-font-weight, 500);
+  color: var(--vaadin-button-text-color, var(--vaadin-text-color));
+  background: var(--vaadin-button-background, var(--vaadin-background-container));
+  background-origin: border-box;
+  border: var(--vaadin-button-border-width, 1px) solid
+    var(--vaadin-button-border-color, var(--vaadin-border-color-secondary));
+  border-radius: var(--vaadin-button-border-radius, var(--vaadin-radius-m));
+  touch-action: manipulation;
+}
+
+.aura-button:focus-visible {
+  outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
+}
+
+.aura-button[theme~='tertiary'] {
+  background: transparent;
+  border-color: transparent;
+}
+
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit, .aura-button) {
   transition: scale 180ms;
   position: relative;
   --_background: var(--aura-accent-surface) padding-box;
@@ -14,23 +57,33 @@ vaadin-drawer-toggle[theme~='tertiary']::part(icon) {
   opacity: 0.6;
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):where(
-  :not([theme~='tertiary'])
-) {
+:is(
+  vaadin-button,
+  vaadin-upload-button,
+  vaadin-menu-bar-button,
+  vaadin-drawer-toggle,
+  vaadin-crud-edit,
+  .aura-button
+):where(:not([theme~='tertiary'])) {
   --aura-surface-level: 4;
   --aura-surface-opacity: 0.5;
   box-shadow: var(--vaadin-button-shadow);
 }
 
 /* prettier-ignore */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):not([theme~='primary'], [theme~='tertiary']) {
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit, .aura-button):not([theme~='primary'], [theme~='tertiary']) {
   background: var(--vaadin-button-background, var(--_background));
   border-color: var(--vaadin-button-border-color, var(--aura-accent-border-color));
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):where(
-  :not([theme~='primary'])
-) {
+:is(
+  vaadin-button,
+  vaadin-upload-button,
+  vaadin-menu-bar-button,
+  vaadin-drawer-toggle,
+  vaadin-crud-edit,
+  .aura-button
+):where(:not([theme~='primary'])) {
   outline-offset: calc(var(--vaadin-button-border-width, 1px) * -1);
 }
 
@@ -39,28 +92,33 @@ Increase padding, but only for buttons that don't have an icon in the default sl
 Buttons that place an icon in the default slot are assumed to be icon-only buttons.
 */
 /* prettier-ignore */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-crud-edit):not(:has(> :is(vaadin-icon, svg, i[class*='fa-'], vaadin-avatar):not([slot]))) {
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-crud-edit, .aura-button):not(:has(> :is(vaadin-icon, svg, i[class*='fa-'], vaadin-avatar):not([slot]))) {
   --vaadin-button-padding: var(--vaadin-padding-block-container)
     var(--vaadin-padding-m);
 }
 
 /* Decrease padding when an icon is placed in the prefix or suffix slot */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button):has(
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, .aura-button):has(
   > [slot='prefix']:is(vaadin-icon, svg, i[class*='fa-'], vaadin-avatar)
 ) {
   padding-inline-start: var(--vaadin-padding-s);
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button):has(
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, .aura-button):has(
   > [slot='suffix']:is(vaadin-icon, svg, i[class*='fa-'], vaadin-avatar)
 ),
 vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
   padding-inline-end: var(--vaadin-padding-s);
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):where(
-  [theme~='primary']
-) {
+:is(
+  vaadin-button,
+  vaadin-upload-button,
+  vaadin-menu-bar-button,
+  vaadin-drawer-toggle,
+  vaadin-crud-edit,
+  .aura-button
+):where([theme~='primary']) {
   outline-offset: 2px;
   --vaadin-button-font-weight: var(--aura-font-weight-semibold);
   --vaadin-button-text-color: var(--aura-accent-contrast-color);
@@ -73,9 +131,14 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
   color: color-mix(in srgb, currentColor 50%, transparent);
 }
 
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):not(
-    [disabled]
-  )::before {
+:is(
+    vaadin-button,
+    vaadin-upload-button,
+    vaadin-menu-bar-button,
+    vaadin-drawer-toggle,
+    vaadin-crud-edit,
+    .aura-button
+  ):not([disabled])::before {
   content: '';
   position: absolute;
   inset: calc(var(--vaadin-button-border-width, 1px) * -1);
@@ -89,28 +152,34 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
 }
 
 @supports (color: hsl(0 0 0)) {
-  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):not(
-      [disabled]
-    )::before {
+  :is(
+      vaadin-button,
+      vaadin-upload-button,
+      vaadin-menu-bar-button,
+      vaadin-drawer-toggle,
+      vaadin-crud-edit,
+      .aura-button
+    ):not([disabled])::before {
     background-color: oklch(from currentColor calc(l + 0.4 - c) c h / calc(1 - l / 2));
   }
 }
 
 @media (any-hover: hover) {
   /* prettier-ignore */
-  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit):hover:not([disabled], [active])::before {
+  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit, .aura-button):hover:not([disabled], [active])::before {
     opacity: 0.03;
   }
 
   /* prettier-ignore */
-  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[theme~='primary']:hover:not([disabled], [active])::before {
+  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit, .aura-button)[theme~='primary']:hover:not([disabled], [active])::before {
     opacity: 0.12;
   }
 }
 
 @media (min-resolution: 2x) {
   /* prettier-ignore */
-  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button[first-visible][last-visible], vaadin-drawer-toggle)[active]:not([disabled], [aria-disabled='true']) {
+  :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button[first-visible][last-visible], vaadin-drawer-toggle)[active]:not([disabled], [aria-disabled='true']),
+  .aura-button:active:not([aria-disabled='true']) {
     scale: 0.98;
     transition-duration: 50ms;
   }
@@ -118,19 +187,22 @@ vaadin-menu-bar-button[aria-haspopup='true']:not([slot='overflow']) {
 
 :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[active]:not(
     [disabled]
-  ) {
+  ),
+.aura-button:active {
   box-shadow: none;
 }
 
 :is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[active]:not(
     [disabled]
-  )::before {
+  )::before,
+.aura-button:active::before {
   transition-duration: 0s;
   opacity: 0.08;
   background: oklch(from currentColor min(c, 1 - l + c) calc(c * 0.9) h);
 }
 
 /* prettier-ignore */
-:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[theme~='primary'][active]:not([disabled])::before {
+:is(vaadin-button, vaadin-upload-button, vaadin-menu-bar-button, vaadin-drawer-toggle, vaadin-crud-edit)[theme~='primary'][active]:not([disabled])::before,
+.aura-button[theme~='primary']:active::before {
   opacity: 0.16;
 }

--- a/packages/vaadin-lumo-styles/components/button.css
+++ b/packages/vaadin-lumo-styles/components/button.css
@@ -10,3 +10,172 @@
   --_lumo-vaadin-button-inject: 1;
   --_lumo-vaadin-button-inject-modules: lumo_components_button;
 }
+
+/*
+Base styles for the .lumo-button class, which lets a plain element (typically <a>)
+look like a vaadin-button. The corresponding rules for vaadin-button itself live
+inside its shadow root via the @media lumo_components_button block. See issue #1803.
+*/
+.lumo-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  text-decoration: none;
+  position: relative;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  --_button-size: var(
+    --vaadin-button-height,
+    var(--lumo-size-m)
+  );
+  --_lumo-button-background: var(
+    --vaadin-button-background,
+    var(--lumo-contrast-5pct)
+  );
+  --_lumo-button-text-color: var(
+    --vaadin-button-text-color,
+    var(--lumo-primary-text-color)
+  );
+  --_lumo-button-primary-background: var(
+    --vaadin-button-primary-background,
+    var(--lumo-primary-color)
+  );
+  --_lumo-button-primary-text-color: var(
+    --vaadin-button-primary-text-color,
+    var(--lumo-primary-contrast-color)
+  );
+  min-width: var(
+    --vaadin-button-min-width,
+    calc(var(--_button-size) * 2)
+  );
+  height: var(--_button-size);
+  padding: var(
+    --vaadin-button-padding,
+    0
+      calc(
+        var(--_button-size) / 3 +
+          var(--lumo-border-radius-m) /
+          2
+      )
+  );
+  margin: var(
+    --vaadin-button-margin,
+    var(--lumo-space-xs) 0
+  );
+  font-family: var(--lumo-font-family);
+  font-size: var(
+    --vaadin-button-font-size,
+    var(--lumo-font-size-m)
+  );
+  font-weight: var(
+    --vaadin-button-font-weight,
+    500
+  );
+  color: var(--_lumo-button-text-color);
+  background: var(
+    --_lumo-button-background
+  );
+  border: var(
+    --vaadin-button-border,
+    none
+  );
+  border-radius: var(
+    --vaadin-button-border-radius,
+    var(--lumo-border-radius-m)
+  );
+  cursor: var(--lumo-clickable-cursor);
+}
+
+.lumo-button::before {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  background-color: currentColor;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 100ms;
+}
+
+.lumo-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0
+    var(--vaadin-focus-ring-width, 2px)
+    var(
+      --vaadin-focus-ring-color,
+      var(--lumo-primary-color-50pct)
+    );
+}
+
+@media (any-hover: hover) {
+  .lumo-button:hover::before {
+    opacity: 0.02;
+  }
+
+  .lumo-button[theme~='primary']:hover::before {
+    opacity: 0.05;
+  }
+}
+
+.lumo-button:active::before {
+  opacity: 0.05;
+  transition-duration: 0s;
+}
+
+.lumo-button[theme~='primary'] {
+  background: var(
+    --_lumo-button-primary-background
+  );
+  border: var(
+    --vaadin-button-primary-border,
+    none
+  );
+  color: var(
+    --_lumo-button-primary-text-color
+  );
+  font-weight: var(
+    --vaadin-button-primary-font-weight,
+    600
+  );
+  min-width: calc(
+    var(--_button-size) * 2.5
+  );
+}
+
+.lumo-button[theme~='primary']::before {
+  background-color: black;
+}
+
+.lumo-button[theme~='primary']:active::before {
+  opacity: 0.1;
+}
+
+.lumo-button[theme~='tertiary'] {
+  background: var(
+    --vaadin-button-tertiary-background,
+    transparent
+  );
+  border: var(
+    --vaadin-button-tertiary-border,
+    none
+  );
+  color: var(
+    --vaadin-button-tertiary-text-color,
+    var(--lumo-primary-text-color)
+  );
+  font-weight: var(
+    --vaadin-button-tertiary-font-weight,
+    500
+  );
+  min-width: 0;
+  padding: var(
+    --vaadin-button-tertiary-padding,
+    0 calc(var(--_button-size) / 6)
+  );
+}


### PR DESCRIPTION
Lets plain elements (typically <a>) take on the vaadin-button look in the Aura theme by adding the .aura-button class, with theme=\"primary\" and theme=\"tertiary\" variants. Useful when a link needs button styling without losing native anchor behavior (Cmd-click, right-click, etc.).

Minimal version of #1803