### PR TITLE
refactor: deprecate select renderer property and Lit directive

### DIFF
--- a/packages/select/src/lit/renderer-directives.d.ts
+++ b/packages/select/src/lit/renderer-directives.d.ts
@@ -52,6 +52,7 @@ export class SelectRendererDirective extends LitRendererDirective<Select, Select
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Use a slotted `<vaadin-select-list-box>` or the `items` property instead
  */
 export declare function selectRenderer(
   renderer: SelectLitRenderer,

--- a/packages/select/src/lit/renderer-directives.js
+++ b/packages/select/src/lit/renderer-directives.js
@@ -56,5 +56,6 @@ export class SelectRendererDirective extends LitRendererDirective {
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Use a slotted `<vaadin-select-list-box>` or the `items` property instead
  */
 export const selectRenderer = directive(SelectRendererDirective);

--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -62,6 +62,8 @@ export declare class SelectBaseMixinClass {
    *
    * - `root` The internal container DOM element. Append your content to it.
    * - `select` The reference to the `<vaadin-select>` element.
+   *
+   * @deprecated Use a slotted `<vaadin-select-list-box>` or the `items` property instead
    */
   renderer: SelectRenderer | undefined;
 

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -63,7 +63,9 @@ export const SelectBaseMixin = (superClass) =>
          *
          * - `root` The internal container DOM element. Append your content to it.
          * - `select` The reference to the `<vaadin-select>` element.
+         *
          * @type {!SelectRenderer | undefined}
+         * @deprecated Use a slotted `<vaadin-select-list-box>` or the `items` property instead
          */
         renderer: {
           type: Object,

--- a/packages/select/src/vaadin-select.d.ts
+++ b/packages/select/src/vaadin-select.d.ts
@@ -95,7 +95,26 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  *
  * ### Rendering
  *
- * Alternatively, the content of the select can be populated by using the renderer callback function.
+ * Alternatively, the content of the select can be populated by using a slotted `<vaadin-select-list-box>`
+ * with `<vaadin-select-item>` children:
+ *
+ * ```html
+ * <vaadin-select>
+ *   <vaadin-select-list-box slot="overlay">
+ *     <vaadin-select-item value="recent">Most recent first</vaadin-select-item>
+ *     <vaadin-select-item value="rating-asc">Rating: low to high</vaadin-select-item>
+ *     <vaadin-select-item value="rating-desc">Rating: high to low</vaadin-select-item>
+ *   </vaadin-select-list-box>
+ * </vaadin-select>
+ * ```
+ *
+ * * Hint: By setting the `label` property of inner vaadin-items you will
+ * be able to change the visual representation of the selected value in the input part.
+ *
+ * #### Renderer (deprecated)
+ *
+ * The content of the select can also be populated by using the renderer callback function, although
+ * this approach is deprecated in favor of the `items` property or a slotted `<vaadin-select-list-box>`.
  *
  * The renderer function provides `root`, `select` arguments.
  * Generate DOM content, append it to the `root` element and control the state
@@ -122,9 +141,6 @@ export interface SelectEventMap extends HTMLElementEventMap, SelectCustomEventMa
  * DOM generated during the renderer call can be reused
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
- *
- * * Hint: By setting the `label` property of inner vaadin-items you will
- * be able to change the visual representation of the selected value in the input part.
  *
  * ### Styling
  *

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -46,7 +46,26 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  *
  * ### Rendering
  *
- * Alternatively, the content of the select can be populated by using the renderer callback function.
+ * Alternatively, the content of the select can be populated by using a slotted `<vaadin-select-list-box>`
+ * with `<vaadin-select-item>` children:
+ *
+ * ```html
+ * <vaadin-select>
+ *   <vaadin-select-list-box slot="overlay">
+ *     <vaadin-select-item value="recent">Most recent first</vaadin-select-item>
+ *     <vaadin-select-item value="rating-asc">Rating: low to high</vaadin-select-item>
+ *     <vaadin-select-item value="rating-desc">Rating: high to low</vaadin-select-item>
+ *   </vaadin-select-list-box>
+ * </vaadin-select>
+ * ```
+ *
+ * * Hint: By setting the `label` property of inner vaadin-items you will
+ * be able to change the visual representation of the selected value in the input part.
+ *
+ * #### Renderer (deprecated)
+ *
+ * The content of the select can also be populated by using the renderer callback function, although
+ * this approach is deprecated in favor of the `items` property or a slotted `<vaadin-select-list-box>`.
  *
  * The renderer function provides `root`, `select` arguments.
  * Generate DOM content, append it to the `root` element and control the state
@@ -73,9 +92,6 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * DOM generated during the renderer call can be reused
  * in the next renderer call and will be provided with the `root` argument.
  * On first call it will be empty.
- *
- * * Hint: By setting the `label` property of inner vaadin-items you will
- * be able to change the visual representation of the selected value in the input part.
  *
  * ### Styling
  *


### PR DESCRIPTION
## Description

- Marked the `renderer` property and the `selectRenderer` Lit directive as deprecated.
- Improved JSDoc to showcase using `vaadin-select-list-box` as alternative to `items`.

## Type of change

- Deprecation