### PR TITLE
fix: resolve context menu target from stored composed path

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -341,13 +341,26 @@ export const ContextMenuMixin = (superClass) =>
       this._setOpened(false);
     }
 
+    /**
+     * Returns the composed path of the event. Falls back to
+     * the path stored at dispatch time, or the event target.
+     * @private
+     */
+    __getComposedPath(e) {
+      const path = e.composedPath();
+      if (path.length > 0) {
+        return path;
+      }
+      return e.__composedPath || e.detail?.sourceEvent?.__composedPath || (e.target ? [e.target] : []);
+    }
+
     /** @private */
     _contextTarget(e) {
       if (this.selector) {
         const targets = this.listenOn.querySelectorAll(this.selector);
 
         return Array.prototype.filter.call(targets, (el) => {
-          return e.composedPath().indexOf(el) > -1;
+          return this.__getComposedPath(e).indexOf(el) > -1;
         })[0];
       } else if (this.listenOn && this.listenOn !== this && this.position) {
         // If listenOn has been set on a different element than the context menu root, then use listenOn as the target.
@@ -362,7 +375,7 @@ export const ContextMenuMixin = (superClass) =>
      */
     open(e) {
       // Ignore events from the overlay
-      if (this._overlayElement && e.composedPath().includes(this._overlayElement)) {
+      if (this._overlayElement && this.__getComposedPath(e).includes(this._overlayElement)) {
         return;
       }
 
@@ -559,7 +572,7 @@ export const ContextMenuMixin = (superClass) =>
 
         if (position === 0) {
           // Native keyboard event
-          const target = event.composedPath()[0] || event.target;
+          const target = this.__getComposedPath(event)[0];
           const rect = target.getBoundingClientRect();
           return coord === 'x' ? rect.left : rect.top + rect.height;
         }

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -559,7 +559,7 @@ export const ContextMenuMixin = (superClass) =>
 
         if (position === 0) {
           // Native keyboard event
-          const target = event.composedPath()[0];
+          const target = event.composedPath()[0] || event.target;
           const rect = target.getBoundingClientRect();
           return coord === 'x' ? rect.left : rect.top + rect.height;
         }

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -342,16 +342,12 @@ export const ContextMenuMixin = (superClass) =>
     }
 
     /**
-     * Returns the composed path of the event. Falls back to
-     * the path stored at dispatch time, or the event target.
+     * Returns the composed path of the event. By default, it uses the path stored
+     * at dispatch time (needed for Flow connector that opens menu asynchronously).
      * @private
      */
     __getComposedPath(e) {
-      const path = e.composedPath();
-      if (path.length > 0) {
-        return path;
-      }
-      return e.__composedPath || e.detail?.sourceEvent?.__composedPath || (e.target ? [e.target] : []);
+      return e.__composedPath ?? e.detail?.sourceEvent?.__composedPath ?? e.composedPath();
     }
 
     /** @private */

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -568,7 +568,7 @@ export const ContextMenuMixin = (superClass) =>
 
         if (position === 0) {
           // Native keyboard event
-          const target = this.__getComposedPath(event)[0];
+          const target = this.__getComposedPath(event)[0] || event.target;
           const rect = target.getBoundingClientRect();
           return coord === 'x' ? rect.left : rect.top + rect.height;
         }

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { click, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, click, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import '../src/vaadin-context-menu.js';
 
 describe('integration', () => {
@@ -45,5 +45,33 @@ describe('integration', () => {
     const overlayRect = overlay.getBoundingClientRect();
     expect(overlayRect.left).to.be.closeTo(100, 0.1);
     expect(overlayRect.top).to.be.closeTo(100, 0.1);
+  });
+});
+
+describe('deferred open', () => {
+  let menu, button;
+
+  beforeEach(async () => {
+    const wrapper = fixtureSync(`
+      <div>
+        <vaadin-context-menu></vaadin-context-menu>
+        <div id="target">Target</div>
+      </div>
+    `);
+    [menu, button] = wrapper.children;
+    menu.renderer = (root) => {
+      root.textContent = 'foo';
+    };
+    await nextRender();
+  });
+
+  it('should open with an event used after it finished dispatching', async () => {
+    // The Flow connector stores the event and opens the menu later, so `open()`
+    // runs once the event finished dispatching and its composed path is empty.
+    const event = click(button, { x: 0, y: 0 });
+    await aTimeout(0);
+    menu.open(event);
+    await nextRender();
+    expect(menu.opened).to.be.true;
   });
 });

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -55,17 +55,6 @@ describe('integration', () => {
   });
 
   describe('deferred open', () => {
-    // The Flow connector stores the openOn event and opens the menu later, after
-    // a server round-trip, so open() runs once the event finished dispatching and
-    // its composed path is empty.
-    it('should open with an event used after it finished dispatching', async () => {
-      const event = click(target, { x: 0, y: 0 });
-      await aTimeout(0);
-      menu.open(event);
-      await nextRender();
-      expect(menu.opened).to.be.true;
-    });
-
     it('should position against the deep target from the stored composed path', async () => {
       // Captured at dispatch time by the gesture / Flow connector
       wrapper.addEventListener('click', (e) => {

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -1,14 +1,16 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, click, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, click, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import '../src/vaadin-context-menu.js';
 
 describe('integration', () => {
-  let menu, button, overlay;
+  let menu, wrapper, target, overlay;
 
   beforeEach(async () => {
     menu = fixtureSync('<vaadin-context-menu></vaadin-context-menu>');
     await nextRender();
-    const wrapper = menu.parentElement;
+    // The target is placed inside the wrapper's shadow root, so an event
+    // originating from it is re-targeted to the wrapper (the shadow host).
+    wrapper = menu.parentElement;
     wrapper.attachShadow({ mode: 'open' });
     wrapper.shadowRoot.innerHTML = `
       <slot></slot>
@@ -17,61 +19,90 @@ describe('integration', () => {
     menu.renderer = (root) => {
       root.textContent = 'foo';
     };
-    wrapper.addEventListener('click', (e) => {
-      menu.open(e);
-    });
-    button = wrapper.shadowRoot.querySelector('button');
+    target = wrapper.shadowRoot.querySelector('button');
     overlay = menu._overlayElement;
   });
 
-  it('should open context menu on .open(e)', () => {
-    click(button);
-    expect(menu.opened).to.eql(true);
+  describe('default', () => {
+    beforeEach(() => {
+      wrapper.addEventListener('click', (e) => {
+        menu.open(e);
+      });
+    });
+
+    it('should open context menu on .open(e)', () => {
+      click(target);
+      expect(menu.opened).to.eql(true);
+    });
+
+    it('should position overlay against the target on keyboard open', async () => {
+      // Emulate keyboard-triggered click that reports clientX/clientY as 0
+      click(target, { x: 0, y: 0 });
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      const targetRect = target.getBoundingClientRect();
+      const overlayRect = overlay.getBoundingClientRect();
+      expect(overlayRect.left).to.be.closeTo(targetRect.left, 0.1);
+      expect(overlayRect.top).to.be.closeTo(targetRect.bottom, 0.1);
+    });
+
+    it('should position overlay at the pointer on mouse open', async () => {
+      click(target, { x: 100, y: 100 });
+      await oneEvent(overlay, 'vaadin-overlay-open');
+      const overlayRect = overlay.getBoundingClientRect();
+      expect(overlayRect.left).to.be.closeTo(100, 0.1);
+      expect(overlayRect.top).to.be.closeTo(100, 0.1);
+    });
   });
 
-  it('should position overlay against the target on keyboard open', async () => {
-    // Emulate keyboard-triggered click that reports clientX/clientY as 0
-    click(button, { x: 0, y: 0 });
-    await oneEvent(overlay, 'vaadin-overlay-open');
-    const buttonRect = button.getBoundingClientRect();
-    const overlayRect = overlay.getBoundingClientRect();
-    expect(overlayRect.left).to.be.closeTo(buttonRect.left, 0.1);
-    expect(overlayRect.top).to.be.closeTo(buttonRect.bottom, 0.1);
-  });
+  describe('deferred open', () => {
+    // The Flow connector stores the openOn event and opens the menu later, after
+    // a server round-trip, so open() runs once the event finished dispatching and
+    // its composed path is empty.
+    it('should open with an event used after it finished dispatching', async () => {
+      const event = click(target, { x: 0, y: 0 });
+      await aTimeout(0);
+      menu.open(event);
+      await nextRender();
+      expect(menu.opened).to.be.true;
+    });
 
-  it('should position overlay at the pointer on mouse open', async () => {
-    click(button, { x: 100, y: 100 });
-    await oneEvent(overlay, 'vaadin-overlay-open');
-    const overlayRect = overlay.getBoundingClientRect();
-    expect(overlayRect.left).to.be.closeTo(100, 0.1);
-    expect(overlayRect.top).to.be.closeTo(100, 0.1);
-  });
-});
+    it('should position against the deep target from the stored composed path', async () => {
+      // Captured at dispatch time by the gesture / Flow connector
+      wrapper.addEventListener('click', (e) => {
+        e.__composedPath = e.composedPath();
+      });
+      const event = click(target, { x: 0, y: 0 });
+      const targetRect = target.getBoundingClientRect();
 
-describe('deferred open', () => {
-  let menu, button;
+      await aTimeout(0);
+      menu.open(event);
+      await oneEvent(overlay, 'vaadin-overlay-open');
 
-  beforeEach(async () => {
-    const wrapper = fixtureSync(`
-      <div>
-        <vaadin-context-menu></vaadin-context-menu>
-        <div id="target">Target</div>
-      </div>
-    `);
-    [menu, button] = wrapper.children;
-    menu.renderer = (root) => {
-      root.textContent = 'foo';
-    };
-    await nextRender();
-  });
+      const overlayRect = overlay.getBoundingClientRect();
+      expect(overlayRect.left).to.be.closeTo(targetRect.left, 0.1);
+      expect(overlayRect.top).to.be.closeTo(targetRect.bottom, 0.1);
+    });
 
-  it('should open with an event used after it finished dispatching', async () => {
-    // The Flow connector stores the event and opens the menu later, so `open()`
-    // runs once the event finished dispatching and its composed path is empty.
-    const event = click(button, { x: 0, y: 0 });
-    await aTimeout(0);
-    menu.open(event);
-    await nextRender();
-    expect(menu.opened).to.be.true;
+    it('should resolve the selector target from the stored composed path', async () => {
+      const item = document.createElement('div');
+      item.className = 'item';
+      wrapper.appendChild(item);
+      menu.selector = '.item';
+      menu.listenOn = wrapper;
+      await nextUpdate(menu);
+
+      // Captured at dispatch time by the gesture / Flow connector
+      item.addEventListener('click', (e) => {
+        e.__composedPath = e.composedPath();
+      });
+      const event = click(item);
+
+      await aTimeout(0);
+      menu.open(event);
+      await nextRender();
+
+      expect(menu.opened).to.be.true;
+      expect(menu._context.target).to.equal(item);
+    });
   });
 });

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -55,6 +55,16 @@ describe('integration', () => {
   });
 
   describe('deferred open', () => {
+    // The Flow connector stores the event and opens the menu later, so open()
+    // runs once the event finished dispatching and its composed path is empty.
+    it('should open with an event used after it finished dispatching', async () => {
+      const event = click(target, { x: 0, y: 0 });
+      await aTimeout(0);
+      menu.open(event);
+      await nextRender();
+      expect(menu.opened).to.be.true;
+    });
+
     it('should position against the deep target from the stored composed path', async () => {
       // Captured at dispatch time by the gesture / Flow connector
       wrapper.addEventListener('click', (e) => {

--- a/packages/context-menu/test/integration.test.js
+++ b/packages/context-menu/test/integration.test.js
@@ -32,7 +32,7 @@ describe('integration', () => {
 
     it('should open context menu on .open(e)', () => {
       click(target);
-      expect(menu.opened).to.eql(true);
+      expect(menu.opened).to.be.true;
     });
 
     it('should position overlay against the target on keyboard open', async () => {


### PR DESCRIPTION
## Description

Fixed a regression introduced in https://github.com/vaadin/web-components/pull/11992.

Flow connector stores the event, and the menu is opened later via a server round-trip. So `open(e)` runs after the event finished dispatching. By that point of time, `event.composedPath()` returns `[]` so it needs to be stored.

Added logic to handle `__composedPath` - already stored by the gesture, needs to be also set in the connector.

## Type of change

- Bugfix