### PR TITLE
docs: cleanup clearButtonVisible property JSDoc, mention Esc

### DIFF
--- a/packages/field-base/src/clear-button-mixin.d.ts
+++ b/packages/field-base/src/clear-button-mixin.d.ts
@@ -17,10 +17,7 @@ export declare function ClearButtonMixin<T extends Constructor<HTMLElement>>(
 export declare class ClearButtonMixinClass {
   /**
    * Set to true to display the clear icon which clears the input.
-   *
-   * It is up to the component to choose where to place the clear icon:
-   * in the Shadow DOM or in the light DOM. In any way, a reference to
-   * the clear icon element should be provided via the `clearElement` getter.
+   * This also enables clearing the input when pressing Esc key.
    *
    * @attr {boolean} clear-button-visible
    */

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -17,10 +17,7 @@ export const ClearButtonMixin = (superclass) =>
       return {
         /**
          * Set to true to display the clear icon which clears the input.
-         *
-         * It is up to the component to choose where to place the clear icon:
-         * in the Shadow DOM or in the light DOM. In any way, a reference to
-         * the clear icon element should be provided via the `clearElement` getter.
+         * This also enables clearing the input when pressing Esc key.
          *
          * @attr {boolean} clear-button-visible
          */


### PR DESCRIPTION
## Description

- Shortened `clearButtonVisible` JSDoc to remove implementation detail
- Added mention that pressing <kbd>Esc</kbd> clears the field when this property is set

## Type of change

- Docs