### PR TITLE
test: remove obsolete pre-opened describe block in select.test.js

### DIFF
--- a/packages/select/test/select.test.js
+++ b/packages/select/test/select.test.js
@@ -761,22 +761,4 @@ describe('vaadin-select', () => {
       expect(parseFloat(window.getComputedStyle(select).width)).to.eql(500);
     });
   });
-
-  describe('pre-opened', () => {
-    beforeEach(() => {
-      select = document.createElement('vaadin-select');
-      select.items = [{ label: 'Option 1', value: 'value-1' }];
-    });
-
-    afterEach(() => {
-      select.remove();
-    });
-
-    it('should not close overlay when opened set before adding to DOM', async () => {
-      select.opened = true;
-      document.body.appendChild(select);
-      await nextUpdate(select);
-      expect(select._overlayElement.opened).to.be.true;
-    });
-  });
 });


### PR DESCRIPTION
Removed the `describe('pre-opened')` block added in #8402 to guard a Polymer-era closure-on-attach bug. After the Lit migration, the defensive `_overlayElement`/`_menuElement`/`focusElement` checks in `_openedChanged` were dropped in #9576, so the regression path no longer exists.

Follow-up to #11802.