### PR TITLE
fix: import vaadin-checkbox in grid selection column base mixin

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import '@vaadin/checkbox/src/vaadin-checkbox.js';
 import { addListener, setTouchAction } from '@vaadin/component-base/src/gestures.js';
 
 /**


### PR DESCRIPTION
`GridSelectionColumnBaseMixin` creates `<vaadin-checkbox>` elements in its cell renderers but does not import the component. It worked only because the web-component consumer (`vaadin-grid-selection-column.js`) imports `@vaadin/checkbox` itself. The mixin is also reused by the Flow component, where that import is not guaranteed, so the checkbox can end up undefined.

Add the import to the mixin so it is self-contained regardless of consumer.
