### PR TITLE
chore: update tsconfig.json to include all .ts files in packages

### DIFF
--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-overlay.d.ts
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-overlay.d.ts
@@ -4,13 +4,13 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
-import { OverlayMixinClass } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
-import { PositionMixinClass } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 
 /**
  * An element used internally by `<vaadin-breadcrumbs>`. Not intended to be used separately.
  */
-declare class BreadcrumbsOverlay extends PositionMixinClass(OverlayMixinClass(DirMixin(HTMLElement))) {}
+declare class BreadcrumbsOverlay extends PositionMixin(OverlayMixin(DirMixin(HTMLElement))) {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "allowImportingTsExtensions": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["packages/**/test", "test"]
+  "include": ["packages/**/*.ts", "test"]
 }


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/11889

Currently, only `packages/**/src/*.d.ts` is not included to `tsconfig.json` by default. As a result, only files imported in `test` folder (unit / typings tests) are linted, which is why the error above wasn't caught. Updated the glob to fix it.

## Type of change

- Internal change