### PR TITLE
test: consolidate activate events, improve their coverage

### DIFF
--- a/packages/grid/test/activate-events.test.js
+++ b/packages/grid/test/activate-events.test.js
@@ -3,7 +3,7 @@ import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-grid.js';
-import { getBodyCellContent } from './helpers.js';
+import { flushGrid, getBodyCellContent } from './helpers.js';
 
 describe('activate events', () => {
   let grid, column;
@@ -19,6 +19,7 @@ describe('activate events', () => {
       root.textContent = `${model.index} ${model.item.name}`;
     };
     grid.items = [{ name: 'Item 0' }, { name: 'Item 1' }];
+    flushGrid(grid);
     // Focus grid
     await sendKeys({ press: 'Tab' });
   });

--- a/packages/grid/test/activate-events.test.js
+++ b/packages/grid/test/activate-events.test.js
@@ -1,0 +1,65 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, isIOS, keyDownOn } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './grid-test-styles.js';
+import '../src/vaadin-grid.js';
+import { flushGrid, getCell } from './helpers.js';
+
+describe('activate events', () => {
+  let grid, column;
+
+  describe('cell-activate', () => {
+    let spy;
+
+    beforeEach(() => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      column = grid.firstElementChild;
+      grid.items = [{ foo: 'bar' }, { foo: 'baz' }];
+      column.renderer = (root, _owner, model) => {
+        root.textContent = `${model.index} ${model.item.foo}`;
+      };
+      flushGrid(grid);
+
+      spy = sinon.spy();
+      grid.addEventListener('cell-activate', spy);
+    });
+
+    it('should fire a `cell-activate` event with correct model on cell click', () => {
+      getCell(grid, 0)._content.click();
+      expect(spy.calledOnce).to.be.true;
+
+      const e = spy.firstCall.args[0];
+      expect(e.detail.model.index).to.eql(0);
+      expect(e.detail.model.item).to.be.ok;
+    });
+
+    (isIOS ? it.skip : it)('should fire a `cell-activate` event with correct model on space', () => {
+      keyDownOn(getCell(grid, 0) || grid.shadowRoot.activeElement, 32, [], ' ');
+      expect(spy.calledOnce).to.be.true;
+
+      const e = spy.firstCall.args[0];
+      expect(e.detail.model.index).to.eql(0);
+      expect(e.detail.model.item).to.be.ok;
+    });
+
+    it('should not fire a `cell-activate` event on focusable element click', () => {
+      column.renderer = (root) => {
+        root.innerHTML = '<input>';
+      };
+      getCell(grid, 0)._content.firstElementChild.click();
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not fire a `cell-activate` event on label click', () => {
+      column.renderer = (root) => {
+        root.innerHTML = '<label for="foo">foo label</label><input id="foo">';
+      };
+      getCell(grid, 0)._content.firstElementChild.click();
+      expect(spy.called).to.be.false;
+    });
+  });
+});

--- a/packages/grid/test/activate-events.test.js
+++ b/packages/grid/test/activate-events.test.js
@@ -62,4 +62,51 @@ describe('activate events', () => {
       expect(spy.called).to.be.false;
     });
   });
+
+  describe('row-activate', () => {
+    let spy;
+
+    beforeEach(() => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      column = grid.firstElementChild;
+      grid.items = [{ foo: 'bar' }, { foo: 'baz' }];
+      column.renderer = (root, _owner, model) => {
+        root.textContent = `${model.index} ${model.item.foo}`;
+      };
+      flushGrid(grid);
+
+      spy = sinon.spy();
+      grid.addEventListener('row-activate', spy);
+    });
+
+    // Focus the first body cell, then press left arrow to enter row focus mode,
+    // where the row itself is focused instead of a cell.
+    function enterRowFocusMode() {
+      getCell(grid, 0).focus();
+      keyDownOn(grid.shadowRoot.activeElement, 37, [], 'ArrowLeft');
+    }
+
+    (isIOS ? it.skip : it)('should fire a `row-activate` event with correct model on space', () => {
+      enterRowFocusMode();
+      keyDownOn(grid.shadowRoot.activeElement, 32, [], ' ');
+      expect(spy.calledOnce).to.be.true;
+
+      const e = spy.firstCall.args[0];
+      expect(e.detail.model.index).to.eql(0);
+      expect(e.detail.model.item).to.be.ok;
+    });
+
+    (isIOS ? it.skip : it)('should not fire a `cell-activate` event on space in row focus mode', () => {
+      const cellSpy = sinon.spy();
+      grid.addEventListener('cell-activate', cellSpy);
+
+      enterRowFocusMode();
+      keyDownOn(grid.shadowRoot.activeElement, 32, [], ' ');
+      expect(cellSpy.called).to.be.false;
+    });
+  });
 });

