### PR TITLE
fix: use duration in addition to animation-name to detect overlay animations

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -407,8 +407,12 @@ export const OverlayMixin = (superClass) =>
     _shouldAnimate() {
       const style = getComputedStyle(this);
       const name = style.getPropertyValue('animation-name');
+      const hasDuration = style
+        .getPropertyValue('animation-duration')
+        .split(',')
+        .some((duration) => parseFloat(duration) > 0);
       const hidden = style.getPropertyValue('display') === 'none';
-      return !hidden && name && name !== 'none';
+      return !hidden && name && name !== 'none' && hasDuration;
     }
 
     /**

--- a/packages/overlay/test/animated-styles.js
+++ b/packages/overlay/test/animated-styles.js
@@ -3,6 +3,11 @@ import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themab
 registerStyles(
   'vaadin-overlay',
   css`
+    :host([zero-duration-animation]) {
+      animation-name: overlay-dummy-animation;
+      animation-duration: 0s;
+    }
+
     :host([animate][opening]),
     :host([animate][closing]) {
       animation: 50ms overlay-dummy-animation;

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -129,21 +129,18 @@ describe('overlay with zero-duration animation', () => {
     const finishClosing = sinon.spy(overlay, '_finishClosing');
 
     expect(getComputedStyle(overlay).animationName).to.equal('overlay-dummy-animation');
-    expect(overlay._shouldAnimate()).to.be.false;
 
     overlay.opened = true;
 
     expect(finishOpening).to.be.calledOnce;
     expect(overlay.hasAttribute('opening')).to.be.false;
     expect(owner.hasAttribute('opening')).to.be.false;
-    expect(overlay.__openingHandler).to.be.undefined;
 
     overlay.opened = false;
 
     expect(finishClosing).to.be.calledOnce;
     expect(overlay.hasAttribute('closing')).to.be.false;
     expect(owner.hasAttribute('closing')).to.be.false;
-    expect(overlay.__closingHandler).to.be.undefined;
   });
 });
 

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './animated-styles.js';
 import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
@@ -106,6 +107,45 @@ function afterOverlayClosingFinished(overlay, callback) {
   });
   observer.observe(overlay, { attributes: true, attributeFilter: ['closing'] });
 }
+
+describe('overlay with zero-duration animation', () => {
+  let overlay, owner;
+
+  beforeEach(async () => {
+    overlay = createOverlay('overlay content');
+    owner = fixtureSync('<div></div>');
+    overlay.owner = owner;
+    overlay.setAttribute('zero-duration-animation', '');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay.opened = false;
+    sinon.restore();
+  });
+
+  it('should finish opening and closing synchronously', () => {
+    const finishOpening = sinon.spy(overlay, '_finishOpening');
+    const finishClosing = sinon.spy(overlay, '_finishClosing');
+
+    expect(getComputedStyle(overlay).animationName).to.equal('overlay-dummy-animation');
+    expect(overlay._shouldAnimate()).to.be.false;
+
+    overlay.opened = true;
+
+    expect(finishOpening).to.be.calledOnce;
+    expect(overlay.hasAttribute('opening')).to.be.false;
+    expect(owner.hasAttribute('opening')).to.be.false;
+    expect(overlay.__openingHandler).to.be.undefined;
+
+    overlay.opened = false;
+
+    expect(finishClosing).to.be.calledOnce;
+    expect(overlay.hasAttribute('closing')).to.be.false;
+    expect(owner.hasAttribute('closing')).to.be.false;
+    expect(overlay.__closingHandler).to.be.undefined;
+  });
+});
 
 [false, true].forEach((withAnimation) => {
   const titleSuffix = withAnimation ? ' (animated)' : '';


### PR DESCRIPTION
Having an `animation-name` doesn't guarantee that an overlay will be animated. It also needs a non-zero duration.

Related to #12120, which introduces a constant `animation-name` for all overlays, with a `0s` duration by default.