### PR TITLE
chore: upgrade dompurify dependency to latest version (#11854) (CP: 25.0)

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -36,7 +36,7 @@
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/component-base": "~25.0.12",
     "@vaadin/vaadin-themable-mixin": "~25.0.12",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.7",
     "lit": "^3.0.0",
     "marked": "^16.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4330,10 +4330,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.1.tgz#c7e1ddebfe3301eacd6c0c12a4af284936dbbb86"
-  integrity sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==
+dompurify@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.7.tgz#e2702ea4fd5d83467f1baef62309466ce7d44a82"
+  integrity sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #11854 to branch 25.0.

---

> ## Description
>
> Closes https://github.com/vaadin/web-components/issues/11853
>
> Note: `^3.4.0` used currently should already pick up latest patch release, but let's update it anyway.
>
> ## Type of change
>
> - Dependency update