### PR TITLE
refactor: extract card title management logic into a controller

### DIFF
--- a/packages/card/src/title-controller.d.ts
+++ b/packages/card/src/title-controller.d.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2024 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
+
+/**
+ * A controller to manage the card title element.
+ */
+export class TitleController extends SlotChildObserveController {
+  constructor(host: HTMLElement);
+
+  /**
+   * Set title based on the corresponding host property.
+   */
+  setTitle(title: string): void;
+
+  /**
+   * Set heading level based on the corresponding host property.
+   */
+  setLevel(level: number): void;
+}

--- a/packages/card/src/title-controller.js
+++ b/packages/card/src/title-controller.js
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright (c) 2024 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { SlotChildObserveController } from '@vaadin/component-base/src/slot-child-observe-controller.js';
+
+/**
+ * A controller to manage the card title element.
+ */
+export class TitleController extends SlotChildObserveController {
+  constructor(host) {
+    // Do not provide tag name, as we create the title lazily.
+    super(host, 'title', null, { uniqueIdPrefix: 'card-title' });
+  }
+
+  /**
+   * Set title based on the corresponding host property.
+   *
+   * @param {string} title
+   */
+  setTitle(title) {
+    this.title = title;
+
+    if (title && title.trim() !== '') {
+      // The string title replaces a custom slotted title, if any.
+      const child = this.getSlotChild();
+      if (child && child !== this.defaultNode) {
+        child.remove();
+      }
+
+      // Create or restore the default title node.
+      this.restoreDefaultNode();
+      this.updateDefaultNode(this.node);
+    } else if (this.node === this.defaultNode) {
+      // Clearing the string title removes the generated node.
+      this.node.remove();
+    }
+  }
+
+  /**
+   * Set heading level based on the corresponding host property.
+   *
+   * @param {number} level
+   */
+  setLevel(level) {
+    this.level = level;
+
+    // When the default title is used, update it.
+    if (this.node && this.node === this.defaultNode) {
+      this.updateDefaultNode(this.node);
+    }
+  }
+
+  /**
+   * Override method inherited from `SlotController` to set up the default
+   * title node as a heading and label the card by it. The heading role and
+   * `aria-labelledby` are only applied to the generated string title, never
+   * to a custom slotted title.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  initNode(node) {
+    if (node && node === this.defaultNode) {
+      node.setAttribute('role', 'heading');
+      this.host.setAttribute('aria-labelledby', node.id);
+    }
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController` to handle a
+   * custom title element. Skips the default `super` call so the custom node
+   * keeps no generated ID. Clears the string title property, as a custom
+   * title takes over.
+   *
+   * @param {Node} _node
+   * @protected
+   * @override
+   */
+  initCustomNode(_node) {
+    this.host.cardTitle = '';
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController` to drop the
+   * labelling once the generated title node leaves the slot and is not
+   * replaced by a custom title.
+   *
+   * @param {Node} node
+   * @protected
+   * @override
+   */
+  teardownNode(node) {
+    if (this.getSlotChild() !== this.defaultNode) {
+      this.host.removeAttribute('aria-labelledby');
+    }
+
+    super.teardownNode(node);
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController`
+   * to create the default title element lazily as needed.
+   *
+   * @protected
+   * @override
+   */
+  restoreDefaultNode() {
+    const { title } = this;
+
+    // No title yet, create one.
+    if (title && title.trim() !== '') {
+      this.tagName = 'div';
+
+      const node = this.attachDefaultNode();
+      this.initNode(node);
+    }
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController`
+   * to update the default title element.
+   *
+   * @param {Node | undefined} node
+   * @protected
+   * @override
+   */
+  updateDefaultNode(node) {
+    if (node) {
+      node.textContent = this.title;
+      node.setAttribute('aria-level', this.level || 2);
+    }
+
+    // Notify the host after update.
+    super.updateDefaultNode(node);
+  }
+}

--- a/packages/card/src/title-controller.js
+++ b/packages/card/src/title-controller.js
@@ -32,7 +32,7 @@ export class TitleController extends SlotChildObserveController {
       // Create or restore the default title node.
       this.restoreDefaultNode();
       this.updateDefaultNode(this.node);
-    } else if (this.node === this.defaultNode) {
+    } else if (this.node && this.node === this.defaultNode) {
       // Clearing the string title removes the generated node.
       this.node.remove();
     }

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -8,10 +8,10 @@ import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { isEmptyTextNode } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
-import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { cardStyles } from './styles/vaadin-card-base-styles.js';
+import { TitleController } from './title-controller.js';
 
 /**
  * `<vaadin-card>` is a versatile container for grouping related content and actions.
@@ -86,7 +86,6 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(Li
        */
       cardTitle: {
         type: String,
-        observer: '__cardTitleChanged',
       },
 
       /**
@@ -97,7 +96,6 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(Li
       titleHeadingLevel: {
         type: Number,
         reflectToAttribute: true,
-        observer: '__titleHeadingLevelChanged',
       },
     };
   }
@@ -139,7 +137,24 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(Li
   /** @protected */
   firstUpdated() {
     super.firstUpdated();
+
+    this.__titleController = new TitleController(this);
+    this.addController(this.__titleController);
+
     this._onSlotChange();
+  }
+
+  /** @protected */
+  updated(props) {
+    super.updated(props);
+
+    if (props.has('cardTitle')) {
+      this.__titleController.setTitle(this.cardTitle);
+    }
+
+    if (props.has('titleHeadingLevel')) {
+      this.__titleController.setLevel(this.titleHeadingLevel);
+    }
   }
 
   /** @private */
@@ -158,85 +173,12 @@ class Card extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(Li
     this.toggleAttribute('_hs', this.querySelector(':scope > [slot="header-suffix"]'));
     this.toggleAttribute('_c', this.__hasContent());
     this.toggleAttribute('_f', this.querySelector(':scope > [slot="footer"]'));
-    if (this.__getCustomTitleElement()) {
-      this.__clearStringTitle();
-    }
   }
 
   /** @private */
   __hasContent() {
     const slot = this.shadowRoot.querySelector('slot:not([name])');
     return slot.assignedNodes({ flatten: true }).filter((node) => !isEmptyTextNode(node)).length > 0;
-  }
-
-  /** @private */
-  __clearStringTitle() {
-    const stringTitleElement = this.__getStringTitleElement();
-    if (stringTitleElement) {
-      this.removeChild(stringTitleElement);
-    }
-    const ariaLabelledby = this.getAttribute('aria-labelledby');
-    if (ariaLabelledby?.startsWith('card-title-')) {
-      this.removeAttribute('aria-labelledby');
-    }
-    if (this.cardTitle) {
-      this.cardTitle = '';
-    }
-  }
-
-  /** @private */
-  __getCustomTitleElement() {
-    return Array.from(this.querySelectorAll('[slot="title"]')).find((el) => {
-      return !el.hasAttribute('card-string-title');
-    });
-  }
-
-  /** @private */
-  __cardTitleChanged(title) {
-    if (!title) {
-      this.__clearStringTitle();
-      return;
-    }
-    const customTitleElement = this.__getCustomTitleElement();
-    if (customTitleElement) {
-      this.removeChild(customTitleElement);
-    }
-    let stringTitleElement = this.__getStringTitleElement();
-    if (!stringTitleElement) {
-      stringTitleElement = this.__createStringTitleElement();
-      this.appendChild(stringTitleElement);
-      this.setAttribute('aria-labelledby', stringTitleElement.id);
-    }
-    stringTitleElement.textContent = title;
-  }
-
-  /** @private */
-  __createStringTitleElement() {
-    const stringTitleElement = document.createElement('div');
-    stringTitleElement.setAttribute('slot', 'title');
-    stringTitleElement.setAttribute('role', 'heading');
-    this.__setTitleHeadingLevel(stringTitleElement, this.titleHeadingLevel);
-    stringTitleElement.setAttribute('card-string-title', '');
-    stringTitleElement.id = `card-title-${generateUniqueId()}`;
-    return stringTitleElement;
-  }
-
-  /** @private */
-  __titleHeadingLevelChanged(titleHeadingLevel) {
-    const stringTitleElement = this.__getStringTitleElement();
-    if (stringTitleElement) {
-      this.__setTitleHeadingLevel(stringTitleElement, titleHeadingLevel);
-    }
-  }
-
-  /** @private */
-  __setTitleHeadingLevel(stringTitleElement, titleHeadingLevel) {
-    stringTitleElement.setAttribute('aria-level', titleHeadingLevel || 2);
-  }
-
-  /** @private */
-  __getStringTitleElement() {
-    return this.querySelector('[slot="title"][card-string-title]');
   }
 
   /**

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -28,12 +28,12 @@ describe('vaadin-card', () => {
 
   describe('title', () => {
     function getStringTitleElement() {
-      return card.querySelector('[slot="title"][card-string-title]') as HTMLElement;
+      return card.querySelector('[slot="title"][role="heading"]') as HTMLElement;
     }
 
     function getCustomTitleElement() {
       return Array.from(card.querySelectorAll('[slot="title"]')).find((el) => {
-        return !el.hasAttribute('card-string-title');
+        return el.getAttribute('role') !== 'heading';
       });
     }
 

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -81,6 +81,13 @@ describe('vaadin-card', () => {
       expect(getStringTitleElement()).to.not.exist;
     });
 
+    it('should not throw when clearing string title before it is rendered', async () => {
+      card.cardTitle = 'Some title';
+      card.cardTitle = '';
+      await nextRender();
+      expect(getStringTitleElement()).to.not.exist;
+    });
+
     it('should clear custom title element when string title is set', async () => {
       const customTitleElement = fixtureSync('<span slot="title">Custom title element</span>');
       card.appendChild(customTitleElement);

--- a/packages/card/test/dom/__snapshots__/card.test.snap.js
+++ b/packages/card/test/dom/__snapshots__/card.test.snap.js
@@ -10,13 +10,12 @@ snapshots["vaadin-card host default"] =
 snapshots["vaadin-card host card-title"] = 
 `<vaadin-card
   _t=""
-  aria-labelledby="card-title-0"
+  aria-labelledby="card-title-vaadin-card-1"
   role="region"
 >
   <div
     aria-level="2"
-    card-string-title=""
-    id="card-title-0"
+    id="card-title-vaadin-card-1"
     role="heading"
     slot="title"
   >


### PR DESCRIPTION
## Description

Moved `card` title logic into a `TitleController` to align with the corresponding `vaadin-login-overlay` [logic](https://github.com/vaadin/web-components/blob/main/packages/login/src/title-controller.js).
This could be also possibly reused by the "view layout" component if we decide to have similar API there.

## Type of change

- Refactor