### PR TITLE
fix: keep focused row inside the viewport after scroll in combo-box

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-focus-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-focus-index-mixin.js
@@ -52,10 +52,45 @@ export const ComboBoxFocusIndexMixin = (superClass) =>
 
       delete this.__pendingFocusIndex;
       requestAnimationFrame(() => {
-        if (this.isConnected) {
-          this._updateActiveDescendant(index);
+        if (!this.isConnected) {
+          return;
         }
+        this._updateActiveDescendant(index);
+        this.__correctScrollPosition(index);
       });
+    }
+
+    /**
+     * After `_focusedIndex` triggered the scroller's `scrollIntoView`, the
+     * row may still extend past the viewport when items above (or below)
+     * have variable heights — iron-list's index-counting heuristic in
+     * `scrollIntoView` counts items, not pixels, so taller-than-average
+     * neighbors push the target outside the viewport. Measure the target's
+     * actual rect after iron-list has settled and nudge `scrollTop` until
+     * the row fits.
+     *
+     * @private
+     */
+    __correctScrollPosition(index) {
+      const scroller = this._scroller;
+      if (!scroller || !this._overlayOpened) {
+        return;
+      }
+      const target = [...scroller.children].find((el) => !el.hidden && el.index === index);
+      if (!target) {
+        return;
+      }
+      const targetRect = target.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      const bottomOvershoot = targetRect.bottom - scrollerRect.bottom + scroller._viewportTotalPaddingBottom;
+      if (bottomOvershoot > 0) {
+        scroller.scrollTop += bottomOvershoot;
+        return;
+      }
+      const topUndershoot = scrollerRect.top - targetRect.top;
+      if (topUndershoot > 0) {
+        scroller.scrollTop -= topUndershoot;
+      }
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-focus-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-focus-index-mixin.js
@@ -52,45 +52,10 @@ export const ComboBoxFocusIndexMixin = (superClass) =>
 
       delete this.__pendingFocusIndex;
       requestAnimationFrame(() => {
-        if (!this.isConnected) {
-          return;
+        if (this.isConnected) {
+          this._updateActiveDescendant(index);
         }
-        this._updateActiveDescendant(index);
-        this.__correctScrollPosition(index);
       });
-    }
-
-    /**
-     * After `_focusedIndex` triggered the scroller's `scrollIntoView`, the
-     * row may still extend past the viewport when items above (or below)
-     * have variable heights — iron-list's index-counting heuristic in
-     * `scrollIntoView` counts items, not pixels, so taller-than-average
-     * neighbors push the target outside the viewport. Measure the target's
-     * actual rect after iron-list has settled and nudge `scrollTop` until
-     * the row fits.
-     *
-     * @private
-     */
-    __correctScrollPosition(index) {
-      const scroller = this._scroller;
-      if (!scroller || !this._overlayOpened) {
-        return;
-      }
-      const target = [...scroller.children].find((el) => !el.hidden && el.index === index);
-      if (!target) {
-        return;
-      }
-      const targetRect = target.getBoundingClientRect();
-      const scrollerRect = scroller.getBoundingClientRect();
-      const bottomOvershoot = targetRect.bottom - scrollerRect.bottom + scroller._viewportTotalPaddingBottom;
-      if (bottomOvershoot > 0) {
-        scroller.scrollTop += bottomOvershoot;
-        return;
-      }
-      const topUndershoot = scrollerRect.top - targetRect.top;
-      if (topUndershoot > 0) {
-        scroller.scrollTop -= topUndershoot;
-      }
     }
 
     /** @private */

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -192,18 +192,23 @@ export const ComboBoxScrollerMixin = (superClass) =>
       }
       this.__virtualizer.scrollToIndex(Math.max(0, targetIndex));
 
-      // Sometimes the item is partly below the bottom edge, detect and adjust.
-      const lastPhysicalItem = [...this.children].find(
-        (el) => !el.hidden && el.index === this.__virtualizer.lastVisibleIndex,
-      );
-      if (!lastPhysicalItem || index !== lastPhysicalItem.index) {
+      // iron-list re-estimates physical positions after each `scrollTop`
+      // write (and debounces some of that work), so the rendered rects only
+      // settle after a flush. Flushing here lets the rect-based correction
+      // below run on the final positions instead of stale ones.
+      this.__virtualizer.flush();
+
+      const target = [...this.children].find((el) => !el.hidden && el.index === index);
+      if (!target) {
         return;
       }
-      const lastPhysicalItemRect = lastPhysicalItem.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
       const scrollerRect = this.getBoundingClientRect();
-      const scrollTopAdjust = lastPhysicalItemRect.bottom - scrollerRect.bottom + this._viewportTotalPaddingBottom;
-      if (scrollTopAdjust > 0) {
-        this.scrollTop += scrollTopAdjust;
+      const targetBottom = targetRect.bottom + this._viewportTotalPaddingBottom;
+      if (targetBottom > scrollerRect.bottom) {
+        this.scrollTop += targetBottom - scrollerRect.bottom;
+      } else if (targetRect.top < scrollerRect.top) {
+        this.scrollTop -= scrollerRect.top - targetRect.top;
       }
     }
 

--- a/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller-mixin.js
@@ -192,10 +192,7 @@ export const ComboBoxScrollerMixin = (superClass) =>
       }
       this.__virtualizer.scrollToIndex(Math.max(0, targetIndex));
 
