### PR TITLE
fix: avoid crashing firefox 140 esr when opening the inspector

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -11,25 +11,6 @@
   --aura-background-color-light: oklch(0.95 0.005 248);
   --aura-background-color-dark: oklch(0.2 0.01 260);
 
-  --_bg-alt: light-dark(
-    oklch(
-      from var(--aura-background-color-light) calc(l + c) min(c, c * 2 - l / 20)
-        calc(h + 180 * var(--_vaadin-safari-17-deg, 1) * l * c * 4)
-    ),
-    oklch(
-      from var(--aura-background-color-dark) calc(l + c) min(c, c * 2 - l / 20)
-        calc(h + 180 * var(--_vaadin-safari-17-deg, 1) * l * c * 4)
-    )
-  );
-
-  --_bg-accent: radial-gradient(
-    circle at 0% 0%,
-    light-dark(
-      oklch(from var(--aura-background-color-light) min(1, l + c * 3) min(c, c * 3) h),
-      oklch(from var(--aura-background-color-dark) min(1, l + c) clamp(0, c * 1.5, 0.4) h)
-    ),
-    transparent 30%
-  );
   --aura-app-background: var(--aura-background-color);
 
   --_aura-highlight-color: light-dark(
@@ -51,6 +32,25 @@
 @supports (color: hsl(0 0 0)) {
   @scope (:root) {
     :where(:scope) {
+      --_bg-alt: light-dark(
+        oklch(
+          from var(--aura-background-color-light) calc(l + c) min(c, c * 2 - l / 20)
+            calc(h + 180 * var(--_vaadin-safari-17-deg, 1) * l * c * 4)
+        ),
+        oklch(
+          from var(--aura-background-color-dark) calc(l + c) min(c, c * 2 - l / 20)
+            calc(h + 180 * var(--_vaadin-safari-17-deg, 1) * l * c * 4)
+        )
+      );
+
+      --_bg-accent: radial-gradient(
+        circle at 0% 0%,
+        light-dark(
+          oklch(from var(--aura-background-color-light) min(1, l + c * 3) min(c, c * 3) h),
+          oklch(from var(--aura-background-color-dark) min(1, l + c) clamp(0, c * 1.5, 0.4) h)
+        ),
+        transparent 30%
+      );
       --aura-app-background:
         var(--_bg-accent),
         radial-gradient(circle at 25% 0% in xyz, var(--aura-background-color) 33%, var(--_bg-alt))


### PR DESCRIPTION
Avoid defining the problematic computed colors in Firefox 140 ESR, that cause the page/browser to crash. 

Fixes #11877 

Related to #10403 