### PR TITLE
refactor: use fractional rects for menu-bar overflow detection

### DIFF
--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -56,6 +56,9 @@ const DEFAULT_I18N = {
   moreOptions: 'More options',
 };
 
+// Sub-pixel differences below this are treated as a fit, not overflow (#11982).
+const SUBPIXEL_TOLERANCE_PX = 1;
+
 export const MenuBarMixin = (superClass) =>
   class MenuBarMixinClass extends I18nMixin(
     KeyboardDirectionMixin(ResizeMixin(FocusMixin(DisabledMixin(superClass)))),
@@ -496,43 +499,85 @@ export const MenuBarMixin = (superClass) =>
 
       // Prevent the container from shrinking while buttons are being hidden.
       // The host has min-width: 0 so it can shrink inside flex/grid layouts.
-      // Without this lock, hiding a button reduces the host width, which
-      // shrinks the container (width: 100%), shifting all button positions
-      // and causing a cascading collapse where every button appears to overflow.
       container.style.minWidth = `${container.offsetWidth}px`;
 
-      if (container.offsetWidth < container.scrollWidth) {
-        this._hasOverflow = true;
+      // getBoundingClientRect() gives fractional positions, unlike offsetWidth/
+      // scrollWidth which round independently and can cause unexpected collapse.
+      // Left/right edges (not a width sum) absorb gaps and negative margins
+      // automatically and stay correct in RTL with no separate branch.
+      const containerRect = container.getBoundingClientRect();
+      const buttonRects = buttons.map((b) => b.getBoundingClientRect());
 
-        const isRTL = this.__isRTL;
-        const containerLeft = container.offsetLeft;
+      // Extent spanned by all buttons, left-most to right-most edge.
+      const usedLeft = Math.min(...buttonRects.map((r) => r.left));
+      const usedRight = Math.max(...buttonRects.map((r) => r.right));
 
-        const remaining = [...buttons];
-        while (remaining.length) {
-          const lastButton = remaining[remaining.length - 1];
-          const btnLeft = lastButton.offsetLeft - containerLeft;
-
-          // If this button isn't overflowing, then the rest aren't either
-          if (
-            (!isRTL && btnLeft + lastButton.offsetWidth < container.offsetWidth - overflow.offsetWidth) ||
-            (isRTL && btnLeft >= overflow.offsetWidth)
-          ) {
-            break;
-          }
-
-          const btn = this.reverseCollapse ? remaining.shift() : remaining.pop();
-
-          // Save width for buttons with component
-          btn.style.width = getComputedStyle(btn).width;
-          btn.style.visibility = 'hidden';
-          btn.style.position = 'absolute';
-        }
-
-        const items = buttons.filter((b) => !remaining.includes(b)).map((b) => b.item);
-        this.__updateOverflow(items);
+      // Do not overflow for sub-pixel rounding cases below the 1px threshold.
+      if (usedRight - usedLeft - containerRect.width < SUBPIXEL_TOLERANCE_PX) {
+        container.style.minWidth = '';
+        return;
       }
 
+      // The overflow button always renders last and nothing reorders it, so
+      // revealing it here can't shift the rects already captured above.
+      this._hasOverflow = true;
+      const overflowRect = overflow.getBoundingClientRect();
+
+      // Width left for the other buttons once the overflow button is shown.
+      const availableSpace = containerRect.width - overflowRect.width;
+
+      const overflowButtons = this.__collectOverflowButtons(buttons, buttonRects, availableSpace);
+
+      // Apply all hides in a single write pass.
+      overflowButtons.forEach((btn) => {
+        // Save width for buttons with component
+        btn.style.width = getComputedStyle(btn).width;
+        btn.style.visibility = 'hidden';
+        btn.style.position = 'absolute';
+      });
+
+      // buttons.filter (not overflowButtons directly) restores original DOM
+      // order: overflowButtons is built from one end inward, so its order is
+      // reversed relative to buttons whenever reverseCollapse is false.
+      const overflowSet = new Set(overflowButtons);
+      const items = buttons.filter((b) => overflowSet.has(b)).map((b) => b.item);
+      this.__updateOverflow(items);
+
       container.style.minWidth = '';
+    }
+
+    /**
+     * Collect the buttons that must move into the overflow menu so the
+     * remaining ones fit within `availableSpace`, using only the already
+     * captured `buttonRects` (no further DOM reads).
+     * @private
+     */
+    __collectOverflowButtons(buttons, buttonRects, availableSpace) {
+      const overflowButtons = [];
+      let lo = 0;
+      let hi = buttons.length - 1;
+
+      const visibleExtent = () => {
+        let left = Infinity;
+        let right = -Infinity;
+        for (let i = lo; i <= hi; i += 1) {
+          left = Math.min(left, buttonRects[i].left);
+          right = Math.max(right, buttonRects[i].right);
+        }
+        return right - left;
+      };
+
+      while (lo <= hi && visibleExtent() - availableSpace >= SUBPIXEL_TOLERANCE_PX) {
+        if (this.reverseCollapse) {
+          overflowButtons.push(buttons[lo]);
+          lo += 1;
+        } else {
+          overflowButtons.push(buttons[hi]);
+          hi -= 1;
+        }
+      }
+
+      return overflowButtons;
     }
 
     /** @private */

--- a/packages/menu-bar/test/overflow.test.js
+++ b/packages/menu-bar/test/overflow.test.js
@@ -603,6 +603,62 @@ describe('overflow', () => {
     });
   });
 
