### PR TITLE
refactor: disallow combining slotted list-box with items or renderer

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -693,11 +693,6 @@ export const SelectBaseMixin = (superClass) =>
      * @private
      */
     __defaultRenderer(root, _select) {
-      if (this.__slottedListBox) {
-        root.textContent = '';
-        return;
-      }
-
       if (!this.items || this.items.length === 0) {
         root.textContent = '';
         return;

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -10,7 +10,6 @@ import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mi
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { TooltipController } from '@vaadin/component-base/src/tooltip-controller.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
-import { issueWarning } from '@vaadin/component-base/src/warnings.js';
 import { FieldMixin } from '@vaadin/field-base/src/field-mixin.js';
 import { LabelController } from '@vaadin/field-base/src/label-controller.js';
 import { ButtonController } from './button-controller.js';
@@ -215,14 +214,6 @@ export const SelectBaseMixin = (superClass) =>
       if (props.has('__slottedListBox')) {
         const slottedListBox = this.__slottedListBox;
         if (slottedListBox) {
-          // Slotted list-box takes precedence over the `renderer` and `items`.
-          if (this.items?.length || this.renderer) {
-            issueWarning(
-              'WARNING: Both a slotted <vaadin-select-list-box> and the "items" / "renderer"' +
-                ' property are set on <vaadin-select>. The slotted list-box takes precedence.',
-            );
-          }
-
           this._assignMenuElement(slottedListBox);
         } else if (props.get('__slottedListBox')) {
           this._menuElement = null;
@@ -280,7 +271,15 @@ export const SelectBaseMixin = (superClass) =>
      * @private
      */
     __onOverlaySlotChange(e) {
-      this.__slottedListBox = e.target.assignedElements().find((el) => el._hasVaadinListMixin);
+      const slottedListBox = e.target.assignedElements().find((el) => el._hasVaadinListMixin);
+      // A slotted list-box and the `items` / `renderer` API are mutually
+      // exclusive ways of defining the content, so combining them is not allowed.
+      if (slottedListBox && (this.items?.length || this.renderer)) {
+        throw new Error(
+          'A slotted <vaadin-select-list-box> cannot be used together with the "items" or "renderer" property.',
+        );
+      }
+      this.__slottedListBox = slottedListBox;
     }
 
     /**

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -211,6 +211,14 @@ export const SelectBaseMixin = (superClass) =>
         this.toggleAttribute('phone', this._phone);
       }
 
+      if (props.has('items') || props.has('renderer') || props.has('__slottedListBox')) {
+        if (this.__slottedListBox && (this.items?.length || this.renderer)) {
+          throw new Error(
+            'A slotted <vaadin-select-list-box> cannot be used together with the "items" or "renderer" property.',
+          );
+        }
+      }
+
       if (props.has('__slottedListBox')) {
         const slottedListBox = this.__slottedListBox;
         if (slottedListBox) {
@@ -271,13 +279,7 @@ export const SelectBaseMixin = (superClass) =>
      * @private
      */
     __onOverlaySlotChange(e) {
-      const slottedListBox = e.target.assignedElements().find((el) => el._hasVaadinListMixin);
-      if (slottedListBox && (this.items?.length || this.renderer)) {
-        throw new Error(
-          'A slotted <vaadin-select-list-box> cannot be used together with the "items" or "renderer" property.',
-        );
-      }
-      this.__slottedListBox = slottedListBox;
+      this.__slottedListBox = e.target.assignedElements().find((el) => el._hasVaadinListMixin);
     }
 
     /**

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -272,8 +272,6 @@ export const SelectBaseMixin = (superClass) =>
      */
     __onOverlaySlotChange(e) {
       const slottedListBox = e.target.assignedElements().find((el) => el._hasVaadinListMixin);
-      // A slotted list-box and the `items` / `renderer` API are mutually
-      // exclusive ways of defining the content, so combining them is not allowed.
       if (slottedListBox && (this.items?.length || this.renderer)) {
         throw new Error(
           'A slotted <vaadin-select-list-box> cannot be used together with the "items" or "renderer" property.',

--- a/packages/select/test/slotted-list-box.test.js
+++ b/packages/select/test/slotted-list-box.test.js
@@ -115,7 +115,7 @@ describe('lazy list-box', () => {
 });
 
 describe('slotted list-box with items or renderer', () => {
-  let select, slot;
+  let select;
 
   beforeEach(async () => {
     select = fixtureSync(`
@@ -128,18 +128,17 @@ describe('slotted list-box with items or renderer', () => {
     `);
     // Let the slotted list-box be detected before combining it with items/renderer.
     await nextRender();
-    slot = select.shadowRoot.querySelector('slot[name="overlay"]');
   });
 
   it('should throw when the items property is also set', () => {
     select.items = [{ label: 'Ignored', value: 'ignored' }];
-    expect(() => select.__onOverlaySlotChange({ target: slot })).to.throw();
+    expect(() => select.performUpdate()).to.throw();
   });
 
   it('should throw when the renderer property is also set', () => {
     select.renderer = (root) => {
       root.textContent = 'Renderer';
     };
-    expect(() => select.__onOverlaySlotChange({ target: slot })).to.throw();
+    expect(() => select.performUpdate()).to.throw();
   });
 });

--- a/packages/select/test/slotted-list-box.test.js
+++ b/packages/select/test/slotted-list-box.test.js
@@ -1,10 +1,8 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import '../src/vaadin-select.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
-import { clearWarnings } from '@vaadin/component-base/src/warnings.js';
 
 describe('slotted list-box', () => {
   let select, overlay, listBox, valueButton;
@@ -116,12 +114,10 @@ describe('lazy list-box', () => {
   });
 });
 
-describe('slotted list-box with items and renderer', () => {
-  let select, listBox, warnSpy;
+describe('slotted list-box with items or renderer', () => {
+  let select, slot;
 
-  beforeEach(() => {
-    clearWarnings();
-    warnSpy = sinon.stub(console, 'warn');
+  beforeEach(async () => {
     select = fixtureSync(`
       <vaadin-select>
         <vaadin-select-list-box slot="overlay">
@@ -130,29 +126,20 @@ describe('slotted list-box with items and renderer', () => {
         </vaadin-select-list-box>
       </vaadin-select>
     `);
-    listBox = select.querySelector('vaadin-select-list-box');
-  });
-
-  afterEach(() => {
-    warnSpy.restore();
-  });
-
-  it('should use the slotted list-box over the items property and warn once', async () => {
-    select.items = [{ label: 'Ignored', value: 'ignored' }];
+    // Let the slotted list-box be detected before combining it with items/renderer.
     await nextRender();
-
-    expect(select._menuElement).to.equal(listBox);
-    expect(listBox.items).to.have.lengthOf(2);
-    expect(warnSpy.callCount).to.equal(1);
+    slot = select.shadowRoot.querySelector('slot[name="overlay"]');
   });
 
-  it('should use the slotted list-box over the renderer and warn once', async () => {
+  it('should throw when the items property is also set', () => {
+    select.items = [{ label: 'Ignored', value: 'ignored' }];
+    expect(() => select.__onOverlaySlotChange({ target: slot })).to.throw();
+  });
+
+  it('should throw when the renderer property is also set', () => {
     select.renderer = (root) => {
       root.textContent = 'Renderer';
     };
-    await nextRender();
-
-    expect(select._menuElement).to.equal(listBox);
-    expect(warnSpy.callCount).to.equal(1);
+    expect(() => select.__onOverlaySlotChange({ target: slot })).to.throw();
   });
 });


### PR DESCRIPTION
## Description

Adapts the `<vaadin-context-menu>` change (https://github.com/vaadin/web-components/pull/12172) to `<vaadin-select>`:

- Combining a slotted `<vaadin-select-list-box>` with the `items` or `renderer` API now throws instead of warning. These are mutually exclusive ways of defining the content, and mixing them is not a supported use case.
- Removes a dead `__slottedListBox` early-return from the default renderer (unreachable: `render()` binds the overlay renderer to `undefined` when a list-box is slotted, and the overlay already clears the renderer root on renderer change).

## Type of change

- Refactor
