### PR TITLE
feat: add i18n for header cell with hidden select all checkbox

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -163,10 +163,21 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       checkbox.indeterminate = this._indeterminate;
       checkbox.style.visibility = this._selectAllHidden ? 'hidden' : '';
 
-      if (this._selectAllHidden) {
-        this._headerCell.setAttribute('aria-label', selectAllEmpty);
-      } else {
-        this._headerCell.removeAttribute('aria-label');
+      // When the Select All checkbox is hidden, the header cell would otherwise
+      // be announced as empty. Render a screen-reader-only label into the cell
+      // (which is in the grid's shadow root, so the `.sr-only` class applies) so
+      // that screen readers announce the `selectAllEmpty` text, including during
+      // table navigation where an `aria-label` on the cell is not read.
+      let label = this._headerCell.querySelector(':scope > .sr-only');
+      if (this._selectAllHidden && selectAllEmpty) {
+        if (!label) {
+          label = document.createElement('span');
+          label.classList.add('sr-only');
+          this._headerCell.appendChild(label);
+        }
+        label.textContent = selectAllEmpty;
+      } else if (label) {
+        label.remove();
       }
     }
 

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -155,7 +155,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.appendChild(checkbox);
       }
 
-      const { selectAll, selectAllEmpty } = this._grid.__effectiveI18n;
+      const { selectAll, selectAllUnavailable } = this._grid.__effectiveI18n;
       checkbox.accessibleName = selectAll;
 
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
@@ -164,18 +164,16 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
       checkbox.style.visibility = this._selectAllHidden ? 'hidden' : '';
 
       // When the Select All checkbox is hidden, the header cell would otherwise
-      // be announced as empty. Render a screen-reader-only label into the cell
-      // (which is in the grid's shadow root, so the `.sr-only` class applies) so
-      // that screen readers announce the `selectAllEmpty` text, including during
-      // table navigation where an `aria-label` on the cell is not read.
+      // be announced as blank. Render a screen-reader-only label into the cell
+      // so that screen readers announce the `selectAllUnavailable` text.
       let label = this._headerCell.querySelector(':scope > .sr-only');
-      if (this._selectAllHidden && selectAllEmpty) {
+      if (this._selectAllHidden && selectAllUnavailable) {
         if (!label) {
           label = document.createElement('span');
           label.classList.add('sr-only');
           this._headerCell.appendChild(label);
         }
-        label.textContent = selectAllEmpty;
+        label.textContent = selectAllUnavailable;
       } else if (label) {
         label.remove();
       }

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -155,12 +155,19 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         root.appendChild(checkbox);
       }
 
-      checkbox.accessibleName = this._grid?.__effectiveI18n?.selectAll;
+      const { selectAll, selectAllEmpty } = this._grid.__effectiveI18n;
+      checkbox.accessibleName = selectAll;
 
       const checked = this.__isChecked(this.selectAll, this._indeterminate);
       checkbox.checked = checked;
       checkbox.indeterminate = this._indeterminate;
       checkbox.style.visibility = this._selectAllHidden ? 'hidden' : '';
+
+      if (this._selectAllHidden) {
+        this._headerCell.setAttribute('aria-label', selectAllEmpty);
+      } else {
+        this._headerCell.removeAttribute('aria-label');
+      }
     }
 
     /**

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -22,9 +22,9 @@ export interface GridI18n {
   selectAll?: string;
 
   /**
-   * The accessible name (aria-label) for the selection column header cell when
-   * the Select All checkbox is hidden (e.g. a data provider is used or
-   * conditional selection is enabled).
+   * The accessible name announced for the selection column header cell when the
+   * Select All checkbox is hidden (e.g. a data provider is used or conditional
+   * selection is enabled), rendered as a screen-reader-only label in the cell.
    */
   selectAllEmpty?: string;
 
@@ -306,8 +306,8 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    *   // Accessible name (aria-label) for the select all checkbox in the
    *   // selection column header cell.
    *   selectAll: 'Select All',
