### PR TITLE
fix: keep combo-box overlay visible during closing animation

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -713,7 +713,7 @@ export const ComboBoxBaseMixin = (superClass) =>
       // Stop this private event from leaking outside.
       e.stopPropagation();
 
-      if (this._overlayElement?.hasAttribute('closing')) {
+      if (this.hasAttribute('closing')) {
         return;
       }
 

--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -212,6 +212,12 @@ export const ComboBoxBaseMixin = (superClass) =>
         this._overlayOpened = e.detail.value;
       });
 
+      // Finish close lifecycle only after the overlay closing animation completes.
+      overlay.addEventListener('vaadin-overlay-closed', () => {
+        this._scroller.items = [];
+        this._onOverlayClosed();
+      });
+
       this._overlayElement = overlay;
     }
 
@@ -258,7 +264,6 @@ export const ComboBoxBaseMixin = (superClass) =>
         this._onOpened();
       } else if (wasOpened && this._hasDropdownItems) {
         this.close();
-        this._onOverlayClosed();
       }
     }
 
@@ -707,6 +712,10 @@ export const ComboBoxBaseMixin = (superClass) =>
     _overlaySelectedItemChanged(e) {
       // Stop this private event from leaking outside.
       e.stopPropagation();
+
+      if (this._overlayElement?.hasAttribute('closing')) {
+        return;
+      }
 
       if (e.detail.item instanceof ComboBoxPlaceholder) {
         // Placeholder items should not be selectable.

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -160,8 +160,10 @@ export const ComboBoxMixin = (superClass) =>
           getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
       }
 
+      const isClosing = this._overlayElement?.hasAttribute('closing');
+
       this._scroller.setProperties({
-        items: opened ? items : [],
+        items: opened || isClosing ? items || [] : [],
         opened,
         focusedIndex,
         theme,

--- a/packages/combo-box/src/vaadin-combo-box-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-mixin.js
@@ -160,10 +160,10 @@ export const ComboBoxMixin = (superClass) =>
           getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
       }
 
-      const isClosing = this._overlayElement?.hasAttribute('closing');
+      const isClosing = this.hasAttribute('closing');
 
       this._scroller.setProperties({
-        items: opened || isClosing ? items || [] : [],
+        items: opened || isClosing ? items : [],
         opened,
         focusedIndex,
         theme,

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -9,6 +9,7 @@ import {
   focusout,
   nextRender,
   nextUpdate,
+  oneEvent,
   outsideClick,
   tabKeyDown,
   tap,
@@ -105,6 +106,48 @@ describe('interactions', () => {
 
       focusout(input);
       expect(input.value).to.be.empty;
+    });
+
+    it('should not select item when clicked during closing animation', async () => {
+      const style = document.createElement('style');
+      style.textContent = `
+        :host([closing]) {
+          animation: 200ms closing-animation;
+        }
+
+        :host([closing]) [part='overlay'] {
+          animation: 200ms overlay-closing-animation;
+        }
+
+        @keyframes closing-animation {
+          to {
+            opacity: 1;
+          }
+        }
+
+        @keyframes overlay-closing-animation {
+          to {
+            opacity: 0;
+          }
+        }
+      `;
+      overlay.shadowRoot.appendChild(style);
+
+      const item = getFirstItem(comboBox);
+      expect(item).to.exist;
+
+      comboBox.close();
+      expect(overlay.hasAttribute('closing')).to.be.true;
+
+      await sendMouseToElement({ type: 'click', element: item });
+
+      expect(comboBox.selectedItem).to.be.null;
+      expect(comboBox.value).to.be.empty;
+
+      await oneEvent(overlay, 'vaadin-overlay-closed');
+
+      expect(comboBox.selectedItem).to.be.null;
+      expect(comboBox.value).to.be.empty;
     });
   });
 

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -134,11 +134,7 @@ describe('interactions', () => {
       overlay.shadowRoot.appendChild(style);
 
       const item = getFirstItem(comboBox);
-      expect(item).to.exist;
-
       comboBox.close();
-      expect(overlay.hasAttribute('closing')).to.be.true;
-
       await sendMouseToElement({ type: 'click', element: item });
 
       expect(comboBox.selectedItem).to.be.null;

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -481,8 +481,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
           getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
       }
 
+      const isClosing = this.hasAttribute('closing');
+
       this._scroller.setProperties({
-        items: opened ? items : [],
+        items: opened || isClosing ? items : [],
         opened,
         focusedIndex,
         theme,
@@ -1313,6 +1315,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      */
     _overlaySelectedItemChanged(event) {
       event.stopPropagation();
+
+      if (this.hasAttribute('closing')) {
+        return;
+      }
 
       // Do not un-select on click when readonly
       if (this.readonly) {

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
-import { fixtureSync, keyboardEventFor, nextRender } from '@vaadin/testing-helpers';
+import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { fixtureSync, keyboardEventFor, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
@@ -202,6 +202,44 @@ describe('selecting items', () => {
       expect(comboBox.opened).to.be.true;
       expect(comboBox.filter).to.equal('an');
       expect(inputElement.value).to.equal('an');
+    });
+
+    it('should not select item when clicked during closing animation', async () => {
+      const overlay = comboBox.$.overlay;
+      const style = document.createElement('style');
+      style.textContent = `
+        :host([closing]) {
+          animation: 200ms closing-animation;
+        }
+
+        :host([closing]) [part='overlay'] {
+          animation: 200ms overlay-closing-animation;
+        }
+
+        @keyframes closing-animation {
+          to {
+            opacity: 1;
+          }
+        }
+
+        @keyframes overlay-closing-animation {
+          to {
+            opacity: 0;
+          }
+        }
+      `;
+      overlay.shadowRoot.appendChild(style);
+
+      await sendKeys({ down: 'ArrowDown' });
+      const item = getFirstItem(comboBox);
+      comboBox.close();
+      await sendMouseToElement({ type: 'click', element: item });
+
+      expect(comboBox.selectedItems).to.deep.equal([]);
+
+      await oneEvent(overlay, 'vaadin-overlay-closed');
+
+      expect(comboBox.selectedItems).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
Allow the closing animation to finish before clearing the items array.

🤖 Implemented with Codex