### PR TITLE
refactor: deprecate dialog renderer properties and Lit directives

### DIFF
--- a/packages/dialog/src/lit/renderer-directives.d.ts
+++ b/packages/dialog/src/lit/renderer-directives.d.ts
@@ -69,6 +69,7 @@ export class DialogFooterRendererDirective extends AbstractDialogRendererDirecti
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add content elements as children of the dialog instead
  */
 export declare function dialogRenderer(
   renderer: DialogLitRenderer,
@@ -100,6 +101,7 @@ export declare function dialogRenderer(
  * @param renderer the renderer callback.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add header content as children of the dialog using `slot="header-content"` instead
  */
 export declare function dialogHeaderRenderer(
   renderer: DialogLitRenderer,
@@ -131,6 +133,7 @@ export declare function dialogHeaderRenderer(
  * @param renderer the renderer callback.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add footer content as children of the dialog using `slot="footer"` instead
  */
 export declare function dialogFooterRenderer(
   renderer: DialogLitRenderer,

--- a/packages/dialog/src/lit/renderer-directives.js
+++ b/packages/dialog/src/lit/renderer-directives.js
@@ -95,6 +95,7 @@ export class DialogFooterRendererDirective extends AbstractDialogRendererDirecti
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add content elements as children of the dialog instead
  */
 export const dialogRenderer = directive(DialogRendererDirective);
 
@@ -123,6 +124,7 @@ export const dialogRenderer = directive(DialogRendererDirective);
  * @param renderer the renderer callback.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add header content as children of the dialog using `slot="header-content"` instead
  */
 export const dialogHeaderRenderer = directive(DialogHeaderRendererDirective);
 
@@ -151,5 +153,6 @@ export const dialogHeaderRenderer = directive(DialogHeaderRendererDirective);
  * @param renderer the renderer callback.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Add footer content as children of the dialog using `slot="footer"` instead
  */
 export const dialogFooterRenderer = directive(DialogFooterRendererDirective);

--- a/packages/dialog/src/vaadin-dialog-renderer-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-renderer-mixin.d.ts
@@ -17,6 +17,8 @@ export declare class DialogRendererMixinClass {
    *
    * - `root` The root container DOM element. Append your content to it.
    * - `dialog` The reference to the `<vaadin-dialog>` element.
+   *
+   * @deprecated Add content elements as children of the dialog instead
    */
   renderer: DialogRenderer | null | undefined;
 
@@ -44,6 +46,8 @@ export declare class DialogRendererMixinClass {
    * each other, with the title coming first.
    *
    * When `headerRenderer` is set, the attribute `has-header` is set on the dialog.
+   *
+   * @deprecated Add header content as children of the dialog using `slot="header-content"` instead
    */
   headerRenderer: DialogRenderer | null | undefined;
 
@@ -55,6 +59,8 @@ export declare class DialogRendererMixinClass {
    * - `dialog` The reference to the `<vaadin-dialog>` element.
    *
    * When `footerRenderer` is set, the attribute `has-footer` is set on the dialog.
+   *
+   * @deprecated Add footer content as children of the dialog using `slot="footer"` instead
    */
   footerRenderer: DialogRenderer | null | undefined;
 

--- a/packages/dialog/src/vaadin-dialog-renderer-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-renderer-mixin.js
@@ -15,6 +15,7 @@ export const DialogRendererMixin = (superClass) =>
          * - `root` The root container DOM element. Append your content to it.
          * - `dialog` The reference to the `<vaadin-dialog>` element.
          * @type {DialogRenderer | undefined}
+         * @deprecated Add content elements as children of the dialog instead
          */
         renderer: {
           type: Object,
@@ -47,6 +48,7 @@ export const DialogRendererMixin = (superClass) =>
          *
          * When `headerRenderer` is set, the attribute `has-header` is set on the dialog.
          * @type {DialogRenderer | undefined}
+         * @deprecated Add header content as children of the dialog using `slot="header-content"` instead
          */
         headerRenderer: {
           type: Object,
@@ -61,6 +63,7 @@ export const DialogRendererMixin = (superClass) =>
          *
          * When `footerRenderer` is set, the attribute `has-footer` is set on the dialog.
          * @type {DialogRenderer | undefined}
+         * @deprecated Add footer content as children of the dialog using `slot="footer"` instead
          */
         footerRenderer: {
           type: Object,

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -139,8 +139,8 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
  * Attribute        | Description
  * -----------------|--------------------------------------------
  * `has-title`      | Set when the element has a title
- * `has-header`     | Set when the element has header renderer
- * `has-footer`     | Set when the element has footer renderer
+ * `has-header`     | Set when the element has header content
+ * `has-footer`     | Set when the element has footer content
  * `overflow`       | Set to `top`, `bottom`, none or both
  *
  * The following custom CSS properties are available for styling:

--- a/packages/dialog/src/vaadin-dialog.d.ts
+++ b/packages/dialog/src/vaadin-dialog.d.ts
@@ -78,9 +78,27 @@ export type DialogEventMap = DialogCustomEventMap & HTMLElementEventMap;
 /**
  * `<vaadin-dialog>` is a Web Component for creating customized modal dialogs.
  *
- * ### Rendering
+ * ```html
+ * <vaadin-dialog header-title="Title">
+ *   <div>Dialog content</div>
+ *   <div slot="footer">Footer</div>
+ * </vaadin-dialog>
+ * ```
  *
- * The content of the dialog can be populated by using the renderer callback function.
+ * ### Slots
+ *
+ * Dialog supports following slots for providing content:
+ *
+ * Name             | Description
+ * -----------------|-------------
+ * (none)           | Default slot for the content
+ * `header-content` | Slot for the header content
+ * `footer`         | Slot for the footer content
+ *
+ * #### Renderer (deprecated)
+ *
+ * The content of the dialog can also be populated by using the renderer callback functions,
+ * although this approach is deprecated in favor of slotted content.
  *
  * The renderer function provides `root`, `dialog` arguments.
  * Generate DOM content, append it to the `root` element and control the state

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -21,9 +21,27 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
 /**
  * `<vaadin-dialog>` is a Web Component for creating customized modal dialogs.
  *
- * ### Rendering
+ * ```html
+ * <vaadin-dialog header-title="Title">
+ *   <div>Dialog content</div>
+ *   <div slot="footer">Footer</div>
+ * </vaadin-dialog>
+ * ```
  *
- * The content of the dialog can be populated by using the renderer callback function.
+ * ### Slots
+ *
+ * Dialog supports following slots for providing content:
+ *
+ * Name             | Description
+ * -----------------|-------------
+ * (none)           | Default slot for the content
+ * `header-content` | Slot for the header content
+ * `footer`         | Slot for the footer content
+ *
+ * #### Renderer (deprecated)
+ *
+ * The content of the dialog can also be populated by using the renderer callback functions,
+ * although this approach is deprecated in favor of slotted content.
  *
  * The renderer function provides `root`, `dialog` arguments.
  * Generate DOM content, append it to the `root` element and control the state

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -82,8 +82,8 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * Attribute        | Description
  * -----------------|--------------------------------------------
  * `has-title`      | Set when the element has a title
- * `has-header`     | Set when the element has header renderer
- * `has-footer`     | Set when the element has footer renderer
+ * `has-header`     | Set when the element has header content
+ * `has-footer`     | Set when the element has footer content
  * `overflow`       | Set to `top`, `bottom`, none or both
  *
  * The following custom CSS properties are available for styling:


### PR DESCRIPTION
The `<vaadin-dialog>` supports slotted content: the default slot for the content,
`slot="header-content"` for the header, and `slot="footer"` for the footer (plus
the `headerTitle` property for the title). The `renderer`, `headerRenderer`, and
`footerRenderer` properties and the matching Lit directives are therefore no
longer needed and are deprecated in favor of slotted content.

This mirrors the select renderer deprecation.

## Changes

- Add `@deprecated` JSDoc to the `renderer`, `headerRenderer`, and `footerRenderer`
  properties (`.js` and `.d.ts`), each pointing at the corresponding slotted content.
- Add `@deprecated` JSDoc to the `dialogRenderer`, `dialogHeaderRenderer`, and
  `dialogFooterRenderer` Lit directives (`.js` and `.d.ts`).
- Rewrite the class-level "Rendering" docs to present slotted content as the primary
  approach, with the renderer callbacks kept under a "Renderer (deprecated)" subsection.

Runtime behavior is unchanged — this is a documentation-only deprecation.

Related to #12155

---

🤖 Generated with Claude Code
