### PR TITLE
refactor: deprecate requestContentUpdate method in dialog

### DIFF
--- a/packages/dialog/src/vaadin-dialog-renderer-mixin.d.ts
+++ b/packages/dialog/src/vaadin-dialog-renderer-mixin.d.ts
@@ -69,6 +69,8 @@ export declare class DialogRendererMixinClass {
    * as well as `headerRender` and `footerRenderer` properties, if these are defined.
    *
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   *
+   * @deprecated This method is only used with renderers and will be removed in Vaadin 26
    */
   requestContentUpdate(): void;
 }

--- a/packages/dialog/src/vaadin-dialog-renderer-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-renderer-mixin.js
@@ -77,6 +77,8 @@ export const DialogRendererMixin = (superClass) =>
      * as well as `headerRender` and `footerRenderer` properties, if these are defined.
      *
      * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+     *
+     * @deprecated This method is only used with renderers and will be removed in Vaadin 26
      */
     requestContentUpdate() {
       if (this._overlayElement) {


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/12158

Deprecated `requestContentUpdate()` in dialog so it could be removed together with renderers in V26.

## Type of change

- Deprecation