### PR TITLE
fix: remove close-overlay-drawer listener with correct reference

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -169,7 +169,7 @@ export const AppLayoutMixin = (superclass) =>
       super.disconnectedCallback();
       this.__resizeObserver.disconnect();
       this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
-      window.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);
+      window.removeEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
       window.removeEventListener('keydown', this.__onDrawerKeyDown);
     }
 

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -442,6 +442,12 @@ describe('vaadin-app-layout', () => {
           expect(layout.drawerOpened).to.be.false;
         });
 
+        it('should not react to the custom event after being disconnected', () => {
+          layout.remove();
+          window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
+          expect(layout.drawerOpened).to.be.true;
+        });
+
         it('should close the drawer on navigation event', () => {
           window.dispatchEvent(new CustomEvent('vaadin-router-location-changed'));
           expect(layout.drawerOpened).to.be.false;


### PR DESCRIPTION
`disconnectedCallback` removed the `close-overlay-drawer` listener using the
wrong function reference (`__drawerToggleClickListener` instead of
`__closeOverlayDrawerListener`), so the listener was never removed. A detached
`vaadin-app-layout` stayed referenced (memory leak) and kept reacting to global
`close-overlay-drawer` events.

Related to #12056

---

🤖 Generated with Claude Code
