### PR TITLE
chore: bump dompurify dependency version to 3.4.8 (24.9)

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -39,7 +39,7 @@
     "@vaadin/vaadin-lumo-styles": "~24.9.15",
     "@vaadin/vaadin-material-styles": "~24.9.15",
     "@vaadin/vaadin-themable-mixin": "~24.9.15",
-    "dompurify": "^3.2.5",
+    "dompurify": "^3.4.8",
     "lit": "^3.0.0",
     "marked": "^15.0.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4458,10 +4458,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.2.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.5.tgz#11b108656a5fb72b24d916df17a1421663d7129c"
-  integrity sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==
+dompurify@^3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
+  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Description

Upgraded version in `24.9` branch to align with bundles PR https://github.com/vaadin/bundles/pull/183.

## Type of change

- Internal change