### PR TITLE
fix: dispatch change event on multi-select-combo-box Esc clear

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -1107,7 +1107,7 @@ export const MultiSelectComboBoxMixin = (superClass) =>
 
       if (this.clearButtonVisible && !this.opened && this.selectedItems && this.selectedItems.length) {
         event.stopPropagation();
-        this.selectedItems = [];
+        this._onClearAction();
       }
 
       super._onEscape(event);

--- a/packages/multi-select-combo-box/test/basic.test.js
+++ b/packages/multi-select-combo-box/test/basic.test.js
@@ -221,6 +221,12 @@ describe('basic', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
+    it('should fire change on clear with Esc when clear button is visible', async () => {
+      comboBox.clearButtonVisible = true;
+      await sendKeys({ press: 'Escape' });
+      expect(spy.calledOnce).to.be.true;
+    });
+
     it('should fire change when chip is removed', () => {
       const chip = comboBox.querySelector('[slot="chip"]');
       chip.shadowRoot.querySelector('[part="remove-button"]').click();


### PR DESCRIPTION
## Description

MSCB did not fire a `change` event when the selection was cleared with the <kbd>Esc</kbd> key - this is inconsistent with regular `combo-box` and `date-picker` which fire it. Updated to call `_onClearAction()` on  <kbd>Esc</kbd> (same as on clear button click) to dispatch `change` and announce cleared selection.

## Type of change

- Bugfix

## Note

This also helps the Flow `MultiSelectComboBox` (vaadin/flow-components#9611). Once every user-initiated value change dispatches `change`, Flow can synchronize the value on the `change` event instead of `selected-items-changed`, which would stop relaying programmatic `selected-items-changed` updates back to the server as spurious client-side value changes.