### PR TITLE
refactor: remove experimental feature flag from MDL component

### DIFF
--- a/dev/aura.html
+++ b/dev/aura.html
@@ -14,10 +14,6 @@
     <link rel="stylesheet" href="./aura/aura-extras.css" />
     <link rel="stylesheet" href="./aura/aura-control.css" />
     <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
       // Enable :active styles on iOS
       document.addEventListener('touchstart', () => {}, { passive: true });
     </script>

--- a/dev/master-detail-layout.html
+++ b/dev/master-detail-layout.html
@@ -83,11 +83,6 @@
     </template>
 
     <script type="module">
-      // Enable feature flag
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
       import '@vaadin/button';
       import '@vaadin/checkbox';
       import '@vaadin/select';

--- a/dev/mdl-use-cases/email-folders-list-message.html
+++ b/dev/mdl-use-cases/email-folders-list-message.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Email — Folders - List - Message</title>
     <script type="module" src="../common.js"></script>
-    <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-    </script>
     <link rel="stylesheet" href="./common.css" />
     <style>
       .folder-cell {

--- a/dev/mdl-use-cases/email-list-message.html
+++ b/dev/mdl-use-cases/email-list-message.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Email — List - Message</title>
     <script type="module" src="../common.js"></script>
-    <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-    </script>
     <link rel="stylesheet" href="./common.css" />
   </head>
   <body>

--- a/dev/mdl-use-cases/list-detail-extra.html
+++ b/dev/mdl-use-cases/list-detail-extra.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>List → Detail → Extra</title>
     <script type="module" src="../common.js"></script>
-    <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-    </script>
     <link rel="stylesheet" href="./common.css" />
     <style>
       .detail-content {

--- a/dev/mdl-use-cases/nav-section-list-detail.html
+++ b/dev/mdl-use-cases/nav-section-list-detail.html
@@ -5,12 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Nav → Section → List → Detail</title>
     <script type="module" src="../common.js"></script>
-    <script type="module">
-      window.Vaadin ||= {};
-      window.Vaadin.featureFlags ||= {};
-      window.Vaadin.featureFlags.badgeComponent = true;
-      window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-    </script>
     <link rel="stylesheet" href="./common.css" />
     <style>
       /* App nav (level 1) */

--- a/packages/master-detail-layout/ARCHITECTURE.md
+++ b/packages/master-detail-layout/ARCHITECTURE.md
@@ -166,4 +166,3 @@ The host sets `isolation: isolate` so these internal z-indices stay contained in
 - **`waitForAnimationProgress(element, offset)`**: waits until an animation is running on the element with translate strictly between 0 and offset (genuinely mid-flight, not at either endpoint's CSS resting state)
 - **Split mode sizing**: measure part elements directly (not `gridTemplateColumns`, which has 4 columns)
 - **Vertical tests**: integrated into each test file under `describe('vertical')` suites
-- **Feature flag**: `window.Vaadin.featureFlags.masterDetailLayoutComponent = true` required before import

--- a/packages/master-detail-layout/README.md
+++ b/packages/master-detail-layout/README.md
@@ -2,8 +2,6 @@
 
 A web component for building UIs with a master (or primary) area and a detail (or secondary) area.
 
-> ⚠️ This component is experimental and the API may change. In order to use it, enable the feature flag by setting `window.Vaadin.featureFlags.masterDetailLayoutComponent = true`.
-
 ```html
 <vaadin-master-detail-layout>
   <div>Master content</div>

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -237,10 +237,6 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
     };
   }
 
-  static get experimental() {
-    return true;
-  }
-
   /** @protected */
   render() {
     const isOverlay = this.hasAttribute('has-detail') && this.hasAttribute('overlay');

--- a/packages/master-detail-layout/test/aria.test.js
+++ b/packages/master-detail-layout/test/aria.test.js
@@ -5,10 +5,6 @@ import './helpers/master-content.js';
 import './helpers/detail-content.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('ARIA', () => {
   let layout, master, detail;
 

--- a/packages/master-detail-layout/test/detail-auto-size.test.js
+++ b/packages/master-detail-layout/test/detail-auto-size.test.js
@@ -5,10 +5,6 @@ import '../src/vaadin-master-detail-layout.js';
 import { css, html, LitElement } from 'lit';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('detail auto size', () => {
   let layout;
 

--- a/packages/master-detail-layout/test/dom/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/dom/master-detail-layout.test.js
@@ -3,10 +3,6 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../../src/vaadin-master-detail-layout.js';
 import { onceResized } from '../helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('vaadin-master-detail-layout', () => {
   let layout;
 

--- a/packages/master-detail-layout/test/events.test.js
+++ b/packages/master-detail-layout/test/events.test.js
@@ -7,10 +7,6 @@ import './helpers/master-content.js';
 import './helpers/detail-content.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('events', () => {
   let layout;
 

--- a/packages/master-detail-layout/test/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/master-detail-layout.test.js
@@ -4,10 +4,6 @@ import sinon from 'sinon';
 import '../src/vaadin-master-detail-layout.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('vaadin-master-detail-layout', () => {
   let layout, master, detail;
 

--- a/packages/master-detail-layout/test/overlay-detection.test.js
+++ b/packages/master-detail-layout/test/overlay-detection.test.js
@@ -3,10 +3,6 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-master-detail-layout.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('overlay detection', () => {
   describe('horizontal', () => {
     let layout;

--- a/packages/master-detail-layout/test/overlay.test.js
+++ b/packages/master-detail-layout/test/overlay.test.js
@@ -3,10 +3,6 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-master-detail-layout.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('overlay', () => {
   describe('default (no overlaySize)', () => {
     describe('horizontal', () => {

--- a/packages/master-detail-layout/test/split-mode.test.js
+++ b/packages/master-detail-layout/test/split-mode.test.js
@@ -3,10 +3,6 @@ import { fixtureSync } from '@vaadin/testing-helpers';
 import '../src/vaadin-master-detail-layout.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 function getPartSizes(layout, dimension) {
   const master = layout.shadowRoot.querySelector('[part="master"]');
   const detail = layout.shadowRoot.querySelector('[part="detail"]');

--- a/packages/master-detail-layout/test/transitions.test.js
+++ b/packages/master-detail-layout/test/transitions.test.js
@@ -6,10 +6,6 @@ import './helpers/master-content.js';
 import './helpers/detail-content.js';
 import { onceResized } from './helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('Transitions', () => {
   let layout;
 

--- a/packages/master-detail-layout/test/visual/aura/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/visual/aura/master-detail-layout.test.js
@@ -4,10 +4,6 @@ import '@vaadin/aura/aura.css';
 import '../../../vaadin-master-detail-layout.js';
 import { onceResized } from '../../helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('master-detail-layout', () => {
   let element, mdl;
 

--- a/packages/master-detail-layout/test/visual/base/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/visual/base/master-detail-layout.test.js
@@ -3,10 +3,6 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../src/vaadin-master-detail-layout.js';
 import { onceResized } from '../../helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('master-detail-layout', () => {
   let div, mdl;
 

--- a/packages/master-detail-layout/test/visual/lumo/master-detail-layout.test.js
+++ b/packages/master-detail-layout/test/visual/lumo/master-detail-layout.test.js
@@ -6,10 +6,6 @@ import '@vaadin/vaadin-lumo-styles/components/master-detail-layout.css';
 import '../../../vaadin-master-detail-layout.js';
 import { onceResized } from '../../helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('master-detail-layout', () => {
   let element;
 

--- a/test/integration/master-detail-layout-form-layout.test.js
+++ b/test/integration/master-detail-layout-form-layout.test.js
@@ -3,10 +3,6 @@ import '@vaadin/form-layout';
 import '@vaadin/master-detail-layout';
 import { assertFormLayoutGrid } from '@vaadin/form-layout/test/helpers.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.masterDetailLayoutComponent = true;
-
 describe('form-layout in master-detail-layout', () => {
   let mdl;
 


### PR DESCRIPTION
## Description

We agreed to make `vaadin-master-detail-layout` stable in 25.2 and remove feature flag. Removed `experimental` getter.

## Type of change

- Refactor