### PR TITLE
refactor: rework combo-box scrollToIndex flow to attempt scroll first

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
@@ -3,8 +3,6 @@
  * Copyright (c) 2015 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
-
 export const ComboBoxScrollToIndexMixin = (superClass) =>
   class ScrollToIndexMixin extends superClass {
     static get observers() {
@@ -30,31 +28,33 @@ export const ComboBoxScrollToIndexMixin = (superClass) =>
         return;
       }
 
-      if (!this._overlayOpened || this.loading) {
+      // Defer until the dropdown is open and the items array has been
+      // populated. `_onOpened` and `__onDataProviderPageLoaded` re-fire
+      // the queued call once those conditions hold.
+      if (!this._overlayOpened || !this._dropdownItems || this._dropdownItems.length === 0) {
         this.__scrollToPendingIndex = index;
         return;
       }
 
-      if (!this._dropdownItems || index >= this._dropdownItems.length) {
+      if (index >= this._dropdownItems.length) {
         return;
       }
 
-      if (this._dropdownItems[index] instanceof ComboBoxPlaceholder) {
-        // The target item is on a page that has not been loaded yet. Request
-        // the page directly and queue the focus-index update for after the
-        // page loads (see `__onDataProviderPageLoaded` →
-        // `__scrollToPendingIndexIfNeeded`). Relying on `_scrollIntoView` to
-        // trigger the page load via the visible-placeholder `index-requested`
-        // chain is unreliable on reopen with cached data: the virtualizer
-        // has just been torn down by closing the overlay and its scroll API
-        // is a no-op while it rebuilds physical items.
+      // Move the viewport and set the focused row. Rendering rows
+      // around `index` lets placeholder rows fire `index-requested`,
+      // which loads any missing pages via the data-provider chain.
+      this._scrollIntoView(index);
+      this._focusedIndex = index;
+
+      // A page-load may have kicked in during the scroll (placeholder
+      // rows in the new viewport requested their pages). Re-fire after
+      // the page lands so the viewport can settle around real items.
+      if (this.loading) {
         this.__scrollToPendingIndex = index;
-        this.__dataProviderController.ensureFlatIndexLoaded(index);
         return;
       }
 
       delete this.__scrollToPendingIndex;
-      this._focusedIndex = index;
       requestAnimationFrame(() => {
         if (this.isConnected) {
           this._updateActiveDescendant(index);

--- a/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
@@ -36,7 +36,7 @@ export const ComboBoxScrollToIndexMixin = (superClass) =>
         return;
       }
 
-      if (index >= this.size - 1) {
+      if (index >= this._dropdownItems.length) {
         return;
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroll-to-index-mixin.js
@@ -36,7 +36,7 @@ export const ComboBoxScrollToIndexMixin = (superClass) =>
         return;
       }
 
-      if (index >= this._dropdownItems.length) {
+      if (index >= this.size - 1) {
         return;
       }
 


### PR DESCRIPTION
The previous implementation special-cased placeholder targets by calling `ensureFlatIndexLoaded` directly, and short-circuited the entire call when `loading` was true. That meant two separate paths handled the "page not loaded yet" case (the explicit branch and the natural `index-requested` chain), and a scroll requested mid-loading was deferred wholesale even when items already existed.

This reworks the method into a single uniform flow:

- Defer only when the dropdown isn't open or the items array is empty.
- Move the viewport and set the focused row in one path, regardless of whether the target is a placeholder or a real item.
- Queue post-attempt when `loading` flips true (a page request was triggered by the new viewport), so the call re-fires after the page lands.

Setting `_focusedIndex` propagates to the scroller and drives viewport rendering; placeholder rows in the new viewport fire `index-requested` and load any missing pages through the data-provider chain — there's no longer a need for `scrollToIndex` itself to drive page loading.

> [!NOTE]
> On placeholder→real transitions, the value-based focus lookup in `_setDropdownItems` may briefly reset `_focusedIndex` before the post-attempt re-fire restores it. Part of #11815 hardens `_setDropdownItems` against this transition; that PR should land alongside or before this one.

Related to #11815

🤖 Generated with [Claude Code](https://claude.com/claude-code)