### PR TITLE
feat: add i18n for grid sorter accessible name

### DIFF
--- a/packages/crud/src/vaadin-crud-grid-mixin.js
+++ b/packages/crud/src/vaadin-crud-grid-mixin.js
@@ -186,8 +186,6 @@ export const CrudGridMixin = (superClass) =>
             // sort column (in case a filter isn't used at all) => add the sort indicator
             const sorter = document.createElement('vaadin-grid-sorter');
             sorter.setAttribute('path', path);
-            // TODO: Localize aria labels
-            sorter.setAttribute('aria-label', `Sort by ${label}`);
             sorter.textContent = label;
             root.appendChild(sorter);
           } else if (!this.noFilter) {

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -165,7 +165,7 @@ export const A11yMixin = (superClass) =>
     /** @private */
     __a11yUpdateSorters() {
       Array.from(this.querySelectorAll('vaadin-grid-sorter')).forEach((sorter) => {
-        sorter._updateAccessibleName?.();
+        sorter.__updateAccessibleName?.();
 
         const cell = getClosestCell(sorter);
         if (cell) {

--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -26,6 +26,8 @@ export const A11yMixin = (superClass) =>
     __a11yI18nChanged() {
       // Update selection column checkboxes accessible name.
       this.requestContentUpdate();
+      // Update sorters accessible name.
+      this.__a11yUpdateSorters();
     }
 
     /** @private */
@@ -163,6 +165,8 @@ export const A11yMixin = (superClass) =>
     /** @private */
     __a11yUpdateSorters() {
       Array.from(this.querySelectorAll('vaadin-grid-sorter')).forEach((sorter) => {
+        sorter._updateAccessibleName?.();
+
         const cell = getClosestCell(sorter);
         if (cell) {
           cell.setAttribute(

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -91,8 +91,12 @@ export const GridSorterMixin = (superClass) =>
     _updateAccessibleName() {
       // `_grid` is only assigned once the sorter becomes activated.
       // Resolve the grid from the parent cell column as a fallback.
-      const grid = this._grid || getClosestCell(this)?._column?._grid;
-      const ariaLabel = grid?.__effectiveI18n?.sorter?.replace('{column}', this.textContent.trim());
+      const grid = this._grid || getClosestCell(this)?.getRootNode().host;
+      if (!grid) {
+        return;
+      }
+
+      const ariaLabel = grid.__effectiveI18n.sorter?.replace('{column}', this.textContent.trim());
       if (ariaLabel) {
         this.setAttribute('aria-label', ariaLabel);
       } else {

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -53,7 +53,7 @@ export const GridSorterMixin = (superClass) =>
       super.ready();
       this.addEventListener('click', this._onClick.bind(this));
 
-      this._updateAccessibleName();
+      this.__updateAccessibleName();
     }
 
     /** @protected */
@@ -86,9 +86,9 @@ export const GridSorterMixin = (superClass) =>
     /**
      * Updates the sorter accessible name based on the grid i18n.
      *
-     * @protected
+     * @private
      */
-    _updateAccessibleName() {
+    __updateAccessibleName() {
       // `_grid` is only assigned once the sorter becomes activated.
       // Resolve the grid from the parent cell column as a fallback.
       const grid = this._grid || getClosestCell(this)?.getRootNode().host;

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { getClosestCell } from './vaadin-grid-helpers.js';
 
 /**
  * A mixin providing common sorter functionality.
@@ -51,6 +52,8 @@ export const GridSorterMixin = (superClass) =>
     ready() {
       super.ready();
       this.addEventListener('click', this._onClick.bind(this));
+
+      this._updateAccessibleName();
     }
 
     /** @protected */
@@ -78,6 +81,23 @@ export const GridSorterMixin = (superClass) =>
     /** @private */
     _pathOrDirectionChanged() {
       this.__dispatchSorterChangedEvenIfPossible();
+    }
+
+    /**
+     * Updates the sorter accessible name based on the grid i18n.
+     *
+     * @protected
+     */
+    _updateAccessibleName() {
+      // `_grid` is only assigned once the sorter becomes activated.
+      // Resolve the grid from the parent cell column as a fallback.
+      const grid = this._grid || getClosestCell(this)?._column?._grid;
+      const ariaLabel = grid?.__effectiveI18n?.sorter?.replace('{column}', this.textContent.trim());
+      if (ariaLabel) {
+        this.setAttribute('aria-label', ariaLabel);
+      } else {
+        this.removeAttribute('aria-label');
+      }
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -67,7 +67,7 @@ class GridSorter extends GridSorterMixin(ThemableMixin(DirMixin(PolylitMixin(Lum
   render() {
     return html`
       <div part="content">
-        <slot></slot>
+        <slot @slotchange="${this._updateAccessibleName}"></slot>
       </div>
       <div part="indicators">
         <span part="order">${this._getDisplayOrder(this._order)}</span>

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -67,7 +67,7 @@ class GridSorter extends GridSorterMixin(ThemableMixin(DirMixin(PolylitMixin(Lum
   render() {
     return html`
       <div part="content">
-        <slot @slotchange="${this._updateAccessibleName}"></slot>
+        <slot @slotchange="${this.__updateAccessibleName}"></slot>
       </div>
       <div part="indicators">
         <span part="order">${this._getDisplayOrder(this._order)}</span>

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -27,6 +27,12 @@ export interface GridI18n {
    * the row header cell text content or row index if there is no row header column.
    */
   selectRow?: string;
+
+  /**
+   * Accessible name (aria-label) for the grid sorters. The `{column}`
+   * placeholder is replaced with the sorter text content.
+   */
+  sorter?: string;
 }
 
 /**
@@ -297,6 +303,9 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // row header cell text content or row index if there is no row header column.
    *   selectRow: 'Select Row {rowHeader}',
+   *   // Accessible name (aria-label) for the grid sorters. The `{column}`
+   *   // placeholder is replaced with the sorter text content.
+   *   sorter: 'Sort by {column}',
    * }
    * ```
    */

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -18,6 +18,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
 const DEFAULT_I18N = {
   selectAll: 'Select All',
   selectRow: 'Select Row {rowHeader}',
+  sorter: 'Sort by {column}',
 };
 
 /**
@@ -303,6 +304,9 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // row header cell text content or row index if there is no row header column.
    *   selectRow: 'Select Row {rowHeader}',
+   *   // Accessible name (aria-label) for the grid sorters. The `{column}`
+   *   // placeholder is replaced with the sorter text content.
+   *   sorter: 'Sort by {column}',
    * }
    * ```
    *

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -809,4 +809,83 @@ describe('sorting', () => {
       expect(grid._sorters).to.contain(firstNameSorter);
     });
   });
+
+  describe('sorter accessible name from i18n', () => {
+    let grid, sortColumn, sorter;
+
+    beforeEach(async () => {
+      grid = fixtureSync(`
+        <vaadin-grid style="width: 200px; height: 200px;">
+          <vaadin-grid-sort-column path="first" header="First name"></vaadin-grid-sort-column>
+        </vaadin-grid>
+      `);
+      grid.items = [{ first: 'John' }, { first: 'Jane' }];
+      flushGrid(grid);
+      await nextFrame();
+      sortColumn = grid.querySelector('vaadin-grid-sort-column');
+      sorter = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-sorter');
+    });
+
+    it('should apply the default i18n template to the sorter', () => {
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort by First name');
+    });
+
+    it('should update the accessible name when the column header changes', async () => {
+      sortColumn.header = 'Last name';
+      await nextFrame();
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort by Last name');
+    });
+
+    it('should update the accessible name when i18n changes', async () => {
+      grid.i18n = { sorter: 'Sortieren nach {column}' };
+      await nextFrame();
+      expect(sorter.getAttribute('aria-label')).to.equal('Sortieren nach First name');
+    });
+
+    it('should apply an i18n template without a placeholder as is', async () => {
+      grid.i18n = { sorter: 'Sort column' };
+      await nextFrame();
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort column');
+    });
+  });
+
+  describe('sorter accessible name without sort-column', () => {
+    let grid, column, sorter;
+
+    beforeEach(async () => {
+      grid = fixtureSync(`
+        <vaadin-grid style="width: 200px; height: 200px;">
+          <vaadin-grid-column path="first"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      column = grid.querySelector('vaadin-grid-column');
+      // Create the sorter manually, as the Flow connector does, instead of
+      // relying on vaadin-grid-sort-column.
+      column.headerRenderer = (root) => {
+        if (!root.firstChild) {
+          root.innerHTML = '<vaadin-grid-sorter path="first">First name</vaadin-grid-sorter>';
+        }
+      };
+      grid.items = [{ first: 'John' }, { first: 'Jane' }];
+      flushGrid(grid);
+      await nextFrame();
+      sorter = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-sorter');
+    });
+
+    it('should derive the accessible name from the grid i18n autonomously', () => {
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort by First name');
+    });
+
+    it('should update the accessible name when the sorter text content changes', async () => {
+      sorter.textContent = 'Last name';
+      await nextFrame();
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort by Last name');
+    });
+
+    it('should update the accessible name when i18n changes', async () => {
+      grid.i18n = { sorter: 'Sortieren nach {column}' };
+      await nextFrame();
+      expect(sorter.getAttribute('aria-label')).to.equal('Sortieren nach First name');
+    });
+  });
 });

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -826,23 +826,23 @@ describe('sorting', () => {
       sorter = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-sorter');
     });
 
-    it('should apply the default i18n template to the sorter', () => {
+    it('should set sorter aria-label based on grid i18n by default', () => {
       expect(sorter.getAttribute('aria-label')).to.equal('Sort by First name');
     });
 
-    it('should update the accessible name when the column header changes', async () => {
+    it('should update sorter aria-label when column header changes', async () => {
       sortColumn.header = 'Last name';
       await nextFrame();
       expect(sorter.getAttribute('aria-label')).to.equal('Sort by Last name');
     });
 
-    it('should update the accessible name when i18n changes', async () => {
+    it('should update sorter aria-label when grid i18n changes', async () => {
       grid.i18n = { sorter: 'Sort using {column}' };
       await nextFrame();
       expect(sorter.getAttribute('aria-label')).to.equal('Sort using First name');
     });
 
-    it('should apply an i18n template without a placeholder as is', async () => {
+    it('should apply grid i18n without the placeholder as is', async () => {
       grid.i18n = { sorter: 'Sort column' };
       await nextFrame();
       expect(sorter.getAttribute('aria-label')).to.equal('Sort column');
@@ -870,17 +870,17 @@ describe('sorting', () => {
       sorter = getHeaderCellContent(grid, 0, 0).querySelector('vaadin-grid-sorter');
     });
 
-    it('should derive the accessible name from the grid i18n autonomously', () => {
+    it('should set sorter aria-label based on grid i18n by default', () => {
       expect(sorter.getAttribute('aria-label')).to.equal('Sort by First name');
     });
 
-    it('should update the accessible name when the sorter text content changes', async () => {
+    it('should update sorter aria-label when text content changes', async () => {
       sorter.textContent = 'Last name';
       await nextFrame();
       expect(sorter.getAttribute('aria-label')).to.equal('Sort by Last name');
     });
 
-    it('should update the accessible name when i18n changes', async () => {
+    it('should update sorter aria-label when grid i18n changes', async () => {
       grid.i18n = { sorter: 'Sort using {column}' };
       await nextFrame();
       expect(sorter.getAttribute('aria-label')).to.equal('Sort using First name');

--- a/packages/grid/test/sorting.test.js
+++ b/packages/grid/test/sorting.test.js
@@ -810,7 +810,7 @@ describe('sorting', () => {
     });
   });
 
-  describe('sorter accessible name from i18n', () => {
+  describe('sort-column accessible name', () => {
     let grid, sortColumn, sorter;
 
     beforeEach(async () => {
@@ -837,9 +837,9 @@ describe('sorting', () => {
     });
 
     it('should update the accessible name when i18n changes', async () => {
-      grid.i18n = { sorter: 'Sortieren nach {column}' };
+      grid.i18n = { sorter: 'Sort using {column}' };
       await nextFrame();
-      expect(sorter.getAttribute('aria-label')).to.equal('Sortieren nach First name');
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort using First name');
     });
 
     it('should apply an i18n template without a placeholder as is', async () => {
@@ -849,7 +849,7 @@ describe('sorting', () => {
     });
   });
 
-  describe('sorter accessible name without sort-column', () => {
+  describe('sorter accessible name', () => {
     let grid, column, sorter;
 
     beforeEach(async () => {
@@ -859,8 +859,6 @@ describe('sorting', () => {
         </vaadin-grid>
       `);
       column = grid.querySelector('vaadin-grid-column');
-      // Create the sorter manually, as the Flow connector does, instead of
-      // relying on vaadin-grid-sort-column.
       column.headerRenderer = (root) => {
         if (!root.firstChild) {
           root.innerHTML = '<vaadin-grid-sorter path="first">First name</vaadin-grid-sorter>';
@@ -883,9 +881,9 @@ describe('sorting', () => {
     });
 
     it('should update the accessible name when i18n changes', async () => {
-      grid.i18n = { sorter: 'Sortieren nach {column}' };
+      grid.i18n = { sorter: 'Sort using {column}' };
       await nextFrame();
-      expect(sorter.getAttribute('aria-label')).to.equal('Sortieren nach First name');
+      expect(sorter.getAttribute('aria-label')).to.equal('Sort using First name');
     });
   });
 });


### PR DESCRIPTION
## Description

Part of #3471

Added `i18n.sorter` to `vaadin-grid` and updated `vaadin-grid-sorter` to find host grid and read its effective `i18n`.

## Type of change

- Feature