### PR TITLE
test: remove obsolete no-throw pre-opened combo-box tests

### DIFF
--- a/packages/combo-box/test/basic.test.js
+++ b/packages/combo-box/test/basic.test.js
@@ -377,14 +377,6 @@ describe('value set before attach', () => {
 });
 
 describe('pre-opened', () => {
-  it('should not throw error when adding a pre-opened combo-box', () => {
-    expect(() => fixtureSync(`<vaadin-combo-box opened></vaadin-combo-box>`)).to.not.throw(Error);
-  });
-
-  it('should not throw error when adding a pre-opened combo-box with items', () => {
-    expect(() => fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`)).to.not.throw(Error);
-  });
-
   it('should have overlay with correct width', async () => {
     const comboBox = fixtureSync(`<vaadin-combo-box opened items="[0]"></vaadin-combo-box>`);
     await nextRender();


### PR DESCRIPTION
Removes the two no-throw smoke tests in `describe('pre-opened')` added in #2611 and #4221. The Polymer-era throw paths they guarded (skipped `requestContentUpdate`, missing `_scroller` access) no longer exist after the Lit migration — `requestContentUpdate` now has an early return when the scroller is not ready, and pre-opened state flows through the reactive lifecycle.

The remaining pre-opened tests still cover overlay width (#2611) and scroller max-height (#4052) with real assertions.