### PR TITLE
refactor: add getClosestCell grid helper to get cell from content

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { findTreeToggleCell, iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
+import { findTreeToggleCell, getClosestCell, iterateChildren, iterateRowCells } from './vaadin-grid-helpers.js';
 
 export const A11yMixin = (superClass) =>
   class A11yMixin extends superClass {
@@ -163,12 +163,8 @@ export const A11yMixin = (superClass) =>
     /** @private */
     __a11yUpdateSorters() {
       Array.from(this.querySelectorAll('vaadin-grid-sorter')).forEach((sorter) => {
-        let cellContent = sorter.parentNode;
-        while (cellContent && cellContent.localName !== 'vaadin-grid-cell-content') {
-          cellContent = cellContent.parentNode;
-        }
-        if (cellContent?.assignedSlot) {
-          const cell = cellContent.assignedSlot.parentNode;
+        const cell = getClosestCell(sorter);
+        if (cell) {
           cell.setAttribute(
             'aria-sort',
             {

--- a/packages/grid/src/vaadin-grid-helpers.js
+++ b/packages/grid/src/vaadin-grid-helpers.js
@@ -5,6 +5,19 @@
  */
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
+
+/**
+ * Returns the grid cell that contains the given node, or `undefined` if the
+ * node is not inside a cell's content.
+ *
+ * @param {Node} node
+ * @return {HTMLElement | undefined}
+ */
+export function getClosestCell(node) {
+  const content = getClosestElement('vaadin-grid-cell-content', node);
+  return content?.assignedSlot?.parentElement;
+}
 
 /**
  * Returns the cells of the given row, excluding the details cell.

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -7,7 +7,6 @@ import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { isAndroid, isChrome, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
-import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { setTouchAction } from '@vaadin/component-base/src/gestures.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -25,6 +24,7 @@ import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
 import {
   getBodyRowCells,
+  getClosestCell,
   iterateChildren,
   iterateRowCells,
   updateBooleanRowStates,
@@ -204,13 +204,7 @@ export const GridMixin = (superClass) =>
 
     /** @protected */
     _getRowContainingNode(node) {
-      const content = getClosestElement('vaadin-grid-cell-content', node);
-      if (!content) {
-        return;
-      }
-
-      const cell = content.assignedSlot.parentElement;
-      return cell.parentElement;
+      return getClosestCell(node)?.parentElement;
     }
 
     /** @protected */


### PR DESCRIPTION
## Description

Extracted shared logic into `getClosestCellHelper` for reusing in `vaadin-grid-sorter` in https://github.com/vaadin/web-components/pull/12028.

## Type of change

- Refactor