### PR TITLE
refactor: update details and accordion Lumo to use base styles

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -76,6 +76,10 @@ class AccordionHeading extends ActiveMixin(DirMixin(ThemableMixin(PolylitMixin(L
     return accordionHeading;
   }
 
+  static get lumoInjector() {
+    return { ...super.lumoInjector, includeBaseStyles: true };
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -49,6 +49,10 @@ class AccordionPanel extends AccordionPanelMixin(ThemableMixin(PolylitMixin(Lumo
     return accordionPanel;
   }
 
+  static get lumoInjector() {
+    return { ...super.lumoInjector, includeBaseStyles: true };
+  }
+
   /** @protected */
   render() {
     return html`

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -63,6 +63,10 @@ class DetailsSummary extends ButtonMixin(DirMixin(ThemableMixin(PolylitMixin(Lum
     return detailsSummary();
   }
 
+  static get lumoInjector() {
+    return { ...super.lumoInjector, includeBaseStyles: true };
+  }
+
   static get properties() {
     return {
       /**

--- a/packages/vaadin-lumo-styles/src/components/accordion-heading.css
+++ b/packages/vaadin-lumo-styles/src/components/accordion-heading.css
@@ -6,28 +6,13 @@
 @media lumo_components_accordion-heading {
   :host {
     display: block;
-    outline: none;
-    -webkit-user-select: none;
-    user-select: none;
     padding: 0;
-  }
-
-  :host([hidden]) {
-    display: none !important;
   }
 
   button {
-    display: flex;
-    align-items: center;
     justify-content: inherit;
     width: 100%;
     margin: 0;
-    padding: 0;
-    background-color: initial;
-    color: inherit;
-    border: initial;
-    outline: none;
-    font: inherit;
     text-align: inherit;
   }
 

--- a/packages/vaadin-lumo-styles/src/components/accordion-panel.css
+++ b/packages/vaadin-lumo-styles/src/components/accordion-panel.css
@@ -5,23 +5,8 @@
  */
 @media lumo_components_accordion-panel {
   :host {
-    display: block;
     margin: 0;
     border-bottom: solid 1px var(--lumo-contrast-10pct);
-  }
-
-  :host([hidden]) {
-    display: none !important;
-  }
-
-  [part='content'] {
-    display: none;
-    overflow: hidden;
-  }
-
-  :host([opened]) [part='content'] {
-    display: block;
-    overflow: visible;
   }
 
   :host(:last-child) {

--- a/packages/vaadin-lumo-styles/src/components/details-summary.css
+++ b/packages/vaadin-lumo-styles/src/components/details-summary.css
@@ -6,33 +6,24 @@
 @media lumo_components_details-summary {
   :host {
     white-space: nowrap;
-    -webkit-user-select: none;
-    user-select: none;
-    display: flex;
-    align-items: center;
+    gap: 0;
     width: 100%;
     outline: none;
     padding: var(--lumo-space-s) 0;
-    box-sizing: border-box;
     font-family: var(--lumo-font-family);
     font-size: var(--lumo-font-size-m);
-    font-weight: 500;
     line-height: var(--lumo-line-height-xs);
     color: var(--lumo-secondary-text-color);
     background-color: inherit;
     border-radius: var(--lumo-border-radius-m);
     cursor: var(--lumo-clickable-cursor);
-    -webkit-tap-highlight-color: transparent;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
 
-  :host([hidden]) {
-    display: none !important;
-  }
-
   :host([disabled]) {
     pointer-events: none;
+    opacity: 1;
   }
 
   :host([disabled]),
@@ -62,11 +53,11 @@
   }
 
   [part='toggle']::before {
-    content: var(--lumo-icons-angle-right);
-  }
-
-  :host([opened]) [part='toggle'] {
-    transform: rotate(90deg);
+    mask: none;
+    background: none;
+    width: auto;
+    height: auto;
+    content: var(--lumo-icons-angle-down);
   }
 
   [part='content'] {
@@ -77,14 +68,6 @@
   :host([dir='rtl']) [part='toggle'] {
     margin-left: var(--lumo-space-xs);
     margin-right: calc(var(--lumo-space-xs) * -1);
-  }
-
-  :host([dir='rtl']) [part='toggle']::before {
-    content: var(--lumo-icons-angle-left);
-  }
-
-  :host([opened][dir='rtl']) [part='toggle'] {
-    transform: rotate(-90deg);
   }
 
   /* Small */


### PR DESCRIPTION
## Description

Updated Lumo to use base styles for the following components:

- `vaadin-details-summary`
- `vaadin-accordion-heading`
- `vaadin-accordion-panel`

This also enables toggle button transition.

## Type of change

- Refactor