### PR TITLE
fix: restore missing background for inline code in markdown

### DIFF
--- a/packages/markdown/src/styles/vaadin-markdown-base-styles.js
+++ b/packages/markdown/src/styles/vaadin-markdown-base-styles.js
@@ -73,6 +73,9 @@ export const markdownSlotStyles = css`
         font-size: 0.9em;
         line-height: 1.25;
         font-weight: 500;
+        background-color: var(--vaadin-background-container);
+        border-radius: var(--vaadin-radius-s);
+        padding: 0.125em 0.25em;
       }
 
       pre {
@@ -83,6 +86,8 @@ export const markdownSlotStyles = css`
 
         code {
           font-weight: 500;
+          background: none;
+          padding: 0;
         }
       }
 

--- a/packages/vaadin-lumo-styles/src/components/markdown.css
+++ b/packages/vaadin-lumo-styles/src/components/markdown.css
@@ -14,4 +14,8 @@
   hr {
     margin-block: revert-layer;
   }
+
+  code {
+    background-color: var(--lumo-contrast-10pct);
+  }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/9688

Added background to inline `code` snippets in markdown:

Lumo:

<img width="416" height="45" alt="Screenshot 2026-07-07 at 12 43 03" src="https://github.com/user-attachments/assets/10f25eea-12f2-450e-bc37-568b9a59f5f6" />

Base styles:

<img width="408" height="42" alt="Screenshot 2026-07-07 at 12 43 16" src="https://github.com/user-attachments/assets/2a5d4f72-48e1-45fb-8924-7bc960374364" />

## Type of change

- Bugfix