### PR TITLE
chore: fix claude workflow token setup

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Stage action infra
         # Copy the action infra out of the repo *before* the PR branch is checked

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -84,7 +84,7 @@ jobs:
             actions: read
           claude_args: |
             --mcp-config '{"mcpServers":{"playwright":{"command":"npx","args":["@playwright/mcp@${{ env.PLAYWRIGHT_MCP_VERSION }}","--headless","--isolated","--browser","chrome"]}}}'
-            --allowedTools "mcp__playwright,Bash(yarn test:*),Bash(yarn lint:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git checkout:*),Bash(git restore:*),Bash(git stash:*),Bash(cd:*),Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(head:*),Bash(tail:*),Bash(sed:*),Bash(wc:*),Bash(echo:*)"
+            --allowedTools "mcp__playwright,Bash(yarn test:*),Bash(yarn update:*),Bash(yarn start:*),Bash(yarn lint:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git checkout:*),Bash(git restore:*),Bash(git stash:*),Bash(cd:*),Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(head:*),Bash(tail:*),Bash(sed:*),Bash(wc:*),Bash(echo:*)"
 
       - name: Summarize Claude session
         if: always() && steps.claude.outputs.execution_file != ''


### PR DESCRIPTION
The newly added Claude workflow works, but is not able to push: https://github.com/vaadin/web-components/issues/12012#issuecomment-4932412165

The problem is that `actions/checkout@v6` by default automatically installs the workflow GitHub token, which only has `contents: read`, into the workspace checkout. Even though `github-claude-action` then creates its own token with write permissions it fails to set it up so that it fully overrides the token set up by the previous action.

The solution is to make `actions/checkout@v6` remove the workflow token after its run with `persist-credentials: false`.