-      // iron-list re-estimates physical positions after each `scrollTop`
-      // write (and debounces some of that work), so the rendered rects only
-      // settle after a flush. Flushing here lets the rect-based correction
-      // below run on the final positions instead of stale ones.
+      // Flush so the rect-based correction below runs on settled positions.
       this.__virtualizer.flush();
 
       const target = [...this.children].find((el) => !el.hidden && el.index === index);

--- a/packages/combo-box/test/focus-index.test.js
+++ b/packages/combo-box/test/focus-index.test.js
@@ -105,6 +105,91 @@ describe('__focusIndex', () => {
     });
   });
 
+  describe('variable-height items', () => {
+    const SIZE = 200;
+    // Long wrapping label every 5th item — rows are taller than average,
+    // so an index-counting heuristic (target = index - visibleCount + 1)
+    // overshoots and the target lands partly or fully below the viewport.
+    const LONG_LABEL = 'Long label that wraps to two or three lines making the row taller than its neighbors';
+    const items = Array.from({ length: SIZE }, (_, i) => (i % 5 === 0 ? `${LONG_LABEL} ${i}` : `item ${i}`));
+
+    function getScrollerRect() {
+      return comboBox._scroller.getBoundingClientRect();
+    }
+
+    function findRenderedItem(index) {
+      return [...comboBox._scroller.children].find((el) => !el.hidden && el.index === index);
+    }
+
+    beforeEach(async () => {
+      comboBox = fixtureSync(`
+        <vaadin-combo-box
+          style="--vaadin-combo-box-overlay-max-height: 400px"
+        ></vaadin-combo-box>
+      `);
+      await nextRender();
+      comboBox.items = items;
+    });
+
+    it('should fully reveal target below the viewport with variable heights', async () => {
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      const targetIndex = 30;
+      comboBox.scrollToIndex(targetIndex);
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      const target = findRenderedItem(targetIndex);
+      expect(target, 'target item is rendered').to.exist;
+      const targetRect = target.getBoundingClientRect();
+      const scrollerRect = getScrollerRect();
+      expect(Math.round(targetRect.bottom)).to.be.at.most(Math.round(scrollerRect.bottom) + 1);
+      expect(Math.round(targetRect.top)).to.be.at.least(Math.round(scrollerRect.top) - 1);
+    });
+
+    it('should fully reveal target above the viewport with variable heights', async () => {
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      // Pre-scroll well past the target, then jump back to a low index.
+      comboBox.scrollToIndex(150);
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      const targetIndex = 5;
+      comboBox.scrollToIndex(targetIndex);
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      const target = findRenderedItem(targetIndex);
+      expect(target, 'target item is rendered').to.exist;
+      const targetRect = target.getBoundingClientRect();
+      const scrollerRect = getScrollerRect();
+      expect(Math.round(targetRect.top)).to.be.at.least(Math.round(scrollerRect.top) - 1);
+      expect(Math.round(targetRect.bottom)).to.be.at.most(Math.round(scrollerRect.bottom) + 1);
+    });
+
+    it('should not shift the viewport when target is already visible', async () => {
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      const firstVisible = comboBox._scroller.__virtualizer.firstVisibleIndex;
+      const lastVisible = comboBox._scroller.__virtualizer.lastVisibleIndex;
+      const targetIndex = firstVisible + Math.floor((lastVisible - firstVisible) / 2);
+
+      const scrollTopBefore = comboBox._scroller.scrollTop;
+      comboBox.scrollToIndex(targetIndex);
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      // The "within viewport" branch must not shift the viewport visibly —
+      // otherwise arrow-key navigation would jerk on every step.
+      expect(Math.abs(comboBox._scroller.scrollTop - scrollTopBefore)).to.be.below(2);
+    });
+  });
+
   describe('data provider', () => {
     const SIZE = 500;
     const PAGE_SIZE = 50;

--- a/packages/combo-box/test/focus-index.test.js
+++ b/packages/combo-box/test/focus-index.test.js
@@ -107,9 +107,9 @@ describe('__focusIndex', () => {
 
   describe('variable-height items', () => {
     const SIZE = 200;
-    // Long wrapping label every 5th item — rows are taller than average,
-    // so an index-counting heuristic (target = index - visibleCount + 1)
-    // overshoots and the target lands partly or fully below the viewport.
+    // Long wrapping label every 5th item makes those rows taller than
+    // the rest, so the index-based positioning in `scrollIntoView` can
+    // place the target outside the viewport.
     const LONG_LABEL = 'Long label that wraps to two or three lines making the row taller than its neighbors';
     const items = Array.from({ length: SIZE }, (_, i) => (i % 5 === 0 ? `${LONG_LABEL} ${i}` : `item ${i}`));
 
@@ -136,12 +136,11 @@ describe('__focusIndex', () => {
       flushComboBox(comboBox);
 
       const targetIndex = 30;
-      comboBox.scrollToIndex(targetIndex);
+      comboBox.__focusIndex(targetIndex);
       flushComboBox(comboBox);
       await nextFrame();
 
       const target = findRenderedItem(targetIndex);
-      expect(target, 'target item is rendered').to.exist;
       const targetRect = target.getBoundingClientRect();
       const scrollerRect = getScrollerRect();
       expect(Math.round(targetRect.bottom)).to.be.at.most(Math.round(scrollerRect.bottom) + 1);
@@ -153,17 +152,16 @@ describe('__focusIndex', () => {
       flushComboBox(comboBox);
 
       // Pre-scroll well past the target, then jump back to a low index.
-      comboBox.scrollToIndex(150);
+      comboBox.__focusIndex(150);
       flushComboBox(comboBox);
       await nextFrame();
 
       const targetIndex = 5;
-      comboBox.scrollToIndex(targetIndex);
+      comboBox.__focusIndex(targetIndex);
       flushComboBox(comboBox);
       await nextFrame();
 
       const target = findRenderedItem(targetIndex);
-      expect(target, 'target item is rendered').to.exist;
       const targetRect = target.getBoundingClientRect();
       const scrollerRect = getScrollerRect();
       expect(Math.round(targetRect.top)).to.be.at.least(Math.round(scrollerRect.top) - 1);
@@ -180,12 +178,11 @@ describe('__focusIndex', () => {
       const targetIndex = firstVisible + Math.floor((lastVisible - firstVisible) / 2);
 
       const scrollTopBefore = comboBox._scroller.scrollTop;
-      comboBox.scrollToIndex(targetIndex);
+      comboBox.__focusIndex(targetIndex);
       flushComboBox(comboBox);
       await nextFrame();
 
-      // The "within viewport" branch must not shift the viewport visibly —
-      // otherwise arrow-key navigation would jerk on every step.
+      // Scrolling to an already-visible item should not shift the viewport.
       expect(Math.abs(comboBox._scroller.scrollTop - scrollTopBefore)).to.be.below(2);
     });
   });

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -663,4 +663,91 @@ describe('keyboard', () => {
       expect(keydownEvent.defaultPrevented).to.be.false;
     });
   });
+
+  describe('focused row visibility', () => {
+    // Long-enough label that wraps to multiple lines under the default combo
+    // overlay width — every 5th item makes the row taller than its neighbors
+    // so `scrollIntoView`'s index-math heuristic overshoots and the focused
+    // row lands outside the viewport without the rect-based correction.
+    const LONG_LABEL = 'Long label that wraps to two or three lines making this row taller than its neighbors';
+    const SIZE = 100;
+
+    function buildItems(size = SIZE) {
+      return Array.from({ length: size }, (_, i) => (i % 5 === 0 ? `${LONG_LABEL} ${i}` : `item ${i}`));
+    }
+
+    function getScrollerRect() {
+      return comboBox._scroller.getBoundingClientRect();
+    }
+
+    function getFocusedItem() {
+      return [...comboBox._scroller.children].find((el) => !el.hidden && el.index === comboBox._focusedIndex);
+    }
+
+    function expectFocusedItemInsideViewport(comboBox) {
+      const focused = getFocusedItem();
+      expect(focused, 'focused item is rendered').to.exist;
+      const focusedRect = focused.getBoundingClientRect();
+      const scrollerRect = getScrollerRect();
+      const padding = comboBox._scroller._viewportTotalPaddingBottom;
+      expect(Math.round(focusedRect.top)).to.be.at.least(Math.round(scrollerRect.top) - 1);
+      expect(Math.round(focusedRect.bottom)).to.be.at.most(Math.round(scrollerRect.bottom) + padding + 1);
+    }
+
+    it('should keep target inside the viewport when stepping into a tall row', async () => {
+      comboBox.style.setProperty('--vaadin-combo-box-overlay-max-height', '400px');
+      comboBox.items = buildItems();
+      comboBox.opened = true;
+      await nextRender();
+
+      // Step past several tall rows; the bug surfaces on transitions where a
+      // tall row enters/leaves the viewport.
+      for (let i = 0; i < 25; i++) {
+        arrowDownKeyDown(input);
+        await nextFrame();
+        await nextFrame();
+        expectFocusedItemInsideViewport(comboBox);
+      }
+    });
+
+    it('should keep target inside the viewport with dataProvider across a page boundary', async () => {
+      const dpSize = 500;
+      const PAGE_SIZE = 50;
+      const items = buildItems(dpSize);
+      const pendingCallbacks = [];
+      comboBox.style.setProperty('--vaadin-combo-box-overlay-max-height', '400px');
+      // Outer beforeEach assigned `comboBox.items = ['foo', 'bar', 'baz']`;
+      // clear it before switching to a dataProvider — they can't coexist.
+      comboBox.items = undefined;
+      comboBox.pageSize = PAGE_SIZE;
+      comboBox.dataProvider = (params, callback) => {
+        pendingCallbacks.push(() => {
+          const slice = items.slice(params.page * params.pageSize, (params.page + 1) * params.pageSize);
+          callback(slice, dpSize);
+        });
+      };
+      comboBox.opened = true;
+      await nextRender();
+      // Drain whatever pages the initial open requested.
+      while (pendingCallbacks.length) {
+        pendingCallbacks.shift()();
+      }
+      await nextFrame();
+
+      // Walk past index 49 → 50 (first page boundary). Drain any new page
+      // loads triggered by the scroll so the focused row resolves to a real
+      // item before we assert. Regression guard for #4046's "every pageSize
+      // items, focus drifts off" pattern.
+      for (let i = 0; i <= 55; i++) {
+        arrowDownKeyDown(input);
+        await nextFrame();
+        while (pendingCallbacks.length) {
+          pendingCallbacks.shift()();
+        }
+        await nextFrame();
+        await nextFrame();
+        expectFocusedItemInsideViewport(comboBox);
+      }
+    });
+  });
 });

--- a/packages/combo-box/test/keyboard.test.js
+++ b/packages/combo-box/test/keyboard.test.js
@@ -665,10 +665,9 @@ describe('keyboard', () => {
   });
 
   describe('focused row visibility', () => {
-    // Long-enough label that wraps to multiple lines under the default combo
-    // overlay width — every 5th item makes the row taller than its neighbors
-    // so `scrollIntoView`'s index-math heuristic overshoots and the focused
-    // row lands outside the viewport without the rect-based correction.
+    // Long wrapping label every 5th item makes those rows taller than the
+    // rest, so the index-based positioning in `scrollIntoView` can place
+    // the focused row outside the viewport without the rect-based correction.
     const LONG_LABEL = 'Long label that wraps to two or three lines making this row taller than its neighbors';
     const SIZE = 100;
 


### PR DESCRIPTION
`scrollToIndex(N)` and keyboard navigation (Arrow Up / Down) both route
through the scroller's `scrollIntoView`, which placed the target row near
the viewport bottom using an index-math heuristic (`targetIndex = index -
visibleItemsCount + 1`). That counts items rather than pixels, so when
iron-list hasn't settled its physical-position estimates — common with
variable-height rows, but also visible with same-height rows during the
brief window before measured heights converge — the target lands partly
or fully outside the viewport. The previous post-scroll correction only
kicked in for the special case of `target == lastVisibleIndex`.

## Reproduction

1. **Imperative**: items array of ~200 entries where every 5th carries
   a long wrapping label; call `scrollToIndex(35)`. Pre-fix the row
   lands ~100 px below the viewport bottom.
2. **Keyboard nav (#4046)**: dataProvider with `pageSize=50`; open the
   combo-box and press Arrow Down past index 49 → 50. Pre-fix the
   focused row drifts out of view as page-boundary loads shift items.

## Changes

`scrollIntoView` calls `__virtualizer.flush()` after the existing two
`scrollToIndex` calls (settling iron-list's debounced physical-position
estimation), then measures any rendered target row against the viewport
and nudges `scrollTop` either down (target past the bottom edge) or up
(target above the top edge) — replacing the `lastPhysicalItem`-only
check. Synchronous flush avoids an earlier rAF-deferral iteration of
this PR; iron-list settles before the correction measures.

Fixes #4046, Follow-up to #11552, Part of #6061

---

🤖 Generated with Claude Code