### PR TITLE
fix(aura): use accent color for text input caret

### DIFF
--- a/packages/aura/src/components/input-container.css
+++ b/packages/aura/src/components/input-container.css
@@ -11,6 +11,7 @@ vaadin-input-container {
   --aura-surface-level: 4;
   --aura-surface-opacity: 0.7;
   background-clip: padding-box;
+  caret-color: var(--vaadin-focus-ring-color);
 }
 
 :not([readonly], [disabled])::part(input-field),

--- a/packages/aura/src/components/rich-text-editor.css
+++ b/packages/aura/src/components/rich-text-editor.css
@@ -14,6 +14,7 @@ vaadin-rich-text-editor {
   --aura-surface-level: 4;
   --aura-surface-opacity: 0.7 !important;
   box-shadow: var(--aura-shadow-xs);
+  caret-color: var(--vaadin-focus-ring-color);
 
   &:not(:focus-within) {
     --vaadin-rich-text-editor-toolbar-button-text-color: var(--vaadin-text-color-disabled);


### PR DESCRIPTION
Minor visual flair.

Before: 
<img width="218" height="88" alt="Screenshot 2026-07-10 at 22 44 40" src="https://github.com/user-attachments/assets/58b1b4eb-e21b-4404-abf6-66eba9b8f791" />


After:
<img width="197" height="83" alt="Screenshot 2026-07-10 at 22 44 16" src="https://github.com/user-attachments/assets/204fc64a-0038-4929-bd57-50fdc401dfa7" />
