### PR TITLE
fix: do not make checkbox active when clicking empty space

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -115,12 +115,14 @@ export const CheckboxMixin = (superclass) =>
      * @override
      */
     _shouldSetActive(event) {
-      const { target } = event;
+      const [target] = event.composedPath();
 
-      if (
-        this.readonly ||
-        !(target === this.inputElement || (this._labelNode.contains(target) && !target.closest('a')))
-      ) {
+      const togglesChecked =
+        target === this.inputElement ||
+        target.part.contains('required-indicator') ||
+        (this._labelNode.contains(target) && !target.closest('a'));
+
+      if (this.readonly || !togglesChecked) {
         return false;
       }
 

--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -106,9 +106,8 @@ export const CheckboxMixin = (superclass) =>
     }
 
     /**
-     * Override method inherited from `ActiveMixin` to prevent setting `active`
-     * attribute when readonly, or when clicking a link placed inside the label,
-     * or when clicking slotted helper or error message element.
+     * Override method inherited from `ActiveMixin` to only set the `active`
+     * attribute for clicks that actually toggle the checked state.
      *
      * @param {Event} event
      * @return {boolean}
@@ -116,11 +115,11 @@ export const CheckboxMixin = (superclass) =>
      * @override
      */
     _shouldSetActive(event) {
+      const { target } = event;
+
       if (
         this.readonly ||
-        event.target.localName === 'a' ||
-        event.target === this._helperNode ||
-        event.target === this._errorNode
+        !(target === this.inputElement || (this._labelNode.contains(target) && !target.closest('a')))
       ) {
         return false;
       }

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -223,6 +223,11 @@ describe('checkbox', () => {
         expect(checkbox.hasAttribute('active')).to.be.false;
       });
 
+      it('should set active attribute on required indicator mousedown', () => {
+        mousedown(checkbox.shadowRoot.querySelector('[part="required-indicator"]'));
+        expect(checkbox.hasAttribute('active')).to.be.true;
+      });
+
       it('should not set active attribute when clicking empty space next to the label', () => {
         mousedown(checkbox.shadowRoot.querySelector('[part="label"]'));
         expect(checkbox.hasAttribute('active')).to.be.false;

--- a/packages/checkbox/test/checkbox.test.js
+++ b/packages/checkbox/test/checkbox.test.js
@@ -222,6 +222,16 @@ describe('checkbox', () => {
         mousedown(checkbox.querySelector('[slot="error-message"]'));
         expect(checkbox.hasAttribute('active')).to.be.false;
       });
+
+      it('should not set active attribute when clicking empty space next to the label', () => {
+        mousedown(checkbox.shadowRoot.querySelector('[part="label"]'));
+        expect(checkbox.hasAttribute('active')).to.be.false;
+      });
+
+      it('should not set active attribute when clicking empty space below the checkbox', () => {
+        mousedown(checkbox);
+        expect(checkbox.hasAttribute('active')).to.be.false;
+      });
     });
 
     describe('change event', () => {

--- a/packages/field-base/src/styles/checkable-base-styles.js
+++ b/packages/field-base/src/styles/checkable-base-styles.js
@@ -37,7 +37,6 @@ export const checkable = (part, propName = part) => css`
     color: var(--vaadin-${unsafeCSS(propName)}-label-color, var(--vaadin-input-field-label-color, var(--vaadin-text-color)));
     word-break: break-word;
     cursor: var(--_cursor);
-    /* TODO clicking the label part doesn't toggle the checked state, even though it triggers the active state */
   }
 
   [part='${unsafeCSS(part)}'],


### PR DESCRIPTION
Clicking the area around the checkbox/switch part or next to the label triggered the `active` state without toggling the checked state.

`_shouldSetActive()` in `CheckboxMixin` now only sets `active` for clicks that actually toggle the checked state - the native input (which covers the checkbox/switch part and the gap) or the label. Empty space, links inside the label, and the helper/error message are excluded. Applies to both `vaadin-checkbox` and `vaadin-switch`.

Fixes #12149

Generated with [Claude Code](https://claude.ai/code)