### PR TITLE
fix!: treat elements with tabindex=-1 as focusable

### DIFF
--- a/packages/a11y-base/src/focus-utils.d.ts
+++ b/packages/a11y-base/src/focus-utils.d.ts
@@ -26,7 +26,8 @@ export declare function isKeyboardActive(): boolean;
 export declare function isElementHidden(element: HTMLElement): boolean;
 
 /**
- * Returns true if the element is focusable, otherwise false.
+ * Returns true if the element is focusable, i.e. can be focused with a
+ * mouse click or a `focus()` call, otherwise false.
  *
  * The list of focusable elements is taken from http://stackoverflow.com/a/1600194/4228703.
  * However, there isn't a definite list, it's up to the browser.

--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -165,7 +165,8 @@ export function isElementHidden(element) {
 }
 
 /**
- * Returns true if the element is focusable, otherwise false.
+ * Returns true if the element is focusable, i.e. can be focused with a
+ * mouse click or a `focus()` call, otherwise false.
  *
  * The list of focusable elements is taken from http://stackoverflow.com/a/1600194/4228703.
  * However, there isn't a definite list, it's up to the browser.
@@ -184,11 +185,6 @@ export function isElementHidden(element) {
  * @return {boolean}
  */
 export function isElementFocusable(element) {
-  // The element cannot be focused if its `tabindex` attribute is set to `-1`.
-  if (element.matches('[tabindex="-1"]')) {
-    return false;
-  }
-
   // Elements that cannot be focused if they have a `disabled` attribute.
   if (element.matches('input, select, textarea, button, object')) {
     return element.matches(':not([disabled])');

--- a/packages/a11y-base/test/focus-utils.test.js
+++ b/packages/a11y-base/test/focus-utils.test.js
@@ -63,12 +63,6 @@ describe('focus-utils', () => {
         element.setAttribute('disabled', '');
         expect(isElementFocusable(element)).to.be.false;
       });
-
-      it(`should return false for <${tagName}> with [tabindex] = -1`, () => {
-        const element = document.createElement(tagName);
-        element.setAttribute('tabindex', '-1');
-        expect(isElementFocusable(element)).to.be.false;
-      });
     });
 
     ['a', 'area'].forEach((tagName) => {
@@ -82,24 +76,11 @@ describe('focus-utils', () => {
         element.href = '#';
         expect(isElementFocusable(element)).to.be.true;
       });
-
-      it(`should return false for <${tagName}> with [href] and [tabindex] = -1`, () => {
-        const element = document.createElement(tagName);
-        element.href = '#';
-        element.setAttribute('tabindex', '-1');
-        expect(isElementFocusable(element)).to.be.false;
-      });
     });
 
     it('should return true for <iframe> by default', () => {
       const element = document.createElement('iframe');
       expect(isElementFocusable(element)).to.be.true;
-    });
-
-    it('should return false for <iframe> with [tabindex] = -1', () => {
-      const element = document.createElement('iframe');
-      element.setAttribute('tabindex', '-1');
-      expect(isElementFocusable(element)).to.be.false;
     });
 
     it('should return false for <div> by default', () => {
@@ -113,17 +94,22 @@ describe('focus-utils', () => {
       expect(isElementFocusable(element)).to.be.true;
     });
 
+    it('should return true for <div> with [tabindex] = 1', () => {
+      const element = document.createElement('div');
+      element.setAttribute('tabindex', '1');
+      expect(isElementFocusable(element)).to.be.true;
+    });
+
+    it('should return true for <div> with [tabindex] = -1', () => {
+      const element = document.createElement('div');
+      element.setAttribute('tabindex', '-1');
+      expect(isElementFocusable(element)).to.be.true;
+    });
+
     it('should return true for <div> with [contenteditable]', () => {
       const element = document.createElement('div');
       element.setAttribute('contenteditable', '');
       expect(isElementFocusable(element)).to.be.true;
-    });
-
-    it('should return false for <div> with [contenteditable] and [tabindex] = -1', () => {
-      const element = document.createElement('div');
-      element.setAttribute('contenteditable', '');
-      element.setAttribute('tabindex', '-1');
-      expect(isElementFocusable(element)).to.be.false;
     });
   });
 


### PR DESCRIPTION
`isElementFocusable` in `@vaadin/a11y-base` returned false for elements with `tabindex="-1"`, although such elements are focusable: the browser focuses them on click, and they can be focused with `focus()`. Only the keyboard Tab order excludes them according to the [HTML spec on focusability](https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute). 

`isElementFocusable` now returns true for elements with `tabindex="-1"`, like grid cells.

Effects on existing call sites:

- `getFocusableElements` still excludes `tabindex="-1"` elements from the Tab order, since it reads the `tabindex` attribute value separately.
- Combo-box and date-picker overlays no longer prevent the default action of an outside mousedown on `tabindex="-1"` elements (the click moves focus to them natively), which is arguably more correct.
- The grid does not activate an item when clicking `tabindex="-1"` content inside a cell, consistent with other focusable content.
- The context menu can focus `tabindex="-1"` elements when it looks for the closest focusable element of a synthetic contextmenu target.

> [!WARNING]
> This is a breaking change for code that imports `isElementFocusable` from `@vaadin/a11y-base`: it now returns true for elements with `tabindex="-1"`.

Related to #12126

---

🤖 Generated with Claude Code