### PR TITLE
test: combine imports from test-runner-commands in CRUD tests

### DIFF
--- a/packages/crud/test/a11y.test.js
+++ b/packages/crud/test/a11y.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { setViewport } from '@vaadin/test-runner-commands';
-import { sendKeys } from '@vaadin/test-runner-commands';
+import { sendKeys, setViewport } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-crud.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';


### PR DESCRIPTION
## Description

Fixed to not import from `@vaadin/test-runner-commands` multiple times.
 
## Type of change

- Test