### PR TITLE
docs: update breadcrumbs spec to list all variants, reorder tasks, fix i18n

### DIFF
--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -272,7 +272,7 @@ Breadcrumbs breadcrumbs = new Breadcrumbs(Mode.MANUAL);
 breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead of the chevron
 ```
 
-**Why this shape:** The web component ships a `theme="slash"` separator variant, exposed through the standard `HasThemeVariant<BreadcrumbsVariant>` surface (guidelines/09-theming.md) rather than a bespoke setter — the same pattern as every other themable Vaadin component, so `addThemeVariants` / `setThemeVariants` / `bindThemeVariant` come for free. `BreadcrumbsVariant.SLASH.getVariantName()` returns the exact `slash` token. `LUMO_PRIMARY` and `AURA_ACCENT` are planned enum values for upcoming Lumo / Aura theme tokens; adding them later is strictly additive.
+**Why this shape:** The web component ships a `theme="slash"` separator variant, exposed through the standard `HasThemeVariant<BreadcrumbsVariant>` surface (guidelines/09-theming.md) rather than a bespoke setter — the same pattern as every other themable Vaadin component, so `addThemeVariants` / `setThemeVariants` / `bindThemeVariant` come for free. `BreadcrumbsVariant.SLASH.getVariantName()` returns the exact `slash` token; `LUMO_PRIMARY` and `AURA_ACCENT` map to the Lumo `primary` and Aura `accent` link-color variants.
 
 ---
 
@@ -293,7 +293,7 @@ breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead
 | `aria-label` on the host | `Breadcrumbs implements HasAriaLabel` | `setAriaLabel(String)` / `getAriaLabel()` from Flow core |
 | `--vaadin-breadcrumbs-separator` CSS custom property | `Breadcrumbs#getStyle().set("--vaadin-breadcrumbs-separator", ...)` via `HasStyle` | per `DESIGN_GUIDELINES.md` "Styling lives in CSS, not Java" — no dedicated Java setter |
 | RTL separator flipping | — (handled in CSS when `dir="rtl"`) | inherited from the application / `HasStyle` |
-| `theme="slash"` (web-component-spec.md "Theme") | `Breadcrumbs implements HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.SLASH)` | typed theme variants; `getVariantName()` returns the `theme` token |
+| `theme` variants (`slash`, `primary`, `accent`; web-component-spec.md "Theme") | `Breadcrumbs implements HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.…)` | typed theme variants; `getVariantName()` returns the `theme` token |
 | Flow: auto-populate from router | `Breadcrumbs.Mode` enum (`ROUTER`, `MANUAL`); `new Breadcrumbs()` / `new Breadcrumbs(Mode)`; `setMode(Mode)` / `getMode()` | default `ROUTER`; `add`/`remove`/`removeAll` throw `IllegalStateException` while in `ROUTER` mode |
 | Flow: route-parent override | `@RouteParent(Class<? extends Component>)` | class-level annotation on `@Route` views |
 

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -263,6 +263,19 @@ public class EditOrderView extends Div { ... }
 
 ---
 
+## 11. Theme variants
+
+Covers requirement(s): 5
+
+```java
+Breadcrumbs breadcrumbs = new Breadcrumbs(Mode.MANUAL);
+breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead of the chevron
+```
+
+**Why this shape:** The web component ships a `theme="slash"` separator variant, exposed through the standard `HasThemeVariant<BreadcrumbsVariant>` surface (guidelines/09-theming.md) rather than a bespoke setter — the same pattern as every other themable Vaadin component, so `addThemeVariants` / `setThemeVariants` / `bindThemeVariant` come for free. `BreadcrumbsVariant.SLASH.getVariantName()` returns the exact `slash` token. `LUMO_PRIMARY` and `AURA_ACCENT` are planned enum values for upcoming Lumo / Aura theme tokens; adding them later is strictly additive.
+
+---
+
 ## Web API coverage check
 
 | Web API surface (from web-component-api.md) | Flow API | Notes |
@@ -280,6 +293,7 @@ public class EditOrderView extends Div { ... }
 | `aria-label` on the host | `Breadcrumbs implements HasAriaLabel` | `setAriaLabel(String)` / `getAriaLabel()` from Flow core |
 | `--vaadin-breadcrumbs-separator` CSS custom property | `Breadcrumbs#getStyle().set("--vaadin-breadcrumbs-separator", ...)` via `HasStyle` | per `DESIGN_GUIDELINES.md` "Styling lives in CSS, not Java" — no dedicated Java setter |
 | RTL separator flipping | — (handled in CSS when `dir="rtl"`) | inherited from the application / `HasStyle` |
+| `theme="slash"` (web-component-spec.md "Theme") | `Breadcrumbs implements HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.SLASH)` | typed theme variants; `getVariantName()` returns the `theme` token |
 | Flow: auto-populate from router | `Breadcrumbs.Mode` enum (`ROUTER`, `MANUAL`); `new Breadcrumbs()` / `new Breadcrumbs(Mode)`; `setMode(Mode)` / `getMode()` | default `ROUTER`; `add`/`remove`/`removeAll` throw `IllegalStateException` while in `ROUTER` mode |
 | Flow: route-parent override | `@RouteParent(Class<? extends Component>)` | class-level annotation on `@Route` views |
 
@@ -305,9 +319,9 @@ Separator presence (req 4), customisation (req 5), and RTL flipping (req 12) are
 
 Items render as plain anchors (`<a href>`) under the hood. With `setPath(Class<? extends Component>)`, Flow's router intercepts the click and navigates without full page reload. With `setPath(String)`, the browser follows the href. Neither path requires a Flow-level listener, and adding one would invite developers to implement navigation twice (once as a listener, once as a route). `SideNavItem` follows the same philosophy — no `addClickListener`.
 
-**Q: Why no theme variants?**
+**Q: Why expose theme variants?**
 
-web-component-api.md does not expose any theme variants for Breadcrumbs — the component has a single canonical appearance with theme-layer differences only (Lumo vs Aura). No `BreadcrumbsVariant` enum is added because there is nothing for it to contain. One can be introduced later if variants emerge.
+The web component now ships a `theme="slash"` separator variant (web-component-spec.md "Theme" table), so `Breadcrumbs` exposes it the standard way — see section 11 for the `BreadcrumbsVariant` enum and usage. An earlier revision added no variants because the web component had none; the slash variant changed that.
 
 **Q: Why use `HasComponentsOfType<BreadcrumbsItem>` rather than a bespoke `setItems(BreadcrumbsItem...)` / `addItem(BreadcrumbsItem...)` API?**
 

--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -20,7 +20,7 @@
 
 8. **No `@Synchronize`'d properties.** No client-driven state round-trips to the server. `has-overflow` is a visual state attribute the server does not need to observe.
 
