### PR TITLE
docs: use getRouteHierarchy for breadcrumbs Flow router trail

### DIFF
--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -259,7 +259,7 @@ public class EditOrderView extends Div { ... }
 // (instead of Home › Orders › Edit › Edit Order implied by the URL segments)
 ```
 
-**Why this shape:** A class-level annotation `@RouteParent(Class<? extends Component>)` declares a view's parent in the application's route hierarchy, overriding URL-prefix walking. It is deliberately named in route-hierarchy terms rather than breadcrumb-specific terms — the relationship it expresses ("this route's conceptual parent is that route") is independent of breadcrumb rendering and can be consumed by any navigation component that needs to traverse the hierarchy. An annotation (vs a method on a new interface) is the right shape for this because the information is static and known at compile time — mirroring how `@Route`, `@RouteAlias`, and `@PageTitle` are themselves annotations. Walking continues from the declared parent using the same rules, so chains of `@RouteParent` compose naturally. The annotation lives alongside the other Flow route metadata on the view class.
+**Why this shape:** `@RouteParent(Class<? extends Component>)` declares a view's parent in the route hierarchy, overriding URL-prefix walking. Chains of `@RouteParent` compose naturally, and the annotation sits on the view class alongside the other route metadata (`@Route`, `@PageTitle`). The annotation is provided by Flow core, which also supports a dynamic `resolver()` for parents that depend on route parameters.
 
 ---
 
@@ -333,11 +333,11 @@ Flow core's `Signal.effect(component, Runnable)` already provides the primitive 
 
 **Q: What happens if `@RouteParent` forms a cycle or points at a class without `@Route`?**
 
-These are implementation concerns the spec (`create-component-flow-spec`) will resolve — the expected behaviour is that cycles are detected and truncated, and a parent class without `@Route` is treated as if the annotation were absent (fall back to URL-prefix walking). The API surface here is only the annotation itself; the resolution algorithm belongs to the specification.
+Flow core handles both: `RouteConfiguration#getRouteHierarchy` is cycle-guarded (it stops when a target repeats), and a parent that cannot be resolved from `@RouteParent` falls back to URL-prefix walking. The breadcrumb relies on that behaviour rather than implementing its own.
 
 **Q: Why `@RouteParent` rather than a breadcrumb-specific name?**
 
-The annotation expresses a route-hierarchy relationship — "the conceptual parent of this route is that route" — which is not inherently tied to breadcrumb rendering. Naming it `@RouteParent` (vs. `@BreadcrumbsParent` or `@BreadcrumbsRouteParent`) keeps the declaration reusable: any future navigation component that needs to walk the route hierarchy (e.g. a back-navigation helper, an SEO link-graph generator, a parent-link utility) can consume the same annotation without the name implying it belongs to Breadcrumbs alone. The `@Route*` prefix also groups it naturally with the existing routing annotations (`@Route`, `@RouteAlias`) in Flow core, so developers find it where they look for route metadata. This avoids coupling application-level hierarchy metadata to a specific presentation component — the view author declares a routing fact, not a breadcrumb hint.
+The name is Flow core's: the annotation expresses a generic route relationship, not a breadcrumb hint, so it is not named after this component.
 
 **Q: Why is `BreadcrumbsI18n` a class rather than a single setter for `moreItems`?**
 

--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -8,11 +8,11 @@
 
 2. **`HasComponentsOfType<BreadcrumbsItem>` for child management.** Per flow-api.md §1 "Why this shape". The Flow core interface extends `HasElement, HasEnabled` and supplies the full child-management surface as default methods (see the class skeleton in "Component Classes"), all of which must be intercepted by the `Mode.ROUTER` guard (see KDD §1). `HasEnabled` is inherited transitively — it does not need to appear in `Breadcrumbs`'s `implements` list.
 
-3. **Router integration via `AfterNavigationListener`.** For `Mode.ROUTER`, the component registers `UI.addAfterNavigationListener(...)` in its attach handler and unregisters in detach. The listener walks the route hierarchy — `@RouteParent` first, then URL-prefix — and calls `updateChildrenInternal(List<BreadcrumbsItem>)` to replace the trail. `updateChildrenInternal` sets an internal `boolean routerUpdateInProgress` flag, routes the update through the normal component API (`removeAll()` + `add(...)`), then clears the flag; the `Mode.ROUTER` guard on the public methods skips the throw when the flag is set.
+3. **Router integration via `AfterNavigationListener`.** For `Mode.ROUTER`, the component registers `UI.addAfterNavigationListener(...)` in its attach handler and unregisters in detach. The listener resolves the route hierarchy via `RouteConfiguration#getRouteHierarchy` and calls `updateChildrenInternal(List<BreadcrumbsItem>)` to replace the trail. `updateChildrenInternal` sets an internal `boolean routerUpdateInProgress` flag, routes the update through the normal component API (`removeAll()` + `add(...)`), then clears the flag; the `Mode.ROUTER` guard on the public methods skips the throw when the flag is set.
 
-4. **`@RouteParent` annotation lives in Flow core.** Per flow-api.md §10. `com.vaadin.flow.router.RouteParent` is introduced in Flow core alongside `@Route`, `@RouteAlias`, `@ParentLayout`. The breadcrumb module only consumes it — it neither defines it nor re-exports it. See "Reuse and Proposed Adjustments" for the Flow core dependency.
+4. **`@RouteParent` comes from Flow core.** Per flow-api.md §10. The annotation declares a route's logical parent (static `value()` or dynamic `resolver()`); the breadcrumb module only consumes it. See "Reuse and Proposed Adjustments" for the Flow core dependency.
 
