### PR TITLE
fix: ensure slider thumb target size and prevent clicks on track

### DIFF
--- a/packages/slider/src/styles/vaadin-slider-base-styles.js
+++ b/packages/slider/src/styles/vaadin-slider-base-styles.js
@@ -105,16 +105,21 @@ export const sliderStyles = css`
     grid-row: 1;
     grid-column: track-start / track-end;
     appearance: none;
-    width: 100%;
-    height: 100%;
+    width: calc(100% + max(0px, 24px - var(--_thumb-width)));
+    height: var(--_thumb-height);
     font: inherit;
     margin: 0;
+    margin-inline: calc(min(0px, var(--_thumb-width) - 24px) / 2);
     background: transparent;
     outline: 0;
     -webkit-tap-highlight-color: transparent;
     cursor: inherit;
     touch-action: none;
     z-index: 999;
+
+    @media (pointer: coarse) {
+      pointer-events: none;
+    }
   }
 
   [part='marks'] {

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -173,7 +173,7 @@ class RangeSlider extends FieldMixin(
 
         ::slotted(input:last-of-type) {
           clip-path: inset(
-            0 0 0
+            min(0px, (var(--_thumb-height) - 24px) / 2) 0 min(0px, (var(--_thumb-height) - 24px) / 2)
               clamp(
                 0%,
                 var(--_thumb-width) / 2 + var(--start-value) * var(--_track-width) +
@@ -185,14 +185,14 @@ class RangeSlider extends FieldMixin(
 
         :host([dir='rtl']) ::slotted(input:last-of-type) {
           clip-path: inset(
-            0
+            min(0px, (var(--_thumb-height) - 24px) / 2)
               clamp(
                 0%,
                 var(--_thumb-width) / 2 + var(--start-value) * var(--_track-width) +
                   (var(--end-value) - var(--start-value)) * var(--_track-width) / 2,
                 100%
               )
-              0 0
+              min(0px, (var(--_thumb-height) - 24px) / 2) 0
           );
         }
       `,

--- a/packages/slider/src/vaadin-slider-mixin.js
+++ b/packages/slider/src/vaadin-slider-mixin.js
@@ -85,18 +85,21 @@ export const SliderMixin = (superClass) =>
 
           ${tag} > input::-webkit-slider-thumb {
             appearance: none;
-            width: var(--_thumb-width);
-            height: 100%;
+            width: max(24px, var(--_thumb-width));
+            height: max(24px, var(--_thumb-height));
+            margin-block: calc((var(--_thumb-height) - 24px) / 2);
             /* iOS needs these */
             background: transparent;
             box-shadow: none;
+            pointer-events: auto;
           }
 
           ${tag} > input::-moz-range-thumb {
             border: 0;
             background: transparent;
-            width: var(--_thumb-width);
-            height: 100%;
+            width: max(24px, var(--_thumb-width));
+            height: max(24px, var(--_thumb-height));
+            pointer-events: auto;
           }
 
           ${tag}:not([readonly]) > input::-webkit-slider-thumb {


### PR DESCRIPTION
Fixes #11904

Make sure the thumb click/touch target size is at least 24x24px. Disallow clicks on the track on touch devices, to prevent accidental value changes when scrolling the view.