### PR TITLE
refactor: remove dead no-scrollbars styles from grid

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -87,10 +87,6 @@ export const gridStyles = css`
     z-index: 0;
   }
 
-  [no-scrollbars]:is([safari], [firefox]) #table {
-    overflow: hidden;
-  }
-
   #header,
   #footer {
     display: block;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -5,7 +5,7 @@
  */
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
-import { isAndroid, isChrome, isFirefox, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { isAndroid, isChrome, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { setTouchAction } from '@vaadin/component-base/src/gestures.js';
@@ -89,12 +89,6 @@ export const GridMixin = (superClass) =>
         _ios: {
           type: Boolean,
           value: isIOS,
-        },
-
-        /** @private */
-        _firefox: {
-          type: Boolean,
-          value: isFirefox,
         },
 
         /** @private */

--- a/packages/vaadin-lumo-styles/src/components/grid.css
+++ b/packages/vaadin-lumo-styles/src/components/grid.css
@@ -204,11 +204,6 @@
     z-index: 2;
   }
 
-  [no-scrollbars][safari] #table,
-  [no-scrollbars][firefox] #table {
-    overflow: hidden;
-  }
-
   /* Empty state */
 
   #scroller:not([empty-state]) #emptystatebody,


### PR DESCRIPTION
The PR removes the `[no-scrollbars]` CSS rule because this attribute isn't set from anywhere. According to Claude, it's a leftover from the old outer-scroller architecture which was abandoned a long time ago.