### PR TITLE
refactor: extract DialogOverflowController for reusing overflow detection logic

### DIFF
--- a/packages/dialog/src/vaadin-dialog-overflow-controller.d.ts
+++ b/packages/dialog/src/vaadin-dialog-overflow-controller.d.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { ReactiveController } from 'lit';
+
+/**
+ * A controller that detects if the content part of a dialog overlay overflows
+ * its scrolling viewport vertically, and sets the `overflow` attribute on the
+ * overlay (and its owner) with `top`, `bottom`, or `top bottom` accordingly, so
+ * that overflow indicators can be styled in CSS.
+ */
+export class DialogOverflowController implements ReactiveController {
+  /**
+   * The overlay element that hosts the controller.
+   */
+  host: HTMLElement;
+
+  constructor(host: HTMLElement);
+
+  hostConnected(): void;
+
+  /**
+   * Forces a synchronous overflow update. Call after changing content that
+   * affects whether the content part overflows.
+   */
+  update(): void;
+}

--- a/packages/dialog/src/vaadin-dialog-overflow-controller.js
+++ b/packages/dialog/src/vaadin-dialog-overflow-controller.js
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { setOverlayStateAttribute } from '@vaadin/overlay/src/vaadin-overlay-utils.js';
+
+/**
+ * A controller that detects if the content part of a dialog overlay overflows
+ * its scrolling viewport vertically, and sets the `overflow` attribute on the
+ * overlay (and its owner) with `top`, `bottom`, or `top bottom` accordingly, so
+ * that overflow indicators can be styled in CSS.
+ */
+export class DialogOverflowController {
+  constructor(host) {
+    /**
+     * The overlay element that hosts the controller.
+     * @type {HTMLElement}
+     */
+    this.host = host;
+  }
+
+  hostConnected() {
+    if (!this.__initialized) {
+      this.__initialized = true;
+
+      const { host } = this;
+
+      // Update overflow attribute on resize
+      this.__resizeObserver = new ResizeObserver(() => this.__updateState());
+      this.__resizeObserver.observe(host.$.resizerContainer);
+
+      // Update overflow attribute on scroll
+      host.$.content.addEventListener('scroll', () => this.__updateState(true));
+
+      // Update overflow attribute on content change
+      host.shadowRoot.addEventListener('slotchange', () => this.__updateState(true));
+    }
+  }
+
+  /**
+   * Forces a synchronous overflow update. Call after changing content that
+   * affects whether the content part overflows.
+   */
+  update() {
+    this.__updateState(true);
+  }
+
+  /** @private */
+  __updateState(sync = false) {
+    cancelAnimationFrame(this.__updateRaf);
+
+    if (sync) {
+      this.__writeState(this.__readState());
+    } else {
+      // Defer reading until the animation frame so that layout has settled
+      // after a resize (some browsers report stale metrics synchronously).
+      this.__updateRaf = requestAnimationFrame(() => this.__writeState(this.__readState()));
+    }
+  }
+
+  /** @private */
+  __readState() {
+    const content = this.host.$.content;
+
+    let overflow = '';
+
+    if (content.scrollTop > 0) {
+      overflow += ' top';
+    }
+
+    if (content.scrollTop < content.scrollHeight - content.clientHeight) {
+      overflow += ' bottom';
+    }
+
+    return overflow.trim();
+  }
+
+  /** @private */
+  __writeState(value) {
+    const { host } = this;
+
+    if (value.length > 0) {
+      setOverlayStateAttribute(host, 'overflow', value);
+    } else {
+      setOverlayStateAttribute(host, 'overflow', null);
+    }
+  }
+}

--- a/packages/dialog/src/vaadin-dialog-overlay-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-overlay-mixin.js
@@ -6,6 +6,7 @@
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { OverlayMixin } from '@vaadin/overlay/src/vaadin-overlay-mixin.js';
 import { setOverlayStateAttribute } from '@vaadin/overlay/src/vaadin-overlay-utils.js';
+import { DialogOverflowController } from './vaadin-dialog-overflow-controller.js';
 
 export const DialogOverlayMixin = (superClass) =>
   class DialogOverlayMixin extends OverlayMixin(superClass) {
@@ -78,36 +79,29 @@ export const DialogOverlayMixin = (superClass) =>
     ready() {
       super.ready();
 
-      // Update overflow attribute on resize
+      // Detect overflow of the content part and toggle the `overflow` attribute
+      this.__overflowController = new DialogOverflowController(this);
+      this.addController(this.__overflowController);
+
+      // Adjust the position on resize to keep the overlay within the viewport
       this.__resizeObserver = new ResizeObserver(() => {
         requestAnimationFrame(() => {
           this.__adjustPosition();
-          this.__updateOverflow();
         });
       });
       this.__resizeObserver.observe(this.$.resizerContainer);
-
-      // Update overflow attribute on scroll
-      this.$.content.addEventListener('scroll', () => {
-        this.__updateOverflow();
-      });
-
-      // Update overflow attribute on content change
-      this.shadowRoot.addEventListener('slotchange', () => {
-        this.__updateOverflow();
-      });
 
       // Observe header-content and footer slots for dynamic content
       const headerSlot = this.shadowRoot.querySelector('slot[name="header-content"]');
       this.__headerSlotObserver = new SlotObserver(headerSlot, ({ currentNodes }) => {
         setOverlayStateAttribute(this, 'has-header', currentNodes.length > 0);
-        this.__updateOverflow();
+        this.__overflowController.update();
       });
 
       const footerSlot = this.shadowRoot.querySelector('slot[name="footer"]');
       this.__footerSlotObserver = new SlotObserver(footerSlot, ({ currentNodes }) => {
         setOverlayStateAttribute(this, 'has-footer', currentNodes.length > 0);
-        this.__updateOverflow();
+        this.__overflowController.update();
       });
 
       this.__handleWindowResize = this.__handleWindowResize.bind(this);
@@ -235,7 +229,9 @@ export const DialogOverlayMixin = (superClass) =>
 
       this._headerTitleRenderer();
 
-      this.__updateOverflow();
+      // May run via observers before the controller is set up in `ready()`;
+      // the initial overflow state is then detected by the resize observer.
+      this.__overflowController?.update();
     }
 
     /**
@@ -259,28 +255,6 @@ export const DialogOverlayMixin = (superClass) =>
     setBounds(bounds, absolute = true) {
       super.setBounds(bounds, absolute);
       this.__adjustPosition();
-    }
-
-    /** @private */
-    __updateOverflow() {
-      let overflow = '';
-
-      const content = this.$.content;
-
-      if (content.scrollTop > 0) {
-        overflow += ' top';
-      }
-
-      if (content.scrollTop < content.scrollHeight - content.clientHeight) {
-        overflow += ' bottom';
-      }
-
-      const value = overflow.trim();
-      if (value.length > 0 && this.getAttribute('overflow') !== value) {
-        setOverlayStateAttribute(this, 'overflow', value);
-      } else if (value.length === 0 && this.hasAttribute('overflow')) {
-        setOverlayStateAttribute(this, 'overflow', null);
-      }
     }
 
     /** @private */


### PR DESCRIPTION
## Description

Move the overflow detection (resize/scroll/slotchange observers and the overflow attribute) out of DialogOverlayMixin into a reusable DialogOverflowController that follows a read/write pattern. The mixin keeps a separate resize observer for keep-in-viewport positioning.

The controller can be reused by other dialog-like overlays (e.g. the CRUD dialog) to get overflow indicators. No behavior change for vaadin-dialog.

## Type of change

- Refactor