### PR TITLE
refactor!: remove cell focus on mousedown workaround

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -606,7 +606,12 @@ export const ContextMenuMixin = (superClass) =>
       });
     }
 
-    /** @private */
+    /**
+     * Mimics the native focus on mousedown: walks up the flat tree from the
+     * target and focuses the closest focusable element, including elements
+     * with `tabindex="-1"` which are focusable by mouse (e.g. grid cells).
+     * @private
+     */
     __focusClosestFocusable(target) {
       let currentElement = target;
       while (currentElement) {
@@ -614,7 +619,8 @@ export const ContextMenuMixin = (superClass) =>
           currentElement.focus();
           return;
         }
-        currentElement = currentElement.parentNode || currentElement.host;
+        // Use assignedSlot to cross shadow DOM boundaries for slotted content
+        currentElement = currentElement.assignedSlot || currentElement.parentNode || currentElement.host;
       }
     }
 
@@ -628,10 +634,8 @@ export const ContextMenuMixin = (superClass) =>
       if (target) {
         // Need to run asynchronously to avoid timing issues with the Lit-based context menu
         queueMicrotask(() => {
-          // Dispatch mousedown and mouseup to the target (grid cell focus depends on it)
-          target.dispatchEvent(this.__createMouseEvent('mousedown', x, y));
-          target.dispatchEvent(this.__createMouseEvent('mouseup', x, y));
-          // Manually try to focus the closest focusable of the target
+          // Focus the target as the native mousedown preceding a real
+          // contextmenu event would do
           this.__focusClosestFocusable(target);
           // Dispatch a contextmenu event to the target
           target.dispatchEvent(this.__createMouseEvent('contextmenu', x, y));

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -5,7 +5,7 @@
  */
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
-import { isAndroid, isChrome, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { isAndroid, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { setTouchAction } from '@vaadin/component-base/src/gestures.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
@@ -402,34 +402,6 @@ export const GridMixin = (superClass) =>
       }
 
       cell._content = cellContent;
-
-      // With native Shadow DOM, mousedown on slotted element does not focus
-      // focusable slot wrapper, that is why cells are not focused with
-      // mousedown. Workaround: listen for mousedown and focus manually.
-      cellContent.addEventListener('mousedown', () => {
-        if (isChrome) {
-          // Chrome bug: focusing before mouseup prevents text selection, see http://crbug.com/771903
-          const mouseUpListener = (event) => {
-            // If focus is on element within the cell content - respect it, do not change
-            const contentContainsFocusedElement = cellContent.contains(this.getRootNode().activeElement);
-            // Only focus if mouse is released on cell content itself
-            const mouseUpWithinCell = event.composedPath().includes(cellContent);
-            if (!contentContainsFocusedElement && mouseUpWithinCell) {
-              cell.focus({ preventScroll: true });
-            }
-            document.removeEventListener('mouseup', mouseUpListener, true);
-          };
-          document.addEventListener('mouseup', mouseUpListener, true);
-        } else {
-          // Focus on mouseup, on the other hand, removes selection on Safari.
-          // Watch out sync focus removal issue, only async focus works here.
-          setTimeout(() => {
-            if (!cellContent.contains(this.getRootNode().activeElement)) {
-              cell.focus({ preventScroll: true });
-            }
-          });
-        }
-      });
 
       return cell;
     }

--- a/packages/grid/test/keyboard-navigation.test.js
+++ b/packages/grid/test/keyboard-navigation.test.js
@@ -1,11 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { sendKeys } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import {
   aTimeout,
   down as mouseDown,
   fixtureSync,
   focusin,
-  isChrome,
   isDesktopSafari,
   keyboardEventFor,
   keyDownOn,
@@ -1727,21 +1726,22 @@ describe('keyboard navigation', () => {
       grid.removeEventListener('cell-focus', spy);
     });
 
-    // Separate test suite for Chrome, where we use a workaround to dispatch
-    // cell-focus on mouse up
-    (isChrome ? describe : describe.skip)('chrome', () => {
-      it('should dispatch cell-focus on mouse up on cell content', () => {
+    describe('mouse', () => {
+      afterEach(async () => {
+        await resetMouse();
+      });
+
+      it('should dispatch cell-focus on cell content mousedown', async () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);
 
-        // Mouse down and release on cell content element
         const cell = getRowFirstCell(0);
-        mouseDown(cell._content);
-        mouseUp(cell._content);
+        await sendMouseToElement({ type: 'move', element: cell._content });
+        await sendMouse({ type: 'down' });
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('should dispatch cell-focus on mouse up on cell content when grid is in shadow DOM', () => {
+      it('should dispatch cell-focus on cell content mousedown when grid is in shadow DOM', async () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);
 
@@ -1750,36 +1750,26 @@ describe('keyboard navigation', () => {
         document.body.appendChild(container);
         container.attachShadow({ mode: 'open' });
         container.shadowRoot.appendChild(grid);
+        await nextFrame();
 
-        // Mouse down and release on cell content element
         const cell = getRowFirstCell(0);
-        mouseDown(cell._content);
-        mouseUp(cell._content);
+        await sendMouseToElement({ type: 'move', element: cell._content });
+        await sendMouse({ type: 'down' });
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('should dispatch cell-focus on mouse up within cell content', () => {
+      it('should dispatch cell-focus on cell content child mousedown', async () => {
         const spy = sinon.spy();
         grid.addEventListener('cell-focus', spy);
 
-        // Mouse down and release on cell content child
         const cell = getRowFirstCell(0);
-        const contentSpan = document.createElement('span');
-        cell._content.appendChild(contentSpan);
+        const span = document.createElement('span');
+        span.textContent = 'span';
+        cell._content.appendChild(span);
 
-        mouseDown(contentSpan);
-        mouseUp(contentSpan);
+        await sendMouseToElement({ type: 'move', element: span });
+        await sendMouse({ type: 'down' });
         expect(spy.calledOnce).to.be.true;
-      });
-
-      // Regression test for https://github.com/vaadin/flow-components/issues/2863
-      it('should not dispatch cell-focus on mouse up outside of cell', () => {
-        const spy = sinon.spy();
-        grid.addEventListener('cell-focus', spy);
-
-        mouseDown(getRowFirstCell(0)._content);
-        mouseUp(document.body);
-        expect(spy.calledOnce).to.be.false;
       });
     });
   });


### PR DESCRIPTION
Since 2017, the grid has focused cells manually on mousedown (0c8ddc718c638133c728e04e8708f790459b4707), because browsers did not focus the cell when the click landed on slotted cell content:

```
// With native Shadow DOM, mousedown on slotted element does not focus
// focusable slot wrapper, that is why cells are not focused with
// mousedown. Workaround: make cellContent focusable and delegate
// focus to assigned cell.
```

At the time, mouse focus only walked up the light DOM tree, so a click on slotted cell content dropped focus on `<body>` instead of the cell (WICG/webcomponents#773). All engines now walk up the flat tree and focus the cell natively:

- Firefox: has always worked this way
- Safari: fixed in [WebKit bug 191694](https://bugs.webkit.org/show_bug.cgi?id=191694), shipped in Safari 12.1 (2019)
- Chrome / Edge: fixed in [crbug 41420461](https://issues.chromium.org/issues/41420461), shipped in Chrome 133, February 2025 ([blink-dev PSA](https://www.mail-archive.com/blink-dev@chromium.org/msg12145.html))

All browsers supported by Vaadin include the fix, so the workaround can be removed. 

> [!WARNING]
> Behavior change: with the workaround, Chrome dispatched `cell-focus` on mouse up and skipped it when the mouse was released outside the cell (vaadin/flow-components#2863), while Firefox and Safari focused on mouse down. Now all browsers dispatch it on mouse down.
