### PR TITLE
fix: use correct CSS selector for MDL containment isolation

### DIFF
--- a/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
+++ b/packages/master-detail-layout/src/styles/vaadin-master-detail-layout-base-styles.js
@@ -20,7 +20,7 @@ export const masterDetailLayoutStyles = css`
     overflow: clip;
   }
 
-  :host:not([overlay-containment='page']) {
+  :host(:not([overlay-containment='page'])) {
     isolation: isolate;
   }
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/11764

Using `:host:not` isn't a correct syntax - noticed this when in StarPass the fix didn't take effect 😞 

## Type of change

- Bugfix