### PR TITLE
fix: keep virtualizer average row height fractional

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -222,6 +222,7 @@ export class IronListAdapter {
     flush();
 
     let newPhysicalSize = 0;
+    let newRawPhysicalSize = 0;
     let oldPhysicalSize = 0;
     const prevAvgCount = this._physicalAverageCount;
     const prevPhysicalAvg = this._physicalAverage;
@@ -230,7 +231,8 @@ export class IronListAdapter {
     this._iterateItems((pidx, vidx) => {
       oldPhysicalSize += this._physicalSizes[pidx];
       const elementOldPhysicalSize = this._physicalSizes[pidx];
-      this._physicalSizes[pidx] = Math.ceil(this.__getBorderBoxHeight(this._physicalItems[pidx]));
+      const borderBoxHeight = this.__getBorderBoxHeight(this._physicalItems[pidx]);
+      this._physicalSizes[pidx] = Math.ceil(borderBoxHeight);
 
       if (this._physicalSizes[pidx] !== elementOldPhysicalSize) {
         // Physical size changed, but resize observer may not catch it if the original size is restored quickly.
@@ -240,15 +242,25 @@ export class IronListAdapter {
       }
 
       newPhysicalSize += this._physicalSizes[pidx];
-      this._physicalAverageCount += this._physicalSizes[pidx] ? 1 : 0;
+      if (this._physicalSizes[pidx]) {
+        // Accumulate the raw (non-ceiled) height for the average.
+        newRawPhysicalSize += borderBoxHeight;
+        this._physicalAverageCount += 1;
+      }
     }, itemSet);
 
     this._physicalSize = this._physicalSize + newPhysicalSize - oldPhysicalSize;
 
     // Update the average if it measured something.
     if (this._physicalAverageCount !== prevAvgCount) {
+      // Average the raw (non-ceiled) heights. Averaging the ceiled per-row
+      // sizes rounds every fractional row up, and scrollToIndex multiplies that
+      // bias by the target index, scrolling past the target row on fractional
+      // row heights. The average stays an integer so item positions derived
+      // from it stay on whole pixels.
+      // See https://github.com/vaadin/flow-components/issues/9665
       this._physicalAverage = Math.round(
-        (prevPhysicalAvg * prevAvgCount + newPhysicalSize) / this._physicalAverageCount,
+        (prevPhysicalAvg * prevAvgCount + newRawPhysicalSize) / this._physicalAverageCount,
       );
     }
   }

--- a/packages/component-base/test/virtualizer-average-height.test.js
+++ b/packages/component-base/test/virtualizer-average-height.test.js
@@ -1,0 +1,55 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
+import { Virtualizer } from '../src/virtualizer.js';
+
+describe('virtualizer - average item height', () => {
+  let virtualizer, scrollTarget, scrollContainer;
+
+  function init(heightForIndex) {
+    scrollTarget = fixtureSync(`
+      <div style="height: 300px;">
+        <div></div>
+      </div>
+    `);
+    scrollContainer = scrollTarget.firstElementChild;
+    virtualizer = new Virtualizer({
+      createElements: (count) => Array.from({ length: count }, () => document.createElement('div')),
+      updateElement: (el, index) => {
+        el.index = index;
+        el.style.width = '100%';
+        el.style.boxSizing = 'border-box';
+        el.style.height = `${heightForIndex(index)}px`;
+        el.textContent = `item ${index}`;
+      },
+      scrollTarget,
+      scrollContainer,
+    });
+    virtualizer.size = 10000;
+  }
+
+  async function measure() {
+    // Scroll away from the top so a metrics update runs and the average is
+    // computed from measured rows.
+    virtualizer.scrollToIndex(5000);
+    await nextFrame();
+    virtualizer.flush();
+  }
+
+  it('should not inflate the average by ceiling fractional row heights', async () => {
+    init(() => 30.1);
+    await measure();
+    // Averaging the ceiled per-row heights would make the average 31.
+    expect(virtualizer.__adapter._physicalAverage).to.equal(30);
+  });
+
+  it('should not overestimate the total scroll height for fractional rows', async () => {
+    init(() => 30.1);
+    await measure();
+    // scrollToIndex estimates the scroll position from the average, so an
+    // inflated average makes the grid scroll past the target row. The total
+    // scrollable height reflects the average and must stay close to the real
+    // total (10000 * ~30.1), not the inflated 10000 * 31.
+    const contentHeight = parseFloat(scrollContainer.style.height);
+    expect(contentHeight).to.be.closeTo(10000 * 30, 10000 * 0.5);
+  });
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/9665

Currently, `scrollToIndex` estimates the scroll position as index * `_physicalAverage`. Ceiling each measured row height and rounding the average biased it upward, and that bias multiplied by the target index made the grid scroll past the target row when row heights were fractional (e.g. on displays with fractional device pixel ratio).

Average the raw, non-ceiled border-box heights and keep the result fractional. The per-row ceiled sizes are still used for the physical pool and layout.

## Type of change

- Bugfix