### PR TITLE
fix: improve non-modal overlay accessibility

### DIFF
--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -153,7 +153,7 @@ class Dialog extends DialogSizeMixin(
         .withBackdrop="${!this.modeless}"
         ?resizable="${this.resizable}"
         restore-focus-on-close
-        ?focus-trap="${!this.noFocusTrap}"
+        ?focus-trap="${!this.modeless && !this.noFocusTrap}"
         exportparts="backdrop, overlay, header, title, header-content, content, footer"
       >
         <slot name="title" slot="title"></slot>

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -149,13 +149,13 @@ describe('vaadin-dialog', () => {
       it('should not have focus-trap when no-focus-trap is true', async () => {
         dialog.noFocusTrap = true;
         await nextUpdate(dialog);
-        expect(overlay.hasAttribute('focus-trap')).to.be.false;
+        expect(overlay.hasAttribute('focus-trap')).to.equal(false);
       });
 
       it('should not have focus-trap when modeless is true', async () => {
         dialog.modeless = true;
         await nextUpdate(dialog);
-        expect(overlay.hasAttribute('focus-trap')).to.be.false;
+        expect(overlay.hasAttribute('focus-trap')).to.equal(false);
       });
     });
 

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -151,6 +151,12 @@ describe('vaadin-dialog', () => {
         await nextUpdate(dialog);
         expect(overlay.hasAttribute('focus-trap')).to.be.false;
       });
+
+      it('should not have focus-trap when modeless is true', async () => {
+        dialog.modeless = true;
+        await nextUpdate(dialog);
+        expect(overlay.hasAttribute('focus-trap')).to.be.false;
+      });
     });
 
     describe('removing and adding to the DOM', () => {

--- a/packages/dialog/test/dialog.test.js
+++ b/packages/dialog/test/dialog.test.js
@@ -149,13 +149,13 @@ describe('vaadin-dialog', () => {
       it('should not have focus-trap when no-focus-trap is true', async () => {
         dialog.noFocusTrap = true;
         await nextUpdate(dialog);
-        expect(overlay.hasAttribute('focus-trap')).to.equal(false);
+        sinon.assert.match(overlay.hasAttribute('focus-trap'), false);
       });
 
       it('should not have focus-trap when modeless is true', async () => {
         dialog.modeless = true;
         await nextUpdate(dialog);
-        expect(overlay.hasAttribute('focus-trap')).to.equal(false);
+        sinon.assert.match(overlay.hasAttribute('focus-trap'), false);
       });
     });
 

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -6,6 +6,7 @@
 import './vaadin-popover-overlay.js';
 import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { announce } from '@vaadin/a11y-base/src/announce.js';
 import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -904,6 +905,29 @@ class Popover extends PopoverPositionMixin(
     if (this.autofocus && !this.modal) {
       this.focus();
     }
+
+    if (!this.autofocus && !this.modal) {
+      const announcement = this.__getAnnouncementText();
+      if (announcement) {
+        announce(announcement);
+      }
+    }
+  }
+
+  /** @private */
+  __getAnnouncementText() {
+    const label = this.getAttribute('aria-label') || this.accessibleName;
+    if (label) {
+      return label.trim();
+    }
+
+    const labelId = this.getAttribute('aria-labelledby') || this.accessibleNameRef;
+    const labelledBy = labelId && document.getElementById(labelId);
+    if (labelledBy?.textContent) {
+      return labelledBy.textContent.trim();
+    }
+
+    return this.textContent.trim();
   }
 
   /** @private */

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -1,6 +1,15 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync, focusout, nextRender, nextUpdate, oneEvent, outsideClick, tab } from '@vaadin/testing-helpers';
+import {
+  aTimeout,
+  fixtureSync,
+  focusout,
+  nextRender,
+  nextUpdate,
+  oneEvent,
+  outsideClick,
+  tab,
+} from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
 import { Popover } from '../src/vaadin-popover.js';
@@ -134,6 +143,25 @@ describe('a11y', () => {
           popover.opened = true;
           await oneEvent(overlay, 'vaadin-overlay-open');
           expect(element.getAttribute('aria-controls')).to.equal(popover.id);
+        });
+
+        it(`should announce the popover text when opened for the ${prop}`, async () => {
+          popover.textContent = 'Popover details';
+          popover.opened = true;
+          await oneEvent(overlay, 'vaadin-overlay-open');
+          await aTimeout(200);
+
+          expect(document.querySelector('[aria-live]').textContent).to.equal('Popover details');
+        });
+
+        it(`should announce the accessible name when opened for the ${prop}`, async () => {
+          popover.accessibleName = 'Popover label';
+          popover.textContent = 'Popover details';
+          popover.opened = true;
+          await oneEvent(overlay, 'vaadin-overlay-open');
+          await aTimeout(200);
+
+          expect(document.querySelector('[aria-live]').textContent).to.equal('Popover label');
         });
 
         it(`should remove aria-controls attribute from the ${prop} when closed`, async () => {


### PR DESCRIPTION
## Summary

This PR improves the accessibility behavior of non-modal overlay components:

- non-modal `vaadin-dialog` no longer enables the overlay focus trap, so keyboard focus that is intentionally moved behind the dialog can continue through the underlying UI instead of being pulled back into the dialog on the next Tab press;
- non-modal `vaadin-popover` now politely announces its available text or accessible name when it opens without moving focus, so screen-reader users get feedback that the popover content appeared;
- regression tests cover both behaviors.

Fixes #11971.
Fixes #11974.

## Validation

- `corepack yarn install --ignore-scripts --frozen-lockfile`
- `corepack yarn playwright install chrome`
- `corepack yarn test packages/dialog/test/dialog.test.js packages/popover/test/a11y.test.js` → 1642 passed, 8 skipped
- `corepack yarn lint:js packages/dialog/src/vaadin-dialog.js packages/dialog/test/dialog.test.js packages/popover/src/vaadin-popover.js packages/popover/test/a11y.test.js`
- `git diff --check`

## Accessibility note

This was validated with source-level tests for focus-trap state and live-region announcement behavior. I did not claim manual NVDA/VoiceOver runtime verification in this PR.
