### PR TITLE
feat: add tooltip ariaLinkMode property to control ARIA attribute

### DIFF
--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-mixin.js
@@ -429,9 +429,9 @@ export const RichTextEditorMixin = (superClass) =>
       // Set up tooltip to show when hovering or focusing toolbar buttons
       this._tooltip = document.createElement('vaadin-tooltip');
       this._tooltip.slot = 'tooltip';
-      // Set ariaTarget to null, as toolbar buttons already have aria-label,
-      // and also cannot be linked with the tooltip being in the light DOM
-      this._tooltip.ariaTarget = null;
+      // Toolbar buttons already have aria-label and cannot be linked with the
+      // tooltip in the light DOM, so disable ARIA linking entirely.
+      this._tooltip.ariaLinkMode = 'none';
       this.append(this._tooltip);
 
       const buttons = this.shadowRoot.querySelectorAll('[part~="toolbar-button"]');

--- a/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.d.ts
@@ -18,11 +18,25 @@ export declare function TooltipMixin<T extends Constructor<HTMLElement>>(
 
 export declare class TooltipMixinClass {
   /**
-   * Element used to link with the `aria-describedby`
-   * attribute. Supports array of multiple elements.
+   * Element used to link with the ARIA attribute controlled by the
+   * `ariaLinkMode` property. Supports array of multiple elements.
    * When not set, defaults to `target`.
    */
   ariaTarget: HTMLElement | HTMLElement[] | null | undefined;
+
+  /**
+   * Controls which ARIA attribute is used to link the target element(s)
+   * with the tooltip content. Supported values:
+   *
+   * - `aria-describedby` - links the tooltip as a description.
+   * - `aria-labelledby` - links the tooltip as an accessible name.
+   * - `none` - does not add any ARIA linking attribute.
+   *
+   * Defaults to `aria-describedby`.
+   *
+   * @attr {string} aria-link-mode
+   */
+  ariaLinkMode: 'aria-describedby' | 'aria-labelledby' | 'none';
 
   /**
    * Object with properties passed to `generator` and

--- a/packages/tooltip/src/vaadin-tooltip-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-mixin.js
@@ -222,12 +222,29 @@ export const TooltipMixin = (superClass) =>
     static get properties() {
       return {
         /**
-         * Element used to link with the `aria-describedby`
-         * attribute. Supports array of multiple elements.
+         * Element used to link with the ARIA attribute controlled by the
+         * `ariaLinkMode` property. Supports array of multiple elements.
          * When not set, defaults to `target`.
          */
         ariaTarget: {
           type: Object,
+        },
+
+        /**
+         * Controls which ARIA attribute is used to link the target element(s)
+         * with the tooltip content. Supported values:
+         *
+         * - `aria-describedby` - links the tooltip as a description.
+         * - `aria-labelledby` - links the tooltip as an accessible name.
+         * - `none` - does not add any ARIA linking attribute.
+         *
+         * Defaults to `aria-describedby`.
+         *
+         * @attr {string} aria-link-mode
+         */
+        ariaLinkMode: {
+          type: String,
+          value: 'aria-describedby',
         },
 
         /**
@@ -346,7 +363,6 @@ export const TooltipMixin = (superClass) =>
         _effectiveAriaTarget: {
           type: Object,
           computed: '__computeAriaTarget(ariaTarget, target)',
-          observer: '__effectiveAriaTargetChanged',
         },
 
         /** @private */
@@ -459,6 +475,16 @@ export const TooltipMixin = (superClass) =>
 
       if (props.has('text') || props.has('generator') || props.has('context') || props.has('markdown')) {
         this.__updateContent();
+      }
+
+      const ariaTargetChanged = props.has('_effectiveAriaTarget');
+      const ariaLinkChanged = props.has('ariaLinkMode');
+
+      if (ariaTargetChanged || ariaLinkChanged) {
+        const oldTarget = ariaTargetChanged ? props.get('_effectiveAriaTarget') : this._effectiveAriaTarget;
+        const oldMode = ariaLinkChanged ? props.get('ariaLinkMode') : this.ariaLinkMode;
+
+        this.__updateAriaAttributes(oldTarget, oldMode);
       }
     }
 
@@ -728,16 +754,20 @@ export const TooltipMixin = (superClass) =>
     }
 
     /** @private */
