### PR TITLE
feat: add AutoTooltipMixin and AutoTooltipController

### DIFF
--- a/packages/component-base/src/auto-tooltip-controller.d.ts
+++ b/packages/component-base/src/auto-tooltip-controller.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { TooltipController } from './tooltip-controller.js';
+
+export interface AutoTooltipControllerOptions {
+  /**
+   * Override how the auto tooltip text is read from the host.
+   * Defaults to joining the textContent of the default slot's
+   * assigned nodes and trimming the result.
+   */
+  getText?(host: HTMLElement): string;
+}
+
+/**
+ * A controller that extends `TooltipController` to lazily create and
+ * maintain an auto-generated `<vaadin-tooltip>` mirroring the host's
+ * visible text. The auto tooltip is created with `ariaTarget = null`
+ * to avoid adding `aria-describedby` to the host.
+ */
+export class AutoTooltipController extends TooltipController {
+  constructor(host: HTMLElement, options?: AutoTooltipControllerOptions);
+
+  /**
+   * Toggle whether the auto tooltip should exist. Re-evaluates immediately.
+   */
+  setEnabled(enabled: boolean): void;
+}

--- a/packages/component-base/src/auto-tooltip-controller.js
+++ b/packages/component-base/src/auto-tooltip-controller.js
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotObserver } from './slot-observer.js';
+import { TooltipController } from './tooltip-controller.js';
+
+function defaultGetText(host) {
+  const slot = host.shadowRoot && host.shadowRoot.querySelector('slot:not([name])');
+  if (!slot) {
+    return '';
+  }
+  return slot
+    .assignedNodes({ flatten: true })
+    .map((node) => node.textContent)
+    .join('')
+    .trim();
+}
+
+/**
+ * A controller that extends `TooltipController` to manage an
+ * automatically created `<vaadin-tooltip>` element. When enabled,
+ * the controller creates the tooltip and slots it into the host's
+ * `tooltip` slot, mirroring the host's visible text. When disabled,
+ * or when the host's text is empty, or when the host already has a
+ * user-provided tooltip, the auto tooltip is removed.
+ *
+ * The auto tooltip is created with `ariaTarget = null` so that it does
+ * not contribute an `aria-describedby` attribute on the host: the text
+ * is already present in the accessibility tree via the host's content.
+ */
+export class AutoTooltipController extends TooltipController {
+  constructor(host, options = {}) {
+    super(host);
+    this.__getText = options.getText || defaultGetText;
+    this.__enabled = false;
+  }
+
+  /**
+   * Toggle whether the auto tooltip should exist. Re-evaluates immediately.
+   *
+   * @param {boolean} enabled
+   */
+  setEnabled(enabled) {
+    this.__enabled = enabled;
+    this.__update();
+  }
+
+  /** @override */
+  hostConnected() {
+    super.hostConnected();
+
+    if (!this.__shadowSlotObserver) {
+      this.__shadowSlotObserver = new SlotObserver(this.host.shadowRoot, () => {
+        this.__update();
+      });
+    }
+  }
+
+  /** @private */
+  __hasCustomTooltip() {
+    return Array.from(this.host.children).some((node) => node !== this.__autoNode && node.slot === 'tooltip');
+  }
+
+  /** @private */
+  __update() {
+    const text = this.__enabled ? this.__getText(this.host) : '';
+
+    if (!this.__enabled || !text || this.__hasCustomTooltip()) {
+      if (this.__autoNode) {
+        this.__autoNode.remove();
+      }
+      return;
+    }
+
+    if (!this.__autoNode) {
+      this.__autoNode = document.createElement('vaadin-tooltip');
+      this.__autoNode.setAttribute('slot', 'tooltip');
+      this.__autoNode.ariaTarget = null;
+    }
+
+    this.__autoNode.setAttribute('text', text);
+
+    if (!this.__autoNode.isConnected) {
+      this.host.appendChild(this.__autoNode);
+    }
+  }
+}

