### PR TITLE
chore: expand permissions to cover all yarn commands

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,8 +54,5 @@ jobs:
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           extra-allowed-tools: |
-            Bash(yarn test:*)
-            Bash(yarn update:*)
-            Bash(yarn start:*)
-            Bash(yarn lint:*)
+            Bash(yarn:*)
           upload-execution-log: ${{ vars.CLAUDE_DEBUG }}


### PR DESCRIPTION
Currently Claude is not able to run nested yarn commands such as `lint:types`, as the `yarn lint:*` apparently means: "Allow any command that matches `yarn:lint` exactly or `yarn:lint`, followed by a space, followed by anything else".

Instead of allow-listing every single command, let's grant access to yarn in general, similar to how mvn is allow-listed for flow-components.