### PR TITLE
fix: initialize empty details summary and accordion heading

### DIFF
--- a/packages/accordion/test/accordion-panel.test.js
+++ b/packages/accordion/test/accordion-panel.test.js
@@ -184,6 +184,36 @@ describe('vaadin-accordion-panel', () => {
     });
   });
 
+  describe('without summary', () => {
+    let heading;
+
+    beforeEach(async () => {
+      panel = fixtureSync(`
+        <vaadin-accordion-panel>
+          <div>Content</div>
+        </vaadin-accordion-panel>
+      `);
+      await nextRender();
+      heading = panel.querySelector('vaadin-accordion-heading');
+    });
+
+    it('should create a default heading', () => {
+      expect(heading).to.be.instanceOf(customElements.get('vaadin-accordion-heading'));
+    });
+
+    it('should set the default heading as the focus element', () => {
+      expect(panel.focusElement).to.equal(heading);
+    });
+
+    it('should toggle opened state on default heading click', () => {
+      heading.click();
+      expect(panel.opened).to.be.true;
+
+      heading.click();
+      expect(panel.opened).to.be.false;
+    });
+  });
+
   describe('link', () => {
     let link;
 

--- a/packages/accordion/test/accordion.test.js
+++ b/packages/accordion/test/accordion.test.js
@@ -276,6 +276,17 @@ describe('vaadin-accordion', () => {
         arrowDownKeyDown(input);
         expect(spy.called).to.be.false;
       });
+
+      it('should focus a panel without a heading when navigating onto it', async () => {
+        const panel = document.createElement('vaadin-accordion-panel');
+        accordion.insertBefore(panel, accordion.items[1]);
+        accordion._observer.flush();
+        await nextRender();
+        accordion.items[2].focus();
+        heading = getHeading(2);
+        arrowUpKeyDown(heading);
+        expect(accordion.items[1].hasAttribute('focused')).to.be.true;
+      });
     });
 
     describe('keydown event', () => {

--- a/packages/details/src/summary-controller.js
+++ b/packages/details/src/summary-controller.js
@@ -14,6 +14,21 @@ export class SummaryController extends SlotChildObserveController {
   }
 
   /**
+   * Override method inherited from `SlotController` to notify the host about
+   * the default empty summary element created during initialization.
+   *
+   * @protected
+   * @override
+   */
+  initSingle() {
+    super.initSingle();
+
+    if (this.node && this.node === this.defaultNode) {
+      this.__notifyChange(this.node);
+    }
+  }
+
+  /**
    * Set summary based on corresponding host property.
    *
    * @param {string} summary

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -232,6 +232,32 @@ describe('vaadin-details', () => {
     });
   });
 
+  describe('without summary', () => {
+    let summary;
+
+    beforeEach(async () => {
+      details = fixtureSync(`
+        <vaadin-details>
+          <div>Content</div>
+        </vaadin-details>
+      `);
+      await nextRender();
+      summary = details.querySelector('vaadin-details-summary');
+    });
+
+    it('should set the default summary as the focus element', () => {
+      expect(details.focusElement).to.equal(summary);
+    });
+
+    it('should toggle opened state on default summary click', () => {
+      summary.click();
+      expect(details.opened).to.be.true;
+
+      summary.click();
+      expect(details.opened).to.be.false;
+    });
+  });
+
   describe('link', () => {
     let link;
 


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/12154

See https://github.com/vaadin/web-components/pull/12154#discussion_r3588357761

## Type of change

- Bugfix