### PR TITLE
chore: detect TTY in visual-tests Docker wrapper

### DIFF
--- a/scripts/run-docker-visual-tests.sh
+++ b/scripts/run-docker-visual-tests.sh
@@ -39,15 +39,17 @@ echo "  Command: yarn $*"
 
 # Run Docker:
 # - --rm: Remove container after exit
-# - -i: Enables input in --watch mode
-# - -t: Enables colored and interactive output in --watch mode
+# - -i -t: Enable input + colored interactive output for --watch mode (only when
+#   stdin is a TTY — skipped under CI, Claude Code, etc. where -t would fail)
 # - --ipc=host: Recommended for Chromium to avoid shared memory crashes
 # - -v $(pwd):/work: Mount repository source into container
 # - -v $VOL:/work/node_modules: Use a named volume for node_modules (overlays host's)
 # - PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1: Use pre-installed browsers from the image
+TTY_FLAGS=()
+[ -t 0 ] && TTY_FLAGS+=("-i" "-t")
+
 docker run --rm --ipc=host \
-  -i \
-  -t \
+  "${TTY_FLAGS[@]}" \
   -v "$(pwd)":/work \
   -v "${NODE_MODULES_VOLUME}":/work/node_modules \
   -w /work \


### PR DESCRIPTION
## Description

`scripts/run-docker-visual-tests.sh` passes `-i -t` to `docker run` unconditionally, which fails in non-TTY contexts (Claude Code's bash tool, Docker-in-Docker). Every `yarn test:{lumo,aura,base}` or `yarn update:*` invocation then needs a manual one-off docker command that reproduces the wrapper's flags by hand.

Detect TTY via `[ -t 0 ]` and only add `-i -t` when stdin is a real terminal to prevent following from happening:

```
⏺ The visual tests run in Docker and need a non-TTY-compatible invocation. Let me check the script.

  Read 1 file (ctrl+o to expand)

⏺ The -t flag fails in this non-TTY environment. I'll run the Docker command directly without -t.
```


## Type of change

- Internal change