### PR TITLE
docs: add missing tag name to switch custom element JSDoc

### DIFF
--- a/packages/switch/src/vaadin-switch.js
+++ b/packages/switch/src/vaadin-switch.js
@@ -17,7 +17,7 @@ import { switchStyles } from './styles/vaadin-switch-base-styles.js';
  * <vaadin-switch label="Notifications"></vaadin-switch>
  * ```
  *
- * @customElement
+ * @customElement vaadin-switch
  * @extends HTMLElement
  */
 class Switch extends ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {


### PR DESCRIPTION
## Description

I missed to add this in https://github.com/vaadin/web-components/pull/12024 as Claude generated the component using old JSDoc syntax.
We must use `@customElement` with a tag name to make sure the element appears in CEM output and web-types.

## Type of change

- Documentation