-5. **Route-hierarchy walking is a Flow core feature, not a breadcrumb-specific resolver.** The "given a route class, walk up via `@RouteParent` then URL-prefix fallback" algorithm is useful to any navigation component (back-button helpers, SEO link-graph generators, sitemap renderers), so it lives in Flow core next to `@RouteParent` itself. The breadcrumb consumes it via a public helper — see "Reuse and Proposed Adjustments → Flow core: route-hierarchy walker". The resolver reads only static metadata (`@PageTitle`, `@RouteParent`) and therefore never instantiates ancestor views; the breadcrumbs adds the dynamic-title step for the current (already-instantiated) view itself.
+5. **Route-hierarchy walking is a Flow core feature, not a breadcrumb-specific resolver.** The breadcrumb consumes the public `RouteConfiguration#getRouteHierarchy(...)`, which walks `@RouteParent` (then URL-prefix) up to the root. Flow core also resolves route titles without an instance (static `@PageTitle` or a `PageTitleGenerator`), so ancestor labels never require instantiating their views; the breadcrumbs still prefers the live `HasDynamicTitle` of the current (already-instantiated) view for the last item. See "Reuse and Proposed Adjustments → Flow core: route hierarchy and titles".
 
 6. **No connector needed.** All state is set via standard Element attributes/properties from server-side Java — `setPath` writes the `path` attribute, `setPrefixComponent` uses `SlotUtils.setSlot` for the prefix slot, `setI18n` pushes a JSON object to the `i18n` client property. The web component's overflow behaviour is entirely client-side, and the web component itself only accepts `<vaadin-breadcrumbs-item>` light-DOM children (no programmatic `items` data-array property — see web-component-api.md §6 and its Discussion). No connector file under `src/main/resources/META-INF/resources/frontend/`.
 
@@ -200,7 +200,7 @@ void rebuildFromRouter(Location currentLocation,
                       RouteConfiguration routeConfiguration);
 ```
 
-Both overloads ultimately build the trail via the same private routine (see "How `Breadcrumbs` builds the trail" below), which calls the Flow core `RouteHierarchy` walker, wraps the returned ancestor classes into `BreadcrumbsItem` instances, and hands the result to `updateChildrenInternal(trail)`. Both guard against stale callbacks: `if (!isAttached()) return;` first.
+Both overloads ultimately build the trail via the same private routine (see "How `Breadcrumbs` builds the trail" below), which calls `RouteConfiguration#getRouteHierarchy`, wraps the returned route references into `BreadcrumbsItem` instances, and hands the result to `updateChildrenInternal(trail)`. Both guard against stale callbacks: `if (!isAttached()) return;` first.
 
 `updateChildrenInternal(List<BreadcrumbsItem> trail)`:
 
@@ -434,57 +434,34 @@ Integration-tests module enables the flag at startup with `src/main/resources/va
 
 ## `@RouteParent` Annotation
 
-`com.vaadin.flow.router.RouteParent` is introduced in Flow core (see "Reuse and Proposed Adjustments → Flow core dependencies"). The breadcrumb module only reads it — it does not redefine or re-export it.
-
-Expected shape in Flow core:
-
-```java
-package com.vaadin.flow.router;
-
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
-@Documented
-public @interface RouteParent {
-    /**
-     * The view class that is the conceptual parent of the annotated
-     * {@link Route @Route} class.
-     *
-     * The parent class should itself be annotated with {@code @Route}. If
-     * it is not, consumers of this annotation (e.g. the breadcrumbs
-     * resolver) fall back to URL-prefix walking for this step.
-     */
-    Class<? extends Component> value();
-}
-```
-
-The annotation is consumed by a Flow core helper (see "Reuse and Proposed Adjustments → Flow core: route-hierarchy walker") — not by breadcrumb-specific code — so any navigation component can use it.
+`com.vaadin.flow.router.RouteParent` is provided by Flow core. It declares a route's logical parent — statically via `value()` or dynamically via a `resolver()` — independent of the layout chain; when absent, `getRouteHierarchy` falls back to URL-prefix walking. The breadcrumb module only reads it through `RouteConfiguration#getRouteHierarchy`; it neither defines nor re-exports it.
 
 ### How `Breadcrumbs` builds the trail
 
 The breadcrumb does no walking of its own. On each navigation it:
 