-9. **Theme variants via `HasThemeVariant<BreadcrumbsVariant>`.** Per guidelines/09-theming.md. `Breadcrumbs` implements `HasThemeVariant<BreadcrumbsVariant>`; the `BreadcrumbsVariant` enum currently carries `SLASH` for the web component's `theme="slash"` separator variant. See "Theme Variants" for the enum and inherited API, and the Discussion ("Why does `Breadcrumbs` expose theme variants?") for the rationale.
+9. **Theme variants via `HasThemeVariant<BreadcrumbsVariant>`.** Per guidelines/09-theming.md. `Breadcrumbs` implements `HasThemeVariant<BreadcrumbsVariant>`; the `BreadcrumbsVariant` enum carries `SLASH` (base-styles separator), `LUMO_PRIMARY` (Lumo), and `AURA_ACCENT` (Aura). See "Theme Variants" for the enum and inherited API, and the Discussion ("Why does `Breadcrumbs` expose theme variants?") for the rationale.
 
 10. **`BreadcrumbsI18n` is a nested static class.** Follows the `SideNavI18n` / `MenuBarI18n` convention — `Serializable`, `@JsonInclude(JsonInclude.Include.NON_NULL)`, fluent setters returning `BreadcrumbsI18n`. Serialised with `JacksonUtils.beanToJson` and pushed to the client via `getElement().setPropertyJson("i18n", ...)` in the attach handler (so re-attach re-sets the property for the fresh client-side element). `setI18n` rejects `null` (`Objects.requireNonNull`) — see the i18n section.
 
@@ -44,7 +44,7 @@ flow-components/
     │       ├── main/java/com/vaadin/flow/component/breadcrumbs/
     │       │   ├── Breadcrumbs.java                # host element, Mode enum, BreadcrumbsI18n nested class
     │       │   ├── BreadcrumbsItem.java                 # <vaadin-breadcrumbs-item>
-    │       │   ├── BreadcrumbsVariant.java              # ThemeVariant enum (SLASH; planned LUMO_PRIMARY, AURA_ACCENT)
+    │       │   ├── BreadcrumbsVariant.java              # ThemeVariant enum (SLASH, LUMO_PRIMARY, AURA_ACCENT)
     │       │   ├── BreadcrumbsFeatureFlagProvider.java  # defines the Feature constant
     │       │   └── ExperimentalFeatureException.java   # local exception with a helpful message
     │       ├── main/resources/
