### PR TITLE
feat: add i18n for grid selection column accessible names

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -19,7 +19,14 @@ export const A11yMixin = (superClass) =>
       };
     }
     static get observers() {
-      return ['__a11yUpdateGridSize(size, _columnTree, __emptyState)'];
+      return ['__a11yUpdateGridSize(size, _columnTree, __emptyState)', '__a11yI18nChanged(__effectiveI18n)'];
+    }
+
+    /** @private */
+    __a11yI18nChanged() {
+      // Re-run renderers so the selection column checkboxes, which read the
+      // grid's effective i18n, pick up the updated accessible names.
+      this.requestContentUpdate();
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -24,8 +24,7 @@ export const A11yMixin = (superClass) =>
 
     /** @private */
     __a11yI18nChanged() {
-      // Re-run renderers so the selection column checkboxes, which read the
-      // grid's effective i18n, pick up the updated accessible names.
+      // Update selection column checkboxes accessible name.
       this.requestContentUpdate();
     }
 

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -209,12 +209,12 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       // the row have run in the current task, as the selection column may
       // render before the row header column.
       queueMicrotask(() => {
-        const row = root.assignedSlot?.parentNode?.parentNode;
+        const row = root.assignedSlot?.parentElement?.__parentRow;
         if (!checkbox.isConnected || !row) {
           return;
         }
-        const rowHeaderContent = [...row.children].find((cell) => cell._column?.rowHeader)?._content;
-        const value = rowHeaderContent?.textContent.trim() || String(row.index + 1);
+        const rowHeaderCell = row.__cells.find((cell) => cell._column?.rowHeader);
+        const value = rowHeaderCell?._content?.textContent.trim() || String(row.index + 1);
         checkbox.accessibleName = ariaLabel.replace('{0}', value);
       });
     }

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -150,11 +150,12 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       let checkbox = root.firstElementChild;
       if (!checkbox) {
         checkbox = document.createElement('vaadin-checkbox');
-        checkbox.accessibleName = 'Select All';
         checkbox.classList.add('vaadin-grid-select-all-checkbox');
         checkbox.addEventListener('change', this.__onSelectAllCheckboxChange);
         root.appendChild(checkbox);
       }
+
+      checkbox.accessibleName = this._grid?.__effectiveI18n?.selectAllCheckboxAriaLabel;
 
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
       checkbox.checked = checked;
@@ -171,7 +172,6 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       let checkbox = root.firstElementChild;
       if (!checkbox) {
         checkbox = document.createElement('vaadin-checkbox');
-        checkbox.accessibleName = 'Select Row';
         checkbox.addEventListener('change', this.__onSelectRowCheckboxChange);
         root.appendChild(checkbox);
         addListener(root, 'track', this.__onCellTrack);
@@ -180,6 +180,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.addEventListener('click', this.__onCellClick);
       }
 
+      this.__updateSelectRowAccessibleName(checkbox, root);
       checkbox.__item = item;
       checkbox.checked = selected;
 
@@ -188,6 +189,34 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
       const isHidden = !isSelectable && !selected;
       checkbox.style.visibility = isHidden ? 'hidden' : '';
+    }
+
+    /**
+     * Sets the Select Row checkbox accessible name based on the grid i18n.
+     * The `{0}` placeholder is replaced with the row header cell text content
+     * or row index the if there is no row header column or it's cell is empty.
+     *
+     * @private
+     */
+    __updateSelectRowAccessibleName(checkbox, root) {
+      const ariaLabel = this._grid?.__effectiveI18n?.selectRowCheckboxAriaLabel;
+      if (!ariaLabel || !ariaLabel.includes('{0}')) {
+        checkbox.accessibleName = ariaLabel;
+        return;
+      }
+
+      // Defer reading the row header cell text until all cell renderers of
+      // the row have run in the current task, as the selection column may
+      // render before the row header column.
+      queueMicrotask(() => {
+        const row = root.assignedSlot?.parentNode?.parentNode;
+        if (!checkbox.isConnected || !row) {
+          return;
+        }
+        const rowHeaderContent = [...row.children].find((cell) => cell._column?.rowHeader)?._content;
+        const value = rowHeaderContent?.textContent.trim() || String(row.index + 1);
+        checkbox.accessibleName = ariaLabel.replace('{0}', value);
+      });
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -155,7 +155,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.appendChild(checkbox);
       }
 
