### PR TITLE
fix: update media query breakpoint from 420px to 450px

### DIFF
--- a/packages/vaadin-lumo-styles/src/components/notification-container.css
+++ b/packages/vaadin-lumo-styles/src/components/notification-container.css
@@ -39,7 +39,7 @@
     flex: 1 1 0%;
   }
 
-  @media (max-width: 420px) {
+  @media (max-width: 450px) {
     [region-group] {
       flex-direction: column;
       align-items: stretch;


### PR DESCRIPTION
## Description

Align notification media query breakpoint with other components.

Related to #4320 and #83

Latest iPhone Pro Max (15, 16, 17..) has 440px width (https://www.ios-resolution.com/iphone-17-pro-max/)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/contributing/pr
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] I have not completed some of the steps above and my pull request can be closed immediately.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