@@ -311,7 +311,9 @@ Setter returns `this` so calls can be chained: `new BreadcrumbsI18n().setMoreIte
 
 ```java
 public enum BreadcrumbsVariant implements ThemeVariant {
-    SLASH("slash");
+    SLASH("slash"),
+    LUMO_PRIMARY("primary"),
+    AURA_ACCENT("accent");
 
     private final String variant;
 
@@ -329,8 +331,10 @@ public enum BreadcrumbsVariant implements ThemeVariant {
 | Enum value | `theme` token | Web component support |
 |---|---|---|
 | `SLASH` | `slash` | Ships in base styles — renders a `/` separator instead of the chevron (web-component-spec.md "Theme" table). |
+| `LUMO_PRIMARY` | `primary` | Lumo variant — restores a distinct link color (web-component-spec.md "Theme" table). |
+| `AURA_ACCENT` | `accent` | Aura variant — restores a distinct link color (web-component-spec.md "Theme" table). |
 
-`LUMO_PRIMARY` (`primary`) and `AURA_ACCENT` (`accent`) are planned: each is added to the enum once the Lumo and Aura themes ship the matching `theme` token. Until then the enum carries only `SLASH`, so every value maps to a token the web component actually honours, as guidelines/09-theming.md requires.
+Every value maps to a `theme` token the web component actually honours, as guidelines/09-theming.md requires.
 
 A `BreadcrumbsVariantTest` maps each enum value to its expected token (guidelines/12-testing.md).
 
@@ -720,5 +724,5 @@ guidelines/10-i18n-and-a11y.md prescribes `Objects.requireNonNull` in `setI18n`,
 
 **Q: Why does `Breadcrumbs` expose theme variants?**
 
-The web component ships a `theme="slash"` separator variant in its base styles (web-component-spec.md "Theme" table), so the Flow wrapper exposes it the standard way rather than inventing a setter — see "Theme Variants" for the enum and inherited API. An earlier revision exposed no variants because the web component had none; the slash variant changed that. Because `HasThemeVariant` lives in `vaadin-flow-components-base` and needs no unreleased Flow core API, this work can land ahead of the router-related tasks (flow-tasks.md Task 3).
+The web component ships theme variants — `theme="slash"` in base styles, `theme="primary"` in Lumo, and `theme="accent"` in Aura (web-component-spec.md "Theme" table) — so the Flow wrapper exposes them the standard way rather than inventing setters. `BreadcrumbsVariant` mirrors the shipped tokens (`SLASH`, `LUMO_PRIMARY`, `AURA_ACCENT`), since guidelines/09-theming.md requires each `getVariantName()` to match a real `theme` token. An earlier revision exposed no variants because the web component had none; the slash variant changed that. Because `HasThemeVariant` lives in `vaadin-flow-components-base` and needs no unreleased Flow core API, this work can land ahead of the router-related tasks (flow-tasks.md Task 3).
 

--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -20,9 +20,9 @@
 
 8. **No `@Synchronize`'d properties.** No client-driven state round-trips to the server. `has-overflow` is a visual state attribute the server does not need to observe.
 
-9. **No theme variants.** Per flow-api.md Discussion "Why no theme variants?" — no `BreadcrumbsVariant` enum.
+9. **Theme variants via `HasThemeVariant<BreadcrumbsVariant>`.** Per guidelines/09-theming.md. `Breadcrumbs` implements `HasThemeVariant<BreadcrumbsVariant>`; the `BreadcrumbsVariant` enum currently carries `SLASH` for the web component's `theme="slash"` separator variant. See "Theme Variants" for the enum and inherited API, and the Discussion ("Why does `Breadcrumbs` expose theme variants?") for the rationale.
 
-10. **`BreadcrumbsI18n` is a nested static class.** Follows the `SideNavI18n` / `MenuBarI18n` convention — `Serializable`, `@JsonInclude(JsonInclude.Include.NON_NULL)`, fluent setters returning `BreadcrumbsI18n`. Serialised with `JacksonUtils.beanToJson` and pushed to the client via `getElement().setPropertyJson("i18n", ...)` in the attach handler (so re-attach re-sets the property for the fresh client-side element).
+10. **`BreadcrumbsI18n` is a nested static class.** Follows the `SideNavI18n` / `MenuBarI18n` convention — `Serializable`, `@JsonInclude(JsonInclude.Include.NON_NULL)`, fluent setters returning `BreadcrumbsI18n`. Serialised with `JacksonUtils.beanToJson` and pushed to the client via `getElement().setPropertyJson("i18n", ...)` in the attach handler (so re-attach re-sets the property for the fresh client-side element). `setI18n` rejects `null` (`Objects.requireNonNull`) — see the i18n section.
 
 11. **Package name `com.vaadin.flow.component.breadcrumbs`.** Mirrors `com.vaadin.flow.component.sidenav` — the short form that drops internal hyphens.
 
@@ -44,6 +44,7 @@ flow-components/
     │       ├── main/java/com/vaadin/flow/component/breadcrumbs/
     │       │   ├── Breadcrumbs.java                # host element, Mode enum, BreadcrumbsI18n nested class
     │       │   ├── BreadcrumbsItem.java                 # <vaadin-breadcrumbs-item>
+    │       │   ├── BreadcrumbsVariant.java              # ThemeVariant enum (SLASH; planned LUMO_PRIMARY, AURA_ACCENT)
     │       │   ├── BreadcrumbsFeatureFlagProvider.java  # defines the Feature constant
     │       │   └── ExperimentalFeatureException.java   # local exception with a helpful message
     │       ├── main/resources/
@@ -53,6 +54,7 @@ flow-components/
     │           ├── BreadcrumbsTest.java
     │           ├── BreadcrumbsModeTest.java
     │           ├── BreadcrumbsItemTest.java
+    │           ├── BreadcrumbsVariantTest.java
     │           ├── BreadcrumbsSerializableTest.java
     │           ├── BreadcrumbsI18nTest.java
     │           └── FeatureFlagTest.java
@@ -93,6 +95,7 @@ Integration-tests module must include `src/main/resources/vaadin-featureflags.pr
 @JsModule("@vaadin/breadcrumbs/src/vaadin-breadcrumbs.js")
 public class Breadcrumbs extends Component
         implements HasSize, HasStyle, HasAriaLabel,
+                   HasThemeVariant<BreadcrumbsVariant>,
                    HasComponentsOfType<BreadcrumbsItem> {
 
     public enum Mode {
@@ -150,6 +153,7 @@ public class Breadcrumbs extends Component
 - `HasSize` — covers requirement that the component can be sized by the application (universal API hygiene).
 - `HasStyle` — required for requirement 5 (customise separator via `--vaadin-breadcrumbs-separator` CSS custom property) and for `getStyle()` access per `DESIGN_GUIDELINES.md` "Styling lives in CSS, not Java".
 - `HasAriaLabel` — requirement 10 (navigation landmark accessible name). Flow core interface.
+- `HasThemeVariant<BreadcrumbsVariant>` — requirement 5 plus general theming. Shared interface from `vaadin-flow-components-base`. See "Theme Variants" for the variant enum and the inherited method surface.
 - `HasComponentsOfType<BreadcrumbsItem>` — requirement 1, 9 (add/remove/manage items with compile-time type safety). Flow core interface. All inherited mutating methods — `add(T...)` / `add(Collection<T>)` / `remove(T...)` / `remove(Collection<T>)` / `removeAll()` / `addComponentAsFirst(T)` / `addComponentAtIndex(int, T)` / `replace(T, T)` / `bindChildren(Signal<List<S>>, SerializableFunction<S, T>)` — are overridden to throw `IllegalStateException` when `Mode.ROUTER` (unless the internal `routerUpdateInProgress` flag is set).
 
 **@Synchronize'd properties:** none.
@@ -289,7 +293,7 @@ public static class BreadcrumbsI18n implements Serializable {
 }
 ```
 
-Exposed on `Breadcrumbs` via `setI18n(BreadcrumbsI18n)` / `getI18n()`. Serialised via `JacksonUtils.beanToJson(i18n)` and pushed to the client through `getElement().setPropertyJson("i18n", json)` inside the attach handler (so that on re-attach the fresh client element receives the property again). Null `i18n` results in the property not being set, letting the web component's default take over.
+Exposed on `Breadcrumbs` via `setI18n(BreadcrumbsI18n)` / `getI18n()`. Serialised via `JacksonUtils.beanToJson(i18n)` and pushed to the client through `getElement().setPropertyJson("i18n", json)` inside the attach handler (so that on re-attach the fresh client element receives the property again). `setI18n` rejects `null` with `Objects.requireNonNull("The i18n properties object should not be null")`, per guidelines/10-i18n-and-a11y.md. Before `setI18n` is first called, `getI18n()` returns `null` and no `i18n` property is pushed, so the web component uses its built-in defaults.
 
 | Field | Type | Default (English) | Web-component `i18n` field | Notes |
 |---|---|---|---|---|
@@ -301,7 +305,34 @@ Setter returns `this` so calls can be chained: `new BreadcrumbsI18n().setMoreIte
 
 ## Theme Variants
 
-Not applicable. No `BreadcrumbsVariant` enum is introduced. See flow-api.md Discussion "Why no theme variants?"
+`Breadcrumbs` implements `HasThemeVariant<BreadcrumbsVariant>` (from `vaadin-flow-components-base`), exposing the typed `addThemeVariants` / `removeThemeVariants` / `setThemeVariants` / `setThemeVariant` / `bindThemeVariant` / `bindThemeVariants` surface. The component writes none of these — every method is a default on the shared interface, so declaring the type parameter is the whole implementation.
+
+`BreadcrumbsVariant` is a `ThemeVariant` enum whose `getVariantName()` returns the exact `theme` token the web component accepts (guidelines/09-theming.md), following the `SideNavVariant` shape:
+
+```java
+public enum BreadcrumbsVariant implements ThemeVariant {
+    SLASH("slash");
+
+    private final String variant;
+
+    BreadcrumbsVariant(String variant) {
+        this.variant = variant;
+    }
+
+    @Override
+    public String getVariantName() {
+        return variant;
+    }
+}
+```
+
+| Enum value | `theme` token | Web component support |
+|---|---|---|
+| `SLASH` | `slash` | Ships in base styles — renders a `/` separator instead of the chevron (web-component-spec.md "Theme" table). |
+
+`LUMO_PRIMARY` (`primary`) and `AURA_ACCENT` (`accent`) are planned: each is added to the enum once the Lumo and Aura themes ship the matching `theme` token. Until then the enum carries only `SLASH`, so every value maps to a token the web component actually honours, as guidelines/09-theming.md requires.
+
+A `BreadcrumbsVariantTest` maps each enum value to its expected token (guidelines/12-testing.md).
 
 ---
 
@@ -632,7 +663,7 @@ No modifications.
 | 2. Current page indication | `BreadcrumbsItem(String text)` (no path) — web component renders as non-link, applies `current` state attribute |
 | 3. Optionally omitting the current page | No API — application chooses whether to add a no-path final item |
 | 4. Visual separator between items | Web component + theme (no Flow API) |
-| 5. Customizable separator appearance | `HasStyle` → `getStyle().set("--vaadin-breadcrumbs-separator", ...)` |
+| 5. Customizable separator appearance | `HasStyle` → `getStyle().set("--vaadin-breadcrumbs-separator", ...)`; `HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.SLASH)` for the bundled slash separator |
 | 6. Overflow collapse of intermediate items | Web component (no Flow API) |
 | 7. Expanding collapsed items | Web component; `BreadcrumbsI18n.moreItems` sets the overflow button's `aria-label` |
 | 8. Items may display icons | `BreadcrumbsItem implements HasPrefix` + constructor overloads ending in `Component prefixComponent` |
@@ -681,5 +712,13 @@ Yes — the listener is unregistered in `onDetach`, but a navigation may fire be
 
 **Q: Why does `getI18n()` return the last-set value (or `null`) rather than lazily creating a default `BreadcrumbsI18n`?**
 
-For consistency with `SideNav.getI18n()`, which returns `null` until `setI18n(...)` is called. Applications that want to tweak a single field build a new instance: `trail.setI18n(new BreadcrumbsI18n().setMoreItems("Show hidden items"))`. A lazy-init getter would hide the fact that the i18n object is a JSON payload pushed to the client — making it feel like a reactive bean when it isn't. The current shape also lets `null` mean "use the web component's built-in defaults", which is a meaningful state the lazy-init pattern cannot express.
+For consistency with `SideNav.getI18n()`, which returns `null` until `setI18n(...)` is called. Applications that want to tweak a single field build a new instance: `trail.setI18n(new BreadcrumbsI18n().setMoreItems("Show hidden items"))`. A lazy-init getter would hide the fact that the i18n object is a JSON payload pushed to the client — making it feel like a reactive bean when it isn't. The `null` return value also expresses the unset state — before any `setI18n` call the web component falls back to its built-in defaults — which a lazy-init getter that eagerly creates a non-default object cannot represent.
+
+**Q: Why does `setI18n` reject `null` rather than treating it as a reset?**
+
+guidelines/10-i18n-and-a11y.md prescribes `Objects.requireNonNull` in `setI18n`, and every other Vaadin component with an i18n object follows it — accepting `null` would diverge from that shared contract. A `null`-as-reset path would also be redundant: the web-component defaults are already the unset state (see the previous entry), not something to reach by clearing a set value. If an explicit "reset to defaults" need emerges, a named method reads more clearly than overloading `null`. Rejecting `null` at the call site turns a likely mistake into an immediate, well-located failure.
+
+**Q: Why does `Breadcrumbs` expose theme variants?**
+
+The web component ships a `theme="slash"` separator variant in its base styles (web-component-spec.md "Theme" table), so the Flow wrapper exposes it the standard way rather than inventing a setter — see "Theme Variants" for the enum and inherited API. An earlier revision exposed no variants because the web component had none; the slash variant changed that. Because `HasThemeVariant` lives in `vaadin-flow-components-base` and needs no unreleased Flow core API, this work can land ahead of the router-related tasks (flow-tasks.md Task 3).
 

--- a/packages/breadcrumbs/spec/flow-tasks.md
+++ b/packages/breadcrumbs/spec/flow-tasks.md
@@ -106,7 +106,7 @@ Implement all seven `BreadcrumbsItem` constructors (mirroring `SideNavItem`'s ov
 **Requirements:** 5
 **Depends on:** 1
 
-Add the `BreadcrumbsVariant` enum implementing `ThemeVariant` with `SLASH("slash")` (the web component's `theme="slash"` separator variant), following the `SideNavVariant` shape. Add `implements HasThemeVariant<BreadcrumbsVariant>` to `Breadcrumbs`; every variant method (`addThemeVariants` / `removeThemeVariants` / `setThemeVariants` / `setThemeVariant` / `bindThemeVariant` / `bindThemeVariants`) comes from the shared interface as a default — the component adds no code beyond the type parameter. `HasThemeVariant` and `ThemeVariant` are in `vaadin-flow-components-base` (already on the classpath via `HasPrefix`), so this task does not need the Flow core bump. `LUMO_PRIMARY` / `AURA_ACCENT` are documented as planned in the spec and are not added until the corresponding web-component theme tokens ship — keep the enum to tokens the web component actually honours (guidelines/09-theming.md).
+Add the `BreadcrumbsVariant` enum implementing `ThemeVariant` with `SLASH("slash")`, `LUMO_PRIMARY("primary")`, and `AURA_ACCENT("accent")` (the web component's `theme="slash"` base separator plus the Lumo / Aura link-color variants), following the `SideNavVariant` shape. Add `implements HasThemeVariant<BreadcrumbsVariant>` to `Breadcrumbs`; every variant method (`addThemeVariants` / `removeThemeVariants` / `setThemeVariants` / `setThemeVariant` / `bindThemeVariant` / `bindThemeVariants`) comes from the shared interface as a default — the component adds no code beyond the type parameter. `HasThemeVariant` and `ThemeVariant` are in `vaadin-flow-components-base` (already on the classpath via `HasPrefix`), so this task does not need the Flow core bump. Each enum value maps to a `theme` token the web component actually honours (guidelines/09-theming.md).
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java` (create)
@@ -114,7 +114,7 @@ Add the `BreadcrumbsVariant` enum implementing `ThemeVariant` with `SLASH("slash
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsVariantTest.java` (create — enum→token mapping per guidelines/09-theming.md)
 
 **Tests:**
-- [ ] `BreadcrumbsVariant.SLASH.getVariantName()` returns `"slash"`
+- [ ] `BreadcrumbsVariant.SLASH.getVariantName()` returns `"slash"`, `LUMO_PRIMARY` returns `"primary"`, `AURA_ACCENT` returns `"accent"`
 - [ ] `BreadcrumbsVariantTest` maps every enum value to its expected `theme` token
 - [ ] `addThemeVariants(BreadcrumbsVariant.SLASH)` adds `slash` to the host `theme` attribute
 - [ ] `removeThemeVariants(BreadcrumbsVariant.SLASH)` removes it

--- a/packages/breadcrumbs/spec/flow-tasks.md
+++ b/packages/breadcrumbs/spec/flow-tasks.md
@@ -10,10 +10,12 @@ Traceability: packages/breadcrumbs/spec/requirements.md (universal + flow)
 Tasks are pointers into the spec, not a second copy of it. The spec sections field tells the implementer where to find the full details. Do not restate class declarations, method tables, or `@Synchronize` lists here.
 
 External Flow core dependencies (not implemented by these tasks):
-- `com.vaadin.flow.component.HasComponentsOfType<T>` — Flow core PR #24186 (required by Task 4)
-- `com.vaadin.flow.router.RouteParent` annotation — Flow core (required by Task 6 + Task 10)
-- `com.vaadin.flow.router.RouteHierarchy.resolveAncestors(...)` walker — Flow core (required by Task 6)
-The Flow-version bump in `flow-components-bom` is part of Task 1.
+- `com.vaadin.flow.component.HasComponentsOfType<T>` — Flow core PR #24186 (required by Task 6)
+- `com.vaadin.flow.router.RouteParent` annotation — Flow core (required by Task 7 + Task 11)
+- `com.vaadin.flow.router.RouteHierarchy.resolveAncestors(...)` walker — Flow core (required by Task 7)
+The Flow-version bump in `flow-components-bom` is part of Task 6 — the first task that needs an unreleased Flow core API. Tasks 1–5 build against the current baseline Flow version.
+
+Ordering rationale: Tasks 3–5 (theme variants, i18n, mode) depend only on already-released Flow APIs, so they can proceed while PR #24186 / `@RouteParent` / `RouteHierarchy` are still in flight. The Flow-core-gated work (Task 6 guard, Task 7 router wiring) and the integration tests that exercise it (Tasks 10, 11) come after.
 
 Do NOT reorder tasks without verifying the dependency graph.
 Do NOT add tasks for features not in the spec.
@@ -31,16 +33,16 @@ Do NOT add tasks for features not in the spec.
 
 ## Task 1: Scaffold `vaadin-breadcrumbs-flow-parent` module with feature-flag plumbing
 
-**Spec sections:** Module / Package Layout, Feature Flag, Reuse and Proposed Adjustments → HasComponentsOfType, RouteParent, RouteHierarchy
+**Spec sections:** Module / Package Layout, Feature Flag
 **Requirements:** —
 **Depends on:** —
 
-Create the three sub-modules (`-flow`, `-flow-integration-tests`, `-testbench`) with `pom.xml` wiring, empty class shells matching the annotations and `implements` clauses from the spec (empty bodies — Mode enum, constructors, `setI18n`, child-management overrides land in later tasks), and the full feature-flag plumbing (`BreadcrumbsFeatureFlagProvider`, ServiceLoader registration, `ExperimentalFeatureException`, `onAttach` check). Bump the Flow version in `flow-components-bom/pom.xml` to a release that includes Flow core PR #24186 (`HasComponentsOfType<T>`), the `@RouteParent` annotation, and `RouteHierarchy.resolveAncestors(...)`. The IT module enables the feature flag via `src/main/resources/vaadin-featureflags.properties`. The smoke test instantiates `Breadcrumbs` (which currently does nothing in its body) and the `SerializableTest` round-trips it.
+Create the three sub-modules (`-flow`, `-flow-integration-tests`, `-testbench`) with `pom.xml` wiring, empty class shells matching the annotations and `implements` clauses from the spec (empty bodies — Mode enum, constructors, `setI18n`, the theme-variant and child-management surface land in later tasks), and the full feature-flag plumbing (`BreadcrumbsFeatureFlagProvider`, ServiceLoader registration, `ExperimentalFeatureException`, `onAttach` check). At this point `Breadcrumbs` implements only `HasSize, HasStyle, HasAriaLabel`; it gains `HasThemeVariant<BreadcrumbsVariant>` in Task 3 and `HasComponentsOfType<BreadcrumbsItem>` in Task 6 (when the Flow core dependency is bumped). The module builds against the current baseline Flow version — no version bump yet. The IT module enables the feature flag via `src/main/resources/vaadin-featureflags.properties`. The smoke test instantiates `Breadcrumbs` (which currently does nothing in its body) and the `SerializableTest` round-trips it.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/pom.xml` (create)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/pom.xml` (create)
-- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (create — `@Tag` + `@NpmPackage` + `@JsModule`, `extends Component` + the four `implements` interfaces from the spec, empty body apart from `onAttach` calling `checkFeatureFlag`)
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (create — `@Tag` + `@NpmPackage` + `@JsModule`, `extends Component` + `implements HasSize, HasStyle, HasAriaLabel`, empty body apart from `onAttach` calling `checkFeatureFlag`)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsItem.java` (create — annotations + `implements HasText, HasEnabled, HasPrefix`, empty body)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsFeatureFlagProvider.java` (create — verbatim from flow-spec.md Feature Flag section)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/ExperimentalFeatureException.java` (create — verbatim from spec)
@@ -54,7 +56,7 @@ Create the three sub-modules (`-flow`, `-flow-integration-tests`, `-testbench`) 
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/src/main/java/com/vaadin/flow/component/breadcrumbs/testbench/BreadcrumbsElement.java` (create — `@Element("vaadin-breadcrumbs")`, empty body)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/src/main/java/com/vaadin/flow/component/breadcrumbs/testbench/BreadcrumbsItemElement.java` (create — `@Element("vaadin-breadcrumbs-item")`, empty body)
 - `pom.xml` (modify — add `vaadin-breadcrumbs-flow-parent` module)
-- `flow-components-bom/pom.xml` (modify — bump Flow version to a release that ships PR #24186 + `@RouteParent` + `RouteHierarchy`; add the new module if the BOM aggregates modules)
+- `flow-components-bom/pom.xml` (modify — add the new module if the BOM aggregates modules; no Flow version bump yet — that lands in Task 6)
 
 **Tests:**
 - [ ] `new Breadcrumbs()` returns a non-null instance whose element tag is `vaadin-breadcrumbs`
@@ -98,13 +100,66 @@ Implement all seven `BreadcrumbsItem` constructors (mirroring `SideNavItem`'s ov
 
 ---
 
-## Task 3: `Breadcrumbs` — `Mode` enum, constructors, mode switching
+## Task 3: `Breadcrumbs` — theme variants (`HasThemeVariant<BreadcrumbsVariant>`)
+
+**Spec sections:** Key Design Decisions §9, Component Classes → `Breadcrumbs` (implements clause + mixin interfaces), Theme Variants
+**Requirements:** 5
+**Depends on:** 1
+
+Add the `BreadcrumbsVariant` enum implementing `ThemeVariant` with `SLASH("slash")` (the web component's `theme="slash"` separator variant), following the `SideNavVariant` shape. Add `implements HasThemeVariant<BreadcrumbsVariant>` to `Breadcrumbs`; every variant method (`addThemeVariants` / `removeThemeVariants` / `setThemeVariants` / `setThemeVariant` / `bindThemeVariant` / `bindThemeVariants`) comes from the shared interface as a default — the component adds no code beyond the type parameter. `HasThemeVariant` and `ThemeVariant` are in `vaadin-flow-components-base` (already on the classpath via `HasPrefix`), so this task does not need the Flow core bump. `LUMO_PRIMARY` / `AURA_ACCENT` are documented as planned in the spec and are not added until the corresponding web-component theme tokens ship — keep the enum to tokens the web component actually honours (guidelines/09-theming.md).
+
+**Files:**
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java` (create)
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify — add `HasThemeVariant<BreadcrumbsVariant>` to the `implements` clause)
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsVariantTest.java` (create — enum→token mapping per guidelines/09-theming.md)
+
+**Tests:**
+- [ ] `BreadcrumbsVariant.SLASH.getVariantName()` returns `"slash"`
+- [ ] `BreadcrumbsVariantTest` maps every enum value to its expected `theme` token
+- [ ] `addThemeVariants(BreadcrumbsVariant.SLASH)` adds `slash` to the host `theme` attribute
+- [ ] `removeThemeVariants(BreadcrumbsVariant.SLASH)` removes it
+- [ ] `setThemeVariants(BreadcrumbsVariant.SLASH)` replaces any previously set theme tokens
+
+**Acceptance criteria:**
+- [ ] All new tests pass; existing tests still pass
+- [ ] `mvn spotless:apply` and `mvn checkstyle:check` clean
+
+---
+
+## Task 4: `Breadcrumbs` — `BreadcrumbsI18n` + `setI18n` / `getI18n`
+
+**Spec sections:** Key Design Decisions §10, Component Classes → `Breadcrumbs` (i18n field), i18n
+**Requirements:** 7
+**Depends on:** 1
+
+Add the nested static `BreadcrumbsI18n` class — `Serializable`, `@JsonInclude(JsonInclude.Include.NON_NULL)`, single `moreItems` field with fluent setter returning `this`. Add `getI18n()` / `setI18n(BreadcrumbsI18n)` on `Breadcrumbs`: `setI18n` stores the instance and pushes `JacksonUtils.beanToJson(i18n)` to the client via `getElement().setPropertyJson("i18n", json)`. Re-push in `onAttach` so a fresh client-side element receives the property after re-attach. `setI18n` rejects `null` via `Objects.requireNonNull` (guidelines/10-i18n-and-a11y.md). `getI18n()` returns the last-set instance, or `null` before the first `setI18n` call — the unset state in which the web component uses its built-in defaults — with no lazy-init.
+
+**Files:**
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify)
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsI18nTest.java` (create)
+
+**Tests:**
+- [ ] `new BreadcrumbsI18n().setMoreItems("Show hidden items").getMoreItems()` returns "Show hidden items"
+- [ ] `BreadcrumbsI18n` serialises to JSON with `NON_NULL` inclusion — a default instance produces `{}`, not `{"moreItems":null}`
+- [ ] `BreadcrumbsI18n` round-trips through Java serialisation
+- [ ] `getI18n()` returns `null` before `setI18n` is called
+- [ ] `setI18n(new BreadcrumbsI18n().setMoreItems("X"))` pushes a JSON object to the `i18n` element property whose `moreItems` field is `"X"`
+- [ ] `setI18n(null)` throws `NullPointerException`
+- [ ] Re-attaching the component re-pushes the last-set `i18n` value
+
+**Acceptance criteria:**
+- [ ] All new tests pass; existing tests still pass
+- [ ] `mvn spotless:apply` and `mvn checkstyle:check` clean
+
+---
+
+## Task 5: `Breadcrumbs` — `Mode` enum, constructors, mode switching
 
 **Spec sections:** Key Design Decisions §1 + §13, Component Classes → `Breadcrumbs` (constructors, `getMode`/`setMode`, mode-switching contract)
 **Requirements:** 14
 **Depends on:** 1
 
