### PR TITLE
feat: add animations properties to overlay base styles

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -8,11 +8,12 @@
  * license.
  */
 import './vaadin-crud-dialog-overlay.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, unsafeCSS } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DialogBaseMixin } from '@vaadin/dialog/src/vaadin-dialog-base-mixin.js';
+import { overlayAnimationProperties } from '@vaadin/overlay/src/styles/vaadin-overlay-base-styles.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 /**
@@ -27,6 +28,15 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
 
   static get styles() {
     return css`
+      :host {
+        /*
+        The overlay animation properties need to be explicitly inherited from the vaadin-crud
+        element to the internal vaadin-crud-dialog element, from where they get explicitly
+        inherited by the internal vaadin-crud-dialog-overlay element.
+        */
+        ${unsafeCSS(overlayAnimationProperties)}
+      }
+
       :host([opened]),
       :host([opening]),
       :host([closing]) {
@@ -34,7 +44,7 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
         position: fixed;
       }
 
-      :host,
+      :host:not([opening], [closing]),
       :host([hidden]) {
         display: none !important;
       }

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -8,12 +8,12 @@
  * license.
  */
 import './vaadin-crud-dialog-overlay.js';
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { DialogBaseMixin } from '@vaadin/dialog/src/vaadin-dialog-base-mixin.js';
-import { overlayAnimationProperties } from '@vaadin/overlay/src/styles/vaadin-overlay-base-styles.js';
+import { overlayAnimationProperties } from '@vaadin/overlay/src/styles/vaadin-overlay-animation-base-styles.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 /**
@@ -34,7 +34,7 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
         element to the internal vaadin-crud-dialog element, from where they get explicitly
         inherited by the internal vaadin-crud-dialog-overlay element.
         */
-        ${unsafeCSS(overlayAnimationProperties)}
+        ${overlayAnimationProperties}
       }
 
       :host([opened]),

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -42,7 +42,7 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
         position: fixed;
       }
 
-      :host:not([opening], [closing]),
+      :host,
       :host([hidden]) {
         display: none !important;
       }

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -27,13 +27,11 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
   }
 
   static get styles() {
+    // The overlay animation properties need to be explicitly inherited from the vaadin-crud
+    // element to the internal vaadin-crud-dialog element, from where they get explicitly
+    // inherited by the internal vaadin-crud-dialog-overlay element.
     return css`
       :host {
-        /*
-        The overlay animation properties need to be explicitly inherited from the vaadin-crud
-        element to the internal vaadin-crud-dialog element, from where they get explicitly
-        inherited by the internal vaadin-crud-dialog-overlay element.
-        */
         ${overlayAnimationProperties}
       }
 

--- a/packages/crud/test/crud-editor.test.js
+++ b/packages/crud/test/crud-editor.test.js
@@ -133,4 +133,52 @@ describe('crud editor', () => {
       expect(crud.editorOpened).to.be.true;
     });
   });
+
+  describe('animation', () => {
+    let dialog, overlay;
+
+    beforeEach(async () => {
+      crud = fixtureSync('<vaadin-crud style="width: 300px; --vaadin-overlay-animation-duration: 10s"></vaadin-crud>');
+      crud.items = [{ foo: 'bar' }];
+      await nextRender();
+      dialog = getDialogEditor(crud);
+      overlay = dialog.$.overlay;
+    });
+
+    afterEach(() => {
+      overlay._flushAnimation('opening');
+      overlay._flushAnimation('closing');
+      crud.editorOpened = false;
+    });
+
+    it('should forward animation properties from the host to the overlay', () => {
+      expect(getComputedStyle(overlay).getPropertyValue('--vaadin-overlay-animation-duration')).to.equal('10s');
+    });
+
+    it('should set opening attribute on the overlay when the editor is opened', async () => {
+      crud.editedItem = crud.items[0];
+      await nextRender();
+
+      expect(overlay.hasAttribute('opening')).to.be.true;
+    });
+
+    it('should not hide the dialog while the overlay is opening', async () => {
+      crud.editedItem = crud.items[0];
+      await nextRender();
+
+      expect(getComputedStyle(dialog).display).to.not.equal('none');
+    });
+
+    it('should not hide the dialog while the overlay is closing', async () => {
+      crud.editedItem = crud.items[0];
+      await nextRender();
+      overlay._flushAnimation('opening');
+
+      crud.editorOpened = false;
+      await nextRender();
+
+      expect(overlay.hasAttribute('closing')).to.be.true;
+      expect(getComputedStyle(dialog).display).to.not.equal('none');
+    });
+  });
 });

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.d.ts
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const overlayAnimationProperties: CSSResult;
+
+export const overlayAnimationStyles: CSSResult;

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -11,21 +11,20 @@ import { registerCSSProperty } from '@vaadin/component-base/src/css-utils.js';
  * property registrations and the `overlayAnimationProperties` snippet below are
  * derived from this list, so a new property only needs to be added here.
  *
