### PR TITLE
fix: keep draggable grid cells announced by screen readers (CP: 24.10)

### DIFF
--- a/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
+++ b/packages/grid/src/vaadin-grid-drag-and-drop-mixin.js
@@ -484,11 +484,23 @@ export const DragAndDropMixin = (superClass) =>
       const dragDisabled = !this.rowsDraggable || loading || (this.dragFilter && !this.dragFilter(model));
       const dropDisabled = !this.dropMode || loading || (this.dropFilter && !this.dropFilter(model));
 
+      // Chromium computes an empty accessible name for cells whose content
+      // element has the `draggable` attribute when the accessibility tree is
+      // built (https://issues.chromium.org/issues/534049472,
+      // https://github.com/vaadin/web-components/issues/11726). Blink maps
+      // `draggable="true"` to the `-webkit-user-drag: element` and
+      // `user-select: none` styles, and the accessible-name bug is keyed to the
+      // attribute, not the styles. So on Chromium, mark the draggable cell
+      // content with the `draggable-source` attribute, which applies the
+      // equivalent styles from the grid styles, instead of the `draggable`
+      // attribute. This can be removed once the Chromium issue is fixed.
+      const draggableAttribute = isChrome ? 'draggable-source' : 'draggable';
+
       iterateRowCells(row, (cell) => {
         if (dragDisabled) {
-          cell._content.removeAttribute('draggable');
+          cell._content.removeAttribute(draggableAttribute);
         } else {
-          cell._content.setAttribute('draggable', true);
+          cell._content.setAttribute(draggableAttribute, true);
         }
       });
 

