### PR TITLE
refactor: remove no longer needed caret-color rule

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
+++ b/packages/vaadin-lumo-styles/src/components/multi-select-combo-box.css
@@ -52,10 +52,6 @@
     padding-inline-start: 0;
   }
 
-  :host([has-value]) ::slotted(input:placeholder-shown) {
-    caret-color: var(--lumo-body-text-color) !important;
-  }
-
   [part='label'] {
     flex-shrink: 0;
   }


### PR DESCRIPTION
The PR removes the following rule from multi-select-combo-box Lumo styles:

```css
:host([has-value]) ::slotted(input:placeholder-shown) {
  caret-color: var(--lumo-body-text-color) !important;
}
```

This rule was added in https://github.com/vaadin/web-components/pull/3779 to keep the caret visible at a time when a similar rule was setting `color: transparent` on the input element to hide the placeholder text – an approach that also affected the caret color. 

Later, in https://github.com/vaadin/web-components/pull/4571, the placeholder-hiding approach was changed to setting `color: transparent` on `input::placeholder` instead, which is more targeted and doesn't affect the caret. However, the rule in question was never cleaned up, and its `!important` actually makes it impossible to override the `caret-color` property from the light DOM.

Finding from https://github.com/vaadin/web-components/pull/11794
