### PR TITLE
refactor!: render grid header and footer declaratively with Lit

### DIFF
--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -106,7 +106,7 @@ snapshots["vaadin-crud host default"] =
     </vaadin-grid-column-group>
     <vaadin-crud-edit-column>
     </vaadin-crud-edit-column>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-0">
+    <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-0-0">
       <vaadin-grid-sorter
         aria-label="Sort by Name"
         path="name"
@@ -114,7 +114,7 @@ snapshots["vaadin-crud host default"] =
         Name
       </vaadin-grid-sorter>
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-1">
+    <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-0-2">
       <vaadin-grid-sorter
         aria-label="Sort by Age"
         path="age"
@@ -122,9 +122,9 @@ snapshots["vaadin-crud host default"] =
         Age
       </vaadin-grid-sorter>
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-2">
+    <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-0-4">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
+    <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-1-1">
       <vaadin-grid-filter
         aria-label="Filter by Name"
         path="name"
@@ -136,26 +136,26 @@ snapshots["vaadin-crud host default"] =
           theme="small"
         >
           <label
-            for="input-vaadin-text-field-6"
-            id="label-vaadin-text-field-0"
+            for="input-vaadin-text-field-8"
+            id="label-vaadin-text-field-5"
             slot="label"
           >
           </label>
           <div
             hidden=""
-            id="error-message-vaadin-text-field-2"
+            id="error-message-vaadin-text-field-7"
             slot="error-message"
           >
           </div>
           <input
-            id="input-vaadin-text-field-6"
+            id="input-vaadin-text-field-8"
             slot="input"
             type="text"
           >
         </vaadin-text-field>
       </vaadin-grid-filter>
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-4">
+    <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-1-3">
       <vaadin-grid-filter
         aria-label="Filter by Age"
         path="age"
@@ -167,52 +167,52 @@ snapshots["vaadin-crud host default"] =
           theme="small"
         >
           <label
-            for="input-vaadin-text-field-7"
-            id="label-vaadin-text-field-3"
+            for="input-vaadin-text-field-12"
+            id="label-vaadin-text-field-9"
             slot="label"
           >
           </label>
           <div
             hidden=""
-            id="error-message-vaadin-text-field-5"
+            id="error-message-vaadin-text-field-11"
             slot="error-message"
           >
           </div>
           <input
-            id="input-vaadin-text-field-7"
+            id="input-vaadin-text-field-12"
             slot="input"
             type="text"
           >
         </vaadin-text-field>
       </vaadin-grid-filter>
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-5">
+    <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-1-4">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-6">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-1">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-7">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-3">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-8">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-4">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-9">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-0">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-10">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-2">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-11">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-4">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-12">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-0">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-13">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-1">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-14">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-2">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-15">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
       John
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-16">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-4">
       30
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-17">
+    <vaadin-grid-cell-content slot="vaadin-grid-cell-content-5">
       <vaadin-crud-edit
         aria-label="Edit"
         role="button"

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -188,17 +188,17 @@ snapshots["vaadin-crud host default"] =
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-1-4">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-1">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-1">
     </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-3">
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-4">
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-0">
-    </vaadin-grid-cell-content>
-    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-2">
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-3">
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-1-4">
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-0">
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-2">
+    </vaadin-grid-cell-content>
+    <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-4">
     </vaadin-grid-cell-content>
     <vaadin-grid-cell-content slot="vaadin-grid-cell-content-0">
     </vaadin-grid-cell-content>

