### PR TITLE
refactor: extract crud dialog overlay into separate file

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog-overlay.js
+++ b/packages/crud/src/vaadin-crud-dialog-overlay.js
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import { html, LitElement } from 'lit';
+import { defineCustomElement } from '@vaadin/component-base/src/define.js';
+import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
+import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
+import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
+import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+import { crudDialogOverlayStyles } from './styles/vaadin-crud-dialog-overlay-base-styles.js';
+
+/**
+ * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
+ *
+ * @customElement vaadin-crud-dialog-overlay
+ * @extends HTMLElement
+ * @private
+ */
+class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
+  static get is() {
+    return 'vaadin-crud-dialog-overlay';
+  }
+
+  static get styles() {
+    return crudDialogOverlayStyles;
+  }
+
+  /**
+   * Override method from OverlayFocusMixin to use dialog as focus trap root
+   * @protected
+   * @override
+   */
+  get _focusTrapRoot() {
+    // Do not use `owner` since that points to `vaadin-crud`
+    return this.getRootNode().host;
+  }
+
+  /** @protected */
+  render() {
+    return html`
+      <div part="backdrop" id="backdrop" ?hidden="${!this.withBackdrop}"></div>
+      <div part="overlay" id="overlay">
+        <section id="resizerContainer" class="resizer-container">
+          <header part="header">
+            <slot name="header"></slot>
+          </header>
+          <div part="content" id="content">
+            <slot name="form"></slot>
+          </div>
+          <footer part="footer" role="toolbar">
+            <slot name="save-button"></slot>
+            <slot name="cancel-button"></slot>
+            <slot name="delete-button"></slot>
+          </footer>
+        </section>
+      </div>
+    `;
+  }
+
+  /**
+   * @protected
+   * @override
+   */
+  ready() {
+    super.ready();
+
+    // CRUD has header and footer but does not use renderers
+    this.setAttribute('has-header', '');
+    this.setAttribute('has-footer', '');
+  }
+}
+
+defineCustomElement(CrudDialogOverlay);

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -7,80 +7,13 @@
  * See https://vaadin.com/commercial-license-and-service-terms for the full
  * license.
  */
+import './vaadin-crud-dialog-overlay.js';
 import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
-import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DialogBaseMixin } from '@vaadin/dialog/src/vaadin-dialog-base-mixin.js';
-import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
-import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
-import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
-import { crudDialogOverlayStyles } from './styles/vaadin-crud-dialog-overlay-base-styles.js';
-
-/**
- * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
- *
- * @customElement vaadin-crud-dialog
- * @extends HTMLElement
- * @private
- */
-class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
-  static get is() {
-    return 'vaadin-crud-dialog-overlay';
-  }
-
-  static get styles() {
-    return crudDialogOverlayStyles;
-  }
-
-  /**
-   * Override method from OverlayFocusMixin to use dialog as focus trap root
-   * @protected
-   * @override
-   */
-  get _focusTrapRoot() {
-    // Do not use `owner` since that points to `vaadin-crud`
-    return this.getRootNode().host;
-  }
-
-  /** @protected */
-  render() {
-    return html`
-      <div part="backdrop" id="backdrop" ?hidden="${!this.withBackdrop}"></div>
-      <div part="overlay" id="overlay">
-        <section id="resizerContainer" class="resizer-container">
-          <header part="header">
-            <slot name="header"></slot>
-          </header>
-          <div part="content" id="content">
-            <slot name="form"></slot>
-          </div>
-          <footer part="footer" role="toolbar">
-            <slot name="save-button"></slot>
-            <slot name="cancel-button"></slot>
-            <slot name="delete-button"></slot>
-          </footer>
-        </section>
-      </div>
-    `;
-  }
-
-  /**
-   * @protected
-   * @override
-   */
-  ready() {
-    super.ready();
-
-    // CRUD has header and footer but does not use renderers
-    this.setAttribute('has-header', '');
-    this.setAttribute('has-footer', '');
-  }
-}
-
-defineCustomElement(CrudDialogOverlay);
 
 /**
  * An element used internally by `<vaadin-crud>`. Not intended to be used separately.


### PR DESCRIPTION
## Description

Pre-requisite for https://github.com/vaadin/web-components/pull/11894 (CRUD overflow indicators).

Currently `vaadin-crud-dialog.js` has 2 custom elements. Extracted overlay to own file before refactoring further.

## Type of change

- Refactor