- * The `transform` properties have no initial value, which makes them resolve to
- * `none` in the keyframes unless a theme sets them.
+ * Only the closed state is part of the API. The opened state is left out of the
+ * keyframes so that it comes from the part itself, see the keyframes below.
+ *
+ * `--vaadin-overlay-transform-closed` has no initial value, which makes it resolve
+ * to `none` in the keyframes unless a theme sets it.
  */
 const animationProperties = [
   { name: '--vaadin-overlay-animation-duration', syntax: '<time>', initialValue: '0s' },
   { name: '--vaadin-overlay-animation-delay', syntax: '<time>', initialValue: '0s' },
   { name: '--vaadin-overlay-animation-timing-function', syntax: '*', initialValue: 'ease' },
   { name: '--vaadin-overlay-opacity-closed', syntax: '<number>', initialValue: '0' },
-  { name: '--vaadin-overlay-opacity-opened', syntax: '<number>', initialValue: '1' },
   { name: '--vaadin-overlay-translate-closed', syntax: '<length>+ | <percentage>+', initialValue: '0px' },
-  { name: '--vaadin-overlay-translate-opened', syntax: '<length>+ | <percentage>+', initialValue: '0px' },
   { name: '--vaadin-overlay-scale-closed', syntax: '<number> | <percentage>', initialValue: '1' },
-  { name: '--vaadin-overlay-scale-opened', syntax: '<number> | <percentage>', initialValue: '1' },
   { name: '--vaadin-overlay-transform-closed', syntax: '*' },
-  { name: '--vaadin-overlay-transform-opened', syntax: '*' },
 ];
 
 animationProperties.forEach((property) => {
@@ -97,27 +96,22 @@ export const overlayAnimationStyles = css`
   @keyframes --no-op {
   }
 
+  /*
+  Both animations only declare the closed state. The opened state is left out on purpose:
+  a missing keyframe uses the value the element already has, so the animation starts from
+  and ends at whatever a theme applies to the part, with no jump at either end.
+  */
   @keyframes --transform {
     0% {
       transform: var(--vaadin-overlay-transform-closed);
       translate: var(--vaadin-overlay-translate-closed);
       scale: var(--vaadin-overlay-scale-closed);
     }
-
-    100% {
-      transform: var(--vaadin-overlay-transform-opened);
-      translate: var(--vaadin-overlay-translate-opened);
-      scale: var(--vaadin-overlay-scale-opened);
-    }
   }
 
   @keyframes --fade {
     0% {
       opacity: var(--vaadin-overlay-opacity-closed);
-    }
-
-    100% {
-      opacity: var(--vaadin-overlay-opacity-opened);
     }
   }
 `;

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -49,11 +49,7 @@ export const overlayAnimationStyles = css`
   }
 
   :host(:where([opening], [closing])) {
-    /*
-    The host is inspected for an animation, to determine whether or not an animation is
-    applied for opening or closing. This empty keyframe animation is used for that,
-    while the real visible animation happens on the "overlay" and "backdrop" parts.
-    */
+    /* This empty animation only reports the state, the parts run the visible animation */
     animation-name: --no-op;
     animation-duration: var(--vaadin-overlay-animation-duration);
     animation-delay: var(--vaadin-overlay-animation-delay);
@@ -69,13 +65,7 @@ export const overlayAnimationStyles = css`
     animation-duration: var(--vaadin-overlay-animation-duration);
     animation-timing-function: var(--vaadin-overlay-animation-timing-function);
     animation-delay: var(--vaadin-overlay-animation-delay);
-    /*
-    Only fill backwards, so that the closed value applies during the animation delay.
-    Filling forwards would keep the last keyframe applied for as long as the attribute
-    is set, which overrides the paint properties a theme sets on these parts whenever
-    the attribute outlives the animation, e.g. a theme that animates the host without
-    setting --vaadin-overlay-animation-duration.
-    */
+    /* Fill backwards only, so the closed value applies during the delay without overriding theme styles */
     animation-fill-mode: backwards;
 
     @media (prefers-reduced-motion) {
@@ -96,11 +86,7 @@ export const overlayAnimationStyles = css`
   @keyframes --no-op {
   }
 
-  /*
-  Both animations only declare the closed state. The opened state is left out on purpose:
-  a missing keyframe uses the value the element already has, so the animation starts from
-  and ends at whatever a theme applies to the part, with no jump at either end.
-  */
+  /* Only the closed state is declared, so the animations end at the value the part already has */
   @keyframes --transform {
     0% {
       transform: var(--vaadin-overlay-transform-closed);

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { css, unsafeCSS } from 'lit';
+import { registerCSSProperty } from '@vaadin/component-base/src/css-utils.js';
+
+/**
+ * The custom properties that make up the overlay animation CSS API. Both the
+ * property registrations and the `overlayAnimationProperties` snippet below are
+ * derived from this list, so a new property only needs to be added here.
+ *
+ * The `transform` properties have no initial value, which makes them resolve to
+ * `none` in the keyframes unless a theme sets them.
+ */
+const animationProperties = [
+  { name: '--vaadin-overlay-animation-duration', syntax: '<time>', initialValue: '0s' },
+  { name: '--vaadin-overlay-animation-delay', syntax: '<time>', initialValue: '0s' },
+  { name: '--vaadin-overlay-animation-timing-function', syntax: '*', initialValue: 'ease' },
+  { name: '--vaadin-overlay-opacity-closed', syntax: '<number>', initialValue: '0' },
+  { name: '--vaadin-overlay-opacity-opened', syntax: '<number>', initialValue: '1' },
+  { name: '--vaadin-overlay-translate-closed', syntax: '<length>+ | <percentage>+', initialValue: '0px' },
+  { name: '--vaadin-overlay-translate-opened', syntax: '<length>+ | <percentage>+', initialValue: '0px' },
+  { name: '--vaadin-overlay-scale-closed', syntax: '<number> | <percentage>', initialValue: '1' },
+  { name: '--vaadin-overlay-scale-opened', syntax: '<number> | <percentage>', initialValue: '1' },
+  { name: '--vaadin-overlay-transform-closed', syntax: '*' },
+  { name: '--vaadin-overlay-transform-opened', syntax: '*' },
+];
+
+animationProperties.forEach((property) => {
+  registerCSSProperty({ inherits: false, ...property });
+});
+
+/**
+ * The overlay animation properties as a set of `inherit` declarations. The properties are
+ * registered as non-inheriting, so components with more than one shadow root boundary
+ * between the host and the overlay need to forward them explicitly.
+ */
+export const overlayAnimationProperties = unsafeCSS(
+  animationProperties.map(({ name }) => `${name}: inherit;`).join('\n'),
+);
+
+/* Reusable animation styles for overlay enter and exit */
+export const overlayAnimationStyles = css`
+  :host,
+  [part='overlay'],
+  [part='backdrop'] {
+    ${overlayAnimationProperties}
+  }
+
+  :host(:where([opening], [closing])) {
+    /*
+    The host is inspected for an animation, to determine whether or not an animation is
+    applied for opening or closing. This empty keyframe animation is used for that,
+    while the real visible animation happens on the "overlay" and "backdrop" parts.
+    */
+    animation-name: --no-op;
+    animation-duration: var(--vaadin-overlay-animation-duration);
+    animation-delay: var(--vaadin-overlay-animation-delay);
+  }
+
+  :host(:where([closing])) [part='overlay'],
+  :host(:where([closing])) ::slotted(*) {
+    pointer-events: none !important;
+  }
+
+  :host(:where([opening], [closing])) :is([part='overlay'], [part='backdrop']) {
+    animation-name: --fade, --transform;
+    animation-duration: var(--vaadin-overlay-animation-duration);
+    animation-timing-function: var(--vaadin-overlay-animation-timing-function);
+    animation-delay: var(--vaadin-overlay-animation-delay);
+    /*
+    Only fill backwards, so that the closed value applies during the animation delay.
+    Filling forwards would keep the last keyframe applied for as long as the attribute
+    is set, which overrides the paint properties a theme sets on these parts whenever
+    the attribute outlives the animation, e.g. a theme that animates the host without
+    setting --vaadin-overlay-animation-duration.
+    */
+    animation-fill-mode: backwards;
+
+    @media (prefers-reduced-motion) {
+      animation-name: --fade;
+    }
+  }
+
+  :host(:where([opening], [closing])) [part='backdrop'] {
+    animation-name: --fade;
+    animation-timing-function: linear;
+    --vaadin-overlay-opacity-closed: 0;
+  }
+
+  :host(:where([closing])) :is([part='overlay'], [part='backdrop']) {
+    animation-direction: reverse;
+  }
+
+  @keyframes --no-op {
+  }
+
+  @keyframes --transform {
+    0% {
+      transform: var(--vaadin-overlay-transform-closed);
+      translate: var(--vaadin-overlay-translate-closed);
+      scale: var(--vaadin-overlay-scale-closed);
+    }
+
+    100% {
+      transform: var(--vaadin-overlay-transform-opened);
+      translate: var(--vaadin-overlay-translate-opened);
+      scale: var(--vaadin-overlay-scale-opened);
+    }
+  }
+
+  @keyframes --fade {
+    0% {
+      opacity: var(--vaadin-overlay-opacity-closed);
+    }
+
+    100% {
+      opacity: var(--vaadin-overlay-opacity-opened);
+    }
+  }
+`;

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -40,7 +40,6 @@ export const overlayAnimationProperties = unsafeCSS(
   animationProperties.map(({ name }) => `${name}: inherit;`).join('\n'),
 );
 
-/* Reusable animation styles for overlay enter and exit */
 export const overlayAnimationStyles = css`
   :host,
   [part='overlay'],

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.d.ts
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { CSSResult } from 'lit';
+
+export const overlayStyles: CSSResult[];

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -4,7 +4,161 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/component-base/src/styles/style-props.js';
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+import { registerCSSProperty } from '@vaadin/component-base/src/css-utils.js';
+
+['--vaadin-overlay-animation-duration', '--vaadin-overlay-animation-delay'].forEach((propertyName) => {
+  registerCSSProperty({
+    name: propertyName,
+    syntax: '<time>',
+    inherits: false,
+    initialValue: '0s',
+  });
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-animation-timing-function',
+  syntax: '*',
+  inherits: false,
+  initialValue: 'ease',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-opacity-closed',
+  syntax: '<number>',
+  inherits: false,
+  initialValue: '0',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-opacity-opened',
+  syntax: '<number>',
+  inherits: false,
+  initialValue: '1',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-translate-closed',
+  syntax: '<length>+ | <percentage>+',
+  inherits: false,
+  initialValue: '0',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-translate-opened',
+  syntax: '<length>+ | <percentage>+',
+  inherits: false,
+  initialValue: '0',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-scale-closed',
+  syntax: '<number> | <percentage>',
+  inherits: false,
+  initialValue: '1',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-scale-opened',
+  syntax: '<number> | <percentage>',
+  inherits: false,
+  initialValue: '1',
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-transform-closed',
+  syntax: '*',
+  inherits: false,
+});
+
+registerCSSProperty({
+  name: '--vaadin-overlay-transform-opened',
+  syntax: '*',
+  inherits: false,
+});
+
+export const overlayAnimationProperties = `
+  --vaadin-overlay-animation-duration: inherit;
+  --vaadin-overlay-animation-delay: inherit;
+  --vaadin-overlay-animation-timing-function: inherit;
+  --vaadin-overlay-opacity-closed: inherit;
+  --vaadin-overlay-opacity-opened: inherit;
+  --vaadin-overlay-translate-closed: inherit;
+  --vaadin-overlay-translate-opened: inherit;
+  --vaadin-overlay-scale-closed: inherit;
+  --vaadin-overlay-scale-opened: inherit;
+  --vaadin-overlay-transform-closed: inherit;
+  --vaadin-overlay-transform-opened: inherit;
+`;
+
+/* Reusable animation styles for overlay enter and exit */
+export const overlayAnimationStyles = css`
+  :host,
+  [part='overlay'],
+  [part='backdrop'] {
+    ${unsafeCSS(overlayAnimationProperties)}
+  }
+
+  :host(:where([opening], [closing])) {
+    /*
+    The host is inspected for an animation, to determine whether or not an animation is
+    applied for opening or closing. This empty keyframe animation is used for that,
+    while the real visible animation happens on the "overlay" and "backdrop" parts.
+    */
+    animation-name: --no-op;
+    animation-duration: var(--vaadin-overlay-animation-duration);
+    animation-delay: var(--vaadin-overlay-animation-delay);
+  }
+
+  :host(:where([opening], [closing])) :is([part='overlay'], [part='backdrop']) {
+    animation-name: --fade, --transform;
+    animation-duration: var(--vaadin-overlay-animation-duration);
+    animation-timing-function: var(--vaadin-overlay-animation-timing-function);
+    animation-delay: var(--vaadin-overlay-animation-delay);
+    animation-fill-mode: both;
+
+    @media (prefers-reduced-motion) {
+      animation-name: --fade;
+    }
+  }
+
+  :host(:where([opening], [closing])) [part='backdrop'] {
+    animation-name: --fade;
+    animation-timing-function: linear;
+    --vaadin-overlay-opacity-closed: 0;
+  }
+
+  :host(:where([closing])) :is([part='overlay'], [part='backdrop']) {
+    animation-direction: reverse;
+  }
+
+  @keyframes --no-op {
+  }
+
+  @keyframes --transform {
+    0% {
+      transform: var(--vaadin-overlay-transform-closed);
+      translate: var(--vaadin-overlay-translate-closed);
+      scale: var(--vaadin-overlay-scale-closed);
+    }
+
+    100% {
+      transform: var(--vaadin-overlay-transform-opened);
+      translate: var(--vaadin-overlay-translate-opened);
+      scale: var(--vaadin-overlay-scale-opened);
+    }
+  }
+
+  @keyframes --fade {
+    0% {
+      opacity: var(--vaadin-overlay-opacity-closed);
+    }
+
+    100% {
+      opacity: var(--vaadin-overlay-opacity-opened);
+    }
+  }
+`;
 
 export const overlayStyles = css`
   :host {
@@ -107,4 +261,6 @@ export const overlayStyles = css`
       border: 3px solid !important;
     }
   }
+
+  ${overlayAnimationStyles}
 `;

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -4,163 +4,10 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import '@vaadin/component-base/src/styles/style-props.js';
-import { css, unsafeCSS } from 'lit';
-import { registerCSSProperty } from '@vaadin/component-base/src/css-utils.js';
+import { css } from 'lit';
+import { overlayAnimationStyles } from './vaadin-overlay-animation-base-styles.js';
 
-['--vaadin-overlay-animation-duration', '--vaadin-overlay-animation-delay'].forEach((propertyName) => {
-  registerCSSProperty({
-    name: propertyName,
-    syntax: '<time>',
-    inherits: false,
-    initialValue: '0s',
-  });
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-animation-timing-function',
-  syntax: '*',
-  inherits: false,
-  initialValue: 'ease',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-opacity-closed',
-  syntax: '<number>',
-  inherits: false,
-  initialValue: '0',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-opacity-opened',
-  syntax: '<number>',
-  inherits: false,
-  initialValue: '1',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-translate-closed',
-  syntax: '<length>+ | <percentage>+',
-  inherits: false,
-  initialValue: '0',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-translate-opened',
-  syntax: '<length>+ | <percentage>+',
-  inherits: false,
-  initialValue: '0',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-scale-closed',
-  syntax: '<number> | <percentage>',
-  inherits: false,
-  initialValue: '1',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-scale-opened',
-  syntax: '<number> | <percentage>',
-  inherits: false,
-  initialValue: '1',
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-transform-closed',
-  syntax: '*',
-  inherits: false,
-});
-
-registerCSSProperty({
-  name: '--vaadin-overlay-transform-opened',
-  syntax: '*',
-  inherits: false,
-});
-
-export const overlayAnimationProperties = `
-  --vaadin-overlay-animation-duration: inherit;
-  --vaadin-overlay-animation-delay: inherit;
-  --vaadin-overlay-animation-timing-function: inherit;
-  --vaadin-overlay-opacity-closed: inherit;
-  --vaadin-overlay-opacity-opened: inherit;
-  --vaadin-overlay-translate-closed: inherit;
-  --vaadin-overlay-translate-opened: inherit;
-  --vaadin-overlay-scale-closed: inherit;
-  --vaadin-overlay-scale-opened: inherit;
-  --vaadin-overlay-transform-closed: inherit;
-  --vaadin-overlay-transform-opened: inherit;
-`;
-
-/* Reusable animation styles for overlay enter and exit */
-export const overlayAnimationStyles = css`
-  :host,
-  [part='overlay'],
-  [part='backdrop'] {
-    ${unsafeCSS(overlayAnimationProperties)}
-  }
-
-  :host(:where([opening], [closing])) {
-    /*
-    The host is inspected for an animation, to determine whether or not an animation is
-    applied for opening or closing. This empty keyframe animation is used for that,
-    while the real visible animation happens on the "overlay" and "backdrop" parts.
-    */
-    animation-name: --no-op;
-    animation-duration: var(--vaadin-overlay-animation-duration);
-    animation-delay: var(--vaadin-overlay-animation-delay);
-  }
-
-  :host(:where([opening], [closing])) :is([part='overlay'], [part='backdrop']) {
-    animation-name: --fade, --transform;
-    animation-duration: var(--vaadin-overlay-animation-duration);
-    animation-timing-function: var(--vaadin-overlay-animation-timing-function);
-    animation-delay: var(--vaadin-overlay-animation-delay);
-    animation-fill-mode: both;
-
-    @media (prefers-reduced-motion) {
-      animation-name: --fade;
-    }
-  }
-
-  :host(:where([opening], [closing])) [part='backdrop'] {
-    animation-name: --fade;
-    animation-timing-function: linear;
-    --vaadin-overlay-opacity-closed: 0;
-  }
-
-  :host(:where([closing])) :is([part='overlay'], [part='backdrop']) {
-    animation-direction: reverse;
-  }
-
-  @keyframes --no-op {
-  }
-
-  @keyframes --transform {
-    0% {
-      transform: var(--vaadin-overlay-transform-closed);
-      translate: var(--vaadin-overlay-translate-closed);
-      scale: var(--vaadin-overlay-scale-closed);
-    }
-
-    100% {
-      transform: var(--vaadin-overlay-transform-opened);
-      translate: var(--vaadin-overlay-translate-opened);
-      scale: var(--vaadin-overlay-scale-opened);
-    }
-  }
-
-  @keyframes --fade {
-    0% {
-      opacity: var(--vaadin-overlay-opacity-closed);
-    }
-
-    100% {
-      opacity: var(--vaadin-overlay-opacity-opened);
-    }
-  }
-`;
-
-export const overlayStyles = css`
+const overlayBase = css`
   :host {
     z-index: 200;
     position: fixed;
@@ -251,16 +98,11 @@ export const overlayStyles = css`
     outline: var(--vaadin-focus-ring-width) solid var(--vaadin-focus-ring-color);
   }
 
