### PR TITLE
chore: upgrade Playwright version to 1.60.0 (CP: 24.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "^5.9.2"
   },
   "resolutions": {
-    "playwright": "^1.56.0"
+    "playwright": "~1.60.0"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -484,11 +484,19 @@ export class IronListAdapter {
 
   /** @private */
   __getFocusedElement(visibleElements = this.__getVisibleElements()) {
-    return visibleElements.find(
-      (element) =>
-        element.contains(this.elementsContainer.getRootNode().activeElement) ||
-        element.contains(this.scrollTarget.getRootNode().activeElement),
-    );
+    // `document.activeElement` retargets to the outermost shadow host when
+    // focus lives in a nested shadow tree. Descend through nested shadow
+    // roots' `activeElement`s to reach the real focused node, then walk up
+    // the flattened tree (via `assignedSlot`/`parentNode`/`host`) until a
+    // visible row is reached.
+    let node = document.activeElement;
+    while (node?.shadowRoot?.activeElement) {
+      node = node.shadowRoot.activeElement;
+    }
+    while (node && !visibleElements.includes(node)) {
+      node = node.assignedSlot || node.parentNode || node.host;
+    }
+    return node;
   }
 
   /** @private */

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -202,4 +202,104 @@ describe('reorder elements', () => {
       expect(scrollTarget.scrollTop).to.equal(scrollTop);
     });
   });
