### PR TITLE
chore: remove no longer needed dotenv config from the repo

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,2 +1,0 @@
-# Template for configuring environment variables used in this repositories scripts
-# To make use of this, copy this file to `.env` and configure the variables below

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,6 @@ of steps to perform when creating a new major or minor version branch of the mon
 - [Getting started](#getting-started)
 - [Linting](#linting)
 - [Testing](#testing)
-  - [Environment variables](#environment-variables)
   - [Unit tests](#unit-tests)
   - [Visual tests](#visual-tests)
   - [Snapshot tests](#snapshot-tests)
@@ -61,18 +60,6 @@ yarn lint:types
 ```
 
 ## Testing
-
-### Environment variables
-
-Setup the environment variables needed by the scripts below, by copying the `.env.dist` template file to `.env`:
-
-```
-cp .env.dist .env
-```
-
-and then configure the individual variable values in the newly created `.env` file.
-
-Not all variables are necessary for all scripts, individual sections below will note which variables are required to run a command.
 
 ### Unit tests
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@web/test-runner": "^0.20.2",
     "@web/test-runner-playwright": "^0.11.1",
     "@web/test-runner-visual-regression": "^0.10.0",
-    "dotenv": "^16.5.0",
     "eslint": "^9.39.2",
     "eslint-config-vaadin": "^1.0.0-beta.6",
     "eslint-plugin-es-x": "^9.6.0",

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -1,15 +1,12 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import { visualRegressionPlugin } from '@web/test-runner-visual-regression/plugin';
-import dotenv from 'dotenv';
 import { globSync } from 'glob';
 import minimist from 'minimist';
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { cssImportPlugin } from './web-dev-server.config.js';
-
-dotenv.config();
 
 const argv = minimist(process.argv.slice(2));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4179,7 +4179,7 @@ dotenv-expand@~11.0.6:
   dependencies:
     dotenv "^16.4.4"
 
-dotenv@^16.4.4, dotenv@^16.5.0:
+dotenv@^16.4.4:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==


### PR DESCRIPTION
## Description

The `.env` support was added in https://github.com/vaadin/web-components/pull/249 to load `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`.
Now when we run visual tests in Docker since https://github.com/vaadin/web-components/pull/11294, it is no longer needed and can be removed.

## Type of change

- Internal change