### PR TITLE
docs: align breadcrumbs flow specs with implemented TestBench API

### DIFF
--- a/packages/breadcrumbs/spec/flow-spec.md
+++ b/packages/breadcrumbs/spec/flow-spec.md
@@ -480,16 +480,6 @@ public class BreadcrumbsElement extends TestBenchElement {
     public BreadcrumbsItemElement getItemByText(String text);
 
     public BreadcrumbsItemElement getItemByPath(String path);
-
-    public boolean hasOverflow();                           // reads has-overflow attribute
-
-    public TestBenchElement getOverflowButton();            // shadow-DOM part="overflow-button"
-
-    public void openOverflowOverlay();                       // click overflow button
-
-    public TestBenchElement getOverflowOverlay();           // the <vaadin-breadcrumbs-overlay> element
-
-    public List<TestBenchElement> getOverflowItems();       // links inside the open overlay
 }
 ```
 
@@ -499,22 +489,22 @@ public class BreadcrumbsElement extends TestBenchElement {
 @Element("vaadin-breadcrumbs-item")
 public class BreadcrumbsItemElement extends TestBenchElement {
 
-    public String getText();
+    @Override
+    public String getText();                                // reads `textContent`
 
-    public String getPath();
+    public String getPath();                                // reads the `path` DOM attribute
 
     public boolean isCurrent();                             // reads `current` state attribute
 
     public boolean hasPrefix();                             // reads `has-prefix` state attribute
 
-    public TestBenchElement getPrefixSlotContent();
+    public TestBenchElement getPrefixComponent();           // the element slotted into slot="prefix"
 
-    @Override
-    public void click();                                    // clicks the anchor in shadow DOM
+    public void navigate();                                 // activates the shadow-DOM anchor
 }
 ```
 
-Queries use the same pattern as `SideNavElement` / `SideNavItemElement`: `$("vaadin-breadcrumbs-item").all()` for items, shadow-DOM CSS for parts and slotted content.
+Queries use the same pattern as `SideNavElement` / `SideNavItemElement`: `$(BreadcrumbsItemElement.class).all()` for items, `getDomAttribute(...)` / `hasAttribute(...)` for path and state attributes, and a `slot="prefix"` element query for the prefix component. `navigate()` clicks the shadow-DOM anchor via `executeScript`, since the Chrome driver cannot click shadow-DOM elements directly.
 
 ---
 
@@ -642,3 +632,7 @@ The default `HasText#setText` replaces all of the element's content, which would
 **Q: Why does `setPath(String)` validate the URL scheme, and why is there a separate `setUnsafePath`?**
 
 A `path` becomes the `href` of an anchor the browser follows, so a `javascript:` (or other non-allow-listed) scheme is a cross-site scripting (XSS) vector when the value comes from untrusted input. `setPath(String)` and the `String path` constructors reject such schemes at the setter, the same defense `SideNavItem.setPath` applies via Flow core's `UrlUtil.isSafeUrl`. `setUnsafePath(String)` is the explicit escape hatch for trusted, hard-coded URLs that must use a scheme outside the allow-list — making the bypass a named, greppable call rather than a silent flag. The `Class`-based overloads need no validation because router-generated URLs are never attacker-controlled.
+
+**Q: Why does the TestBench API expose no overflow helpers, and why `navigate()` instead of overriding `click()`?**
+
+The TestBench elements cover the breadcrumb's server-driven surface — items, their text, path, current/prefix state, and link activation — which is what Flow integration tests assert. Overflow collapse is purely client-side behavior with no Flow API behind it, so it is exercised by the web component's own tests rather than duplicated as TestBench helpers; the IT tasks have no overflow scenario. `navigate()` is a distinct method rather than an override of `TestBenchElement#click()` because activating the link goes through the shadow-DOM anchor via `executeScript` (the Chrome driver cannot click shadow-DOM elements directly), and a current item has no anchor — naming it `navigate()` signals that it follows a link rather than clicking the host element.

--- a/packages/breadcrumbs/spec/flow-tasks.md
+++ b/packages/breadcrumbs/spec/flow-tasks.md
@@ -232,7 +232,7 @@ Register `UI#addAfterNavigationListener(this::rebuildFromRouter)` in `onAttach` 
 **Requirements:** —
 **Depends on:** 1
 
-Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec — every public method listed there must be present. Queries follow the `SideNavElement` / `SideNavItemElement` pattern: `$("vaadin-breadcrumbs-item").all()` for items, shadow-DOM CSS via `$(TestBenchElement.class).attribute("part", ...)` for parts, slotted-content queries via the standard `getPropertyElement(...)`. The actual IT exercise of these methods lands in Tasks 9–12.
+Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec. `BreadcrumbsElement` exposes `getItems()`, `getCurrentItem()`, `getItemByText(String)`, and `getItemByPath(String)`. `BreadcrumbsItemElement` exposes `getText()`, `getPath()`, `isCurrent()`, `hasPrefix()`, `getPrefixComponent()`, and `navigate()`. Queries follow the `SideNavElement` / `SideNavItemElement` pattern: `$(BreadcrumbsItemElement.class).all()` for items, `getDomAttribute(...)` / `hasAttribute(...)` for path and state attributes, and a `slot="prefix"` element query for the prefix component. `navigate()` clicks the shadow-DOM anchor via `executeScript` (the Chrome driver cannot click shadow-DOM elements directly). The actual IT exercise of these methods lands in Tasks 9–12.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench/src/main/java/com/vaadin/flow/component/breadcrumbs/testbench/BreadcrumbsElement.java` (modify)
@@ -240,7 +240,7 @@ Implement `BreadcrumbsElement` and `BreadcrumbsItemElement` per the spec — eve
 
 **Tests:**
 - [ ] The testbench module compiles cleanly when added as a dependency of the `-flow-integration-tests` module
-- [ ] (Verification of behaviour deferred to the integration-test tasks — `BreadcrumbsElement#getItems()` returns the slotted items in document order; `getCurrentItem()` returns the item with the `current` state attribute; `getItemByPath` returns the matching item or `null`; `hasOverflow()` reads the `has-overflow` host attribute; `openOverflowOverlay()` clicks the overflow button and waits for `vaadin-overlay-open`; `BreadcrumbsItemElement#isCurrent` / `hasPrefix` / `getPath` / `getText` / `click` all read or interact with the expected attributes / shadow elements)
+- [ ] (Verification of behaviour deferred to the integration-test tasks — `BreadcrumbsElement#getItems()` returns the slotted items in document order; `getCurrentItem()` returns the item with the `current` state attribute; `getItemByText` / `getItemByPath` return the matching item or `null`; `BreadcrumbsItemElement#isCurrent` / `hasPrefix` / `getPath` / `getText` / `getPrefixComponent` / `navigate` all read or interact with the expected attributes / shadow elements)
 
 **Acceptance criteria:**
 - [ ] `mvn clean install -DskipTests -pl vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-testbench` succeeds
@@ -332,7 +332,7 @@ Add a view `RouteParentPage` whose `@Route` URL would, under URL-prefix walking,
 **Requirements:** 8
 **Depends on:** 2, 8
 
-Add a view `IconBreadcrumbsPage` that constructs items via the prefix-component constructor overloads — at minimum: a home icon on the root, a folder icon on an intermediate item, and a current-page item without prefix. The IT asserts via `BreadcrumbsItemElement#hasPrefix()` and `getPrefixSlotContent()` that the prefix slot is wired and the icons render.
+Add a view `IconBreadcrumbsPage` that constructs items via the prefix-component constructor overloads — at minimum: a home icon on the root, a folder icon on an intermediate item, and a current-page item without prefix. The IT asserts via `BreadcrumbsItemElement#hasPrefix()` and `getPrefixComponent()` that the prefix slot is wired and the icons render.
 
 **Files:**
 - `vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests/src/main/java/com/vaadin/flow/component/breadcrumbs/tests/IconBreadcrumbsPage.java` (create)
@@ -341,7 +341,7 @@ Add a view `IconBreadcrumbsPage` that constructs items via the prefix-component 
 **Tests:**
 - [ ] Items constructed with a prefix component carry `has-prefix` on their host element
 - [ ] The current-page item (constructed without prefix) does not carry `has-prefix`
-- [ ] `BreadcrumbsItemElement#getPrefixSlotContent()` resolves to the icon element passed to the constructor
+- [ ] `BreadcrumbsItemElement#getPrefixComponent()` resolves to the icon element passed to the constructor
 
 **Acceptance criteria:**
 - [ ] `mvn verify -am -pl vaadin-breadcrumbs-flow-parent/vaadin-breadcrumbs-flow-integration-tests -Dit.test='IconBreadcrumbsIT*' -DskipUnitTests` passes


### PR DESCRIPTION
The TestBench element classes shipped in flow-components differ from the API the Breadcrumbs Flow specs referenced. The spec and task descriptions pointed at method names that were renamed during implementation and at overflow helpers that were never built, so they no longer match the code.

Aligns `flow-spec.md` (TestBench Elements section) and `flow-tasks.md` with the implemented TestBench API:

- `BreadcrumbsItemElement#getPrefixSlotContent()` → `getPrefixComponent()`.
- The overridden `click()` → a distinct `navigate()` (clicks the shadow-DOM anchor via `executeScript`, since the Chrome driver cannot click shadow-DOM elements directly).
- Removed the `BreadcrumbsElement` overflow helpers (`hasOverflow`, `getOverflowButton`, `openOverflowOverlay`, `getOverflowOverlay`, `getOverflowItems`) — overflow is client-side only, with no Flow API behind it.
- Added a Discussion entry in `flow-spec.md` recording why the TestBench API omits overflow helpers and uses `navigate()`.

---

🤖 Generated with Claude Code
