### PR TITLE
docs: update CheckboxMixin JSDoc for reusing in switch

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.d.ts
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.d.ts
@@ -39,14 +39,14 @@ export declare function CheckboxMixin<T extends Constructor<HTMLElement>>(
 
 export declare class CheckboxMixinClass {
   /**
-   * The name of the checkbox.
+   * The name of the control, which is submitted with the form data.
    */
   name: string;
 
   /**
-   * When true, the user cannot modify the value of the checkbox.
+   * When true, the user cannot modify the value of the control.
    * The difference between `disabled` and `readonly` is that the
-   * read-only checkbox remains focusable, is announced by screen
+   * read-only element remains focusable, is announced by screen
    * readers and its value can be submitted as part of the form.
    */
   readonly: boolean;

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -21,7 +21,7 @@ export const CheckboxMixin = (superclass) =>
     static get properties() {
       return {
         /**
-         * The name of the checkbox.
+         * The name of the control, which is submitted with the form data.
          */
         name: {
           type: String,
@@ -29,9 +29,9 @@ export const CheckboxMixin = (superclass) =>
         },
 
         /**
-         * When true, the user cannot modify the value of the checkbox.
+         * When true, the user cannot modify the value of the control.
          * The difference between `disabled` and `readonly` is that the
-         * read-only checkbox remains focusable, is announced by screen
+         * read-only element remains focusable, is announced by screen
          * readers and its value can be submitted as part of the form.
          */
         readonly: {


### PR DESCRIPTION
## Description

Updated JSDoc for `name` and `readonly` properties to use `control` instead of `checkbox`.
`CheckboxMixin` is now used by `vaadin-switch` so let's use more common words for it.

## Type of change

- Documentation