### PR TITLE
feat: implement arrow key navigation for breadcrumbs overlay items

### DIFF
--- a/packages/breadcrumbs/spec/implementation-notes.md
+++ b/packages/breadcrumbs/spec/implementation-notes.md
@@ -161,3 +161,15 @@ Task 9 needed two properties the controller-based setup did not provide: a singl
   - Spec gap: Lumo/Aura overflow-button and overlay styling not added — `figma-design.md` does not exist yet, so the visual contract is missing. Tracked separately; will land alongside Step 5 (figma design) or as a follow-up commit.
   - Non-blocking: `__onOverlayOpen` explicitly focuses the first item, which may duplicate `OverlayMixin._trapFocus()`'s built-in initial focus. Could be removed if the explicit-focus tests still pass without it. Left in for now to keep focus behaviour deterministic.
   - Non-blocking: synchronous overflow measurement may under-count the overflow button's width during the collapse loop because `[part="overflow"]`'s `hidden` attribute lags Lit's render tick. A boundary-width test would catch this; not observed in the current visual snapshots.
+
+## Task 10 — Keyboard navigation in the overflow overlay
+
+- **Commit:** d4b250fef7
+- **Date:** 2026-05-22
+- **Decisions:**
+  - Arrow / Home / End handling extends the existing `__onOverlayKeyDown` rather than composing `KeyboardDirectionMixin`. The mixin's `isElementFocused(item)` membership test would fail here because `delegatesFocus: true` on `<vaadin-breadcrumbs-item>` makes the item itself the host-level `activeElement`, but the mixin also assumes orientation / Tab roving / `_focused`-attribute semantics that don't apply to a transient overlay; the inline branch is ~25 lines and stays focused.
+  - Focused-item resolution uses `isElementFocused` from `@vaadin/a11y-base/src/focus-utils.js`. `delegatesFocus: true` on the item element bubbles the focused element up to the item at the host level, so `getRootNode().activeElement === item` is true whenever the inner link has focus.
+  - Wrap-around at both ends mirrors `<vaadin-context-menu-list-box>` and `<vaadin-menu-bar>` (both compose `KeyboardDirectionMixin._getAvailableIndex`). Documented inline as a code comment in `__onOverlayKeyDown`; no spec change.
+  - Tests added under a new `describe('navigation', …)` block at `max-width: 200px` (5 items collapse to overlay). Each test starts from a known focused link — relying on the Task 9 focus-on-open invariant — and asserts focus moves to the expected sibling.
+- **Surprises:** —
+- **Spec adjustments:** —

--- a/packages/breadcrumbs/spec/implementation-notes.md
+++ b/packages/breadcrumbs/spec/implementation-notes.md
@@ -173,3 +173,16 @@ Task 9 needed two properties the controller-based setup did not provide: a singl
   - Tests added under a new `describe('navigation', …)` block at `max-width: 200px` (5 items collapse to overlay). Each test starts from a known focused link — relying on the Task 9 focus-on-open invariant — and asserts focus moves to the expected sibling.
 - **Surprises:** —
 - **Spec adjustments:** —
