### PR TITLE
fix: checkbox and radio-button default size based on font-size

### DIFF
--- a/packages/aura/src/components/checkbox-radio.css
+++ b/packages/aura/src/components/checkbox-radio.css
@@ -1,8 +1,8 @@
 :where(:root),
 :where(:host) {
   --vaadin-radio-button-marker-size: 6px;
-  --vaadin-checkbox-size: round(1lh - 2px, 2px);
-  --vaadin-radio-button-size: round(1lh - 2px, 2px);
+  --vaadin-checkbox-size: round(1.25em, 2px);
+  --vaadin-radio-button-size: round(1.25em, 2px);
 }
 
 vaadin-checkbox::part(checkbox),

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -91,8 +91,8 @@ export const checkable = (part, propName = part) => css`
     box-sizing: border-box;
     --_color: var(--vaadin-${unsafeCSS(propName)}-marker-color, var(--vaadin-${unsafeCSS(propName)}-background, var(--vaadin-background-color)));
     color: var(--_color);
-    height: var(--vaadin-${unsafeCSS(propName)}-size, 1lh);
-    width: var(--vaadin-${unsafeCSS(propName)}-size, 1lh);
+    height: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
+    width: var(--vaadin-${unsafeCSS(propName)}-size, round(1.125em, 2px));
     position: relative;
     cursor: var(--_cursor);
     display: flex;


### PR DESCRIPTION
It feels more reasonable to size the control based on the font-size rather than the line-height.