-Add the public nested `Mode` enum (`ROUTER`, `MANUAL`) and the two constructors (`Breadcrumbs()` → defaults to `Mode.ROUTER`, `Breadcrumbs(Mode)`). Implement `getMode()` and `setMode(Mode)` with the symmetric clear-and-rewire contract from the spec: both transitions discard existing children, `ROUTER → MANUAL` also unregisters the navigation listener (if registered later in Task 6), `MANUAL → ROUTER` triggers an initial trail build. The `add`/`remove`/`removeAll` guard methods do not exist yet — they land in Task 4. The router listener wiring lands in Task 6; at this point `setMode(ROUTER)` only flips the internal flag and clears children.
+Add the public nested `Mode` enum (`ROUTER`, `MANUAL`) and the two constructors (`Breadcrumbs()` → defaults to `Mode.ROUTER`, `Breadcrumbs(Mode)`). Implement `getMode()` and `setMode(Mode)` with the symmetric clear-and-rewire contract from the spec: both transitions discard existing children, `ROUTER → MANUAL` also unregisters the navigation listener (if registered later in Task 7), `MANUAL → ROUTER` triggers an initial trail build. The `add`/`remove`/`removeAll` guard methods do not exist yet — they land in Task 6. The router listener wiring lands in Task 7; at this point `setMode(ROUTER)` only flips the internal flag and clears children.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify)
@@ -123,16 +178,17 @@ Add the public nested `Mode` enum (`ROUTER`, `MANUAL`) and the two constructors 
 
 ---
 