-    __effectiveAriaTargetChanged(ariaTarget, oldAriaTarget) {
-      if (oldAriaTarget) {
-        [oldAriaTarget].flat().forEach((target) => {
-          removeValueFromAttribute(target, 'aria-describedby', this._uniqueId);
+    __updateAriaAttributes(oldTarget, oldMode) {
+      // Remove the previously applied attribute from the previous target(s).
+      if (oldTarget && oldMode && oldMode !== 'none') {
+        [oldTarget].flat().forEach((target) => {
+          removeValueFromAttribute(target, oldMode, this._uniqueId);
         });
       }
 
-      if (ariaTarget) {
-        [ariaTarget].flat().forEach((target) => {
-          addValueToAttribute(target, 'aria-describedby', this._uniqueId);
+      // Apply the current attribute to the current target(s).
+      const target = this._effectiveAriaTarget;
+      const mode = this.ariaLinkMode;
+      if (target && mode && mode !== 'none') {
+        [target].flat().forEach((el) => {
+          addValueToAttribute(el, mode, this._uniqueId);
         });
       }
     }

--- a/packages/tooltip/test/tooltip-target.test.js
+++ b/packages/tooltip/test/tooltip-target.test.js
@@ -143,6 +143,111 @@ describe('tooltip target', () => {
     });
   });
 
+  describe('ariaLinkMode', () => {
+    let target, ariaTarget;
+
+    beforeEach(() => {
+      target = document.createElement('div');
+      target.textContent = 'Target';
+      document.body.appendChild(target);
+
+      ariaTarget = document.createElement('input');
+      target.appendChild(ariaTarget);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(target);
+    });
+
+    it('should be set to aria-describedby by default', () => {
+      expect(tooltip.ariaLinkMode).to.equal('aria-describedby');
+    });
+
+    it('should apply aria-labelledby when set before the target', async () => {
+      tooltip.ariaLinkMode = 'aria-labelledby';
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      expect(target.getAttribute('aria-labelledby')).to.equal(contentNode.id);
+      expect(target.hasAttribute('aria-describedby')).to.be.false;
+    });
+
+    it('should not set any ARIA attribute when set to none before the target', async () => {
+      tooltip.ariaLinkMode = 'none';
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      expect(target.hasAttribute('aria-describedby')).to.be.false;
+      expect(target.hasAttribute('aria-labelledby')).to.be.false;
+    });
+
+    it('should update ARIA attributes when set to aria-labelledby', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.ariaLinkMode = 'aria-labelledby';
+      await nextUpdate(tooltip);
+
+      expect(target.hasAttribute('aria-describedby')).to.be.false;
+      expect(target.getAttribute('aria-labelledby')).to.equal(contentNode.id);
+    });
+
+    it('should remove ARIA attribute when set to none', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.ariaLinkMode = 'none';
+      await nextUpdate(tooltip);
+
+      expect(target.hasAttribute('aria-describedby')).to.be.false;
+      expect(target.hasAttribute('aria-labelledby')).to.be.false;
+    });
+
+    it('should restore attribute when setting from none back to describedby', async () => {
+      tooltip.ariaLinkMode = 'none';
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.ariaLinkMode = 'aria-describedby';
+      await nextUpdate(tooltip);
+
+      expect(target.getAttribute('aria-describedby')).to.equal(contentNode.id);
+    });
+
+    it('should swap attribute across an ariaTarget array', async () => {
+      const ariaTarget2 = document.createElement('button');
+      target.appendChild(ariaTarget2);
+
+      tooltip.target = target;
+      tooltip.ariaTarget = [ariaTarget, ariaTarget2];
+      await nextUpdate(tooltip);
+      expect(ariaTarget.getAttribute('aria-describedby')).to.equal(contentNode.id);
+      expect(ariaTarget2.getAttribute('aria-describedby')).to.equal(contentNode.id);
+
+      tooltip.ariaLinkMode = 'aria-labelledby';
+      await nextUpdate(tooltip);
+
+      expect(ariaTarget.hasAttribute('aria-describedby')).to.be.false;
+      expect(ariaTarget2.hasAttribute('aria-describedby')).to.be.false;
+      expect(ariaTarget.getAttribute('aria-labelledby')).to.equal(contentNode.id);
+      expect(ariaTarget2.getAttribute('aria-labelledby')).to.equal(contentNode.id);
+    });
+
+    it('should preserve a pre-existing ARIA attribute value when changing mode', async () => {
+      target.setAttribute('aria-describedby', 'foo');
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+      expect(target.getAttribute('aria-describedby')).to.contain('foo');
+      expect(target.getAttribute('aria-describedby')).to.contain(contentNode.id);
+
+      tooltip.ariaLinkMode = 'aria-labelledby';
+      await nextUpdate(tooltip);
+
+      expect(target.getAttribute('aria-describedby')).to.equal('foo');
+      expect(target.getAttribute('aria-labelledby')).to.equal(contentNode.id);
+    });
+  });
+
   describe('for', () => {
     let target;
 

--- a/packages/tooltip/test/tooltip-target.test.js
+++ b/packages/tooltip/test/tooltip-target.test.js
@@ -144,15 +144,12 @@ describe('tooltip target', () => {
   });
 
   describe('ariaLinkMode', () => {
-    let target, ariaTarget;
+    let target;
 
     beforeEach(() => {
       target = document.createElement('div');
       target.textContent = 'Target';
       document.body.appendChild(target);
-
-      ariaTarget = document.createElement('input');
-      target.appendChild(ariaTarget);
     });
 
     afterEach(() => {
@@ -214,13 +211,16 @@ describe('tooltip target', () => {
       expect(target.getAttribute('aria-describedby')).to.equal(contentNode.id);
     });
 
-    it('should swap attribute across an ariaTarget array', async () => {
+    it('should update attribute for all target elements when using ariaTarget array', async () => {
+      const ariaTarget = document.createElement('input');
       const ariaTarget2 = document.createElement('button');
-      target.appendChild(ariaTarget2);
+
+      target.append(ariaTarget, ariaTarget2);
 
       tooltip.target = target;
       tooltip.ariaTarget = [ariaTarget, ariaTarget2];
       await nextUpdate(tooltip);
+
       expect(ariaTarget.getAttribute('aria-describedby')).to.equal(contentNode.id);
       expect(ariaTarget2.getAttribute('aria-describedby')).to.equal(contentNode.id);
 


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/flow-components/issues/8905

Added `ariaLinkMode` property to `vaadin-tooltip` with following supported values:

- `aria-describedby` (default)
- `aria-labelledby`
- `none`

## Type of change

- Feature