### PR TITLE
chore: remove modularUpload and messageListAttachments flags

### DIFF
--- a/dev/messages-ai-chat.html
+++ b/dev/messages-ai-chat.html
@@ -46,11 +46,6 @@
       }
     </style>
 
-    <script>
-      window.Vaadin ??= {};
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.aiComponents = true;
-    </script>
     <script type="module">
       import '@vaadin/message-input';
       import '@vaadin/message-list';

--- a/dev/upload-manager.html
+++ b/dev/upload-manager.html
@@ -35,11 +35,6 @@
     <vaadin-upload-file-list id="file-list"></vaadin-upload-file-list>
 
     <script type="module">
-      // Enable the modularUpload feature flag before importing
-      window.Vaadin ??= {};
-      window.Vaadin.featureFlags ??= {};
-      window.Vaadin.featureFlags.modularUpload = true;
-
       import '@vaadin/upload/vaadin-upload-button.js';
       import '@vaadin/upload/vaadin-upload-drop-zone.js';
       import '@vaadin/upload/vaadin-upload-file-list.js';

--- a/packages/message-list/src/vaadin-message-mixin.js
+++ b/packages/message-list/src/vaadin-message-mixin.js
@@ -118,16 +118,6 @@ export const MessageMixin = (superClass) =>
      * @private
      */
     __renderAttachments() {
-      if (
-        !(
-          window.Vaadin &&
-          window.Vaadin.featureFlags &&
-          (window.Vaadin.featureFlags.messageListAttachments || window.Vaadin.featureFlags.aiComponents)
-        )
-      ) {
-        return '';
-      }
-
       const attachments = this.attachments;
       if (!attachments || attachments.length === 0) {
         return '';

--- a/packages/message-list/test/dom/message-list.test.js
+++ b/packages/message-list/test/dom/message-list.test.js
@@ -1,10 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
-
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.messageListAttachments = true;
-
 import '../../src/vaadin-message-list.js';
 
 describe('vaadin-message-list', () => {

--- a/packages/message-list/test/dom/message.test.js
+++ b/packages/message-list/test/dom/message.test.js
@@ -1,10 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
-
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.messageListAttachments = true;
-
 import '../../src/vaadin-message.js';
 
 describe('vaadin-message', () => {

--- a/packages/message-list/test/message-list.test.js
+++ b/packages/message-list/test/message-list.test.js
@@ -15,11 +15,6 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.messageListAttachments = true;
-
 import '../src/vaadin-message-list.js';
 
 describe('message-list', () => {

--- a/packages/message-list/test/message.test.js
+++ b/packages/message-list/test/message.test.js
@@ -1,11 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.messageListAttachments = true;
-
 import '../src/vaadin-message.js';
 
 describe('message', () => {

--- a/packages/upload/src/vaadin-upload-file-list-mixin.js
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.js
@@ -405,11 +405,7 @@ export const UploadFileListMixin = (superClass) =>
                   .status="${file.status}"
                   .uploading="${file.uploading}"
                   .i18n="${i18n}"
-                  theme="${ifDefined(
-                    window.Vaadin.featureFlags.modularUpload || window.Vaadin.featureFlags.aiComponents
-                      ? this._theme
-                      : undefined,
-                  )}"
+                  theme="${ifDefined(this._theme)}"
                 ></vaadin-upload-file>
               </li>
             `,

--- a/packages/upload/src/vaadin-upload-manager.js
+++ b/packages/upload/src/vaadin-upload-manager.js
@@ -4,18 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-
 /**
  * A pure JavaScript class that manages file upload state and XHR requests.
  * It has no knowledge of UI components - components should listen to events and
  * call methods to interact with the manager.
- *
- * **Note:** This class is experimental and requires the `modularUpload` or `aiComponents` feature flag to be enabled:
- * ```javascript
- * window.Vaadin.featureFlags.modularUpload = true;
- * ```
  *
  * @example
  * ```javascript
@@ -107,12 +99,6 @@ export class UploadManager extends EventTarget {
    */
   constructor(options = {}) {
     super();
-
-    if (!window.Vaadin.featureFlags.modularUpload && !window.Vaadin.featureFlags.aiComponents) {
-      throw new Error(
-        'UploadManager requires the modularUpload feature flag. Enable it with: window.Vaadin.featureFlags.modularUpload = true',
-      );
-    }
 
     // Configuration properties - use setters for validation
     this.target = options.target || '';

--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -581,12 +581,7 @@ export const UploadMixin = (superClass) =>
         list.items = [...files];
         list.i18n = effectiveI18n;
         list.disabled = disabled;
-        if (
-          window.Vaadin &&
-          window.Vaadin.featureFlags &&
-          (window.Vaadin.featureFlags.modularUpload || window.Vaadin.featureFlags.aiComponents) &&
-          this._theme
-        ) {
+        if (this._theme) {
           list.setAttribute('theme', this._theme);
         } else {
           list.removeAttribute('theme');

--- a/packages/upload/test/dom/vaadin-upload-button.test.js
+++ b/packages/upload/test/dom/vaadin-upload-button.test.js
@@ -1,11 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, mousedown, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
-
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 import '../../src/vaadin-upload-button.js';
 import { UploadManager } from '../../src/vaadin-upload-manager.js';
 

--- a/packages/upload/test/dom/vaadin-upload-file.test.js
+++ b/packages/upload/test/dom/vaadin-upload-file.test.js
@@ -1,10 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextUpdate } from '@vaadin/testing-helpers';
-
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 import '../../src/vaadin-upload-file.js';
 
 describe('vaadin-upload-file', () => {

--- a/packages/upload/test/upload-button.test.ts
+++ b/packages/upload/test/upload-button.test.ts
@@ -1,11 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { enterKeyDown, fixtureSync, nextFrame, nextRender, spaceKeyDown } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 import '../src/vaadin-upload-button.js';
 import type { UploadButton } from '../src/vaadin-upload-button.js';
 import { UploadManager } from '../src/vaadin-upload-manager.js';

--- a/packages/upload/test/upload-drop-zone.test.ts
+++ b/packages/upload/test/upload-drop-zone.test.ts
@@ -1,11 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 import '../src/vaadin-upload-drop-zone.js';
 import type { UploadDropZone } from '../src/vaadin-upload-drop-zone.js';
 import { UploadManager } from '../src/vaadin-upload-manager.js';

--- a/packages/upload/test/upload-file-list.test.ts
+++ b/packages/upload/test/upload-file-list.test.ts
@@ -1,11 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 import '../src/vaadin-upload-file-list.js';
 import type { UploadFileList } from '../src/vaadin-upload-file-list.js';
 import { UploadManager } from '../src/vaadin-upload-manager.js';

--- a/packages/upload/test/upload-manager.test.ts
+++ b/packages/upload/test/upload-manager.test.ts
@@ -4,10 +4,6 @@ import type { UploadFile } from '../src/vaadin-upload-manager.js';
 import { UploadManager } from '../src/vaadin-upload-manager.js';
 import { createFile, createFiles, xhrCreator } from './helpers.js';
 
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 type MockXhr = {
   readyState: number;
   status: number;

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -1,11 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 import '../src/vaadin-upload.js';
 import { createFile, createFiles, removeFile, xhrCreator } from './helpers.js';
 

--- a/packages/upload/test/visual/aura/upload-button.test.js
+++ b/packages/upload/test/visual/aura/upload-button.test.js
@@ -8,10 +8,6 @@ import '../not-animated-styles.js';
 import '../../../vaadin-upload-button.js';
 import { UploadManager } from '../../../src/vaadin-upload-manager.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 describe('upload-button', () => {
   let div, element;
 

--- a/packages/upload/test/visual/aura/upload-file-list-thumbnails.test.js
+++ b/packages/upload/test/visual/aura/upload-file-list-thumbnails.test.js
@@ -4,11 +4,6 @@ import '@vaadin/aura/aura.css';
 import '../../../vaadin-upload-file-list.js';
 import { freezeLoaderAnimation, waitForRendered } from '../common.js';
 
-// Enable the feature flag so the theme propagates to upload-file children
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 describe('upload-file-list-thumbnails', () => {
   let div, element;
 

--- a/packages/upload/test/visual/base/upload-button.test.js
+++ b/packages/upload/test/visual/base/upload-button.test.js
@@ -7,10 +7,6 @@ import '../not-animated-styles.js';
 import '../../../src/vaadin-upload-button.js';
 import { UploadManager } from '../../../src/vaadin-upload-manager.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 describe('upload-button', () => {
   let div, element;
 

--- a/packages/upload/test/visual/base/upload-file-list-thumbnails.test.js
+++ b/packages/upload/test/visual/base/upload-file-list-thumbnails.test.js
@@ -3,11 +3,6 @@ import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../src/vaadin-upload-file-list.js';
 import { freezeLoaderAnimation, waitForRendered } from '../common.js';
 
-// Enable the feature flag so the theme propagates to upload-file children
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 describe('upload-file-list-thumbnails', () => {
   let div, element;
 

--- a/packages/upload/test/visual/lumo/upload-button.test.js
+++ b/packages/upload/test/visual/lumo/upload-button.test.js
@@ -9,10 +9,6 @@ import '../not-animated-styles.js';
 import '../../../vaadin-upload-button.js';
 import { UploadManager } from '../../../src/vaadin-upload-manager.js';
 
-window.Vaadin ||= {};
-window.Vaadin.featureFlags ||= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 describe('upload-button', () => {
   let div, element;
 

--- a/packages/upload/test/visual/lumo/upload-file-list-thumbnails.test.js
+++ b/packages/upload/test/visual/lumo/upload-file-list-thumbnails.test.js
@@ -5,11 +5,6 @@ import '@vaadin/vaadin-lumo-styles/components/upload.css';
 import '../../../vaadin-upload-file-list.js';
 import { freezeLoaderAnimation, waitForRendered } from '../common.js';
 
-// Enable the feature flag so the theme propagates to upload-file children
-window.Vaadin ??= {};
-window.Vaadin.featureFlags ??= {};
-window.Vaadin.featureFlags.modularUpload = true;
-
 describe('upload-file-list-thumbnails', () => {
   let div, element;
 


### PR DESCRIPTION
## Summary
- Drop the `modularUpload` and `messageListAttachments` feature-flag gates so the upload manager and message-list attachments work without opt-in.
- The umbrella `aiComponents` flag falls out as a side effect; the rest of the AI components remain experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)