### PR TITLE
chore: fix incorrect protected method in ActiveMixin typings

### DIFF
--- a/packages/a11y-base/src/active-mixin.d.ts
+++ b/packages/a11y-base/src/active-mixin.d.ts
@@ -32,7 +32,7 @@ export declare class ActiveMixinClass {
   /**
    * Override to define if the component needs to be activated.
    */
-  protected _shouldSetFocus(event: KeyboardEvent | MouseEvent): boolean;
+  protected _shouldSetActive(event: KeyboardEvent | MouseEvent): boolean;
 
   /**
    * Toggles the `active` attribute on the element.


### PR DESCRIPTION
## Description

Fixed a copy-paste in typings - the method name is actually `_shouldSetActive` and not `_shouldSetFocus`.

## Type of change

- Internal change