### PR TITLE
fix: use CSS property to set highcharts label text color

### DIFF
--- a/packages/charts/theme/vaadin-chart-base-theme.js
+++ b/packages/charts/theme/vaadin-chart-base-theme.js
@@ -824,6 +824,10 @@ const chartBaseTheme = css`
     fill: inherit;
   }
 
+  :where([styled-mode]) .highcharts-label text {
+    fill: var(--vaadin-charts-data-label, hsla(214, 42%, 18%, 0.72));
+  }
+
   :where([styled-mode]) .highcharts-candlestick-series .highcharts-point {
     stroke: var(--vaadin-charts-contrast-60pct, hsla(214, 43%, 19%, 0.61));
     stroke-width: 1px;


### PR DESCRIPTION
## Description

The `fill` value for the `<text>` elements inside `.highcharts-label` is not set leading to low contrast values when dark mode is being used, for instance (in the screenshots below, that happens to the **Zoom** text in the top-left of the images).

This change adds a new CSS rule to set the `fill` color for such elements using the `--vaadin-charts-data-label`, which is the same value being used in v25. Both the CSS property and the fallback values are the same used in other similar elements.

#### Before
| Light | Dark |
|--------|--------|
| <img width="944" height="800" alt="localhost_8000_dev_charts_lumo_candlestick html" src="https://github.com/user-attachments/assets/fc6c048e-7c8e-4aab-b6a7-0fd9ea4e8af8" /> | <img width="944" height="800" alt="localhost_8000_dev_charts_lumo_candlestick html (1)" src="https://github.com/user-attachments/assets/08fe3ea2-cea3-4d8c-b383-35c83b3d0faa" /> |

#### After
| Light | Dark |
|--------|--------|
| <img width="944" height="800" alt="localhost_8000_dev_charts_lumo_candlestick html (2)" src="https://github.com/user-attachments/assets/bdaf08a3-1d21-4f72-9e16-c23de0b2e802" /> | <img width="944" height="800" alt="localhost_8000_dev_charts_lumo_candlestick html (3)" src="https://github.com/user-attachments/assets/1b9e65c9-694b-45e6-92ec-8f8c014f94a7" /> |

Fixes #11777

## Type of change

- Bugfix