-      checkbox.accessibleName = this._grid?.__effectiveI18n?.selectAllCheckboxAriaLabel;
+      checkbox.accessibleName = this._grid?.__effectiveI18n?.selectAll;
 
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
       checkbox.checked = checked;
@@ -199,7 +199,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
      * @private
      */
     __updateSelectRowAccessibleName(checkbox, root) {
-      const ariaLabel = this._grid?.__effectiveI18n?.selectRowCheckboxAriaLabel;
+      const ariaLabel = this._grid?.__effectiveI18n?.selectRow;
       if (!ariaLabel || !ariaLabel.includes('{0}')) {
         checkbox.accessibleName = ariaLabel;
         return;

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -194,7 +194,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     /**
      * Sets the Select Row checkbox accessible name based on the grid i18n.
      * The `{0}` placeholder is replaced with the row header cell text content
-     * or row index the if there is no row header column or it's cell is empty.
+     * or row index if there is no row header column or it's cell is empty.
      *
      * @private
      */

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -193,14 +193,14 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
     /**
      * Sets the Select Row checkbox accessible name based on the grid i18n.
-     * The `{0}` placeholder is replaced with the row header cell text content
+     * The `{rowHeader}` placeholder is replaced with the row header cell text content
      * or row index if there is no row header column or it's cell is empty.
      *
      * @private
      */
     __updateSelectRowAccessibleName(checkbox, root) {
       const ariaLabel = this._grid?.__effectiveI18n?.selectRow;
-      if (!ariaLabel || !ariaLabel.includes('{0}')) {
+      if (!ariaLabel || !ariaLabel.includes('{rowHeader}')) {
         checkbox.accessibleName = ariaLabel;
         return;
       }
@@ -215,7 +215,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         }
         const rowHeaderCell = row.__cells.find((cell) => cell._column?.rowHeader);
         const value = rowHeaderCell?._content?.textContent.trim() || String(row.index + 1);
-        checkbox.accessibleName = ariaLabel.replace('{0}', value);
+        checkbox.accessibleName = ariaLabel.replace('{rowHeader}', value);
       });
     }
 

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -282,6 +282,28 @@ export interface GridI18n {
  * @fires {CustomEvent} item-toggle - Fired when the user selects or deselects an item through the selection column.
  */
 declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
+  /**
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
+   *
+   * The object has the following JSON structure and default values:
+   *
+   * ```js
+   * {
+   *   // Accessible name (aria-label) for the select all checkbox in the
+   *   // selection column header cell.
+   *   selectAllCheckboxAriaLabel: 'Select All',
+   *   // Accessible name (aria-label) for the select row checkbox in each
+   *   // selection column body cell. The `{0}` placeholder is replaced with the
+   *   // text content of the row's row-header cell, or the 1-based row index
+   *   // when there is no row-header column.
+   *   selectRowCheckboxAriaLabel: 'Select Row {0}',
+   * }
+   * ```
+   */
+  i18n: GridI18n;
+
   addEventListener<K extends keyof GridEventMap<TItem>>(
     type: K,
     listener: (this: Grid<TItem>, ev: GridEventMap<TItem>[K]) => void,

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -24,8 +24,7 @@ export interface GridI18n {
   /**
    * The accessible name (aria-label) template for the Select Row checkbox in
    * each selection column body cell. The `{rowHeader}` placeholder is replaced with
-   * the text content of the row's row-header cell, or the 1-based row index
-   * when there is no row-header column.
+   * the row header cell text content or row index if there is no row header column.
    */
   selectRow?: string;
 }
@@ -296,8 +295,7 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    *   selectAll: 'Select All',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
-   *   // text content of the row's row-header cell, or the 1-based row index
-   *   // when there is no row-header column.
+   *   // row header cell text content or row index if there is no row header column.
    *   selectRow: 'Select Row {rowHeader}',
    * }
    * ```

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -5,6 +5,7 @@
  */
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type { GridEventMap, GridMixinClass } from './vaadin-grid-mixin.js';
@@ -12,6 +13,22 @@ import type { GridEventMap, GridMixinClass } from './vaadin-grid-mixin.js';
 export * from './vaadin-grid-mixin.js';
 
 export type GridDefaultItem = any;
+
+export interface GridI18n {
+  /**
+   * The accessible name (aria-label) for the Select All checkbox in the
+   * selection column header cell.
+   */
+  selectAllCheckboxAriaLabel?: string;
+
+  /**
+   * The accessible name (aria-label) template for the Select Row checkbox in
+   * each selection column body cell. The `{0}` placeholder is replaced with
+   * the text content of the row's row-header cell, or the 1-based row index
+   * when there is no row-header column.
+   */
+  selectRowCheckboxAriaLabel?: string;
+}
 
 /**
  * `<vaadin-grid>` is a free, high quality data grid / data table Web Component. The content of the
@@ -279,7 +296,13 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
 }
 
 interface Grid<TItem = GridDefaultItem>
-  extends DisabledMixinClass, ElementMixinClass, ThemableMixinClass, ThemePropertyMixinClass, GridMixinClass<TItem> {}
+  extends
+    DisabledMixinClass,
+    ElementMixinClass,
+    I18nMixinClass<GridI18n>,
+    ThemableMixinClass,
+    ThemePropertyMixinClass,
+    GridMixinClass<TItem> {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -23,7 +23,7 @@ export interface GridI18n {
 
   /**
    * The accessible name (aria-label) template for the Select Row checkbox in
-   * each selection column body cell. The `{0}` placeholder is replaced with
+   * each selection column body cell. The `{rowHeader}` placeholder is replaced with
    * the text content of the row's row-header cell, or the 1-based row index
    * when there is no row-header column.
    */
@@ -295,10 +295,10 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    *   // selection column header cell.
    *   selectAll: 'Select All',
    *   // Accessible name (aria-label) for the select row checkbox in each
-   *   // selection column body cell. The `{0}` placeholder is replaced with the
+   *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // text content of the row's row-header cell, or the 1-based row index
    *   // when there is no row-header column.
-   *   selectRow: 'Select Row {0}',
+   *   selectRow: 'Select Row {rowHeader}',
    * }
    * ```
    */

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -19,7 +19,7 @@ export interface GridI18n {
    * The accessible name (aria-label) for the Select All checkbox in the
    * selection column header cell.
    */
-  selectAllCheckboxAriaLabel?: string;
+  selectAll?: string;
 
   /**
    * The accessible name (aria-label) template for the Select Row checkbox in
@@ -27,7 +27,7 @@ export interface GridI18n {
    * the text content of the row's row-header cell, or the 1-based row index
    * when there is no row-header column.
    */
-  selectRowCheckboxAriaLabel?: string;
+  selectRow?: string;
 }
 
 /**
@@ -293,12 +293,12 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    * {
    *   // Accessible name (aria-label) for the select all checkbox in the
    *   // selection column header cell.
-   *   selectAllCheckboxAriaLabel: 'Select All',
+   *   selectAll: 'Select All',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{0}` placeholder is replaced with the
    *   // text content of the row's row-header cell, or the 1-based row index
    *   // when there is no row-header column.
-   *   selectRowCheckboxAriaLabel: 'Select Row {0}',
+   *   selectRow: 'Select Row {0}',
    * }
    * ```
    */

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -17,7 +17,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
 
 const DEFAULT_I18N = {
   selectAll: 'Select All',
-  selectRow: 'Select Row {0}',
+  selectRow: 'Select Row {rowHeader}',
 };
 
 /**
@@ -300,10 +300,10 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    *   // selection column header cell.
    *   selectAll: 'Select All',
    *   // Accessible name (aria-label) for the select row checkbox in each
-   *   // selection column body cell. The `{0}` placeholder is replaced with the
+   *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // text content of the row's row-header cell, or the 1-based row index
    *   // when there is no row-header column.
-   *   selectRow: 'Select Row {0}',
+   *   selectRow: 'Select Row {rowHeader}',
    * }
    * ```
    *

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -8,11 +8,17 @@ import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
+import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { gridStyles } from './styles/vaadin-grid-base-styles.js';
 import { GridMixin } from './vaadin-grid-mixin.js';
+
+const DEFAULT_I18N = {
+  selectAllCheckboxAriaLabel: 'Select All',
+  selectRowCheckboxAriaLabel: 'Select Row {0}',
+};
 
 /**
  * `<vaadin-grid>` is a free, high quality data grid / data table Web Component. The content of the
@@ -268,13 +274,47 @@ import { GridMixin } from './vaadin-grid-mixin.js';
  * @customElement vaadin-grid
  * @extends HTMLElement
  */
-class Grid extends GridMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
+class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))))) {
   static get is() {
     return 'vaadin-grid';
   }
 
   static get styles() {
     return gridStyles;
+  }
+
+  static get defaultI18n() {
+    return DEFAULT_I18N;
+  }
+
+  /**
+   * The object used to localize this component. To change the default
+   * localization, replace this with an object that provides all properties, or
+   * just the individual properties you want to change.
+   *
+   * The object has the following JSON structure and default values:
+   *
+   * ```js
+   * {
+   *   // Accessible name (aria-label) for the select all checkbox in the
+   *   // selection column header cell.
+   *   selectAllCheckboxAriaLabel: 'Select All',
+   *   // Accessible name (aria-label) for the select row checkbox in each
+   *   // selection column body cell. The `{0}` placeholder is replaced with the
+   *   // text content of the row's row-header cell, or the 1-based row index
+   *   // when there is no row-header column.
+   *   selectRowCheckboxAriaLabel: 'Select Row {0}',
+   * }
+   * ```
+   *
+   * @return {!GridI18n}
+   */
+  get i18n() {
+    return super.i18n;
+  }
+
+  set i18n(value) {
+    super.i18n = value;
   }
 
   /** @protected */

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -301,8 +301,7 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    *   selectAll: 'Select All',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
-   *   // text content of the row's row-header cell, or the 1-based row index
-   *   // when there is no row-header column.
+   *   // row header cell text content or row index if there is no row header column.
    *   selectRow: 'Select Row {rowHeader}',
    * }
    * ```

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -16,8 +16,8 @@ import { gridStyles } from './styles/vaadin-grid-base-styles.js';
 import { GridMixin } from './vaadin-grid-mixin.js';
 
 const DEFAULT_I18N = {
-  selectAllCheckboxAriaLabel: 'Select All',
-  selectRowCheckboxAriaLabel: 'Select Row {0}',
+  selectAll: 'Select All',
+  selectRow: 'Select Row {0}',
 };
 
 /**
@@ -298,12 +298,12 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    * {
    *   // Accessible name (aria-label) for the select all checkbox in the
    *   // selection column header cell.
-   *   selectAllCheckboxAriaLabel: 'Select All',
+   *   selectAll: 'Select All',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{0}` placeholder is replaced with the
    *   // text content of the row's row-header cell, or the 1-based row index
    *   // when there is no row-header column.
