### PR TITLE
test: improve coverage for tabsheet loading state fallback height

### DIFF
--- a/packages/tabsheet/test/tabsheet.test.js
+++ b/packages/tabsheet/test/tabsheet.test.js
@@ -259,10 +259,22 @@ describe('tabsheet', () => {
       expect(tabsheet.hasAttribute('loading')).to.be.false;
     });
 
-    it('should not change height when entering loading state', () => {
-      const height = tabsheet.offsetHeight;
+    it('should preserve content height when entering loading state', async () => {
+      const content = tabsheet.shadowRoot.querySelector('[part="content"]');
+      const contentHeight = content.offsetHeight;
       newTab.click();
-      expect(tabsheet.offsetHeight).to.equal(height);
+      await nextFrame();
+      expect(content.offsetHeight).to.be.at.least(contentHeight);
+    });
+
+    it('should release content height when leaving loading state', async () => {
+      const content = tabsheet.shadowRoot.querySelector('[part="content"]');
+      newTab.click();
+      await nextFrame();
+      expect(content.style.minHeight).to.not.equal('');
+      tabsheet.appendChild(newPanel);
+      await nextFrame();
+      expect(content.style.minHeight).to.equal('');
     });
 
     it('should allow changing height when leaving loading state', async () => {


### PR DESCRIPTION
## Description

Improved tests for the fallback height: current test was unreliable and didn't use any `await`.
This resolves following issues revealed when running [Stryker](https://stryker-mutator.io/) mutation testing:

```
[Survived] StringLiteral
src/vaadin-tabsheet-mixin.js:223:35
-           content.style.minHeight = `${content.offsetHeight}px`;
+           content.style.minHeight = ``;

[Survived] BlockStatement
src/vaadin-tabsheet-mixin.js:221:38
-         } else if (hasOneVisiblePanel) {
-           // Make sure the empty content has a fallback height in loading state..
-           content.style.minHeight = `${content.offsetHeight}px`;
-         }
+         } else if (hasOneVisiblePanel) {}

[Survived] ConditionalExpression
src/vaadin-tabsheet-mixin.js:221:18
-         } else if (hasOneVisiblePanel) {
+         } else if (false) {
```

## Type of change

- Test