### PR TITLE
refactor: remove dead slotted list-box guard in select renderer

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -693,11 +693,6 @@ export const SelectBaseMixin = (superClass) =>
      * @private
      */
     __defaultRenderer(root, _select) {
-      if (this.__slottedListBox) {
-        root.textContent = '';
-        return;
-      }
-
       if (!this.items || this.items.length === 0) {
         root.textContent = '';
         return;


### PR DESCRIPTION
## Description

Removes an unreachable `__slottedListBox` early-return from `__defaultRenderer` in `<vaadin-select>`.

`render()` binds the overlay `renderer` to `undefined` whenever a `<vaadin-select-list-box>` is slotted, so `__defaultRenderer` is never invoked while `__slottedListBox` is set. Clearing the previously rendered content on that transition is already handled by the overlay in `_rendererOrDataChanged`, which resets the renderer root when the renderer changes.

No behavior change; select tests and lint pass without it.

## Type of change

- Refactor
