### PR TITLE
fix: incorrect white-space character in breadcrumbs icon pseudos

### DIFF
--- a/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-base-styles.js
+++ b/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-base-styles.js
@@ -59,7 +59,7 @@ export const breadcrumbsStyles = css`
   }
 
   [part='overflow-button']::before {
-    content: '\\e2003' / '';
+    content: '\\2003' / '';
     display: inline-flex;
     align-items: center;
     width: var(--vaadin-icon-size, 1lh);
@@ -75,7 +75,7 @@ export const breadcrumbsStyles = css`
   }
 
   [part='overflow']::after {
-    content: '\\e2003' / '';
+    content: '\\2003' / '';
     display: inline-flex;
     align-items: center;
     width: var(--vaadin-icon-size, 1lh);

--- a/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
+++ b/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
@@ -51,7 +51,7 @@ export const breadcrumbsItemStyles = css`
   }
 
   :host::after {
-    content: '\\e2003' / '';
+    content: '\\2003' / '';
     display: inline-flex;
     align-items: center;
     width: var(--vaadin-icon-size, 1lh);


### PR DESCRIPTION
I mistakenly included the unnecessary `e` (for extended codespace) in the character code.