### PR TITLE
test: cover header row visibility with null header and header renderer

### DIFF
--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -353,6 +353,16 @@ describe('column', () => {
         expect(grid.$.header.children[0].hidden).to.be.ok;
       });
 
+      it('should not hide the header row with null header and header renderer', () => {
+        emptyColumn.headerRenderer = (root) => {
+          root.textContent = 'foo';
+        };
+        emptyColumn.header = null;
+        grid.removeChild(grid.querySelector('vaadin-grid-column-group'));
+        flushGrid(grid);
+        expect(grid.$.header.children[0].hidden).not.to.be.ok;
+      });
+
       it('should produce an empty header cell', () => {
         emptyColumn.path = 'foo';
         emptyColumn.header = '';


### PR DESCRIPTION
Setting `header` to `null` hides the header row unless something else keeps it visible. When a column also has a `headerRenderer`, the row must stay visible: a null header should only suppress the default header text, not hide content produced by the renderer. This behavior wasn't covered by tests, and an early version of the declarative header/footer rendering refactor accidentally broke it. This adds a test to lock in the current behavior.

Extracted from https://github.com/vaadin/web-components/pull/12134

Part of https://github.com/vaadin/web-components/issues/10789

---

🤖 Generated with Claude Code