--- a/packages/grid/test/activate-events.test.js
+++ b/packages/grid/test/activate-events.test.js
@@ -1,65 +1,74 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, isIOS, keyDownOn } from '@vaadin/testing-helpers';
+import { sendKeys } from '@vaadin/test-runner-commands';
+import { fixtureSync } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
-import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
-import { flushGrid, getCell } from './helpers.js';
+import { getBodyCellContent } from './helpers.js';
 
 describe('activate events', () => {
   let grid, column;
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid>
+        <vaadin-grid-column></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    column = grid.firstElementChild;
+    column.renderer = (root, _owner, model) => {
+      root.textContent = `${model.index} ${model.item.name}`;
+    };
+    grid.items = [{ name: 'Item 0' }, { name: 'Item 1' }];
+    // Focus grid
+    await sendKeys({ press: 'Tab' });
+  });
 
   describe('cell-activate', () => {
     let spy;
 
     beforeEach(() => {
-      grid = fixtureSync(`
-        <vaadin-grid>
-          <vaadin-grid-column></vaadin-grid-column>
-        </vaadin-grid>
-      `);
-      column = grid.firstElementChild;
-      grid.items = [{ foo: 'bar' }, { foo: 'baz' }];
-      column.renderer = (root, _owner, model) => {
-        root.textContent = `${model.index} ${model.item.foo}`;
-      };
-      flushGrid(grid);
-
       spy = sinon.spy();
       grid.addEventListener('cell-activate', spy);
     });
 
-    it('should fire a `cell-activate` event with correct model on cell click', () => {
-      getCell(grid, 0)._content.click();
-      expect(spy.calledOnce).to.be.true;
+    it('should fire on cell click', () => {
+      getBodyCellContent(grid, 0, 0).click();
+      expect(spy).to.be.calledOnce;
 
       const e = spy.firstCall.args[0];
-      expect(e.detail.model.index).to.eql(0);
+      expect(e.detail.model.index).to.equal(0);
       expect(e.detail.model.item).to.be.ok;
     });
 
-    (isIOS ? it.skip : it)('should fire a `cell-activate` event with correct model on space', () => {
-      keyDownOn(getCell(grid, 0) || grid.shadowRoot.activeElement, 32, [], ' ');
-      expect(spy.calledOnce).to.be.true;
+    it('should fire on cell Space', async () => {
+      await sendKeys({ press: 'Space' });
+      expect(spy).to.be.calledOnce;
 
       const e = spy.firstCall.args[0];
-      expect(e.detail.model.index).to.eql(0);
+      expect(e.detail.model.index).to.equal(0);
       expect(e.detail.model.item).to.be.ok;
     });
 
-    it('should not fire a `cell-activate` event on focusable element click', () => {
+    it('should not fire on row Space', async () => {
+      await sendKeys({ press: 'ArrowLeft' });
+      await sendKeys({ press: 'Space' });
+      expect(spy).not.to.be.called;
+    });
+
+    it('should not fire on focusable element click', () => {
       column.renderer = (root) => {
         root.innerHTML = '<input>';
       };
-      getCell(grid, 0)._content.firstElementChild.click();
-      expect(spy.called).to.be.false;
+      getBodyCellContent(grid, 0, 0).firstElementChild.click();
+      expect(spy).not.to.be.called;
     });
 
-    it('should not fire a `cell-activate` event on label click', () => {
+    it('should not fire on label click', () => {
       column.renderer = (root) => {
         root.innerHTML = '<label for="foo">foo label</label><input id="foo">';
       };
-      getCell(grid, 0)._content.firstElementChild.click();
-      expect(spy.called).to.be.false;
+      getBodyCellContent(grid, 0, 0).firstElementChild.click();
+      expect(spy).not.to.be.called;
     });
   });
 
@@ -67,46 +76,24 @@ describe('activate events', () => {
     let spy;
 
     beforeEach(() => {
-      grid = fixtureSync(`
-        <vaadin-grid>
-          <vaadin-grid-column></vaadin-grid-column>
-        </vaadin-grid>
-      `);
-      column = grid.firstElementChild;
-      grid.items = [{ foo: 'bar' }, { foo: 'baz' }];
-      column.renderer = (root, _owner, model) => {
-        root.textContent = `${model.index} ${model.item.foo}`;
-      };
-      flushGrid(grid);
-
       spy = sinon.spy();
       grid.addEventListener('row-activate', spy);
     });
 
-    // Focus the first body cell, then press left arrow to enter row focus mode,
-    // where the row itself is focused instead of a cell.
-    function enterRowFocusMode() {
-      getCell(grid, 0).focus();
-      keyDownOn(grid.shadowRoot.activeElement, 37, [], 'ArrowLeft');
-    }
-
-    (isIOS ? it.skip : it)('should fire a `row-activate` event with correct model on space', () => {
-      enterRowFocusMode();
-      keyDownOn(grid.shadowRoot.activeElement, 32, [], ' ');
-      expect(spy.calledOnce).to.be.true;
+    it('should fire on row Space', async () => {
+      await sendKeys({ press: 'ArrowLeft' });
+      await sendKeys({ press: 'Space' });
+      expect(spy).to.be.calledOnce;
 
       const e = spy.firstCall.args[0];
-      expect(e.detail.model.index).to.eql(0);
+      expect(e.detail.model.index).to.equal(0);
       expect(e.detail.model.item).to.be.ok;
     });
 
-    (isIOS ? it.skip : it)('should not fire a `cell-activate` event on space in row focus mode', () => {
-      const cellSpy = sinon.spy();
-      grid.addEventListener('cell-activate', cellSpy);
-
-      enterRowFocusMode();
-      keyDownOn(grid.shadowRoot.activeElement, 32, [], ' ');
-      expect(cellSpy.called).to.be.false;
+    it('should not fire on cell Space', async () => {
+      await sendKeys({ press: 'ArrowRight' });
+      await sendKeys({ press: 'Space' });
+      expect(spy).not.to.be.called;
     });
   });
 });

--- a/packages/grid/test/renderers.test.js
+++ b/packages/grid/test/renderers.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, isIOS, keyDownOn, nextFrame } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
@@ -156,49 +156,6 @@ describe('renderers', () => {
         column.renderer.resetHistory();
         grid.detailsOpenedItems = [grid.items[0]];
         expect(column.renderer.called).to.be.false;
-      });
-    });
-
-    describe('cell-activate', () => {
-      let spy;
-
-      beforeEach(() => {
-        spy = sinon.spy();
-        grid.addEventListener('cell-activate', spy);
-      });
-
-      it('should fire a `cell-activate` event with correct model on cell click', () => {
-        getCell(grid, 0)._content.click();
-        expect(spy.calledOnce).to.be.true;
-
-        const e = spy.firstCall.args[0];
-        expect(e.detail.model.index).to.eql(0);
-        expect(e.detail.model.item).to.be.ok;
-      });
-
-      (isIOS ? it.skip : it)('should fire a `cell-activate` event with correct model on space', () => {
-        keyDownOn(getCell(grid, 0) || grid.shadowRoot.activeElement, 32, [], ' ');
-        expect(spy.calledOnce).to.be.true;
-
-        const e = spy.firstCall.args[0];
-        expect(e.detail.model.index).to.eql(0);
-        expect(e.detail.model.item).to.be.ok;
-      });
-
-      it('should not fire a `cell-activate` event on focusable element click', () => {
-        column.renderer = (root) => {
-          root.innerHTML = '<input>';
-        };
-        getCell(grid, 0)._content.firstElementChild.click();
-        expect(spy.called).to.be.false;
-      });
-
-      it('should not fire a `cell-activate` event on label click', () => {
-        column.renderer = (root) => {
-          root.innerHTML = '<label for="foo">foo label</label><input id="foo">';
-        };
-        getCell(grid, 0)._content.firstElementChild.click();
-        expect(spy.called).to.be.false;
       });
     });
   });


### PR DESCRIPTION
- Move the grid's cell-activate tests from `renderers.test.js` into a dedicated `activate-events.test.js` suite
- Add coverage for the row-activate event, which had none: the new tests check that pressing Space in row focus mode fires row-activate