### PR TITLE
refactor: apply same readonly styles to all checkable components

### DIFF
--- a/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
+++ b/packages/checkbox/src/styles/vaadin-checkbox-base-styles.js
@@ -20,13 +20,6 @@ const checkbox = css`
     filter: var(--vaadin-checkbox-checkmark-color, var(--_filter));
   }
 
-  :host([readonly]) {
-    --vaadin-checkbox-background: transparent;
-    --vaadin-checkbox-border-color: var(--vaadin-border-color);
-    --vaadin-checkbox-marker-color: var(--vaadin-text-color);
-    --_border-style: dashed;
-  }
-
   :host([indeterminate]) [part='checkbox']::after {
     mask-image: var(--_vaadin-icon-minus);
   }

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -18,10 +18,6 @@ export const checkable = (part, propName = part) => css`
     --_cursor: var(--vaadin-clickable-cursor);
   }
 
-  :host([disabled]) {
-    --_cursor: var(--vaadin-disabled-cursor);
-  }
-
   :host(:not([has-label])) {
     column-gap: 0;
   }
@@ -109,10 +105,24 @@ export const checkable = (part, propName = part) => css`
     --vaadin-${unsafeCSS(propName)}-border-color: transparent;
   }
 
+  :host([readonly]) {
+    --vaadin-${unsafeCSS(part)}-background: transparent;
+    --vaadin-${unsafeCSS(part)}-border-color: var(--vaadin-border-color);
+    --vaadin-${unsafeCSS(part)}-marker-color: var(--vaadin-text-color);
+    --_border-style: dashed;
+    --_cursor: var(--vaadin-disabled-cursor);
+
+    [part='label'],
+    ::slotted(label) {
+      cursor: default;
+    }
+  }
+
   :host([disabled]) {
     --vaadin-${unsafeCSS(propName)}-background: var(--vaadin-input-field-disabled-background, var(--vaadin-background-container-strong));
     --vaadin-${unsafeCSS(propName)}-border-color: transparent;
     --vaadin-${unsafeCSS(propName)}-marker-color: var(--vaadin-text-color-disabled);
+    --_cursor: var(--vaadin-disabled-cursor);
   }
 
   /* Focus ring */

--- a/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
+++ b/packages/radio-group/src/styles/vaadin-radio-group-base-styles.js
@@ -16,6 +16,7 @@ export const radioGroupStyles = [
       --vaadin-radio-button-border-color: var(--vaadin-border-color);
       --vaadin-radio-button-marker-color: var(--vaadin-text-color);
       --_border-style: dashed;
+      --_cursor: var(--vaadin-disabled-cursor);
     }
   `,
 ];


### PR DESCRIPTION
Apply the same readonly visual styles for all checkable components. Radio-button is a special case (no individual readonly state), and those styles need to be applied through the radio-group component.

Apply the disabled cursor on the checkbox/radio-button/switch part also in readonly state, to make it clearer that the component is not interactive.