### PR TITLE
test: use Math.ceil for focus index calculation

### DIFF
--- a/packages/combo-box/test/focus-index.test.js
+++ b/packages/combo-box/test/focus-index.test.js
@@ -205,7 +205,7 @@ describe('__focusIndex', () => {
 
       const firstVisible = comboBox._scroller.__virtualizer.firstVisibleIndex;
       const lastVisible = comboBox._scroller.__virtualizer.lastVisibleIndex;
-      const targetIndex = firstVisible + Math.floor((lastVisible - firstVisible) / 2);
+      const targetIndex = firstVisible + Math.ceil((lastVisible - firstVisible) / 2);
 
       comboBox.__focusIndex(targetIndex);
       flushComboBox(comboBox);


### PR DESCRIPTION
Fix the target index calculation in focus-index tests to use `Math.ceil` instead of `Math.floor`, ensuring the middle item selection rounds up rather than down.

🤖 Fixed with Codex