### PR TITLE
docs: reduce duplication between breadcrumbs flow-api and flow-spec

### DIFF
--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -81,7 +81,7 @@ breadcrumbs.add(
 breadcrumbs.setI18n(new BreadcrumbsI18n().setMoreItems("Show hidden items"));
 ```
 
-**Why this shape:** Overflow collapse and the expansion menu opened by the overflow indicator (req 7) are handled entirely inside the web component — the collapsed items reappear as menu rows sourced from the same `BreadcrumbsItem` components the container already holds, so no Flow-side surface is needed to wire them up. The only Flow-visible concern is the overflow indicator's accessible label, localised via a nested `BreadcrumbsI18n` class following the `SideNavI18n` / `MenuBarI18n` convention: `Serializable`, `@JsonInclude(JsonInclude.Include.NON_NULL)`, fluent setters. Exposed via `setI18n(BreadcrumbsI18n)` / `getI18n()` on `Breadcrumbs`.
+**Why this shape:** Overflow collapse and the expansion menu opened by the overflow indicator (req 7) are handled entirely inside the web component — the collapsed items reappear as menu rows sourced from the same `BreadcrumbsItem` components the container already holds, so no Flow-side surface is needed to wire them up. The only Flow-visible concern is the overflow indicator's accessible label, localised via a nested `BreadcrumbsI18n` class following the `SideNavI18n` / `MenuBarI18n` convention, exposed via `setI18n(BreadcrumbsI18n)` / `getI18n()` on `Breadcrumbs` (see flow-spec.md "i18n" for the class shape).
 
 ---
 
@@ -298,7 +298,7 @@ breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead
 | `aria-current="page"` on current item | — (set automatically by the web component) | no Flow API needed |
 | `slot="prefix"` on item | `BreadcrumbsItem implements HasPrefix` → `setPrefixComponent(Component)` | shared mixin from `vaadin-flow-components-base` |
 | Programmatic items data array | — (no such property on the web component, see web-component-api.md §6) | not applicable; Flow manages items as a tree of `BreadcrumbsItem` components via `HasComponentsOfType<BreadcrumbsItem>` |
-| `i18n` JS property | `Breadcrumbs#setI18n(BreadcrumbsI18n)` / `getI18n()` | nested class; `Serializable`, `@JsonInclude(NON_NULL)`, fluent setters |
+| `i18n` JS property | `Breadcrumbs#setI18n(BreadcrumbsI18n)` / `getI18n()` | nested i18n class (see flow-spec.md "i18n") |
 | `i18n.moreItems` | `BreadcrumbsI18n#setMoreItems(String)` / `getMoreItems()` | overflow button accessible label |
 | `<nav>` landmark rendering | — (automatic in web component) | no Flow API needed |
 | `aria-label` on the host | `Breadcrumbs implements HasAriaLabel` | `setAriaLabel(String)` / `getAriaLabel()` from Flow core |

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -338,7 +338,7 @@ Flow core's `Signal.effect(component, Runnable)` already provides the primitive 
 
 **Q: What happens if `@RouteParent` forms a cycle or points at a class without `@Route`?**
 
-Flow core handles both: `RouteConfiguration#getRouteHierarchy` is cycle-guarded (it stops when a target repeats), and a parent that cannot be resolved from `@RouteParent` falls back to URL-prefix walking. The breadcrumb relies on that behaviour rather than implementing its own.
+Flow core handles both — `getRouteHierarchy` is cycle-guarded and falls back to URL-prefix walking when `@RouteParent` is absent. The breadcrumb relies on that rather than implementing its own; see flow-spec.md "How `Breadcrumbs` builds the trail".
 
 **Q: Why `@RouteParent` rather than a breadcrumb-specific name?**
 

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -38,7 +38,7 @@ breadcrumbs.add(
   - `MANUAL` (the application manages the items).
 - The mode is chosen at construction — `new Breadcrumbs()` defaults to `ROUTER`, `new Breadcrumbs(Mode.MANUAL)` is explicit.
 - Adding or removing children while in `ROUTER` mode throws `IllegalStateException`, so the two models never silently mix.
-- In `MANUAL` mode, `Breadcrumbs` is a standard Flow container — it implements `HasComponentsOfType<BreadcrumbsItem>` and accepts items through the inherited `add(BreadcrumbsItem...)` / `addComponentAsFirst(BreadcrumbsItem)` / `addComponentAtIndex(int, BreadcrumbsItem)` / `remove(BreadcrumbsItem...)` / `removeAll()` methods, with compile-time enforcement that only `BreadcrumbsItem` instances can be added.
+- In `MANUAL` mode, `Breadcrumbs` is a standard Flow container implementing `HasComponentsOfType<BreadcrumbsItem>`, whose inherited typed container methods accept only `BreadcrumbsItem` instances at compile time (flow-spec.md "Component Classes" lists the full method set).
 - The web component itself accepts only `<vaadin-breadcrumbs-item>` light-DOM children, so the Flow component-tree model maps directly to the underlying DOM.
 - `BreadcrumbsItem` offers the same constructor overloads as `SideNavItem`:
   - `(label)` for the current page (no path),
@@ -297,7 +297,7 @@ breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead
 | Web API surface (from web-component-api.md) | Flow API | Notes |
 |---|---|---|
 | `<vaadin-breadcrumbs>` element | `new Breadcrumbs()` | constructor; `HasSize`, `HasStyle`, `HasAriaLabel`, `HasComponentsOfType<BreadcrumbsItem>` |
-| `<vaadin-breadcrumbs-item>` child | `HasComponentsOfType<BreadcrumbsItem>#add(BreadcrumbsItem...)`, `addComponentAsFirst(BreadcrumbsItem)`, `addComponentAtIndex(int, BreadcrumbsItem)`, `remove(BreadcrumbsItem...)`, `removeAll()` | standard component-tree management, typed to `BreadcrumbsItem` at compile time; no component-specific `setItems`/`addItem` |
+| `<vaadin-breadcrumbs-item>` child | `HasComponentsOfType<BreadcrumbsItem>` container methods | standard component-tree management, typed to `BreadcrumbsItem` at compile time; no component-specific `setItems`/`addItem` |
 | `path` attribute on item | `BreadcrumbsItem#setPath(String)` / `setPath(Class<? extends Component>)` / `setPath(Class, RouteParameters)` / constructor overloads | type-safe primary form per `DESIGN_GUIDELINES.md` "Integrate with Flow Router" |
 | last-item-without-path → current item | implicit — construct with `new BreadcrumbsItem(String label)` (no path) | no dedicated current flag |
 | `aria-current="page"` on current item | — (set automatically by the web component) | no Flow API needed |
@@ -340,7 +340,7 @@ The web component now ships a `theme="slash"` separator variant (web-component-s
 
 **Q: Why use `HasComponentsOfType<BreadcrumbsItem>` rather than a bespoke `setItems(BreadcrumbsItem...)` / `addItem(BreadcrumbsItem...)` API?**
 
-Breadcrumbs is a container of items — in Flow terms, a component that holds child components. Expressing that through the standard `HasComponentsOfType<T>` interface from Flow core keeps the API consistent with every other typed Flow container, gives developers `add`, `addComponentAsFirst`, `addComponentAtIndex`, `remove`, and `removeAll` for free, and avoids inventing yet another bespoke item-collection surface. The generic parameter `BreadcrumbsItem` gives compile-time enforcement that only `BreadcrumbsItem` instances can be added, so developers get type safety without the component needing to reject foreign children at runtime. The web component itself only accepts `<vaadin-breadcrumbs-item>` light-DOM children (no parallel data-array `items` property), so the Flow wrapper's component-tree model is a one-to-one fit.
+Breadcrumbs is a container of items — in Flow terms, a component that holds child components. Expressing that through the standard `HasComponentsOfType<T>` interface from Flow core keeps the API consistent with every other typed Flow container, gives developers the standard typed container methods for free, and avoids inventing yet another bespoke item-collection surface. The generic parameter `BreadcrumbsItem` gives compile-time enforcement that only `BreadcrumbsItem` instances can be added, so developers get type safety without the component needing to reject foreign children at runtime. The web component itself only accepts `<vaadin-breadcrumbs-item>` light-DOM children (no parallel data-array `items` property), so the Flow wrapper's component-tree model is a one-to-one fit.
 
 **Q: Why no dedicated `bindItems(Signal<...>)` method?**
 

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -40,12 +40,7 @@ breadcrumbs.add(
 - Adding or removing children while in `ROUTER` mode throws `IllegalStateException`, so the two models never silently mix.
 - In `MANUAL` mode, `Breadcrumbs` is a standard Flow container implementing `HasComponentsOfType<BreadcrumbsItem>`, whose inherited typed container methods accept only `BreadcrumbsItem` instances at compile time (flow-spec.md "Component Classes" lists the full method set).
 - The web component itself accepts only `<vaadin-breadcrumbs-item>` light-DOM children, so the Flow component-tree model maps directly to the underlying DOM.
-- `BreadcrumbsItem` offers the same constructor overloads as `SideNavItem`:
-  - `(label)` for the current page (no path),
-  - `(label, String path)` for hand-managed paths,
-  - `(label, Class<? extends Component> view)` as the type-safe primary form required by `DESIGN_GUIDELINES.md` "Integrate with Flow Router",
-  - `(label, Class<? extends Component> view, RouteParameters routeParameters)` for parameterised routes.
-- Each path-taking overload also has a prefix-component variant ending in `Component prefixComponent` (see section 4).
+- `BreadcrumbsItem` mirrors `SideNavItem`'s constructor overloads — a no-path form (current page), string-path and route-class forms (the route-class form is the type-safe primary one, per guidelines/02-design.md "Integrate with Flow Router"), and a parameterised form, each with a prefix-component variant (see section 4); flow-spec.md "Component Classes" lists the signatures.
 - The "current" distinction needs no extra API — an item without a path is the current item, matching the web component's declarative convention.
 
 ---

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -32,12 +32,7 @@ breadcrumbs.add(
 
 **Why this shape:**
 
-- `Breadcrumbs` has an explicit `Mode` that determines who owns the trail.
-- The nested enum `Breadcrumbs.Mode` has two values:
-  - `ROUTER` (default — auto-populated from Flow routing metadata, see section 8)
-  - `MANUAL` (the application manages the items).
-- The mode is chosen at construction — `new Breadcrumbs()` defaults to `ROUTER`, `new Breadcrumbs(Mode.MANUAL)` is explicit.
-- Adding or removing children while in `ROUTER` mode throws `IllegalStateException`, so the two models never silently mix.
+- `Breadcrumbs` has an explicit `Mode` — `ROUTER` (default, auto-populated from routing metadata, see section 8) or `MANUAL` (the application manages the items); this section uses `MANUAL`. Section 9 defines the full mode contract (construction, `setMode`, and the `ROUTER` guard).
 - In `MANUAL` mode, `Breadcrumbs` is a standard Flow container implementing `HasComponentsOfType<BreadcrumbsItem>`, whose inherited typed container methods accept only `BreadcrumbsItem` instances at compile time (flow-spec.md "Component Classes" lists the full method set).
 - The web component itself accepts only `<vaadin-breadcrumbs-item>` light-DOM children, so the Flow component-tree model maps directly to the underlying DOM.
 - `BreadcrumbsItem` mirrors `SideNavItem`'s constructor overloads — a no-path form (current page), string-path and route-class forms (the route-class form is the type-safe primary one, per guidelines/02-design.md "Integrate with Flow Router"), and a parameterised form, each with a prefix-component variant (see section 4); flow-spec.md "Component Classes" lists the signatures.

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -30,7 +30,23 @@ breadcrumbs.add(
         new BreadcrumbsItem("External", "https://example.com/docs"));
 ```
 
-**Why this shape:** `Breadcrumbs` has an explicit `Mode` that determines who owns the trail. The nested enum `Breadcrumbs.Mode` has two values: `ROUTER` (default — auto-populated from Flow routing metadata, see section 8) and `MANUAL` (the application manages the items). The mode is chosen at construction — `new Breadcrumbs()` defaults to `ROUTER`, `new Breadcrumbs(Mode.MANUAL)` is explicit. Adding or removing children while in `ROUTER` mode throws `IllegalStateException`, so the two models never silently mix. In `MANUAL` mode, `Breadcrumbs` is a standard Flow container — it implements `HasComponentsOfType<BreadcrumbsItem>` and accepts items through the inherited `add(BreadcrumbsItem...)` / `addComponentAsFirst(BreadcrumbsItem)` / `addComponentAtIndex(int, BreadcrumbsItem)` / `remove(BreadcrumbsItem...)` / `removeAll()` methods, with compile-time enforcement that only `BreadcrumbsItem` instances can be added. The web component itself accepts only `<vaadin-breadcrumbs-item>` light-DOM children (no parallel programmatic items property — see web-component-api.md §6), so the Flow component-tree model maps directly to the underlying DOM. `BreadcrumbsItem` offers the same constructor overloads as `SideNavItem`: `(label)` for the current page (no path), `(label, String path)` for hand-managed paths, `(label, Class<? extends Component> view)` as the type-safe primary form required by `DESIGN_GUIDELINES.md` "Integrate with Flow Router", and `(label, Class<? extends Component> view, RouteParameters routeParameters)` for parameterised routes. Each path-taking overload also has a prefix-component variant ending in `Component prefixComponent` (see section 4). The "current" distinction needs no extra API — an item without a path is the current item, matching the web component's declarative convention.
+**Why this shape:**
+
+- `Breadcrumbs` has an explicit `Mode` that determines who owns the trail.
+- The nested enum `Breadcrumbs.Mode` has two values:
+  - `ROUTER` (default — auto-populated from Flow routing metadata, see section 8)
+  - `MANUAL` (the application manages the items).
+- The mode is chosen at construction — `new Breadcrumbs()` defaults to `ROUTER`, `new Breadcrumbs(Mode.MANUAL)` is explicit.
+- Adding or removing children while in `ROUTER` mode throws `IllegalStateException`, so the two models never silently mix.
+- In `MANUAL` mode, `Breadcrumbs` is a standard Flow container — it implements `HasComponentsOfType<BreadcrumbsItem>` and accepts items through the inherited `add(BreadcrumbsItem...)` / `addComponentAsFirst(BreadcrumbsItem)` / `addComponentAtIndex(int, BreadcrumbsItem)` / `remove(BreadcrumbsItem...)` / `removeAll()` methods, with compile-time enforcement that only `BreadcrumbsItem` instances can be added.
+- The web component itself accepts only `<vaadin-breadcrumbs-item>` light-DOM children, so the Flow component-tree model maps directly to the underlying DOM.
+- `BreadcrumbsItem` offers the same constructor overloads as `SideNavItem`:
+  - `(label)` for the current page (no path),
+  - `(label, String path)` for hand-managed paths,
+  - `(label, Class<? extends Component> view)` as the type-safe primary form required by `DESIGN_GUIDELINES.md` "Integrate with Flow Router",
+  - `(label, Class<? extends Component> view, RouteParameters routeParameters)` for parameterised routes.
+- Each path-taking overload also has a prefix-component variant ending in `Component prefixComponent` (see section 4).
+- The "current" distinction needs no extra API — an item without a path is the current item, matching the web component's declarative convention.
 
 ---
 

--- a/packages/breadcrumbs/spec/flow-api.md
+++ b/packages/breadcrumbs/spec/flow-api.md
@@ -288,7 +288,7 @@ breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead
 |---|---|---|
 | `<vaadin-breadcrumbs>` element | `new Breadcrumbs()` | constructor; `HasSize`, `HasStyle`, `HasAriaLabel`, `HasComponentsOfType<BreadcrumbsItem>` |
 | `<vaadin-breadcrumbs-item>` child | `HasComponentsOfType<BreadcrumbsItem>` container methods | standard component-tree management, typed to `BreadcrumbsItem` at compile time; no component-specific `setItems`/`addItem` |
-| `path` attribute on item | `BreadcrumbsItem#setPath(String)` / `setPath(Class<? extends Component>)` / `setPath(Class, RouteParameters)` / constructor overloads | type-safe primary form per `DESIGN_GUIDELINES.md` "Integrate with Flow Router" |
+| `path` attribute on item | `BreadcrumbsItem#setPath(...)` overloads + constructors | route-class form is the type-safe primary one, per guidelines/02-design.md "Integrate with Flow Router" |
 | last-item-without-path → current item | implicit — construct with `new BreadcrumbsItem(String label)` (no path) | no dedicated current flag |
 | `aria-current="page"` on current item | — (set automatically by the web component) | no Flow API needed |
 | `slot="prefix"` on item | `BreadcrumbsItem implements HasPrefix` → `setPrefixComponent(Component)` | shared mixin from `vaadin-flow-components-base` |
@@ -299,7 +299,7 @@ breadcrumbs.addThemeVariants(BreadcrumbsVariant.SLASH); // "/" separator instead
 | `aria-label` on the host | `Breadcrumbs implements HasAriaLabel` | `setAriaLabel(String)` / `getAriaLabel()` from Flow core |
 | RTL separator flipping | — (handled in CSS when `dir="rtl"`) | inherited from the application / `HasStyle` |
 | `theme` variants (`slash`, `primary`, `accent`; web-component-spec.md "Theme") | `Breadcrumbs implements HasThemeVariant<BreadcrumbsVariant>` → `addThemeVariants(BreadcrumbsVariant.…)` | typed theme variants; `getVariantName()` returns the `theme` token |
-| Flow: auto-populate from router | `Breadcrumbs.Mode` enum (`ROUTER`, `MANUAL`); `new Breadcrumbs()` / `new Breadcrumbs(Mode)`; `setMode(Mode)` / `getMode()` | default `ROUTER`; `add`/`remove`/`removeAll` throw `IllegalStateException` while in `ROUTER` mode |
+| Flow: auto-populate from router | `Breadcrumbs.Mode` (`ROUTER` default / `MANUAL`); see §8–§9 | `add`/`remove`/`removeAll` throw `IllegalStateException` in `ROUTER` mode |
 | Flow: route-parent override | `@RouteParent(Class<? extends Component>)` | class-level annotation on `@Route` views |
 
 ## Discussion

--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -625,7 +625,7 @@ guidelines/10-i18n-and-a11y.md prescribes `Objects.requireNonNull` in `setI18n`,
 
 **Q: Why does `Breadcrumbs` expose theme variants?**
 
-The web component ships theme variants — `theme="slash"` in base styles, `theme="primary"` in Lumo, and `theme="accent"` in Aura (web-component-spec.md "Theme" table) — so the Flow wrapper exposes them the standard way rather than inventing setters. `BreadcrumbsVariant` mirrors the shipped tokens (`SLASH`, `LUMO_PRIMARY`, `AURA_ACCENT`), since guidelines/09-theming.md requires each `getVariantName()` to match a real `theme` token. An earlier revision exposed no variants because the web component had none; the slash variant changed that.
+See flow-api.md Discussion "Why expose theme variants?" — the web component ships the `slash` separator variant, so the wrapper exposes it through the standard `HasThemeVariant` surface rather than inventing setters. The enum and its `theme`-token mapping are specified in "Theme Variants" above.
 
 **Q: Why are query parameters applied only to the current item's title?**
 

--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -4,12 +4,7 @@
 
 ## Key Design Decisions
 
-1. **`Mode` enum drives ownership.**
-
-- `Breadcrumbs.Mode` is a public nested enum with values `ROUTER` (default) and `MANUAL` (see flow-api.md §1 and §9).
-- The mode is set at construction (`new Breadcrumbs()` / `new Breadcrumbs(Mode)`) and can be switched at runtime via `setMode(Mode)`.
-- `add`/`remove`/`removeAll` throw `IllegalStateException` while in `Mode.ROUTER`.
-- `setMode(Mode)` clears the current children and installs the new mode's handling (see "Mode switching").
+1. **`Mode` enum drives ownership.** `Breadcrumbs.Mode` is a public nested enum (`ROUTER` default, `MANUAL`); flow-api.md §9 defines the developer contract — construction, `setMode`, and the `IllegalStateException` guard on `add`/`remove`/`removeAll` in `Mode.ROUTER`. This spec covers enforcement: `setMode(Mode)` clears the current children and re-wires the mode (see "Mode switching"); the guard bypasses internal updates via `internalChildUpdate` (see KDD §3).
 
 2. **`HasComponentsOfType<BreadcrumbsItem>` for child management.** Per flow-api.md §1 "Why this shape". The Flow core interface extends `HasElement, HasEnabled` and supplies the full child-management surface as default methods (see the class skeleton in "Component Classes"), all of which must be intercepted by the `Mode.ROUTER` guard (see KDD §1). `HasEnabled` is inherited transitively — it does not need to appear in `Breadcrumbs`'s `implements` list.
 


### PR DESCRIPTION
## Description

Reduce duplication between `flow-api.md` and `flow-spec.md`. The api doc was re-listing method signatures and impl details that the spec already owns, and a few rationale entries were repeated in both files. Each fix is a separate commit.

- Format the §1 trail rationale as a sub-list (readability).
- Stop enumerating `HasComponentsOfType` methods in api.md — the full set lives in flow-spec.md "Component Classes".
- Describe `BreadcrumbsItem` constructors in prose instead of listing signatures; reference the spec skeleton.
- Keep the i18n class internals (`Serializable`, `@JsonInclude`, fluent setters) in flow-spec.md "i18n".
- Give the `Mode` contract a single home (api §9); §1 and flow-spec.md KDD §1 reference it.
- De-duplicate the "why expose theme variants" rationale across the two files.
- Map the Web API coverage table to API names + section refs, not full overload lists.
- Reference flow-spec.md for the route-hierarchy cycle/fallback mechanism.

Also fixes stale `DESIGN_GUIDELINES.md` references to `guidelines/02-design.md` on the touched lines.

Wording only — no API, behavior, or decision changed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
