### PR TITLE
chore: remove no longer needed visual tests environment check

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   base:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'PR-validation' || '' }}
     name: Base
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'
@@ -52,7 +51,6 @@ jobs:
             packages/*/test/visual/base/screenshots/*/failed/*.png
 
   lumo:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'PR-validation' || '' }}
     name: Lumo
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'
@@ -92,7 +90,6 @@ jobs:
             packages/vaadin-lumo-styles/test/visual/screenshots/failed/*.png
 
   aura:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'PR-validation' || '' }}
     name: Aura
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vaadin'

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -15,7 +15,6 @@ jobs:
   base:
     name: Base
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-noble
       options: --ipc=host
@@ -53,7 +52,6 @@ jobs:
   lumo:
     name: Lumo
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-noble
       options: --ipc=host
@@ -92,7 +90,6 @@ jobs:
   aura:
     name: Aura
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'vaadin'
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-noble
       options: --ipc=host


### PR DESCRIPTION
## Description

This reverts https://github.com/vaadin/web-components/pull/11035.

The check is no longer needed as we use `pull_request` after switching from SauceLabs to Docker:

- https://github.com/vaadin/web-components/pull/11323
- https://github.com/vaadin/web-components/pull/11294

## Type of change

- Internal change