### PR TITLE
chore: add code review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -59,7 +59,7 @@ jobs:
             -f content=eyes
 
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
           fetch-depth: 1

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,78 @@
+name: Code Review
+
+# Reviews a pull request, triggered automatically when a PR is opened
+# (eligibility rules on the job condition) or by a "/code-review" PR comment.
+# The review itself lives in the shared vaadin/github-actions/code-review
+# action (prepared review inputs, the Claude review, posting the findings as
+# one review); this workflow owns the triggers, eligibility rules, and the
+# reaction to the trigger.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened]
+    branches: [main]
+
+# One review per PR at a time; a re-trigger queues instead of aborting a run
+# that may be mid-posting.
+concurrency:
+  group: code-review-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+
+jobs:
+  review:
+    # Comment trigger: collaborators only. Auto trigger on opened PRs skips
+    # drafts, chore PRs, known bots, and non-collaborators (also keeps fork
+    # PRs out, which would fail on missing secrets anyway).
+    if: |
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.body == '/code-review' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft == false &&
+       !contains(fromJSON('["dependabot[bot]", "vaadin-bot"]'), github.event.pull_request.user.login) &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+       !startsWith(github.event.pull_request.title, 'chore:') &&
+       !startsWith(github.event.pull_request.title, 'chore('))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: React to trigger
+        env:
+          GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            target="issues/comments/${{ github.event.comment.id }}"
+          else
+            target="issues/$PR_NUMBER"
+          fi
+          gh api "repos/${{ github.repository }}/$target/reactions" \
+            -f content=eyes
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Run code review
+        uses: vaadin/github-actions/code-review@c04ff50de09876b2db4240291f9cbc6c0711b181
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          pr-number: ${{ env.PR_NUMBER }}
+          github-token: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
+          upload-execution-log: ${{ vars.CLAUDE_DEBUG }}


### PR DESCRIPTION
Adds a GitHub workflow for doing code review using Claude Code:

- Triggered either when a pull request is opened or a maintainer comments with `/code-review`
- Prepares code review inputs deterministically via script (PR metadata, changes files, diff)
- Runs Claude Code with a customized version of the `/code-review` skill prompt
- Posts results deterministically via script (one comment per finding, summary with overview)
- Reviews are posted as `vaadin-review-bot`, using `claude` is not possible as the GH token for that user is only available in the Claude action