### PR TITLE
chore: upgrade dompurify dependency to latest version

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -37,7 +37,7 @@
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/component-base": "25.2.0-beta1",
     "@vaadin/vaadin-themable-mixin": "25.2.0-beta1",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.7",
     "lit": "^3.0.0",
     "marked": "^16.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4132,10 +4132,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
-  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
+dompurify@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.7.tgz#e2702ea4fd5d83467f1baef62309466ce7d44a82"
+  integrity sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Description

Closes https://github.com/vaadin/web-components/issues/11853

Note: `^3.4.0` used currently should already pick up latest patch release, but let's update it anyway.

## Type of change

- Dependency update