### PR TITLE
fix: always set aria-controls attribute on popover target

### DIFF
--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -697,11 +697,8 @@ class Popover extends PopoverPositionMixin(
 
       effectiveTarget.setAttribute('aria-expanded', opened ? 'true' : 'false');
 
-      if (opened) {
-        effectiveTarget.setAttribute('aria-controls', this.id);
-      } else {
-        effectiveTarget.removeAttribute('aria-controls');
-      }
+      // Always set aria-controls to make VoiceOver + Chrome announce it.
+      effectiveTarget.setAttribute('aria-controls', this.id);
 
       this.__oldTarget = target;
     }

--- a/packages/popover/test/a11y.test.js
+++ b/packages/popover/test/a11y.test.js
@@ -130,19 +130,17 @@ describe('a11y', () => {
           expect(element.getAttribute('aria-expanded')).to.equal('true');
         });
 
-        it(`should set aria-controls attribute on the ${prop} when opened`, async () => {
-          popover.opened = true;
-          await oneEvent(overlay, 'vaadin-overlay-open');
+        it(`should set aria-controls attribute on the ${prop} by default`, () => {
           expect(element.getAttribute('aria-controls')).to.equal(popover.id);
         });
 
-        it(`should remove aria-controls attribute from the ${prop} when closed`, async () => {
+        it(`should keep aria-controls attribute on the ${prop} when closed`, async () => {
           popover.opened = true;
           await oneEvent(overlay, 'vaadin-overlay-open');
 
           popover.opened = false;
           await nextUpdate(popover);
-          expect(element.hasAttribute('aria-controls')).to.be.false;
+          expect(element.getAttribute('aria-controls')).to.equal(popover.id);
         });
 
         it(`should remove aria-haspopup attribute from ${prop} when target is cleared`, async () => {


### PR DESCRIPTION
## Description

Updated to always set `aria-controls` on the popover target to make VoiceOver + Chrome announce it.
See https://github.com/vaadin/web-components/issues/11974#issuecomment-4831278233 for manual screen reader testing summary..

Note: `aria-expanded` + `aria-haspopup` combination is still [not announced](https://www.matuzo.at/blog/2023/aria-haspopup) by VoiceOver on Safari.

Part of #11974

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)