--- a/packages/component-base/src/auto-tooltip-mixin.d.ts
+++ b/packages/component-base/src/auto-tooltip-mixin.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { Constructor } from '@open-wc/dedupe-mixin';
+import type { AutoTooltipController, AutoTooltipControllerOptions } from './auto-tooltip-controller.js';
+
+export declare function AutoTooltipMixin<T extends Constructor<HTMLElement>>(
+  base: T,
+): Constructor<AutoTooltipMixinClass> & T;
+
+export declare class AutoTooltipMixinClass {
+  /**
+   * When enabled, the host's visible text is mirrored into an
+   * automatically created tooltip. The host is responsible for
+   * visually hiding its text content.
+   */
+  autoTooltip: boolean;
+
+  protected _tooltipController: AutoTooltipController;
+
+  /**
+   * Override to customize how the auto tooltip text is read.
+   * Return an options object passed to `AutoTooltipController`.
+   * Invoked once during `ready()`; the returned options are captured
+   * for the lifetime of the host.
+   */
+  protected _getAutoTooltipOptions(): AutoTooltipControllerOptions | undefined;
+}

--- a/packages/component-base/src/auto-tooltip-mixin.js
+++ b/packages/component-base/src/auto-tooltip-mixin.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright (c) 2026 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { AutoTooltipController } from './auto-tooltip-controller.js';
+
+/**
+ * A mixin that adds an `autoTooltip` property to a host component.
+ * When enabled, a `<vaadin-tooltip>` is automatically created and slotted
+ * into the host's `tooltip` slot, mirroring the host's visible text.
+ *
+ * Hosts opting in must:
+ * - Import `@vaadin/tooltip` themselves — this mixin does not pull it in.
+ * - Render a default `<slot>` as the text source and a `<slot name="tooltip">`.
+ * - Visually hide the text source themselves (typically via the `sr-only`
+ *   class) when `autoTooltip` is enabled — the mixin does not impose
+ *   template structure.
+ *
+ * Override `_getAutoTooltipOptions()` to customize how the tooltip text is read.
+ */
+export const AutoTooltipMixin = (superClass) =>
+  class AutoTooltipMixinClass extends superClass {
+    static get properties() {
+      return {
+        /**
+         * When enabled, the host's visible text is mirrored into an
+         * automatically created tooltip. The host is responsible for
+         * visually hiding its text content.
+         */
+        autoTooltip: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true,
+          sync: true,
+        },
+      };
+    }
+
+    /** @protected */
+    ready() {
+      super.ready();
+
+      this._tooltipController = new AutoTooltipController(this, this._getAutoTooltipOptions());
+      this.addController(this._tooltipController);
+      this._tooltipController.setEnabled(this.autoTooltip);
+    }
+
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('autoTooltip')) {
+        this._tooltipController.setEnabled(this.autoTooltip);
+      }
+    }
+
+    /**
+     * Override to customize how the auto tooltip text is read.
+     * Return an options object passed to `AutoTooltipController`.
+     * Invoked once during `ready()`; the returned options are captured
+     * for the lifetime of the host. For runtime branching, use a
+     * `host`-aware `getText` callback.
+     *
+     * @protected
+     */
+    _getAutoTooltipOptions() {
+      return undefined;
+    }
+  };

