### PR TITLE
refactor: remove obsolete .d.ts file for MDL transition styles

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-transition-base-styles.d.ts
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-transition-base-styles.d.ts
@@ -1,8 +1,0 @@
-/**
- * @license
- * Copyright (c) 2025 - 2026 Vaadin Ltd.
- * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
- */
-import type { CSSResult } from 'lit';
-
-export const masterDetailLayoutTransitionStyles: CSSResult;


### PR DESCRIPTION
## Description

The `.js` file was removed in https://github.com/vaadin/web-components/pull/11371 but I missed to remove `.d.ts`. This PR fixes that.

## Type of change

- Refactor