### PR TITLE
feat: make select-item and select-list-box public, add SelectItemData

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -13,7 +13,7 @@ import type { DelegateStateMixinClass } from '@vaadin/component-base/src/delegat
 import type { FieldMixinClass } from '@vaadin/field-base/src/field-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
-import type { SelectItem, SelectRenderer } from './vaadin-select.js';
+import type { SelectItemData, SelectRenderer } from './vaadin-select.js';
 
 export declare function SelectBaseMixin<T extends Constructor<HTMLElement>>(
   base: T,
@@ -49,7 +49,7 @@ export declare class SelectBaseMixinClass {
    * Note: each item is rendered by default as the internal `<vaadin-select-item>` that is an extension of `<vaadin-item>`.
    * To render the item with a custom component, provide a tag name by the `component` property.
    */
-  items: SelectItem[] | null | undefined;
+  items: SelectItemData[] | null | undefined;
 
   /**
    * Set when the select is open

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -37,7 +37,7 @@ export const SelectBaseMixin = (superClass) =>
          * Note: each item is rendered by default as the internal `<vaadin-select-item>` that is an extension of `<vaadin-item>`.
          * To render the item with a custom component, provide a tag name by the `component` property.
          *
-         * @type {!Array<!SelectItem>}
+         * @type {!Array<!SelectItemData>}
          */
         items: {
           type: Array,
@@ -231,8 +231,8 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     /**
-     * @param {SelectItem[] | undefined | null} newItems
-     * @param {SelectItem[] | undefined | null} oldItems
+     * @param {SelectItemData[] | undefined | null} newItems
+     * @param {SelectItemData[] | undefined | null} oldItems
      * @private
      */
     __itemsChanged(newItems, oldItems) {
@@ -467,7 +467,7 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     /**
-     * @param {!SelectItem} item
+     * @param {!SelectItemData} item
      * @private
      */
     __createItemElement(item) {

--- a/packages/select/src/vaadin-select-item.d.ts
+++ b/packages/select/src/vaadin-select-item.d.ts
@@ -8,7 +8,39 @@ import { ItemMixin } from '@vaadin/item/src/vaadin-item-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ * `<vaadin-select-item>` is a Web Component for creating `<vaadin-select>` items.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name    | Description
+ * -------------|----------------
+ * `checkmark`  | The graphical checkmark shown for a selected item
+ * `content`    | The element that wraps the slot
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `active`     | Set when the item is pressed down, either with mouse, touch or the keyboard.
+ * `disabled`   | Set when the item is disabled.
+ * `focus-ring` | Set when the item is focused using the keyboard.
+ * `focused`    | Set when the item is focused.
+ * `selected`   | Set when the item is selected
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-item-border-radius`    |
+ * | `--vaadin-item-checkmark-color`  |
+ * | `--vaadin-item-gap`              |
+ * | `--vaadin-item-height`           |
+ * | `--vaadin-item-padding`          |
+ * | `--vaadin-item-text-align`       |
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
 declare class SelectItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
 

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -13,11 +13,42 @@ import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ * `<vaadin-select-item>` is a Web Component for creating `<vaadin-select>` items.
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name    | Description
+ * -------------|----------------
+ * `checkmark`  | The graphical checkmark shown for a selected item
+ * `content`    | The element that wraps the slot
+ *
+ * The following state attributes are available for styling:
+ *
+ * Attribute    | Description
+ * -------------|-------------
+ * `active`     | Set when the item is pressed down, either with mouse, touch or the keyboard.
+ * `disabled`   | Set when the item is disabled.
+ * `focus-ring` | Set when the item is focused using the keyboard.
+ * `focused`    | Set when the item is focused.
+ * `selected`   | Set when the item is selected
+ *
+ * The following custom CSS properties are available for styling:
+ *
+ * Custom CSS property                |
+ * :----------------------------------|
+ * | `--vaadin-item-border-radius`    |
+ * | `--vaadin-item-checkmark-color`  |
+ * | `--vaadin-item-gap`              |
+ * | `--vaadin-item-height`           |
+ * | `--vaadin-item-padding`          |
+ * | `--vaadin-item-text-align`       |
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @customElement vaadin-select-item
  * @extends HTMLElement
- * @protected
  */
 class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/select/src/vaadin-select-list-box.d.ts
+++ b/packages/select/src/vaadin-select-list-box.d.ts
@@ -8,7 +8,26 @@ import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ * `<vaadin-select-list-box>` is a Web Component for wrapping `<vaadin-select>` items.
+ *
+ * ```html
+ * <vaadin-select>
+ *   <vaadin-select-list-box slot="overlay">
+ *     <vaadin-select-item value="foo">Foo</vaadin-select-item>
+ *     <vaadin-select-item value="bar">Bar</vaadin-select-item>
+ *   </vaadin-select-list-box>
+ * </vaadin-select>
+ * ```
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name         | Description
+ * ------------------|------------------------
+ * `items`           | The items container
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
 declare class SelectListBox extends ListMixin(DirMixin(ThemableMixin(HTMLElement))) {}
 

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -13,11 +13,29 @@ import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 
 /**
- * An element used internally by `<vaadin-select>`. Not intended to be used separately.
+ * `<vaadin-select-list-box>` is a Web Component for wrapping `<vaadin-select>` items.
+ *
+ * ```html
+ * <vaadin-select>
+ *   <vaadin-select-list-box slot="overlay">
+ *     <vaadin-select-item value="foo">Foo</vaadin-select-item>
+ *     <vaadin-select-item value="bar">Bar</vaadin-select-item>
+ *   </vaadin-select-list-box>
+ * </vaadin-select>
+ * ```
+ *
+ * ### Styling
+ *
+ * The following shadow DOM parts are available for styling:
+ *
+ * Part name         | Description
+ * ------------------|------------------------
+ * `items`           | The items container
+ *
+ * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @customElement vaadin-select-list-box
  * @extends HTMLElement
- * @protected
  */
 class SelectListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -7,13 +7,18 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
 
-export interface SelectItem {
+export interface SelectItemData {
   label?: string;
   value?: string;
   component?: string;
   disabled?: boolean;
   className?: string;
 }
+
+/**
+ * @deprecated Use `SelectItemData` instead.
+ */
+export type SelectItem = SelectItemData;
 
 /**
  * Fired when the user commits a value change.
@@ -163,12 +168,12 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  *
  * ### Internal components
  *
- * In addition to `<vaadin-select>` itself, the following internal
- * components are themable:
+ * In addition to `<vaadin-select>` itself, the following internal components are used
+ * and themable:
  *
  * - `<vaadin-select-value-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
- * - `<vaadin-select-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
- * - `<vaadin-select-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
+ * - [`<vaadin-select-list-box>`](#/elements/vaadin-select-list-box) - a list-box element.
+ * - [`<vaadin-select-item>`](#/elements/vaadin-select-item) - an item element.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -119,12 +119,12 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  *
  * ### Internal components
  *
- * In addition to `<vaadin-select>` itself, the following internal
- * components are themable:
+ * In addition to `<vaadin-select>` itself, the following internal components are used
+ * and themable:
  *
  * - `<vaadin-select-value-button>` - has the same API as [`<vaadin-button>`](#/elements/vaadin-button).
- * - `<vaadin-select-list-box>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
- * - `<vaadin-select-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
+ * - [`<vaadin-select-list-box>`](#/elements/vaadin-select-list-box) - a list-box element.
+ * - [`<vaadin-select-item>`](#/elements/vaadin-select-item) - an item element.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -12,25 +12,26 @@ import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ItemMixinClass } from '@vaadin/item/src/vaadin-item-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { SelectItem } from '../../src/vaadin-select-item.js';
-import type { SelectListBox } from '../../src/vaadin-select-list-box.js';
 import type {
   Select,
   SelectChangeEvent,
   SelectInvalidChangedEvent,
-  SelectItem as Item,
+  SelectItem as DeprecatedItem,
+  SelectItemData,
   SelectOpenedChangedEvent,
   SelectRenderer,
   SelectValidatedEvent,
   SelectValueChangedEvent,
 } from '../../vaadin-select.js';
+import type { SelectItem } from '../../vaadin-select-item.js';
+import type { SelectListBox } from '../../vaadin-select-list-box.js';
 
 const assertType = <TExpected>(actual: TExpected) => actual;
 
 const select: Select = document.createElement('vaadin-select');
 
 // Properties
-assertType<Item[] | null | undefined>(select.items);
+assertType<SelectItemData[] | null | undefined>(select.items);
 assertType<boolean>(select.opened);
 assertType<SelectRenderer | undefined>(select.renderer);
 assertType<string>(select.value);
@@ -54,12 +55,16 @@ assertType<ThemableMixinClass>(select);
 assertType<ValidateMixinClass>(select);
 
 // Item properties
-const item: Item = select.items ? select.items[0] : {};
+const item: SelectItemData = select.items ? select.items[0] : {};
 assertType<string | undefined>(item.label);
 assertType<string | undefined>(item.value);
 assertType<boolean | undefined>(item.disabled);
 assertType<string | undefined>(item.component);
 assertType<string | undefined>(item.className);
+
+// Deprecated `SelectItem` type alias still resolves to `SelectItemData`.
+const deprecatedItem: DeprecatedItem = item;
+assertType<SelectItemData>(deprecatedItem);
 
 // Events
 select.addEventListener('change', (event) => {

--- a/packages/select/vaadin-select-item.d.ts
+++ b/packages/select/vaadin-select-item.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-select-item.js';

--- a/packages/select/vaadin-select-item.js
+++ b/packages/select/vaadin-select-item.js
@@ -1,0 +1,2 @@
+import './src/vaadin-select-item.js';
+export * from './src/vaadin-select-item.js';

--- a/packages/select/vaadin-select-list-box.d.ts
+++ b/packages/select/vaadin-select-list-box.d.ts
@@ -1,0 +1,1 @@
+export * from './src/vaadin-select-list-box.js';

--- a/packages/select/vaadin-select-list-box.js
+++ b/packages/select/vaadin-select-list-box.js
@@ -1,0 +1,2 @@
+import './src/vaadin-select-list-box.js';
+export * from './src/vaadin-select-list-box.js';


### PR DESCRIPTION
## Description

Part of #9977
Fixes #11421

Related to https://github.com/vaadin/web-components/pull/12131

- Added public `vaadin-select-item` and `vaadin-select-list-box` entrypoints
- Added proper JSDoc for corresponding classes including Styling sections
- Added `SelectItemData` TS type and deprecated `SelectItem` in favor of it

## Type of change

- Feature