### PR TITLE
chore: configure esbuildPlugin targets to esnext

### DIFF
--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -99,7 +99,7 @@ export default {
         }
       },
     },
-    esbuildPlugin({ ts: true }),
+    esbuildPlugin({ ts: true, target: 'esnext' }),
     enforceThemePlugin(theme),
     cssImportPlugin(),
   ],

--- a/wtr-utils.js
+++ b/wtr-utils.js
@@ -302,7 +302,7 @@ const createVisualTestsConfig = (theme) => {
     },
     browsers: [browser],
     plugins: [
-      esbuildPlugin({ ts: true }),
+      esbuildPlugin({ ts: true, target: 'esnext' }),
       visualRegressionPlugin({
         baseDir: 'packages',
         getBaselineName(args) {


### PR DESCRIPTION
Since the web-test-runner 1.0.0 update, `@web/dev-server-esbuild` 2.0.0 resolves esbuild to 0.28.x. esbuild 0.28 marks destructuring as broken in Safari < 14.1 and cannot compile it down, so it fails with an error for any code that uses destructuring when the target includes `safari11.1`.

With the default `target: 'auto'`, the plugin picks the target from the request's user agent. When the user agent is not recognized as a recent browser (bots, tools like `curl`, IDE previews), it falls back to a hardcoded list that includes `safari11.1`, and the dev server responds with an error:

```
$ curl http://localhost:8000/dev/combo-box.html
Error while transforming dev/combo-box.html: Transforming destructuring to the
configured target environment ("chrome64", "edge79", "firefox67", "safari11.1")
is not supported yet
```

Setting the target to `esnext` explicitly [skips](https://modern-web.dev/docs/dev-server/plugins/esbuild/#no-target) the user agent detection. JS files and inline scripts in HTML pages are then served as-is, and `.ts` files are still compiled to JS without changing modern syntax. Both the dev server and tests only need to support recent browsers, so nothing is lost.

Follow-up to #12047

---

🤖 Generated with Claude Code