+  describe('sub-pixel rounding', () => {
+    // Reproduces #11982: a sub-pixel overflow used to false-collapse because
+    // offsetWidth/scrollWidth round independently (e.g. 60.5px in 60px read
+    // as 60 < 61).
+    let wrapper, menu, overflow;
+
+    // Overrides the outer beforeEach's whole-pixel button width, which would
+    // otherwise mask the sub-pixel scenario.
+    const CONTAINER_WIDTH = 60;
+
+    async function initSingleItem(buttonWidth) {
+      wrapper = fixtureSync(`
+        <div>
+          <style>
+            #sub-pixel-menu-bar vaadin-menu-bar-button:not([slot='overflow']) {
+              width: ${buttonWidth}px;
+            }
+          </style>
+          <vaadin-menu-bar id="sub-pixel-menu-bar" style="width: ${CONTAINER_WIDTH}px"></vaadin-menu-bar>
+        </div>
+      `);
+      menu = wrapper.querySelector('vaadin-menu-bar');
+      menu.items = [{ text: 'Item 1' }];
+
+      await nextResize(menu);
+      overflow = menu._buttons.at(-1);
+    }
+
+    // Must be read while the button is still visible — a hidden button is
+    // position: absolute and its rect no longer reflects the overflow.
+    function measureOverflowPx() {
+      return menu._buttons[0].getBoundingClientRect().right - menu._container.getBoundingClientRect().right;
+    }
+
+    it('should not collapse a single item overflowing by a sub-pixel amount', async () => {
+      await initSingleItem(60.5);
+      // Sanity check: this fixture really overflows, it isn't just a fit.
+      expect(measureOverflowPx()).to.be.within(0, 1);
+      expect(overflow.hasAttribute('hidden')).to.be.true;
+      expect(overflow.item.children.length).to.equal(0);
+      assertVisible(menu._buttons[0]);
+    });
+
+    it('should not collapse a single item across a sweep of sub-pixel overflows', async () => {
+      // Guards against a narrower version of #11982 slipping through, the way
+      // a fixed +1px tolerance did in the rejected #11986.
+      for (let buttonWidth = 60.1; buttonWidth <= 60.9; buttonWidth += 0.1) {
+        await initSingleItem(buttonWidth);
+        const label = `button width ${buttonWidth.toFixed(1)}px`;
+        expect(overflow.hasAttribute('hidden'), label).to.be.true;
+        expect(overflow.item.children.length, label).to.equal(0);
+        assertVisible(menu._buttons[0]);
+      }
+    });
+  });
+
   describe('performance', () => {
     let menu, spy;
 


### PR DESCRIPTION
The menu-bar overflow gate compared `offsetWidth` and `scrollWidth` of the container. Both are independently rounded to whole pixels, so a real overflow of less than a pixel could round into a mismatch and trigger a false collapse. In practice a single icon-only item ended up nested inside its own overflow ellipsis under non-default browser zoom (issue #11982). The reporter noted it is better to overflow by a pixel than to collapse in that situation.

A prior attempt (PR #11986) added a fixed `+1px` tolerance to that integer comparison. Review showed it does not fix the reported case: because `offsetWidth` and `scrollWidth` are each rounded, their mismatch can be larger than 1px depending on sub-pixel rendering, so a fixed integer tolerance only moves the failure boundary.

## Changes

- Measure overflow with `getBoundingClientRect()` (fractional) instead of `offsetWidth`/`scrollWidth`, so the fit decision is made on un-rounded numbers. A sub-pixel overflow (less than one full pixel) no longer collapses.
- Batch all reads into one phase, then apply all hides in one write phase. This also removes the per-button forced reflow the old loop caused by reading `offsetLeft` after each `visibility` write.
- Use the visual left/right edges of the buttons (min/max of the rects) rather than a sum of widths, so gaps and the buttons' negative inline margins are accounted for automatically, and the math stays correct in RTL without a separate branch.
- The `min-width` lock added in PR #11358 and its regression test coverage (flex/grid cascading collapse) are kept unchanged.
- Replace the sub-pixel test with two real-rendering tests (no metric stubbing): one at a known sub-pixel-overflow geometry, and one sweeping the button width across the sub-pixel band to guard against a future narrower version of the same rounding bug.

Fixes #11982

---

🤖 Generated with Claude Code
