### PR TITLE
docs: drop separator CSS property from breadcrumbs Flow spec

### DIFF
--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -291,7 +291,6 @@ breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead
 | `i18n.moreItems` | `BreadcrumbsI18n#setMoreItems(String)` / `getMoreItems()` | overflow button accessible label |
 | `<nav>` landmark rendering | — (automatic in web component) | no Flow API needed |
 | `aria-label` on the host | `Breadcrumbs implements HasAriaLabel` | `setAriaLabel(String)` / `getAriaLabel()` from Flow core |
-| `--vaadin-breadcrumbs-separator` CSS custom property | `Breadcrumbs#getStyle().set("--vaadin-breadcrumbs-separator", ...)` via `HasStyle` | per `DESIGN_GUIDELINES.md` "Styling lives in CSS, not Java" — no dedicated Java setter |
 | RTL separator flipping | — (handled in CSS when `dir="rtl"`) | inherited from the application / `HasStyle` |
 | `theme` variants (`slash`, `primary`, `accent`; web-component-spec.md "Theme") | `Breadcrumbs implements HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.…)` | typed theme variants; `getVariantName()` returns the `theme` token |
 | Flow: auto-populate from router | `Breadcrumbs.Mode` enum (`ROUTER`, `MANUAL`); `new Breadcrumbs()` / `new Breadcrumbs(Mode)`; `setMode(Mode)` / `getMode()` | default `ROUTER`; `add`/`remove`/`removeAll` throw `IllegalStateException` while in `ROUTER` mode |
@@ -313,7 +312,7 @@ It is covered by manual construction: the application loads the data it needs in
 
 **Q: Why is there no section for the separator (reqs 4, 5, 12)?**
 
-Separator presence (req 4), customisation (req 5), and RTL flipping (req 12) are all handled entirely by the web component and the theme — there is no Flow-specific Java API to demonstrate. Per `DESIGN_GUIDELINES.md` "Styling lives in CSS, not Java", visual customisations like the separator icon are exposed as CSS custom properties on the host, not as Java setters: applications use `HasStyle#getStyle().set("--vaadin-breadcrumbs-separator", ...)` or a theme stylesheet. A dedicated "here's how to call `getStyle()`" section would duplicate generic Flow knowledge without adding Breadcrumbs-specific value, so these requirements are documented solely in the Web API coverage table (the `--vaadin-breadcrumbs-separator` row and the RTL row).
+Separator presence (req 4), customisation (req 5), and RTL flipping (req 12) are all handled entirely by the web component and the theme — there is no Flow-specific Java API to demonstrate.
 
 **Q: Why no click listener on `BreadcrumbsItem`?**
 

--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -151,7 +151,7 @@ public class Breadcrumbs extends Component
 **Implemented mixin interfaces:**
 
 - `HasSize` — covers requirement that the component can be sized by the application (universal API hygiene).
-- `HasStyle` — required for requirement 5 (customise separator via `--vaadin-breadcrumbs-separator` CSS custom property) and for `getStyle()` access per `DESIGN_GUIDELINES.md` "Styling lives in CSS, not Java".
+- `HasStyle` — covers requirement that the component can be styled by the application (universal API hygiene).
 - `HasAriaLabel` — requirement 10 (navigation landmark accessible name). Flow core interface.
 - `HasThemeVariant<BreadcrumbsVariant>` — requirement 5 plus general theming. Shared interface from `vaadin-flow-components-base`. See "Theme Variants" for the variant enum and the inherited method surface.
 - `HasComponentsOfType<BreadcrumbsItem>` — requirement 1, 9 (add/remove/manage items with compile-time type safety). Flow core interface. All inherited mutating methods (see the class skeleton above) are overridden to throw `IllegalStateException` when `Mode.ROUTER` (unless the internal `routerUpdateInProgress` flag is set).
@@ -600,7 +600,7 @@ No modifications.
 | 2. Current page indication | `BreadcrumbsItem(String text)` (no path) — web component renders as non-link, applies `current` state attribute |
 | 3. Optionally omitting the current page | No API — application chooses whether to add a no-path final item |
 | 4. Visual separator between items | Web component + theme (no Flow API) |
-| 5. Customizable separator appearance | `HasStyle` → `getStyle().set("--vaadin-breadcrumbs-separator", ...)`; `HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.SLASH)` for the bundled slash separator |
+| 5. Customizable separator appearance | `HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.SLASH)` for the bundled slash separator |
 | 6. Overflow collapse of intermediate items | Web component (no Flow API) |
 | 7. Expanding collapsed items | Web component; `BreadcrumbsI18n.moreItems` sets the overflow button's `aria-label` |
 | 8. Items may display icons | `BreadcrumbsItem implements HasPrefix` + constructor overloads ending in `Component prefixComponent` |


### PR DESCRIPTION
## Description

The `--vaadin-breadcrumbs-separator` was renamed to `--vaadin-breadcrumbs-separator-icon` in https://github.com/vaadin/web-components/pull/11868 but the change was not reflected in the Flow spec. Removed it from there altogether, also simplified the spec:

- `HasStyle` is now described  as a universal styling contract (like `HasSize`).
- Removed mention of `DESIGN_GUIDELINES.md` - guidelines have been restructured.
- Removed the `--vaadin-breadcrumbs-separator` row from the Web API coverage table (flow-api.md).
- Requirement 5 coverage now points to `HasThemeVariant<BreadcrumbsVariant>` (the `slash` variant).
- Shortened the "Why is there no section for the separator" discussion entry.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
