### PR TITLE
test: combine testing helpers imports in form layout tests

### DIFF
--- a/packages/form-layout/test/visual/base/form-layout-auto-responsive.test.js
+++ b/packages/form-layout/test/visual/base/form-layout-auto-responsive.test.js
@@ -1,5 +1,4 @@
-import { nextResize } from '@vaadin/testing-helpers';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextResize } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '../../../src/vaadin-form-layout.js';
 import '../../../src/vaadin-form-item.js';

--- a/packages/form-layout/test/visual/base/form-layout.test.js
+++ b/packages/form-layout/test/visual/base/form-layout.test.js
@@ -1,5 +1,4 @@
-import { nextFrame } from '@vaadin/testing-helpers';
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/text-field/src/vaadin-text-field.js';
 import '../../../src/vaadin-form-layout.js';

--- a/packages/form-layout/test/visual/lumo/form-layout-auto-responsive.test.js
+++ b/packages/form-layout/test/visual/lumo/form-layout-auto-responsive.test.js
@@ -1,5 +1,4 @@
-import { nextResize } from '@vaadin/testing-helpers';
-import { fixtureSync } from '@vaadin/testing-helpers';
+import { fixtureSync, nextResize } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/vaadin-lumo-styles/src/props/index.css';
 import '@vaadin/vaadin-lumo-styles/components/form-layout.css';

--- a/packages/form-layout/test/visual/lumo/form-layout.test.js
+++ b/packages/form-layout/test/visual/lumo/form-layout.test.js
@@ -1,5 +1,4 @@
-import { nextFrame } from '@vaadin/testing-helpers';
-import { fixtureSync } from '@vaadin/testing-helpers/dist/fixture.js';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/text-field';
 import '@vaadin/vaadin-lumo-styles/src/props/index.css';


### PR DESCRIPTION
## Description

Combined duplicate imports from `@vaadin/testing-helpers` in visual tests.

## Type of change

- Test