### PR TITLE
fix: apply breadcrumbs font-size var to overlay items in base styles

### DIFF
--- a/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
+++ b/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
@@ -11,6 +11,9 @@ export const breadcrumbsItemStyles = css`
     display: inline-flex;
     align-items: baseline;
     flex-shrink: 0;
+    /* Set explicitly so overlay items, which are slotted outside the
+       breadcrumbs font-size inheritance chain, use the same variable. */
+    font-size: var(--vaadin-breadcrumbs-font-size, 1em);
   }
 
   :host([hidden]) {

--- a/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
+++ b/packages/breadcrumbs/src/styles/vaadin-breadcrumbs-item-base-styles.js
@@ -11,8 +11,6 @@ export const breadcrumbsItemStyles = css`
     display: inline-flex;
     align-items: baseline;
     flex-shrink: 0;
-    /* Set explicitly so overlay items, which are slotted outside the
-       breadcrumbs font-size inheritance chain, use the same variable. */
     font-size: var(--vaadin-breadcrumbs-font-size, 1em);
   }
 

--- a/packages/breadcrumbs/test/overflow.test.js
+++ b/packages/breadcrumbs/test/overflow.test.js
@@ -524,6 +524,27 @@ describe('overflow', () => {
     });
   });
 
+  describe('font-size', () => {
+    beforeEach(async () => {
+      breadcrumbs.style.setProperty('--vaadin-breadcrumbs-font-size', '12px');
+
+      // Collapse all items to the overlay
+      breadcrumbs.style.maxWidth = '200px';
+      await nextResize(breadcrumbs);
+
+      button.click();
+      await oneEvent(overlay, 'vaadin-overlay-open');
+    });
+
+    it('should apply --vaadin-breadcrumbs-font-size to overlay items', () => {
+      const overlayItems = items.filter((item) => item.slot === 'overlay');
+      expect(overlayItems).to.not.be.empty;
+      overlayItems.forEach((item) => {
+        expect(getComputedStyle(item).fontSize).to.equal('12px');
+      });
+    });
+  });
+
   describe('focus()', () => {
     it('should focus the overflow button when the root item is disabled', async () => {
       breadcrumbs.style.maxWidth = '600px';

--- a/packages/breadcrumbs/test/overflow.test.js
+++ b/packages/breadcrumbs/test/overflow.test.js
@@ -524,27 +524,6 @@ describe('overflow', () => {
     });
   });
 
-  describe('font-size', () => {
-    beforeEach(async () => {
-      breadcrumbs.style.setProperty('--vaadin-breadcrumbs-font-size', '12px');
-
-      // Collapse all items to the overlay
-      breadcrumbs.style.maxWidth = '200px';
-      await nextResize(breadcrumbs);
-
-      button.click();
-      await oneEvent(overlay, 'vaadin-overlay-open');
-    });
-
-    it('should apply --vaadin-breadcrumbs-font-size to overlay items', () => {
-      const overlayItems = items.filter((item) => item.slot === 'overlay');
-      expect(overlayItems).to.not.be.empty;
-      overlayItems.forEach((item) => {
-        expect(getComputedStyle(item).fontSize).to.equal('12px');
-      });
-    });
-  });
-
   describe('focus()', () => {
     it('should focus the overflow button when the root item is disabled', async () => {
       breadcrumbs.style.maxWidth = '600px';


### PR DESCRIPTION
### Motivation

In base styles, `--vaadin-breadcrumbs-font-size` did not control the font size of items inside `vaadin-breadcrumbs-overlay`, unlike Lumo and Aura.

### Reproduction

```css
vaadin-breadcrumbs {
  --vaadin-breadcrumbs-font-size: 12px;
}
```

The overflow overlay items stayed at the default 16px.

### Changes

Overlay items are slotted into the overlay's shadow content, so they inherit `font-size` from the overlay content in the flattened tree, not from the breadcrumbs host. Set `font-size` from the variable directly on the item host, matching Lumo and Aura. The `1em` fallback resolves to the inherited value, so rendering is unchanged when the variable is unset.

Fixes #12012

---

🤖 Generated with [Claude Code](https://claude.ai/code)