### PR TITLE
fix: do not mark breadcrumbs item as focused when disabled

### DIFF
--- a/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
+++ b/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
@@ -17,10 +17,6 @@ export const breadcrumbsItemStyles = css`
     display: none !important;
   }
 
-  :host([disabled]) {
-    pointer-events: none;
-  }
-
   :host([disabled]) [part='link'] {
     color: var(--vaadin-text-color-disabled);
   }

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -137,6 +137,29 @@ class BreadcrumbsItem extends FocusMixin(DisabledMixin(ElementMixin(PolylitMixin
     });
     this.__slotObserver.flush();
   }
+
+  /**
+   * @param {FocusOptions=} options
+   * @protected
+   * @override
+   */
+  focus(options) {
+    if (!this.disabled) {
+      super.focus(options);
+    }
+  }
+
+  /**
+   * Override method inherited from `FocusMixin`
+   * to not set `focused` attribute when disabled.
+   *
+   * @return {boolean}
+   * @protected
+   * @override
+   */
+  _shouldSetFocus() {
+    return !this.disabled;
+  }
 }
 
 defineCustomElement(BreadcrumbsItem);

--- a/packages/breadcrumbs/test/breadcrumbs-item.test.js
+++ b/packages/breadcrumbs/test/breadcrumbs-item.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../vaadin-breadcrumbs-item.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 
 window.Vaadin ??= {};
 window.Vaadin.featureFlags ??= {};
@@ -46,6 +47,40 @@ describe('vaadin-breadcrumbs-item', () => {
       it('should not override custom role', () => {
         expect(item.getAttribute('role')).to.equal('presentation');
       });
+    });
+  });
+
+  describe('focus', () => {
+    let link;
+
+    beforeEach(async () => {
+      item.path = '/path';
+      await nextUpdate(item);
+      link = item.shadowRoot.querySelector('a');
+    });
+
+    it('should focus the link on focus() by default', () => {
+      item.focus();
+      expect(getDeepActiveElement()).to.equal(link);
+    });
+
+    it('should not focus the link on focus() when disabled', async () => {
+      item.disabled = true;
+      await nextUpdate(item);
+      item.focus();
+      expect(getDeepActiveElement()).to.not.equal(link);
+    });
+
+    it('should set focused attribute on link focus by default', () => {
+      link.focus();
+      expect(item.hasAttribute('focused')).to.be.true;
+    });
+
+    it('should not set focused attribute on link focus when disabled', async () => {
+      item.disabled = true;
+      await nextUpdate(item);
+      link.focus();
+      expect(item.hasAttribute('focused')).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description

- Added `focus()` method override to disallow focusing breadcrumbs item link when disabled
- Added `_shouldSetFocus()` override to not set `focused` / `focus-ring` attributes when disabled
- Removed `pointer-events: none` to allow text selection for disabled breadcrumbs items

## Type of change

- Bugfix