### PR TITLE
chore: fix incorrect mixin usage in breadcrumbs overlay typings

### DIFF
--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-overlay.d.ts
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-overlay.d.ts
@@ -4,13 +4,13 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { OverlayMixinClass } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
-import { PositionMixinClass } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
 /**
  * An element used internally by `<vaadin-breadcrumbs>`. Not intended to be used separately.
  */
-declare class BreadcrumbsOverlay extends PositionMixinClass(OverlayMixinClass(DirMixin(HTMLElement))) {}
+declare class BreadcrumbsOverlay extends PositionMixin(OverlayMixin(DirMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {


### PR DESCRIPTION
## Description

Breadcrumbs mixin typings were messed up by Claude an I didn't catch this during review 🤦‍♂️ 

I'll make a separate follow-up PR to include `packages/**/*.d.ts` in `tsconfig.json`.

## Type of change

- Internal change