-   *   // Accessible name (aria-label) for the selection column header cell when
-   *   // the Select All checkbox is hidden (data provider or conditional selection).
+   *   // Screen-reader-only label announced for the selection column header cell
+   *   // when the Select All checkbox is hidden (data provider or conditional selection).
    *   selectAllEmpty: 'Select All unavailable',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -26,7 +26,7 @@ export interface GridI18n {
    * Select All checkbox is hidden (e.g. a data provider is used or conditional
    * selection is enabled), rendered as a screen-reader-only label in the cell.
    */
-  selectAllEmpty?: string;
+  selectAllUnavailable?: string;
 
   /**
    * The accessible name (aria-label) template for the Select Row checkbox in
@@ -308,7 +308,7 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    *   selectAll: 'Select All',
    *   // Screen-reader-only label announced for the selection column header cell
    *   // when the Select All checkbox is hidden (data provider or conditional selection).
-   *   selectAllEmpty: 'Select All unavailable',
+   *   selectAllUnavailable: 'Select All unavailable',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // row header cell text content or row index if there is no row header column.

--- a/packages/grid/src/vaadin-grid.d.ts
+++ b/packages/grid/src/vaadin-grid.d.ts
@@ -22,6 +22,13 @@ export interface GridI18n {
   selectAll?: string;
 
   /**
+   * The accessible name (aria-label) for the selection column header cell when
+   * the Select All checkbox is hidden (e.g. a data provider is used or
+   * conditional selection is enabled).
+   */
+  selectAllEmpty?: string;
+
+  /**
    * The accessible name (aria-label) template for the Select Row checkbox in
    * each selection column body cell. The `{rowHeader}` placeholder is replaced with
    * the row header cell text content or row index if there is no row header column.
@@ -299,6 +306,9 @@ declare class Grid<TItem = GridDefaultItem> extends HTMLElement {
    *   // Accessible name (aria-label) for the select all checkbox in the
    *   // selection column header cell.
    *   selectAll: 'Select All',
+   *   // Accessible name (aria-label) for the selection column header cell when
+   *   // the Select All checkbox is hidden (data provider or conditional selection).
+   *   selectAllEmpty: 'Select All unavailable',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // row header cell text content or row index if there is no row header column.

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -17,6 +17,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
 
 const DEFAULT_I18N = {
   selectAll: 'Select All',
+  selectAllEmpty: 'Select All unavailable',
   selectRow: 'Select Row {rowHeader}',
   sorter: 'Sort by {column}',
 };
@@ -300,6 +301,9 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    *   // Accessible name (aria-label) for the select all checkbox in the
    *   // selection column header cell.
    *   selectAll: 'Select All',
+   *   // Accessible name (aria-label) for the selection column header cell when
+   *   // the Select All checkbox is hidden (data provider or conditional selection).
+   *   selectAllEmpty: 'Select All unavailable',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // row header cell text content or row index if there is no row header column.

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -18,7 +18,7 @@ import { GridMixin } from './vaadin-grid-mixin.js';
 
 const DEFAULT_I18N = {
   selectAll: 'Select All',
-  selectAllEmpty: 'Select All unavailable',
+  selectAllUnavailable: 'Select All unavailable',
   selectRow: 'Select Row {rowHeader}',
   sorter: 'Sort by {column}',
 };
@@ -304,7 +304,7 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    *   selectAll: 'Select All',
    *   // Screen-reader-only label announced for the selection column header cell
    *   // when the Select All checkbox is hidden (data provider or conditional selection).
-   *   selectAllEmpty: 'Select All unavailable',
+   *   selectAllUnavailable: 'Select All unavailable',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the
    *   // row header cell text content or row index if there is no row header column.

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -6,6 +6,7 @@
 import './vaadin-grid-column.js';
 import { html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { screenReaderOnly } from '@vaadin/a11y-base/src/styles/sr-only-styles.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { I18nMixin } from '@vaadin/component-base/src/i18n-mixin.js';
@@ -282,7 +283,7 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
   }
 
   static get styles() {
-    return gridStyles;
+    return [gridStyles, screenReaderOnly];
   }
 
   static get defaultI18n() {
@@ -301,8 +302,8 @@ class Grid extends GridMixin(I18nMixin(ElementMixin(ThemableMixin(PolylitMixin(L
    *   // Accessible name (aria-label) for the select all checkbox in the
    *   // selection column header cell.
    *   selectAll: 'Select All',
-   *   // Accessible name (aria-label) for the selection column header cell when
-   *   // the Select All checkbox is hidden (data provider or conditional selection).
+   *   // Screen-reader-only label announced for the selection column header cell
+   *   // when the Select All checkbox is hidden (data provider or conditional selection).
    *   selectAllEmpty: 'Select All unavailable',
    *   // Accessible name (aria-label) for the select row checkbox in each
    *   // selection column body cell. The `{rowHeader}` placeholder is replaced with the

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -505,6 +505,48 @@ describe('multi selection column', () => {
     expect(selectAllCheckbox.checkVisibility({ visibilityProperty: true })).to.be.true;
   });
 
+  it('should set aria-label on the header cell when select all is hidden due to data provider', async () => {
+    grid.items = undefined;
+    grid.dataProvider = infiniteDataProvider;
+    await nextFrame();
+
+    expect(selectionColumn._headerCell.getAttribute('aria-label')).to.equal('Select All unavailable');
+  });
+
+  it('should set aria-label on the header cell when select all is hidden due to conditional selection', async () => {
+    grid.isItemSelectable = () => true;
+    await nextFrame();
+
+    expect(selectionColumn._headerCell.getAttribute('aria-label')).to.equal('Select All unavailable');
+  });
+
+  it('should not set aria-label on the header cell when select all is visible', () => {
+    expect(selectionColumn._headerCell.hasAttribute('aria-label')).to.be.false;
+  });
+
+  it('should remove aria-label from the header cell when select all becomes visible again', async () => {
+    grid.items = undefined;
+    grid.dataProvider = infiniteDataProvider;
+    await nextFrame();
+
+    expect(selectionColumn._headerCell.hasAttribute('aria-label')).to.be.true;
+
+    grid.dataProvider = undefined;
+    grid.items = ['foo'];
+    await nextFrame();
+
+    expect(selectionColumn._headerCell.hasAttribute('aria-label')).to.be.false;
+  });
+
+  it('should use custom i18n for the header cell aria-label when select all is hidden', async () => {
+    grid.items = undefined;
+    grid.dataProvider = infiniteDataProvider;
+    grid.i18n = { selectAllEmpty: 'X' };
+    await nextFrame();
+
+    expect(selectionColumn._headerCell.getAttribute('aria-label')).to.equal('X');
+  });
+
   it('should be possible to override the body renderer', () => {
     const secondCell = getCellContent(getRowCells(rows[0])[1]);
 

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -505,46 +505,50 @@ describe('multi selection column', () => {
     expect(selectAllCheckbox.checkVisibility({ visibilityProperty: true })).to.be.true;
   });
 
-  it('should set aria-label on the header cell when select all is hidden due to data provider', async () => {
+  function getSelectAllEmptyLabel() {
+    return selectionColumn._headerCell.querySelector(':scope > .sr-only');
+  }
+
+  it('should render a screen-reader-only label in the header cell when select all is hidden due to data provider', async () => {
     grid.items = undefined;
     grid.dataProvider = infiniteDataProvider;
     await nextFrame();
 
-    expect(selectionColumn._headerCell.getAttribute('aria-label')).to.equal('Select All unavailable');
+    expect(getSelectAllEmptyLabel().textContent).to.equal('Select All unavailable');
   });
 
-  it('should set aria-label on the header cell when select all is hidden due to conditional selection', async () => {
+  it('should render a screen-reader-only label in the header cell when select all is hidden due to conditional selection', async () => {
     grid.isItemSelectable = () => true;
     await nextFrame();
 
-    expect(selectionColumn._headerCell.getAttribute('aria-label')).to.equal('Select All unavailable');
+    expect(getSelectAllEmptyLabel().textContent).to.equal('Select All unavailable');
   });
 
-  it('should not set aria-label on the header cell when select all is visible', () => {
-    expect(selectionColumn._headerCell.hasAttribute('aria-label')).to.be.false;
+  it('should not render the screen-reader-only label when select all is visible', () => {
+    expect(getSelectAllEmptyLabel()).to.be.null;
   });
 
-  it('should remove aria-label from the header cell when select all becomes visible again', async () => {
+  it('should remove the screen-reader-only label when select all becomes visible again', async () => {
     grid.items = undefined;
     grid.dataProvider = infiniteDataProvider;
     await nextFrame();
 
-    expect(selectionColumn._headerCell.hasAttribute('aria-label')).to.be.true;
+    expect(getSelectAllEmptyLabel()).to.exist;
 
     grid.dataProvider = undefined;
     grid.items = ['foo'];
     await nextFrame();
 
-    expect(selectionColumn._headerCell.hasAttribute('aria-label')).to.be.false;
+    expect(getSelectAllEmptyLabel()).to.be.null;
   });
 
-  it('should use custom i18n for the header cell aria-label when select all is hidden', async () => {
+  it('should use custom i18n for the screen-reader-only label when select all is hidden', async () => {
     grid.items = undefined;
     grid.dataProvider = infiniteDataProvider;
     grid.i18n = { selectAllEmpty: 'X' };
     await nextFrame();
 
-    expect(selectionColumn._headerCell.getAttribute('aria-label')).to.equal('X');
+    expect(getSelectAllEmptyLabel().textContent).to.equal('X');
   });
 
   it('should be possible to override the body renderer', () => {

--- a/packages/grid/test/selection.test.js
+++ b/packages/grid/test/selection.test.js
@@ -545,7 +545,7 @@ describe('multi selection column', () => {
   it('should use custom i18n for the screen-reader-only label when select all is hidden', async () => {
     grid.items = undefined;
     grid.dataProvider = infiniteDataProvider;
-    grid.i18n = { selectAllEmpty: 'X' };
+    grid.i18n = { selectAllUnavailable: 'X' };
     await nextFrame();
 
     expect(getSelectAllEmptyLabel().textContent).to.equal('X');


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/issues/3471#issuecomment-4922989873

Added `aria-label` to the selection column header cell for cases where checkbox is hidden.

## Type of change

- Feature

## Note

This is how this looks in screen readers:

### VoiceOver

Safari:

<img width="375" height="214" alt="select-all-vo-safari" src="https://github.com/user-attachments/assets/308e9669-6ff5-4e27-ac19-6f93b82a7410" />

Chrome:

<img width="370" height="179" alt="Screenshot 2026-07-09 at 15 49 31" src="https://github.com/user-attachments/assets/0befeb75-88bb-4792-8f85-d347dd2526ba" />

#### NVDA

Announces header cell aria-label for every row:

<img width="420" height="33" alt="Screenshot 2026-07-09 at 15 51 40" src="https://github.com/user-attachments/assets/ca20fe08-ba56-43f8-9c33-3d64ab47d7da" />

#### JAWS

<img width="258" height="129" alt="Screenshot 2026-07-09 at 15 55 30" src="https://github.com/user-attachments/assets/62ac6723-46df-4b34-87ed-97ec7999f2e7" />