### PR TITLE
fix: render all rows on deep expand with all-rows-visible

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -201,11 +201,6 @@ export class IronListAdapter {
     }
   }
 
-  /** @override */
-  _updateScrollerSize(forceUpdate) {
-    super._updateScrollerSize(forceUpdate || !!this.__alwaysUpdateScrollerSize?.());
-  }
-
   hostConnected() {
     // Restore scroll position, which is reset when host is removed from DOM,
     // since virtualizer doesn't re-render when adding it to the DOM again.
@@ -226,6 +221,11 @@ export class IronListAdapter {
     });
 
     this.__afterElementsUpdated(updatedElements);
+  }
+
+  /** @override */
+  _updateScrollerSize(forceUpdate) {
+    super._updateScrollerSize(forceUpdate || !!this.__alwaysUpdateScrollerSize?.());
   }
 
   /**

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -22,6 +22,7 @@ export class IronListAdapter {
     reorderElements,
     elementsContainer,
     __disableHeightPlaceholder,
+    __alwaysUpdateScrollerSize,
   }) {
     this.isAttached = true;
     this._vidxOffset = 0;
@@ -36,6 +37,12 @@ export class IronListAdapter {
     // (see __afterElementsUpdated) for components that always render virtual
     // elements with a non-zero height. Not for public use.
     this.__disableHeightPlaceholder = __disableHeightPlaceholder ?? false;
+
+    // Internal option: a predicate that, when it returns true, makes the scroller
+    // height always be applied instead of amortized (see `_updateScrollerSize`).
+    // Used by components whose height tracks the content exactly (e.g. the grid's
+    // `allRowsVisible` mode). Not for public use.
+    this.__alwaysUpdateScrollerSize = __alwaysUpdateScrollerSize;
 
     // Iron-list uses this value to determine how many pages of elements to render
     this._maxPages = 1.3;
@@ -192,6 +199,11 @@ export class IronListAdapter {
     if (this.__debouncerWheelAnimationFrame) {
       this.__debouncerWheelAnimationFrame.flush();
     }
+  }
+
+  /** @override */
+  _updateScrollerSize(forceUpdate) {
+    super._updateScrollerSize(forceUpdate || !!this.__alwaysUpdateScrollerSize?.());
   }
 
   hostConnected() {

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -235,17 +235,14 @@ export const GridMixin = (superClass) =>
         // otherwise be triggered by this logic because it reads the row height
         // right after updating the rows' content.
         __disableHeightPlaceholder: true,
+        // The virtualizer amortizes scroller height updates to avoid reflows while
+        // scrolling. In `allRowsVisible` mode the grid has no scrolling and its
+        // height must track the content exactly, so tell the virtualizer to always
+        // apply the scroller height. Otherwise the items container can be left at a
+        // stale, too-small height and clip rows when the grid grows (e.g. when
+        // expanding a tree grid from a small size).
+        __alwaysUpdateScrollerSize: () => this.allRowsVisible,
       });
-
-      // The virtualizer amortizes scroller height updates to avoid reflows while
-      // scrolling. In `allRowsVisible` mode the grid has no scrolling and its
-      // height must track the content exactly, so always apply the scroller
-      // height in that mode. Otherwise the items container can be left at a
-      // stale, too-small height and clip rows when the grid grows (e.g. when
-      // expanding a tree grid from a small size).
-      const adapter = this.__virtualizer.__adapter;
-      const updateScrollerSize = adapter._updateScrollerSize.bind(adapter);
-      adapter._updateScrollerSize = (forceUpdate) => updateScrollerSize(forceUpdate || this.allRowsVisible);
 
       this._tooltipController = new TooltipController(this);
       this.addController(this._tooltipController);

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -237,6 +237,16 @@ export const GridMixin = (superClass) =>
         __disableHeightPlaceholder: true,
       });
 
+      // The virtualizer amortizes scroller height updates to avoid reflows while
+      // scrolling. In `allRowsVisible` mode the grid has no scrolling and its
+      // height must track the content exactly, so always apply the scroller
+      // height in that mode. Otherwise the items container can be left at a
+      // stale, too-small height and clip rows when the grid grows (e.g. when
+      // expanding a tree grid from a small size).
+      const adapter = this.__virtualizer.__adapter;
+      const updateScrollerSize = adapter._updateScrollerSize.bind(adapter);
+      adapter._updateScrollerSize = (forceUpdate) => updateScrollerSize(forceUpdate || this.allRowsVisible);
+
       this._tooltipController = new TooltipController(this);
       this.addController(this._tooltipController);
       this._tooltipController.setManual(true);

--- a/packages/grid/test/resizing.test.js
+++ b/packages/grid/test/resizing.test.js
@@ -339,6 +339,10 @@ describe('all rows visible', () => {
         };
         cb([item], 1);
       };
+      // Let the grid fully render and settle at its initial (single-row) size
+      // before expanding, so the deep expand has to grow the grid from a small
+      // viewport.
+      flushGrid(grid);
     });
 
     it('should have all rows visible on deep expand', () => {
@@ -359,6 +363,9 @@ describe('all rows visible', () => {
     });
 
     it('should have all rows visible on deep expand with no header', () => {
+      const column = grid.querySelector('vaadin-grid-tree-column');
+      column.header = null;
+
       grid.expandedItems = [
         { value: '0' },
         { value: '0-0' },
@@ -369,9 +376,6 @@ describe('all rows visible', () => {
         { value: '0-0-0-0-0-0-0' },
         { value: '0-0-0-0-0-0-0-0' },
       ];
-
-      const column = grid.querySelector('vaadin-grid-tree-column');
-      column.header = null;
 
       flushGrid(grid);
       expect(grid._firstVisibleIndex).to.equal(0);

--- a/packages/grid/test/resizing.test.js
+++ b/packages/grid/test/resizing.test.js
@@ -339,9 +339,6 @@ describe('all rows visible', () => {
         };
         cb([item], 1);
       };
-      // Let the grid fully render and settle at its initial (single-row) size
-      // before expanding, so the deep expand has to grow the grid from a small
-      // viewport.
       flushGrid(grid);
     });
 


### PR DESCRIPTION
A tree grid with `allRowsVisible` that grows from a small size did not show all its rows. For example, when the grid first renders a single root row and the user then expands several levels, only the first few rows became visible instead of all of them.

The virtualizer normally delays updating its scroller height to avoid extra layout work while scrolling. In `allRowsVisible` mode the grid has no scrolling and its height must match the content exactly, so this delay could leave the items container at a stale, too-small height and clip the new rows when the grid grew.

| Before | After |
|--------|------|
| <video src="https://github.com/user-attachments/assets/d68e02dc-f2ae-45ed-9f2c-5c353d0d82bd" /> |  <video src="https://github.com/user-attachments/assets/9bee81aa-5243-4dab-8e57-c71092477eeb" /> |

## Reproduction

```html
<vaadin-grid all-rows-visible>
  <vaadin-grid-tree-column path="value"></vaadin-grid-tree-column>
</vaadin-grid>
```

## Changes

- Add an internal virtualizer option `__alwaysUpdateScrollerSize`: a predicate that, when it returns `true`, makes the adapter always apply the scroller height instead of amortizing it.
- The grid passes `() => this.allRowsVisible`, so the height tracks the content exactly only in that mode. Other virtualizer users (combo-box, virtual-list) are unaffected.
- The two `all rows visible > tree grid` resizing tests now let the grid settle before expanding, so they actually exercise the growth path (they previously passed only because an empty footer row was briefly measured, which masked the problem).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
