### PR TITLE
test: cover cell content attach and detach on column add/remove

### DIFF
--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -503,6 +503,49 @@ describe('column', () => {
     });
   });
 
+  describe('cell content attach and detach', () => {
+    it('should remove header cell content from the grid when column is removed', async () => {
+      const content = getHeaderCellContent(grid, 1, 0);
+
+      column.remove();
+      await nextFrame();
+
+      expect(content.parentElement).to.be.null;
+    });
+
+    it('should remove footer cell content from the grid when column is removed', async () => {
+      const content = getContainerCellContent(grid.$.footer, 0, 0);
+
+      column.remove();
+      await nextFrame();
+
+      expect(content.parentElement).to.be.null;
+    });
+
+    it('should remove body cell content from the grid when column is removed', async () => {
+      const content = getBodyCellContent(grid, 0, 0);
+
+      column.remove();
+      await nextFrame();
+
+      expect(content.parentElement).to.be.null;
+    });
+
+    it('should render cell content when column is added back', async () => {
+      const group = column.parentElement;
+      column.remove();
+      await nextFrame();
+
+      group.insertBefore(column, group.firstElementChild);
+      await nextFrame();
+      flushGrid(grid);
+
+      expect(getHeaderCellContent(grid, 1, 0).textContent).to.equal('header1');
+      expect(getContainerCellContent(grid.$.footer, 0, 0).textContent).to.equal('footer1');
+      expect(getBodyCellContent(grid, 0, 0).textContent).to.equal('cell');
+    });
+  });
+
   it('should not throw an exception when size is changed after removing column', () => {
     expect(grid.size).to.equal(10);
     expect(column.isConnected).to.be.true;

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -508,14 +508,15 @@ describe('column', () => {
       let content;
 
       beforeEach(() => {
-        if (sectionName === 'header') {
-          content = getHeaderCellContent(grid, 1, 0);
-        }
-        if (sectionName === 'footer') {
-          content = getContainerCellContent(grid.$.footer, 0, 0);
-        }
-        if (sectionName === 'body') {
-          content = getBodyCellContent(grid, 0, 0);
+        switch (sectionName) {
+          case 'header':
+            content = getHeaderCellContent(grid, 1, 0);
+            break;
+          case 'footer':
+            content = getContainerCellContent(grid.$.footer, 0, 0);
+            break;
+          default:
+            content = getBodyCellContent(grid, 0, 0);
         }
       });
 

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -504,31 +504,27 @@ describe('column', () => {
   });
 
   describe('cell content attach and detach', () => {
-    it('should remove header cell content from the grid when column is removed', async () => {
-      const content = getHeaderCellContent(grid, 1, 0);
+    ['header', 'body', 'footer'].forEach((sectionName) => {
+      let content;
 
-      column.remove();
-      await nextFrame();
+      beforeEach(() => {
+        if (sectionName === 'header') {
+          content = getHeaderCellContent(grid, 1, 0);
+        }
+        if (sectionName === 'footer') {
+          content = getContainerCellContent(grid.$.footer, 0, 0);
+        }
+        if (sectionName === 'body') {
+          content = getBodyCellContent(grid, 0, 0);
+        }
+      });
 
-      expect(content.parentElement).to.be.null;
-    });
+      it(`should remove ${sectionName} cell content from the grid when column is removed`, async () => {
+        column.remove();
+        await nextFrame();
 
-    it('should remove footer cell content from the grid when column is removed', async () => {
-      const content = getContainerCellContent(grid.$.footer, 0, 0);
-
-      column.remove();
-      await nextFrame();
-
-      expect(content.parentElement).to.be.null;
-    });
-
-    it('should remove body cell content from the grid when column is removed', async () => {
-      const content = getBodyCellContent(grid, 0, 0);
-
-      column.remove();
-      await nextFrame();
-
-      expect(content.parentElement).to.be.null;
+        expect(content.parentElement).to.be.null;
+      });
     });
 
     it('should render cell content when column is added back', async () => {


### PR DESCRIPTION
When a column is removed, the grid also removes the column's `<vaadin-grid-cell-content>` elements from its light DOM, and adds them back when the column is added again. This behavior wasn't covered by tests for header and footer cells. The declarative header/footer rendering refactor changes how header and footer cell content is managed, so this adds tests to lock in the current behavior first.

Extracted from https://github.com/vaadin/web-components/pull/12134

Part of https://github.com/vaadin/web-components/issues/10789

---

🤖 Generated with Claude Code