### PR TITLE
chore: source claude actions from latest commit

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn --frozen-lockfile --no-progress --non-interactive
 
       - name: Run Claude Code
-        uses: vaadin/github-actions/claude-code@bfb2659c1efe77731d70b4bb57f1433f5dbf3d90
+        uses: vaadin/github-actions/claude-code@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           extra-allowed-tools: |

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -94,7 +94,7 @@ jobs:
           node-version: '24'
 
       - name: Run code review
-        uses: vaadin/github-actions/code-review@c04ff50de09876b2db4240291f9cbc6c0711b181
+        uses: vaadin/github-actions/code-review@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           pr-number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
While we are iterating on the shared Claude actions, let's source them from the main branch so that we don't need a separate PR for every tweak.
