### PR TITLE
chore: fix inconsistent default property values in guidelines

### DIFF
--- a/guidelines/01-repository.md
+++ b/guidelines/01-repository.md
@@ -7,9 +7,7 @@
   [TypeScript](07-typescript.md)).
 
 Every component is built as a Lit `LitElement`, layered with the Vaadin
-mixins documented in [Common packages](05-common-packages.md). New components
-use Lit-native features (`static properties`, `firstUpdated`, `updated`,
-field initializers) rather than Polymer-style options.
+mixins documented in [Common packages](05-common-packages.md).
 
 ## Test stack
 

--- a/guidelines/13-checklist.md
+++ b/guidelines/13-checklist.md
@@ -30,7 +30,7 @@ not a substitute for reading [Component Structure](03-component-structure.md) an
 - [ ] `static get styles()` returns the imported base styles.
 - [ ] `static get properties()` declares every reactive property with a
       JSDoc comment (and `@attr` for camelCase ones).
-- [ ] Defaults set via field initializers, not a `value:` property option.
+- [ ] Defaults set via `value:` property option.
 - [ ] `ready()` sets host attributes (e.g. `role`) and attaches controllers.
 - [ ] `updated(changed)` reacts to property changes (no Polymer observers).
 - [ ] `defineCustomElement(...)` called at the bottom of the source file.


### PR DESCRIPTION
## Description

There's a minor internal contradiction in the guidelines: 

- `04-coding-conventions` correctly requires to set default property values via `value:`
- `13-checklist` still mentions field initializers (not working, original guidelines leftover)

Updated to use `value:` and trimmed down code conventions from `01-repository`.

## Type of change

- Internal change