### PR TITLE
fix: preserve focused index across sibling page-loads in combo-box

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -518,6 +518,16 @@ export const ComboBoxMixin = (superClass) =>
         this.selectedItem = newItems[valueIndex];
       }
 
+      // Preserve `_focusedIndex` when the same item reference still occupies it
+      // in the new array. The dataProvider page-load path replaces the items
+      // array reference (`[...rootCache.items]`) but reuses item references at
+      // unchanged indices, so this short-circuits the value-lookup fallback
+      // below which can collapse to "[object Object]" === "[object Object]"
+      // for object items without `itemValuePath` set.
+      if (this._focusedIndex >= 0 && oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
+        return;
+      }
+
       // Try to first set focus on the item that had been focused before `newItems` were updated
       // if it is still present in the `newItems` array. Otherwise, set the focused index
       // depending on the selected item or the filter query.

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -519,18 +519,11 @@ export const ComboBoxMixin = (superClass) =>
         this.selectedItem = newItems[valueIndex];
       }
 
-      // The dataProvider page-load path can re-push `_setDropdownItems`
-      // while `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
-      // both placeholders (e.g. the Flow connector mid-scroll). The
-      // value-lookup fallback below collapses to `"[object Object]"`
-      // for placeholders and drops `_focusedIndex`; short-circuit to
-      // preserve focus until a follow-up call with a real item resolves
-      // the position properly.
-      if (
-        oldItems &&
-        oldItems[this._focusedIndex] instanceof ComboBoxPlaceholder &&
-        newItems[this._focusedIndex] instanceof ComboBoxPlaceholder
-      ) {
+      // When both the previously-focused entry and the new entry at the
+      // same index are placeholders (e.g. the Flow connector mid-scroll
+      // re-pushing `_setDropdownItems`), preserve `_focusedIndex` until
+      // a follow-up call lands a real item at that position.
+      if (focusedItem instanceof ComboBoxPlaceholder && newItems[this._focusedIndex] instanceof ComboBoxPlaceholder) {
         return;
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -523,7 +523,11 @@ export const ComboBoxMixin = (superClass) =>
       // same index are placeholders (e.g. the Flow connector mid-scroll
       // re-pushing `_setDropdownItems`), preserve `_focusedIndex` until
       // a follow-up call lands a real item at that position.
-      if (focusedItem instanceof ComboBoxPlaceholder && newItems[this._focusedIndex] instanceof ComboBoxPlaceholder) {
+      if (
+        oldItems &&
+        oldItems[this._focusedIndex] instanceof ComboBoxPlaceholder &&
+        newItems[this._focusedIndex] instanceof ComboBoxPlaceholder
+      ) {
         return;
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -519,29 +519,19 @@ export const ComboBoxMixin = (superClass) =>
         this.selectedItem = newItems[valueIndex];
       }
 
-      // Preserve `_focusedIndex` across dataProvider page mutations.
-      // First, when `itemIdPath` is set, locate the focused item by id
-      // anywhere in the new array — this also covers cases where the
-      // item moves to a different position. Otherwise (no `itemIdPath`,
-      // or the focused entry is a placeholder with no id), fall back to
-      // reference equality at the same index, which handles the
-      // page-load path where `[...rootCache.items]` replaces the array
-      // reference but reuses item refs (placeholder refs included).
-      if (this._focusedIndex >= 0 && focusedItem) {
-        if (this.itemIdPath && !(focusedItem instanceof ComboBoxPlaceholder)) {
-          const focusedId = focusedItem[this.itemIdPath];
-          if (focusedId !== undefined) {
-            const newIndex = newItems.findIndex(
-              (item) => item && !(item instanceof ComboBoxPlaceholder) && item[this.itemIdPath] === focusedId,
-            );
-            if (newIndex >= 0) {
-              this._focusedIndex = newIndex;
-              return;
-            }
-          }
-        } else if (oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
-          return;
-        }
+      // The dataProvider page-load path can re-push `_setDropdownItems`
+      // while `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
+      // both placeholders (e.g. the Flow connector mid-scroll). The
+      // value-lookup fallback below collapses to `"[object Object]"`
+      // for placeholders and drops `_focusedIndex`; short-circuit to
+      // preserve focus until a follow-up call with a real item resolves
+      // the position properly.
+      if (
+        oldItems &&
+        oldItems[this._focusedIndex] instanceof ComboBoxPlaceholder &&
+        newItems[this._focusedIndex] instanceof ComboBoxPlaceholder
+      ) {
+        return;
       }
 
       // Try to first set focus on the item that had been focused before `newItems` were updated

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -5,6 +5,7 @@
  */
 import { ValidateMixin } from '@vaadin/field-base/src/validate-mixin.js';
 import { ComboBoxItemsMixin } from './vaadin-combo-box-items-mixin.js';
+import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
 /**
  * Checks if the value is supported as an item value in this control.
@@ -518,14 +519,29 @@ export const ComboBoxMixin = (superClass) =>
         this.selectedItem = newItems[valueIndex];
       }
 
-      // Preserve `_focusedIndex` when the same item reference still occupies it
-      // in the new array. The dataProvider page-load path replaces the items
-      // array reference (`[...rootCache.items]`) but reuses item references at
-      // unchanged indices, so this short-circuits the value-lookup fallback
-      // below which can collapse to "[object Object]" === "[object Object]"
-      // for object items without `itemValuePath` set.
-      if (this._focusedIndex >= 0 && oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
-        return;
+      // Preserve `_focusedIndex` across dataProvider page mutations.
+      // First, when `itemIdPath` is set, locate the focused item by id
+      // anywhere in the new array — this also covers cases where the
+      // item moves to a different position. Otherwise (no `itemIdPath`,
+      // or the focused entry is a placeholder with no id), fall back to
+      // reference equality at the same index, which handles the
+      // page-load path where `[...rootCache.items]` replaces the array
+      // reference but reuses item refs (placeholder refs included).
+      if (this._focusedIndex >= 0 && focusedItem) {
+        if (this.itemIdPath && !(focusedItem instanceof ComboBoxPlaceholder)) {
+          const focusedId = focusedItem[this.itemIdPath];
+          if (focusedId !== undefined) {
+            const newIndex = newItems.findIndex(
+              (item) => item && !(item instanceof ComboBoxPlaceholder) && item[this.itemIdPath] === focusedId,
+            );
+            if (newIndex >= 0) {
+              this._focusedIndex = newIndex;
+              return;
+            }
+          }
+        } else if (oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
+          return;
+        }
       }
 
       // Try to first set focus on the item that had been focused before `newItems` were updated

--- a/packages/combo-box/test/scroll-to-index.test.js
+++ b/packages/combo-box/test/scroll-to-index.test.js
@@ -205,74 +205,35 @@ describe('scrollToIndex', () => {
       expect(viewport.some((item) => item.index === 300 && !(item.item instanceof ComboBoxPlaceholder))).to.be.true;
     });
 
-    it('should preserve focused index when a sibling page loads (object items)', async () => {
-      // Object items without `itemValuePath` set — `_getItemValue` falls back
-      // to `item.toString()` ("[object Object]"), so the value-lookup focus
-      // preservation in `_setDropdownItems` collapses across all object items.
-      // Without the same-reference short-circuit, a sibling page-load after
-      // scrollToIndex would reset `_focusedIndex` to 0.
-      const objectItems = Array.from({ length: SIZE }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
-      const objectDataProvider = (params, callback) => {
-        pendingCallbacks.push(() => {
-          const slice = objectItems.slice(params.page * params.pageSize, (params.page + 1) * params.pageSize);
-          callback(slice, SIZE);
-        });
-      };
-
-      comboBox.itemLabelPath = 'label';
-      comboBox.itemIdPath = 'key';
-      comboBox.dataProvider = objectDataProvider;
+    it('should preserve focused index when both items at focusedIndex are placeholders', async () => {
+      // The Flow connector reaches a state mid-scroll where both
+      // `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
+      // `ComboBoxPlaceholder` instances. The value-lookup fallback
+      // collapses placeholders via toString and resets `_focusedIndex`;
+      // the placeholder-instanceof short-circuit prevents that until a
+      // follow-up `_setDropdownItems` lands a real item.
       comboBox.opened = true;
-
-      // Drain the first page so index 30 is loaded.
+      // Drain page 0 so the controller knows the total size and the
+      // remaining slots get populated with placeholders.
       flushPendingCallbacks();
       await nextFrame();
       flushComboBox(comboBox);
 
-      comboBox.scrollToIndex(30);
-      flushComboBox(comboBox);
-      await nextFrame();
-      expect(comboBox._focusedIndex).to.equal(30);
+      // Index 200 sits on an unloaded page → placeholder slot.
+      expect(comboBox._dropdownItems[200]).to.be.instanceof(ComboBoxPlaceholder);
 
-      // Trigger a sibling page-load. `__onDataProviderPageLoaded` will call
-      // `_setDropdownItems` with a fresh array reference, but the item at
-      // index 30 is unchanged, so focus must stick.
-      comboBox.__dataProviderController.ensureFlatIndexLoaded(300);
-      flushPendingCallbacks();
-      await nextFrame();
-      flushComboBox(comboBox);
+      // Simulate the post-scroll state where focused points at a
+      // placeholder slot (Flow's connector sets focus while the
+      // underlying item is still a placeholder).
+      comboBox._focusedIndex = 200;
 
-      expect(comboBox._focusedIndex).to.equal(30);
-    });
+      // Re-push items with a different placeholder instance at the same
+      // position — the connector creates fresh placeholders when it
+      // rebuilds the cache.
+      const repushed = comboBox._dropdownItems.map((item, i) => (i === 200 ? new ComboBoxPlaceholder() : item));
+      comboBox.filteredItems = repushed;
 
-    it('should move focused index to the new position when items are rearranged (itemIdPath)', async () => {
-      // When `itemIdPath` is set, the focus-preservation logic should locate
-      // the focused item by id anywhere in the new array — not just at the
-      // same index — so focus follows the item if it moves.
-      const objectItems = Array.from({ length: 100 }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
-      // Outer beforeEach assigned `dataProvider`; clear it before switching
-      // to plain items (the two can't coexist).
-      comboBox.dataProvider = undefined;
-      comboBox.itemLabelPath = 'label';
-      comboBox.itemIdPath = 'key';
-      comboBox.items = objectItems;
-      comboBox.opened = true;
-      flushComboBox(comboBox);
-
-      comboBox.scrollToIndex(30);
-      flushComboBox(comboBox);
-      await nextFrame();
-      expect(comboBox._focusedIndex).to.equal(30);
-
-      // Move the focused item (k30) from index 30 to index 50.
-      const reordered = [...objectItems];
-      const [focused] = reordered.splice(30, 1);
-      reordered.splice(50, 0, focused);
-      comboBox.items = reordered;
-      flushComboBox(comboBox);
-      await nextFrame();
-
-      expect(comboBox._focusedIndex).to.equal(50);
+      expect(comboBox._focusedIndex).to.equal(200);
     });
 
     it('should render real content (not placeholders) at the top on reopen after a scroll', async () => {

--- a/packages/combo-box/test/scroll-to-index.test.js
+++ b/packages/combo-box/test/scroll-to-index.test.js
@@ -218,12 +218,9 @@ describe('scrollToIndex', () => {
       expect(comboBox._focusedIndex).to.equal(lastIndex);
       expect(comboBox._dropdownItems[lastIndex]).to.be.instanceof(ComboBoxPlaceholder);
 
-      // Re-push items with a fresh placeholder at the focused slot —
-      // the placeholder-instanceof short-circuit in `_setDropdownItems`
-      // must preserve focus.
-      comboBox.filteredItems = comboBox._dropdownItems.map((item, i) =>
-        i === lastIndex ? new ComboBoxPlaceholder() : item,
-      );
+      // Clearing the cache should preserve the focused index,
+      // even though it is still a placeholder after the clear.
+      comboBox.clearCache();
 
       expect(comboBox._focusedIndex).to.equal(lastIndex);
     });

--- a/packages/combo-box/test/scroll-to-index.test.js
+++ b/packages/combo-box/test/scroll-to-index.test.js
@@ -245,6 +245,36 @@ describe('scrollToIndex', () => {
       expect(comboBox._focusedIndex).to.equal(30);
     });
 
+    it('should move focused index to the new position when items are rearranged (itemIdPath)', async () => {
+      // When `itemIdPath` is set, the focus-preservation logic should locate
+      // the focused item by id anywhere in the new array — not just at the
+      // same index — so focus follows the item if it moves.
+      const objectItems = Array.from({ length: 100 }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
+      // Outer beforeEach assigned `dataProvider`; clear it before switching
+      // to plain items (the two can't coexist).
+      comboBox.dataProvider = undefined;
+      comboBox.itemLabelPath = 'label';
+      comboBox.itemIdPath = 'key';
+      comboBox.items = objectItems;
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      comboBox.scrollToIndex(30);
+      flushComboBox(comboBox);
+      await nextFrame();
+      expect(comboBox._focusedIndex).to.equal(30);
+
+      // Move the focused item (k30) from index 30 to index 50.
+      const reordered = [...objectItems];
+      const [focused] = reordered.splice(30, 1);
+      reordered.splice(50, 0, focused);
+      comboBox.items = reordered;
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      expect(comboBox._focusedIndex).to.equal(50);
+    });
+
     it('should render real content (not placeholders) at the top on reopen after a scroll', async () => {
       // Open, drain page 0, scroll to a far index, drain its page, then close.
       comboBox.opened = true;

--- a/packages/combo-box/test/scroll-to-index.test.js
+++ b/packages/combo-box/test/scroll-to-index.test.js
@@ -205,6 +205,46 @@ describe('scrollToIndex', () => {
       expect(viewport.some((item) => item.index === 300 && !(item.item instanceof ComboBoxPlaceholder))).to.be.true;
     });
 
+    it('should preserve focused index when a sibling page loads (object items)', async () => {
+      // Object items without `itemValuePath` set — `_getItemValue` falls back
+      // to `item.toString()` ("[object Object]"), so the value-lookup focus
+      // preservation in `_setDropdownItems` collapses across all object items.
+      // Without the same-reference short-circuit, a sibling page-load after
+      // scrollToIndex would reset `_focusedIndex` to 0.
+      const objectItems = Array.from({ length: SIZE }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
+      const objectDataProvider = (params, callback) => {
+        pendingCallbacks.push(() => {
+          const slice = objectItems.slice(params.page * params.pageSize, (params.page + 1) * params.pageSize);
+          callback(slice, SIZE);
+        });
+      };
+
+      comboBox.itemLabelPath = 'label';
+      comboBox.itemIdPath = 'key';
+      comboBox.dataProvider = objectDataProvider;
+      comboBox.opened = true;
+
+      // Drain the first page so index 30 is loaded.
+      flushPendingCallbacks();
+      await nextFrame();
+      flushComboBox(comboBox);
+
+      comboBox.scrollToIndex(30);
+      flushComboBox(comboBox);
+      await nextFrame();
+      expect(comboBox._focusedIndex).to.equal(30);
+
+      // Trigger a sibling page-load. `__onDataProviderPageLoaded` will call
+      // `_setDropdownItems` with a fresh array reference, but the item at
+      // index 30 is unchanged, so focus must stick.
+      comboBox.__dataProviderController.ensureFlatIndexLoaded(300);
+      flushPendingCallbacks();
+      await nextFrame();
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(30);
+    });
+
     it('should render real content (not placeholders) at the top on reopen after a scroll', async () => {
       // Open, drain page 0, scroll to a far index, drain its page, then close.
       comboBox.opened = true;

--- a/packages/combo-box/test/scroll-to-index.test.js
+++ b/packages/combo-box/test/scroll-to-index.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { arrowUpKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-combo-box.js';
 import { ComboBoxPlaceholder } from '../src/vaadin-combo-box-placeholder.js';
 import { flushComboBox, getViewportItems, makeItems } from './helpers.js';
@@ -206,34 +206,26 @@ describe('scrollToIndex', () => {
     });
 
     it('should preserve focused index when both items at focusedIndex are placeholders', async () => {
-      // The Flow connector reaches a state mid-scroll where both
-      // `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
-      // `ComboBoxPlaceholder` instances. The value-lookup fallback
-      // collapses placeholders via toString and resets `_focusedIndex`;
-      // the placeholder-instanceof short-circuit prevents that until a
-      // follow-up `_setDropdownItems` lands a real item.
       comboBox.opened = true;
-      // Drain page 0 so the controller knows the total size and the
-      // remaining slots get populated with placeholders.
       flushPendingCallbacks();
       await nextFrame();
       flushComboBox(comboBox);
 
-      // Index 200 sits on an unloaded page → placeholder slot.
-      expect(comboBox._dropdownItems[200]).to.be.instanceof(ComboBoxPlaceholder);
+      // Arrow-Up wraps focus to the last index — a placeholder slot,
+      // because only page 0 has been drained.
+      arrowUpKeyDown(comboBox.inputElement);
+      const lastIndex = comboBox._dropdownItems.length - 1;
+      expect(comboBox._focusedIndex).to.equal(lastIndex);
+      expect(comboBox._dropdownItems[lastIndex]).to.be.instanceof(ComboBoxPlaceholder);
 
-      // Simulate the post-scroll state where focused points at a
-      // placeholder slot (Flow's connector sets focus while the
-      // underlying item is still a placeholder).
-      comboBox._focusedIndex = 200;
+      // Re-push items with a fresh placeholder at the focused slot —
+      // the placeholder-instanceof short-circuit in `_setDropdownItems`
+      // must preserve focus.
+      comboBox.filteredItems = comboBox._dropdownItems.map((item, i) =>
+        i === lastIndex ? new ComboBoxPlaceholder() : item,
+      );
 
-      // Re-push items with a different placeholder instance at the same
-      // position — the connector creates fresh placeholders when it
-      // rebuilds the cache.
-      const repushed = comboBox._dropdownItems.map((item, i) => (i === 200 ? new ComboBoxPlaceholder() : item));
-      comboBox.filteredItems = repushed;
-
-      expect(comboBox._focusedIndex).to.equal(200);
+      expect(comboBox._focusedIndex).to.equal(lastIndex);
     });
 
     it('should render real content (not placeholders) at the top on reopen after a scroll', async () => {

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -729,6 +729,16 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       // when the user types in a filter query.
       const focusedItem = oldItems ? oldItems[this._focusedIndex] : null;
 
+      // Preserve `_focusedIndex` when the same item reference still occupies it
+      // in the new array. The dataProvider page-load path replaces the items
+      // array reference (`[...rootCache.items]`) but reuses item references at
+      // unchanged indices, so this short-circuits the value-lookup fallback
+      // below which can collapse to "[object Object]" === "[object Object]"
+      // for object items without `itemValuePath` set.
+      if (this._focusedIndex >= 0 && oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
+        return;
+      }
+
       // Try to first set focus on the item that had been focused before `newItems` were updated
       // if it is still present in the `newItems` array. Otherwise, set the focused index
       // depending on the selected item or the filter query.

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -729,29 +729,19 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       // when the user types in a filter query.
       const focusedItem = oldItems ? oldItems[this._focusedIndex] : null;
 
-      // Preserve `_focusedIndex` across dataProvider page mutations.
-      // First, when `itemIdPath` is set, locate the focused item by id
-      // anywhere in the new array — this also covers cases where the
-      // item moves to a different position. Otherwise (no `itemIdPath`,
-      // or the focused entry is a placeholder with no id), fall back to
-      // reference equality at the same index, which handles the
-      // page-load path where `[...rootCache.items]` replaces the array
-      // reference but reuses item refs (placeholder refs included).
-      if (this._focusedIndex >= 0 && focusedItem) {
-        if (this.itemIdPath && !(focusedItem instanceof ComboBoxPlaceholder)) {
-          const focusedId = focusedItem[this.itemIdPath];
-          if (focusedId !== undefined) {
-            const newIndex = newItems.findIndex(
-              (item) => item && !(item instanceof ComboBoxPlaceholder) && item[this.itemIdPath] === focusedId,
-            );
-            if (newIndex >= 0) {
-              this._focusedIndex = newIndex;
-              return;
-            }
-          }
-        } else if (oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
-          return;
-        }
+      // The dataProvider page-load path can re-push `__setDropdownItems`
+      // while `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
+      // both placeholders (e.g. the Flow connector mid-scroll). The
+      // value-lookup fallback below collapses to `"[object Object]"`
+      // for placeholders and drops `_focusedIndex`; short-circuit to
+      // preserve focus until a follow-up call with a real item resolves
+      // the position properly.
+      if (
+        oldItems &&
+        oldItems[this._focusedIndex] instanceof ComboBoxPlaceholder &&
+        newItems[this._focusedIndex] instanceof ComboBoxPlaceholder
+      ) {
+        return;
       }
 
       // Try to first set focus on the item that had been focused before `newItems` were updated

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -729,14 +729,29 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       // when the user types in a filter query.
       const focusedItem = oldItems ? oldItems[this._focusedIndex] : null;
 
-      // Preserve `_focusedIndex` when the same item reference still occupies it
-      // in the new array. The dataProvider page-load path replaces the items
-      // array reference (`[...rootCache.items]`) but reuses item references at
-      // unchanged indices, so this short-circuits the value-lookup fallback
-      // below which can collapse to "[object Object]" === "[object Object]"
-      // for object items without `itemValuePath` set.
-      if (this._focusedIndex >= 0 && oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
-        return;
+      // Preserve `_focusedIndex` across dataProvider page mutations.
+      // First, when `itemIdPath` is set, locate the focused item by id
+      // anywhere in the new array — this also covers cases where the
+      // item moves to a different position. Otherwise (no `itemIdPath`,
+      // or the focused entry is a placeholder with no id), fall back to
+      // reference equality at the same index, which handles the
+      // page-load path where `[...rootCache.items]` replaces the array
+      // reference but reuses item refs (placeholder refs included).
+      if (this._focusedIndex >= 0 && focusedItem) {
+        if (this.itemIdPath && !(focusedItem instanceof ComboBoxPlaceholder)) {
+          const focusedId = focusedItem[this.itemIdPath];
+          if (focusedId !== undefined) {
+            const newIndex = newItems.findIndex(
+              (item) => item && !(item instanceof ComboBoxPlaceholder) && item[this.itemIdPath] === focusedId,
+            );
+            if (newIndex >= 0) {
+              this._focusedIndex = newIndex;
+              return;
+            }
+          }
+        } else if (oldItems && oldItems[this._focusedIndex] === newItems[this._focusedIndex]) {
+          return;
+        }
       }
 
       // Try to first set focus on the item that had been focused before `newItems` were updated

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -733,7 +733,11 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       // same index are placeholders (e.g. the Flow connector mid-scroll
       // re-pushing `__setDropdownItems`), preserve `_focusedIndex` until
       // a follow-up call lands a real item at that position.
-      if (focusedItem instanceof ComboBoxPlaceholder && newItems[this._focusedIndex] instanceof ComboBoxPlaceholder) {
+      if (
+        oldItems &&
+        oldItems[this._focusedIndex] instanceof ComboBoxPlaceholder &&
+        newItems[this._focusedIndex] instanceof ComboBoxPlaceholder
+      ) {
         return;
       }
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -729,18 +729,11 @@ export const MultiSelectComboBoxMixin = (superClass) =>
       // when the user types in a filter query.
       const focusedItem = oldItems ? oldItems[this._focusedIndex] : null;
 
-      // The dataProvider page-load path can re-push `__setDropdownItems`
-      // while `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
-      // both placeholders (e.g. the Flow connector mid-scroll). The
-      // value-lookup fallback below collapses to `"[object Object]"`
-      // for placeholders and drops `_focusedIndex`; short-circuit to
-      // preserve focus until a follow-up call with a real item resolves
-      // the position properly.
-      if (
-        oldItems &&
-        oldItems[this._focusedIndex] instanceof ComboBoxPlaceholder &&
-        newItems[this._focusedIndex] instanceof ComboBoxPlaceholder
-      ) {
+      // When both the previously-focused entry and the new entry at the
+      // same index are placeholders (e.g. the Flow connector mid-scroll
+      // re-pushing `__setDropdownItems`), preserve `_focusedIndex` until
+      // a follow-up call lands a real item at that position.
+      if (focusedItem instanceof ComboBoxPlaceholder && newItems[this._focusedIndex] instanceof ComboBoxPlaceholder) {
         return;
       }
 

--- a/packages/multi-select-combo-box/test/scroll-to-index.test.js
+++ b/packages/multi-select-combo-box/test/scroll-to-index.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { arrowUpKeyDown, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-multi-select-combo-box.js';
 import { ComboBoxPlaceholder } from '@vaadin/combo-box/src/vaadin-combo-box-placeholder.js';
 import { flushComboBox, getViewportItems } from './helpers.js';
@@ -103,25 +103,21 @@ describe('scrollToIndex', () => {
     });
 
     it('should preserve focused index when both items at focusedIndex are placeholders', async () => {
-      // The Flow connector reaches a state mid-scroll where both
-      // `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
-      // `ComboBoxPlaceholder` instances. The value-lookup fallback
-      // collapses placeholders via toString and resets `_focusedIndex`;
-      // the placeholder-instanceof short-circuit prevents that until a
-      // follow-up `__setDropdownItems` lands a real item.
       comboBox.opened = true;
       flushPendingCallbacks();
       await nextFrame();
       flushComboBox(comboBox);
 
-      expect(comboBox._dropdownItems[200]).to.be.instanceof(ComboBoxPlaceholder);
+      arrowUpKeyDown(comboBox.inputElement);
+      const lastIndex = comboBox._dropdownItems.length - 1;
+      expect(comboBox._focusedIndex).to.equal(lastIndex);
+      expect(comboBox._dropdownItems[lastIndex]).to.be.instanceof(ComboBoxPlaceholder);
 
-      comboBox._focusedIndex = 200;
+      comboBox.filteredItems = comboBox._dropdownItems.map((item, i) =>
+        i === lastIndex ? new ComboBoxPlaceholder() : item,
+      );
 
-      const repushed = comboBox._dropdownItems.map((item, i) => (i === 200 ? new ComboBoxPlaceholder() : item));
-      comboBox.filteredItems = repushed;
-
-      expect(comboBox._focusedIndex).to.equal(200);
+      expect(comboBox._focusedIndex).to.equal(lastIndex);
     });
   });
 });

--- a/packages/multi-select-combo-box/test/scroll-to-index.test.js
+++ b/packages/multi-select-combo-box/test/scroll-to-index.test.js
@@ -113,9 +113,9 @@ describe('scrollToIndex', () => {
       expect(comboBox._focusedIndex).to.equal(lastIndex);
       expect(comboBox._dropdownItems[lastIndex]).to.be.instanceof(ComboBoxPlaceholder);
 
-      comboBox.filteredItems = comboBox._dropdownItems.map((item, i) =>
-        i === lastIndex ? new ComboBoxPlaceholder() : item,
-      );
+      // Clearing the cache should preserve the focused index,
+      // even though it is still a placeholder after the clear.
+      comboBox.clearCache();
 
       expect(comboBox._focusedIndex).to.equal(lastIndex);
     });

--- a/packages/multi-select-combo-box/test/scroll-to-index.test.js
+++ b/packages/multi-select-combo-box/test/scroll-to-index.test.js
@@ -101,5 +101,41 @@ describe('scrollToIndex', () => {
       const viewport = getViewportItems(comboBox);
       expect(viewport.some((item) => item.index === 30 && !(item.item instanceof ComboBoxPlaceholder))).to.be.true;
     });
+
+    it('should preserve focused index when a sibling page loads (object items)', async () => {
+      // Object items without `itemValuePath` set — `_getItemValue` falls back
+      // to `item.toString()` ("[object Object]"), so the value-lookup focus
+      // preservation in `__setDropdownItems` collapses across all object items.
+      // Without the same-reference short-circuit, a sibling page-load after
+      // scrollToIndex would reset `_focusedIndex` to 0.
+      const objectItems = Array.from({ length: SIZE }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
+      const objectDataProvider = (params, callback) => {
+        pendingCallbacks.push(() => {
+          const slice = objectItems.slice(params.page * params.pageSize, (params.page + 1) * params.pageSize);
+          callback(slice, SIZE);
+        });
+      };
+
+      comboBox.itemLabelPath = 'label';
+      comboBox.itemIdPath = 'key';
+      comboBox.dataProvider = objectDataProvider;
+      comboBox.opened = true;
+
+      flushPendingCallbacks();
+      await nextFrame();
+      flushComboBox(comboBox);
+
+      comboBox.scrollToIndex(30);
+      flushComboBox(comboBox);
+      await nextFrame();
+      expect(comboBox._focusedIndex).to.equal(30);
+
+      comboBox.__dataProviderController.ensureFlatIndexLoaded(300);
+      flushPendingCallbacks();
+      await nextFrame();
+      flushComboBox(comboBox);
+
+      expect(comboBox._focusedIndex).to.equal(30);
+    });
   });
 });

--- a/packages/multi-select-combo-box/test/scroll-to-index.test.js
+++ b/packages/multi-select-combo-box/test/scroll-to-index.test.js
@@ -137,5 +137,32 @@ describe('scrollToIndex', () => {
 
       expect(comboBox._focusedIndex).to.equal(30);
     });
+
+    it('should move focused index to the new position when items are rearranged (itemIdPath)', async () => {
+      // When `itemIdPath` is set, focus-preservation should locate the focused
+      // item by id anywhere in the new array, so focus follows the item if it
+      // moves.
+      const objectItems = Array.from({ length: 100 }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
+      comboBox.dataProvider = undefined;
+      comboBox.itemLabelPath = 'label';
+      comboBox.itemIdPath = 'key';
+      comboBox.items = objectItems;
+      comboBox.opened = true;
+      flushComboBox(comboBox);
+
+      comboBox.scrollToIndex(30);
+      flushComboBox(comboBox);
+      await nextFrame();
+      expect(comboBox._focusedIndex).to.equal(30);
+
+      const reordered = [...objectItems];
+      const [focused] = reordered.splice(30, 1);
+      reordered.splice(50, 0, focused);
+      comboBox.items = reordered;
+      flushComboBox(comboBox);
+      await nextFrame();
+
+      expect(comboBox._focusedIndex).to.equal(50);
+    });
   });
 });

--- a/packages/multi-select-combo-box/test/scroll-to-index.test.js
+++ b/packages/multi-select-combo-box/test/scroll-to-index.test.js
@@ -102,67 +102,26 @@ describe('scrollToIndex', () => {
       expect(viewport.some((item) => item.index === 30 && !(item.item instanceof ComboBoxPlaceholder))).to.be.true;
     });
 
-    it('should preserve focused index when a sibling page loads (object items)', async () => {
-      // Object items without `itemValuePath` set — `_getItemValue` falls back
-      // to `item.toString()` ("[object Object]"), so the value-lookup focus
-      // preservation in `__setDropdownItems` collapses across all object items.
-      // Without the same-reference short-circuit, a sibling page-load after
-      // scrollToIndex would reset `_focusedIndex` to 0.
-      const objectItems = Array.from({ length: SIZE }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
-      const objectDataProvider = (params, callback) => {
-        pendingCallbacks.push(() => {
-          const slice = objectItems.slice(params.page * params.pageSize, (params.page + 1) * params.pageSize);
-          callback(slice, SIZE);
-        });
-      };
-
-      comboBox.itemLabelPath = 'label';
-      comboBox.itemIdPath = 'key';
-      comboBox.dataProvider = objectDataProvider;
+    it('should preserve focused index when both items at focusedIndex are placeholders', async () => {
+      // The Flow connector reaches a state mid-scroll where both
+      // `oldItems[focusedIndex]` and `newItems[focusedIndex]` are
+      // `ComboBoxPlaceholder` instances. The value-lookup fallback
+      // collapses placeholders via toString and resets `_focusedIndex`;
+      // the placeholder-instanceof short-circuit prevents that until a
+      // follow-up `__setDropdownItems` lands a real item.
       comboBox.opened = true;
-
       flushPendingCallbacks();
       await nextFrame();
       flushComboBox(comboBox);
 
-      comboBox.scrollToIndex(30);
-      flushComboBox(comboBox);
-      await nextFrame();
-      expect(comboBox._focusedIndex).to.equal(30);
+      expect(comboBox._dropdownItems[200]).to.be.instanceof(ComboBoxPlaceholder);
 
-      comboBox.__dataProviderController.ensureFlatIndexLoaded(300);
-      flushPendingCallbacks();
-      await nextFrame();
-      flushComboBox(comboBox);
+      comboBox._focusedIndex = 200;
 
-      expect(comboBox._focusedIndex).to.equal(30);
-    });
+      const repushed = comboBox._dropdownItems.map((item, i) => (i === 200 ? new ComboBoxPlaceholder() : item));
+      comboBox.filteredItems = repushed;
 
-    it('should move focused index to the new position when items are rearranged (itemIdPath)', async () => {
-      // When `itemIdPath` is set, focus-preservation should locate the focused
-      // item by id anywhere in the new array, so focus follows the item if it
-      // moves.
-      const objectItems = Array.from({ length: 100 }, (_, i) => ({ key: `k${i}`, label: `Item ${i}` }));
-      comboBox.dataProvider = undefined;
-      comboBox.itemLabelPath = 'label';
-      comboBox.itemIdPath = 'key';
-      comboBox.items = objectItems;
-      comboBox.opened = true;
-      flushComboBox(comboBox);
-
-      comboBox.scrollToIndex(30);
-      flushComboBox(comboBox);
-      await nextFrame();
-      expect(comboBox._focusedIndex).to.equal(30);
-
-      const reordered = [...objectItems];
-      const [focused] = reordered.splice(30, 1);
-      reordered.splice(50, 0, focused);
-      comboBox.items = reordered;
-      flushComboBox(comboBox);
-      await nextFrame();
-
-      expect(comboBox._focusedIndex).to.equal(50);
+      expect(comboBox._focusedIndex).to.equal(200);
     });
   });
 });


### PR DESCRIPTION
## Why

`scrollToIndex(N)` can land `_focusedIndex` on an unloaded (`ComboBoxPlaceholder`) row in data-provider mode. If the items array is then re-pushed — for example by `clearCache()` or a mid-scroll Flow-connector update — and the slot at `_focusedIndex` is still a placeholder in the new array, `_setDropdownItems` reruns its value-based focus lookup:

```js
const focusedItemIndex = this.__getItemIndexByValue(newItems, this._getItemValue(focusedItem));
```

`_getItemValue` called on a placeholder returns its stringified form, which doesn't match any real item, so `__getItemIndexByValue` returns `-1` and `_focusedIndex` collapses. The user loses their keyboard position and Arrow Down advances from the wrong row. `MultiSelectComboBox` has the same lookup in `__setDropdownItems` and the same bug.

## Reproduction

1. A `ComboBox` with a paged `DataProvider`.
2. Open the dropdown — only the first page is loaded.
3. Press <kbd>↑</kbd> while the input is empty so focus wraps to the last index, which is still a placeholder.
4. Trigger a re-push that keeps that slot a placeholder (`clearCache()` is the simplest path; the Flow connector's mid-scroll updates do the same).
5. Pre-fix: `_focusedIndex` becomes `-1`. The next Arrow Down advances from row 0.

## Changes

Short-circuit `_setDropdownItems` (and `__setDropdownItems`) when the entries at `_focusedIndex` in both the old and the new arrays are `ComboBoxPlaceholder` instances. That transition carries no information about where the focused row actually moved to, so preserve `_focusedIndex` and skip the value-lookup. Filter changes and items resets — where the new array has real items at that index — still run the fallback as before.

Related to #11851

Follow-up to #11552, Part of #6061