-  :host(:where([closing])) [part='overlay'],
-  :host(:where([closing])) ::slotted(*) {
-    pointer-events: none !important;
-  }
-
   @media (forced-colors: active) {
     [part='overlay'] {
       border: 3px solid !important;
     }
   }
-
-  ${overlayAnimationStyles}
 `;
+
+export const overlayStyles = [overlayBase, overlayAnimationStyles];

--- a/packages/overlay/test/animated-styles.js
+++ b/packages/overlay/test/animated-styles.js
@@ -19,6 +19,15 @@ registerStyles(
       animation: 5s overlay-dummy-animation;
     }
 
+    /* Paint properties applied by a theme, which the base animation must not override */
+    :host([themed-parts]) [part='overlay'],
+    :host([themed-parts]) [part='backdrop'] {
+      transform: rotate(45deg);
+      translate: 11px 12px;
+      scale: 0.75;
+      opacity: 0.5;
+    }
+
     @keyframes overlay-dummy-animation {
       to {
         opacity: 1 !important; /* stylelint-disable-line keyframe-declaration-no-important */

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { emulateMedia, resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
-import { escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './animated-styles.js';
 import '../src/vaadin-overlay.js';
@@ -555,6 +555,32 @@ describe('animation properties', () => {
     expect(overlay.hasAttribute('closing')).to.be.true;
   });
 
+  // The empty keyframe animation on the host is what reports the end of the animation, so
+  // these do not flush: they verify that the attributes are cleared on their own.
+  it('should clear the opening attribute when the animation ends', async () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '50ms');
+
+    overlay.opened = true;
+    expect(overlay.hasAttribute('opening')).to.be.true;
+
+    await oneEvent(overlay, 'animationend');
+    expect(overlay.hasAttribute('opening')).to.be.false;
+  });
+
+  it('should clear the closing attribute when the animation ends', async () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '50ms');
+
+    overlay.opened = true;
+    // Let the opening animation run out, so that closing starts from a fully opened overlay
+    await aTimeout(100);
+
+    overlay.opened = false;
+    expect(overlay.hasAttribute('closing')).to.be.true;
+
+    await oneEvent(overlay, 'animationend');
+    expect(overlay.hasAttribute('closing')).to.be.false;
+  });
+
   it('should use animation duration and delay for opening and closing animations', () => {
     overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
 
@@ -664,6 +690,15 @@ describe('animation properties', () => {
       expect(keyframes[0].opacity).to.equal('0');
       expect(keyframes[1].opacity).to.equal('1');
     });
+
+    it('should reverse the backdrop animation direction while closing', () => {
+      overlay.opened = true;
+      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('normal');
+
+      overlay._flushAnimation('opening');
+      overlay.opened = false;
+      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('reverse');
+    });
   });
 
   describe('prefers-reduced-motion', () => {
@@ -679,6 +714,33 @@ describe('animation properties', () => {
       overlay.opened = true;
       const names = overlay.$.overlay.getAnimations().map((animation) => animation.animationName);
       expect(names).to.eql(['--fade']);
+    });
+  });
+
+  describe('fill mode', () => {
+    beforeEach(async () => {
+      overlay.setAttribute('themed-parts', '');
+      overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+      await nextRender();
+    });
+
+    it('should apply the closed value during the opening animation delay', () => {
+      overlay.opened = true;
+
+      // The backwards fill keeps the overlay at its closed opacity for the delay,
+      // instead of painting the theme value until the animation starts.
+      expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
+    });
+
+    it('should apply the value of the part during the closing animation delay', () => {
+      overlay.opened = true;
+      overlay._flushAnimation('opening');
+      overlay.opened = false;
+
+      // The closing animation is reversed, so the fill applies the opened state. That state
+      // is not declared in the keyframes, so the part keeps its own opacity and does not
+      // jump to a different value before the closing animation starts.
+      expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0.5');
     });
   });
 });
@@ -775,42 +837,5 @@ describe('theme paint properties without an opted-in duration', () => {
 
     expect(overlay.hasAttribute('closing')).to.be.true;
     assertThemedValues(overlay.$.backdrop);
-  });
-});
-
-describe('animation fill mode', () => {
-  let overlay;
-
-  beforeEach(async () => {
-    overlay = createOverlay('overlay content');
-    overlay.setAttribute('themed-parts', '');
-    overlay.style.setProperty('--vaadin-overlay-animation-duration', '10s');
-    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
-    await nextRender();
-  });
-
-  afterEach(() => {
-    overlay._flushAnimation('opening');
-    overlay._flushAnimation('closing');
-    overlay.opened = false;
-  });
-
-  it('should apply the closed value during the opening animation delay', () => {
-    overlay.opened = true;
-
-    // The backwards fill keeps the overlay at its closed opacity for the delay,
-    // instead of painting the theme value until the animation starts.
-    expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
-  });
-
-  it('should apply the value of the part during the closing animation delay', () => {
-    overlay.opened = true;
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-
-    // The closing animation is reversed, so the fill applies the opened state. That state
-    // is not declared in the keyframes, so the part keeps its own opacity and does not
-    // jump to a different value before the closing animation starts.
-    expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0.5');
   });
 });

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -507,3 +507,98 @@ describe('interaction while closing', () => {
     expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('auto');
   });
 });
+
+function getAnimation(element, name) {
+  return element.getAnimations().find((animation) => animation.animationName === name);
+}
+
+describe('animation properties', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = createOverlay('overlay content');
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '10s');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay._flushAnimation('closing');
+    overlay.opened = false;
+  });
+
+  it('should set opening and closing attributes when animation duration is not 0s', () => {
+    overlay.opened = true;
+    expect(overlay.hasAttribute('opening')).to.be.true;
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    expect(overlay.hasAttribute('closing')).to.be.true;
+  });
+
+  it('should use animation duration and delay for opening and closing animations', () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+
+    overlay.opened = true;
+    let timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
+    expect(timing.duration).to.equal(10000);
+    expect(timing.delay).to.equal(2000);
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
+    expect(timing.duration).to.equal(10000);
+    expect(timing.delay).to.equal(2000);
+  });
+
+  it('should use animation timing function for opening and closing animations', () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+
+    overlay.opened = true;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
+  });
+
+  it('should use closed and opened opacity for the fade animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
+    overlay.style.setProperty('--vaadin-overlay-opacity-opened', '0.75');
+
+    overlay.opened = true;
+    const keyframes = getAnimation(overlay.$.overlay, '--fade').effect.getKeyframes();
+    expect(keyframes[0].opacity).to.equal('0.25');
+    expect(keyframes[1].opacity).to.equal('0.75');
+  });
+
+  it('should use closed and opened translate for the transform animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-translate-closed', '10px 20px');
+    overlay.style.setProperty('--vaadin-overlay-translate-opened', '30px 40px');
+
+    overlay.opened = true;
+    const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
+    expect(keyframes[0].translate).to.equal('10px 20px');
+    expect(keyframes[1].translate).to.equal('30px 40px');
+  });
+
+  it('should use closed and opened scale for the transform animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-scale-closed', '0.5');
+    overlay.style.setProperty('--vaadin-overlay-scale-opened', '1.5');
+
+    overlay.opened = true;
+    const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
+    expect(keyframes[0].scale).to.equal('0.5');
+    expect(keyframes[1].scale).to.equal('1.5');
+  });
+
+  it('should use closed and opened transform for the transform animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-transform-closed', 'rotate(10deg)');
+    overlay.style.setProperty('--vaadin-overlay-transform-opened', 'rotate(20deg)');
+
+    overlay.opened = true;
+    const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
+    expect(keyframes[0].transform).to.equal('rotate(10deg)');
+    expect(keyframes[1].transform).to.equal('rotate(20deg)');
+  });
+});

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -512,6 +512,25 @@ function getAnimation(element, name) {
   return element.getAnimations().find((animation) => animation.animationName === name);
 }
 
+/**
+ * Returns the styles of the element at the given time of the named animation. The animated
+ * value is read instead of the keyframes, because WebKit does not substitute `var()` in the
+ * keyframes returned by `getAnimations()` when a keyframe is left out of the animation.
+ */
+function stylesDuringAnimation(element, name, time) {
+  const animation = getAnimation(element, name);
+  animation.pause();
+  animation.currentTime = time;
+  return getComputedStyle(element);
+}
+
+/** Returns the value the browser computes for the given style, to compare animated values against. */
+function computedValue(property, value) {
+  const element = fixtureSync('<div></div>');
+  element.style.setProperty(property, value);
+  return getComputedStyle(element)[property];
+}
+
 describe('animation properties', () => {
   let overlay;
 
@@ -562,44 +581,51 @@ describe('animation properties', () => {
     expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
   });
 
-  it('should use closed and opened opacity for the fade animation', () => {
+  // The animations start at the closed value and end at the value of the part, because the
+  // opened state is left out of the keyframes. With a linear timing function the value in the
+  // middle of the animation is exactly between the two, which pins down both ends.
+  it('should use the closed opacity for the fade animation', () => {
     overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
-    overlay.style.setProperty('--vaadin-overlay-opacity-opened', '0.75');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.opacity = '0.6';
 
     overlay.opened = true;
-    const keyframes = getAnimation(overlay.$.overlay, '--fade').effect.getKeyframes();
-    expect(keyframes[0].opacity).to.equal('0.25');
-    expect(keyframes[1].opacity).to.equal('0.75');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 0).opacity).to.equal('0.25');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 5000).opacity).to.equal('0.425');
   });
 
-  it('should use closed and opened translate for the transform animation', () => {
+  it('should use the closed translate for the transform animation', () => {
     overlay.style.setProperty('--vaadin-overlay-translate-closed', '10px 20px');
-    overlay.style.setProperty('--vaadin-overlay-translate-opened', '30px 40px');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.translate = '30px 40px';
 
     overlay.opened = true;
-    const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
-    expect(keyframes[0].translate).to.equal('10px 20px');
-    expect(keyframes[1].translate).to.equal('30px 40px');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).translate).to.equal('10px 20px');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).translate).to.equal('20px 30px');
   });
 
-  it('should use closed and opened scale for the transform animation', () => {
+  it('should use the closed scale for the transform animation', () => {
     overlay.style.setProperty('--vaadin-overlay-scale-closed', '0.5');
-    overlay.style.setProperty('--vaadin-overlay-scale-opened', '1.5');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.scale = '1.5';
 
     overlay.opened = true;
-    const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
-    expect(keyframes[0].scale).to.equal('0.5');
-    expect(keyframes[1].scale).to.equal('1.5');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).scale).to.equal('0.5');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).scale).to.equal('1');
   });
 
-  it('should use closed and opened transform for the transform animation', () => {
+  it('should use the closed transform for the transform animation', () => {
     overlay.style.setProperty('--vaadin-overlay-transform-closed', 'rotate(10deg)');
-    overlay.style.setProperty('--vaadin-overlay-transform-opened', 'rotate(20deg)');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.transform = 'rotate(20deg)';
 
     overlay.opened = true;
-    const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
-    expect(keyframes[0].transform).to.equal('rotate(10deg)');
-    expect(keyframes[1].transform).to.equal('rotate(20deg)');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).transform).to.equal(
+      computedValue('transform', 'rotate(10deg)'),
+    );
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).transform).to.equal(
+      computedValue('transform', 'rotate(15deg)'),
+    );
   });
 
   it('should reverse the animation direction while closing', () => {
@@ -777,11 +803,14 @@ describe('animation fill mode', () => {
     expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
   });
 
-  it('should apply the opened value during the closing animation delay', () => {
+  it('should apply the value of the part during the closing animation delay', () => {
     overlay.opened = true;
     overlay._flushAnimation('opening');
     overlay.opened = false;
 
-    expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('1');
+    // The closing animation is reversed, so the fill applies the opened state. That state
+    // is not declared in the keyframes, so the part keeps its own opacity and does not
+    // jump to a different value before the closing animation starts.
+    expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0.5');
   });
 });

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { emulateMedia, resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './animated-styles.js';
@@ -600,5 +600,188 @@ describe('animation properties', () => {
     const keyframes = getAnimation(overlay.$.overlay, '--transform').effect.getKeyframes();
     expect(keyframes[0].transform).to.equal('rotate(10deg)');
     expect(keyframes[1].transform).to.equal('rotate(20deg)');
+  });
+
+  it('should reverse the animation direction while closing', () => {
+    overlay.opened = true;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('normal');
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('reverse');
+  });
+
+  describe('backdrop', () => {
+    beforeEach(async () => {
+      overlay.withBackdrop = true;
+      await nextRender();
+    });
+
+    it('should only run the fade animation on the backdrop', () => {
+      overlay.opened = true;
+      const names = overlay.$.backdrop.getAnimations().map((animation) => animation.animationName);
+      expect(names).to.eql(['--fade']);
+    });
+
+    it('should use linear timing function for the backdrop animation', () => {
+      overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'ease-in');
+
+      overlay.opened = true;
+      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().easing).to.equal('linear');
+    });
+
+    it('should always use zero closed opacity for the backdrop animation', () => {
+      overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
+
+      overlay.opened = true;
+      const keyframes = getAnimation(overlay.$.backdrop, '--fade').effect.getKeyframes();
+      expect(keyframes[0].opacity).to.equal('0');
+      expect(keyframes[1].opacity).to.equal('1');
+    });
+  });
+
+  describe('prefers-reduced-motion', () => {
+    before(async () => {
+      await emulateMedia({ reducedMotion: 'reduce' });
+    });
+
+    after(async () => {
+      await emulateMedia({ reducedMotion: 'no-preference' });
+    });
+
+    it('should only run the fade animation on the overlay part', () => {
+      overlay.opened = true;
+      const names = overlay.$.overlay.getAnimations().map((animation) => animation.animationName);
+      expect(names).to.eql(['--fade']);
+    });
+  });
+});
+
+describe('animation delay without duration', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = createOverlay('overlay content');
+    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay.opened = false;
+  });
+
+  it('should not set opening attribute when animation duration is 0s', () => {
+    overlay.opened = true;
+    expect(overlay.hasAttribute('opening')).to.be.false;
+  });
+
+  it('should not set closing attribute when animation duration is 0s', () => {
+    overlay.opened = true;
+    overlay.opened = false;
+    expect(overlay.hasAttribute('closing')).to.be.false;
+  });
+});
+
+describe('theme paint properties without an opted-in duration', () => {
+  let overlay;
+
+  // The paint properties a theme applies to the overlay parts. These must survive
+  // the opening and closing windows of a host animation that does not opt in to
+  // the overlay animation duration, e.g. a theme with its own `:host([opening])`
+  // animation. See `animated-styles.js` for the values.
+  const themedValues = {
+    transform: 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)',
+    translate: '11px 12px',
+    scale: '0.75',
+    opacity: '0.5',
+  };
+
+  function assertThemedValues(element) {
+    const style = getComputedStyle(element);
+    expect(style.transform).to.equal(themedValues.transform);
+    expect(style.translate).to.equal(themedValues.translate);
+    expect(style.scale).to.equal(themedValues.scale);
+    expect(style.opacity).to.equal(themedValues.opacity);
+  }
+
+  beforeEach(async () => {
+    overlay = createOverlay('overlay content');
+    // A 5s animation on the host, while --vaadin-overlay-animation-duration stays 0s
+    overlay.setAttribute('long-animation', '');
+    overlay.setAttribute('themed-parts', '');
+    overlay.withBackdrop = true;
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay._flushAnimation('closing');
+    overlay.opened = false;
+  });
+
+  it('should not override the overlay part paint properties while opening', () => {
+    overlay.opened = true;
+
+    expect(overlay.hasAttribute('opening')).to.be.true;
+    assertThemedValues(overlay.$.overlay);
+  });
+
+  it('should not override the backdrop paint properties while opening', () => {
+    overlay.opened = true;
+
+    expect(overlay.hasAttribute('opening')).to.be.true;
+    assertThemedValues(overlay.$.backdrop);
+  });
+
+  it('should not override the overlay part paint properties while closing', () => {
+    overlay.opened = true;
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+
+    expect(overlay.hasAttribute('closing')).to.be.true;
+    assertThemedValues(overlay.$.overlay);
+  });
+
+  it('should not override the backdrop paint properties while closing', () => {
+    overlay.opened = true;
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+
+    expect(overlay.hasAttribute('closing')).to.be.true;
+    assertThemedValues(overlay.$.backdrop);
+  });
+});
+
+describe('animation fill mode', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = createOverlay('overlay content');
+    overlay.setAttribute('themed-parts', '');
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '10s');
+    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay._flushAnimation('closing');
+    overlay.opened = false;
+  });
+
+  it('should apply the closed value during the opening animation delay', () => {
+    overlay.opened = true;
+
+    // The backwards fill keeps the overlay at its closed opacity for the delay,
+    // instead of painting the theme value until the animation starts.
+    expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
+  });
+
+  it('should apply the opened value during the closing animation delay', () => {
+    overlay.opened = true;
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+
+    expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('1');
   });
 });


### PR DESCRIPTION
Fixes #11321

Add built-in keyframe animations to all overlays, which a theme can then turn on via CSS custom properties. For a simple fade-in/out animation, all that is needed is to define the `--vaadin-overlay-animation-duration` property on a component with an overlay.

See issue #11321 for examples.

Notification has animations enabled by default, as they require a bit more elaborate configuration so that the stacking notifications enter and leave without all the other notifications jumping suddenly. I view this more as a feature of the notification component rather than a theme.