### PR TITLE
chore: align snapshot test browser timeouts with unit tests

### DIFF
--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -224,6 +224,7 @@ const createSnapshotTestsConfig = (config) => {
 
   return {
     ...config,
+    concurrency: 1,
     nodeResolve: true,
     groups,
     testRunnerHtml: getTestRunnerHtml(),

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -224,8 +224,10 @@ const createSnapshotTestsConfig = (config) => {
 
   return {
     ...config,
-    concurrency: 1,
     nodeResolve: true,
+    browserStartTimeout: 60000, // Default 30000
+    testsStartTimeout: 60000, // Default 10000
+    testsFinishTimeout: 120000, // Default 20000
     groups,
     testRunnerHtml: getTestRunnerHtml(),
     filterBrowserLogs,


### PR DESCRIPTION
## Description

After upgrading `web-test-runner` snapshot tests started to fail more often in CI

```
packages/a11y-base/test/dom/aria-hidden.test.js:

 ❌ The browser was unable to create and start a test page after 30000ms. You can increase this timeout with the browserStartTimeout option. 

Chromium: |▊                             | 1/72 test files | 0 passed, 0 failed

Running tests...


packages/accordion/test/dom/accordion-heading.test.js:

 ❌ The browser was unable to create and start a test page after 30000ms. You can increase this timeout with the browserStartTimeout option. 
```


Updated timeouts to be aligned with those used by unit tests config.

## Type of change

- Internal change