### PR TITLE
refactor: remove experimental feature flag from badge component

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -17,7 +17,6 @@
       window.Vaadin ||= {};
       window.Vaadin.featureFlags ||= {};
       window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-      window.Vaadin.featureFlags.badgeComponent = true;
 
       // Enable :active styles on iOS
       document.addEventListener('touchstart', () => {}, { passive: true });

--- a/dev/aura/colors.html
+++ b/dev/aura/colors.html
@@ -13,7 +13,6 @@
       window.Vaadin = {};
       window.Vaadin.featureFlags = {};
       window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-      window.Vaadin.featureFlags.badgeComponent = true;
     </script>
     <script type="module">
       import './aura-scheme-control.js';

--- a/dev/aura/sizes.html
+++ b/dev/aura/sizes.html
@@ -12,7 +12,6 @@
       window.Vaadin = {};
       window.Vaadin.featureFlags = {};
       window.Vaadin.featureFlags.accessibleDisabledButtons = true;
-      window.Vaadin.featureFlags.badgeComponent = true;
     </script>
     <script type="module">
       import '@vaadin/avatar';

--- a/dev/badge.html
+++ b/dev/badge.html
@@ -6,11 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Badge</title>
     <script type="module" src="./common.js"></script>
-    <script>
-      window.Vaadin ??= {};
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.badgeComponent = true;
-    </script>
     <script type="module">
       import '@vaadin/badge';
       import '@vaadin/icon';

--- a/dev/card.html
+++ b/dev/card.html
@@ -7,11 +7,6 @@
     <title>Card</title>
     <script type="module" src="./common.js"></script>
     <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.badgeComponent = true;
-    </script>
-    <script type="module">
       import '@vaadin/avatar';
       import '@vaadin/badge';
       import '@vaadin/button';

--- a/dev/side-nav.html
+++ b/dev/side-nav.html
@@ -7,11 +7,6 @@
     <title>Side Nav</title>
     <script type="module" src="./common.js"></script>
     <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.badgeComponent = true;
-    </script>
-    <script type="module">
       import '@vaadin/badge';
       import '@vaadin/icon';
       import '@vaadin/icons';

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -6,8 +6,6 @@ A web component for displaying badges with various theme variants.
 
 [![npm version](https://badgen.net/npm/v/@vaadin/badge)](https://www.npmjs.com/package/@vaadin/badge)
 
-> ⚠️ This component is experimental and the API may change. In order to use it, enable the feature flag by setting `window.Vaadin.featureFlags.badgeComponent = true`.
-
 ```html
 <vaadin-badge>Badge</vaadin-badge>
 <vaadin-badge theme="success">Success</vaadin-badge>

--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -81,10 +81,6 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
     return { ...super.lumoInjector, includeBaseStyles: true };
   }
 
-  static get experimental() {
-    return true;
-  }
-
   static get properties() {
     return {
       /**

--- a/packages/badge/test/badge.test.ts
+++ b/packages/badge/test/badge.test.ts
@@ -3,10 +3,6 @@ import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../src/vaadin-badge.js';
 import type { Badge } from '../src/vaadin-badge.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.badgeComponent = true;
-
 describe('vaadin-badge', () => {
   let badge: Badge;
 

--- a/packages/badge/test/dom/badge.test.ts
+++ b/packages/badge/test/dom/badge.test.ts
@@ -3,10 +3,6 @@ import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
 import '../../src/vaadin-badge.js';
 import type { Badge } from '../../src/vaadin-badge.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.badgeComponent = true;
-
 describe('vaadin-badge', () => {
   let badge: Badge;
 

--- a/packages/badge/test/visual/aura/badge.test.ts
+++ b/packages/badge/test/visual/aura/badge.test.ts
@@ -7,10 +7,6 @@ import '../../../vaadin-badge.js';
 import type { Icon } from '@vaadin/icon';
 import type { Badge } from '../../../vaadin-badge.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.badgeComponent = true;
-
 describe('badge', () => {
   let div: HTMLDivElement;
   let element: Badge;

--- a/packages/badge/test/visual/base/badge.test.ts
+++ b/packages/badge/test/visual/base/badge.test.ts
@@ -6,10 +6,6 @@ import '../../../src/vaadin-badge.js';
 import type { Icon } from '@vaadin/icon';
 import type { Badge } from '../../../src/vaadin-badge.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.badgeComponent = true;
-
 describe('badge', () => {
   let div: HTMLDivElement;
   let element: Badge;

--- a/packages/badge/test/visual/lumo/badge.test.ts
+++ b/packages/badge/test/visual/lumo/badge.test.ts
@@ -8,10 +8,6 @@ import '../../../vaadin-badge.js';
 import type { Icon } from '@vaadin/icon';
 import type { Badge } from '../../../vaadin-badge.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.badgeComponent = true;
-
 describe('badge', () => {
   let div: HTMLDivElement;
   let element: Badge;


### PR DESCRIPTION
## Description

We agreed to make `vaadin-badge` stable in 25.2 and remove feature flag. Removed `experimental` getter.

## Type of change

- Refactor