### PR TITLE
test: disable breadcrumbs link color transitions in visual tests

### DIFF
--- a/packages/breadcrumbs/test/visual/not-animated-styles.js
+++ b/packages/breadcrumbs/test/visual/not-animated-styles.js
@@ -16,7 +16,9 @@ registerStyles(
   css`
     :host,
     :host::before,
-    :host::after {
+    :host::after,
+    [part='link'],
+    [part='nolink'] {
       transition: none !important;
     }
   `,


### PR DESCRIPTION
The Lumo theme animates the breadcrumbs item link color over 140 ms
and Aura over 80 ms. Visual snapshots fired shortly after the test
loads can land mid-transition, producing tiny baseline drift that
differs between local and CI runs and shows up as 1–2 % image diffs
on otherwise unchanged tests.

The existing `not-animated-styles.js` already clears transitions on
the host and its pseudo-elements, but the link is a real child in
the item's shadow DOM, so the rule didn't reach it. Extend the
registration to also target `[part='link']` and `[part='nolink']`.

Baselines regenerated so every captured state lands on the final
color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)