### PR TITLE
feat: add accessible name properties to grid selection column

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.d.ts
@@ -40,6 +40,21 @@ export declare class GridSelectionColumnBaseMixinClass<TItem> {
   dragSelect: boolean;
 
   /**
+   * The accessible name (aria-label) for the Select All checkbox in the
+   * header cell. Defaults to "Select All".
+   *
+   * @attr {string} select-all-accessible-name
+   */
+  selectAllAccessibleName: string;
+
+  /**
+   * A function that receives an item and returns the accessible name
+   * (aria-label) for the checkbox rendered in the corresponding row.
+   * Defaults to a function that returns "Select Row".
+   */
+  selectRowAccessibleNameGenerator: (item: TItem) => string;
+
+  /**
    * Indicates whether the shift key is currently pressed.
    */
   protected _shiftKeyDown: boolean;

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -146,7 +146,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      *
      * @private
      */
-    __getSelectRowAccessibleName(item) {
+    __generateSelectRowAccessibleName(item) {
       const generator = this.selectRowAccessibleNameGenerator;
       return typeof generator === 'function' ? generator(item) : '';
     }
@@ -226,7 +226,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.addEventListener('click', this.__onCellClick);
       }
 
-      checkbox.accessibleName = this.__getSelectRowAccessibleName(item);
+      checkbox.accessibleName = this.__generateSelectRowAccessibleName(item);
       checkbox.__item = item;
       checkbox.checked = selected;
 

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -131,26 +131,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       ];
     }
 
-    /** @protected */
-    updated(props) {
-      super.updated(props);
-
-      if (props.has('selectRowAccessibleNameGenerator')) {
-        this._grid?.requestContentUpdate?.();
-      }
-    }
-
-    /**
-     * Returns the Select Row checkbox accessible name for the given item from
-     * `selectRowAccessibleNameGenerator`.
-     *
-     * @private
-     */
-    __generateSelectRowAccessibleName(item) {
-      const generator = this.selectRowAccessibleNameGenerator;
-      return typeof generator === 'function' ? generator(item) : '';
-    }
-
     constructor() {
       super();
       this.__onCellTrack = this.__onCellTrack.bind(this);
@@ -184,6 +164,15 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         this._grid.removeEventListener('mousedown', this.__onGridInteraction);
         this._grid.removeEventListener('active-item-changed', this.__onActiveItemChanged);
         this._grid.removeEventListener('touchstart', this.__onTouchStart);
+      }
+    }
+
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('selectRowAccessibleNameGenerator')) {
+        this._grid?.requestContentUpdate?.();
       }
     }
 
@@ -235,6 +224,12 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
       const isHidden = !isSelectable && !selected;
       checkbox.style.visibility = isHidden ? 'hidden' : '';
+    }
+
+    /** @private */
+    __generateSelectRowAccessibleName(item) {
+      const generator = this.selectRowAccessibleNameGenerator;
+      return typeof generator === 'function' ? generator(item) : '';
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -78,6 +78,32 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
           sync: true,
         },
 
+        /**
+         * The accessible name (aria-label) for the Select All checkbox in the
+         * header cell. Defaults to "Select All".
+         *
+         * @attr {string} select-all-accessible-name
+         */
+        selectAllAccessibleName: {
+          type: String,
+          value: 'Select All',
+          sync: true,
+        },
+
+        /**
+         * A function that receives an item and returns the accessible name
+         * (aria-label) for the checkbox rendered in the corresponding row.
+         * Defaults to a function that returns "Select Row".
+         *
+         * @type {(item: !GridItem) => string}
+         */
+        selectRowAccessibleNameGenerator: {
+          type: Object,
+          value: () => {
+            return (_item) => 'Select Row';
+          },
+        },
+
         /** @protected */
         _indeterminate: {
           type: Boolean,
@@ -101,8 +127,28 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
     static get observers() {
       return [
-        '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, _indeterminate, _selectAllHidden)',
+        '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, selectAll, _indeterminate, _selectAllHidden, selectAllAccessibleName)',
       ];
+    }
+
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('selectRowAccessibleNameGenerator')) {
+        this._grid?.requestContentUpdate?.();
+      }
+    }
+
+    /**
+     * Returns the Select Row checkbox accessible name for the given item from
+     * `selectRowAccessibleNameGenerator`.
+     *
+     * @private
+     */
+    __getSelectRowAccessibleName(item) {
+      const generator = this.selectRowAccessibleNameGenerator;
+      return typeof generator === 'function' ? generator(item) : '';
     }
 
     constructor() {
@@ -150,11 +196,12 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       let checkbox = root.firstElementChild;
       if (!checkbox) {
         checkbox = document.createElement('vaadin-checkbox');
-        checkbox.accessibleName = 'Select All';
         checkbox.classList.add('vaadin-grid-select-all-checkbox');
         checkbox.addEventListener('change', this.__onSelectAllCheckboxChange);
         root.appendChild(checkbox);
       }
+
+      checkbox.accessibleName = this.selectAllAccessibleName;
 
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
       checkbox.checked = checked;
@@ -171,7 +218,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       let checkbox = root.firstElementChild;
       if (!checkbox) {
         checkbox = document.createElement('vaadin-checkbox');
-        checkbox.accessibleName = 'Select Row';
         checkbox.addEventListener('change', this.__onSelectRowCheckboxChange);
         root.appendChild(checkbox);
         addListener(root, 'track', this.__onCellTrack);
@@ -180,6 +226,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.addEventListener('click', this.__onCellClick);
       }
 
+      checkbox.accessibleName = this.__getSelectRowAccessibleName(item);
       checkbox.__item = item;
       checkbox.checked = selected;
 

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -273,6 +273,21 @@ describe('multi selection column', () => {
     expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select Row');
   });
 
+  it('should use the value from the generator as the row accessible name', async () => {
+    selectionColumn.selectRowAccessibleNameGenerator = (item) => `Select row ${item}`;
+    await nextRender();
+    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select row foo');
+  });
+
+  it('should re-render rows when the generator changes', async () => {
+    selectionColumn.selectRowAccessibleNameGenerator = (item) => `Select row ${item}`;
+    await nextRender();
+    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select row foo');
+    selectionColumn.selectRowAccessibleNameGenerator = (item) => `Pick ${item}`;
+    await nextRender();
+    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Pick foo');
+  });
+
   it('should select item when checkbox is checked', async () => {
     firstBodyCheckbox.click();
     await nextFrame();
@@ -395,6 +410,12 @@ describe('multi selection column', () => {
 
   it('should set aria-label on the select all checkbox input element', () => {
     expect(selectAllCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select All');
+  });
+
+  it('should update aria-label on the select all checkbox based on selectAllAccessibleName', async () => {
+    selectionColumn.selectAllAccessibleName = 'Select All Items';
+    await nextRender();
+    expect(selectAllCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select All Items');
   });
 
   it('should set selectAll when header checkbox is clicked', async () => {


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/3471

Added following properties to `vaadin-grid-selection-column` base mixin:

- `selectAllAccessibleName` - defaults to `Select All`
- `selectRowAccessibleNameGenerator` - defaults to function that returns `Select Row`

## Type of change

- Feature

## Note

Flow component PR: https://github.com/vaadin/flow-components/pull/9642