### PR TITLE
refactor: rename getFocusableElements to getTabbableElements

### DIFF
--- a/packages/a11y-base/index.d.ts
+++ b/packages/a11y-base/index.d.ts
@@ -5,7 +5,7 @@ export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaController } from './src/field-aria-controller.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export {
-  getFocusableElements,
+  getTabbableElements,
   isElementFocusable,
   isElementFocused,
   isElementHidden,

--- a/packages/a11y-base/index.js
+++ b/packages/a11y-base/index.js
@@ -7,7 +7,7 @@ export { FocusMixin } from './src/focus-mixin.js';
 export { FocusTrapController } from './src/focus-trap-controller.js';
 export { FocusRestorationController } from './src/focus-restoration-controller.js';
 export {
-  getFocusableElements,
+  getTabbableElements,
   isElementFocusable,
   isElementFocused,
   isElementHidden,

--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getFocusableElements, isElementFocused, isKeyboardActive } from './focus-utils.js';
+import { getTabbableElements, isElementFocused, isKeyboardActive } from './focus-utils.js';
 
 const instances = [];
 
@@ -57,7 +57,7 @@ export class FocusTrapController {
    * @private
    */
   get __focusableElements() {
-    return getFocusableElements(this.__trapNode);
+    return getTabbableElements(this.__trapNode);
   }
 
   /**

--- a/packages/a11y-base/src/focus-utils.d.ts
+++ b/packages/a11y-base/src/focus-utils.d.ts
@@ -54,4 +54,4 @@ export declare function isElementFocused(element: HTMLElement): boolean;
  *
  * The method traverses nodes in shadow DOM trees too if any.
  */
-export declare function getFocusableElements(element: HTMLElement): HTMLElement[];
+export declare function getTabbableElements(element: HTMLElement): HTMLElement[];

--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -271,7 +271,7 @@ function collectFocusableNodes(node, result) {
  * @param {HTMLElement} element
  * @return {HTMLElement[]}
  */
-export function getFocusableElements(element) {
+export function getTabbableElements(element) {
   const focusableElements = [];
   const needsSortByTabIndex = collectFocusableNodes(element, focusableElements);
   // If there is at least one element with tabindex > 0,

--- a/packages/a11y-base/test/focus-utils.test.js
+++ b/packages/a11y-base/test/focus-utils.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { defineCE, fixtureSync, mousedown, tabKeyDown } from '@vaadin/testing-helpers';
 import {
   getDeepActiveElement,
-  getFocusableElements,
+  getTabbableElements,
   isElementFocusable,
   isElementFocused,
   isElementHidden,
@@ -127,7 +127,7 @@ describe('focus-utils', () => {
     });
   });
 
-  describe('getFocusableElements', () => {
+  describe('getTabbableElements', () => {
     customElements.define(
       'custom-element',
       class extends HTMLElement {
@@ -164,7 +164,7 @@ describe('focus-utils', () => {
         </div>
       `);
 
-      const focusableElements = getFocusableElements(root);
+      const focusableElements = getTabbableElements(root);
       expect(focusableElements.map((element) => element.id)).to.deep.equal([
         'element-4',
         'element-3',
@@ -185,7 +185,7 @@ describe('focus-utils', () => {
         </div>
       `);
 
-      const focusableElements = getFocusableElements(ancestor.querySelector('#root'));
+      const focusableElements = getTabbableElements(ancestor.querySelector('#root'));
       expect(focusableElements).to.have.lengthOf(1);
       expect(focusableElements[0].id).to.equal('root');
     });

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement, nothing } from 'lit';
-import { getFocusableElements, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getTabbableElements, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { getClosestElement } from '@vaadin/component-base/src/dom-utils.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
@@ -379,7 +379,7 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
 
     const hasOverflow =
       (hasDetail || hasDetailPlaceholder) && (this.forceOverlay || detectOverflow(hostSize, trackSizes));
-    const focusTarget = !hadDetail && hasDetail && hasOverflow ? getFocusableElements(slottedDetail)[0] : null;
+    const focusTarget = !hadDetail && hasDetail && hasOverflow ? getTabbableElements(slottedDetail)[0] : null;
 
     return {
       hasMaster,

--- a/packages/overlay/test/focus-trap.test.js
+++ b/packages/overlay/test/focus-trap.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import '../src/vaadin-overlay.js';
-import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getTabbableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('focus-trap', () => {
   let overlay, overlayPart, focusableElements;
@@ -29,7 +29,7 @@ describe('focus-trap', () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
       overlayPart = overlay.$.overlay;
-      focusableElements = getFocusableElements(overlayPart);
+      focusableElements = getTabbableElements(overlayPart);
     });
 
     afterEach(() => {
@@ -86,7 +86,7 @@ describe('focus-trap', () => {
       overlay.focusTrap = true;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlayPart);
+      focusableElements = getTabbableElements(overlayPart);
       expect(focusableElements[0]).to.equal(overlayPart);
       expect(getFocusedElementIndex()).to.equal(0);
     });
@@ -95,7 +95,7 @@ describe('focus-trap', () => {
       overlay.focusTrap = false;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlayPart);
+      focusableElements = getTabbableElements(overlayPart);
       expect(getFocusedElementIndex()).to.equal(-1);
     });
 
@@ -104,7 +104,7 @@ describe('focus-trap', () => {
       overlay.focusTrap = true;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlayPart);
+      focusableElements = getTabbableElements(overlayPart);
       expect(getFocusedElementIndex()).to.equal(-1);
     });
   });
@@ -129,7 +129,7 @@ describe('focus-trap', () => {
       };
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlay.$.overlay);
+      focusableElements = getTabbableElements(overlay.$.overlay);
       nested = overlay.querySelector('vaadin-overlay');
     });
 

--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { getActiveTrappingNode } from '@vaadin/a11y-base/src/focus-trap-controller.js';
-import { getDeepActiveElement, getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, getTabbableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 /**
  * Controller that routes Tab and Shift+Tab when a non-modal popover is opened.
@@ -158,7 +158,7 @@ export class PopoverFocusController {
    * @private
    */
   __getLastPopoverFocusable() {
-    const lastContent = getFocusableElements(this.host._overlayElement.$.content).pop();
+    const lastContent = getTabbableElements(this.host._overlayElement.$.content).pop();
     return lastContent || this.host;
   }
 
@@ -171,7 +171,7 @@ export class PopoverFocusController {
   __getScopeFocusables() {
     const host = this.host;
     const scope = getActiveTrappingNode(host) || document.body;
-    return getFocusableElements(scope).filter((el) => el === host || !host.contains(el));
+    return getTabbableElements(scope).filter((el) => el === host || !host.contains(el));
   }
 
   /**

--- a/test/integration/overlay-focus-trap.test.js
+++ b/test/integration/overlay-focus-trap.test.js
@@ -4,7 +4,7 @@ import '@vaadin/button/src/vaadin-button.js';
 import '@vaadin/overlay/src/vaadin-overlay.js';
 import '@vaadin/radio-group/src/vaadin-radio-group.js';
 import '@vaadin/text-field/src/vaadin-text-field.js';
-import { getFocusableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getTabbableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('focus-trap', () => {
   let overlay, focusableElements;
@@ -33,7 +33,7 @@ describe('focus-trap', () => {
       overlay.requestContentUpdate();
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlay.$.overlay);
+      focusableElements = getTabbableElements(overlay.$.overlay);
     });
 
     afterEach(() => {
@@ -91,7 +91,7 @@ describe('focus-trap', () => {
     it('should properly detect multiple focusable elements inside shadow DOM', async () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlay.$.overlay);
+      focusableElements = getTabbableElements(overlay.$.overlay);
       expect(focusableElements.length).to.equal(4);
       const div = overlay.querySelector('div');
       expect(focusableElements[1]).to.equal(div.shadowRoot.querySelector('input'));
@@ -101,7 +101,7 @@ describe('focus-trap', () => {
     it('should not focus the overlay part if the content is already focused', async () => {
       overlay.opened = true;
       // Needs to happen after opened and before focus-trap loop is executed
-      focusableElements = getFocusableElements(overlay.$.overlay);
+      focusableElements = getTabbableElements(overlay.$.overlay);
       focusableElements[1].focus();
       await oneEvent(overlay, 'vaadin-overlay-open');
       expect(getFocusedElementIndex()).not.to.equal(0);
@@ -110,7 +110,7 @@ describe('focus-trap', () => {
     it('should focus first element with tabIndex=1', async () => {
       // It's an arguable behavior, probably overlay should be focused instead
       overlay.opened = true;
-      focusableElements = getFocusableElements(overlay.$.overlay);
+      focusableElements = getTabbableElements(overlay.$.overlay);
       focusableElements[1].tabIndex = 1;
       await oneEvent(overlay, 'vaadin-overlay-open');
       const idx = getFocusedElementIndex();
@@ -120,7 +120,7 @@ describe('focus-trap', () => {
     it('should focus focusable elements in shadow DOM on Tab and Shift Tab', async () => {
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
-      focusableElements = getFocusableElements(overlay.$.overlay);
+      focusableElements = getTabbableElements(overlay.$.overlay);
 
       // Tab
       for (let i = 0; i < focusableElements.length; i++) {


### PR DESCRIPTION
The `getFocusableElements` name does not match what the function returns. It skips elements with `tabindex="-1"`, which are focusable but not reachable with the Tab key, and sorts the result by tab order. The new name `getTabbableElements` describes the actual behavior.

---

🤖 Generated with Claude Code