### PR TITLE
test: cover header/footer rendering with hidden column group

### DIFF
--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -477,6 +477,30 @@ describe('column groups', () => {
       expect(columns[0].hidden).to.be.true;
       expect(columns[1].hidden).not.to.be.true;
     });
+
+    it('should update header row visibility when toggling group hidden state', () => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column-group header="Group">
+            <vaadin-grid-column></vaadin-grid-column>
+          </vaadin-grid-column-group>
+        </vaadin-grid>
+      `);
+      flushGrid(grid);
+
+      const group = grid.querySelector('vaadin-grid-column-group');
+
+      group.hidden = true;
+      flushGrid(grid);
+      expect(getRows(grid.$.header)[0].hidden).to.be.true;
+      expect(grid.$.table.hasAttribute('has-header')).to.be.false;
+
+      group.hidden = false;
+      flushGrid(grid);
+      expect(getRows(grid.$.header)[0].hidden).to.be.false;
+      expect(grid.$.table.hasAttribute('has-header')).to.be.true;
+    });
   });
 
   describe('Large nested groups', () => {

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -1820,3 +1820,699 @@ snapshots["vaadin-grid column groups with footer"] =
 `;
 /* end snapshot vaadin-grid column groups with footer */
 
+snapshots["vaadin-grid hidden column group with group header"] = 
+`<div
+  id="scroller"
+  style=""
+>
+  <table
+    aria-colcount="2"
+    aria-multiselectable="true"
+    aria-rowcount="2"
+    id="table"
+    role="treegrid"
+    tabindex="0"
+  >
+    <caption
+      id="sizer"
+      part="row"
+    >
+    </caption>
+    <tbody>
+      <tr>
+        <td
+          class="body-cell cell first-column-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-4"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-4">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <thead
+      id="header"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="1"
+        class="header-row row"
+        hidden=""
+        part="row header-row"
+        role="row"
+        tabindex="-1"
+      >
+        <th
+          class="cell first-column-cell header-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-0"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-0">
+          </slot>
+        </th>
+      </tr>
+      <tr
+        aria-rowindex="2"
+        class="header-row row"
+        hidden=""
+        part="row header-row"
+        role="row"
+        style="--_grid-horizontal-scroll-position: 0px;"
+        tabindex="-1"
+      >
+        <th
+          class="cell first-column-cell header-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-1"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-1">
+          </slot>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="items"
+      role="rowgroup"
+      style="transform: translate(0px, 0px); height: 72px;"
+    >
+      <tr
+        aria-rowindex="1"
+        aria-selected="false"
+        class="body-row drag-disabled-row drop-disabled-row even-row first-row row"
+        drag-disabled=""
+        drop-disabled=""
+        even=""
+        first=""
+        part="row body-row first-row even-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(0px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-5"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-5">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="2"
+        aria-selected="false"
+        class="body-row drag-disabled-row drop-disabled-row last-row odd-row row"
+        drag-disabled=""
+        drop-disabled=""
+        last=""
+        odd=""
+        part="row body-row last-row odd-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(36px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
+          first-column=""
+          id="vaadin-grid-cell-6"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-6">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tbody id="emptystatebody">
+      <tr id="emptystaterow">
+        <td
+          class="empty-state"
+          id="emptystatecell"
+          part="empty-state"
+          tabindex="0"
+        >
+          <slot
+            id="emptystateslot"
+            name="empty-state"
+          >
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      id="footer"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="3"
+        class="footer-row row"
+        hidden=""
+        part="row footer-row"
+        role="row"
+        style="--_grid-horizontal-scroll-position: 0px;"
+        tabindex="-1"
+      >
+        <td
+          class="cell first-column-cell footer-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-2"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-2">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="4"
+        class="footer-row row"
+        hidden=""
+        part="row footer-row"
+        role="row"
+        tabindex="-1"
+      >
+        <td
+          class="cell first-column-cell footer-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-3"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-3">
+          </slot>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <div
+    class="reorder-ghost"
+    part="reorder-ghost"
+  >
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+<div
+  id="focusexit"
+  tabindex="0"
+>
+</div>
+`;
+/* end snapshot vaadin-grid hidden column group with group header */
+
+snapshots["vaadin-grid hidden column group with group and column header"] = 
+`<div
+  id="scroller"
+  style=""
+>
+  <table
+    aria-colcount="2"
+    aria-multiselectable="true"
+    aria-rowcount="4"
+    has-header=""
+    id="table"
+    role="treegrid"
+    tabindex="0"
+  >
+    <caption
+      id="sizer"
+      part="row"
+    >
+    </caption>
+    <tbody>
+      <tr>
+        <td
+          class="body-cell cell first-column-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-4"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-4">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <thead
+      id="header"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="1"
+        class="header-row row"
+        hidden=""
+        part="row header-row"
+        role="row"
+        tabindex="-1"
+      >
+        <th
+          class="cell first-column-cell header-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-0"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-0">
+          </slot>
+        </th>
+      </tr>
+      <tr
+        aria-rowindex="2"
+        class="first-header-row header-row last-header-row row"
+        part="row header-row first-header-row last-header-row"
+        role="row"
+        style="--_grid-horizontal-scroll-position: 0px;"
+        tabindex="-1"
+      >
+        <th
+          class="cell first-column-cell first-header-row-cell header-cell last-column-cell last-header-row-cell"
+          first-column=""
+          id="vaadin-grid-cell-1"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell first-header-row-cell last-header-row-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-1">
+          </slot>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="items"
+      role="rowgroup"
+      style="transform: translate(0px, 0px); height: 72px;"
+    >
+      <tr
+        aria-rowindex="1"
+        aria-selected="false"
+        class="body-row drag-disabled-row drop-disabled-row even-row first-row row"
+        drag-disabled=""
+        drop-disabled=""
+        even=""
+        first=""
+        part="row body-row first-row even-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(0px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-5"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-5">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="2"
+        aria-selected="false"
+        class="body-row drag-disabled-row drop-disabled-row last-row odd-row row"
+        drag-disabled=""
+        drop-disabled=""
+        last=""
+        odd=""
+        part="row body-row last-row odd-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(36px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
+          first-column=""
+          id="vaadin-grid-cell-6"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-6">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tbody id="emptystatebody">
+      <tr id="emptystaterow">
+        <td
+          class="empty-state"
+          id="emptystatecell"
+          part="empty-state"
+          tabindex="0"
+        >
+          <slot
+            id="emptystateslot"
+            name="empty-state"
+          >
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      id="footer"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="5"
+        class="footer-row row"
+        hidden=""
+        part="row footer-row"
+        role="row"
+        style="--_grid-horizontal-scroll-position: 0px;"
+        tabindex="-1"
+      >
+        <td
+          class="cell first-column-cell footer-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-2"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-2">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="6"
+        class="footer-row row"
+        hidden=""
+        part="row footer-row"
+        role="row"
+        tabindex="-1"
+      >
+        <td
+          class="cell first-column-cell footer-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-3"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-3">
+          </slot>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <div
+    class="reorder-ghost"
+    part="reorder-ghost"
+  >
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+<div
+  id="focusexit"
+  tabindex="0"
+>
+</div>
+`;
+/* end snapshot vaadin-grid hidden column group with group and column header */
+
+snapshots["vaadin-grid hidden column group with group footer"] = 
+`<div
+  id="scroller"
+  style=""
+>
+  <table
+    aria-colcount="2"
+    aria-multiselectable="true"
+    aria-rowcount="2"
+    id="table"
+    role="treegrid"
+    tabindex="0"
+  >
+    <caption
+      id="sizer"
+      part="row"
+    >
+    </caption>
+    <tbody>
+      <tr>
+        <td
+          class="body-cell cell first-column-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-4"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-4">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <thead
+      id="header"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="1"
+        class="header-row row"
+        hidden=""
+        part="row header-row"
+        role="row"
+        tabindex="-1"
+      >
+        <th
+          class="cell first-column-cell header-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-0"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-0">
+          </slot>
+        </th>
+      </tr>
+      <tr
+        aria-rowindex="2"
+        class="header-row row"
+        hidden=""
+        part="row header-row"
+        role="row"
+        style="--_grid-horizontal-scroll-position: 0px;"
+        tabindex="-1"
+      >
+        <th
+          class="cell first-column-cell header-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-1"
+          last-column=""
+          part="cell header-cell first-column-cell last-column-cell"
+          role="columnheader"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-1">
+          </slot>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      id="items"
+      role="rowgroup"
+      style="transform: translate(0px, 0px); height: 72px;"
+    >
+      <tr
+        aria-rowindex="1"
+        aria-selected="false"
+        class="body-row drag-disabled-row drop-disabled-row even-row first-row row"
+        drag-disabled=""
+        drop-disabled=""
+        even=""
+        first=""
+        part="row body-row first-row even-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(0px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-5"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-5">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="2"
+        aria-selected="false"
+        class="body-row drag-disabled-row drop-disabled-row last-row odd-row row"
+        drag-disabled=""
+        drop-disabled=""
+        last=""
+        odd=""
+        part="row body-row last-row odd-row drag-disabled-row drop-disabled-row"
+        role="row"
+        style="position: absolute; transform: translateY(36px);"
+        tabindex="-1"
+      >
+        <td
+          aria-selected="false"
+          class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-column-cell last-row-cell odd-row-cell"
+          first-column=""
+          id="vaadin-grid-cell-6"
+          last-column=""
+          part="cell body-cell first-column-cell last-column-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-6">
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tbody id="emptystatebody">
+      <tr id="emptystaterow">
+        <td
+          class="empty-state"
+          id="emptystatecell"
+          part="empty-state"
+          tabindex="0"
+        >
+          <slot
+            id="emptystateslot"
+            name="empty-state"
+          >
+          </slot>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot
+      id="footer"
+      role="rowgroup"
+      style="transform: translate(0px, 0px);"
+    >
+      <tr
+        aria-rowindex="3"
+        class="footer-row row"
+        hidden=""
+        part="row footer-row"
+        role="row"
+        style="--_grid-horizontal-scroll-position: 0px;"
+        tabindex="-1"
+      >
+        <td
+          class="cell first-column-cell footer-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-2"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="0"
+        >
+          <slot name="vaadin-grid-cell-content-2">
+          </slot>
+        </td>
+      </tr>
+      <tr
+        aria-rowindex="4"
+        class="footer-row row"
+        hidden=""
+        part="row footer-row"
+        role="row"
+        tabindex="-1"
+      >
+        <td
+          class="cell first-column-cell footer-cell last-column-cell"
+          first-column=""
+          id="vaadin-grid-cell-3"
+          last-column=""
+          part="cell footer-cell first-column-cell last-column-cell"
+          role="gridcell"
+          style="width: 100px; flex-grow: 1;"
+          tabindex="-1"
+        >
+          <slot name="vaadin-grid-cell-content-3">
+          </slot>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+  <div
+    class="reorder-ghost"
+    part="reorder-ghost"
+  >
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+<div
+  id="focusexit"
+  tabindex="0"
+>
+</div>
+`;
+/* end snapshot vaadin-grid hidden column group with group footer */
+

--- a/packages/grid/test/dom/grid.test.js
+++ b/packages/grid/test/dom/grid.test.js
@@ -101,4 +101,40 @@ describe('vaadin-grid', () => {
       await expect(grid.$.footer).dom.to.equalSnapshot();
     });
   });
