### PR TITLE
fix: keep draggable grid cells announced by screen readers

### DIFF
--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -597,12 +597,7 @@ export const gridStyles = css`
     outline-offset: calc(var(--vaadin-grid-border-width, 1px) * -1);
   }
 
-  /*
-   * Chromium a11y workaround: draggable cell content is marked with the
-   * draggable-source attribute instead of the draggable attribute, which would
-   * empty the cell's accessible name. These are the styles that draggable would
-   * apply. See _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js.
-   */
+  /* Styles applied to draggable cell content; see _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js. */
   ::slotted(vaadin-grid-cell-content[draggable-source]) {
     -webkit-user-drag: element;
     -webkit-user-select: none;

--- a/packages/grid/src/styles/vaadin-grid-base-styles.js
+++ b/packages/grid/src/styles/vaadin-grid-base-styles.js
@@ -597,6 +597,18 @@ export const gridStyles = css`
     outline-offset: calc(var(--vaadin-grid-border-width, 1px) * -1);
   }
 
+  /*
+   * Chromium a11y workaround: draggable cell content is marked with the
+   * draggable-source attribute instead of the draggable attribute, which would
+   * empty the cell's accessible name. These are the styles that draggable would
+   * apply. See _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js.
+   */
+  ::slotted(vaadin-grid-cell-content[draggable-source]) {
+    -webkit-user-drag: element;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   .row[dragover] {
     z-index: 100 !important;
   }

--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -481,11 +481,23 @@ export const DragAndDropMixin = (superClass) =>
       const dragDisabled = !this.rowsDraggable || loading || (this.dragFilter && !this.dragFilter(model));
       const dropDisabled = !this.dropMode || loading || (this.dropFilter && !this.dropFilter(model));
 
+      // Chromium computes an empty accessible name for cells whose content
+      // element has the `draggable` attribute when the accessibility tree is
+      // built (https://issues.chromium.org/issues/534049472,
+      // https://github.com/vaadin/web-components/issues/11726). Blink maps
+      // `draggable="true"` to the `-webkit-user-drag: element` and
+      // `user-select: none` styles, and the accessible-name bug is keyed to the
+      // attribute, not the styles. So on Chromium, mark the draggable cell
+      // content with the `draggable-source` attribute, which applies the
+      // equivalent styles from the grid styles, instead of the `draggable`
+      // attribute. This can be removed once the Chromium issue is fixed.
+      const draggableAttribute = isChrome ? 'draggable-source' : 'draggable';
+
       iterateRowCells(row, (cell) => {
         if (dragDisabled) {
-          cell._content.removeAttribute('draggable');
+          cell._content.removeAttribute(draggableAttribute);
         } else {
-          cell._content.setAttribute('draggable', true);
+          cell._content.setAttribute(draggableAttribute, true);
         }
       });
 

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -3,7 +3,15 @@ import { aTimeout, fixtureSync, keyDownOn, nextFrame, nextResize, oneEvent } fro
 import Sinon from 'sinon';
 import './grid-test-styles.js';
 import '../all-imports.js';
-import { dragAndDropOver, dragStart, fire, flushGrid, getCellContent, getHeaderCellContent } from './helpers.js';
+import {
+  cellDraggableAttribute,
+  dragAndDropOver,
+  dragStart,
+  fire,
+  flushGrid,
+  getCellContent,
+  getHeaderCellContent,
+} from './helpers.js';
 
 ['ltr', 'rtl'].forEach((dir) => {
   describe(`lazy column rendering - ${dir}`, () => {
@@ -411,12 +419,12 @@ import { dragAndDropOver, dragStart, fire, flushGrid, getCellContent, getHeaderC
         grid.rowsDraggable = true;
         await nextFrame();
 
-        expect(getBodyCellContent(getLastVisibleColumnIndex()).getAttribute('draggable')).to.equal('true');
+        expect(getBodyCellContent(getLastVisibleColumnIndex()).getAttribute(cellDraggableAttribute)).to.equal('true');
 
         // Scroll back to the beginning
         await scrollHorizontally(-grid.$.table.scrollWidth);
         // Expect the cell that was previously not visible to have the draggable attribute
-        expect(getBodyCellContent(0).getAttribute('draggable')).to.equal('true');
+        expect(getBodyCellContent(0).getAttribute(cellDraggableAttribute)).to.equal('true');
       });
 
       it('should not create excess cells for a row', async () => {

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -156,15 +156,8 @@ describe('drag and drop', () => {
       expect(getDraggable(grid)).not.to.be.ok;
     });
 
-    // Regression tests for https://github.com/vaadin/web-components/issues/11726:
-    // the `draggable` attribute empties a cell's accessible name on Chromium, so
-    // there the grid marks draggable content with `draggable-source` (+ the
-    // styles `draggable` would apply) instead. The accessible name itself can't
-    // be computed in the test environment, so these assert the mechanism that
-    // preserves it: no `draggable` attribute, plus the equivalent user-drag and
-    // user-select styles. The native drag source (the content element) is
-    // unchanged.
-    describe('accessible name workaround (#11726)', () => {
+    // See https://github.com/vaadin/web-components/issues/11726
+    describe('accessible name workaround', () => {
       const getContent = (row = 0) => getBodyCellContent(grid, row, 0);
 
       (isChrome ? it : it.skip)('should not set the draggable attribute on Chromium', () => {

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -4,7 +4,9 @@ import { aTimeout, fixtureSync, listenOnce, nextFrame, nextResize } from '@vaadi
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
+import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
 import {
+  cellDraggableAttribute,
   dragAndDropOver,
   flushGrid,
   getBodyCellContent,
@@ -25,7 +27,7 @@ describe('drag and drop', () => {
   const getDraggable = (grid, rowIndex = 0) => {
     const row = Array.from(grid.$.items.children).find((row) => row.index === rowIndex);
     const cellContent = row.querySelector('slot').assignedNodes()[0];
-    return [row, cellContent].find((node) => node.getAttribute('draggable') === 'true');
+    return [row, cellContent].find((node) => node.getAttribute(cellDraggableAttribute) === 'true');
   };
 
   const fireDragStart = (draggable = getDraggable(grid)) => {
@@ -152,6 +154,46 @@ describe('drag and drop', () => {
     it('should not be draggable', () => {
       grid.rowsDraggable = false;
       expect(getDraggable(grid)).not.to.be.ok;
+    });
+
+    // Regression tests for https://github.com/vaadin/web-components/issues/11726:
+    // the `draggable` attribute empties a cell's accessible name on Chromium, so
+    // there the grid marks draggable content with `draggable-source` (+ the
+    // styles `draggable` would apply) instead. The accessible name itself can't
+    // be computed in the test environment, so these assert the mechanism that
+    // preserves it: no `draggable` attribute, plus the equivalent user-drag and
+    // user-select styles. The native drag source (the content element) is
+    // unchanged.
+    describe('accessible name workaround (#11726)', () => {
+      const getContent = (row = 0) => getBodyCellContent(grid, row, 0);
+
+      (isChrome ? it : it.skip)('should not set the draggable attribute on Chromium', () => {
+        expect(getContent().hasAttribute('draggable')).to.be.false;
+      });
+
+      (isChrome ? it : it.skip)('should mark draggable content with draggable-source styles on Chromium', () => {
+        expect(getContent().getAttribute('draggable-source')).to.equal('true');
+        const style = getComputedStyle(getContent());
+        expect(style.webkitUserDrag).to.equal('element');
+        expect(style.userSelect).to.equal('none');
+      });
+
+      (isChrome ? it.skip : it)('should set the draggable attribute on other browsers', () => {
+        expect(getContent().getAttribute('draggable')).to.equal('true');
+      });
+
+      it('should unset the drag marker when rowsDraggable is disabled', () => {
+        grid.rowsDraggable = false;
+        flushGrid(grid);
+        expect(getContent().hasAttribute(cellDraggableAttribute)).to.be.false;
+      });
+
+      it('should not set the drag marker on rows excluded by dragFilter', () => {
+        grid.dragFilter = (model) => model.index !== 0;
+        flushGrid(grid);
+        expect(getContent(0).hasAttribute(cellDraggableAttribute)).to.be.false;
+        expect(getContent(1).getAttribute(cellDraggableAttribute)).to.equal('true');
+      });
     });
 
     describe('dragstart', () => {

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -1,10 +1,7 @@
 import sinon from 'sinon';
 import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
 
-// The grid marks draggable cell content with `draggable-source` on Chromium
-// instead of `draggable` to avoid an accessible-name bug (see _filterDragAndDrop
-// in vaadin-grid-drag-and-drop-mixin.js). Tests must query the attribute that is
-// actually used on the current browser.
+// Draggable cell content uses a browser-specific attribute; see _filterDragAndDrop.
 export const cellDraggableAttribute = isChrome ? 'draggable-source' : 'draggable';
 
 export const flushGrid = (grid) => {

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -1,4 +1,11 @@
 import sinon from 'sinon';
+import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
+
+// The grid marks draggable cell content with `draggable-source` on Chromium
+// instead of `draggable` to avoid an accessible-name bug (see _filterDragAndDrop
+// in vaadin-grid-drag-and-drop-mixin.js). Tests must query the attribute that is
+// actually used on the current browser.
+export const cellDraggableAttribute = isChrome ? 'draggable-source' : 'draggable';
 
 export const flushGrid = (grid) => {
   grid.performUpdate?.();

--- a/packages/vaadin-lumo-styles/src/components/grid.css
+++ b/packages/vaadin-lumo-styles/src/components/grid.css
@@ -415,6 +415,14 @@
   }
 
   /* Drag and Drop styles */
+
+  /* Draggable cell content; see _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js. */
+  ::slotted(vaadin-grid-cell-content[draggable-source]) {
+    -webkit-user-drag: element;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   :host([dragover])::after {
     content: '';
     position: absolute;


### PR DESCRIPTION
When a `vaadin-grid` has `rowsDraggable` enabled, screen reader users on
Chromium (Chrome and Edge) stop hearing the cell value while navigating rows —
only the row and column position is announced. Chromium computes an empty
accessible name for a `gridcell` whose content element has the `draggable`
attribute at the time the accessibility tree is built
(https://issues.chromium.org/issues/534049472). This hits the main case from
the report: NVDA on Windows in Chrome/Edge.

Enable `rowsDraggable` before the grid first renders and navigate the cells
with a screen reader: the value is not announced. It reproduces without
Vaadin — a `role="gridcell"` holding a `<span draggable="true">` is enough.

Chromium maps `draggable="true"` to the `-webkit-user-drag: element` and
`user-select: none` styles, and the bug is keyed to the attribute, not the
styles. On Chromium the grid now marks draggable cell content with a
`draggable-source` attribute that applies those styles from the grid styles,
instead of the `draggable` attribute. The drag source element is unchanged, so
native row dragging still works from the cell content. Firefox and Safari keep
the `draggable` attribute — they don't have the bug. The marker is named
`draggable-source` to avoid clashing with the existing `drag-source` row state.

#### NVDA + Edge
```
table
First name  column header  row 1  column 1
Ada 1 Lovelace Mathematician Priority Edit Ada 1  not selected  2 of 14
```
<img width="804" height="186" alt="image" src="https://github.com/user-attachments/assets/e3cddc45-da55-4491-8cc2-3bc50f58b923" />

Fixes #11726

---

🤖 Generated with Claude Code