--- a/packages/grid/src/vaadin-grid-styles.js
+++ b/packages/grid/src/vaadin-grid-styles.js
@@ -244,6 +244,13 @@ export const gridStyles = css`
     user-select: none;
   }
 
+  /* Styles applied to draggable cell content; see _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js. */
+  ::slotted(vaadin-grid-cell-content[draggable-source]) {
+    -webkit-user-drag: element;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   /* Resizing styles */
   [part~='resize-handle'] {
     position: absolute;

--- a/packages/grid/test/column-rendering.test.js
+++ b/packages/grid/test/column-rendering.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, keyDownOn, nextFrame, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import Sinon from 'sinon';
 import '../all-imports.js';
-import { flushGrid, getCellContent, getHeaderCellContent } from './helpers.js';
+import { cellDraggableAttribute, flushGrid, getCellContent, getHeaderCellContent } from './helpers.js';
 
 ['ltr', 'rtl'].forEach((dir) => {
   describe(`lazy column rendering - ${dir}`, () => {
@@ -419,12 +419,12 @@ import { flushGrid, getCellContent, getHeaderCellContent } from './helpers.js';
         grid.rowsDraggable = true;
         await nextFrame();
 
-        expect(getBodyCellContent(getLastVisibleColumnIndex()).getAttribute('draggable')).to.equal('true');
+        expect(getBodyCellContent(getLastVisibleColumnIndex()).getAttribute(cellDraggableAttribute)).to.equal('true');
 
         // Scroll back to the beginning
         await scrollHorizontally(-grid.$.table.scrollWidth);
         // Expect the cell that was previously not visible to have the draggable attribute
-        expect(getBodyCellContent(0).getAttribute('draggable')).to.equal('true');
+        expect(getBodyCellContent(0).getAttribute(cellDraggableAttribute)).to.equal('true');
       });
 
       it('should not create excess cells for a row', async () => {

--- a/packages/grid/test/drag-and-drop.test.js
+++ b/packages/grid/test/drag-and-drop.test.js
@@ -4,7 +4,15 @@ import { aTimeout, fixtureSync, listenOnce, nextFrame, oneEvent } from '@vaadin/
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
-import { flushGrid, getBodyCellContent, getFirstCell, getRowBodyCells, getRows } from './helpers.js';
+import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
+import {
+  cellDraggableAttribute,
+  flushGrid,
+  getBodyCellContent,
+  getFirstCell,
+  getRowBodyCells,
+  getRows,
+} from './helpers.js';
 
 describe('drag and drop', () => {
   let grid, dragData;
@@ -17,7 +25,7 @@ describe('drag and drop', () => {
   const getDraggable = (grid, rowIndex = 0) => {
     const row = Array.from(grid.$.items.children).find((row) => row.index === rowIndex);
     const cellContent = row.querySelector('slot').assignedNodes()[0];
-    return [row, cellContent].find((node) => node.getAttribute('draggable') === 'true');
+    return [row, cellContent].find((node) => node.getAttribute(cellDraggableAttribute) === 'true');
   };
 
   const fireDragStart = (draggable = getDraggable(grid)) => {
@@ -144,6 +152,39 @@ describe('drag and drop', () => {
     it('should not be draggable', () => {
       grid.rowsDraggable = false;
       expect(getDraggable(grid)).not.to.be.ok;
+    });
+
+    // See https://github.com/vaadin/web-components/issues/11726
+    describe('accessible name workaround', () => {
+      const getContent = (row = 0) => getBodyCellContent(grid, row, 0);
+
+      (isChrome ? it : it.skip)('should not set the draggable attribute on Chromium', () => {
+        expect(getContent().hasAttribute('draggable')).to.be.false;
+      });
+
+      (isChrome ? it : it.skip)('should mark draggable content with draggable-source styles on Chromium', () => {
+        expect(getContent().getAttribute('draggable-source')).to.equal('true');
+        const style = getComputedStyle(getContent());
+        expect(style.webkitUserDrag).to.equal('element');
+        expect(style.userSelect).to.equal('none');
+      });
+
+      (isChrome ? it.skip : it)('should set the draggable attribute on other browsers', () => {
+        expect(getContent().getAttribute('draggable')).to.equal('true');
+      });
+
+      it('should unset the drag marker when rowsDraggable is disabled', () => {
+        grid.rowsDraggable = false;
+        flushGrid(grid);
+        expect(getContent().hasAttribute(cellDraggableAttribute)).to.be.false;
+      });
+
+      it('should not set the drag marker on rows excluded by dragFilter', () => {
+        grid.dragFilter = (model) => model.index !== 0;
+        flushGrid(grid);
+        expect(getContent(0).hasAttribute(cellDraggableAttribute)).to.be.false;
+        expect(getContent(1).getAttribute(cellDraggableAttribute)).to.equal('true');
+      });
     });
 
     describe('dragstart', () => {

--- a/packages/grid/test/helpers.js
+++ b/packages/grid/test/helpers.js
@@ -1,4 +1,8 @@
 import sinon from 'sinon';
+import { isChrome } from '@vaadin/component-base/src/browser-utils.js';
+
+// Draggable cell content uses a browser-specific attribute; see _filterDragAndDrop.
+export const cellDraggableAttribute = isChrome ? 'draggable-source' : 'draggable';
 
 export const flushGrid = (grid) => {
   grid._observer.flush();

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -97,7 +97,6 @@ registerStyles(
     }
 
     /* Drag and Drop styles */
-
     :host([dragover])::after {
       content: '';
       position: absolute;

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -97,6 +97,14 @@ registerStyles(
     }
 
     /* Drag and Drop styles */
+
+    /* Draggable cell content; see _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js. */
+    ::slotted(vaadin-grid-cell-content[draggable-source]) {
+      -webkit-user-drag: element;
+      -webkit-user-select: none;
+      user-select: none;
+    }
+
     :host([dragover])::after {
       content: '';
       position: absolute;

--- a/packages/grid/theme/lumo/vaadin-grid-styles.js
+++ b/packages/grid/theme/lumo/vaadin-grid-styles.js
@@ -98,13 +98,6 @@ registerStyles(
 
     /* Drag and Drop styles */
 
-    /* Draggable cell content; see _filterDragAndDrop in vaadin-grid-drag-and-drop-mixin.js. */
-    ::slotted(vaadin-grid-cell-content[draggable-source]) {
-      -webkit-user-drag: element;
-      -webkit-user-select: none;
-      user-select: none;
-    }
-
     :host([dragover])::after {
       content: '';
       position: absolute;


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12135 to branch 24.10.

---

> When a `vaadin-grid` has `rowsDraggable` enabled, screen reader users on
> Chromium (Chrome and Edge) stop hearing the cell value while navigating rows —
> only the row and column position is announced. Chromium computes an empty
> accessible name for a `gridcell` whose content element has the `draggable`
> attribute at the time the accessibility tree is built
> (https://issues.chromium.org/issues/534049472). This hits the main case from
> the report: NVDA on Windows in Chrome/Edge.
>
> Enable `rowsDraggable` before the grid first renders and navigate the cells
> with a screen reader: the value is not announced. It reproduces without
> Vaadin — a `role="gridcell"` holding a `<span draggable="true">` is enough.
>
> Chromium maps `draggable="true"` to the `-webkit-user-drag: element` and
> `user-select: none` styles, and the bug is keyed to the attribute, not the
> styles. On Chromium the grid now marks draggable cell content with a
> `draggable-source` attribute that applies those styles from the grid styles,
> instead of the `draggable` attribute. The drag source element is unchanged, so
> native row dragging still works from the cell content. Firefox and Safari keep
> the `draggable` attribute — they don't have the bug. The marker is named
> `draggable-source` to avoid clashing with the existing `drag-source` row state.
>
> #### NVDA + Edge
> ```
> table
> First name  column header  row 1  column 1
> Ada 1 Lovelace Mathematician Priority Edit Ada 1  not selected  2 of 14
> ```
> <img width="804" height="186" alt="image" src="https://github.com/user-attachments/assets/e3cddc45-da55-4491-8cc2-3bc50f58b923" />
>
> Fixes #11726
>
> ---
>
> 🤖 Generated with Claude Code