-## Task 4: `Breadcrumbs` — `HasComponentsOfType<BreadcrumbsItem>` with `Mode.ROUTER` guard
+## Task 6: `Breadcrumbs` — `HasComponentsOfType<BreadcrumbsItem>` with `Mode.ROUTER` guard
 
-**Spec sections:** Key Design Decisions §2 + §3, Component Classes → `Breadcrumbs` (items section + `routerUpdateInProgress` bypass + `updateChildrenInternal`)
+**Spec sections:** Key Design Decisions §2 + §3, Component Classes → `Breadcrumbs` (items section + `routerUpdateInProgress` bypass + `updateChildrenInternal`), Reuse and Proposed Adjustments → HasComponentsOfType
 **Requirements:** 1, 9, 14
-**Depends on:** 2, 3
+**Depends on:** 2, 5
 
-Add `implements HasComponentsOfType<BreadcrumbsItem>` to `Breadcrumbs`. Override every mutating default method — `add(T...)`, `add(Collection<T>)`, `remove(T...)`, `remove(Collection<T>)`, `removeAll()`, `addComponentAsFirst(T)`, `addComponentAtIndex(int, T)`, `replace(T, T)`, `bindChildren(Signal<List<S>>, SerializableFunction<S, T>)` — so each one throws `IllegalStateException` when `mode == Mode.ROUTER && !routerUpdateInProgress`, otherwise delegates to `HasComponentsOfType.super.<method>(...)`. Add the private `routerUpdateInProgress` flag and the `updateChildrenInternal(List<BreadcrumbsItem>)` helper that sets the flag, calls `removeAll() + add(...)`, and clears the flag in a `finally`. `getChildren()` reads remain unguarded.
+First task that needs an unreleased Flow core API. Bump the Flow version in `flow-components-bom/pom.xml` to a release that includes Flow core PR #24186 (`HasComponentsOfType<T>`). Add `implements HasComponentsOfType<BreadcrumbsItem>` to `Breadcrumbs`. Override every mutating default method — `add(T...)`, `add(Collection<T>)`, `remove(T...)`, `remove(Collection<T>)`, `removeAll()`, `addComponentAsFirst(T)`, `addComponentAtIndex(int, T)`, `replace(T, T)`, `bindChildren(Signal<List<S>>, SerializableFunction<S, T>)` — so each one throws `IllegalStateException` when `mode == Mode.ROUTER && !routerUpdateInProgress`, otherwise delegates to `HasComponentsOfType.super.<method>(...)`. Add the private `routerUpdateInProgress` flag and the `updateChildrenInternal(List<BreadcrumbsItem>)` helper that sets the flag, calls `removeAll() + add(...)`, and clears the flag in a `finally`. `getChildren()` reads remain unguarded.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify)
+- `flow-components-bom/pom.xml` (modify — bump Flow version to a release that ships PR #24186)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsTest.java` (modify — add the guard tests next to the existing smoke test)
 
 **Tests:**
@@ -148,43 +204,17 @@ Add `implements HasComponentsOfType<BreadcrumbsItem>` to `Breadcrumbs`. Override
 
 ---
 
-## Task 5: `Breadcrumbs` — `BreadcrumbsI18n` + `setI18n` / `getI18n`
+## Task 7: `Breadcrumbs` — `Mode.ROUTER` listener wiring + router trail builder
 
-**Spec sections:** Key Design Decisions §10, Component Classes → `Breadcrumbs` (i18n field), i18n
-**Requirements:** 7
-**Depends on:** 3
-
-Add the nested static `BreadcrumbsI18n` class — `Serializable`, `@JsonInclude(JsonInclude.Include.NON_NULL)`, single `moreItems` field with fluent setter returning `this`. Add `getI18n()` / `setI18n(BreadcrumbsI18n)` on `Breadcrumbs`: `setI18n` stores the instance and pushes `JacksonUtils.beanToJson(i18n)` to the client via `getElement().setPropertyJson("i18n", json)`. Re-push in `onAttach` so a fresh client-side element receives the property after re-attach. `null` clears the stored instance and unsets the client property, letting the web component's default take over. `getI18n()` returns the last-set instance (or `null`) — no lazy-init.
-
-**Files:**
-- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify)
-- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsI18nTest.java` (create)
-
-**Tests:**
-- [ ] `new BreadcrumbsI18n().setMoreItems("Show hidden items").getMoreItems()` returns "Show hidden items"
-- [ ] `BreadcrumbsI18n` serialises to JSON with `NON_NULL` inclusion — a default instance produces `{}`, not `{"moreItems":null}`
-- [ ] `BreadcrumbsI18n` round-trips through Java serialisation
-- [ ] `getI18n()` returns `null` before `setI18n` is called
-- [ ] `setI18n(new BreadcrumbsI18n().setMoreItems("X"))` pushes a JSON object to the `i18n` element property whose `moreItems` field is `"X"`
-- [ ] `setI18n(null)` clears the client `i18n` property
-- [ ] Re-attaching the component re-pushes the last-set `i18n` value
-
-**Acceptance criteria:**
-- [ ] All new tests pass; existing tests still pass
-- [ ] `mvn spotless:apply` and `mvn checkstyle:check` clean
-
----
-
-## Task 6: `Breadcrumbs` — `Mode.ROUTER` listener wiring + router trail builder
-
-**Spec sections:** Key Design Decisions §3 + §5, Component Classes → `Breadcrumbs` (Router mode wiring, `rebuildFromRouter`), `@RouteParent` Annotation → How `Breadcrumbs` builds the trail
+**Spec sections:** Key Design Decisions §3 + §5, Component Classes → `Breadcrumbs` (Router mode wiring, `rebuildFromRouter`), `@RouteParent` Annotation → How `Breadcrumbs` builds the trail, Reuse and Proposed Adjustments → RouteParent, RouteHierarchy
 **Requirements:** 13, 15
-**Depends on:** 4
+**Depends on:** 6
 
-Register `UI#addAfterNavigationListener(this::rebuildFromRouter)` in `onAttach` when `mode == Mode.ROUTER`, hold the returned `Registration` in a `transient navigationRegistration` field, and unregister in `onDetach`. Add both `rebuildFromRouter` overloads (event-driven + direct-state for initial attach reading `UIInternals.getActiveViewLocation()` / `getActiveRouterTargetsChain()`); both guard with `if (!isAttached()) return;` and delegate to a private builder that calls `RouteHierarchy.resolveAncestors(currentRoute, routeConfiguration)` from Flow core, wraps every ancestor class except the last as `new BreadcrumbsItem(title, ancestorClass)` (title from `@PageTitle`), wraps the last entry as `new BreadcrumbsItem(title)` with no path (title from `HasDynamicTitle#getPageTitle()` on the active view instance if present, otherwise its class `@PageTitle`), and hands the list to `updateChildrenInternal`. Also wire `Mode.MANUAL → Mode.ROUTER` transitions in `setMode` to register the listener and trigger an initial `rebuildFromRouter` if currently attached.
+Requires the Flow version bumped in Task 6 to also include `com.vaadin.flow.router.RouteParent` and `RouteHierarchy.resolveAncestors(...)`; if those ship in a later Flow release than PR #24186, bump `flow-components-bom` again here. Register `UI#addAfterNavigationListener(this::rebuildFromRouter)` in `onAttach` when `mode == Mode.ROUTER`, hold the returned `Registration` in a `transient navigationRegistration` field, and unregister in `onDetach`. Add both `rebuildFromRouter` overloads (event-driven + direct-state for initial attach reading `UIInternals.getActiveViewLocation()` / `getActiveRouterTargetsChain()`); both guard with `if (!isAttached()) return;` and delegate to a private builder that calls `RouteHierarchy.resolveAncestors(currentRoute, routeConfiguration)` from Flow core, wraps every ancestor class except the last as `new BreadcrumbsItem(title, ancestorClass)` (title from `@PageTitle`), wraps the last entry as `new BreadcrumbsItem(title)` with no path (title from `HasDynamicTitle#getPageTitle()` on the active view instance if present, otherwise its class `@PageTitle`), and hands the list to `updateChildrenInternal`. Also wire `Mode.MANUAL → Mode.ROUTER` transitions in `setMode` to register the listener and trigger an initial `rebuildFromRouter` if currently attached.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify)
+- `flow-components-bom/pom.xml` (modify only if `@RouteParent` / `RouteHierarchy` require a later Flow release than Task 6's bump)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java` (modify — extend the existing test class with router-listener cases using stubbed `RouteConfiguration` / mocked `UI`)
 
 **Tests:**
@@ -202,13 +232,13 @@ Register `UI#addAfterNavigationListener(this::rebuildFromRouter)` in `onAttach` 
 
 ---
 
-## Task 7: TestBench element classes
+## Task 8: TestBench element classes
 
 **Spec sections:** TestBench Elements (both classes)
 **Requirements:** —
 **Depends on:** 1
 
-Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec — every public method listed there must be present. Queries follow the `SideNavElement` / `SideNavItemElement` pattern: `$("vaadin-breadcrumbs-item").all()` for items, shadow-DOM CSS via `$(TestBenchElement.class).attribute("part", ...)` for parts, slotted-content queries via the standard `getPropertyElement(...)`. The actual IT exercise of these methods lands in Tasks 8–11.
+Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec — every public method listed there must be present. Queries follow the `SideNavElement` / `SideNavItemElement` pattern: `$("vaadin-breadcrumbs-item").all()` for items, shadow-DOM CSS via `$(TestBenchElement.class).attribute("part", ...)` for parts, slotted-content queries via the standard `getPropertyElement(...)`. The actual IT exercise of these methods lands in Tasks 9–12.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/src/main/java/com/vaadin/flow/component/breadcrumbs/testbench/BreadcrumbsElement.java` (modify)
@@ -224,11 +254,11 @@ Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec — eve
 
 ---
 
-## Task 8: Manual-mode integration test view + IT
+## Task 9: Manual-mode integration test view + IT
 
 **Spec sections:** Module / Package Layout (integration-tests file list), Component Classes → `Breadcrumbs` (`Mode.MANUAL`)
 **Requirements:** 1, 9, 14
-**Depends on:** 4, 7
+**Depends on:** 6, 8
 
 Add a Flow view `ManualBreadcrumbsPage` that constructs `new Breadcrumbs(Mode.MANUAL)`, adds three items declaratively (one with a path-class, one with a string path, one with no path representing the current page), and exposes test affordances for the IT (`@Id` buttons to add / remove items at runtime to exercise reactive updates). The IT class `ManualBreadcrumbsIT` opens the view, uses `BreadcrumbsElement` + `BreadcrumbsItemElement` to assert the rendered trail, then exercises an add and a remove to confirm `Mode.MANUAL` reactive updates flow to the DOM.
 
@@ -249,11 +279,11 @@ Add a Flow view `ManualBreadcrumbsPage` that constructs `new Breadcrumbs(Mode.MA
 
 ---
 
-## Task 9: Router-mode integration test view + IT
+## Task 10: Router-mode integration test view + IT
 
 **Spec sections:** Key Design Decisions §3 + §5, Component Classes → `Breadcrumbs` (Router mode wiring), `@RouteParent` Annotation → How `Breadcrumbs` builds the trail
 **Requirements:** 13
-**Depends on:** 6, 7
+**Depends on:** 7, 8
 
 Add a small route hierarchy of four `@Route`'d views, each with a `@PageTitle` (and one with `HasDynamicTitle` to cover the dynamic-title path) and `add(new Breadcrumbs())` in its constructor — defaulting to `Mode.ROUTER`. Navigate from the IT, assert the trail matches the route hierarchy, and verify the current item's text reflects `HasDynamicTitle` when the view implements it.
 
@@ -275,11 +305,11 @@ Add a small route hierarchy of four `@Route`'d views, each with a `@PageTitle` (
 
 ---
 
-## Task 10: `@RouteParent` integration test view + IT
+## Task 11: `@RouteParent` integration test view + IT
 
 **Spec sections:** Key Design Decisions §4 + §5, `@RouteParent` Annotation → How `Breadcrumbs` builds the trail
 **Requirements:** 15
-**Depends on:** 6, 7
+**Depends on:** 7, 8
 
 Add a view `RouteParentPage` whose `@Route` URL would, under URL-prefix walking, resolve to one parent — but which carries `@RouteParent(OtherView.class)` to declare a different conceptual parent. The IT navigates to the view and asserts that the rendered trail walks through the declared parent, not the URL-derived one. This task verifies the Flow core `RouteHierarchy` walker's `@RouteParent`-first behaviour end-to-end through the breadcrumbs.
 
@@ -298,11 +328,11 @@ Add a view `RouteParentPage` whose `@Route` URL would, under URL-prefix walking,
 
 ---
 
-## Task 11: Icon (prefix-component) integration test view + IT
+## Task 12: Icon (prefix-component) integration test view + IT
 
 **Spec sections:** Component Classes → `BreadcrumbsItem` (constructors ending in `Component prefixComponent`)
 **Requirements:** 8
-**Depends on:** 2, 7
+**Depends on:** 2, 8
 
 Add a view `IconBreadcrumbsPage` that constructs items via the prefix-component constructor overloads — at minimum: a home icon on the root, a folder icon on an intermediate item, and a current-page item without prefix. The IT asserts via `BreadcrumbsItemElement#hasPrefix()` and `getPrefixSlotContent()` that the prefix slot is wired and the icons render.
 
@@ -321,18 +351,18 @@ Add a view `IconBreadcrumbsPage` that constructs items via the prefix-component 
 
 ---
 
-## Task 12: Final validation
+## Task 13: Final validation
 
 **Spec sections:** All
 **Requirements:** —
-**Depends on:** 5, 8, 9, 10, 11
+**Depends on:** 3, 4, 9, 10, 11, 12
 
 Final clean-up and validation pass before the module is merge-ready. Run formatting / static analysis / unit tests / integration tests across the whole new module, and update repo-level documentation: add the new module to `flow-components/README.md`'s component list if the project convention requires it, and confirm `flow-components-bom` references the new artefact if the BOM aggregates modules. Verify that no `dispatchEvent` was added on the Flow side (the spec lists zero events; the test agent's earlier feature-flag test already covers attach-time enforcement).
 
 **Files:**
 - `flow-components/README.md` (modify if convention requires component listing)
 - `flow-components-bom/pom.xml` (modify if BOM aggregates module artefacts)
-- All files touched by Tasks 1–11 (validation only — no edits expected)
+- All files touched by Tasks 1–12 (validation only — no edits expected)
 
 **Tests:**
 - [ ] `mvn test -pl vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow` — full unit test suite passes

--- a/packages/breadcrumbs/spec/web-component-api.md
+++ b/packages/breadcrumbs/spec/web-component-api.md
@@ -55,7 +55,16 @@ vaadin-breadcrumbs {
 }
 ```
 
-**Why this shape:** The separator is rendered as a `::after` pseudo-element on each item using `mask-image`, matching the pattern used across Vaadin components (select's toggle button, combo-box's dropdown arrow, clear buttons). The pseudo-element has `background: currentColor` shaped by `mask-image: var(--vaadin-breadcrumbs-separator)`. Applications override the separator by setting the CSS custom property on the item. The theme handles flipping the separator direction in RTL contexts. This keeps the HTML clean — separators are purely visual, styled through CSS, not DOM content.
+```html
+<!-- Or switch to the bundled slash separator via the theme attribute -->
+<vaadin-breadcrumbs theme="slash">
+  <vaadin-breadcrumbs-item path="/">Home</vaadin-breadcrumbs-item>
+  <vaadin-breadcrumbs-item path="/products">Products</vaadin-breadcrumbs-item>
+  <vaadin-breadcrumbs-item>Laptops</vaadin-breadcrumbs-item>
+</vaadin-breadcrumbs>
+```
+
+**Why this shape:** The separator is rendered as a `::after` pseudo-element on each item using `mask-image`, matching the pattern used across Vaadin components (select's toggle button, combo-box's dropdown arrow, clear buttons). The pseudo-element has `background: currentColor` shaped by `mask-image: var(--vaadin-breadcrumbs-separator)`. Applications override the separator by setting the CSS custom property on the item. For the common slash separator, base styles ship a `theme="slash"` variant (see Discussion). The theme handles flipping the separator direction in RTL contexts. This keeps the HTML clean — separators are purely visual, styled through CSS, not DOM content.
 
 ---
 
@@ -231,6 +240,10 @@ On `vaadin-breadcrumbs` (the parent), not on individual items. The property casc
 **Q: Should the separator `mask-image` reference the SVG directly or via a CSS custom property?**
 
 Via a CSS custom property (`--vaadin-breadcrumbs-separator`). The base styles set `mask-image: var(--vaadin-breadcrumbs-separator)` on the `::after` pseudo-element, and applications override the custom property to change the icon. This matches how other Vaadin components handle icon customization.
+
+**Q: Why offer a `theme="slash"` variant when the separator is already customizable via CSS?**
+
+The slash is the second most common breadcrumb separator after the chevron, and the `mask-image` recipe makes the variant trivial — `theme="slash"` rebinds `--vaadin-breadcrumbs-separator` to a bundled slash icon. Shipping it in base styles means applications get the slash separator without writing their own CSS or embedding an SVG, and Lumo / Aura do not have to re-implement the same selector. Arbitrary separators still go through the custom property; the variant just covers the common case.
 
 **Q: Why is there no programmatic `items` property?**
 

--- a/packages/breadcrumbs/spec/web-component-spec.md
+++ b/packages/breadcrumbs/spec/web-component-spec.md
@@ -83,9 +83,13 @@ The overflow overlay's outer panel and inner wrapper are re-exported on the brea
 |---|---|
 | `has-overflow` | Set when one or more items are collapsed into the overflow overlay. |
 
-| Theme | Description |
-|---|---|
-| `slash` | Renders a slash (`/`) instead of the default chevron between items. Set via `theme="slash"` on `<vaadin-breadcrumbs>`. |
+| Theme | Defined in | Description |
+|---|---|---|
+| `slash` | Base styles | Renders a slash (`/`) instead of the default chevron between items. |
+| `primary` | Lumo | Restores a distinct link color (`--lumo-primary-text-color`) so links stand out from non-link items. |
+| `accent` | Aura | Restores a distinct link color (`--aura-accent-text-color`) so links stand out from non-link items. |
+
+All variants are set via `theme="…"` on `<vaadin-breadcrumbs>`. See the Discussion entry on `--vaadin-breadcrumbs-link-color` for why Lumo and Aura ship the `primary` / `accent` variants.
 
 | CSS Custom Property | Default | Description |
 |---|---|---|


### PR DESCRIPTION
Validates the breadcrumbs Flow spec against the current flow-components guidelines and reflects the web component's new `theme="slash"` separator variant.

- **Theme variants** — `Breadcrumbs` now implements `HasThemeVariant<BreadcrumbsVariant>` with `SLASH("slash")` (planned `LUMO_PRIMARY` / `AURA_ACCENT`), per guidelines/09-theming.md. Reverses the earlier "no theme variants" decision now that the web component ships `theme="slash"`.
- **i18n** — `setI18n` rejects `null` via `Objects.requireNonNull` (guidelines/10-i18n-and-a11y.md) instead of treating `null` as a reset; the unset/defaults state is the pre-`setI18n` state.
- **Task reordering** — theme variants (Task 3) and i18n (Task 4) move ahead of the Flow-core-gated tasks, and the `flow-components-bom` Flow-version bump moves from Task 1 to Task 6 (the first task needing PR #24186 / `@RouteParent` / `RouteHierarchy`), so the guideline-only work can proceed while those APIs are in flight.
- **Web component API doc** — documents the `theme="slash"` variant in the separator section.
- **Dedup** — each new fact has one canonical home (Theme Variants / i18n sections) with cross-references; Discussion entries added for every behavior change, bodies kept current-state-only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)