### PR TITLE
refactor: update virtualizer calls to use optional chaining

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -925,9 +925,7 @@ export const GridMixin = (superClass) =>
 
     /** @protected */
     __updateVisibleRows(start, end) {
-      if (this.__virtualizer) {
-        this.__virtualizer.update(start, end);
-      }
+      this.__virtualizer?.update(start, end);
     }
 
     /** @private */

--- a/packages/virtual-list/src/vaadin-virtual-list-mixin.js
+++ b/packages/virtual-list/src/vaadin-virtual-list-mixin.js
@@ -228,8 +228,6 @@ export const VirtualListMixin = (superClass) =>
      * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
      */
     requestContentUpdate() {
-      if (this.__virtualizer) {
-        this.__virtualizer.update();
-      }
+      this.__virtualizer?.update();
     }
   };


### PR DESCRIPTION
## Description

Modified `vaadin-virtual-list` to use optional chaining for accessing `__virtualizer`.

## Type of change

- Refactor

## Note

Reverted `?.` from `scrollToIndex` etc even though IMO it should be there, let's add later if we switch to TS.