### PR TITLE
feat: add inputMode property to text-field

### DIFF
--- a/packages/text-field/src/vaadin-text-field-mixin.d.ts
+++ b/packages/text-field/src/vaadin-text-field-mixin.d.ts
@@ -57,4 +57,12 @@ export declare class TextFieldMixinClass {
    * The pattern must match the entire value, not just some subset.
    */
   pattern: string;
+
+  /**
+   * A hint to the browser about the type of virtual keyboard to display
+   * when the user interacts with the field on a mobile device.
+   * List of available options at:
+   * https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/inputmode
+   */
+  inputMode: string;
 }

--- a/packages/text-field/src/vaadin-text-field-mixin.js
+++ b/packages/text-field/src/vaadin-text-field-mixin.js
@@ -35,11 +35,21 @@ export const TextFieldMixin = (superClass) =>
         pattern: {
           type: String,
         },
+
+        /**
+         * A hint to the browser about the type of virtual keyboard to display
+         * when the user interacts with the field on a mobile device.
+         * List of available options at:
+         * https://developer.mozilla.org/en/docs/Web/HTML/Global_attributes/inputmode
+         */
+        inputMode: {
+          type: String,
+        },
       };
     }
 
     static get delegateAttrs() {
-      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern'];
+      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern', 'inputMode'];
     }
 
     static get constraints() {

--- a/packages/text-field/src/vaadin-text-field-mixin.js
+++ b/packages/text-field/src/vaadin-text-field-mixin.js
@@ -49,7 +49,11 @@ export const TextFieldMixin = (superClass) =>
     }
 
     static get delegateAttrs() {
-      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern', 'inputMode'];
+      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern'];
+    }
+
+    static get delegateProps() {
+      return [...super.delegateProps, 'inputMode'];
     }
 
     static get constraints() {

--- a/packages/text-field/src/vaadin-text-field-mixin.js
+++ b/packages/text-field/src/vaadin-text-field-mixin.js
@@ -44,16 +44,13 @@ export const TextFieldMixin = (superClass) =>
          */
         inputMode: {
           type: String,
+          attribute: 'inputmode',
         },
       };
     }
 
     static get delegateAttrs() {
-      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern'];
-    }
-
-    static get delegateProps() {
-      return [...super.delegateProps, 'inputMode'];
+      return [...super.delegateAttrs, 'maxlength', 'minlength', 'pattern', 'inputMode'];
     }
 
     static get constraints() {

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -108,6 +108,54 @@ snapshots["vaadin-text-field host error"] =
 `;
 /* end snapshot vaadin-text-field host error */
 
+snapshots["vaadin-text-field host inputMode property"] = 
+`<vaadin-text-field>
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-text-field-3"
+    inputmode="search"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host inputMode property */
+
+snapshots["vaadin-text-field host inputmode attribute"] = 
+`<vaadin-text-field inputmode="search">
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-text-field-3"
+    inputmode="search"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host inputmode attribute */
+
 snapshots["vaadin-text-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -349,28 +397,4 @@ snapshots["vaadin-text-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-text-field shadow theme */
-
-snapshots["vaadin-text-field host inputMode"] = 
-`<vaadin-text-field>
-  <label
-    for="input-vaadin-text-field-3"
-    id="label-vaadin-text-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-text-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    id="input-vaadin-text-field-3"
-    inputmode="numeric"
-    slot="input"
-    type="text"
-  >
-</vaadin-text-field>
-`;
-/* end snapshot vaadin-text-field host inputMode */
 

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -350,3 +350,27 @@ snapshots["vaadin-text-field shadow theme"] =
 `;
 /* end snapshot vaadin-text-field shadow theme */
 
+snapshots["vaadin-text-field host inputMode"] = 
+`<vaadin-text-field>
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    id="input-vaadin-text-field-3"
+    inputmode="numeric"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host inputMode */
+

--- a/packages/text-field/test/dom/text-field.test.js
+++ b/packages/text-field/test/dom/text-field.test.js
@@ -35,8 +35,14 @@ describe('vaadin-text-field', () => {
       await expect(field).dom.to.equalSnapshot();
     });
 
-    it('inputMode', async () => {
-      field.inputMode = 'numeric';
+    it('inputMode property', async () => {
+      field.inputMode = 'search';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
+
+    it('inputmode attribute', async () => {
+      field.setAttribute('inputmode', 'search');
       await nextUpdate(field);
       await expect(field).dom.to.equalSnapshot();
     });

--- a/packages/text-field/test/dom/text-field.test.js
+++ b/packages/text-field/test/dom/text-field.test.js
@@ -34,6 +34,12 @@ describe('vaadin-text-field', () => {
       await aTimeout(0);
       await expect(field).dom.to.equalSnapshot();
     });
+
+    it('inputMode', async () => {
+      field.inputMode = 'numeric';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {


### PR DESCRIPTION
Allow specifying the virtual keyboard hint for mobile devices by delegating the inputmode attribute to the native input.

Part of https://github.com/vaadin/flow-components/issues/8903
