### PR TITLE
docs: list ellipsis icon in breadcrumbs spec reuse section

### DIFF
--- a/packages/breadcrumbs/spec/web-component-spec.md
+++ b/packages/breadcrumbs/spec/web-component-spec.md
@@ -218,13 +218,15 @@ Internal behavior:
 
 ### `packages/component-base/src/styles/style-props.js` — Modification needed
 
-Add two icon definitions to the shared icon set:
+Add three icon definitions to the shared icon set:
 
 - `--_vaadin-icon-chevron-right` — the default separator icon. The breadcrumb separator defaults to a right-pointing chevron, which did not exist in the shared icon set.
 - `--_vaadin-icon-slash` — the icon bound to `--vaadin-breadcrumbs-separator-icon` by the `theme="slash"` variant (see "Theme" table on the container).
+- `--_vaadin-icon-ellipsis` — the default for `--vaadin-breadcrumbs-overflow-icon`, the overflow button's mask-image icon (see the CSS custom properties table on the container).
 
 ```css
 --_vaadin-icon-chevron-right: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>');
+--_vaadin-icon-ellipsis: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>');
 --_vaadin-icon-slash: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"><rect x="13.7812" y="4.22583" width="1.5" height="16" rx="0.75" transform="rotate(20 13.7812 4.22583)" fill="currentColor"/></svg>');
 ```
 


### PR DESCRIPTION
<!-- Why this change was made. Focus on the problem and context. -->
The CSS custom properties table lists `--vaadin-breadcrumbs-overflow-icon` defaulting to `--_vaadin-icon-ellipsis`, but the Reuse and Proposed Adjustments section only declared the `--_vaadin-icon-chevron-right` and `--_vaadin-icon-slash` additions to `style-props.js`. The ellipsis icon is breadcrumbs-only (the overflow button) and was added to the shared set alongside them, so the section was missing one entry.

<!-- The non-obvious parts of what changed. Skip if the diff speaks for itself. -->
- Add `--_vaadin-icon-ellipsis` to the `style-props.js` reuse entry (bullet + CSS), matching the shipped definition.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
