### PR TITLE
chore: drop retry action from visual test worfklow

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -42,12 +42,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: yarn test --config web-test-runner-base.config.js
+        run: yarn test --config web-test-runner-base.config.js
 
       - uses: actions/upload-artifact@v6
         if: ${{ failure() }}
@@ -86,12 +81,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: yarn test --config web-test-runner-lumo.config.js
+        run: yarn test --config web-test-runner-lumo.config.js
 
       - uses: actions/upload-artifact@v6
         if: ${{ failure() }}
@@ -131,20 +121,10 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Visual tests (default)
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: yarn test --config web-test-runner-aura.config.js
+        run: yarn test --config web-test-runner-aura.config.js
 
       - name: Visual tests (dark)
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 20
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: yarn test --config web-test-runner-aura.config.js --dark
+        run: yarn test --config web-test-runner-aura.config.js --dark
 
       - uses: actions/upload-artifact@v6
         if: ${{ failure() }}


### PR DESCRIPTION
The retry action was introduced to handle flakiness from running visual tests in Sauce Labs where differences in environments could result in subtle screenshot changes. Now that visual tests are run with Docker that is not a problem anymore. There might still be flaky tests in the future due to test setups, but we should attempt to fix those. This also improves CI runtime as an actual failing test will not run through three attempts and block the runner from doing other work.