+
+  describe('hidden column group', () => {
+    beforeEach(async () => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column></vaadin-grid-column>
+          <vaadin-grid-column-group hidden>
+            <vaadin-grid-column></vaadin-grid-column>
+          </vaadin-grid-column-group>
+        </vaadin-grid>
+      `);
+      grid.items = users.slice(0, 2);
+      await nextFrame();
+    });
+
+    it('with group header', async () => {
+      grid.querySelector('vaadin-grid-column-group').header = 'Group';
+      await nextFrame();
+      await expect(grid).shadowDom.to.equalSnapshot();
+    });
+
+    it('with group and column header', async () => {
+      grid.querySelector('vaadin-grid-column').header = 'Col';
+      grid.querySelector('vaadin-grid-column-group').header = 'Group';
+      await nextFrame();
+      await expect(grid).shadowDom.to.equalSnapshot();
+    });
+
+    it('with group footer', async () => {
+      grid.querySelector('vaadin-grid-column-group').footerRenderer = (root) => {
+        root.textContent = 'Footer';
+      };
+      await nextFrame();
+      await expect(grid).shadowDom.to.equalSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
The grid has no tests covering how header and footer rows render when a column group is hidden: header row visibility and the `has-header` attribute when toggling the group's `hidden` state, and the DOM structure with a hidden group that has a header or footer. This adds tests to lock in the current behavior before the declarative header/footer rendering refactor.

Extracted from https://github.com/vaadin/web-components/pull/12134

Part of https://github.com/vaadin/web-components/issues/10789

---

🤖 Generated with Claude Code