+
+  // Regression tests for vaadin/web-components#11639. When the virtualizer
+  // lives inside a shadow root, the focused row must be located via the
+  // shadow root's `activeElement` (focus inside the shadow tree) or by
+  // walking the flattened ancestors via `assignedSlot` from the scroll
+  // target's root activeElement (focus on slotted light-DOM content).
+  describe('focused element detection in shadow tree', () => {
+    beforeEach(() => {
+      // Remove default scroll target
+      scrollTarget.remove();
+      clock.restore();
+
+      scrollTarget = fixtureSync('<div style="height: 100px;"></div>');
+      const shadowRoot = scrollTarget.attachShadow({ mode: 'open' });
+      shadowRoot.innerHTML = `
+        <style>:host { display: block; height: 100%; }</style>
+        <div id="scrollTarget" style="height: 100%; overflow: auto;">
+          <div id="container"></div>
+        </div>
+      `;
+
+      virtualizer = new Virtualizer({
+        createElements: (count) =>
+          Array.from(Array(count)).map(() => {
+            const row = document.createElement('div');
+            const slot = document.createElement('slot');
+            slot.name = `cell-${scrollTarget.children.length}`;
+            row.appendChild(slot);
+
+            const cellContent = document.createElement('div');
+            cellContent.slot = slot.name;
+            cellContent.tabIndex = 0;
+            scrollTarget.appendChild(cellContent);
+
+            return row;
+          }),
+        updateElement: (row, index) => {
+          row.index = index;
+          row.id = `row-${index}`;
+          const cellContent = row.querySelector('slot').assignedNodes()[0];
+          cellContent.textContent = index;
+        },
+        scrollTarget: shadowRoot.getElementById('scrollTarget'),
+        scrollContainer: shadowRoot.getElementById('container'),
+        reorderElements: true,
+      });
+      virtualizer.size = 100;
+      elementsContainer = shadowRoot.getElementById('container');
+    });
+
+    it('should not detach a focused row on reorder', async () => {
+      // The row that will receive focus (should not get detached)
+      const rowContainingFocus = elementsContainer.children[4];
+      // Focus the row directly. The row lives inside the shadow tree, so
+      // `document.activeElement` resolves to the shadow host, not the row.
+      rowContainingFocus.tabIndex = 0;
+      rowContainingFocus.focus();
+
+      // Scroll and collect the detached elements
+      const detachedElements = await scrollRecycle();
+      // Expect the focused row to not have been detached
+      expect(detachedElements).not.to.include(rowContainingFocus);
+    });
+
+    it('should not detach a row whose slotted content has focus on reorder', async () => {
+      // The row that will include the focused cell (should not get detached)
+      const rowContainingFocus = elementsContainer.children[4];
+      // Focus the slotted cell content on the row
+      rowContainingFocus.querySelector('slot').assignedNodes()[0].focus();
+
+      // Scroll and collect the detached elements
+      const detachedElements = await scrollRecycle();
+      // Expect the row containing focus to not have been detached
+      expect(detachedElements).not.to.include(rowContainingFocus);
+    });
+
+    // When the entire virtualizer host is itself nested inside another
+    // shadow root, `document.activeElement` retargets to the outermost
+    // host. The scroll target's root activeElement remains the actual
+    // slotted focused element and must be used as the walk's starting
+    // point.
+    it('should not detach a row whose slotted content has focus when wrapped in an outer shadow', async () => {
+      // Move the virtualizer host into an outer shadow root, keeping the
+      // slotted cell contents (currently in `scrollTarget`'s light DOM)
+      // wrapped inside the outer shadow as well.
+      const outerHost = fixtureSync('<div></div>');
+      const outerShadow = outerHost.attachShadow({ mode: 'open' });
+      outerShadow.appendChild(scrollTarget);
+
+      // The row that will include the focused cell (should not get detached)
+      const rowContainingFocus = elementsContainer.children[4];
+      // Focus the slotted cell content on the row
+      rowContainingFocus.querySelector('slot').assignedNodes()[0].focus();
+
+      // Scroll and collect the detached elements
+      const detachedElements = await scrollRecycle();
+      // Expect the row containing focus to not have been detached
+      expect(detachedElements).not.to.include(rowContainingFocus);
+    });
+  });
 });

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -282,6 +282,7 @@ class Dashboard extends DashboardLayoutMixin(
     let wrappers = [...hostElement.children].filter((el) => el.localName === WRAPPER_LOCAL_NAME);
 
     const focusedWrapper = wrappers.find((wrapper) => wrapper.querySelector(':focus'));
+    const focusedElement = focusedWrapper && focusedWrapper.querySelector(':focus');
     const focusedWrapperWillBeRemoved = focusedWrapper && !this.__isActiveWrapper(focusedWrapper);
     const wrapperClosestToRemovedFocused =
       focusedWrapperWillBeRemoved && this.__getClosestActiveWrapper(focusedWrapper);
@@ -330,6 +331,10 @@ class Dashboard extends DashboardLayoutMixin(
       if (focusedWrapperWillBeRemoved) {
         // The wrapper containing the focused element was removed. Try to focus the element in the closest wrapper.
         this.__focusWrapperContent(wrapperClosestToRemovedFocused || this.querySelector(WRAPPER_LOCAL_NAME));
+      } else if (focusedElement && !focusedElement.matches(':focus')) {
+        // Firefox loses focus from a slotted element when the <slot> it was projected through is
+        // removed during the shadow re-render, even after re-projection through a different slot.
+        focusedElement.focus();
       }
 
       const focusedItem = this.querySelector(':focus');

--- a/yarn.lock
+++ b/yarn.lock
@@ -9436,17 +9436,17 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.56.0:
-  version "1.56.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.56.0.tgz#14b40ea436551b0bcefe19c5bfb8d1804c83739c"
-  integrity sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@^1.22.2, playwright@^1.56.0:
-  version "1.56.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.56.0.tgz#71c533c61da33e95812f8c6fa53960e073548d9a"
-  integrity sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==
+playwright@^1.22.2, playwright@~1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.56.0"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Description

Firefox & WebKit tests get stuck in CI with older Playwright version used in `24.10` branch.
The browser downloading part never terminates so apparently we need to upgrade.

This PR backports necessary changes picked from `25.0`:

- #11658
- #11666 
- #11882

## Type of change

- Cherry-pick