### PR TITLE
fix: avoid hover and cursor styles on empty date cells

### DIFF
--- a/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
+++ b/packages/date-picker/src/styles/vaadin-month-calendar-base-styles.js
@@ -81,6 +81,10 @@ export const monthCalendarStyles = css`
     outline: none;
   }
 
+  [part~='date']:empty {
+    pointer-events: none !important;
+  }
+
   [part~='date']::after {
     border-radius: inherit;
     content: '';


### PR DESCRIPTION
`pointer-events: none` avoids triggering hover styles or cursor styles on empty date cells.