-1. Identifies the current route class and the current view instance from `AfterNavigationEvent#getActiveChain()`.
-2. Calls the Flow core walker to get the ancestor chain: `List<Class<? extends Component>> chain = RouteHierarchy.resolveAncestors(currentRoute, routeConfiguration);` (root-first, inclusive of `currentRoute` as the last entry — see the walker's contract in "Reuse and Proposed Adjustments").
-3. For each ancestor class in `chain` except the last, reads its `@PageTitle` and resolves its URL via `RouteConfiguration#getUrl(ancestorClass, RouteParameters.empty())`, producing `new BreadcrumbsItem(title, ancestorClass)`.
-4. For the last entry (the current route): uses `HasDynamicTitle#getPageTitle()` on the current view instance if it implements the interface, otherwise reads `@PageTitle` on the class. Constructs `new BreadcrumbsItem(title)` with no path — the current item is the non-link.
+1. Identifies the current route target and its `RouteParameters` from `AfterNavigationEvent#getActiveChain()` / `#getRouteParameters()`.
+2. Calls `routeConfiguration.getRouteHierarchy(currentTarget, parameters)` to get the trail as a `List<RouteParentReference>`, ordered root → current and cycle-guarded. Each reference carries the route target and the `RouteParameters` to resolve it with.
+3. For each reference except the last, resolves the label from the route's title metadata (instance-free — static `@PageTitle` or a `PageTitleGenerator`) and the URL via `RouteConfiguration#getUrl(target, parameters)`, producing `new BreadcrumbsItem(title, target, parameters)`.
+4. For the last reference (the current route): prefers the live `HasDynamicTitle#getPageTitle()` of the already-instantiated current view, falling back to the same instance-free resolution. Constructs `new BreadcrumbsItem(title)` with no path — the current item is the non-link.
 5. Calls `updateChildrenInternal(trail)`.
 
-Everything the breadcrumbs contributes — the dynamic-title step for the current view, the wrapping into `BreadcrumbsItem` components, the `Mode.ROUTER` guard bypass — is breadcrumb-specific. The hierarchy walking, cycle detection, and `@RouteParent`-versus-URL-prefix fallback live in Flow core.
+Everything the breadcrumbs contributes — preferring the current view's live title, wrapping into `BreadcrumbsItem` components, the `Mode.ROUTER` guard bypass — is breadcrumb-specific. The hierarchy walking, cycle detection, `@RouteParent`/URL-prefix resolution, and instance-free title resolution live in Flow core.
 
-**Flow APIs used directly by the breadcrumbs (all public):**
+**Flow APIs used directly by the breadcrumbs:**
 
 | Purpose | API call |
 |---|---|
 | Current active chain at navigation time | `AfterNavigationEvent#getActiveChain()` |
 | Current route params at navigation time | `AfterNavigationEvent#getRouteParameters()` |
 | Current location at navigation time | `AfterNavigationEvent#getLocation()` |
+| Walk the route hierarchy | `RouteConfiguration#getRouteHierarchy(Class, RouteParameters)` |
 | Resolve `Class<? extends Component>` → URL | `RouteConfiguration#getUrl(Class, RouteParameters)` |
 | Obtain the registry-scoped config | `RouteConfiguration.forRegistry(ComponentUtil.getRouter(this).getRegistry())` |
-| Read the current view's dynamic title | `HasDynamicTitle#getPageTitle()` on the view instance |
-| Read a route class's static title | `routeClass.getAnnotation(PageTitle.class).value()` |
-| Walk the route hierarchy | Flow core walker (see Reuse) |
+| Resolve an ancestor's title without an instance | Flow core instance-free title resolution (`@PageTitle` / `PageTitleGenerator`) |
+| Read the current view's live title | `HasDynamicTitle#getPageTitle()` on the view instance |
 
-**Route parameters on ancestors:** the breadcrumbs resolves ancestor URLs with `RouteParameters.empty()`, because ancestor routes may have a different parameter set from the current route. Applications that need ancestor labels with live data should use `Mode.MANUAL` and build the trail themselves (flow-api.md §9).
+**Route parameters on ancestors:** `getRouteHierarchy` returns each ancestor with the `RouteParameters` narrowed to its own route template, so the breadcrumbs resolves ancestor labels and URLs with those parameters. Applications that need ancestor labels derived from data beyond the route metadata use `Mode.MANUAL` and build the trail themselves (flow-api.md §9).
 
 ---
 
@@ -587,59 +564,17 @@ Until the signal ships, the resolver calls `UIInternals` directly and accepts th
 
 Affects: Flow core. Fits the broader direction of making Flow state reactive-first (alongside `ValueSignal`, `Signal.effect`, `HasComponentsOfType.bindChildren`).
 
-### Flow core: route-hierarchy walker — Proposed
+### Flow core: route hierarchy and titles — Dependency
 
-`@RouteParent` is generic routing metadata, so the code that reads it and walks the route hierarchy is generic too. Rather than ship breadcrumb-specific resolver logic that any future navigation component would have to duplicate, the walker lands in Flow core alongside `@RouteParent`.
+`Mode.ROUTER` builds on the following Flow core APIs, which the breadcrumb consumes but does not implement:
 
-Expected shape (names indicative; exact placement is a Flow-core decision):
+- `@RouteParent` (static `value()` or dynamic `resolver()`) — declares a route's logical parent, independent of the layout chain.
+- `RouteConfiguration#getRouteHierarchy(target, params)` — returns the trail as a cycle-guarded `List<RouteParentReference>`, root → current, resolving `@RouteParent` then URL-prefix; `getRouteParent(...)` resolves a single level.
+- Instance-free titles — `@PageTitle` (now with an optional `generator`) and `PageTitleGenerator` resolve a route's label without creating the view, so ancestor labels need no instances.
 
-```java
-// in com.vaadin.flow.router
-public final class RouteHierarchy {
+The breadcrumb adds only the `Mode.ROUTER` glue (listener wiring, wrapping references into `BreadcrumbsItem`, the guard bypass).
 
-    /**
-     * Returns the chain of route classes from the root down to and
-     * including {@code routeClass}, using {@code @RouteParent} when
-     * present and falling back to URL-prefix walking otherwise. Cycles
-     * are detected and truncated.
-     *
-     * @return a root-first list; the last element is always
-     *         {@code routeClass} when it is routable.
-     */
-    public static List<Class<? extends Component>> resolveAncestors(
-            Class<? extends Component> routeClass,
-            RouteConfiguration routeConfiguration);
-
-    /**
-     * Returns the immediate parent of {@code routeClass}, or empty if
-     * no parent can be resolved. Reads {@code @RouteParent} first, then
-     * URL-prefix walks.
-     */
-    public static Optional<Class<? extends Component>> resolveParent(
-            Class<? extends Component> routeClass,
-            RouteConfiguration routeConfiguration);
-}
-```
-
-**Algorithm contract** (implemented in Flow core; the breadcrumbs only consumes it):
-
-1. Start with `routeClass`; if it has no `@Route` annotation, return an empty list (no hierarchy to walk).
-2. Maintain `Set<Class<? extends Component>> visited`, initialised with `routeClass`.
-3. At each step: read `@RouteParent` from the current class. If present and its value has `@Route`, jump there. Otherwise (annotation absent, or target is not a `@Route`), strip the last `/`-separated segment from the current class's URL (resolved via `RouteConfiguration#getUrl`) and call `RouteConfiguration#getRoute(strippedUrl)`; use that as the parent if present.
-4. Terminate when no parent is found, when the candidate is already in `visited` (cycle), or when URL-prefix stripping produces an empty URL.
-5. Return the list root-first, inclusive of the original `routeClass` as the last element.
-
-This is additive to Flow core — one new class next to `@RouteParent`, no change to existing router API. Tests for the walker (including cycle handling and parent-without-`@Route` fallback) live with Flow core, not with the breadcrumbs module.
-
-Affects: Flow core. The breadcrumb depends on it for `Mode.ROUTER` but adds no code of its own for hierarchy walking.
-
-### `com.vaadin.flow.router.RouteParent` — Flow core dependency
-
-`@RouteParent` is not tied to breadcrumb rendering — per flow-api.md Discussion "Why `@RouteParent` rather than a breadcrumb-specific name?", the annotation belongs in `com.vaadin.flow.router` alongside `@Route`, `@RouteAlias`, `@ParentLayout`. This lets any future navigation component (back-helpers, parent-link renderers, SEO link-graph utilities) consume the same declaration.
-
-The annotation will land in Flow core and this module depends on it. Ensure `flow-components-bom` targets a Flow version that includes the `RouteParent` annotation.
-
-Affects: no flow-components module defines this annotation; the breadcrumbs module imports `com.vaadin.flow.router.RouteParent` indirectly through the Flow core `RouteHierarchy` walker.
+Affects: Flow core — no flow-components module defines any of this. `RouteConfiguration#getRouteHierarchy` / `getUrl` are public; instance-free title resolution may go through an internal helper until a public entry point lands.
 
 ### `HasComponentsOfType<T>` in Flow core — Dependency
 
@@ -673,9 +608,9 @@ No modifications.
 | 10. Navigation landmark | `Breadcrumbs implements HasAriaLabel` |
 | 11. Current page announced as current | Web component (no Flow API) |
 | 12. Directional separator flips in RTL | Web component + theme (no Flow API) |
-| 13. Flow: Default trail derived from router | `Mode.ROUTER` (default); `onAttach` registers `AfterNavigationListener`; the Flow core `RouteHierarchy.resolveAncestors(...)` walker walks `@RouteParent` + URL prefixes; the breadcrumbs adds `@PageTitle` / `HasDynamicTitle` label resolution for the returned classes |
+| 13. Flow: Default trail derived from router | `Mode.ROUTER` (default); `onAttach` registers `AfterNavigationListener`; `RouteConfiguration#getRouteHierarchy(...)` walks `@RouteParent` + URL prefixes; labels come from instance-free titles, with the current view's live `HasDynamicTitle` for the last item |
 | 14. Flow: Opting out of automatic trail population | `Mode.MANUAL` (via constructor or `setMode`); `add`/`remove`/`removeAll` throw `IllegalStateException` in `Mode.ROUTER` |
-| 15. Flow: Sitemap parent annotation overrides URL-based parent lookup | `@RouteParent` annotation in Flow core; `RouteHierarchy.resolveAncestors` consults it before URL-prefix walking |
+| 15. Flow: Sitemap parent annotation overrides URL-based parent lookup | `@RouteParent`; `RouteConfiguration#getRouteHierarchy` consults it before URL-prefix walking |
 | 16. Flow: Routes can dynamically supply their breadcrumb contribution | Covered via the manual-construction pattern: `Mode.MANUAL` + application-side data loading + `add(...)` (see flow-api.md Discussion "How is requirement 16 … covered without a dedicated API?"). No new Flow API in this iteration — explicitly documented as a possible future addition. |
 
 ---
@@ -686,7 +621,11 @@ Questions raised during spec production, with their resolutions.
 
 **Q: How does `Mode.ROUTER` react to navigation?**
 
-`onAttach` registers `UI.addAfterNavigationListener(event -> rebuildFromRouter(...))` and holds the returned `Registration` in a transient field. `onDetach` unregisters. Each navigation rebuilds the trail by calling the Flow core `RouteHierarchy.resolveAncestors(...)` walker, wrapping each returned class into a `BreadcrumbsItem`, and handing the list to an internal `updateChildrenInternal(List<BreadcrumbsItem>)` that bypasses the `Mode.ROUTER` guard on `add`/`remove`/`removeAll` — user code cannot reach this path.
+`onAttach` registers `UI.addAfterNavigationListener(event -> rebuildFromRouter(...))` and holds the returned `Registration` in a transient field. `onDetach` unregisters. Each navigation rebuilds the trail by calling `RouteConfiguration#getRouteHierarchy(...)`, wrapping each returned route reference into a `BreadcrumbsItem`, and handing the list to an internal `updateChildrenInternal(List<BreadcrumbsItem>)` that bypasses the `Mode.ROUTER` guard on `add`/`remove`/`removeAll` — user code cannot reach this path.
+
+**Q: Why does the trail build on `RouteConfiguration#getRouteHierarchy` rather than a breadcrumb-specific walker?**
+
+Hierarchy walking, cycle handling, `@RouteParent` resolution, and instance-free titles are generic routing concerns provided by Flow core. Consuming `RouteConfiguration#getRouteHierarchy` keeps the breadcrumb free of duplicated walking logic; the component keeps only the `Mode.ROUTER` glue. See "Reuse and Proposed Adjustments → Flow core: route hierarchy and titles".
 
 **Q: What happens if the user calls `setMode(Mode.ROUTER)` on a trail that already has children?**
 
@@ -722,5 +661,4 @@ guidelines/10-i18n-and-a11y.md prescribes `Objects.requireNonNull` in `setI18n`,
 
 **Q: Why does `Breadcrumbs` expose theme variants?**
 
-The web component ships theme variants — `theme="slash"` in base styles, `theme="primary"` in Lumo, and `theme="accent"` in Aura (web-component-spec.md "Theme" table) — so the Flow wrapper exposes them the standard way rather than inventing setters. `BreadcrumbsVariant` mirrors the shipped tokens (`SLASH`, `LUMO_PRIMARY`, `AURA_ACCENT`), since guidelines/09-theming.md requires each `getVariantName()` to match a real `theme` token. An earlier revision exposed no variants because the web component had none; the slash variant changed that. Because `HasThemeVariant` lives in `vaadin-flow-components-base` and needs no unreleased Flow core API, this work can land ahead of the router-related tasks (flow-tasks.md Task 3).
-
+The web component ships theme variants — `theme="slash"` in base styles, `theme="primary"` in Lumo, and `theme="accent"` in Aura (web-component-spec.md "Theme" table) — so the Flow wrapper exposes them the standard way rather than inventing setters. `BreadcrumbsVariant` mirrors the shipped tokens (`SLASH`, `LUMO_PRIMARY`, `AURA_ACCENT`), since guidelines/09-theming.md requires each `getVariantName()` to match a real `theme` token. An earlier revision exposed no variants because the web component had none; the slash variant changed that.

--- a/packages/breadcrumbs/spec/flow-tasks.md
+++ b/packages/breadcrumbs/spec/flow-tasks.md
@@ -11,11 +11,7 @@ Tasks are pointers into the spec, not a second copy of it. The spec sections fie
 
 External Flow core dependencies (not implemented by these tasks):
 - `com.vaadin.flow.component.HasComponentsOfType<T>` — Flow core (available; implemented in Task 1, guarded in Task 6)
-- `com.vaadin.flow.router.RouteParent` annotation — Flow core (required by Task 7 + Task 11)
-- `com.vaadin.flow.router.RouteHierarchy.resolveAncestors(...)` walker — Flow core (required by Task 7)
-The Flow-version bump in `flow-components-bom` is part of Task 7 — the first task that needs an unreleased Flow core API. Tasks 1–6 build against the current baseline Flow version.
-
-Ordering rationale: Tasks 1–6 depend only on released Flow APIs, so they can proceed while `@RouteParent` / `RouteHierarchy` are still in flight. The Flow-core-gated work (Task 7 router wiring) and the integration tests that exercise it (Tasks 10, 11) come after.
+- `@RouteParent`, `RouteConfiguration#getRouteHierarchy(...)`, and instance-free titles — Flow core (required by Task 7 + Task 11)
 
 Do NOT reorder tasks without verifying the dependency graph.
 Do NOT add tasks for features not in the spec.
@@ -37,7 +33,7 @@ Do NOT add tasks for features not in the spec.
 **Requirements:** —
 **Depends on:** —
 
-Create the three sub-modules (`-flow`, `-flow-integration-tests`, `-testbench`) with `pom.xml` wiring, empty class shells matching the annotations and `implements` clauses from the spec (empty bodies — Mode enum, constructors, `setI18n`, the theme-variant surface, and the `Mode.ROUTER` guard land in later tasks), and the full feature-flag plumbing (`BreadcrumbsFeatureFlagProvider`, ServiceLoader registration, `ExperimentalFeatureException`, `onAttach` check). At this point `Breadcrumbs` implements `HasSize, HasStyle, HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>` — the child-management methods come as inherited defaults, with the `Mode.ROUTER` guard added in Task 6 — and gains `HasThemeVariant<BreadcrumbsVariant>` in Task 3. The module builds against the current baseline Flow version — no version bump yet. The IT module enables the feature flag via `src/main/resources/vaadin-featureflags.properties`. The smoke test instantiates `Breadcrumbs` (which currently does nothing in its body) and the `SerializableTest` round-trips it.
+Create the three sub-modules (`-flow`, `-flow-integration-tests`, `-testbench`) with `pom.xml` wiring, empty class shells matching the annotations and `implements` clauses from the spec (empty bodies — Mode enum, constructors, `setI18n`, the theme-variant surface, and the `Mode.ROUTER` guard land in later tasks), and the full feature-flag plumbing (`BreadcrumbsFeatureFlagProvider`, ServiceLoader registration, `ExperimentalFeatureException`, `onAttach` check). At this point `Breadcrumbs` implements `HasSize, HasStyle, HasAriaLabel, HasComponentsOfType<BreadcrumbsItem>` — the child-management methods come as inherited defaults, with the `Mode.ROUTER` guard added in Task 6 — and gains `HasThemeVariant<BreadcrumbsVariant>` in Task 3. The IT module enables the feature flag via `src/main/resources/vaadin-featureflags.properties`. The smoke test instantiates `Breadcrumbs` (which currently does nothing in its body) and the `SerializableTest` round-trips it.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/pom.xml` (create)
@@ -56,7 +52,7 @@ Create the three sub-modules (`-flow`, `-flow-integration-tests`, `-testbench`) 
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/src/main/java/com/vaadin/flow/component/breadcrumbs/testbench/BreadcrumbsElement.java` (create — `@Element("vaadin-breadcrumbs")`, empty body)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/src/main/java/com/vaadin/flow/component/breadcrumbs/testbench/BreadcrumbsItemElement.java` (create — `@Element("vaadin-breadcrumbs-item")`, empty body)
 - `pom.xml` (modify — add `vaadin-breadcrumbs-flow-parent` module)
-- `flow-components-bom/pom.xml` (modify — add the new module if the BOM aggregates modules; no Flow version bump yet — that lands in Task 7)
+- `flow-components-bom/pom.xml` (modify — add the new module if the BOM aggregates modules)
 
 **Tests:**
 - [ ] `new Breadcrumbs()` returns a non-null instance whose element tag is `vaadin-breadcrumbs`
@@ -106,7 +102,7 @@ Implement all seven `BreadcrumbsItem` constructors (mirroring `SideNavItem`'s ov
 **Requirements:** 5
 **Depends on:** 1
 
-Add the `BreadcrumbsVariant` enum implementing `ThemeVariant` with `SLASH("slash")`, `LUMO_PRIMARY("primary")`, and `AURA_ACCENT("accent")` (the web component's `theme="slash"` base separator plus the Lumo / Aura link-color variants), following the `SideNavVariant` shape. Add `implements HasThemeVariant<BreadcrumbsVariant>` to `Breadcrumbs`; every variant method (`addThemeVariants` / `removeThemeVariants` / `setThemeVariants` / `setThemeVariant` / `bindThemeVariant` / `bindThemeVariants`) comes from the shared interface as a default — the component adds no code beyond the type parameter. `HasThemeVariant` and `ThemeVariant` are in `vaadin-flow-components-base` (already on the classpath via `HasPrefix`), so this task does not need the Flow core bump. Each enum value maps to a `theme` token the web component actually honours (guidelines/09-theming.md).
+Add the `BreadcrumbsVariant` enum implementing `ThemeVariant` with `SLASH("slash")`, `LUMO_PRIMARY("primary")`, and `AURA_ACCENT("accent")` (the web component's `theme="slash"` base separator plus the Lumo / Aura link-color variants), following the `SideNavVariant` shape. Add `implements HasThemeVariant<BreadcrumbsVariant>` to `Breadcrumbs`; every variant method (`addThemeVariants` / `removeThemeVariants` / `setThemeVariants` / `setThemeVariant` / `bindThemeVariant` / `bindThemeVariants`) comes from the shared interface as a default — the component adds no code beyond the type parameter. `HasThemeVariant` and `ThemeVariant` are in `vaadin-flow-components-base` (already on the classpath via `HasPrefix`). Each enum value maps to a `theme` token the web component actually honours (guidelines/09-theming.md).
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/BreadcrumbsVariant.java` (create)
@@ -205,15 +201,14 @@ Guard the inherited `HasComponentsOfType<BreadcrumbsItem>` child-management meth
 
 ## Task 7: `Breadcrumbs` — `Mode.ROUTER` listener wiring + router trail builder
 
-**Spec sections:** Key Design Decisions §3 + §5, Component Classes → `Breadcrumbs` (Router mode wiring, `rebuildFromRouter`), `@RouteParent` Annotation → How `Breadcrumbs` builds the trail, Reuse and Proposed Adjustments → RouteParent, RouteHierarchy
+**Spec sections:** Key Design Decisions §3 + §5, Component Classes → `Breadcrumbs` (Router mode wiring, `rebuildFromRouter`), `@RouteParent` Annotation → How `Breadcrumbs` builds the trail, Reuse and Proposed Adjustments → Flow core: route hierarchy and titles
 **Requirements:** 13, 15
 **Depends on:** 6
 
-Bump the Flow version in `flow-components-bom/pom.xml` to a release that includes `com.vaadin.flow.router.RouteParent` and `RouteHierarchy.resolveAncestors(...)`. Register `UI#addAfterNavigationListener(this::rebuildFromRouter)` in `onAttach` when `mode == Mode.ROUTER`, hold the returned `Registration` in a `transient navigationRegistration` field, and unregister in `onDetach`. Add both `rebuildFromRouter` overloads (event-driven + direct-state for initial attach reading `UIInternals.getActiveViewLocation()` / `getActiveRouterTargetsChain()`); both guard with `if (!isAttached()) return;` and delegate to a private builder that calls `RouteHierarchy.resolveAncestors(currentRoute, routeConfiguration)` from Flow core, wraps every ancestor class except the last as `new BreadcrumbsItem(title, ancestorClass)` (title from `@PageTitle`), wraps the last entry as `new BreadcrumbsItem(title)` with no path (title from `HasDynamicTitle#getPageTitle()` on the active view instance if present, otherwise its class `@PageTitle`), and hands the list to `updateChildrenInternal`. Also wire `Mode.MANUAL → Mode.ROUTER` transitions in `setMode` to register the listener and trigger an initial `rebuildFromRouter` if currently attached.
+Register `UI#addAfterNavigationListener(this::rebuildFromRouter)` in `onAttach` when `mode == Mode.ROUTER`, hold the returned `Registration` in a `transient navigationRegistration` field, and unregister in `onDetach`. Add both `rebuildFromRouter` overloads (event-driven + direct-state for initial attach reading `UIInternals.getActiveViewLocation()` / `getActiveRouterTargetsChain()`); both guard with `if (!isAttached()) return;` and delegate to a private builder that calls `routeConfiguration.getRouteHierarchy(currentTarget, parameters)` for the root → current trail of `RouteParentReference`s, wraps every reference except the last as `new BreadcrumbsItem(title, target, parameters)` (label from instance-free title resolution), wraps the last entry as `new BreadcrumbsItem(title)` with no path (label from the current view's live `HasDynamicTitle#getPageTitle()` if present, otherwise instance-free resolution), and hands the list to `updateChildrenInternal`. Also wire `Mode.MANUAL → Mode.ROUTER` transitions in `setMode` to register the listener and trigger an initial `rebuildFromRouter` if currently attached.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/main/java/com/vaadin/flow/component/breadcrumbs/Breadcrumbs.java` (modify)
-- `flow-components-bom/pom.xml` (modify — bump Flow version to a release that ships `@RouteParent` and `RouteHierarchy`)
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/BreadcrumbsModeTest.java` (modify — extend the existing test class with router-listener cases using stubbed `RouteConfiguration` / mocked `UI`)
 
 **Tests:**
@@ -255,15 +250,18 @@ Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec — eve
 
 ## Task 9: Manual-mode integration test view + IT
 
-**Spec sections:** Module / Package Layout (integration-tests file list), Component Classes → `Breadcrumbs` (`Mode.MANUAL`)
-**Requirements:** 1, 9, 14
+**Spec sections:** Module / Package Layout (integration-tests file list), Component Classes → `Breadcrumbs` (`Mode.MANUAL`), Coverage (req 16 row)
+**Requirements:** 1, 9, 14, 16
 **Depends on:** 6, 8
 
 Add a Flow view `ManualBreadcrumbsPage` that constructs `new Breadcrumbs(Mode.MANUAL)`, adds three items declaratively (one with a path-class, one with a string path, one with no path representing the current page), and exposes test affordances for the IT (`@Id` buttons to add / remove items at runtime to exercise reactive updates). The IT class `ManualBreadcrumbsIT` opens the view, uses `BreadcrumbsElement` + `BreadcrumbsItemElement` to assert the rendered trail, then exercises an add and a remove to confirm `Mode.MANUAL` reactive updates flow to the DOM.
 
+This task also covers requirement 16 (routes dynamically supplying their breadcrumbs contribution). Add a second `Mode.MANUAL` scenario — a view that simulates loading domain data and builds a trail containing a data-derived ancestor that has **no backing `@Route`** plus a data-derived current-page label (e.g. `Home › Customers › Enterprise › Acme Corp`, where `Enterprise` is the loaded customer's segment and `Acme Corp` is the loaded customer name). This is the part of req 16 that `Mode.ROUTER` cannot express — `getRouteHierarchy` only yields items for matched routes — so the manual-construction path is what satisfies it. The dynamic current-view label half of req 16 is already exercised by Task 10's `HasDynamicTitle` case.
+
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/src/main/java/com/vaadin/flow/component/breadcrumbs/tests/ManualBreadcrumbsPage.java` (create)
-- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/ManualBreadcrumbsIT.java` (create)
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/src/main/java/com/vaadin/flow/component/breadcrumbs/tests/DataDrivenBreadcrumbsPage.java` (create — `Mode.MANUAL` view that builds a trail from simulated loaded data, covering req 16)
+- `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/src/test/java/com/vaadin/flow/component/breadcrumbs/tests/ManualBreadcrumbsIT.java` (create — asserts both the static manual trail and the data-driven req-16 trail)
 
 **Tests:**
 - [ ] Initial render: `getItems()` returns three items whose `getText()` values match the seeded labels
@@ -271,6 +269,7 @@ Add a Flow view `ManualBreadcrumbsPage` that constructs `new Breadcrumbs(Mode.MA
 - [ ] The last item's `getPath()` is empty / null; the others return their assigned paths
 - [ ] Clicking the "add item" affordance inserts a new item into the trail, observable via `BreadcrumbsElement#getItems()`
 - [ ] Clicking the "remove item" affordance removes the matching item
+- [ ] (req 16) The data-driven view renders a trail whose labels match the loaded data in order — including a data-derived ancestor with no backing `@Route` (e.g. `Enterprise`) and a data-derived current-page label (e.g. `Acme Corp`)
 
 **Acceptance criteria:**
 - [ ] `mvn verify -am -pl vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests -Dit.test='ManualBreadcrumbsIT*' -DskipUnitTests` passes
@@ -310,7 +309,7 @@ Add a small route hierarchy of four `@Route`'d views, each with a `@PageTitle` (
 **Requirements:** 15
 **Depends on:** 7, 8
 
-Add a view `RouteParentPage` whose `@Route` URL would, under URL-prefix walking, resolve to one parent — but which carries `@RouteParent(OtherView.class)` to declare a different conceptual parent. The IT navigates to the view and asserts that the rendered trail walks through the declared parent, not the URL-derived one. This task verifies the Flow core `RouteHierarchy` walker's `@RouteParent`-first behaviour end-to-end through the breadcrumbs.
+Add a view `RouteParentPage` whose `@Route` URL would, under URL-prefix walking, resolve to one parent — but which carries `@RouteParent(OtherView.class)` to declare a different conceptual parent. The IT navigates to the view and asserts that the rendered trail walks through the declared parent, not the URL-derived one. This task verifies `RouteConfiguration#getRouteHierarchy`'s `@RouteParent`-first behaviour end-to-end through the breadcrumbs.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/src/main/java/com/vaadin/flow/component/breadcrumbs/tests/RouteParentPage.java` (create — declared-parent view + the conceptual parent it points to)

--- a/packages/breadcrumbs/spec/web-component-tasks.md
+++ b/packages/breadcrumbs/spec/web-component-tasks.md
@@ -1,0 +1,38 @@
+# Breadcrumbs Implementation Tasks (index)
+
+<!--
+This is a slim, generated index of the implementation tasks. It is NOT the source of truth.
+The source of truth is the GitHub issues in vaadin/web-components, label `vaadin-breadcrumbs`,
+titled `[breadcrumbs] Task N: <desc>`. Task state (which tasks exist, which are done) is read
+live from GitHub by the orchestrator and the implementation skill — this file only enumerates the
+issue numbers so the set can be reconstructed offline.
+
+Format: one line per task — `- Task N — <short title> — #<issue>` with an optional `(depends on #<issue>, ...)`.
+
+Do NOT add a Discussion section, full task bodies, shadow DOM structures, property tables, or behavioral
+logic here. The issue body holds the concise task content; the spec holds the full detail.
+-->
+
+Source of truth: GitHub issues in vaadin/web-components, label `vaadin-breadcrumbs`. Umbrella: #7960.
+This file is generated; task state is read live from GitHub.
+
+## Spec References
+
+- [web-component-spec.md](web-component-spec.md)
+- [requirements.md](requirements.md)
+- [web-component-api.md](web-component-api.md)
+
+## Tasks
+
+- Task 1 — package scaffolding and element shells — #11826
+- Task 2 — BreadcrumbsItem: link vs non-link rendering with path — #11827
+- Task 3 — BreadcrumbsItem: prefix slot and has-prefix reflection — #11828
+- Task 4 — BreadcrumbsItem: current state and aria-current="page" — #11829
+- Task 5 — render the trail — #11830
+- Task 6 — RTL: directional flip — #11831
+- Task 7 — Lumo theme — #11832
+- Task 8 — Aura theme — #11834
+- Task 9 — overflow behavior end-to-end — #11835
+- Task 10 — keyboard navigation in the overflow overlay — #11836
+- Task 11 — integration & validation — #11837
+- Task 12 — documentation pass — #11838


### PR DESCRIPTION
Depends on #11923 

Aligns the breadcrumbs Flow spec, API, and tasks with Flow core [PR #24550](https://github.com/vaadin/flow/pull/24550), which ships the route-hierarchy and instance-free-title APIs the router mode needs.

- **Trail builder** — uses the public `RouteConfiguration#getRouteHierarchy(target, params)` (returns `List<RouteParentReference>`, root→current, cycle-guarded) instead of the earlier proposed `RouteHierarchy.resolveAncestors` walker.
- **Instance-free titles** — ancestor labels resolve from `@PageTitle` / `PageTitleGenerator` without instantiating views; the current view's live `HasDynamicTitle` is still preferred for the last item. Ancestors resolve with the `RouteParameters` narrowed to their own template.
- **`@RouteParent`** — now documented as shipping in PR #24550 (static `value()` + dynamic `resolver()`); removed the speculative annotation/algorithm code blocks in favour of a PR reference.
- **Reuse section** — the "route-hierarchy walker — Proposed" and separate `@RouteParent` dependency subsections collapse into one concise "Flow core: route hierarchy and titles (PR #24550)" dependency note.
- **Tasks** — Task 7 (router wiring) and the dependency header now reference PR #24550; the version-bump note updated accordingly.

Discussion entries added/updated for the API change; spec bodies kept current-state-only and defer API detail to the Flow PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)