### PR TITLE
fix: apply accordion heading level from the panel side

### DIFF
--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -106,7 +106,9 @@ export const AccordionMixin = (superClass) =>
       super.updated(props);
 
       if (props.has('items') || props.has('headingLevel')) {
-        this.__updateHeadingLevel();
+        (this.items || []).forEach((item) => {
+          item._headingLevel = this.headingLevel;
+        });
       }
     }
 
@@ -129,16 +131,6 @@ export const AccordionMixin = (superClass) =>
      */
     _filterItems(array) {
       return array.filter((el) => el instanceof customElements.get('vaadin-accordion-panel'));
-    }
-
-    /** @private */
-    __updateHeadingLevel() {
-      // Propagate the level to each panel, which applies it to its heading.
-      // The panel re-applies the level whenever its heading is recreated,
-      // so no attribute is set here directly.
-      (this.items || []).forEach((item) => {
-        item._headingLevel = this.headingLevel;
-      });
     }
 
     /** @private */

--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -133,16 +133,11 @@ export const AccordionMixin = (superClass) =>
 
     /** @private */
     __updateHeadingLevel() {
-      const { headingLevel } = this;
-
+      // Propagate the level to each panel, which applies it to its heading.
+      // The panel re-applies the level whenever its heading is recreated,
+      // so no attribute is set here directly.
       (this.items || []).forEach((item) => {
-        const heading = item.focusElement;
-
-        if (headingLevel != null) {
-          heading.setAttribute('aria-level', headingLevel);
-        } else {
-          heading.removeAttribute('aria-level');
-        }
+        item._headingLevel = this.headingLevel;
       });
     }
 

--- a/packages/accordion/src/vaadin-accordion-panel-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-panel-mixin.js
@@ -24,6 +24,16 @@ export const AccordionPanelMixin = (superClass) =>
           type: String,
           observer: '_summaryChanged',
         },
+
+        /**
+         * The ARIA heading level for the panel heading, propagated from the
+         * `headingLevel` property of the parent `<vaadin-accordion>`.
+         *
+         * @protected
+         */
+        _headingLevel: {
+          type: Number,
+        },
       };
     }
 
@@ -32,7 +42,7 @@ export const AccordionPanelMixin = (superClass) =>
     }
 
     static get delegateProps() {
-      return ['disabled', 'opened', '_theme'];
+      return ['disabled', 'opened', '_theme', '_headingLevel'];
     }
 
     constructor() {
@@ -88,6 +98,11 @@ export const AccordionPanelMixin = (superClass) =>
 
       if (name === '_theme') {
         this._delegateAttribute('theme', value);
+        return;
+      }
+
+      if (name === '_headingLevel') {
+        this._delegateAttribute('aria-level', value);
         return;
       }
 

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -363,5 +363,28 @@ describe('vaadin-accordion', () => {
 
       expect(panel.focusElement.getAttribute('aria-level')).to.equal('3');
     });
+
+    it('should set aria-level on the heading created lazily from summary', async () => {
+      const panel = document.createElement('vaadin-accordion-panel');
+      accordion.appendChild(panel);
+      await nextRender();
+
+      panel.summary = 'Lazy summary';
+      await nextRender();
+
+      expect(panel.focusElement.getAttribute('aria-level')).to.equal('3');
+    });
+
+    it('should set aria-level on the heading replacing the existing one', async () => {
+      const panel = accordion.items[0];
+      panel.querySelector('vaadin-accordion-heading').remove();
+
+      const heading = document.createElement('vaadin-accordion-heading');
+      heading.setAttribute('slot', 'summary');
+      panel.appendChild(heading);
+      await nextRender();
+
+      expect(heading.getAttribute('aria-level')).to.equal('3');
+    });
   });
 });


### PR DESCRIPTION
Setting `heading-level` on `<vaadin-accordion>` had two problems:

1. In Firefox it threw `TypeError: can't access property "removeAttribute", heading is undefined`, because the `items`-triggered `updated()` could run before a panel's `SummaryController` had created its heading.
2. More importantly, `aria-level` was silently dropped whenever a panel heading appeared or changed *after* that callback — a default heading, a `summary` set after attach, or a swapped heading element — since nothing on the accordion reacts to a panel's `focusElement` becoming available.

## Changes

Apply the level from the panel side instead of the accordion side:

- The accordion propagates its `headingLevel` to an internal `_headingLevel` property on each panel (in `updated()` on `items` / `headingLevel`).
- The panel delegates `_headingLevel` to its heading as the `aria-level` attribute through `DelegateStateMixin`. Because the mixin re-delegates all props when its `stateTarget` (the heading) changes, `aria-level` is re-applied automatically whenever the heading element is (re)created.

This removes the earlier crash entirely (the accordion no longer touches `focusElement`) and fixes the dropped-attribute cases.

## Tests

Added regression tests (both fail on the previous approach, pass now):
- heading created lazily from `summary`
- heading replaced by a new element

Verified in Chromium and Firefox.

Follow-up to #12133

---

🤖 Generated with Claude Code