### PR TITLE
refactor: combine imports to not import from same file twice

### DIFF
--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -14,8 +14,7 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dashboardSectionStyles } from './styles/vaadin-dashboard-section-base-styles.js';
-import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
-import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
+import { DashboardItemMixin, getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
 
 /**
  * A section component for use with the Dashboard component

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -15,8 +15,7 @@ import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dashboardWidgetStyles } from './styles/vaadin-dashboard-widget-base-styles.js';
 import { findAncestorInstance, SYNCHRONIZED_ATTRIBUTES, WRAPPER_LOCAL_NAME } from './vaadin-dashboard-helpers.js';
-import { DashboardItemMixin } from './vaadin-dashboard-item-mixin.js';
-import { getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
+import { DashboardItemMixin, getDefaultI18n } from './vaadin-dashboard-item-mixin.js';
 import { DashboardSection } from './vaadin-dashboard-section.js';
 
 /**


### PR DESCRIPTION
## Description

Fixed duplicate imports from `vaadin-dashboard-item-mixin.js`.

## Type of change

- Refactor