### PR TITLE
docs: mark tabindex and value property defaults as internal

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -58,12 +58,18 @@ export const CheckboxMixin = (superclass) =>
 
       this._boundOnInputClick = this._onInputClick.bind(this);
 
-      // Set the string "on" as the default value for the checkbox following the HTML specification:
-      // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+      /**
+       * Set the string "on" as the default value for the checkbox following the HTML specification:
+       * https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+       * @internal to not document it in CEM
+       */
       this.value = 'on';
 
-      // Set tabindex to 0 by default to not lose focus on click in Safari
-      // See https://github.com/vaadin/web-components/pull/6780
+      /**
+       * Set tabindex to 0 by default to not lose focus on click in Safari
+       * See https://github.com/vaadin/web-components/pull/6780
+       * @internal to not document it in CEM
+       */
       this.tabindex = 0;
     }
 

--- a/packages/radio-group/src/vaadin-radio-button-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-button-mixin.js
@@ -40,12 +40,18 @@ export const RadioButtonMixin = (superclass) =>
 
       this._setType('radio');
 
-      // Set the string "on" as the default value for the radio button following the HTML specification:
-      // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+      /**
+       * Set the string "on" as the default value for the radio button following the HTML specification:
+       * https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+       * @internal to not document it in CEM
+       */
       this.value = 'on';
 
-      // Set tabindex to 0 by default to not lose focus on click in Safari
-      // See https://github.com/vaadin/web-components/pull/6780
+      /**
+       * Set tabindex to 0 by default to not lose focus on click in Safari
+       * See https://github.com/vaadin/web-components/pull/6780
+       * @internal to not document it in CEM
+       */
       this.tabindex = 0;
     }
 


### PR DESCRIPTION
## Description

Updated comments to use `@internal` JSDoc to avoid empty properties in CEM & API docs:

| Before | After |
| ------- | -----|
| <img width="367" height="492" alt="Screenshot 2026-07-10 at 10 43 47" src="https://github.com/user-attachments/assets/230a3e3b-6bba-4d6c-a73b-85cdf19ae357" /> |  <img width="352" height="429" alt="Screenshot 2026-07-10 at 10 48 16" src="https://github.com/user-attachments/assets/2792f6f9-9940-4400-9d5a-28e3c64c74cf" /> |


## Type of change

- Documentation