-   *   selectRowCheckboxAriaLabel: 'Select Row {0}',
+   *   selectRow: 'Select Row {0}',
    * }
    * ```
    *

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -269,8 +269,23 @@ describe('multi selection column', () => {
     expect(firstBodyCheckbox.checked).to.be.false;
   });
 
-  it('should set aria-label on the checkbox input element', () => {
-    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select Row');
+  it('should set aria-label on the checkbox input element using row index', async () => {
+    // No row header column defined, so the {0} placeholder falls back to the
+    // 1-based row index.
+    await nextRender();
+    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select Row 1');
+  });
+
+  it('should re-render rows when the i18n select row template changes', async () => {
+    grid.i18n = { selectRowCheckboxAriaLabel: 'Pick {0}' };
+    await nextRender();
+    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Pick 1');
+  });
+
+  it('should use an i18n template without the placeholder as is', async () => {
+    grid.i18n = { selectRowCheckboxAriaLabel: 'Select item' };
+    await nextRender();
+    expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select item');
   });
 
   it('should select item when checkbox is checked', async () => {
@@ -395,6 +410,12 @@ describe('multi selection column', () => {
 
   it('should set aria-label on the select all checkbox input element', () => {
     expect(selectAllCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select All');
+  });
+
+  it('should update aria-label on the select all checkbox based on i18n', async () => {
+    grid.i18n = { selectAllCheckboxAriaLabel: 'Select All Items' };
+    await nextRender();
+    expect(selectAllCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select All Items');
   });
 
   it('should set selectAll when header checkbox is clicked', async () => {
@@ -1252,6 +1273,51 @@ describe('multi selection column', () => {
         document.getSelection().selectAllChildren(row2CellContent1);
         expect(document.getSelection().toString()).to.be.not.empty;
       });
+    });
+  });
+});
+
+describe('select row accessible name', () => {
+  let grid;
+
+  function getBodyCheckbox(rowIndex) {
+    return getBodyCellContent(grid, rowIndex, 0).firstElementChild;
+  }
+
+  describe('with row header', () => {
+    beforeEach(async () => {
+      grid = fixtureSync(`
+      <vaadin-grid style="width: 300px; height: 300px;">
+        <vaadin-grid-selection-column></vaadin-grid-selection-column>
+        <vaadin-grid-column path="name" row-header></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+      grid.items = [{ name: 'John' }, { name: 'Jane' }];
+      flushGrid(grid);
+      await nextRender();
+    });
+
+    it('should use the row header cell text for the placeholder', () => {
+      expect(getBodyCheckbox(0).accessibleName).to.equal('Select Row John');
+      expect(getBodyCheckbox(1).accessibleName).to.equal('Select Row Jane');
+    });
+  });
+
+  describe('empty row header', () => {
+    beforeEach(async () => {
+      grid = fixtureSync(`
+      <vaadin-grid style="width: 300px; height: 300px;">
+        <vaadin-grid-selection-column></vaadin-grid-selection-column>
+        <vaadin-grid-column row-header></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+      grid.items = [{ name: 'John' }];
+      flushGrid(grid);
+      await nextRender();
+    });
+
+    it('should fall back to the row index when the row header cell has no text', () => {
+      expect(getBodyCheckbox(0).accessibleName).to.equal('Select Row 1');
     });
   });
 });

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -277,13 +277,13 @@ describe('multi selection column', () => {
   });
 
   it('should re-render rows when the i18n select row template changes', async () => {
-    grid.i18n = { selectRowCheckboxAriaLabel: 'Pick {0}' };
+    grid.i18n = { selectRow: 'Pick {0}' };
     await nextRender();
     expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Pick 1');
   });
 
   it('should use an i18n template without the placeholder as is', async () => {
-    grid.i18n = { selectRowCheckboxAriaLabel: 'Select item' };
+    grid.i18n = { selectRow: 'Select item' };
     await nextRender();
     expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select item');
   });
@@ -413,7 +413,7 @@ describe('multi selection column', () => {
   });
 
   it('should update aria-label on the select all checkbox based on i18n', async () => {
-    grid.i18n = { selectAllCheckboxAriaLabel: 'Select All Items' };
+    grid.i18n = { selectAll: 'Select All Items' };
     await nextRender();
     expect(selectAllCheckbox.inputElement.getAttribute('aria-label')).to.equal('Select All Items');
   });

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -270,14 +270,14 @@ describe('multi selection column', () => {
   });
 
   it('should set aria-label on the checkbox input element using row index', async () => {
-    // No row header column defined, so the {0} placeholder falls back to the
+    // No row header column defined, so the {rowHeader} placeholder falls back to the
     // 1-based row index.
     await nextRender();
     expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select Row 1');
   });
 
   it('should re-render rows when the i18n select row template changes', async () => {
-    grid.i18n = { selectRow: 'Pick {0}' };
+    grid.i18n = { selectRow: 'Pick {rowHeader}' };
     await nextRender();
     expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.equal('Pick 1');
   });

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -270,8 +270,6 @@ describe('multi selection column', () => {
   });
 
   it('should set aria-label on the checkbox input element using row index', async () => {
-    // No row header column defined, so the {rowHeader} placeholder falls back to the
-    // 1-based row index.
     await nextRender();
     expect(firstBodyCheckbox.inputElement.getAttribute('aria-label')).to.eql('Select Row 1');
   });
@@ -1287,11 +1285,11 @@ describe('select row accessible name', () => {
   describe('with row header', () => {
     beforeEach(async () => {
       grid = fixtureSync(`
-      <vaadin-grid style="width: 300px; height: 300px;">
-        <vaadin-grid-selection-column></vaadin-grid-selection-column>
-        <vaadin-grid-column path="name" row-header></vaadin-grid-column>
-      </vaadin-grid>
-    `);
+        <vaadin-grid style="width: 300px; height: 300px;">
+          <vaadin-grid-selection-column></vaadin-grid-selection-column>
+          <vaadin-grid-column path="name" row-header></vaadin-grid-column>
+        </vaadin-grid>
+      `);
       grid.items = [{ name: 'John' }, { name: 'Jane' }];
       flushGrid(grid);
       await nextRender();
@@ -1306,11 +1304,11 @@ describe('select row accessible name', () => {
   describe('empty row header', () => {
     beforeEach(async () => {
       grid = fixtureSync(`
-      <vaadin-grid style="width: 300px; height: 300px;">
-        <vaadin-grid-selection-column></vaadin-grid-selection-column>
-        <vaadin-grid-column row-header></vaadin-grid-column>
-      </vaadin-grid>
-    `);
+        <vaadin-grid style="width: 300px; height: 300px;">
+          <vaadin-grid-selection-column></vaadin-grid-selection-column>
+          <vaadin-grid-column row-header></vaadin-grid-column>
+        </vaadin-grid>
+      `);
       grid.items = [{ name: 'John' }];
       flushGrid(grid);
       await nextRender();

--- a/packages/grid/test/typings/grid.types.ts
+++ b/packages/grid/test/typings/grid.types.ts
@@ -1,5 +1,6 @@
 import type { DisabledMixinClass } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import type { ElementMixinClass } from '@vaadin/component-base/src/element-mixin.js';
+import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin';
 import type {
   GridColumnGroup,
@@ -49,6 +50,7 @@ import type {
   GridEventContext,
   GridExpandedItemsChangedEvent,
   GridFilterDefinition,
+  GridI18n,
   GridItemModel,
   GridItemToggleEvent,
   GridLoadingChangedEvent,
@@ -73,6 +75,7 @@ assertType<Grid>(genericGrid);
 const narrowedGrid = genericGrid as Grid<TestGridItem>;
 assertType<DisabledMixinClass>(narrowedGrid);
 assertType<ElementMixinClass>(narrowedGrid);
+assertType<I18nMixinClass<GridI18n>>(narrowedGrid);
 assertType<ThemableMixinClass>(narrowedGrid);
 assertType<ActiveItemMixinClass<TestGridItem>>(narrowedGrid);
 assertType<ArrayDataProviderMixinClass<TestGridItem>>(narrowedGrid);
@@ -180,6 +183,8 @@ assertType<boolean>(narrowedGrid.columnReorderingAllowed);
 assertType<TestGridItem[]>(narrowedGrid.selectedItems);
 assertType<TestGridItem[]>(narrowedGrid.detailsOpenedItems);
 assertType<TestGridItem[]>(narrowedGrid.expandedItems);
+
+assertType<GridI18n>(narrowedGrid.i18n);
 
 assertType<(arg0: TestGridItem) => TestGridItem | unknown>(narrowedGrid.getItemId);
 assertType<(arg0: TestGridItem) => void>(narrowedGrid.expandItem);


### PR DESCRIPTION
## Description

Part of https://github.com/vaadin/web-components/issues/3471

Added `I18nMixin` to and `i18n` property to `vaadin-grid` with 2 fields: `selectAll` and `selectRow`.

Selection column reads the grid's effective i18n. The select row label is a string with `{0}` placeholder, which is replaced with the row-header cell text content or the 1-based row index if there is no row-header column.

## Type of change

- Feature