### PR TITLE
fix(aura): use dark color scheme backdrop color for page contained MDL overlays

### DIFF
--- a/packages/aura/src/components/master-detail-layout.css
+++ b/packages/aura/src/components/master-detail-layout.css
@@ -1,3 +1,17 @@
+/* Register a property so that the color is evaluated and cached at the scope where the property is set,
+instead of computing light-dark() only at the scope where the property value is used/referenced. */
+@property --_aura-mdl-page-contained-backdrop {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: transparent;
+}
+
+:where(:root),
+:where(:host) {
+  /* This caches the value of --vaadin-overlay-backdrop-background based on the color-scheme of the root/host element */
+  --_aura-mdl-page-contained-backdrop: var(--vaadin-overlay-backdrop-background);
+}
+
 vaadin-master-detail-layout::part(detail) {
   background: var(--vaadin-master-detail-layout-detail-background, var(--aura-surface-color) padding-box);
 }
@@ -30,4 +44,8 @@ vaadin-master-detail-layout > vaadin-master-detail-layout,
 vaadin-master-detail-layout:not([overlay])::part(detail) {
   border-start-end-radius: var(--_app-layout-radius);
   border-end-end-radius: var(--_app-layout-radius);
+}
+
+vaadin-master-detail-layout[overlay-containment='page'] {
+  --vaadin-overlay-backdrop-background: var(--_aura-mdl-page-contained-backdrop);
 }


### PR DESCRIPTION
Register a new custom property and set its value on the `:root` scope so that it's evaluated based on the color-scheme in that scope.

Use that property as the backdrop color when master-detail-layout uses `overlay-containment="page"`.

Before:
<img width="996" height="853" alt="Screenshot 2026-07-10 at 22 48 18" src="https://github.com/user-attachments/assets/569c5ea2-51d7-411b-9334-38a93743b120" />

After:
<img width="996" height="852" alt="Screenshot 2026-07-10 at 22 48 05" src="https://github.com/user-attachments/assets/113b1041-dc55-4c2b-ab9d-df3340cf2ace" />
