### PR TITLE
fix: allow menu-bar 1px overflow to prevent sub-pixel rounding

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -501,7 +501,9 @@ export const MenuBarMixin = (superClass) =>
       // and causing a cascading collapse where every button appears to overflow.
       container.style.minWidth = `${container.offsetWidth}px`;
 
-      if (container.offsetWidth < container.scrollWidth) {
+      // Allow 1px tolerance before collapsing to avoid unexpected overflow
+      // due to sub-pixel rounding, e.g. with a non-default browser zoom.
+      if (container.scrollWidth - container.offsetWidth > 1) {
         this._hasOverflow = true;
 
         const isRTL = this.__isRTL;
@@ -514,8 +516,8 @@ export const MenuBarMixin = (superClass) =>
 
           // If this button isn't overflowing, then the rest aren't either
           if (
-            (!isRTL && btnLeft + lastButton.offsetWidth < container.offsetWidth - overflow.offsetWidth) ||
-            (isRTL && btnLeft >= overflow.offsetWidth)
+            (!isRTL && btnLeft + lastButton.offsetWidth - (container.offsetWidth - overflow.offsetWidth) <= 1) ||
+            (isRTL && btnLeft >= overflow.offsetWidth - 1)
           ) {
             break;
           }

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -618,4 +618,29 @@ describe('overflow', () => {
       expect(spy.set.callCount).to.equal(2);
     });
   });
+
+  describe('sub-pixel rounding', () => {
+    let menu, container, overflow;
+
+    beforeEach(async () => {
+      menu = fixtureSync('<vaadin-menu-bar></vaadin-menu-bar>');
+      menu.items = [{ text: 'Item 1' }];
+      await nextRender();
+      container = menu._container;
+      overflow = menu._overflow;
+    });
+
+    it('should not collapse a button that overflows by less than 1px', async () => {
+      // Override the metrics to mimic the 1px sub-pixel rounding.
+      const width = menu._buttons[0].offsetWidth;
+      Object.defineProperty(container, 'offsetWidth', { configurable: true, get: () => width - 1 });
+      Object.defineProperty(container, 'scrollWidth', { configurable: true, get: () => width });
+
+      // Update items to trigger overflow detection
+      menu.items = [...menu.items];
+      await nextRender();
+
+      expect(overflow.item.children.length).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/11982

Added 1px tolerance to prevent items from collapsing to overflow in case of sub-pixel rounding.

## Type of change

- Bugfix