### PR TITLE
refactor: clarify handler names in grid selection column

### DIFF
--- a/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
+++ b/packages/grid/src/vaadin-grid-selection-column-base-mixin.js
@@ -107,12 +107,12 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
 
     constructor() {
       super();
-      this.__onCellTrack = this.__onCellTrack.bind(this);
-      this.__onCellClick = this.__onCellClick.bind(this);
-      this.__onCellMouseDown = this.__onCellMouseDown.bind(this);
+      this.__onCellContentTrack = this.__onCellContentTrack.bind(this);
+      this.__onCellContentClick = this.__onCellContentClick.bind(this);
+      this.__onCellContentMouseDown = this.__onCellContentMouseDown.bind(this);
       this.__onGridInteraction = this.__onGridInteraction.bind(this);
-      this.__onActiveItemChanged = this.__onActiveItemChanged.bind(this);
-      this.__onTouchStart = this.__onTouchStart.bind(this);
+      this.__onGridActiveItemChanged = this.__onGridActiveItemChanged.bind(this);
+      this.__onGridTouchStart = this.__onGridTouchStart.bind(this);
       this.__onSelectRowCheckboxChange = this.__onSelectRowCheckboxChange.bind(this);
       this.__onSelectAllCheckboxChange = this.__onSelectAllCheckboxChange.bind(this);
     }
@@ -124,8 +124,8 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         this._grid.addEventListener('keyup', this.__onGridInteraction);
         this._grid.addEventListener('keydown', this.__onGridInteraction, { capture: true });
         this._grid.addEventListener('mousedown', this.__onGridInteraction);
-        this._grid.addEventListener('active-item-changed', this.__onActiveItemChanged);
-        this._grid.addEventListener('touchstart', this.__onTouchStart);
+        this._grid.addEventListener('active-item-changed', this.__onGridActiveItemChanged);
+        this._grid.addEventListener('touchstart', this.__onGridTouchStart);
       }
     }
 
@@ -136,8 +136,8 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         this._grid.removeEventListener('keyup', this.__onGridInteraction);
         this._grid.removeEventListener('keydown', this.__onGridInteraction, { capture: true });
         this._grid.removeEventListener('mousedown', this.__onGridInteraction);
-        this._grid.removeEventListener('active-item-changed', this.__onActiveItemChanged);
-        this._grid.removeEventListener('touchstart', this.__onTouchStart);
+        this._grid.removeEventListener('active-item-changed', this.__onGridActiveItemChanged);
+        this._grid.removeEventListener('touchstart', this.__onGridTouchStart);
       }
     }
 
@@ -190,10 +190,10 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
         checkbox = document.createElement('vaadin-checkbox');
         checkbox.addEventListener('change', this.__onSelectRowCheckboxChange);
         root.appendChild(checkbox);
-        addListener(root, 'track', this.__onCellTrack);
+        addListener(root, 'track', this.__onCellContentTrack);
         setTouchAction(root, 'pinch-zoom');
-        root.addEventListener('mousedown', this.__onCellMouseDown);
-        root.addEventListener('click', this.__onCellClick);
+        root.addEventListener('mousedown', this.__onCellContentMouseDown);
+        root.addEventListener('click', this.__onCellContentClick);
       }
 
       this.__updateSelectRowAccessibleName(checkbox, root);
@@ -270,7 +270,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    __onCellTrack(event) {
+    __onCellContentTrack(event) {
       if (!this.dragSelect) {
         return;
       }
@@ -306,7 +306,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    __onCellMouseDown(e) {
+    __onCellContentMouseDown(e) {
       if (this.dragSelect) {
         // Prevent text selection when starting to drag
         e.preventDefault();
@@ -314,7 +314,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    __onTouchStart(e) {
+    __onGridTouchStart(e) {
       if (e.touches.length > 1) {
         this.__multiTouchActive = true;
         // Cancel in-progress drag-select on multi-touch (e.g. pinch-zoom)
@@ -326,7 +326,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    __onCellClick(e) {
+    __onCellContentClick(e) {
       if (this.__dragStartIndex !== undefined) {
         // Stop the click event if drag was enabled. This click event should
         // only occur if drag started and stopped on the same item. In that case
@@ -357,7 +357,7 @@ export const GridSelectionColumnBaseMixin = (superClass) =>
     }
 
     /** @private */
-    __onActiveItemChanged(e) {
+    __onGridActiveItemChanged(e) {
       const activeItem = e.detail.value;
       if (this.autoSelect) {
         const item = activeItem || this.__previousActiveItem;


### PR DESCRIPTION
The selection column has private event handlers attached to two different elements: some listen on the cell content root (the checkbox wrapper), others on the grid. The current names don't tell which element each handler is bound to. The PR renames the handlers after the element they listen on, e.g. `__onCellTrack` becomes `__onCellContentTrack`.

Part of https://github.com/vaadin/web-components/issues/10789