### PR TITLE
feat: add headingLevel property to accordion

### DIFF
--- a/packages/accordion/src/vaadin-accordion-mixin.d.ts
+++ b/packages/accordion/src/vaadin-accordion-mixin.d.ts
@@ -22,6 +22,19 @@ export declare class AccordionMixinClass {
   opened: number | null;
 
   /**
+   * The ARIA heading level applied to every panel heading, used to set
+   * the `aria-level` attribute on the `<vaadin-accordion-heading>` element
+   * of each panel.
+   *
+   * By default, no `aria-level` is set and the headings are announced by
+   * screen readers using their default level. Set this property to expose
+   * the headings at the level that matches the surrounding page structure.
+   *
+   * @attr {number} heading-level
+   */
+  headingLevel: number | null | undefined;
+
+  /**
    * The list of `<vaadin-accordion-panel>` child elements.
    * It is populated from the elements passed to the light DOM,
    * and updated dynamically when adding or removing panels.

--- a/packages/accordion/src/vaadin-accordion-mixin.d.ts
+++ b/packages/accordion/src/vaadin-accordion-mixin.d.ts
@@ -22,9 +22,8 @@ export declare class AccordionMixinClass {
   opened: number | null;
 
   /**
-   * The ARIA heading level applied to every panel heading, used to set
-   * the `aria-level` attribute on the `<vaadin-accordion-heading>` element
-   * of each panel.
+   * The ARIA heading level, used to set the `aria-level` attribute
+   * on the `<vaadin-accordion-heading>` element of each panel.
    *
    * By default, no `aria-level` is set and the headings are announced by
    * screen readers using their default level. Set this property to expose

--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -27,9 +27,8 @@ export const AccordionMixin = (superClass) =>
         },
 
         /**
-         * The ARIA heading level applied to every panel heading, used to set
-         * the `aria-level` attribute on the `<vaadin-accordion-heading>` element
-         * of each panel.
+         * The ARIA heading level, used to set the `aria-level` attribute
+         * on the `<vaadin-accordion-heading>` element of each panel.
          *
          * By default, no `aria-level` is set and the headings are announced by
          * screen readers using their default level. Set this property to expose

--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -27,6 +27,21 @@ export const AccordionMixin = (superClass) =>
         },
 
         /**
+         * The ARIA heading level applied to every panel heading, used to set
+         * the `aria-level` attribute on the `<vaadin-accordion-heading>` element
+         * of each panel.
+         *
+         * By default, no `aria-level` is set and the headings are announced by
+         * screen readers using their default level. Set this property to expose
+         * the headings at the level that matches the surrounding page structure.
+         *
+         * @attr {number} heading-level
+         */
+        headingLevel: {
+          type: Number,
+        },
+
+        /**
          * The list of `<vaadin-accordion-panel>` child elements.
          * It is populated from the elements passed to the light DOM,
          * and updated dynamically when adding or removing panels.
@@ -87,6 +102,15 @@ export const AccordionMixin = (superClass) =>
       });
     }
 
+    /** @protected */
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('items') || props.has('headingLevel')) {
+        this.__updateHeadingLevel();
+      }
+    }
+
     /**
      * Override method inherited from `KeyboardDirectionMixin`
      * to use the stored list of accordion panels as items.
@@ -106,6 +130,21 @@ export const AccordionMixin = (superClass) =>
      */
     _filterItems(array) {
       return array.filter((el) => el instanceof customElements.get('vaadin-accordion-panel'));
+    }
+
+    /** @private */
+    __updateHeadingLevel() {
+      const { headingLevel } = this;
+
+      (this.items || []).forEach((item) => {
+        const heading = item.focusElement;
+
+        if (headingLevel != null) {
+          heading.setAttribute('aria-level', headingLevel);
+        } else {
+          heading.removeAttribute('aria-level');
+        }
+      });
     }
 
     /** @private */

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -334,4 +334,34 @@ describe('vaadin-accordion', () => {
       expect(heading.hasAttribute('aria-controls')).to.be.false;
     });
   });
+
+  describe('heading level', () => {
+    beforeEach(async () => {
+      accordion.headingLevel = 3;
+      await nextUpdate(accordion);
+    });
+
+    it('should set aria-level on all headings when headingLevel is set', () => {
+      accordion.items.forEach((_, idx) => {
+        expect(getHeading(idx).getAttribute('aria-level')).to.equal('3');
+      });
+    });
+
+    it('should remove aria-level from all headings when headingLevel is set to null', async () => {
+      accordion.headingLevel = null;
+      await nextUpdate(accordion);
+      accordion.items.forEach((_, idx) => {
+        expect(getHeading(idx).hasAttribute('aria-level')).to.be.false;
+      });
+    });
+
+    it('should set aria-level on the heading of a panel added lazily', async () => {
+      const panel = document.createElement('vaadin-accordion-panel');
+      panel.summary = 'Lazy panel';
+      accordion.appendChild(panel);
+      await nextRender();
+
+      expect(panel.focusElement.getAttribute('aria-level')).to.equal('3');
+    });
+  });
 });

--- a/packages/accordion/test/typings/accordion.types.ts
+++ b/packages/accordion/test/typings/accordion.types.ts
@@ -8,6 +8,8 @@ const accordion = document.createElement('vaadin-accordion');
 
 accordion.opened = null;
 
+assertType<number | null | undefined>(accordion.headingLevel);
+
 accordion.addEventListener('opened-changed', (event) => {
   assertType<AccordionOpenedChangedEvent>(event);
   assertType<number | null>(event.detail.value);


### PR DESCRIPTION
Adds a `headingLevel` property to `vaadin-accordion-panel` that sets the `aria-level` attribute on the `vaadin-accordion-heading` element, so the heading can be exposed at the level matching the page structure.

Part of #6900

Generated with [Claude Code](https://claude.ai/code)