### PR TITLE
fix: align vaadin-select-item typings with vaadin-item

### DIFF
--- a/packages/select/src/vaadin-select-item.d.ts
+++ b/packages/select/src/vaadin-select-item.d.ts
@@ -42,7 +42,17 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  */
-declare class SelectItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {}
+declare class SelectItem extends ItemMixin(DirMixin(ThemableMixin(HTMLElement))) {
+  /**
+   * Submittable string value. The default value is the trimmed text content of the element.
+   */
+  value: string;
+
+  /**
+   * String that can be set to visually represent the selected item in `vaadin-select`.
+   */
+  label: string | undefined;
+}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -77,6 +77,22 @@ class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjec
     };
   }
 
+  constructor() {
+    super();
+
+    /**
+     * Submittable string value. The default value is the trimmed text content of the element.
+     * @type {string}
+     */
+    this.value;
+
+    /**
+     * String that can be set to visually represent the selected item in `vaadin-select`.
+     * @type {string}
+     */
+    this.label;
+  }
+
   /** @protected */
   render() {
     return html`

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -47,6 +47,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @prop {string} label - String that can be set to visually represent the selected item in `vaadin-select`.
  * @customElement vaadin-select-item
  * @extends HTMLElement
  */
@@ -75,22 +76,6 @@ class SelectItem extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjec
         reflectToAttribute: true,
       },
     };
-  }
-
-  constructor() {
-    super();
-
-    /**
-     * Submittable string value. The default value is the trimmed text content of the element.
-     * @type {string}
-     */
-    this.value;
-
-    /**
-     * String that can be set to visually represent the selected item in `vaadin-select`.
-     * @type {string}
-     */
-    this.label;
   }
 
   /** @protected */

--- a/packages/select/test/typings/select.types.ts
+++ b/packages/select/test/typings/select.types.ts
@@ -107,7 +107,10 @@ assertType<ItemMixinClass>(option);
 assertType<DirMixinClass>(option);
 assertType<ThemableMixinClass>(option);
 
-// Item
+assertType<string>(option.value);
+assertType<string | undefined>(option.label);
+
+// List box
 const listBox = document.createElement('vaadin-select-list-box');
 
 assertType<SelectListBox>(listBox);


### PR DESCRIPTION
## Description

- Added `label` property declaration - needed for [custom renderer](https://github.com/vaadin/react-components/blob/4b9848e96b31a4782d5f38b87b18a5dfd24ce630/dev/pages/Select.tsx#L124) case in React component.
- Added `value` property declaration - it's inherited from `ItemMixin` but lacked a description.

## Type of change

- Bugfix