### PR TITLE
refactor: move indeterminate property from CheckboxMixin to checkbox

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.d.ts
@@ -39,15 +39,6 @@ export declare function CheckboxMixin<T extends Constructor<HTMLElement>>(
 
 export declare class CheckboxMixinClass {
   /**
-   * True if the checkbox is in the indeterminate state which means
-   * it is not possible to say whether it is checked or unchecked.
-   * The state is reset once the user switches the checkbox by hand.
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Indeterminate_state_checkboxes
-   */
-  indeterminate: boolean;
-
-  /**
    * The name of the checkbox.
    */
   name: string;

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -21,20 +21,6 @@ export const CheckboxMixin = (superclass) =>
     static get properties() {
       return {
         /**
-         * True if the checkbox is in the indeterminate state which means
-         * it is not possible to say whether it is checked or unchecked.
-         * The state is reset once the user switches the checkbox by hand.
-         *
-         * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Indeterminate_state_checkboxes
-         */
-        indeterminate: {
-          type: Boolean,
-          notify: true,
-          value: false,
-          reflectToAttribute: true,
-        },
-
-        /**
          * The name of the checkbox.
          */
         name: {
@@ -58,11 +44,6 @@ export const CheckboxMixin = (superclass) =>
 
     static get observers() {
       return ['__readonlyChanged(readonly, inputElement)'];
-    }
-
-    /** @override */
-    static get delegateProps() {
-      return [...super.delegateProps, 'indeterminate'];
     }
 
     /** @override */
@@ -185,22 +166,6 @@ export const CheckboxMixin = (superclass) =>
       } else {
         inputElement.removeAttribute('aria-readonly');
       }
-    }
-
-    /**
-     * Override method inherited from `CheckedMixin` to reset
-     * `indeterminate` state checkbox is toggled by the user.
-     *
-     * @param {boolean} checked
-     * @protected
-     * @override
-     */
-    _toggleChecked(checked) {
-      if (this.indeterminate) {
-        this.indeterminate = false;
-      }
-
-      super._toggleChecked(checked);
     }
 
     /**

--- a/packages/checkbox/src/vaadin-checkbox.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox.d.ts
@@ -120,6 +120,15 @@ export interface CheckboxEventMap extends HTMLElementEventMap, CheckboxCustomEve
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  */
 declare class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(HTMLElement))) {
+  /**
+   * True if the checkbox is in the indeterminate state which means
+   * it is not possible to say whether it is checked or unchecked.
+   * The state is reset once the user switches the checkbox by hand.
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/checkbox#indeterminate_state_checkboxes
+   */
+  indeterminate: boolean;
+
   addEventListener<K extends keyof CheckboxEventMap>(
     type: K,
     listener: (this: Checkbox, ev: CheckboxEventMap[K]) => void,

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -96,6 +96,29 @@ export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMi
     return checkboxStyles;
   }
 
+  static get properties() {
+    return {
+      /**
+       * True if the checkbox is in the indeterminate state which means
+       * it is not possible to say whether it is checked or unchecked.
+       * The state is reset once the user switches the checkbox by hand.
+       *
+       * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/checkbox#indeterminate_state_checkboxes
+       */
+      indeterminate: {
+        type: Boolean,
+        notify: true,
+        value: false,
+        reflectToAttribute: true,
+      },
+    };
+  }
+
+  /** @override */
+  static get delegateProps() {
+    return [...super.delegateProps, 'indeterminate'];
+  }
+
   /** @protected */
   render() {
     return html`
@@ -124,6 +147,22 @@ export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMi
     this._tooltipController = new TooltipController(this);
     this._tooltipController.setAriaTarget(this.inputElement);
     this.addController(this._tooltipController);
+  }
+
+  /**
+   * Override method inherited from `CheckedMixin` to reset
+   * `indeterminate` when the checkbox is toggled by the user.
+   *
+   * @param {boolean} checked
+   * @protected
+   * @override
+   */
+  _toggleChecked(checked) {
+    if (this.indeterminate) {
+      this.indeterminate = false;
+    }
+
+    super._toggleChecked(checked);
   }
 }
 


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/11760

This is a pre-requisite for reusing `CheckboxMixin` in the upcoming `vaadin-switch` component.

## Type of change

- Refactor