+
+## Task 10 follow-up — Adopt `KeyboardDirectionMixin`, skip disabled overlay items
+
+- **Date:** 2026-05-22
+- **Decisions:**
+  - Replaced the ~25-line inline `__onOverlayKeyDown` handler with `KeyboardDirectionMixin` from `@vaadin/a11y-base`. The original "mixin is not a fit" rationale (above) turned out to be wrong: `KeyboardDirectionMixin`'s default `focused` getter uses `isElementFocused(item)`, which returns `true` when `delegatesFocus: true` routes the inner link's focus up to the item itself. No override of `focused` is needed. `_vertical` defaults to `true` (we want ArrowUp/Down) and `_tabNavigation` defaults to `false` (we don't want roving tabindex on Tab), so neither needs overriding either.
+  - Three overrides on `<vaadin-breadcrumbs>`: (1) `_getItems()` returns only `slot="overlay"` items so arrow nav stays inside the overlay; (2) `_onKeyDown(event)` short-circuits unless `this.__overlayOpened` is truthy, with a Tab branch that closes the overlay before delegating to `super` — explicit state check is preferred over the mixin's `focused` getter so the guard does not depend on which descendant element currently owns focus; (3) `focus(options)` targets the root item, falling back to the overflow button when the root is disabled or collapsed into the overlay — so `breadcrumbs.focus()` lands on a visible focusable element instead of the mixin's default "first overlay item".
+  - The legacy private helper that returned all light-DOM `<vaadin-breadcrumbs-item>` children was renamed from `__getItems` → `__getAllItems` to disambiguate from the mixin's `_getItems` override (used only for arrow-nav).
+  - The template's `@keydown="${this.__onOverlayKeyDown}"` binding on `<vaadin-breadcrumbs-overlay>` was removed — `KeyboardMixin` attaches the listener on the host instead, and the events still bubble up from slotted overlay items.
+  - `__onOverlayOpen` now uses the mixin's `_getAvailableIndex(items, 0, 1, null)` + `_focus(idx)` to land on the first non-disabled overlay item. If every collapsed item is disabled, no focus is moved.
+  - Five new disabled-skip tests landed under `describe('navigation with disabled items', …)`: ArrowDown/ArrowUp over a disabled middle item, Home/End when the boundary item is disabled, and open-time focus when the first overlay item is disabled.
+- **Surprises:** —
+- **Spec adjustments:** Spec body keyboard section updated to mention disabled-item skipping in arrow / Home / End navigation and the "first non-disabled" semantics of open-time focus. New Discussion entry `Q: Why does arrow-key navigation skip disabled overlay items?` added to `web-component-spec.md`.

--- a/packages/breadcrumbs/spec/web-component-spec.md
+++ b/packages/breadcrumbs/spec/web-component-spec.md
@@ -184,8 +184,8 @@ Internal behavior:
 - **Close on outside click and Escape.** Provided by `OverlayMixin`. The breadcrumb does not re-implement either.
 - **Positioning relative to the overflow button.** Driven by the `positionTarget` property from `PositionMixin`, matching the convention used by `<vaadin-combo-box-overlay>` and `<vaadin-avatar-group-overlay>`.
 - **Keyboard interaction within the open overlay.**
-  - **Focus on open** — when the overlay opens (via overflow-button click, Enter, or Space), the breadcrumbs container moves focus to the first slotted overlay item's link so keyboard users land directly inside the popup.
-  - **Arrow keys** — Up/Down arrows move focus between adjacent links inside the open overlay (Home/End jump to first/last). The overlay reads as a menu visually, so menu-style keyboard navigation is the primary way to traverse its items.
+  - **Focus on open** — when the overlay opens (via overflow-button click, Enter, or Space), the breadcrumbs container moves focus to the first non-disabled slotted overlay item's link so keyboard users land directly inside the popup.
+  - **Arrow keys** — Up/Down arrows move focus between adjacent links inside the open overlay (Home/End jump to first/last). Disabled items are skipped — arrow keys, Home, and End land on the nearest non-disabled item in the requested direction. The overlay reads as a menu visually, so menu-style keyboard navigation is the primary way to traverse its items.
   - **Tab / Shift+Tab** — closes the overlay. `restore-focus-on-close` returns focus to the overflow button, from which the native Tab / Shift+Tab traversal then moves focus to the next / previous focusable trail item in document order.
   - **Escape** — closes the overlay and returns focus to the overflow button.
 
@@ -260,6 +260,14 @@ The overlay reads visually as a menu, so users coming from menu-bar / context-me
 **Q: Why does Tab close the overflow overlay?**
 
 For consistency with the other Vaadin overlay-with-overflow component, `<vaadin-avatar-group>`, whose overflow menu also closes on Tab and Shift+Tab. The overflow overlay is a transient popup anchored to a trigger button; keeping it open while focus has already moved past the trigger creates an orphaned popup whose contents no longer match where the user is in the document. Closing on Tab matches the dismiss-on-blur behavior users expect from any popover, and `restore-focus-on-close` returns focus to the overflow button when needed so the trail's tab order remains predictable.
+
+**Q: Why does arrow-key navigation skip disabled overlay items?**
+
+Arrow / Home / End navigation in the overflow overlay is implemented via `KeyboardDirectionMixin` from `@vaadin/a11y-base`, the same primitive that powers `<vaadin-context-menu-list-box>`, `<vaadin-menu-bar>`, and `<vaadin-accordion>`. The mixin's `_isItemFocusable(item)` defaults to `!item.hasAttribute('disabled')` and is honored by both the per-keystroke lookup and the open-time first-focus path, so disabled items are skipped uniformly. The alternative — letting focus land on a disabled item — would conflict with the item's own `tabindex="-1"`, `aria-disabled="true"`, and suppressed click contract, and would diverge from the menu-style navigation users encounter everywhere else in the library.
+
+**Q: Why does `breadcrumbs.focus()` target the root item, with the overflow button as a fallback?**
+
+The root is the trail's natural entry point — applications that programmatically focus the component expect focus to land at the start of the trail. When the root is unavailable (its `disabled` attribute is set, or overflow has collapsed it into the overlay so it is no longer rendered in the trail), the next visible focusable element belonging to the breadcrumbs is the overflow button — focusing that gives keyboard users an unambiguous handle on the navigation without quietly no-op'ing or jumping into the collapsed overlay. The mixin's default `focus()` would walk into the first slotted overlay item, which is not the right entry surface for a navigation landmark.
 
 **Q: Should `<vaadin-breadcrumbs-item>` expose a `target` property?**
 

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.d.ts
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.d.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2026 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import type { KeyboardDirectionMixinClass } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ResizeMixinClass } from '@vaadin/component-base/src/resize-mixin.js';
@@ -17,7 +18,7 @@ export interface BreadcrumbsI18n {
  */
 declare class Breadcrumbs extends ElementMixin(HTMLElement) {}
 
-interface Breadcrumbs extends I18nMixinClass<BreadcrumbsI18n>, ResizeMixinClass {}
+interface Breadcrumbs extends I18nMixinClass<BreadcrumbsI18n>, KeyboardDirectionMixinClass, ResizeMixinClass {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.js
@@ -6,7 +6,7 @@
 import './vaadin-breadcrumbs-item.js';
 import './vaadin-breadcrumbs-overlay.js';
 import { html, LitElement } from 'lit';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
@@ -27,7 +27,9 @@ const DEFAULT_I18N = {
  * @customElement vaadin-breadcrumbs
  * @extends HTMLElement
  */
-class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
+class Breadcrumbs extends KeyboardDirectionMixin(
+  ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
+) {
   static get is() {
     return 'vaadin-breadcrumbs';
   }
@@ -119,7 +121,6 @@ class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoIn
         exportparts="overlay, content: overlay-content"
         @opened-changed="${this.__onOverlayOpenedChanged}"
         @vaadin-overlay-open="${this.__onOverlayOpen}"
-        @keydown="${this.__onOverlayKeyDown}"
       >
         <slot name="overlay"></slot>
       </vaadin-breadcrumbs-overlay>
@@ -154,7 +155,7 @@ class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoIn
   }
 
   /** @private */
-  __getItems() {
+  __getAllItems() {
     return [...this.children].filter((node) => node.localName === 'vaadin-breadcrumbs-item');
   }
 
@@ -164,7 +165,7 @@ class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoIn
    * @private
    */
   __updateItems() {
-    const items = this.__getItems();
+    const items = this.__getAllItems();
     const lastIndex = items.length - 1;
     items.forEach((item, index) => {
       const isCurrent = index === lastIndex && item.path == null;
@@ -201,7 +202,7 @@ class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoIn
    * @private
    */
   __updateOverflow() {
-    const items = this.__getItems();
+    const items = this.__getAllItems();
     this.__restoreSlots(items);
 
     if (items.length <= 1) {
@@ -266,52 +267,67 @@ class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoIn
 
   /** @private */
   __onOverlayOpen() {
-    // Move focus to the first slotted overlay item's link, if any.
-    const firstItem = this.querySelector('vaadin-breadcrumbs-item[slot="overlay"]');
-    if (firstItem) {
-      firstItem.focus();
+    // Focus first non-disabled overlay item
+    const idx = this._getFocusableIndex();
+    if (idx >= 0) {
+      this._focus(idx);
     }
   }
 
-  /** @private */
-  __onOverlayKeyDown(event) {
+  /**
+   * Override the method inherited from `KeyboardDirectionMixin` to
+   * close on Tab and implement arrow key navigation in the overlay.
+   *
+   * @param {KeyboardEvent} event
+   * @protected
+   * @override
+   */
+  _onKeyDown(event) {
+    if (!this.__overlayOpened) {
+      return;
+    }
+
     if (event.key === 'Tab') {
       this.__overlayOpened = false;
       return;
     }
 
-    const { key } = event;
-    if (key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Home' && key !== 'End') {
+    super._onKeyDown(event);
+  }
+
+  /**
+   * Override method inherited from `KeyboardDirectionMixin`
+   * to only use overlay items for the arrow key navigation.
+   *
+   * @return {Element[]}
+   * @protected
+   * @override
+   */
+  _getItems() {
+    return [...this.querySelectorAll('vaadin-breadcrumbs-item[slot="overlay"]')];
+  }
+
+  /**
+   * Override the method inherited from `KeyboardDirectionMixin` to make
+   * `breadcrumbs.focus()` lands on the root item. When the root item is
+   * disabled or collapsed to overlay, focus the overflow button instead.
+   *
+   * @param {FocusOptions=} options
+   * @protected
+   * @override
+   */
+  focus(options) {
+    const rootItem = this.querySelector('vaadin-breadcrumbs-item');
+    if (!rootItem) {
       return;
     }
 
-    const overlayItems = [...this.querySelectorAll('vaadin-breadcrumbs-item[slot="overlay"]')];
-    if (overlayItems.length === 0) {
+    if (rootItem.disabled || rootItem.slot === 'overlay') {
+      this.$.overflow.focus(options);
       return;
     }
 
-    event.preventDefault();
-
-    // `delegatesFocus: true` on the item element means the item is reported
-    // as the focused element at the host level when its inner link has focus.
-    const currentIndex = overlayItems.findIndex((item) => isElementFocused(item));
-
-    // ArrowDown / ArrowUp wrap at both ends to match the menu-style navigation
-    // used by `<vaadin-context-menu-list-box>` and `<vaadin-menu-bar>` (both
-    // composed over `KeyboardDirectionMixin`).
-    const lastIndex = overlayItems.length - 1;
-    let nextIndex = currentIndex;
-    if (key === 'ArrowDown') {
-      nextIndex = currentIndex >= lastIndex ? 0 : currentIndex + 1;
-    } else if (key === 'ArrowUp') {
-      nextIndex = currentIndex <= 0 ? lastIndex : currentIndex - 1;
-    } else if (key === 'Home') {
-      nextIndex = 0;
-    } else if (key === 'End') {
-      nextIndex = lastIndex;
-    }
-
-    overlayItems[nextIndex].focus();
+    rootItem.focus(options);
   }
 }
 

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.js
@@ -6,6 +6,7 @@
 import './vaadin-breadcrumbs-item.js';
 import './vaadin-breadcrumbs-overlay.js';
 import { html, LitElement } from 'lit';
+import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
@@ -276,7 +277,41 @@ class Breadcrumbs extends ResizeMixin(I18nMixin(ElementMixin(PolylitMixin(LumoIn
   __onOverlayKeyDown(event) {
     if (event.key === 'Tab') {
       this.__overlayOpened = false;
+      return;
     }
+
+    const { key } = event;
+    if (key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Home' && key !== 'End') {
+      return;
+    }
+
+    const overlayItems = [...this.querySelectorAll('vaadin-breadcrumbs-item[slot="overlay"]')];
+    if (overlayItems.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    // `delegatesFocus: true` on the item element means the item is reported
+    // as the focused element at the host level when its inner link has focus.
+    const currentIndex = overlayItems.findIndex((item) => isElementFocused(item));
+
+    // ArrowDown / ArrowUp wrap at both ends to match the menu-style navigation
+    // used by `<vaadin-context-menu-list-box>` and `<vaadin-menu-bar>` (both
+    // composed over `KeyboardDirectionMixin`).
+    const lastIndex = overlayItems.length - 1;
+    let nextIndex = currentIndex;
+    if (key === 'ArrowDown') {
+      nextIndex = currentIndex >= lastIndex ? 0 : currentIndex + 1;
+    } else if (key === 'ArrowUp') {
+      nextIndex = currentIndex <= 0 ? lastIndex : currentIndex - 1;
+    } else if (key === 'Home') {
+      nextIndex = 0;
+    } else if (key === 'End') {
+      nextIndex = lastIndex;
+    }
+
+    overlayItems[nextIndex].focus();
   }
 }
 

--- a/packages/breadcrumbs/test/overflow.test.js
+++ b/packages/breadcrumbs/test/overflow.test.js
@@ -240,4 +240,74 @@ describe('overflow', () => {
       expect(overlay.opened).to.be.false;
     });
   });
+
+  describe('navigation', () => {
+    let overlayItems;
+
+    beforeEach(async () => {
+      // Collapse all items to the overlay
+      breadcrumbs.style.maxWidth = '200px';
+      await nextResize(breadcrumbs);
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      overlayItems = items.filter((item) => item.slot === 'overlay');
+    });
+
+    it('should move focus to the next link on ArrowDown', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender();
+
+      expectFocusedItem(overlayItems[1]);
+    });
+
+    it('should move focus to the previous link on ArrowUp', async () => {
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender();
+
+      await sendKeys({ press: 'ArrowUp' });
+      await nextRender();
+
+      expectFocusedItem(overlayItems[0]);
+    });
+
+    it('should focus the first link on ArrowDown when the last one is focused', async () => {
+      for (let i = 0; i < overlayItems.length - 1; i += 1) {
+        await sendKeys({ press: 'ArrowDown' });
+        await nextRender();
+      }
+
+      expectFocusedItem(overlayItems.at(-1));
+
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender();
+
+      expectFocusedItem(overlayItems[0]);
+    });
+
+    it('should focus the last link on ArrowUp when the first one is focused', async () => {
+      await sendKeys({ press: 'ArrowUp' });
+      await nextRender();
+
+      expectFocusedItem(overlayItems.at(-1));
+    });
+
+    it('should focus the last link on End', async () => {
+      await sendKeys({ press: 'End' });
+      await nextRender();
+
+      expectFocusedItem(overlayItems.at(-1));
+    });
+
+    it('should focus the first link on Home', async () => {
+      await sendKeys({ press: 'End' });
+      await nextRender();
+
+      await sendKeys({ press: 'Home' });
+      await nextRender();
+
+      expectFocusedItem(overlayItems[0]);
+    });
+  });
 });

--- a/packages/breadcrumbs/test/overflow.test.js
+++ b/packages/breadcrumbs/test/overflow.test.js
@@ -310,4 +310,96 @@ describe('overflow', () => {
       expectFocusedItem(overlayItems[0]);
     });
   });
+
+  describe('disabled items', () => {
+    beforeEach(async () => {
+      // Collapse all items to the overlay
+      breadcrumbs.style.maxWidth = '200px';
+      await nextResize(breadcrumbs);
+    });
+
+    it('should skip a disabled item on ArrowDown', async () => {
+      items[1].disabled = true;
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      await sendKeys({ press: 'ArrowDown' });
+      await nextRender();
+
+      expectFocusedItem(items[2]);
+    });
+
+    it('should skip a disabled item on ArrowUp', async () => {
+      items[3].disabled = true;
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      await sendKeys({ press: 'End' });
+      await nextRender();
+
+      await sendKeys({ press: 'ArrowUp' });
+      await nextRender();
+
+      expectFocusedItem(items[2]);
+    });
+
+    it('should focus the previous focusable item on End when last is disabled', async () => {
+      items[4].disabled = true;
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      await sendKeys({ press: 'End' });
+      await nextRender();
+
+      expectFocusedItem(items[3]);
+    });
+
+    it('should focus the next focusable item on Home when first is disabled', async () => {
+      items[0].disabled = true;
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      await sendKeys({ press: 'End' });
+      await nextRender();
+
+      await sendKeys({ press: 'Home' });
+      await nextRender();
+
+      expectFocusedItem(items[1]);
+    });
+
+    it('should focus the first non-disabled overlay item on open', async () => {
+      items[0].disabled = true;
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+
+      expectFocusedItem(items[1]);
+    });
+  });
+
+  describe('focus()', () => {
+    it('should focus the overflow button when the root item is disabled', async () => {
+      breadcrumbs.style.maxWidth = '600px';
+      await nextResize(breadcrumbs);
+      items[0].disabled = true;
+
+      breadcrumbs.focus();
+
+      expect(breadcrumbs.shadowRoot.activeElement).to.equal(button);
+    });
+
+    it('should focus the overflow button when the root item is collapsed', async () => {
+      breadcrumbs.style.maxWidth = '200px';
+      await nextResize(breadcrumbs);
+
+      breadcrumbs.focus();
+
+      expect(breadcrumbs.shadowRoot.activeElement).to.equal(button);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Implemented breadcrumbs task 10: overflow items arrow key navigation.

## Type of change

- Feature

## Note

First 2 commits are auto-generated by skill. I will add review comments and address them in follow-up commits.