### PR TITLE
refactor: deprecate requestContentUpdate method in select

### DIFF
--- a/packages/select/src/vaadin-select-base-mixin.d.ts
+++ b/packages/select/src/vaadin-select-base-mixin.d.ts
@@ -112,6 +112,8 @@ export declare class SelectBaseMixinClass {
    * While performing the update, it invokes the renderer passed in the `renderer` property.
    *
    * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+   *
+   * @deprecated This method is deprecated and will be removed in Vaadin 26
    */
   requestContentUpdate(): void;
 }

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -41,7 +41,6 @@ export const SelectBaseMixin = (superClass) =>
          */
         items: {
           type: Array,
-          observer: '__itemsChanged',
         },
 
         /**
@@ -219,6 +218,10 @@ export const SelectBaseMixin = (superClass) =>
         }
       }
 
+      if (props.has('items')) {
+        this._overlayElement.requestContentUpdate();
+      }
+
       if (props.has('__slottedListBox')) {
         const slottedListBox = this.__slottedListBox;
         if (slottedListBox) {
@@ -236,6 +239,8 @@ export const SelectBaseMixin = (superClass) =>
      * While performing the update, it invokes the renderer passed in the `renderer` property.
      *
      * It is not guaranteed that the update happens immediately (synchronously) after it is requested.
+     *
+     * @deprecated This method is deprecated and will be removed in Vaadin 26
      */
     requestContentUpdate() {
       if (!this._overlayElement) {
@@ -257,17 +262,6 @@ export const SelectBaseMixin = (superClass) =>
 
       if (required === false) {
         this._requestValidation();
-      }
-    }
-
-    /**
-     * @param {SelectItemData[] | undefined | null} newItems
-     * @param {SelectItemData[] | undefined | null} oldItems
-     * @private
-     */
-    __itemsChanged(newItems, oldItems) {
-      if (newItems || oldItems) {
-        this.requestContentUpdate();
       }
     }
 


### PR DESCRIPTION
## Description

- Deprecated `requestContentUpdate()` in dialog so it could be removed together with `renderer` in V26.
- Replaced the property observer with `updated()` lifecycle hook to run after check for `items` vs `renderer`

## Type of change

- Refactor

## Note

Flow still uses `requestContentUpdate()` since it relies on a side-effect: re-assigning menu element.
This will be covered by separate PR - we'll have to observe selected item DOM / `label` mutations.