--- a/packages/grid/src/directives/cell-content-directive.js
+++ b/packages/grid/src/directives/cell-content-directive.js
@@ -17,8 +17,7 @@ class CellContentDirective extends AsyncDirective {
     this.#cell._content ??= document.createElement('vaadin-grid-cell-content');
     this.#cell._content.slot = slotName;
 
-    const { isConnected } = this.#cell._content;
-    if (!isConnected) {
+    if (!grid.contains(this.#cell._content)) {
       grid.appendChild(this.#cell._content);
     }
 

--- a/packages/grid/src/directives/cell-content-directive.js
+++ b/packages/grid/src/directives/cell-content-directive.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html } from 'lit';
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+
+/**
+ * A directive that manages the `<vaadin-grid-cell-content>` element for a cell.
+ */
+class CellContentDirective extends AsyncDirective {
+  #cell;
+
+  update(part, [grid, slotName]) {
+    this.#cell = part.parentNode;
+    this.#cell._content ??= document.createElement('vaadin-grid-cell-content');
+    this.#cell._content.slot = slotName;
+
+    const { isConnected } = this.#cell._content;
+    if (!isConnected) {
+      grid.appendChild(this.#cell._content);
+    }
+
+    return html`<slot name="${slotName}"></slot>`;
+  }
+
+  disconnected() {
+    this.#cell._content?.remove();
+  }
+}
+
+export const cellContent = directive(CellContentDirective);

--- a/packages/grid/src/directives/cell-content-directive.js
+++ b/packages/grid/src/directives/cell-content-directive.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * Copyright (c) 2016 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html } from 'lit';

--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -137,7 +137,7 @@ export const ColumnAutoWidthMixin = (superClass) =>
     _recalculateColumnWidths() {
       // Flush to make sure DOM is up-to-date when measuring the column widths
       this.__virtualizer.flush();
-      this.__renderHeaderFooter();
+      this.__renderHeaderFooterDebouncer?.flush();
 
       this.__hasHadRenderedRowsForColumnWidthCalculation ||= this._getRenderedRows().length > 0;
 

--- a/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-auto-width-mixin.js
@@ -137,11 +137,7 @@ export const ColumnAutoWidthMixin = (superClass) =>
     _recalculateColumnWidths() {
       // Flush to make sure DOM is up-to-date when measuring the column widths
       this.__virtualizer.flush();
-      [...this.$.header.children, ...this.$.footer.children].forEach((row) => {
-        if (row.__debounceUpdateHeaderFooterRowVisibility) {
-          row.__debounceUpdateHeaderFooterRowVisibility.flush();
-        }
-      });
+      this.__renderHeaderFooter();
 
       this.__hasHadRenderedRowsForColumnWidthCalculation ||= this._getRenderedRows().length > 0;
 

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -503,7 +503,7 @@ export const ColumnBaseMixin = (superClass) =>
         return;
       }
 
-      this._grid.__renderHeaderFooter?.();
+      this._grid.__scheduleRenderHeaderFooter?.();
     }
 
     /** @private */

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -326,7 +326,7 @@ export const ColumnBaseMixin = (superClass) =>
           return;
         }
 
-        this._allCells.forEach((cell) => {
+        this._cells?.forEach((cell) => {
           if (!cell._content.parentNode) {
             this._grid.appendChild(cell._content);
           }
@@ -345,7 +345,7 @@ export const ColumnBaseMixin = (superClass) =>
           return;
         }
 
-        this._allCells.forEach((cell) => {
+        this._cells?.forEach((cell) => {
           if (cell._content.parentNode) {
             cell._content.parentNode.removeChild(cell._content);
           }

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -7,7 +7,8 @@ import { animationFrame } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { get } from '@vaadin/component-base/src/path-utils.js';
-import { updateCellState, updatePart } from './vaadin-grid-helpers.js';
+import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
+import { updateCellState } from './vaadin-grid-helpers.js';
 
 export const ColumnBaseMixin = (superClass) =>
   class ColumnBaseMixin extends superClass {
@@ -153,6 +154,18 @@ export const ColumnBaseMixin = (superClass) =>
           sync: true,
         },
 
+        /**
+         * A stable unique id assigned once per column instance. Used to build
+         * cell content slot names that stay stable across re-renders, so lit
+         * can reuse the cell content elements when the column tree changes.
+         *
+         * @protected
+         */
+        _id: {
+          type: Number,
+          value: () => generateUniqueId(),
+        },
+
         /** @private */
         _reorderStatus: {
           type: Boolean,
@@ -270,7 +283,7 @@ export const ColumnBaseMixin = (superClass) =>
         '_onRendererOrBindingChanged(_renderer, _cells, _bodyContentHidden, path)',
         '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header)',
         '_onFooterRendererOrBindingChanged(_footerRenderer, _footerCell)',
-        '_resizableChanged(resizable, _headerCell)',
+        '_resizableChanged(resizable)',
         '_reorderStatusChanged(_reorderStatus, _headerCell, _footerCell, _cells)',
         '_hiddenChanged(hidden, _headerCell, _footerCell, _cells)',
         '_rowHeaderChanged(rowHeader, _cells)',
@@ -485,27 +498,12 @@ export const ColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _resizableChanged(resizable, headerCell) {
-      if (resizable === undefined || headerCell === undefined) {
+    _resizableChanged(resizable) {
+      if (resizable === undefined || this._grid === undefined) {
         return;
       }
 
-      if (headerCell) {
-        [headerCell].concat(this._emptyCells).forEach((cell) => {
-          if (cell) {
-            const existingHandle = cell.querySelector('[part~="resize-handle"]');
-            if (existingHandle) {
-              cell.removeChild(existingHandle);
-            }
-
-            if (resizable) {
-              const handle = document.createElement('div');
-              updatePart(handle, 'resize-handle', true);
-              cell.appendChild(handle);
-            }
-          }
-        });
-      }
+      this._grid.__renderHeaderFooter?.();
     }
 
     /** @private */
@@ -531,7 +529,7 @@ export const ColumnBaseMixin = (superClass) =>
 
       if (!!hidden !== !!this._previousHidden && this._grid) {
         if (hidden === true) {
-          this._allCells.forEach((cell) => {
+          this._cells?.forEach((cell) => {
             if (cell._content.parentNode) {
               cell._content.parentNode.removeChild(cell._content);
             }
@@ -632,9 +630,8 @@ export const ColumnBaseMixin = (superClass) =>
       }
 
       this.__renderCellsContent(headerRenderer, [headerCell]);
-      if (this._grid && headerCell.parentElement) {
-        this._grid.__debounceUpdateHeaderFooterRowVisibility(headerCell.parentElement);
-      }
+
+      this._grid?.__scheduleRenderHeaderFooter();
     }
 
     /** @protected */
@@ -689,9 +686,8 @@ export const ColumnBaseMixin = (superClass) =>
       }
 
       this.__renderCellsContent(footerRenderer, [footerCell]);
-      if (this._grid && footerCell.parentElement) {
-        this._grid.__debounceUpdateHeaderFooterRowVisibility(footerCell.parentElement);
-      }
+
+      this._grid?.__scheduleRenderHeaderFooter();
     }
 
     /** @protected */

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -154,18 +154,6 @@ export const ColumnBaseMixin = (superClass) =>
           sync: true,
         },
 
-        /**
-         * A stable unique id assigned once per column instance. Used to build
-         * cell content slot names that stay stable across re-renders, so lit
-         * can reuse the cell content elements when the column tree changes.
-         *
-         * @protected
-         */
-        _id: {
-          type: Number,
-          value: () => generateUniqueId(),
-        },
-
         /** @private */
         _reorderStatus: {
           type: Boolean,
@@ -313,6 +301,19 @@ export const ColumnBaseMixin = (superClass) =>
         .concat(this._headerCell)
         .concat(this._footerCell)
         .filter((cell) => cell);
+    }
+
+    constructor() {
+      super();
+
+      /**
+       * A stable unique id assigned once per column instance. Used to build
+       * cell content slot names that stay stable across re-renders, so lit
+       * can reuse the cell content elements when the column tree changes.
+       *
+       * @protected
+       */
+      this._id = generateUniqueId();
     }
 
     /** @protected */

--- a/packages/grid/src/vaadin-grid-column-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-rendering-mixin.js
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { html, nothing, render } from 'lit';
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+import { cache } from 'lit/directives/cache.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+
+/**
+ * A directive that manages the `<vaadin-grid-cell-content>` element for a cell.
+ */
+class CellContentDirective extends AsyncDirective {
+  #cell;
+
+  update(part, [grid, slotName]) {
+    this.#cell = part.parentNode;
+    this.#cell._content ??= document.createElement('vaadin-grid-cell-content');
+    this.#cell._content.slot = slotName;
+
+    const { isConnected } = this.#cell._content;
+    if (!isConnected) {
+      grid.appendChild(this.#cell._content);
+    }
+
+    return html`<slot name="${slotName}"></slot>`;
+  }
+
+  disconnected() {
+    this.#cell._content?.remove();
+  }
+}
+
+const cellContent = directive(CellContentDirective);
+
+/**
+ * A mixin providing rendering of rows based on the column tree.
+ */
+export const ColumnRenderingMixin = (superClass) =>
+  class ColumnRenderingMixin extends superClass {
+    /** @private */
+    __scheduleRenderHeaderFooter() {
+      this.__renderHeaderFooterDebouncer = Debouncer.debounce(this.__renderHeaderFooterDebouncer, microTask, () => {
+        this.__renderHeaderFooter();
+      });
+    }
+
+    /** @private */
+    __renderHeaderFooter() {
+      this.__renderHeaderFooterDebouncer?.cancel();
+
+      const sortedColumnTree = (this._columnTree ?? []).map((columns) => {
+        return columns.toSorted((a, b) => a._order - b._order);
+      });
+
+      this.#renderHeader(sortedColumnTree);
+      this.#renderFooter(sortedColumnTree);
+
+      this._resetKeyboardNavigation();
+      this.__a11yUpdateGridSize(this.size, this._columnTree, this.__emptyState);
+    }
+
+    #renderHeader(columnTree) {
+      render(
+        repeat(columnTree, (columns, level) => this.#renderHeaderRow(columns, level)),
+        this.$.header,
+        { host: this },
+      );
+
+      this.$.table.toggleAttribute('has-header', !!this.$.header.querySelector('tr:not([hidden])'));
+      this.__updateHeaderFooterRowParts('header');
+    }
+
+    #renderHeaderRow(columns, level) {
+      const isRowVisible = this.#isHeaderRowVisible(columns, level);
+
+      return html`
+        <tr role="row" part="row header-row" class="row header-row" tabindex="-1" ?hidden=${!isRowVisible}>
+          ${repeat(
+            columns,
+            (column) => column._id,
+            (column) => {
+              // `cache` keeps the cell and its rendered content when the
+              // column gets hidden, so it can be restored as-is when the
+              // column is shown again.
+              if (column.hidden) {
+                return cache(nothing);
+              }
+
+              return cache(html`
+                <th
+                  role="columnheader"
+                  part="cell header-cell"
+                  class="cell header-cell"
+                  @keydown="${this.__onCellKeyDown}"
+                  @mousedown=${this.__onCellMouseDown}
+                  @mouseenter=${this.__onCellMouseEnter}
+                  @mouseleave=${this.__onCellMouseLeave}
+                  tabindex="-1"
+                  ._column=${column}
+                >
+                  ${cellContent(this, `vaadin-grid-header-cell-content-${level}-${column._id}`)}
+                  ${column.resizable ? html`<div part="resize-handle" class="resize-handle"></div>` : nothing}
+                </th>
+              `);
+            },
+          )}
+        </tr>
+      `;
+    }
+
+    #renderFooter(columnTree) {
+      render(
+        repeat(columnTree.toReversed(), (columns, level) => this.#renderFooterRow(columns, level)),
+        this.$.footer,
+        { host: this },
+      );
+
+      this.$.table.toggleAttribute('has-footer', !!this.$.footer.querySelector('tr:not([hidden])'));
+      this.__updateHeaderFooterRowParts('footer');
+    }
+
+    #renderFooterRow(columns, level) {
+      const isRowVisible = this.#isFooterRowVisible(columns, level);
+
+      return html`
+        <tr role="row" part="row footer-row" class="row footer-row" tabindex="-1" ?hidden=${!isRowVisible}>
+          ${repeat(
+            columns,
+            (column) => column._id,
+            (column) => {
+              // `cache` keeps the cell and its rendered content when the
+              // column gets hidden, so it can be restored as-is when the
+              // column is shown again.
+              if (column.hidden) {
+                return cache(nothing);
+              }
+
+              return cache(html`
+                <td
+                  role="gridcell"
+                  part="cell footer-cell"
+                  class="cell footer-cell"
+                  @keydown="${this.__onCellKeyDown}"
+                  @mousedown=${this.__onCellMouseDown}
+                  @mouseenter=${this.__onCellMouseEnter}
+                  @mouseleave=${this.__onCellMouseLeave}
+                  tabindex="-1"
+                  ._column=${column}
+                >
+                  ${cellContent(this, `vaadin-grid-footer-cell-content-${level}-${column._id}`)}
+                </td>
+              `);
+            },
+          )}
+        </tr>
+      `;
+    }
+
+    #isHeaderRowVisible(columns, level) {
+      const isColumnRow = level === this._columnTree.length - 1;
+
+      return columns.some((column) => {
+        const isEmptyCell = !isColumnRow && column.localName !== 'vaadin-grid-column-group';
+        if (isEmptyCell || column.hidden) {
+          return false;
+        }
+
+        if (column.header === null) {
+          // The column header is explicilty set to null -> row should be hidden
+          return false;
+        }
+
+        return column.headerRenderer || column.path || column.header !== undefined;
+      });
+    }
+
+    #isFooterRowVisible(columns, level) {
+      // Footer rows are rendered in reverse order, so the column row is the first one
+      const isColumnRow = level === 0;
+
+      return columns.some((column) => {
+        const isEmptyCell = !isColumnRow && column.localName !== 'vaadin-grid-column-group';
+        if (isEmptyCell || column.hidden) {
+          return false;
+        }
+
+        return column.footerRenderer;
+      });
+    }
+  };

--- a/packages/grid/src/vaadin-grid-column-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-rendering-mixin.js
@@ -4,37 +4,46 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, nothing, render } from 'lit';
-import { AsyncDirective, directive } from 'lit/async-directive.js';
 import { cache } from 'lit/directives/cache.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { cellContent } from './directives/cell-content-directive.js';
 
-/**
- * A directive that manages the `<vaadin-grid-cell-content>` element for a cell.
- */
-class CellContentDirective extends AsyncDirective {
-  #cell;
-
-  update(part, [grid, slotName]) {
-    this.#cell = part.parentNode;
-    this.#cell._content ??= document.createElement('vaadin-grid-cell-content');
-    this.#cell._content.slot = slotName;
-
-    const { isConnected } = this.#cell._content;
-    if (!isConnected) {
-      grid.appendChild(this.#cell._content);
-    }
-
-    return html`<slot name="${slotName}"></slot>`;
-  }
-
-  disconnected() {
-    this.#cell._content?.remove();
-  }
+function isEmptyCell(column, level, columnTree) {
+  const isColumnRow = level === columnTree.length - 1;
+  return !isColumnRow && column.localName !== 'vaadin-grid-column-group';
 }
 
-const cellContent = directive(CellContentDirective);
+function isHeaderRowVisible(columns, level, columnTree) {
+  return columns.some((column) => {
+    if (column.hidden || isEmptyCell(column, level, columnTree)) {
+      return false;
+    }
+
+    if (column.headerRenderer) {
+      // The column has a header renderer -> row should be visible
+      return true;
+    }
+
+    if (column.header === null) {
+      // The column header is explicitly set to null -> doesn't block hiding the row
+      return false;
+    }
+
+    return column.path || column.header !== undefined;
+  });
+}
+
+function isFooterRowVisible(columns, level, columnTree) {
+  return columns.some((column) => {
+    if (column.hidden || isEmptyCell(column, level, columnTree)) {
+      return false;
+    }
+
+    return column.footerRenderer;
+  });
+}
 
 /**
  * A mixin providing rendering of rows based on the column tree.
@@ -64,21 +73,21 @@ export const ColumnRenderingMixin = (superClass) =>
     }
 
     #renderHeader(columnTree) {
-      render(
-        repeat(columnTree, (columns, level) => this.#renderHeaderRow(columns, level)),
-        this.$.header,
-        { host: this },
-      );
+      render(columnTree.map(this.#renderHeaderRow), this.$.header, { host: this });
 
       this.$.table.toggleAttribute('has-header', !!this.$.header.querySelector('tr:not([hidden])'));
       this.__updateHeaderFooterRowParts('header');
     }
 
-    #renderHeaderRow(columns, level) {
-      const isRowVisible = this.#isHeaderRowVisible(columns, level);
-
+    #renderHeaderRow = (columns, level, columnTree) => {
       return html`
-        <tr role="row" part="row header-row" class="row header-row" tabindex="-1" ?hidden=${!isRowVisible}>
+        <tr
+          role="row"
+          part="row header-row"
+          class="row header-row"
+          tabindex="-1"
+          ?hidden=${!isHeaderRowVisible(columns, level, columnTree)}
+        >
           ${repeat(
             columns,
             (column) => column._id,
@@ -110,24 +119,24 @@ export const ColumnRenderingMixin = (superClass) =>
           )}
         </tr>
       `;
-    }
+    };
 
     #renderFooter(columnTree) {
-      render(
-        repeat(columnTree.toReversed(), (columns, level) => this.#renderFooterRow(columns, level)),
-        this.$.footer,
-        { host: this },
-      );
+      render(columnTree.map(this.#renderFooterRow).toReversed(), this.$.footer, { host: this });
 
       this.$.table.toggleAttribute('has-footer', !!this.$.footer.querySelector('tr:not([hidden])'));
       this.__updateHeaderFooterRowParts('footer');
     }
 
-    #renderFooterRow(columns, level) {
-      const isRowVisible = this.#isFooterRowVisible(columns, level);
-
+    #renderFooterRow = (columns, level, columnTree) => {
       return html`
-        <tr role="row" part="row footer-row" class="row footer-row" tabindex="-1" ?hidden=${!isRowVisible}>
+        <tr
+          role="row"
+          part="row footer-row"
+          class="row footer-row"
+          tabindex="-1"
+          ?hidden=${!isFooterRowVisible(columns, level, columnTree)}
+        >
           ${repeat(
             columns,
             (column) => column._id,
@@ -158,37 +167,5 @@ export const ColumnRenderingMixin = (superClass) =>
           )}
         </tr>
       `;
-    }
-
-    #isHeaderRowVisible(columns, level) {
-      const isColumnRow = level === this._columnTree.length - 1;
-
-      return columns.some((column) => {
-        const isEmptyCell = !isColumnRow && column.localName !== 'vaadin-grid-column-group';
-        if (isEmptyCell || column.hidden) {
-          return false;
-        }
-
-        if (column.header === null) {
-          // The column header is explicilty set to null -> row should be hidden
-          return false;
-        }
-
-        return column.headerRenderer || column.path || column.header !== undefined;
-      });
-    }
-
-    #isFooterRowVisible(columns, level) {
-      // Footer rows are rendered in reverse order, so the column row is the first one
-      const isColumnRow = level === 0;
-
-      return columns.some((column) => {
-        const isEmptyCell = !isColumnRow && column.localName !== 'vaadin-grid-column-group';
-        if (isEmptyCell || column.hidden) {
-          return false;
-        }
-
-        return column.footerRenderer;
-      });
-    }
+    };
   };

--- a/packages/grid/src/vaadin-grid-column-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-rendering-mixin.js
@@ -65,6 +65,10 @@ export const ColumnRenderingMixin = (superClass) =>
         return columns.toSorted((a, b) => a._order - b._order);
       });
 
+      sortedColumnTree.flat().forEach((column) => {
+        column._emptyCells = [];
+      });
+
       this.#renderHeader(sortedColumnTree);
       this.#renderFooter(sortedColumnTree);
 
@@ -77,6 +81,16 @@ export const ColumnRenderingMixin = (superClass) =>
 
       this.$.table.toggleAttribute('has-header', !!this.$.header.querySelector('tr:not([hidden])'));
       this.__updateHeaderFooterRowParts('header');
+
+      this.$.header.querySelectorAll('.header-cell').forEach((cell) => {
+        const column = cell._column;
+        const isColumnRow = cell.parentElement === this.$.header.lastElementChild;
+        if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
+          column._headerCell = cell;
+        } else {
+          column._emptyCells.push(cell);
+        }
+      });
     }
 
     #renderHeaderRow = (columns, level, columnTree) => {
@@ -126,6 +140,16 @@ export const ColumnRenderingMixin = (superClass) =>
 
       this.$.table.toggleAttribute('has-footer', !!this.$.footer.querySelector('tr:not([hidden])'));
       this.__updateHeaderFooterRowParts('footer');
+
+      this.$.footer.querySelectorAll('.footer-cell').forEach((cell) => {
+        const column = cell._column;
+        const isColumnRow = cell.parentElement === this.$.footer.firstElementChild;
+        if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
+          column._footerCell = cell;
+        } else {
+          column._emptyCells.push(cell);
+        }
+      });
     }
 
     #renderFooterRow = (columns, level, columnTree) => {

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -203,9 +203,10 @@ export const ColumnReorderingMixin = (superClass) =>
         for (let i = startIndex; i !== endIndex; i += direction) {
           this._swapColumnOrders(this._draggedColumn, levelColumnsInOrder[i + direction]);
         }
+
+        this.__renderHeaderFooter();
       }
 
-      this.__renderHeaderFooter();
       this._updateGhostPosition(e.detail.x, this._touchDevice ? e.detail.y - 50 : e.detail.y);
       this._lastDragClientX = e.detail.x;
     }

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -205,6 +205,7 @@ export const ColumnReorderingMixin = (superClass) =>
         }
       }
 
+      this.__renderHeaderFooter();
       this._updateGhostPosition(e.detail.x, this._touchDevice ? e.detail.y - 50 : e.detail.y);
       this._lastDragClientX = e.detail.x;
     }
@@ -434,7 +435,7 @@ export const ColumnReorderingMixin = (superClass) =>
     }
 
     /**
-     * Swaps column orders and physically reorders cells in all rows.
+     * Swaps column orders and reorders cells in all rows.
      * @param {!GridColumn} column1
      * @param {!GridColumn} column2
      * @protected
@@ -444,8 +445,7 @@ export const ColumnReorderingMixin = (superClass) =>
       [column1._order, column2._order] = [column2._order, column1._order];
       const [firstColumn, secondColumn] = column1._order < column2._order ? [column1, column2] : [column2, column1];
 
-      // Reorder cells in all rows (header, footer, body, sizer)
-      [...this.$.header.children, ...this.$.footer.children, ...this.$.items.children, this.$.sizer].forEach((row) => {
+      [...this.$.items.children, this.$.sizer].forEach((row) => {
         const cells = getBodyRowCells(row);
         const firstColumnCells = cells.filter((cell) => firstColumn.contains(cell._column));
         const secondColumnFirstCell = cells.find((cell) => secondColumn.contains(cell._column));
@@ -456,6 +456,7 @@ export const ColumnReorderingMixin = (superClass) =>
         }
       });
 
+      this.__scheduleRenderHeaderFooter();
       this._debounceUpdateFrozenColumn();
       this._updateFirstAndLastColumn();
     }

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -590,33 +590,7 @@ export const GridMixin = (superClass) =>
         this.__updateRow(row);
       });
 
-      // Reset before collecting, so stale cells from a previous render (including
-      // cells of columns that just became hidden) don't accumulate.
-      this._columnTree.flat().forEach((column) => {
-        column._emptyCells = [];
-      });
-
       this.__renderHeaderFooter();
-
-      this.$.header.querySelectorAll('.header-cell').forEach((cell) => {
-        const column = cell._column;
-        const isColumnRow = cell.parentElement === this.$.header.lastElementChild;
-        if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
-          column._headerCell = cell;
-        } else {
-          column._emptyCells.push(cell);
-        }
-      });
-
-      this.$.footer.querySelectorAll('.footer-cell').forEach((cell) => {
-        const column = cell._column;
-        const isColumnRow = cell.parentElement === this.$.footer.firstElementChild;
-        if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
-          column._footerCell = cell;
-        } else {
-          column._emptyCells.push(cell);
-        }
-      });
 
       // Sizer rows
       this.__initRow(this.$.sizer, columnTree[columnTree.length - 1]);

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -4,9 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { TabindexMixin } from '@vaadin/a11y-base/src/tabindex-mixin.js';
-import { microTask } from '@vaadin/component-base/src/async.js';
 import { isAndroid, isIOS, isSafari, isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { setTouchAction } from '@vaadin/component-base/src/gestures.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
@@ -15,6 +13,7 @@ import { A11yMixin } from './vaadin-grid-a11y-mixin.js';
 import { ActiveItemMixin } from './vaadin-grid-active-item-mixin.js';
 import { ArrayDataProviderMixin } from './vaadin-grid-array-data-provider-mixin.js';
 import { ColumnAutoWidthMixin } from './vaadin-grid-column-auto-width-mixin.js';
+import { ColumnRenderingMixin } from './vaadin-grid-column-rendering-mixin.js';
 import { ColumnReorderingMixin } from './vaadin-grid-column-reordering-mixin.js';
 import { ColumnResizingMixin } from './vaadin-grid-column-resizing-mixin.js';
 import { DataProviderMixin } from './vaadin-grid-data-provider-mixin.js';
@@ -48,17 +47,21 @@ export const GridMixin = (superClass) =>
     ArrayDataProviderMixin(
       DataProviderMixin(
         DynamicColumnsMixin(
-          ActiveItemMixin(
-            ScrollMixin(
-              SelectionMixin(
-                SortMixin(
-                  RowDetailsMixin(
-                    KeyboardNavigationMixin(
-                      A11yMixin(
-                        FilterMixin(
-                          ColumnReorderingMixin(
-                            ColumnResizingMixin(
-                              EventContextMixin(DragAndDropMixin(StylingMixin(TabindexMixin(ResizeMixin(superClass))))),
+          ColumnRenderingMixin(
+            ActiveItemMixin(
+              ScrollMixin(
+                SelectionMixin(
+                  SortMixin(
+                    RowDetailsMixin(
+                      KeyboardNavigationMixin(
+                        A11yMixin(
+                          FilterMixin(
+                            ColumnReorderingMixin(
+                              ColumnResizingMixin(
+                                EventContextMixin(
+                                  DragAndDropMixin(StylingMixin(TabindexMixin(ResizeMixin(superClass)))),
+                                ),
+                              ),
                             ),
                           ),
                         ),
@@ -351,7 +354,7 @@ export const GridMixin = (superClass) =>
         updatePart(row, 'row', true);
         updatePart(row, 'body-row', true);
         if (this._columnTree) {
-          this.__initRow(row, this._columnTree[this._columnTree.length - 1], 'body', false, true);
+          this.__initRow(row, this._columnTree[this._columnTree.length - 1], 'body', true);
         }
         rows.push(row);
       }
@@ -444,11 +447,10 @@ export const GridMixin = (superClass) =>
      * @param {!HTMLTableRowElement} row
      * @param {!Array<!GridColumn>} columns
      * @param {?string} section
-     * @param {boolean} isColumnRow
      * @param {boolean} noNotify
      * @private
      */
-    __initRow(row, columns, section = 'body', isColumnRow = false, noNotify = false) {
+    __initRow(row, columns, section = 'body', noNotify = false) {
       const contentsFragment = document.createDocumentFragment();
 
       iterateRowCells(row, (cell) => {
@@ -516,30 +518,6 @@ export const GridMixin = (superClass) =>
             if (!noNotify) {
               column._cells = [...column._cells];
             }
-          } else {
-            // Header & footer
-            const tagName = section === 'header' ? 'th' : 'td';
-            if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
-              cell = column[`_${section}Cell`];
-              if (!cell) {
-                cell = this._createCell(tagName);
-              }
-              cell._column = column;
-              row.appendChild(cell);
-              column[`_${section}Cell`] = cell;
-            } else {
-              if (!column._emptyCells) {
-                column._emptyCells = [];
-              }
-              cell = column._emptyCells.find((cell) => cell._vacant) || this._createCell(tagName);
-              cell._column = column;
-              row.appendChild(cell);
-              if (column._emptyCells.indexOf(cell) === -1) {
-                column._emptyCells.push(cell);
-              }
-            }
-            updatePart(cell, 'cell', true);
-            updatePart(cell, `${section}-cell`, true);
           }
 
           if (!cell._content.parentElement) {
@@ -549,84 +527,11 @@ export const GridMixin = (superClass) =>
           cell._column = column;
         });
 
-      if (section !== 'body') {
-        this.__debounceUpdateHeaderFooterRowVisibility(row);
-      }
-
       // Might be empty if only cache was used
       this.appendChild(contentsFragment);
 
       this._frozenCellsChanged();
       this._updateFirstAndLastColumnForRow(row);
-    }
-
-    /**
-     * @param {HTMLTableRowElement} row
-     * @protected
-     */
-    __debounceUpdateHeaderFooterRowVisibility(row) {
-      row.__debounceUpdateHeaderFooterRowVisibility = Debouncer.debounce(
-        row.__debounceUpdateHeaderFooterRowVisibility,
-        microTask,
-        () => this.__updateHeaderFooterRowVisibility(row),
-      );
-    }
-
-    /**
-     * @param {HTMLTableRowElement} row
-     * @protected
-     */
-    __updateHeaderFooterRowVisibility(row) {
-      if (!row) {
-        return;
-      }
-
-      const visibleRowCells = Array.from(row.children).filter((cell) => {
-        const column = cell._column;
-        if (column._emptyCells && column._emptyCells.indexOf(cell) > -1) {
-          // The cell is an "empty cell"  -> doesn't block hiding the row
-          return false;
-        }
-        if (row.parentElement === this.$.header) {
-          if (column.headerRenderer) {
-            // The cell is the header cell of a column that has a header renderer
-            // -> row should be visible
-            return true;
-          }
-          if (column.header === null) {
-            // The column header is explicilty set to null -> doesn't block hiding the row
-            return false;
-          }
-          if (column.path || column.header !== undefined) {
-            // The column has an explicit non-null header or a path that generates a header
-            // -> row should be visible
-            return true;
-          }
-        } else if (column.footerRenderer) {
-          // The cell is the footer cell of a column that has a footer renderer
-          // -> row should be visible
-          return true;
-        }
-        return false;
-      });
-
-      if (row.hidden !== !visibleRowCells.length) {
-        row.hidden = !visibleRowCells.length;
-      }
-
-      if (row.parentElement === this.$.header) {
-        this.$.table.toggleAttribute('has-header', this.$.header.querySelector('tr:not([hidden])'));
-        this.__updateHeaderFooterRowParts('header');
-      }
-
-      if (row.parentElement === this.$.footer) {
-        this.$.table.toggleAttribute('has-footer', this.$.footer.querySelector('tr:not([hidden])'));
-        this.__updateHeaderFooterRowParts('footer');
-      }
-
-      // Make sure the section has a tabbable element
-      this._resetKeyboardNavigation();
-      this.__a11yUpdateGridSize(this.size, this._columnTree, this.__emptyState);
     }
 
     /** @private */
@@ -681,43 +586,41 @@ export const GridMixin = (superClass) =>
      */
     _renderColumnTree(columnTree) {
       iterateChildren(this.$.items, (row) => {
-        this.__initRow(row, columnTree[columnTree.length - 1], 'body', false, true);
+        this.__initRow(row, columnTree[columnTree.length - 1], 'body', true);
         this.__updateRow(row);
       });
 
-      while (this.$.header.children.length < columnTree.length) {
-        const headerRow = document.createElement('tr');
-        headerRow.setAttribute('role', 'row');
-        headerRow.setAttribute('tabindex', '-1');
-        updatePart(headerRow, 'row', true);
-        updatePart(headerRow, 'header-row', true);
-        this.$.header.appendChild(headerRow);
-
-        const footerRow = document.createElement('tr');
-        footerRow.setAttribute('role', 'row');
-        footerRow.setAttribute('tabindex', '-1');
-        updatePart(footerRow, 'row', true);
-        updatePart(footerRow, 'footer-row', true);
-        this.$.footer.appendChild(footerRow);
-      }
-      while (this.$.header.children.length > columnTree.length) {
-        this.$.header.removeChild(this.$.header.firstElementChild);
-        this.$.footer.removeChild(this.$.footer.firstElementChild);
-      }
-
-      iterateChildren(this.$.header, (headerRow, index) => {
-        this.__initRow(headerRow, columnTree[index], 'header', index === columnTree.length - 1);
+      // Reset before collecting, so stale cells from a previous render (including
+      // cells of columns that just became hidden) don't accumulate.
+      this._columnTree.flat().forEach((column) => {
+        column._emptyCells = [];
       });
 
-      iterateChildren(this.$.footer, (footerRow, index) => {
-        this.__initRow(footerRow, columnTree[columnTree.length - 1 - index], 'footer', index === 0);
+      this.__renderHeaderFooter();
+
+      this.$.header.querySelectorAll('.header-cell').forEach((cell) => {
+        const column = cell._column;
+        const isColumnRow = cell.parentElement === this.$.header.lastElementChild;
+        if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
+          column._headerCell = cell;
+        } else {
+          column._emptyCells.push(cell);
+        }
+      });
+
+      this.$.footer.querySelectorAll('.footer-cell').forEach((cell) => {
+        const column = cell._column;
+        const isColumnRow = cell.parentElement === this.$.footer.firstElementChild;
+        if (isColumnRow || column.localName === 'vaadin-grid-column-group') {
+          column._footerCell = cell;
+        } else {
+          column._emptyCells.push(cell);
+        }
       });
 
       // Sizer rows
       this.__initRow(this.$.sizer, columnTree[columnTree.length - 1]);
 
-      this.__updateHeaderFooterRowParts('header');
-      this.__updateHeaderFooterRowParts('footer');
       this._resizeHandler();
       this._frozenCellsChanged();
       this._updateFirstAndLastColumn();
@@ -739,6 +642,8 @@ export const GridMixin = (superClass) =>
           updatePart(cell, `first-${section}-row-cell`, row === visibleRows.at(0));
           updatePart(cell, `last-${section}-row-cell`, row === visibleRows.at(-1));
         });
+
+        this._updateFirstAndLastColumnForRow(row);
       });
     }
 

--- a/packages/grid/src/vaadin-grid-sort-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-sort-column-mixin.js
@@ -46,16 +46,25 @@ export const GridSortColumnMixin = (superClass) =>
      */
     _defaultHeaderRenderer(root, _column) {
       let sorter = root.firstElementChild;
-      if (!sorter) {
+      const isNewSorter = !sorter;
+      if (isNewSorter) {
         sorter = document.createElement('vaadin-grid-sorter');
         sorter.addEventListener('direction-changed', this.__boundOnDirectionChanged);
-        root.appendChild(sorter);
       }
 
       sorter.path = this.path;
       sorter.__rendererDirection = this.direction;
       sorter.direction = this.direction;
       sorter.textContent = this.__getHeader(this.header, this.path);
+
+      // Append the sorter only after its direction has been set. If the cell
+      // content is already connected (as with the declarative header rendering),
+      // appending an unconfigured sorter makes it notify its default `null`
+      // direction before `__rendererDirection` is set, which would reset the
+      // column's direction. See __onDirectionChanged.
+      if (isNewSorter) {
+        root.appendChild(sorter);
+      }
     }
 
     /**

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -328,6 +328,7 @@ describe('column groups', () => {
         group.footerRenderer = attributeRenderer('footer');
       });
 
+      sinon.spy(grid, '__renderHeaderFooter');
       sinon.spy(grid, '_updateColumnTree');
       grid.dataProvider = infiniteDataProvider;
       flushGrid(grid);
@@ -335,7 +336,12 @@ describe('column groups', () => {
       await nextResize(grid);
     });
 
-    it('should update column tree once', () => {
+    it('should not update header and footer rows too many times', () => {
+      // One from _updateColumnTree, another one from column observers
+      expect(grid.__renderHeaderFooter.callCount).to.equal(2);
+    });
+
+    it('should not update column tree too many times', () => {
       expect(grid._updateColumnTree.callCount).to.equal(1);
     });
 

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -328,17 +328,11 @@ describe('column groups', () => {
         group.footerRenderer = attributeRenderer('footer');
       });
 
-      sinon.spy(grid, '__updateHeaderFooterRowVisibility');
       sinon.spy(grid, '_updateColumnTree');
       grid.dataProvider = infiniteDataProvider;
       flushGrid(grid);
 
       await nextResize(grid);
-    });
-
-    it('should update header and footer rows visibility once', () => {
-      // 6 header and footer rows are created
-      expect(grid.__updateHeaderFooterRowVisibility.callCount).to.equal(6);
     });
 
     it('should update column tree once', () => {

--- a/packages/grid/test/column-resizing.test.js
+++ b/packages/grid/test/column-resizing.test.js
@@ -174,6 +174,7 @@ describe('column resizing', () => {
 
   it('should fix width for preceding columns', () => {
     grid._columnTree[0][1].resizable = true;
+    flushGrid(grid);
 
     grid._columnTree[0][0].width = '50%';
     grid._columnTree[0][0].flexGrow = 1;

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -1805,14 +1805,14 @@ snapshots["vaadin-grid hidden column group with group header"] =
         <td
           class="body-cell cell first-column-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
       </tr>
@@ -1833,14 +1833,13 @@ snapshots["vaadin-grid hidden column group with group header"] =
         <th
           class="cell first-column-cell header-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-23">
           </slot>
         </th>
       </tr>
@@ -1850,20 +1849,18 @@ snapshots["vaadin-grid hidden column group with group header"] =
         hidden=""
         part="row header-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <th
           class="cell first-column-cell header-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-1"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-1-23">
           </slot>
         </th>
       </tr>
@@ -1890,14 +1887,14 @@ snapshots["vaadin-grid hidden column group with group header"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -1918,14 +1915,14 @@ snapshots["vaadin-grid hidden column group with group header"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
       </tr>
@@ -1957,20 +1954,18 @@ snapshots["vaadin-grid hidden column group with group header"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-1-23">
           </slot>
         </td>
       </tr>
@@ -1985,14 +1980,13 @@ snapshots["vaadin-grid hidden column group with group header"] =
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-23">
           </slot>
         </td>
       </tr>
@@ -2038,14 +2032,14 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
         <td
           class="body-cell cell first-column-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
       </tr>
@@ -2066,14 +2060,13 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
         <th
           class="cell first-column-cell header-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-26">
           </slot>
         </th>
       </tr>
@@ -2088,14 +2081,13 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-1"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell first-header-row-cell last-header-row-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-1-26">
           </slot>
         </th>
       </tr>
@@ -2122,14 +2114,14 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -2150,14 +2142,14 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
       </tr>
@@ -2189,20 +2181,18 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-1-26">
           </slot>
         </td>
       </tr>
@@ -2217,14 +2207,13 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-26">
           </slot>
         </td>
       </tr>
@@ -2269,14 +2258,14 @@ snapshots["vaadin-grid hidden column group with group footer"] =
         <td
           class="body-cell cell first-column-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
       </tr>
@@ -2297,14 +2286,13 @@ snapshots["vaadin-grid hidden column group with group footer"] =
         <th
           class="cell first-column-cell header-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-29">
           </slot>
         </th>
       </tr>
@@ -2314,20 +2302,18 @@ snapshots["vaadin-grid hidden column group with group footer"] =
         hidden=""
         part="row header-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <th
           class="cell first-column-cell header-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-1"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-1-29">
           </slot>
         </th>
       </tr>
@@ -2354,14 +2340,14 @@ snapshots["vaadin-grid hidden column group with group footer"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -2382,14 +2368,14 @@ snapshots["vaadin-grid hidden column group with group footer"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           last-column=""
           part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
       </tr>
@@ -2421,20 +2407,18 @@ snapshots["vaadin-grid hidden column group with group footer"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-1-29">
           </slot>
         </td>
       </tr>
@@ -2449,14 +2433,13 @@ snapshots["vaadin-grid hidden column group with group footer"] =
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-29">
           </slot>
         </td>
       </tr>

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -7,30 +7,30 @@ snapshots["vaadin-grid basic host default"] =
   </vaadin-grid-column>
   <vaadin-grid-column path="name.last">
   </vaadin-grid-column>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-0">
+  <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-0-0">
     First
   </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-1">
+  <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-0-1">
     Last
   </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-0">
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-1">
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-0">
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-1">
+  </vaadin-grid-cell-content>
   <vaadin-grid-cell-content slot="vaadin-grid-cell-content-2">
-  </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
-  </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-4">
-  </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-5">
-  </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-6">
     Laura
   </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-7">
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
     Arnaud
   </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-8">
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-4">
     Fabien
   </vaadin-grid-cell-content>
-  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-9">
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-5">
     Le gall
   </vaadin-grid-cell-content>
 </vaadin-grid>
@@ -61,25 +61,25 @@ snapshots["vaadin-grid basic shadow default"] =
         <td
           class="body-cell cell first-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           part="cell body-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
         <td
           class="body-cell cell last-column-cell"
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -100,25 +100,23 @@ snapshots["vaadin-grid basic shadow default"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
-          part="cell header-cell first-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-2">
           </slot>
         </th>
         <th
           class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
-          id="vaadin-grid-cell-1"
           last-column=""
-          part="cell header-cell last-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-0-3">
           </slot>
         </th>
       </tr>
@@ -145,26 +143,26 @@ snapshots["vaadin-grid basic shadow default"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell"
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -185,26 +183,26 @@ snapshots["vaadin-grid basic shadow default"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-8"
+          id="vaadin-grid-cell-4"
           part="cell body-cell first-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-8">
+          <slot name="vaadin-grid-cell-content-4">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell"
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -236,31 +234,28 @@ snapshots["vaadin-grid basic shadow default"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           part="cell footer-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-0-2">
           </slot>
         </td>
         <td
           class="cell footer-cell last-column-cell"
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-3">
           </slot>
         </td>
       </tr>
@@ -306,25 +301,25 @@ snapshots["vaadin-grid basic shadow selected"] =
         <td
           class="body-cell cell first-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           part="cell body-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
         <td
           class="body-cell cell last-column-cell"
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -345,25 +340,23 @@ snapshots["vaadin-grid basic shadow selected"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
-          part="cell header-cell first-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-4">
           </slot>
         </th>
         <th
           class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
-          id="vaadin-grid-cell-1"
           last-column=""
-          part="cell header-cell last-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-0-5">
           </slot>
         </th>
       </tr>
@@ -391,26 +384,26 @@ snapshots["vaadin-grid basic shadow selected"] =
           aria-selected="true"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell selected-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell selected-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
         <td
           aria-selected="true"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell selected-row-cell"
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell selected-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -431,26 +424,26 @@ snapshots["vaadin-grid basic shadow selected"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-8"
+          id="vaadin-grid-cell-4"
           part="cell body-cell first-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-8">
+          <slot name="vaadin-grid-cell-content-4">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell"
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -482,31 +475,28 @@ snapshots["vaadin-grid basic shadow selected"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           part="cell footer-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-0-4">
           </slot>
         </td>
         <td
           class="cell footer-cell last-column-cell"
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-5">
           </slot>
         </td>
       </tr>
@@ -552,25 +542,25 @@ snapshots["vaadin-grid basic shadow details opened"] =
         <td
           class="body-cell cell first-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           part="cell body-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
         <td
           class="body-cell cell last-column-cell"
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -591,25 +581,23 @@ snapshots["vaadin-grid basic shadow details opened"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
-          part="cell header-cell first-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-6">
           </slot>
         </th>
         <th
           class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
-          id="vaadin-grid-cell-1"
           last-column=""
-          part="cell header-cell last-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-0-7">
           </slot>
         </th>
       </tr>
@@ -636,26 +624,26 @@ snapshots["vaadin-grid basic shadow details opened"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell"
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -676,26 +664,26 @@ snapshots["vaadin-grid basic shadow details opened"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-8"
+          id="vaadin-grid-cell-4"
           part="cell body-cell first-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-8">
+          <slot name="vaadin-grid-cell-content-4">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell"
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -727,31 +715,28 @@ snapshots["vaadin-grid basic shadow details opened"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           part="cell footer-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
-          tabindex="0"
+          tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-0-6">
           </slot>
         </td>
         <td
           class="cell footer-cell last-column-cell"
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-7">
           </slot>
         </td>
       </tr>
@@ -797,14 +782,14 @@ snapshots["vaadin-grid basic shadow hidden column"] =
         <td
           class="body-cell cell first-column-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -825,14 +810,13 @@ snapshots["vaadin-grid basic shadow hidden column"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-1"
           last-column=""
-          part="cell header-cell last-column-cell first-header-row-cell last-header-row-cell first-column-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-0-9">
           </slot>
         </th>
       </tr>
@@ -859,14 +843,14 @@ snapshots["vaadin-grid basic shadow hidden column"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -887,14 +871,14 @@ snapshots["vaadin-grid basic shadow hidden column"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -926,20 +910,18 @@ snapshots["vaadin-grid basic shadow hidden column"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell last-column-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-9">
           </slot>
         </td>
       </tr>
@@ -985,14 +967,14 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
         <td
           class="body-cell cell first-column-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -1013,14 +995,13 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-1"
           last-column=""
-          part="cell header-cell last-column-cell first-header-row-cell last-header-row-cell first-column-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-0-11">
           </slot>
         </th>
       </tr>
@@ -1048,14 +1029,14 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
           aria-selected="true"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell selected-row-cell"
           first-column=""
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell selected-row-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -1076,14 +1057,14 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -1115,20 +1096,18 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
         hidden=""
         part="row footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell footer-cell last-column-cell"
           first-column=""
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell last-column-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-11">
           </slot>
         </td>
       </tr>
@@ -1175,25 +1154,25 @@ snapshots["vaadin-grid basic shadow with footer"] =
         <td
           class="body-cell cell first-column-cell"
           first-column=""
-          id="vaadin-grid-cell-4"
+          id="vaadin-grid-cell-0"
           part="cell body-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
         <td
           class="body-cell cell last-column-cell"
-          id="vaadin-grid-cell-5"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -1214,25 +1193,23 @@ snapshots["vaadin-grid basic shadow with footer"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-0"
-          part="cell header-cell first-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-12">
           </slot>
         </th>
         <th
           class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
-          id="vaadin-grid-cell-1"
           last-column=""
-          part="cell header-cell last-column-cell first-header-row-cell last-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-0-13">
           </slot>
         </th>
       </tr>
@@ -1259,26 +1236,26 @@ snapshots["vaadin-grid basic shadow with footer"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-2"
           part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell"
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -1299,26 +1276,26 @@ snapshots["vaadin-grid basic shadow with footer"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-8"
+          id="vaadin-grid-cell-4"
           part="cell body-cell first-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-8">
+          <slot name="vaadin-grid-cell-content-4">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell"
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -1349,31 +1326,28 @@ snapshots["vaadin-grid basic shadow with footer"] =
         class="first-footer-row footer-row last-footer-row row"
         part="row footer-row first-footer-row last-footer-row"
         role="row"
-        style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
       >
         <td
           class="cell first-column-cell first-footer-row-cell footer-cell last-footer-row-cell"
           first-column=""
-          id="vaadin-grid-cell-2"
           part="cell footer-cell first-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-footer-cell-content-0-12">
           </slot>
         </td>
         <td
           class="cell first-footer-row-cell footer-cell last-column-cell last-footer-row-cell"
-          id="vaadin-grid-cell-3"
           last-column=""
           part="cell footer-cell last-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-13">
           </slot>
         </td>
       </tr>
@@ -1420,25 +1394,25 @@ snapshots["vaadin-grid column groups default"] =
         <td
           class="body-cell cell first-column-cell"
           first-column=""
-          id="vaadin-grid-cell-6"
+          id="vaadin-grid-cell-0"
           part="cell body-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-6">
+          <slot name="vaadin-grid-cell-content-0">
           </slot>
         </td>
         <td
           class="body-cell cell last-column-cell"
-          id="vaadin-grid-cell-7"
+          id="vaadin-grid-cell-1"
           last-column=""
           part="cell body-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-7">
+          <slot name="vaadin-grid-cell-content-1">
           </slot>
         </td>
       </tr>
@@ -1461,21 +1435,20 @@ snapshots["vaadin-grid column groups default"] =
           class="cell first-column-cell header-cell last-column-cell"
           colspan="2"
           first-column=""
-          id="vaadin-grid-cell-0"
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
           style="width: calc(200px); flex-grow: 2;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-0">
+          <slot name="vaadin-grid-header-cell-content-0-14">
           </slot>
         </th>
       </tr>
       <tr
         aria-rowindex="2"
         class="first-header-row header-row last-header-row row"
-        part="row header-row last-header-row first-header-row"
+        part="row header-row first-header-row last-header-row"
         role="row"
         style="--_grid-horizontal-scroll-position: 0px;"
         tabindex="-1"
@@ -1483,25 +1456,23 @@ snapshots["vaadin-grid column groups default"] =
         <th
           class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell"
           first-column=""
-          id="vaadin-grid-cell-1"
-          part="cell header-cell first-column-cell last-header-row-cell first-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-1">
+          <slot name="vaadin-grid-header-cell-content-1-15">
           </slot>
         </th>
         <th
           class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
-          id="vaadin-grid-cell-2"
           last-column=""
-          part="cell header-cell last-column-cell last-header-row-cell first-header-row-cell"
+          part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-2">
+          <slot name="vaadin-grid-header-cell-content-1-16">
           </slot>
         </th>
       </tr>
@@ -1528,26 +1499,26 @@ snapshots["vaadin-grid column groups default"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell"
           first-column=""
-          id="vaadin-grid-cell-8"
+          id="vaadin-grid-cell-2"
           part="cell body-cell first-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-8">
+          <slot name="vaadin-grid-cell-content-2">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell"
-          id="vaadin-grid-cell-9"
+          id="vaadin-grid-cell-3"
           last-column=""
           part="cell body-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-9">
+          <slot name="vaadin-grid-cell-content-3">
           </slot>
         </td>
       </tr>
@@ -1568,26 +1539,26 @@ snapshots["vaadin-grid column groups default"] =
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell"
           first-column=""
-          id="vaadin-grid-cell-10"
+          id="vaadin-grid-cell-4"
           part="cell body-cell first-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-10">
+          <slot name="vaadin-grid-cell-content-4">
           </slot>
         </td>
         <td
           aria-selected="false"
           class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell"
-          id="vaadin-grid-cell-11"
+          id="vaadin-grid-cell-5"
           last-column=""
           part="cell body-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-11">
+          <slot name="vaadin-grid-cell-content-5">
           </slot>
         </td>
       </tr>
@@ -1624,25 +1595,23 @@ snapshots["vaadin-grid column groups default"] =
         <td
           class="cell first-column-cell first-footer-row-cell footer-cell last-footer-row-cell"
           first-column=""
-          id="vaadin-grid-cell-3"
-          part="cell footer-cell first-column-cell first-footer-row-cell last-footer-row-cell"
+          part="cell footer-cell first-footer-row-cell last-footer-row-cell first-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-cell-content-3">
+          <slot name="vaadin-grid-footer-cell-content-0-15">
           </slot>
         </td>
         <td
           class="cell first-footer-row-cell footer-cell last-column-cell last-footer-row-cell"
-          id="vaadin-grid-cell-4"
           last-column=""
-          part="cell footer-cell last-column-cell first-footer-row-cell last-footer-row-cell"
+          part="cell footer-cell first-footer-row-cell last-footer-row-cell last-column-cell"
           role="gridcell"
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-4">
+          <slot name="vaadin-grid-footer-cell-content-0-16">
           </slot>
         </td>
       </tr>
@@ -1659,14 +1628,13 @@ snapshots["vaadin-grid column groups default"] =
           class="cell first-column-cell footer-cell last-column-cell"
           colspan="2"
           first-column=""
-          id="vaadin-grid-cell-5"
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
           style="width: calc(200px); flex-grow: 2;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-cell-content-5">
+          <slot name="vaadin-grid-footer-cell-content-1-14">
           </slot>
         </td>
       </tr>
@@ -1706,14 +1674,13 @@ snapshots["vaadin-grid column groups with header"] =
       class="cell first-column-cell first-header-row-cell header-cell last-column-cell"
       colspan="2"
       first-column=""
-      id="vaadin-grid-cell-0"
       last-column=""
       part="cell header-cell first-column-cell last-column-cell first-header-row-cell"
       role="columnheader"
       style="width: calc(200px); flex-grow: 2;"
       tabindex="-1"
     >
-      <slot name="vaadin-grid-cell-content-0">
+      <slot name="vaadin-grid-header-cell-content-0-17">
       </slot>
     </th>
   </tr>
@@ -1728,25 +1695,23 @@ snapshots["vaadin-grid column groups with header"] =
     <th
       class="cell first-column-cell header-cell last-header-row-cell"
       first-column=""
-      id="vaadin-grid-cell-1"
-      part="cell header-cell first-column-cell last-header-row-cell"
+      part="cell header-cell last-header-row-cell first-column-cell"
       role="columnheader"
       style="width: 100px; flex-grow: 1;"
       tabindex="0"
     >
-      <slot name="vaadin-grid-cell-content-1">
+      <slot name="vaadin-grid-header-cell-content-1-18">
       </slot>
     </th>
     <th
       class="cell header-cell last-column-cell last-header-row-cell"
-      id="vaadin-grid-cell-2"
       last-column=""
-      part="cell header-cell last-column-cell last-header-row-cell"
+      part="cell header-cell last-header-row-cell last-column-cell"
       role="columnheader"
       style="width: 100px; flex-grow: 1;"
       tabindex="-1"
     >
-      <slot name="vaadin-grid-cell-content-2">
+      <slot name="vaadin-grid-header-cell-content-1-19">
       </slot>
     </th>
   </tr>
@@ -1771,25 +1736,23 @@ snapshots["vaadin-grid column groups with footer"] =
     <td
       class="cell first-column-cell first-footer-row-cell footer-cell"
       first-column=""
-      id="vaadin-grid-cell-3"
-      part="cell footer-cell first-column-cell first-footer-row-cell"
+      part="cell footer-cell first-footer-row-cell first-column-cell"
       role="gridcell"
       style="width: 100px; flex-grow: 1;"
       tabindex="0"
     >
-      <slot name="vaadin-grid-cell-content-3">
+      <slot name="vaadin-grid-footer-cell-content-0-21">
       </slot>
     </td>
     <td
       class="cell first-footer-row-cell footer-cell last-column-cell"
-      id="vaadin-grid-cell-4"
       last-column=""
-      part="cell footer-cell last-column-cell first-footer-row-cell"
+      part="cell footer-cell first-footer-row-cell last-column-cell"
       role="gridcell"
       style="width: 100px; flex-grow: 1;"
       tabindex="-1"
     >
-      <slot name="vaadin-grid-cell-content-4">
+      <slot name="vaadin-grid-footer-cell-content-0-22">
       </slot>
     </td>
   </tr>
@@ -1805,14 +1768,13 @@ snapshots["vaadin-grid column groups with footer"] =
       class="cell first-column-cell footer-cell last-column-cell last-footer-row-cell"
       colspan="2"
       first-column=""
-      id="vaadin-grid-cell-5"
       last-column=""
       part="cell footer-cell first-column-cell last-column-cell last-footer-row-cell"
       role="gridcell"
       style="width: calc(200px); flex-grow: 2;"
       tabindex="-1"
     >
-      <slot name="vaadin-grid-cell-content-5">
+      <slot name="vaadin-grid-footer-cell-content-1-20">
       </slot>
     </td>
   </tr>

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -1600,7 +1600,7 @@ snapshots["vaadin-grid column groups default"] =
           style="width: 100px; flex-grow: 1;"
           tabindex="0"
         >
-          <slot name="vaadin-grid-footer-cell-content-0-15">
+          <slot name="vaadin-grid-footer-cell-content-1-15">
           </slot>
         </td>
         <td
@@ -1611,7 +1611,7 @@ snapshots["vaadin-grid column groups default"] =
           style="width: 100px; flex-grow: 1;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-footer-cell-content-0-16">
+          <slot name="vaadin-grid-footer-cell-content-1-16">
           </slot>
         </td>
       </tr>
@@ -1634,7 +1634,7 @@ snapshots["vaadin-grid column groups default"] =
           style="width: calc(200px); flex-grow: 2;"
           tabindex="-1"
         >
-          <slot name="vaadin-grid-footer-cell-content-1-14">
+          <slot name="vaadin-grid-footer-cell-content-0-14">
           </slot>
         </td>
       </tr>
@@ -1741,7 +1741,7 @@ snapshots["vaadin-grid column groups with footer"] =
       style="width: 100px; flex-grow: 1;"
       tabindex="0"
     >
-      <slot name="vaadin-grid-footer-cell-content-0-21">
+      <slot name="vaadin-grid-footer-cell-content-1-21">
       </slot>
     </td>
     <td
@@ -1752,7 +1752,7 @@ snapshots["vaadin-grid column groups with footer"] =
       style="width: 100px; flex-grow: 1;"
       tabindex="-1"
     >
-      <slot name="vaadin-grid-footer-cell-content-0-22">
+      <slot name="vaadin-grid-footer-cell-content-1-22">
       </slot>
     </td>
   </tr>
@@ -1774,7 +1774,7 @@ snapshots["vaadin-grid column groups with footer"] =
       style="width: calc(200px); flex-grow: 2;"
       tabindex="-1"
     >
-      <slot name="vaadin-grid-footer-cell-content-1-20">
+      <slot name="vaadin-grid-footer-cell-content-0-20">
       </slot>
     </td>
   </tr>

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -15,13 +15,8 @@ export const flushGrid = (grid) => {
     grid._debouncerHiddenChanged,
     grid._debouncerApplyCachedData,
     grid.__debounceUpdateFrozenColumn,
+    grid.__renderHeaderFooterDebouncer,
   ].forEach((debouncer) => debouncer?.flush());
-
-  [...grid.$.header.children, ...grid.$.footer.children].forEach((row) => {
-    if (row.__debounceUpdateHeaderFooterRowVisibility) {
-      row.__debounceUpdateHeaderFooterRowVisibility.flush();
-    }
-  });
 
   grid.__virtualizer.flush();
   grid.__preventScrollerRotatingCellFocusDebouncer?.flush();

--- a/packages/grid/test/keyboard-navigation-cell-button.test.js
+++ b/packages/grid/test/keyboard-navigation-cell-button.test.js
@@ -98,6 +98,6 @@ describe('keyboard navigation - focus button mode', () => {
 
   it('should not create a focusable div with role="button" inside the header cell', () => {
     const headerCell = getHeaderCell(grid, 0);
-    expect(headerCell.firstChild.localName).to.equal('slot');
+    expect(headerCell.firstElementChild.localName).to.equal('slot');
   });
 });


### PR DESCRIPTION
The grid currently builds its header and footer imperatively: rows and cells are created and removed by hand, row visibility is updated through per-row debouncers, and column reordering moves cells around in the DOM. This makes the rendering logic hard to follow and easy to get out of sync with the column tree.

This PR takes the first step in moving the header and footer rendering to declarative Lit templates: it covers the initial rendering of their rows and cells, reordering, visibility changes, and resize handles. Dynamic parts, classes, and various other cell and row state are still applied imperatively on top of the rendered DOM. They will be gradually moved into the templates in future PRs.

**Non-obvious changes**

- Cells are keyed by a new stable per-column id (`column._id`), and cells of hidden columns are kept alive with the `cache` directive, so cells and their content are reused when columns are reordered, hidden, or shown.
- However, cells are not reused when a column moves to a different row level, for example when adding a header row wraps columns in a `vaadin-grid-column-group`. The cell and its content element are then recreated, and the column's header or footer renderer runs again to fill the new content element. Renderers now need to handle running multiple times; previously the cell element was moved between rows, so its content survived such changes without a re-render: https://github.com/vaadin/flow-components/pull/9757/
- Header and footer row visibility is now computed as part of rendering, replacing the per-row `__updateHeaderFooterRowVisibility` debouncers. Column property changes that affect the header or footer now schedule a single render of both sections, debounced on a microtask. This also changes the timing of `resizable`: the resize handle used to be added or removed synchronously, now it appears after the microtask.
- Header and footer cell content slot names now include the section, row level, and column id (e.g. `vaadin-grid-header-cell-content-0-1`) so they stay stable across re-renders. Body cell slot names keep the old format, but their numbering shifts because header and footer cells no longer share the same counter.
- `vaadin-grid-sorter` is now appended to the cell content only after its direction is set. With declarative rendering, the content element is already connected when the default header renderer runs, and appending an unconfigured sorter would reset the column's sort direction.
- Empty footer rows are now hidden synchronously during rendering. This exposed an existing virtualizer issue in `allRowsVisible` mode where the scroller height update could be skipped, leaving the grid clipped after it grows. That issue was fixed separately in https://github.com/vaadin/web-components/pull/12146

**Depends on**
- https://github.com/vaadin/web-components/pull/12146
- https://github.com/vaadin/web-components/pull/12178
- https://github.com/vaadin/web-components/pull/12181
- https://github.com/vaadin/web-components/pull/12179
- https://github.com/vaadin/flow-components/pull/9757

Part of https://github.com/vaadin/web-components/issues/10789
