### PR TITLE
docs: remove no longer needed JSDoc for item properties

### DIFF
--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -83,22 +83,6 @@ class Item extends ItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMi
     `;
   }
 
-  constructor() {
-    super();
-
-    /**
-     * Submittable string value. The default value is the trimmed text content of the element.
-     * @type {string}
-     */
-    this.value;
-
-    /**
-     * String that can be set to visually represent the selected item in `vaadin-select`.
-     * @type {string}
-     */
-    this.label;
-  }
-
   /** @protected */
   ready() {
     super.ready();


### PR DESCRIPTION
## Description

These `@type` annotations were used by Polymer Analyzer and are no longer needed with CEM: `label` is annotated using `@prop` - see https://github.com/vaadin/web-components/pull/11290. As for `value`, its description is picked up form the mixin. Validated by running `yarn release`.

## Type of change

- Documentation