### PR TITLE
refactor: centralize grid cell event handlers

### DIFF
--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -158,6 +158,15 @@ export const GridMixin = (superClass) =>
       return lastVisibleItem ? lastVisibleItem.index : undefined;
     }
 
+    constructor() {
+      super();
+
+      this.__onCellMouseEnter = this.__onCellMouseEnter.bind(this);
+      this.__onCellMouseLeave = this.__onCellMouseLeave.bind(this);
+      this.__onCellMouseDown = this.__onCellMouseDown.bind(this);
+      this.__onCellKeyDown = this.__onCellKeyDown.bind(this);
+    }
+
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
@@ -352,6 +361,36 @@ export const GridMixin = (superClass) =>
     }
 
     /** @private */
+    __onCellKeyDown(event) {
+      const cell = event.currentTarget;
+      cell._column?.__onCellKeyDown?.(event);
+    }
+
+    /** @private */
+    __onCellMouseEnter(event) {
+      // For now we only support tooltip on desktop
+      if (!isAndroid && !isIOS && !this.$.scroller.hasAttribute('scrolling')) {
+        this._showTooltip(event);
+      }
+    }
+
+    /** @private */
+    __onCellMouseLeave() {
+      // For now we only support tooltip on desktop
+      if (!isAndroid && !isIOS) {
+        this._hideTooltip();
+      }
+    }
+
+    /** @private */
+    __onCellMouseDown() {
+      // For now we only support tooltip on desktop
+      if (!isAndroid && !isIOS) {
+        this._hideTooltip(true);
+      }
+    }
+
+    /** @private */
     _createCell(tagName, column) {
       const contentId = (this._contentIndex = this._contentIndex + 1 || 0);
       const slotName = `vaadin-grid-cell-content-${contentId}`;
@@ -363,22 +402,10 @@ export const GridMixin = (superClass) =>
       cell.id = slotName.replace('-content-', '-');
       cell.setAttribute('role', tagName === 'td' ? 'gridcell' : 'columnheader');
 
-      // For now we only support tooltip on desktop
-      if (!isAndroid && !isIOS) {
-        cell.addEventListener('mouseenter', (event) => {
-          if (!this.$.scroller.hasAttribute('scrolling')) {
-            this._showTooltip(event);
-          }
-        });
-
-        cell.addEventListener('mouseleave', () => {
-          this._hideTooltip();
-        });
-
-        cell.addEventListener('mousedown', () => {
-          this._hideTooltip(true);
-        });
-      }
+      cell.addEventListener('mouseenter', this.__onCellMouseEnter);
+      cell.addEventListener('mouseleave', this.__onCellMouseLeave);
+      cell.addEventListener('mousedown', this.__onCellMouseDown);
+      cell.addEventListener('keydown', this.__onCellKeyDown);
 
       const slot = document.createElement('slot');
       slot.setAttribute('name', slotName);
@@ -441,9 +468,6 @@ export const GridMixin = (superClass) =>
             cell = column._cells.find((cell) => cell._vacant);
             if (!cell) {
               cell = this._createCell('td', column);
-              if (column._onCellKeyDown) {
-                cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
-              }
               column._cells.push(cell);
             }
             updatePart(cell, 'cell', true);
@@ -492,9 +516,6 @@ export const GridMixin = (superClass) =>
               cell = column[`_${section}Cell`];
               if (!cell) {
                 cell = this._createCell(tagName);
-                if (column._onCellKeyDown) {
-                  cell.addEventListener('keydown', column._onCellKeyDown.bind(column));
-                }
               }
               cell._column = column;
               row.appendChild(cell);

--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -338,7 +338,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _onCellKeyDown(e) {
+    __onCellKeyDown(e) {
       const target = e.composedPath()[0];
       // Toggle on Space without having to enter interaction mode first
       if (e.keyCode !== 32) {


### PR DESCRIPTION
The grid attaches cell event listeners in different places and in different ways: the tooltip mouse listeners are created as new closures for every cell in `_createCell`, while the `keydown` listener is bound per column and attached in two separate places in `__initRow`, but only for columns that define `_onCellKeyDown`.

This moves all cell event handling to the grid itself:

- The grid gets shared bound methods (`__onCellMouseEnter`, `__onCellMouseLeave`, `__onCellMouseDown`, `__onCellKeyDown`) that are attached once per cell in `_createCell`.
- On `keydown`, the cell delegates to its column through `column.__onCellKeyDown`, so the per-column listener setup in `__initRow` is no longer needed. The selection column's `_onCellKeyDown` is renamed to `__onCellKeyDown` to match.
- Cells without a column (the row details cell) skip the delegation, so behavior stays the same.

This also prepares for rendering header and footer rows declaratively with Lit, where the same handler references can be used directly in the template.

Extracted from https://github.com/vaadin/web-components/pull/12134

Part of https://github.com/vaadin/web-components/issues/10789
