### PR TITLE
fix: defer element reordering only on scroll target mousedown

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -88,7 +88,12 @@ export class IronListAdapter {
     if (this.reorderElements) {
       // Reordering the physical elements cancels the user's grab of the scroll bar handle on Safari.
       // Need to defer reordering until the user lets go of the scroll bar handle.
-      this.scrollTarget.addEventListener('mousedown', () => {
+      this.scrollTarget.addEventListener('mousedown', (event) => {
+        // Only handle clicks on the scroll target itself
+        if (event.target !== this.scrollTarget) {
+          return;
+        }
+
         this.__mouseDown = true;
       });
       this.scrollTarget.addEventListener('mouseup', () => {

--- a/packages/component-base/test/virtualizer-reorder-elements.test.js
+++ b/packages/component-base/test/virtualizer-reorder-elements.test.js
@@ -115,16 +115,22 @@ describe('reorder elements', () => {
     expect(elementsInOrder()).to.be.true;
   });
 
-  it('should not reorder while mouse down', () => {
-    mousedown(elementsContainer);
+  it('should not reorder while mouse down on scroll target', () => {
+    mousedown(scrollTarget);
     scrollRecycle();
     expect(elementsInOrder()).to.be.false;
   });
 
-  it('should reorder once mousedown is released', () => {
-    mousedown(elementsContainer);
+  it('should reorder once mousedown on scroll target is released', () => {
+    mousedown(scrollTarget);
     scrollRecycle();
-    mouseup(elementsContainer);
+    mouseup(scrollTarget);
+    expect(elementsInOrder()).to.be.true;
+  });
+
+  it('should reorder while mouse down on child element', () => {
+    mousedown(elementsContainer.children[0]);
+    scrollRecycle();
     expect(elementsInOrder()).to.be.true;
   });
 


### PR DESCRIPTION
The virtualizer defers reordering of its physical elements while the mouse is down. This works around a Safari issue where reordering the elements cancels the user's grab of the scroll bar handle. However, the deferral was activated by any `mousedown` inside the scroll target, including clicks on rows, and that caused a bug in Grid:

1. The user scrolls the grid, which leaves the row elements out of DOM order until a debouncer reorders them.
2. The user clicks a row before the debouncer fires. The `mousedown` sets the `__mouseDown` flag.
3. The clicked row receives focus, and the focus handler tries to flush the reordering to guarantee correct Tab order, but the flag blocks it.
4. The focus handler falls back to its other strategy for fixing the Tab order: scrolling. This moves the clicked row away from under the mouse before `mouseup`, so the click lands on a different row.

A `mousedown` on the scrollbar has the scroll target element itself as the event target, while a click on content targets a child element. The listener now checks the event target and only defers reordering when the scrollbar is grabbed.

Fixes vaadin/flow-components#9665