--- a/packages/component-base/test/auto-tooltip-controller.test.js
+++ b/packages/component-base/test/auto-tooltip-controller.test.js
@@ -1,0 +1,194 @@
+import { expect } from '@vaadin/chai-plugins';
+import { defineLit, fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
+import { AutoTooltipController } from '../src/auto-tooltip-controller.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
+
+describe('AutoTooltipController', () => {
+  const tag = defineLit(
+    'auto-tooltip-host',
+    '<slot></slot><slot name="tooltip"></slot>',
+    (Base) => class extends PolylitMixin(Base) {},
+  );
+
+  let host, controller;
+
+  beforeEach(() => {
+    host = fixtureSync(`<${tag}>Label text</${tag}>`);
+    controller = new AutoTooltipController(host);
+    host.addController(controller);
+  });
+
+  const getAutoTooltip = () => host.querySelector('vaadin-tooltip');
+
+  describe('disabled by default', () => {
+    it('should not create a tooltip when controller is added', async () => {
+      await nextFrame();
+      expect(getAutoTooltip()).to.be.null;
+    });
+
+    it('should not set has-tooltip on the host', async () => {
+      await nextFrame();
+      expect(host.hasAttribute('has-tooltip')).to.be.false;
+    });
+  });
+
+  describe('enabled', () => {
+    beforeEach(async () => {
+      controller.setEnabled(true);
+      await nextFrame();
+    });
+
+    it('should create a tooltip slotted into the tooltip slot', () => {
+      const tooltip = getAutoTooltip();
+      expect(tooltip).to.be.ok;
+      expect(tooltip.getAttribute('slot')).to.equal('tooltip');
+    });
+
+    it('should set the tooltip text from the host default slot', () => {
+      expect(getAutoTooltip().getAttribute('text')).to.equal('Label text');
+    });
+
+    it('should set ariaTarget to null on the auto tooltip', () => {
+      expect(getAutoTooltip().ariaTarget).to.equal(null);
+    });
+
+    it('should not add aria-describedby on the host', () => {
+      expect(host.hasAttribute('aria-describedby')).to.be.false;
+    });
+
+    it('should remove the auto tooltip when disabled', async () => {
+      controller.setEnabled(false);
+      await nextFrame();
+      expect(getAutoTooltip()).to.be.null;
+    });
+
+    it('should reuse the same auto tooltip node when re-enabled', async () => {
+      const tooltip = getAutoTooltip();
+      controller.setEnabled(false);
+      await nextFrame();
+      controller.setEnabled(true);
+      await nextFrame();
+      expect(getAutoTooltip()).to.equal(tooltip);
+    });
+
+    it('should update the tooltip text when the host text changes', async () => {
+      host.textContent = 'Updated text';
+      await nextFrame();
+      expect(getAutoTooltip().getAttribute('text')).to.equal('Updated text');
+    });
+
+    it('should remove the auto tooltip when host text becomes empty', async () => {
+      host.textContent = '';
+      await nextFrame();
+      expect(getAutoTooltip()).to.be.null;
+    });
+
+    it('should remove the auto tooltip when a custom tooltip is slotted', async () => {
+      const custom = document.createElement('vaadin-tooltip');
+      custom.setAttribute('slot', 'tooltip');
+      host.appendChild(custom);
+      await nextFrame();
+      const tooltips = host.querySelectorAll('vaadin-tooltip');
+      expect(tooltips.length).to.equal(1);
+      expect(tooltips[0]).to.equal(custom);
+    });
+
+    it('should restore the auto tooltip when the custom tooltip is removed', async () => {
+      const custom = document.createElement('vaadin-tooltip');
+      custom.setAttribute('slot', 'tooltip');
+      host.appendChild(custom);
+      await nextFrame();
+
+      custom.remove();
+      await nextFrame();
+
+      expect(getAutoTooltip()).to.be.ok;
+      expect(getAutoTooltip().getAttribute('text')).to.equal('Label text');
+    });
+  });
+
+  describe('initial state with text', () => {
+    it('should create the auto tooltip immediately when enabled in setup', async () => {
+      // Fresh host so we observe initial enable behavior.
+      const freshHost = fixtureSync(`<${tag}>Initial</${tag}>`);
+      const freshController = new AutoTooltipController(freshHost);
+      freshHost.addController(freshController);
+      freshController.setEnabled(true);
+      await nextFrame();
+      expect(freshHost.querySelector('vaadin-tooltip').getAttribute('text')).to.equal('Initial');
+    });
+  });
+
+  describe('pre-existing custom tooltip', () => {
+    let preHost, preController;
+
+    beforeEach(async () => {
+      preHost = fixtureSync(`
+        <${tag}>
+          Label text
+          <vaadin-tooltip slot="tooltip" text="User"></vaadin-tooltip>
+        </${tag}>
+      `);
+      preController = new AutoTooltipController(preHost);
+      preHost.addController(preController);
+      preController.setEnabled(true);
+      await nextFrame();
+    });
+
+    it('should not create an auto tooltip when a custom one is already slotted', () => {
+      const tooltips = preHost.querySelectorAll('vaadin-tooltip');
+      expect(tooltips.length).to.equal(1);
+      expect(tooltips[0].getAttribute('text')).to.equal('User');
+    });
+  });
+
+  describe('host with no default slot', () => {
+    const tooltipOnlyTag = defineLit(
+      'auto-tooltip-host-no-default-slot',
+      '<slot name="tooltip"></slot>',
+      (Base) => class extends PolylitMixin(Base) {},
+    );
+
+    it('should not create an auto tooltip when host has no default slot', async () => {
+      const slotlessHost = fixtureSync(`<${tooltipOnlyTag}></${tooltipOnlyTag}>`);
+      const slotlessController = new AutoTooltipController(slotlessHost);
+      slotlessHost.addController(slotlessController);
+      slotlessController.setEnabled(true);
+      await nextFrame();
+      expect(slotlessHost.querySelector('vaadin-tooltip')).to.be.null;
+    });
+  });
+
+  describe('custom getText option', () => {
+    let customHost, customController;
+
+    beforeEach(async () => {
+      customHost = fixtureSync(`<${tag}>Default slot text</${tag}>`);
+      customController = new AutoTooltipController(customHost, {
+        getText: () => 'Computed text',
+      });
+      customHost.addController(customController);
+      customController.setEnabled(true);
+      await nextFrame();
+    });
+
+    it('should use the provided getText function', () => {
+      expect(customHost.querySelector('vaadin-tooltip').getAttribute('text')).to.equal('Computed text');
+    });
+
+    it('should pass the host as the first argument to getText', () => {
+      let received;
+      const probeHost = fixtureSync(`<${tag}></${tag}>`);
+      const probeController = new AutoTooltipController(probeHost, {
+        getText: (h) => {
+          received = h;
+          return 'x';
+        },
+      });
+      probeHost.addController(probeController);
+      probeController.setEnabled(true);
+      expect(received).to.equal(probeHost);
+    });
+  });
+});

--- a/packages/component-base/test/auto-tooltip-mixin.test.js
+++ b/packages/component-base/test/auto-tooltip-mixin.test.js
@@ -1,0 +1,128 @@
+import { expect } from '@vaadin/chai-plugins';
+import { defineLit, fixtureSync, nextFrame, nextUpdate } from '@vaadin/testing-helpers';
+import '@vaadin/tooltip/src/vaadin-tooltip.js';
+import { AutoTooltipController } from '../src/auto-tooltip-controller.js';
+import { AutoTooltipMixin } from '../src/auto-tooltip-mixin.js';
+import { PolylitMixin } from '../src/polylit-mixin.js';
+
+describe('AutoTooltipMixin', () => {
+  const tag = defineLit(
+    'auto-tooltip-mixin-host',
+    '<slot></slot><slot name="tooltip"></slot>',
+    (Base) => class extends AutoTooltipMixin(PolylitMixin(Base)) {},
+  );
+
+  let host;
+
+  const getAutoTooltip = () => host.querySelector('vaadin-tooltip');
+
+  describe('property', () => {
+    beforeEach(async () => {
+      host = fixtureSync(`<${tag}>Label</${tag}>`);
+      await nextFrame();
+    });
+
+    it('should default autoTooltip to false', () => {
+      expect(host.autoTooltip).to.be.false;
+    });
+
+    it('should not create a tooltip by default', () => {
+      expect(getAutoTooltip()).to.be.null;
+    });
+
+    it('should not reflect autoTooltip attribute when false', () => {
+      expect(host.hasAttribute('auto-tooltip')).to.be.false;
+    });
+
+    it('should reflect autoTooltip attribute when set to true', async () => {
+      host.autoTooltip = true;
+      await nextUpdate(host);
+      expect(host.hasAttribute('auto-tooltip')).to.be.true;
+    });
+  });
+
+  describe('toggling autoTooltip', () => {
+    beforeEach(async () => {
+      host = fixtureSync(`<${tag}>Label</${tag}>`);
+      await nextFrame();
+    });
+
+    it('should create the auto tooltip when autoTooltip becomes true', async () => {
+      host.autoTooltip = true;
+      await nextUpdate(host);
+      await nextFrame();
+      expect(getAutoTooltip()).to.be.ok;
+      expect(getAutoTooltip().getAttribute('text')).to.equal('Label');
+    });
+
+    it('should remove the auto tooltip when autoTooltip becomes false', async () => {
+      host.autoTooltip = true;
+      await nextUpdate(host);
+      await nextFrame();
+      host.autoTooltip = false;
+      await nextUpdate(host);
+      await nextFrame();
+      expect(getAutoTooltip()).to.be.null;
+    });
+
+    it('should set ariaTarget to null on the auto tooltip', async () => {
+      host.autoTooltip = true;
+      await nextUpdate(host);
+      await nextFrame();
+      expect(getAutoTooltip().ariaTarget).to.equal(null);
+    });
+
+    it('should not add aria-describedby on the host', async () => {
+      host.autoTooltip = true;
+      await nextUpdate(host);
+      await nextFrame();
+      expect(host.hasAttribute('aria-describedby')).to.be.false;
+    });
+  });
+
+  describe('initial autoTooltip via attribute', () => {
+    beforeEach(async () => {
+      host = fixtureSync(`<${tag} auto-tooltip>Label</${tag}>`);
+      await nextFrame();
+    });
+
+    it('should reflect the property from the attribute', () => {
+      expect(host.autoTooltip).to.be.true;
+    });
+
+    it('should create the auto tooltip on ready', () => {
+      expect(getAutoTooltip()).to.be.ok;
+      expect(getAutoTooltip().getAttribute('text')).to.equal('Label');
+    });
+  });
+
+  describe('controller exposure', () => {
+    beforeEach(async () => {
+      host = fixtureSync(`<${tag}>Label</${tag}>`);
+      await nextFrame();
+    });
+
+    it('should expose the AutoTooltipController as _tooltipController', () => {
+      expect(host._tooltipController).to.be.instanceOf(AutoTooltipController);
+    });
+  });
+
+  describe('custom _getAutoTooltipOptions', () => {
+    const customTag = defineLit(
+      'auto-tooltip-mixin-custom-host',
+      '<slot></slot><slot name="tooltip"></slot>',
+      (Base) =>
+        class extends AutoTooltipMixin(PolylitMixin(Base)) {
+          _getAutoTooltipOptions() {
+            return { getText: () => 'Forced text' };
+          }
+        },
+    );
+
+    it('should pass the options to the controller', async () => {
+      const customHost = fixtureSync(`<${customTag} auto-tooltip>Ignored</${customTag}>`);
+      await nextFrame();
+      expect(customHost.querySelector('vaadin-tooltip').getAttribute('text')).to.equal('Forced text');
+    });
+  });
+});


### PR DESCRIPTION
Extracts the duplicated ``autoTooltip`` logic that would otherwise live in `vaadin-button` and `vaadin-badge` into a shared primitive in `@vaadin/component-base`. Splitting the work this way keeps the primitive review focused and lets each adopting component land in its own PR.

## Changes

- `AutoTooltipController` extends `TooltipController` and owns the lazy `<vaadin-tooltip>` lifecycle. It uses `SlotObserver` in ShadowRoot mode so a single observer reacts to both the text-source slot and the `tooltip` slot — replacing the dual ``@slotchange`` handlers the duplicated implementations would otherwise need in each host template.
- `AutoTooltipMixin` declares the `autoTooltip` property and wires the controller. The mixin does not pull in `@vaadin/tooltip` — adopting components must import it themselves to keep `component-base` free of a package edge.
- Visual hiding (e.g. `sr-only` toggling) stays in the host template since the criteria differ across adopters (button toggles on `autoTooltip` alone; badge ORs with theme variants).
- 29 unit tests covering text mirroring, enable/disable cycles, custom-tooltip suppression and restoration, pre-existing custom tooltip, host with no default slot, custom ``getText`` option, and ``ariaTarget = null`` suppression of ``aria-describedby``.

## Follow-ups

This is part 1 of 3. Two follow-up PRs will adopt the primitive in `vaadin-button` and `vaadin-badge` respectively, each branched off main after this lands.

---

🤖 Generated with Claude Code