### PR TITLE
refactor: remove redundant _afterScroll call after creating grid rows

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
-import { animationFrame, microTask } from '@vaadin/component-base/src/async.js';
+import { microTask } from '@vaadin/component-base/src/async.js';
 import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
@@ -356,13 +356,6 @@ export const GridMixin = (superClass) =>
         });
       }
 
-      this.__afterCreateScrollerRowsDebouncer = Debouncer.debounce(
-        this.__afterCreateScrollerRowsDebouncer,
-        animationFrame,
-        () => {
-          this._afterScroll();
-        },
-      );
       return rows;
     }
 

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -776,7 +776,6 @@ snapshots["vaadin-grid basic shadow details opened"] =
 snapshots["vaadin-grid basic shadow hidden column"] = 
 `<div
   id="scroller"
-  scrolling=""
   style=""
 >
   <table
@@ -965,7 +964,6 @@ snapshots["vaadin-grid basic shadow hidden column"] =
 snapshots["vaadin-grid basic shadow hidden column selected"] = 
 `<div
   id="scroller"
-  scrolling=""
   style=""
 >
   <table
@@ -1155,7 +1153,6 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
 snapshots["vaadin-grid basic shadow with footer"] = 
 `<div
   id="scroller"
-  scrolling=""
   style=""
 >
   <table


### PR DESCRIPTION
When the grid switched from the iron-list fork to Virtualizer (#321), an `_afterScroll()` call was added after row creation to preserve the old behavior where creating pool rows ended up running `_afterScroll()` through the scroll handler. The main purpose was to apply frozen cell transforms to the newly created rows when the grid is scrolled horizontally.

This is redundant now, so the call and its debouncer can be removed:

- Frozen cell transforms for new rows are applied by `_frozenCellsChanged()`, which row creation already triggers through `__initRow()` and the column `_cells` observers. It collects the new frozen cells and calls `__updateHorizontalScrollPosition()` itself.
- `__updateColumnsBodyContentHidden()` also still runs after row creation through `_frozenCellsChanged()` → `_updateFrozenColumn()`. In addition, new rows are already created with the cells of lazily hidden columns excluded, so they don't need a separate update. The debounced update in `_afterScroll()` was a no-op after row creation anyway, since it only runs when `scrollLeft` has changed.
- The remaining `_afterScroll()` effects (toggling the `scrolling` attribute, hiding the tooltip) are scroll-specific and not needed after creating rows.