### PR TITLE
test: import custom element classes instead of relying on side-effects

### DIFF
--- a/packages/notification/test/statichelper.test.js
+++ b/packages/notification/test/statichelper.test.js
@@ -1,9 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, nextFrame } from '@vaadin/testing-helpers';
-import '../src/vaadin-notification.js';
 import { html } from 'lit';
-
-const Notification = customElements.get('vaadin-notification');
+import { Notification } from '../src/vaadin-notification.js';
 
 describe('static helpers', () => {
   it('show should show a text notification', async () => {

--- a/packages/rich-text-editor/test/toolbar.test.js
+++ b/packages/rich-text-editor/test/toolbar.test.js
@@ -16,6 +16,7 @@ import {
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-rich-text-editor.js';
+import { Tooltip } from '@vaadin/tooltip/src/vaadin-tooltip.js';
 import { createImage } from './helpers.js';
 
 describe('toolbar controls', () => {
@@ -634,7 +635,6 @@ describe('toolbar controls', () => {
   });
 
   describe('tooltip', () => {
-    const Tooltip = customElements.get('vaadin-tooltip');
     let tooltip, overlay;
 
     before(() => {

--- a/packages/tooltip/test/tooltip-offset.test.js
+++ b/packages/tooltip/test/tooltip-offset.test.js
@@ -1,11 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
-import '../src/vaadin-tooltip.js';
+import { Tooltip } from '../src/vaadin-tooltip.js';
 
 describe('offset', () => {
   let tooltip, target, overlay;
-
-  const Tooltip = customElements.get('vaadin-tooltip');
 
   before(() => {
     Tooltip.setDefaultFocusDelay(0);

--- a/packages/tooltip/test/tooltip-position.test.js
+++ b/packages/tooltip/test/tooltip-position.test.js
@@ -1,12 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fire, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import './position-styles.js';
-import '../src/vaadin-tooltip.js';
+import { Tooltip } from '../src/vaadin-tooltip.js';
 
 describe('position', () => {
   let tooltip, target, overlay;
-
-  const Tooltip = customElements.get('vaadin-tooltip');
 
   before(() => {
     Tooltip.setDefaultFocusDelay(0);

--- a/packages/tooltip/test/tooltip-timers.test.js
+++ b/packages/tooltip/test/tooltip-timers.test.js
@@ -11,14 +11,12 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-tooltip.js';
+import { Tooltip } from '../src/vaadin-tooltip.js';
 import { resetGlobalTooltipState } from '../src/vaadin-tooltip-mixin.js';
 import { mouseenter, mouseleave } from './helpers.js';
 
 describe('timers', () => {
   let clock;
-
-  const Tooltip = customElements.get('vaadin-tooltip');
 
   // Used as a fallback delay
   const DEFAULT_DELAY = 500;

--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -13,13 +13,11 @@ import {
   tabKeyDown,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import '../src/vaadin-tooltip.js';
 import '@vaadin/overlay/vaadin-overlay.js';
+import { Tooltip } from '../src/vaadin-tooltip.js';
 import { mouseenter, mouseleave, waitForIntersectionObserver } from './helpers.js';
 
 describe('vaadin-tooltip', () => {
-  const Tooltip = customElements.get('vaadin-tooltip');
-
   before(() => {
     Tooltip.setDefaultFocusDelay(0);
     Tooltip.setDefaultHoverDelay(0);


### PR DESCRIPTION
## Description

Replaced `const Tooltip = customElements.get('vaadin-tooltip')` etc in tests. These are leftovers from V24 version where we used to have same tests running for Polymer / Lit versions. Now when we only have Lit version, we can import directly.

## Type of change

- Test