### PR TITLE
fix: do not use light-dark() in registerProperty for Safari 17

### DIFF
--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -22,8 +22,6 @@ import { addGlobalStyles } from './add-global-styles.js';
     name: propertyName,
     syntax: '<color>',
     inherits: true,
-    // Use initial value without light-dark() syntax so that registering
-    // does not throw in earlier Safari 17 minors which don't support it.
     initialValue: 'transparent',
   });
 });

--- a/packages/component-base/src/styles/style-props.js
+++ b/packages/component-base/src/styles/style-props.js
@@ -22,9 +22,9 @@ import { addGlobalStyles } from './add-global-styles.js';
     name: propertyName,
     syntax: '<color>',
     inherits: true,
-    // Use this initial value so the color stays visible when the property
-    // is set to an invalid value to make debugging a bit easier.
-    initialValue: 'light-dark(black, white)',
+    // Use initial value without light-dark() syntax so that registering
+    // does not throw in earlier Safari 17 minors which don't support it.
+    initialValue: 'transparent',
   });
 });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11776

## Type of change

- Bugfix