### PR TITLE
feat: add Highcharts pattern-fill support to vaadin-chart

### DIFF
--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -63,20 +63,21 @@ export function prepareExport(chart) {
   // the 'after print' event.
   if (!chart.tempBodyStyle) {
     let effectiveCss = '';
+    const cssFromSheet = (sheet) => `${[...sheet.cssRules].map((rule) => rule.cssText).join('\n')}\n`;
 
     // LitElement uses `adoptedStyleSheets` for adding styles
     if (chart.shadowRoot.adoptedStyleSheets) {
       chart.shadowRoot.adoptedStyleSheets.forEach((sheet) => {
-        effectiveCss += `${[...sheet.cssRules].map((rule) => rule.cssText).join('\n')}\n`;
+        effectiveCss += cssFromSheet(sheet);
       });
     }
 
-    // The pattern-fill bridge injects its rules into a top-level `<style>` child instead
-    // of `adoptedStyleSheets`, so copy those too. Use `:scope >` to skip Highcharts' own
-    // nested `<svg><defs><style>`.
+    // Also copy any top-level `<style>` children (e.g. injected by a feature bridge),
+    // which are not in `adoptedStyleSheets`. `:scope >` skips Highcharts' own nested
+    // `<svg><defs><style>`.
     chart.shadowRoot.querySelectorAll(':scope > style').forEach((styleEl) => {
       if (styleEl.sheet) {
-        effectiveCss += `${[...styleEl.sheet.cssRules].map((rule) => rule.cssText).join('\n')}\n`;
+        effectiveCss += cssFromSheet(styleEl.sheet);
       }
     });
 

--- a/packages/charts/src/helpers.js
+++ b/packages/charts/src/helpers.js
@@ -71,6 +71,15 @@ export function prepareExport(chart) {
       });
     }
 
+    // The pattern-fill bridge injects its rules into a top-level `<style>` child instead
+    // of `adoptedStyleSheets`, so copy those too. Use `:scope >` to skip Highcharts' own
+    // nested `<svg><defs><style>`.
+    chart.shadowRoot.querySelectorAll(':scope > style').forEach((styleEl) => {
+      if (styleEl.sheet) {
+        effectiveCss += `${[...styleEl.sheet.cssRules].map((rule) => rule.cssText).join('\n')}\n`;
+      }
+    });
+
     // Strip off host selectors that target individual instances
     effectiveCss = effectiveCss.replace(/:host\(.+?\)/gu, (match) => {
       const selector = match.substr(6, match.length - 7);

--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -356,54 +356,52 @@ export const chartStyles = css`
   /* Series options */
 
   /* Default colors */
-  /* The :not([fill^='url(']) exclusion keeps the theme color off elements with a
-     pattern fill attribute (the pattern bridge's per-point fallback, and user url() fills). */
-  :where([styled-mode]) .highcharts-color-0:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-0 {
     fill: var(--_color-0);
     stroke: var(--_color-0);
   }
 
-  :where([styled-mode]) .highcharts-color-1:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-1 {
     fill: var(--_color-1);
     stroke: var(--_color-1);
   }
 
-  :where([styled-mode]) .highcharts-color-2:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-2 {
     fill: var(--_color-2);
     stroke: var(--_color-2);
   }
 
-  :where([styled-mode]) .highcharts-color-3:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-3 {
     fill: var(--_color-3);
     stroke: var(--_color-3);
   }
 
-  :where([styled-mode]) .highcharts-color-4:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-4 {
     fill: var(--_color-4);
     stroke: var(--_color-4);
   }
 
-  :where([styled-mode]) .highcharts-color-5:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-5 {
     fill: var(--_color-5);
     stroke: var(--_color-5);
   }
 
-  :where([styled-mode]) .highcharts-color-6:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-6 {
     fill: var(--_color-6);
     stroke: var(--_color-6);
   }
 
-  :where([styled-mode]) .highcharts-color-7:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-7 {
     fill: var(--_color-7);
     stroke: var(--_color-7);
   }
 
-  :where([styled-mode]) .highcharts-color-8:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-8 {
     fill: var(--_color-8);
     stroke: var(--_color-8);
   }
 
-  :where([styled-mode]) .highcharts-color-9:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-color-9 {
     fill: var(--_color-9);
     stroke: var(--_color-9);
   }
@@ -514,9 +512,7 @@ export const chartStyles = css`
     fill: var(--highcharts-neutral-color-80, var(--_data-label));
   }
 
-  /* Needs the same guard: without it the color-N rules above (also connectors carry
-     .highcharts-color-N) outrank this and fill the connector with the series color. */
-  :where([styled-mode]) .highcharts-data-label-connector:not([fill^='url(']) {
+  :where([styled-mode]) .highcharts-data-label-connector {
     fill: none;
   }
 

--- a/packages/charts/src/styles/vaadin-chart-base-styles.js
+++ b/packages/charts/src/styles/vaadin-chart-base-styles.js
@@ -356,52 +356,54 @@ export const chartStyles = css`
   /* Series options */
 
   /* Default colors */
-  :where([styled-mode]) .highcharts-color-0 {
+  /* The :not([fill^='url(']) exclusion keeps the theme color off elements with a
+     pattern fill attribute (the pattern bridge's per-point fallback, and user url() fills). */
+  :where([styled-mode]) .highcharts-color-0:not([fill^='url(']) {
     fill: var(--_color-0);
     stroke: var(--_color-0);
   }
 
-  :where([styled-mode]) .highcharts-color-1 {
+  :where([styled-mode]) .highcharts-color-1:not([fill^='url(']) {
     fill: var(--_color-1);
     stroke: var(--_color-1);
   }
 
-  :where([styled-mode]) .highcharts-color-2 {
+  :where([styled-mode]) .highcharts-color-2:not([fill^='url(']) {
     fill: var(--_color-2);
     stroke: var(--_color-2);
   }
 
-  :where([styled-mode]) .highcharts-color-3 {
+  :where([styled-mode]) .highcharts-color-3:not([fill^='url(']) {
     fill: var(--_color-3);
     stroke: var(--_color-3);
   }
 
-  :where([styled-mode]) .highcharts-color-4 {
+  :where([styled-mode]) .highcharts-color-4:not([fill^='url(']) {
     fill: var(--_color-4);
     stroke: var(--_color-4);
   }
 
-  :where([styled-mode]) .highcharts-color-5 {
+  :where([styled-mode]) .highcharts-color-5:not([fill^='url(']) {
     fill: var(--_color-5);
     stroke: var(--_color-5);
   }
 
-  :where([styled-mode]) .highcharts-color-6 {
+  :where([styled-mode]) .highcharts-color-6:not([fill^='url(']) {
     fill: var(--_color-6);
     stroke: var(--_color-6);
   }
 
-  :where([styled-mode]) .highcharts-color-7 {
+  :where([styled-mode]) .highcharts-color-7:not([fill^='url(']) {
     fill: var(--_color-7);
     stroke: var(--_color-7);
   }
 
-  :where([styled-mode]) .highcharts-color-8 {
+  :where([styled-mode]) .highcharts-color-8:not([fill^='url(']) {
     fill: var(--_color-8);
     stroke: var(--_color-8);
   }
 
-  :where([styled-mode]) .highcharts-color-9 {
+  :where([styled-mode]) .highcharts-color-9:not([fill^='url(']) {
     fill: var(--_color-9);
     stroke: var(--_color-9);
   }
@@ -512,7 +514,9 @@ export const chartStyles = css`
     fill: var(--highcharts-neutral-color-80, var(--_data-label));
   }
 
-  :where([styled-mode]) .highcharts-data-label-connector {
+  /* Needs the same guard: without it the color-N rules above (also connectors carry
+     .highcharts-color-N) outrank this and fill the connector with the series color. */
+  :where([styled-mode]) .highcharts-data-label-connector:not([fill^='url(']) {
     fill: none;
   }
 

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -712,6 +712,10 @@ export const ChartMixin = (superClass) =>
     /** @private */
     __initChart(options) {
       this.__initEventsListeners(options);
+      // Discard any previous bridge before re-creating the chart. The reset re-init path
+      // reaches here with the old chart still live, so this removes its injected `<style>`
+      // and defs instead of orphaning them.
+      this.__patternFillBridge?.destroy();
       this.__styledMode = options.chart.styledMode;
       if (options.chart.type === 'gantt') {
         this.configuration = Highcharts.ganttChart(this.$.chart, options);
@@ -722,8 +726,8 @@ export const ChartMixin = (superClass) =>
       }
 
       // Bridge Highcharts pattern-fill into styled mode; re-applied on every render.
-      // Teardown rides on `configuration.destroy()`; the listener misses the first
-      // (synchronous) render, so also apply once now.
+      // It is destroyed on re-init (above) and on disconnect; the listener misses the
+      // first (synchronous) render, so also apply once now.
       this.__patternFillBridge = new PatternFillBridge(this.configuration, this.shadowRoot);
       Highcharts.addEvent(this.configuration, 'render', () => this.__patternFillBridge.apply());
       this.__patternFillBridge.apply();

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -729,7 +729,7 @@ export const ChartMixin = (superClass) =>
       // It is destroyed on re-init (above) and on disconnect; the listener misses the
       // first (synchronous) render, so also apply once now.
       this.__patternFillBridge = new PatternFillBridge(this.configuration, this.shadowRoot);
-      Highcharts.addEvent(this.configuration, 'render', () => this.__patternFillBridge.apply());
+      Highcharts.addEvent(this.configuration, 'render', () => this.__patternFillBridge?.apply());
       this.__patternFillBridge.apply();
 
       this.__forceResize();

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -27,7 +27,6 @@ import 'highcharts/es-modules/masters/modules/xrange.src.js';
 import 'highcharts/es-modules/masters/modules/bullet.src.js';
 import 'highcharts/es-modules/masters/modules/gantt.src.js';
 import 'highcharts/es-modules/masters/modules/draggable-points.src.js';
-import 'highcharts/es-modules/masters/modules/pattern-fill.src.js';
 import KeyboardNavigation from 'highcharts/es-modules/Accessibility/KeyboardNavigation.js';
 import HTMLUtilities from 'highcharts/es-modules/Accessibility/Utils/HTMLUtilities.js';
 import Pointer from 'highcharts/es-modules/Core/Pointer.js';
@@ -36,6 +35,7 @@ import { get } from '@vaadin/component-base/src/path-utils.js';
 import { ResizeMixin } from '@vaadin/component-base/src/resize-mixin.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 import { cleanupExport, deepMerge, inflateFunctions, prepareExport } from './helpers.js';
+import { PatternFillBridge } from './vaadin-chart-pattern-fill.js';
 
 ['exportChart', 'exportChartLocal', 'getSVG'].forEach((methodName) => {
   /* eslint-disable @typescript-eslint/no-invalid-this, prefer-arrow-callback */
@@ -721,268 +721,14 @@ export const ChartMixin = (superClass) =>
         this.configuration = Highcharts.chart(this.$.chart, options);
       }
 
-      // Re-apply on every render; teardown rides on `configuration.destroy()`. The
-      // listener misses the first (synchronous) render, so also apply once now.
-      Highcharts.addEvent(this.configuration, 'render', () => this.__applyPatternFills());
-      this.__applyPatternFills();
+      // Bridge Highcharts pattern-fill into styled mode; re-applied on every render.
+      // Teardown rides on `configuration.destroy()`; the listener misses the first
+      // (synchronous) render, so also apply once now.
+      this.__patternFillBridge = new PatternFillBridge(this.configuration, this.shadowRoot);
+      Highcharts.addEvent(this.configuration, 'render', () => this.__patternFillBridge.apply());
+      this.__patternFillBridge.apply();
 
       this.__forceResize();
-    }
-
-    /**
-     * Renders `color: { pattern }` / `color: { patternIndex }` in styled mode, where
-     * Highcharts' own pattern-fill handler never fires (fills come from CSS classes).
-     * Per render: create the `<pattern>` def (deduped by content hash) and style its path,
-     * then inject one CSS rule per series color index (`.highcharts-color-N { fill: url }`),
-     * which also covers the legend symbol and tooltip swatch and survives the export copy.
-     * A point whose own pattern differs from its series falls back to a `fill` attribute.
-     *
-     * Known limitation: server-side `exportChart` renders a fresh chart this hook never
-     * runs on, so server SVGs lack these patterns (follow-up).
-     * @private
-     */
-    __applyPatternFills() {
-      const chart = this.configuration;
-      if (!chart || !chart.renderer) {
-        return;
-      }
-
-      // Styled mode only: non-styled mode renders patterns natively, and running the
-      // bridge there would strip that fill. `styledMode` is fixed at construction.
-      if (!this.__styledMode) {
-        return;
-      }
-
-      this.__shimPatternIds ||= new Set();
-
-      // Bail out when there are no patterns and none were created on a previous render.
-      const hasPatterns = chart.series.some(
-        (series) =>
-          this.__isPatternColor(series.options && series.options.color) ||
-          series.points.some((point) => this.__isPatternColor(point.options && point.options.color)),
-      );
-      if (!hasPatterns && this.__shimPatternIds.size === 0 && !this.__patternSheet) {
-        return;
-      }
-
-      const usedIds = new Set();
-      // colorIndex -> pattern id, for series that carry a single series-wide pattern.
-      const colorIndexRules = new Map();
-
-      if (hasPatterns) {
-        chart.series.forEach((series) => {
-          const seriesColorOptions = series.options && series.options.color;
-          let seriesPatternId;
-          if (this.__isPatternColor(seriesColorOptions)) {
-            const colorIndex = this.__resolveColorIndex(series.colorIndex);
-            seriesPatternId = this.__ensurePatternDef(seriesColorOptions, colorIndex);
-            if (seriesPatternId) {
-              usedIds.add(seriesPatternId);
-              colorIndexRules.set(colorIndex, seriesPatternId);
-            }
-          }
-
-          series.points.forEach((point) => {
-            const id = this.__applyPointPatternFill(point, seriesPatternId);
-            if (id) {
-              usedIds.add(id);
-            }
-          });
-        });
-      }
-
-      this.__rebuildPatternSheet(colorIndexRules);
-      this.__cleanupPatternDefs(usedIds);
-    }
-
-    /**
-     * Whether a color option is a pattern (`{ pattern }` or `{ patternIndex }`).
-     * @private
-     * @return {boolean}
-     */
-    __isPatternColor(color) {
-      return Highcharts.isObject(color) && (!!color.pattern || typeof color.patternIndex === 'number');
-    }
-
-    /**
-     * Color index, defaulting to `0` so patterns never resolve `var(--_color-undefined)`.
-     * @private
-     * @return {number}
-     */
-    __resolveColorIndex(colorIndex) {
-      return Highcharts.pick(colorIndex, 0);
-    }
-
-    /**
-     * Creates (or reuses) the `<pattern>` def for a pattern color option and applies the
-     * path styling the pattern-fill module skips in styled mode. Returns the def id.
-     * @private
-     * @return {string | undefined}
-     */
-    __ensurePatternDef(colorOptions, colorIndex) {
-      let pattern = colorOptions.pattern;
-      if (typeof colorOptions.patternIndex === 'number') {
-        pattern = Highcharts.patterns && Highcharts.patterns[colorOptions.patternIndex];
-      }
-      if (!pattern) {
-        return undefined;
-      }
-
-      const chart = this.configuration;
-      // Fall back to the series' theme color when the pattern sets no explicit color.
-      const patternColor = pattern.color || `var(--_color-${colorIndex})`;
-
-      const id =
-        pattern.id ||
-        `vaadin-pattern-${this.__hashPattern({ ...this.__stripInternalKeys(pattern), color: patternColor })}`;
-
-      // No-op if the id already exists.
-      chart.renderer.addPattern({ ...pattern, id });
-
-      // Track bridge-created ids (incl. explicit `pattern.id`) for membership-based cleanup.
-      this.__shimPatternIds.add(id);
-
-      // Module skips the path's stroke/fill in styled mode; apply inline (presentation
-      // attributes don't resolve CSS variables, inline styles do).
-      const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
-      const pathElement = patternElement && patternElement.element.querySelector('path');
-      if (pathElement) {
-        const pathOptions = typeof pattern.path === 'object' && pattern.path !== null ? pattern.path : {};
-        pathElement.style.stroke = pathOptions.stroke || patternColor;
-        pathElement.style.strokeWidth = String(pathOptions.strokeWidth != null ? pathOptions.strokeWidth : 2);
-        pathElement.style.fill = pathOptions.fill || 'none';
-      }
-
-      return id;
-    }
-
-    /**
-     * Per-point fallback: when a point's own pattern differs from its series pattern, a
-     * class-level rule can't target it, so set the `fill` attribute directly (the base-style
-     * `:not([fill^='url('])` exclusion keeps the theme rule off it). Otherwise clear any
-     * stale fallback attribute so the injected colorIndex rule applies.
-     * @private
-     * @return {string | undefined} the def id when the point uses the fallback
-     */
-    __applyPointPatternFill(point, seriesPatternId) {
-      const graphic = point.graphic && point.graphic.element;
-      const pointColorOptions = point.options && point.options.color;
-
-      if (this.__isPatternColor(pointColorOptions)) {
-        const colorIndex = this.__resolveColorIndex(
-          point.colorIndex != null ? point.colorIndex : point.series.colorIndex,
-        );
-        const id = this.__ensurePatternDef(pointColorOptions, colorIndex);
-        if (id && id !== seriesPatternId) {
-          if (graphic) {
-            const url = this.configuration.renderer.url || '';
-            graphic.setAttribute('fill', `url(${url}#${id})`);
-          }
-          return id;
-        }
-      }
-
-      // Not a fallback point: drop any stale `url(...)` fill so the colorIndex rule applies.
-      if (graphic) {
-        const fill = graphic.getAttribute('fill');
-        if (fill && fill.startsWith('url(')) {
-          graphic.removeAttribute('fill');
-        }
-      }
-      return undefined;
-    }
-
-    /**
-     * Rebuilds the adopted stylesheet mapping each patterned color index to its fill.
-     * Rebuilding wholesale via `replaceSync` drops rules for indexes that lost their
-     * pattern. The selector omits `:where()` so its specificity (0,3,0) beats the base
-     * theme rule (0,2,0); its `:not([fill^='url('])` guard spares per-point fallback fills.
-     * @private
-     */
-    __rebuildPatternSheet(colorIndexRules) {
-      if (colorIndexRules.size === 0 && !this.__patternSheet) {
-        return;
-      }
-
-      if (!this.__patternSheet) {
-        this.__patternSheet = new CSSStyleSheet();
-      }
-      if (!this.shadowRoot.adoptedStyleSheets.includes(this.__patternSheet)) {
-        this.shadowRoot.adoptedStyleSheets = [...this.shadowRoot.adoptedStyleSheets, this.__patternSheet];
-      }
-
-      const url = this.configuration.renderer.url || '';
-      const cssText = [...colorIndexRules.entries()]
-        .map(
-          ([colorIndex, id]) =>
-            `[styled-mode] .highcharts-color-${colorIndex}:not([fill^='url(']) { fill: url(${url}#${id}); }`,
-        )
-        .join('\n');
-      this.__patternSheet.replaceSync(cssText);
-    }
-
-    /**
-     * Removes `<pattern>` defs created by this shim that are no longer referenced,
-     * to avoid leaking or duplicating defs across updates and redraws.
-     * @private
-     */
-    __cleanupPatternDefs(usedIds) {
-      const shimIds = this.__shimPatternIds;
-      if (!shimIds || shimIds.size === 0) {
-        return;
-      }
-
-      const { renderer } = this.configuration;
-      const patternElements = renderer.patternElements || {};
-      // Remove by membership so Highcharts' own `highcharts-pattern-*` defs are untouched.
-      shimIds.forEach((id) => {
-        if (usedIds.has(id)) {
-          return;
-        }
-        if (patternElements[id]) {
-          patternElements[id].destroy();
-          delete patternElements[id];
-        }
-        if (renderer.defIds) {
-          Highcharts.erase(renderer.defIds, id);
-        }
-        shimIds.delete(id);
-      });
-    }
-
-    /**
-     * Shallow copy without Highcharts' internal `_`-prefixed keys (e.g. `_width`/`_height`),
-     * which it writes onto image patterns between renders. Stripping them keeps the hashed
-     * id stable across redraws so the def isn't needlessly recreated.
-     * @private
-     * @return {Object}
-     */
-    __stripInternalKeys(pattern) {
-      const result = {};
-      Object.keys(pattern).forEach((key) => {
-        if (key[0] !== '_') {
-          result[key] = pattern[key];
-        }
-      });
-      return result;
-    }
-
-    /**
-     * Computes a stable hash from a pattern config, used to build a deduplicated pattern id.
-     * The id only needs to be stable across redraws and unique among this chart's own
-     * patterns (it is always prefixed `vaadin-pattern-`, so it never has to match
-     * Highcharts' native ids), so a single deterministic pass is sufficient.
-     * @private
-     * @return {string}
-     */
-    __hashPattern(pattern) {
-      const str = JSON.stringify(pattern);
-      let hash = 0;
-      for (let i = 0; i < str.length; i++) {
-        hash = (hash << 5) - hash + str.charCodeAt(i);
-        hash &= hash;
-      }
-      return hash.toString(16).replace('-', '1');
     }
 
     /** @protected */

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -27,6 +27,7 @@ import 'highcharts/es-modules/masters/modules/xrange.src.js';
 import 'highcharts/es-modules/masters/modules/bullet.src.js';
 import 'highcharts/es-modules/masters/modules/gantt.src.js';
 import 'highcharts/es-modules/masters/modules/draggable-points.src.js';
+import 'highcharts/es-modules/masters/modules/pattern-fill.src.js';
 import KeyboardNavigation from 'highcharts/es-modules/Accessibility/KeyboardNavigation.js';
 import HTMLUtilities from 'highcharts/es-modules/Accessibility/Utils/HTMLUtilities.js';
 import Pointer from 'highcharts/es-modules/Core/Pointer.js';
@@ -720,7 +721,268 @@ export const ChartMixin = (superClass) =>
         this.configuration = Highcharts.chart(this.$.chart, options);
       }
 
+      // Re-apply on every render; teardown rides on `configuration.destroy()`. The
+      // listener misses the first (synchronous) render, so also apply once now.
+      Highcharts.addEvent(this.configuration, 'render', () => this.__applyPatternFills());
+      this.__applyPatternFills();
+
       this.__forceResize();
+    }
+
+    /**
+     * Renders `color: { pattern }` / `color: { patternIndex }` in styled mode, where
+     * Highcharts' own pattern-fill handler never fires (fills come from CSS classes).
+     * Per render: create the `<pattern>` def (deduped by content hash) and style its path,
+     * then inject one CSS rule per series color index (`.highcharts-color-N { fill: url }`),
+     * which also covers the legend symbol and tooltip swatch and survives the export copy.
+     * A point whose own pattern differs from its series falls back to a `fill` attribute.
+     *
+     * Known limitation: server-side `exportChart` renders a fresh chart this hook never
+     * runs on, so server SVGs lack these patterns (follow-up).
+     * @private
+     */
+    __applyPatternFills() {
+      const chart = this.configuration;
+      if (!chart || !chart.renderer) {
+        return;
+      }
+
+      // Styled mode only: non-styled mode renders patterns natively, and running the
+      // bridge there would strip that fill. `styledMode` is fixed at construction.
+      if (!this.__styledMode) {
+        return;
+      }
+
+      this.__shimPatternIds ||= new Set();
+
+      // Bail out when there are no patterns and none were created on a previous render.
+      const hasPatterns = chart.series.some(
+        (series) =>
+          this.__isPatternColor(series.options && series.options.color) ||
+          series.points.some((point) => this.__isPatternColor(point.options && point.options.color)),
+      );
+      if (!hasPatterns && this.__shimPatternIds.size === 0 && !this.__patternSheet) {
+        return;
+      }
+
+      const usedIds = new Set();
+      // colorIndex -> pattern id, for series that carry a single series-wide pattern.
+      const colorIndexRules = new Map();
+
+      if (hasPatterns) {
+        chart.series.forEach((series) => {
+          const seriesColorOptions = series.options && series.options.color;
+          let seriesPatternId;
+          if (this.__isPatternColor(seriesColorOptions)) {
+            const colorIndex = this.__resolveColorIndex(series.colorIndex);
+            seriesPatternId = this.__ensurePatternDef(seriesColorOptions, colorIndex);
+            if (seriesPatternId) {
+              usedIds.add(seriesPatternId);
+              colorIndexRules.set(colorIndex, seriesPatternId);
+            }
+          }
+
+          series.points.forEach((point) => {
+            const id = this.__applyPointPatternFill(point, seriesPatternId);
+            if (id) {
+              usedIds.add(id);
+            }
+          });
+        });
+      }
+
+      this.__rebuildPatternSheet(colorIndexRules);
+      this.__cleanupPatternDefs(usedIds);
+    }
+
+    /**
+     * Whether a color option is a pattern (`{ pattern }` or `{ patternIndex }`).
+     * @private
+     * @return {boolean}
+     */
+    __isPatternColor(color) {
+      return Highcharts.isObject(color) && (!!color.pattern || typeof color.patternIndex === 'number');
+    }
+
+    /**
+     * Color index, defaulting to `0` so patterns never resolve `var(--_color-undefined)`.
+     * @private
+     * @return {number}
+     */
+    __resolveColorIndex(colorIndex) {
+      return Highcharts.pick(colorIndex, 0);
+    }
+
+    /**
+     * Creates (or reuses) the `<pattern>` def for a pattern color option and applies the
+     * path styling the pattern-fill module skips in styled mode. Returns the def id.
+     * @private
+     * @return {string | undefined}
+     */
+    __ensurePatternDef(colorOptions, colorIndex) {
+      let pattern = colorOptions.pattern;
+      if (typeof colorOptions.patternIndex === 'number') {
+        pattern = Highcharts.patterns && Highcharts.patterns[colorOptions.patternIndex];
+      }
+      if (!pattern) {
+        return undefined;
+      }
+
+      const chart = this.configuration;
+      // Fall back to the series' theme color when the pattern sets no explicit color.
+      const patternColor = pattern.color || `var(--_color-${colorIndex})`;
+
+      const id =
+        pattern.id ||
+        `vaadin-pattern-${this.__hashPattern({ ...this.__stripInternalKeys(pattern), color: patternColor })}`;
+
+      // No-op if the id already exists.
+      chart.renderer.addPattern({ ...pattern, id });
+
+      // Track bridge-created ids (incl. explicit `pattern.id`) for membership-based cleanup.
+      this.__shimPatternIds.add(id);
+
+      // Module skips the path's stroke/fill in styled mode; apply inline (presentation
+      // attributes don't resolve CSS variables, inline styles do).
+      const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
+      const pathElement = patternElement && patternElement.element.querySelector('path');
+      if (pathElement) {
+        const pathOptions = typeof pattern.path === 'object' && pattern.path !== null ? pattern.path : {};
+        pathElement.style.stroke = pathOptions.stroke || patternColor;
+        pathElement.style.strokeWidth = String(pathOptions.strokeWidth != null ? pathOptions.strokeWidth : 2);
+        pathElement.style.fill = pathOptions.fill || 'none';
+      }
+
+      return id;
+    }
+
+    /**
+     * Per-point fallback: when a point's own pattern differs from its series pattern, a
+     * class-level rule can't target it, so set the `fill` attribute directly (the base-style
+     * `:not([fill^='url('])` exclusion keeps the theme rule off it). Otherwise clear any
+     * stale fallback attribute so the injected colorIndex rule applies.
+     * @private
+     * @return {string | undefined} the def id when the point uses the fallback
+     */
+    __applyPointPatternFill(point, seriesPatternId) {
+      const graphic = point.graphic && point.graphic.element;
+      const pointColorOptions = point.options && point.options.color;
+
+      if (this.__isPatternColor(pointColorOptions)) {
+        const colorIndex = this.__resolveColorIndex(
+          point.colorIndex != null ? point.colorIndex : point.series.colorIndex,
+        );
+        const id = this.__ensurePatternDef(pointColorOptions, colorIndex);
+        if (id && id !== seriesPatternId) {
+          if (graphic) {
+            const url = this.configuration.renderer.url || '';
+            graphic.setAttribute('fill', `url(${url}#${id})`);
+          }
+          return id;
+        }
+      }
+
+      // Not a fallback point: drop any stale `url(...)` fill so the colorIndex rule applies.
+      if (graphic) {
+        const fill = graphic.getAttribute('fill');
+        if (fill && fill.startsWith('url(')) {
+          graphic.removeAttribute('fill');
+        }
+      }
+      return undefined;
+    }
+
+    /**
+     * Rebuilds the adopted stylesheet mapping each patterned color index to its fill.
+     * Rebuilding wholesale via `replaceSync` drops rules for indexes that lost their
+     * pattern. The selector omits `:where()` so its specificity (0,3,0) beats the base
+     * theme rule (0,2,0); its `:not([fill^='url('])` guard spares per-point fallback fills.
+     * @private
+     */
+    __rebuildPatternSheet(colorIndexRules) {
+      if (colorIndexRules.size === 0 && !this.__patternSheet) {
+        return;
+      }
+
+      if (!this.__patternSheet) {
+        this.__patternSheet = new CSSStyleSheet();
+      }
+      if (!this.shadowRoot.adoptedStyleSheets.includes(this.__patternSheet)) {
+        this.shadowRoot.adoptedStyleSheets = [...this.shadowRoot.adoptedStyleSheets, this.__patternSheet];
+      }
+
+      const url = this.configuration.renderer.url || '';
+      const cssText = [...colorIndexRules.entries()]
+        .map(
+          ([colorIndex, id]) =>
+            `[styled-mode] .highcharts-color-${colorIndex}:not([fill^='url(']) { fill: url(${url}#${id}); }`,
+        )
+        .join('\n');
+      this.__patternSheet.replaceSync(cssText);
+    }
+
+    /**
+     * Removes `<pattern>` defs created by this shim that are no longer referenced,
+     * to avoid leaking or duplicating defs across updates and redraws.
+     * @private
+     */
+    __cleanupPatternDefs(usedIds) {
+      const shimIds = this.__shimPatternIds;
+      if (!shimIds || shimIds.size === 0) {
+        return;
+      }
+
+      const { renderer } = this.configuration;
+      const patternElements = renderer.patternElements || {};
+      // Remove by membership so Highcharts' own `highcharts-pattern-*` defs are untouched.
+      shimIds.forEach((id) => {
+        if (usedIds.has(id)) {
+          return;
+        }
+        if (patternElements[id]) {
+          patternElements[id].destroy();
+          delete patternElements[id];
+        }
+        if (renderer.defIds) {
+          Highcharts.erase(renderer.defIds, id);
+        }
+        shimIds.delete(id);
+      });
+    }
+
+    /**
+     * Shallow copy without Highcharts' internal `_`-prefixed keys (e.g. `_width`/`_height`),
+     * which it writes onto image patterns between renders. Stripping them keeps the hashed
+     * id stable across redraws so the def isn't needlessly recreated.
+     * @private
+     * @return {Object}
+     */
+    __stripInternalKeys(pattern) {
+      const result = {};
+      Object.keys(pattern).forEach((key) => {
+        if (key[0] !== '_') {
+          result[key] = pattern[key];
+        }
+      });
+      return result;
+    }
+
+    /**
+     * Computes a stable hash from a pattern config, used to build a deduplicated pattern id.
+     * The id only needs to be stable across redraws and unique among this chart's own
+     * patterns (it is always prefixed `vaadin-pattern-`, so it never has to match
+     * Highcharts' native ids), so a single deterministic pass is sufficient.
+     * @private
+     * @return {string}
+     */
+    __hashPattern(pattern) {
+      const str = JSON.stringify(pattern);
+      let hash = 0;
+      for (let i = 0; i < str.length; i++) {
+        hash = (hash << 5) - hash + str.charCodeAt(i);
+        hash &= hash;
+      }
+      return hash.toString(16).replace('-', '1');
     }
 
     /** @protected */

--- a/packages/charts/src/vaadin-chart-mixin.js
+++ b/packages/charts/src/vaadin-chart-mixin.js
@@ -745,6 +745,8 @@ export const ChartMixin = (superClass) =>
         }
 
         if (this.configuration) {
+          this.__patternFillBridge?.destroy();
+          this.__patternFillBridge = undefined;
           this.configuration.destroy();
           this.configuration = undefined;
 

--- a/packages/charts/src/vaadin-chart-pattern-fill.js
+++ b/packages/charts/src/vaadin-chart-pattern-fill.js
@@ -19,9 +19,9 @@ import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
  * 1. Creates the `<pattern>` def (deduped by content hash) and styles its path, which
  *    the pattern-fill module skips in styled mode.
  * 2. Injects one CSS rule per series color index (`.highcharts-color-N { fill: url }`)
- *    into a constructable stylesheet on the chart's `adoptedStyleSheets`. That single
- *    rule also covers the legend symbol and tooltip swatch, and survives the export copy.
- * 3. Uses a per-point `fill` attribute only when a point's own pattern differs from its
+ *    into a `<style>` element appended to the chart's shadow root. That single rule also
+ *    covers the legend symbol and tooltip swatch, and survives the export copy.
+ * 3. Uses a per-point inline `fill` style only when a point's own pattern differs from its
  *    series pattern (a class-level rule can't target one point in a series).
  *
  * Non-styled mode renders patterns natively, so the bridge does nothing there (the
@@ -39,8 +39,8 @@ export class PatternFillBridge {
   /** @type {Set<string>} */
   #patternIds = new Set();
 
-  /** @type {CSSStyleSheet | undefined} */
-  #patternSheet;
+  /** @type {HTMLStyleElement | undefined} */
+  #patternStyle;
 
   /**
    * @param {object} configuration the Highcharts chart instance
@@ -66,24 +66,33 @@ export class PatternFillBridge {
       return;
     }
 
-    // Bail out when there are no patterns and none were created on a previous render.
     const hasPatterns = chart.series.some(
       (series) =>
         this.#isPatternColor(series.options && series.options.color) ||
         series.points.some((point) => this.#isPatternColor(point.options && point.options.color)),
     );
-    if (!hasPatterns && this.#patternIds.size === 0 && !this.#patternSheet) {
+
+    // Bail out only when there is genuinely nothing to do: no patterns now and none
+    // created on a previous render (nothing stale to clear).
+    if (!hasPatterns && this.#patternIds.size === 0 && !this.#patternStyle) {
       return;
     }
 
     const usedIds = new Set();
-    // colorIndex -> pattern id, for series that carry a single series-wide pattern.
+    // colorIndex -> pattern id, for series that carry a single series-wide pattern. The
+    // injected rule keys on `.highcharts-color-N`: two patterned series that share a
+    // color index (more than 10 patterned series, or an explicit duplicate `colorIndex`)
+    // therefore render the same pattern. This is what also lets one rule cover the legend
+    // symbol and tooltip swatch, so it is an accepted limitation.
     const colorIndexRules = new Map();
 
-    if (hasPatterns) {
-      chart.series.forEach((series) => {
+    // Always visit every point so a stale inline pattern fill is cleared even when all
+    // patterns were removed (its def is about to be destroyed). Pattern defs and rules
+    // are only (re)created when patterns are present.
+    chart.series.forEach((series) => {
+      let seriesPatternId;
+      if (hasPatterns) {
         const seriesColorOptions = series.options && series.options.color;
-        let seriesPatternId;
         if (this.#isPatternColor(seriesColorOptions)) {
           const colorIndex = this.#resolveColorIndex(series.colorIndex);
           seriesPatternId = this.#ensurePatternDef(seriesColorOptions, colorIndex);
@@ -92,18 +101,28 @@ export class PatternFillBridge {
             colorIndexRules.set(colorIndex, seriesPatternId);
           }
         }
+      }
 
-        series.points.forEach((point) => {
-          const id = this.#applyPointPatternFill(point, seriesPatternId);
-          if (id) {
-            usedIds.add(id);
-          }
-        });
+      series.points.forEach((point) => {
+        const id = this.#applyPointPatternFill(point, seriesPatternId);
+        if (id) {
+          usedIds.add(id);
+        }
       });
-    }
+    });
 
     this.#rebuildPatternSheet(colorIndexRules);
     this.#cleanupPatternDefs(usedIds);
+  }
+
+  /**
+   * Removes the injected `<style>` element and all pattern defs created by this bridge.
+   * Called on chart teardown so no orphaned nodes or defs survive a disconnect.
+   */
+  destroy() {
+    this.#patternStyle?.remove();
+    this.#patternStyle = undefined;
+    this.#cleanupPatternDefs(new Set());
   }
 
   /**
@@ -165,10 +184,10 @@ export class PatternFillBridge {
 
   /**
    * When a point's own pattern differs from its series pattern, a class-level rule can't
-   * target it, so set the `fill` attribute directly (the base-style `:not([fill^='url('])`
-   * exclusion keeps the theme rule off it). Otherwise clear any stale attribute so the
-   * injected colorIndex rule applies.
-   * @return {string | undefined} the def id when the point sets its own fill attribute
+   * target it, so set the `fill` inline style directly (an inline style beats the theme
+   * `.highcharts-color-N` fill regardless of specificity). Otherwise clear any stale
+   * inline fill so the injected colorIndex rule (or theme color) applies.
+   * @return {string | undefined} the def id when the point sets its own inline fill
    */
   #applyPointPatternFill(point, seriesPatternId) {
     const graphic = point.graphic && point.graphic.element;
@@ -180,47 +199,45 @@ export class PatternFillBridge {
       if (id && id !== seriesPatternId) {
         if (graphic) {
           const url = this.#configuration.renderer.url || '';
-          graphic.setAttribute('fill', `url(${url}#${id})`);
+          graphic.style.fill = `url(${url}#${id})`;
         }
         return id;
       }
     }
 
-    if (graphic) {
-      const fill = graphic.getAttribute('fill');
-      if (fill && fill.startsWith('url(')) {
-        graphic.removeAttribute('fill');
-      }
+    if (graphic && graphic.style.fill.startsWith('url(')) {
+      graphic.style.removeProperty('fill');
     }
     return undefined;
   }
 
   /**
-   * Rebuilds the adopted stylesheet mapping each patterned color index to its fill.
-   * Rebuilding wholesale via `replaceSync` drops rules for indexes that lost their
-   * pattern. The selector omits `:where()` so its specificity (0,3,0) beats the base
-   * theme rule (0,2,0); its `:not([fill^='url('])` guard spares per-point fills.
+   * Rebuilds the injected `<style>` element mapping each patterned color index to its
+   * fill. Rebuilding wholesale drops rules for indexes that lost their pattern. The
+   * selector omits `:where()` so its specificity (0,3,0) beats the base theme rule
+   * (0,2,0) regardless of source order. A `<style>` DOM child is used (not a
+   * constructable sheet on `adoptedStyleSheets`), because the LumoInjectionMixin replaces
+   * `adoptedStyleSheets` wholesale on theme switch, which would drop a constructable
+   * sheet; a `<style>` child survives.
    */
   #rebuildPatternSheet(colorIndexRules) {
-    if (colorIndexRules.size === 0 && !this.#patternSheet) {
+    if (colorIndexRules.size === 0 && !this.#patternStyle) {
       return;
     }
 
-    if (!this.#patternSheet) {
-      this.#patternSheet = new CSSStyleSheet();
+    if (!this.#patternStyle) {
+      this.#patternStyle = document.createElement('style');
+      this.#patternStyle.setAttribute('data-vaadin-pattern-fill', '');
     }
-    if (!this.#shadowRoot.adoptedStyleSheets.includes(this.#patternSheet)) {
-      this.#shadowRoot.adoptedStyleSheets = [...this.#shadowRoot.adoptedStyleSheets, this.#patternSheet];
+    if (this.#patternStyle.parentNode !== this.#shadowRoot) {
+      this.#shadowRoot.appendChild(this.#patternStyle);
     }
 
     const url = this.#configuration.renderer.url || '';
     const cssText = [...colorIndexRules.entries()]
-      .map(
-        ([colorIndex, id]) =>
-          `[styled-mode] .highcharts-color-${colorIndex}:not([fill^='url(']) { fill: url(${url}#${id}); }`,
-      )
+      .map(([colorIndex, id]) => `[styled-mode] .highcharts-color-${colorIndex} { fill: url(${url}#${id}); }`)
       .join('\n');
-    this.#patternSheet.replaceSync(cssText);
+    this.#patternStyle.textContent = cssText;
   }
 
   /**
@@ -280,6 +297,6 @@ export class PatternFillBridge {
       hash = (hash << 5) - hash + str.charCodeAt(i);
       hash &= hash;
     }
-    return hash.toString(16).replace('-', '1');
+    return (hash >>> 0).toString(16);
   }
 }

--- a/packages/charts/src/vaadin-chart-pattern-fill.js
+++ b/packages/charts/src/vaadin-chart-pattern-fill.js
@@ -1,0 +1,285 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See https://vaadin.com/commercial-license-and-service-terms for the full
+ * license.
+ */
+import 'highcharts/es-modules/masters/modules/pattern-fill.src.js';
+import Highcharts from 'highcharts/es-modules/masters/highstock.src.js';
+
+/**
+ * Renders `color: { pattern }` / `color: { patternIndex }` options in styled mode,
+ * where Highcharts' own pattern-fill handler never fires (fills come from CSS classes).
+ * One bridge instance is created per chart and its {@link PatternFillBridge#apply} is
+ * called on every render. Per render it:
+ *
+ * 1. Creates the `<pattern>` def (deduped by content hash) and styles its path, which
+ *    the pattern-fill module skips in styled mode.
+ * 2. Injects one CSS rule per series color index (`.highcharts-color-N { fill: url }`)
+ *    into a constructable stylesheet on the chart's `adoptedStyleSheets`. That single
+ *    rule also covers the legend symbol and tooltip swatch, and survives the export copy.
+ * 3. Uses a per-point `fill` attribute only when a point's own pattern differs from its
+ *    series pattern (a class-level rule can't target one point in a series).
+ *
+ * Non-styled mode renders patterns natively, so the bridge does nothing there (the
+ * styled-mode state is read live from the chart on each `apply`, not cached). Known
+ * limitation: server-side `exportChart` renders a fresh chart this hook never runs on,
+ * so server SVGs lack these patterns (follow-up).
+ */
+export class PatternFillBridge {
+  /** @type {object} */
+  #configuration;
+
+  /** @type {ShadowRoot} */
+  #shadowRoot;
+
+  /** @type {Set<string>} */
+  #patternIds = new Set();
+
+  /** @type {CSSStyleSheet | undefined} */
+  #patternSheet;
+
+  /**
+   * @param {object} configuration the Highcharts chart instance
+   * @param {ShadowRoot} shadowRoot the chart element's shadow root
+   */
+  constructor(configuration, shadowRoot) {
+    this.#configuration = configuration;
+    this.#shadowRoot = shadowRoot;
+  }
+
+  /** Applies pattern fills for the current render. */
+  apply() {
+    const chart = this.#configuration;
+    if (!chart || !chart.renderer) {
+      return;
+    }
+
+    // Styled mode only: non-styled mode renders patterns natively, and running the
+    // bridge there would strip that fill. Read it live from the chart (not cached at
+    // construction) so the bridge stays correct if the configuration's styled mode
+    // changes.
+    if (!chart.styledMode) {
+      return;
+    }
+
+    // Bail out when there are no patterns and none were created on a previous render.
+    const hasPatterns = chart.series.some(
+      (series) =>
+        this.#isPatternColor(series.options && series.options.color) ||
+        series.points.some((point) => this.#isPatternColor(point.options && point.options.color)),
+    );
+    if (!hasPatterns && this.#patternIds.size === 0 && !this.#patternSheet) {
+      return;
+    }
+
+    const usedIds = new Set();
+    // colorIndex -> pattern id, for series that carry a single series-wide pattern.
+    const colorIndexRules = new Map();
+
+    if (hasPatterns) {
+      chart.series.forEach((series) => {
+        const seriesColorOptions = series.options && series.options.color;
+        let seriesPatternId;
+        if (this.#isPatternColor(seriesColorOptions)) {
+          const colorIndex = this.#resolveColorIndex(series.colorIndex);
+          seriesPatternId = this.#ensurePatternDef(seriesColorOptions, colorIndex);
+          if (seriesPatternId) {
+            usedIds.add(seriesPatternId);
+            colorIndexRules.set(colorIndex, seriesPatternId);
+          }
+        }
+
+        series.points.forEach((point) => {
+          const id = this.#applyPointPatternFill(point, seriesPatternId);
+          if (id) {
+            usedIds.add(id);
+          }
+        });
+      });
+    }
+
+    this.#rebuildPatternSheet(colorIndexRules);
+    this.#cleanupPatternDefs(usedIds);
+  }
+
+  /**
+   * Whether a color option is a pattern (`{ pattern }` or `{ patternIndex }`).
+   * @return {boolean}
+   */
+  #isPatternColor(color) {
+    return Highcharts.isObject(color) && (!!color.pattern || typeof color.patternIndex === 'number');
+  }
+
+  /**
+   * Color index, defaulting to `0` so patterns never resolve `var(--_color-undefined)`.
+   * @return {number}
+   */
+  #resolveColorIndex(colorIndex) {
+    return Highcharts.pick(colorIndex, 0);
+  }
+
+  /**
+   * Creates (or reuses) the `<pattern>` def for a pattern color option and applies the
+   * path styling the pattern-fill module skips in styled mode. Returns the def id.
+   * @return {string | undefined}
+   */
+  #ensurePatternDef(colorOptions, colorIndex) {
+    let pattern = colorOptions.pattern;
+    if (typeof colorOptions.patternIndex === 'number') {
+      pattern = Highcharts.patterns && Highcharts.patterns[colorOptions.patternIndex];
+    }
+    if (!pattern) {
+      return undefined;
+    }
+
+    const chart = this.#configuration;
+    // Use the series' theme color when the pattern sets no explicit color.
+    const patternColor = pattern.color || `var(--_color-${colorIndex})`;
+
+    const id =
+      pattern.id || `vaadin-pattern-${this.#hashPattern({ ...this.#stripInternalKeys(pattern), color: patternColor })}`;
+
+    // No-op if the id already exists.
+    chart.renderer.addPattern({ ...pattern, id });
+
+    // Track bridge-created ids (incl. explicit `pattern.id`) for membership-based cleanup.
+    this.#patternIds.add(id);
+
+    // Module skips the path's stroke/fill in styled mode; apply inline (presentation
+    // attributes don't resolve CSS variables, inline styles do).
+    const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
+    const pathElement = patternElement && patternElement.element.querySelector('path');
+    if (pathElement) {
+      const pathOptions = typeof pattern.path === 'object' && pattern.path !== null ? pattern.path : {};
+      pathElement.style.stroke = pathOptions.stroke || patternColor;
+      pathElement.style.strokeWidth = String(pathOptions.strokeWidth != null ? pathOptions.strokeWidth : 2);
+      pathElement.style.fill = pathOptions.fill || 'none';
+    }
+
+    return id;
+  }
+
+  /**
+   * When a point's own pattern differs from its series pattern, a class-level rule can't
+   * target it, so set the `fill` attribute directly (the base-style `:not([fill^='url('])`
+   * exclusion keeps the theme rule off it). Otherwise clear any stale attribute so the
+   * injected colorIndex rule applies.
+   * @return {string | undefined} the def id when the point sets its own fill attribute
+   */
+  #applyPointPatternFill(point, seriesPatternId) {
+    const graphic = point.graphic && point.graphic.element;
+    const pointColorOptions = point.options && point.options.color;
+
+    if (this.#isPatternColor(pointColorOptions)) {
+      const colorIndex = this.#resolveColorIndex(point.colorIndex != null ? point.colorIndex : point.series.colorIndex);
+      const id = this.#ensurePatternDef(pointColorOptions, colorIndex);
+      if (id && id !== seriesPatternId) {
+        if (graphic) {
+          const url = this.#configuration.renderer.url || '';
+          graphic.setAttribute('fill', `url(${url}#${id})`);
+        }
+        return id;
+      }
+    }
+
+    if (graphic) {
+      const fill = graphic.getAttribute('fill');
+      if (fill && fill.startsWith('url(')) {
+        graphic.removeAttribute('fill');
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Rebuilds the adopted stylesheet mapping each patterned color index to its fill.
+   * Rebuilding wholesale via `replaceSync` drops rules for indexes that lost their
+   * pattern. The selector omits `:where()` so its specificity (0,3,0) beats the base
+   * theme rule (0,2,0); its `:not([fill^='url('])` guard spares per-point fills.
+   */
+  #rebuildPatternSheet(colorIndexRules) {
+    if (colorIndexRules.size === 0 && !this.#patternSheet) {
+      return;
+    }
+
+    if (!this.#patternSheet) {
+      this.#patternSheet = new CSSStyleSheet();
+    }
+    if (!this.#shadowRoot.adoptedStyleSheets.includes(this.#patternSheet)) {
+      this.#shadowRoot.adoptedStyleSheets = [...this.#shadowRoot.adoptedStyleSheets, this.#patternSheet];
+    }
+
+    const url = this.#configuration.renderer.url || '';
+    const cssText = [...colorIndexRules.entries()]
+      .map(
+        ([colorIndex, id]) =>
+          `[styled-mode] .highcharts-color-${colorIndex}:not([fill^='url(']) { fill: url(${url}#${id}); }`,
+      )
+      .join('\n');
+    this.#patternSheet.replaceSync(cssText);
+  }
+
+  /**
+   * Removes `<pattern>` defs created by this bridge that are no longer referenced,
+   * to avoid leaking or duplicating defs across updates and redraws.
+   */
+  #cleanupPatternDefs(usedIds) {
+    if (this.#patternIds.size === 0) {
+      return;
+    }
+
+    const { renderer } = this.#configuration;
+    const patternElements = renderer.patternElements || {};
+    // Remove by membership so Highcharts' own `highcharts-pattern-*` defs are untouched.
+    this.#patternIds.forEach((id) => {
+      if (usedIds.has(id)) {
+        return;
+      }
+      if (patternElements[id]) {
+        patternElements[id].destroy();
+        delete patternElements[id];
+      }
+      if (renderer.defIds) {
+        Highcharts.erase(renderer.defIds, id);
+      }
+      this.#patternIds.delete(id);
+    });
+  }
+
+  /**
+   * Shallow copy without Highcharts' internal `_`-prefixed keys (e.g. `_width`/`_height`),
+   * which it writes onto image patterns between renders. Stripping them keeps the hashed
+   * id stable across redraws so the def isn't needlessly recreated.
+   * @return {Object}
+   */
+  #stripInternalKeys(pattern) {
+    const result = {};
+    Object.keys(pattern).forEach((key) => {
+      if (key[0] !== '_') {
+        result[key] = pattern[key];
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Computes a stable hash from a pattern config, used to build a deduplicated pattern id.
+   * The id only needs to be stable across redraws and unique among this chart's own
+   * patterns (it is always prefixed `vaadin-pattern-`, so it never has to match
+   * Highcharts' native ids), so a single deterministic pass is sufficient.
+   * @return {string}
+   */
+  #hashPattern(pattern) {
+    const str = JSON.stringify(pattern);
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = (hash << 5) - hash + str.charCodeAt(i);
+      hash &= hash;
+    }
+    return hash.toString(16).replace('-', '1');
+  }
+}

--- a/packages/charts/src/vaadin-chart-pattern-fill.js
+++ b/packages/charts/src/vaadin-chart-pattern-fill.js
@@ -159,6 +159,10 @@ export class PatternFillBridge {
     // Use the series' theme color when the pattern sets no explicit color.
     const patternColor = pattern.color || `var(--_color-${colorIndex})`;
 
+    // Without an explicit `pattern.id`, the id is derived from the pattern's content
+    // (incl. color), so patterns that differ get distinct defs. An explicit `pattern.id`
+    // identifies one shared def: reusing it across patterns that differ (e.g. a different
+    // color) intentionally reuses the first def — pick distinct ids for distinct patterns.
     const id =
       pattern.id || `vaadin-pattern-${this.#hashPattern({ ...this.#stripInternalKeys(pattern), color: patternColor })}`;
 
@@ -284,13 +288,7 @@ export class PatternFillBridge {
    * @return {Object}
    */
   #stripInternalKeys(pattern) {
-    const result = {};
-    Object.keys(pattern).forEach((key) => {
-      if (!key.startsWith('_')) {
-        result[key] = pattern[key];
-      }
-    });
-    return result;
+    return Object.fromEntries(Object.entries(pattern).filter(([key]) => !key.startsWith('_')));
   }
 
   /**

--- a/packages/charts/src/vaadin-chart-pattern-fill.js
+++ b/packages/charts/src/vaadin-chart-pattern-fill.js
@@ -36,17 +36,11 @@ export class PatternFillBridge {
   /** @type {ShadowRoot} */
   #shadowRoot;
 
-  /** @type {Set<string>} */
+  /** @type {Set<string>} ids of defs this bridge created (also gates one-time styling) */
   #patternIds = new Set();
-
-  /** @type {Set<string>} ids whose def path has already been styled (styling is immutable) */
-  #styledIds = new Set();
 
   /** @type {HTMLStyleElement | undefined} */
   #patternStyle;
-
-  /** @type {string | undefined} last CSS written to the style element, to skip re-parsing */
-  #lastCssText;
 
   /**
    * @param {object} configuration the Highcharts chart instance
@@ -128,9 +122,7 @@ export class PatternFillBridge {
   destroy() {
     this.#patternStyle?.remove();
     this.#patternStyle = undefined;
-    this.#lastCssText = undefined;
     this.#cleanupPatternDefs(new Set());
-    this.#styledIds.clear();
   }
 
   /**
@@ -170,16 +162,16 @@ export class PatternFillBridge {
     const id =
       pattern.id || `vaadin-pattern-${this.#hashPattern({ ...this.#stripInternalKeys(pattern), color: patternColor })}`;
 
-    // No-op if the id already exists.
-    chart.renderer.addPattern({ ...pattern, id });
+    // Create and style the def once. `#patternIds` both tracks the def for
+    // membership-based cleanup and gates this block: while an id is tracked its def
+    // exists, so later renders skip it entirely (addPattern would be a no-op and the
+    // path styling is immutable).
+    if (!this.#patternIds.has(id)) {
+      chart.renderer.addPattern({ ...pattern, id });
+      this.#patternIds.add(id);
 
-    // Track bridge-created ids (incl. explicit `pattern.id`) for membership-based cleanup.
-    this.#patternIds.add(id);
-
-    // Module skips the path's stroke/fill in styled mode; apply inline (presentation
-    // attributes don't resolve CSS variables, inline styles do). The def persists across
-    // redraws, so style it once per id — skip the query and writes on later renders.
-    if (!this.#styledIds.has(id)) {
+      // Module skips the path's stroke/fill in styled mode; apply inline (presentation
+      // attributes don't resolve CSS variables, inline styles do).
       const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
       const pathElement = patternElement && patternElement.element.querySelector('path');
       if (pathElement) {
@@ -188,7 +180,6 @@ export class PatternFillBridge {
         pathElement.style.strokeWidth = String(pathOptions.strokeWidth != null ? pathOptions.strokeWidth : 2);
         pathElement.style.fill = pathOptions.fill || 'none';
       }
-      this.#styledIds.add(id);
     }
 
     return id;
@@ -206,7 +197,7 @@ export class PatternFillBridge {
     const pointColorOptions = point.options && point.options.color;
 
     if (this.#isPatternColor(pointColorOptions)) {
-      const colorIndex = this.#resolveColorIndex(point.colorIndex != null ? point.colorIndex : point.series.colorIndex);
+      const colorIndex = this.#resolveColorIndex(Highcharts.pick(point.colorIndex, point.series.colorIndex));
       const id = this.#ensurePatternDef(pointColorOptions, colorIndex);
       if (id && id !== seriesPatternId) {
         if (graphic) {
@@ -233,7 +224,16 @@ export class PatternFillBridge {
    * sheet; a `<style>` child survives.
    */
   #rebuildPatternSheet(colorIndexRules) {
-    if (colorIndexRules.size === 0 && !this.#patternStyle) {
+    const url = this.#configuration.renderer.url || '';
+    const cssText = [...colorIndexRules.entries()]
+      .map(([colorIndex, id]) => `[styled-mode] .highcharts-color-${colorIndex} { fill: url(${url}#${id}); }`)
+      .join('\n');
+
+    if (!cssText) {
+      // No pattern rules: drop the `<style>` so the cheap bail-out in `apply()` fires
+      // again on later renders once all patterns are gone.
+      this.#patternStyle?.remove();
+      this.#patternStyle = undefined;
       return;
     }
 
@@ -244,16 +244,9 @@ export class PatternFillBridge {
     if (this.#patternStyle.parentNode !== this.#shadowRoot) {
       this.#shadowRoot.appendChild(this.#patternStyle);
     }
-
-    const url = this.#configuration.renderer.url || '';
-    const cssText = [...colorIndexRules.entries()]
-      .map(([colorIndex, id]) => `[styled-mode] .highcharts-color-${colorIndex} { fill: url(${url}#${id}); }`)
-      .join('\n');
-    // Skip the write (and its CSS re-parse) when the rules are unchanged, e.g. on a
-    // hover/zoom/resize redraw where the pattern config is identical to the last render.
-    if (cssText !== this.#lastCssText) {
+    // Only write when changed — a write re-parses the CSS, reading `textContent` does not.
+    if (cssText !== this.#patternStyle.textContent) {
       this.#patternStyle.textContent = cssText;
-      this.#lastCssText = cssText;
     }
   }
 
@@ -281,8 +274,6 @@ export class PatternFillBridge {
         Highcharts.erase(renderer.defIds, id);
       }
       this.#patternIds.delete(id);
-      // Forget the styling flag so a def later recreated with this id is re-styled.
-      this.#styledIds.delete(id);
     });
   }
 

--- a/packages/charts/src/vaadin-chart-pattern-fill.js
+++ b/packages/charts/src/vaadin-chart-pattern-fill.js
@@ -39,8 +39,14 @@ export class PatternFillBridge {
   /** @type {Set<string>} */
   #patternIds = new Set();
 
+  /** @type {Set<string>} ids whose def path has already been styled (styling is immutable) */
+  #styledIds = new Set();
+
   /** @type {HTMLStyleElement | undefined} */
   #patternStyle;
+
+  /** @type {string | undefined} last CSS written to the style element, to skip re-parsing */
+  #lastCssText;
 
   /**
    * @param {object} configuration the Highcharts chart instance
@@ -122,7 +128,9 @@ export class PatternFillBridge {
   destroy() {
     this.#patternStyle?.remove();
     this.#patternStyle = undefined;
+    this.#lastCssText = undefined;
     this.#cleanupPatternDefs(new Set());
+    this.#styledIds.clear();
   }
 
   /**
@@ -169,14 +177,18 @@ export class PatternFillBridge {
     this.#patternIds.add(id);
 
     // Module skips the path's stroke/fill in styled mode; apply inline (presentation
-    // attributes don't resolve CSS variables, inline styles do).
-    const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
-    const pathElement = patternElement && patternElement.element.querySelector('path');
-    if (pathElement) {
-      const pathOptions = typeof pattern.path === 'object' && pattern.path !== null ? pattern.path : {};
-      pathElement.style.stroke = pathOptions.stroke || patternColor;
-      pathElement.style.strokeWidth = String(pathOptions.strokeWidth != null ? pathOptions.strokeWidth : 2);
-      pathElement.style.fill = pathOptions.fill || 'none';
+    // attributes don't resolve CSS variables, inline styles do). The def persists across
+    // redraws, so style it once per id — skip the query and writes on later renders.
+    if (!this.#styledIds.has(id)) {
+      const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
+      const pathElement = patternElement && patternElement.element.querySelector('path');
+      if (pathElement) {
+        const pathOptions = typeof pattern.path === 'object' && pattern.path !== null ? pattern.path : {};
+        pathElement.style.stroke = pathOptions.stroke || patternColor;
+        pathElement.style.strokeWidth = String(pathOptions.strokeWidth != null ? pathOptions.strokeWidth : 2);
+        pathElement.style.fill = pathOptions.fill || 'none';
+      }
+      this.#styledIds.add(id);
     }
 
     return id;
@@ -237,7 +249,12 @@ export class PatternFillBridge {
     const cssText = [...colorIndexRules.entries()]
       .map(([colorIndex, id]) => `[styled-mode] .highcharts-color-${colorIndex} { fill: url(${url}#${id}); }`)
       .join('\n');
-    this.#patternStyle.textContent = cssText;
+    // Skip the write (and its CSS re-parse) when the rules are unchanged, e.g. on a
+    // hover/zoom/resize redraw where the pattern config is identical to the last render.
+    if (cssText !== this.#lastCssText) {
+      this.#patternStyle.textContent = cssText;
+      this.#lastCssText = cssText;
+    }
   }
 
   /**
@@ -264,6 +281,8 @@ export class PatternFillBridge {
         Highcharts.erase(renderer.defIds, id);
       }
       this.#patternIds.delete(id);
+      // Forget the styling flag so a def later recreated with this id is re-styled.
+      this.#styledIds.delete(id);
     });
   }
 

--- a/packages/charts/src/vaadin-chart-pattern-fill.js
+++ b/packages/charts/src/vaadin-chart-pattern-fill.js
@@ -68,8 +68,8 @@ export class PatternFillBridge {
 
     const hasPatterns = chart.series.some(
       (series) =>
-        this.#isPatternColor(series.options && series.options.color) ||
-        series.points.some((point) => this.#isPatternColor(point.options && point.options.color)),
+        this.#isPatternColor(series.options?.color) ||
+        series.points.some((point) => this.#isPatternColor(point.options?.color)),
     );
 
     // Bail out only when there is genuinely nothing to do: no patterns now and none
@@ -92,7 +92,7 @@ export class PatternFillBridge {
     chart.series.forEach((series) => {
       let seriesPatternId;
       if (hasPatterns) {
-        const seriesColorOptions = series.options && series.options.color;
+        const seriesColorOptions = series.options?.color;
         if (this.#isPatternColor(seriesColorOptions)) {
           const colorIndex = this.#resolveColorIndex(series.colorIndex);
           seriesPatternId = this.#ensurePatternDef(seriesColorOptions, colorIndex);
@@ -149,7 +149,7 @@ export class PatternFillBridge {
   #ensurePatternDef(colorOptions, colorIndex) {
     let pattern = colorOptions.pattern;
     if (typeof colorOptions.patternIndex === 'number') {
-      pattern = Highcharts.patterns && Highcharts.patterns[colorOptions.patternIndex];
+      pattern = Highcharts.patterns?.[colorOptions.patternIndex];
     }
     if (!pattern) {
       return undefined;
@@ -172,8 +172,8 @@ export class PatternFillBridge {
 
       // Module skips the path's stroke/fill in styled mode; apply inline (presentation
       // attributes don't resolve CSS variables, inline styles do).
-      const patternElement = chart.renderer.patternElements && chart.renderer.patternElements[id];
-      const pathElement = patternElement && patternElement.element.querySelector('path');
+      const patternElement = chart.renderer.patternElements?.[id];
+      const pathElement = patternElement?.element.querySelector('path');
       if (pathElement) {
         const pathOptions = typeof pattern.path === 'object' && pattern.path !== null ? pattern.path : {};
         pathElement.style.stroke = pathOptions.stroke || patternColor;
@@ -193,8 +193,8 @@ export class PatternFillBridge {
    * @return {string | undefined} the def id when the point sets its own inline fill
    */
   #applyPointPatternFill(point, seriesPatternId) {
-    const graphic = point.graphic && point.graphic.element;
-    const pointColorOptions = point.options && point.options.color;
+    const graphic = point.graphic?.element;
+    const pointColorOptions = point.options?.color;
 
     if (this.#isPatternColor(pointColorOptions)) {
       const colorIndex = this.#resolveColorIndex(Highcharts.pick(point.colorIndex, point.series.colorIndex));
@@ -208,7 +208,7 @@ export class PatternFillBridge {
       }
     }
 
-    if (graphic && graphic.style.fill.startsWith('url(')) {
+    if (graphic?.style.fill.startsWith('url(')) {
       graphic.style.removeProperty('fill');
     }
     return undefined;
@@ -239,7 +239,7 @@ export class PatternFillBridge {
 
     if (!this.#patternStyle) {
       this.#patternStyle = document.createElement('style');
-      this.#patternStyle.setAttribute('data-vaadin-pattern-fill', '');
+      this.#patternStyle.dataset.vaadinPatternFill = '';
     }
     if (this.#patternStyle.parentNode !== this.#shadowRoot) {
       this.#shadowRoot.appendChild(this.#patternStyle);
@@ -286,7 +286,7 @@ export class PatternFillBridge {
   #stripInternalKeys(pattern) {
     const result = {};
     Object.keys(pattern).forEach((key) => {
-      if (key[0] !== '_') {
+      if (!key.startsWith('_')) {
         result[key] = pattern[key];
       }
     });

--- a/packages/charts/test/pattern-fill.test.js
+++ b/packages/charts/test/pattern-fill.test.js
@@ -1,0 +1,431 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
+import '../src/vaadin-chart.js';
+
+const PATTERN_PATH = 'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11';
+
+describe('pattern fill', () => {
+  let chart, chartContainer;
+
+  function getDefsPatterns() {
+    return Array.from(chartContainer.querySelectorAll('defs pattern'));
+  }
+
+  function getSeriesPoints(seriesIndex = 0) {
+    const series = chartContainer.querySelectorAll('.highcharts-series')[seriesIndex];
+    return Array.from(series.querySelectorAll('.highcharts-point'));
+  }
+
+  function getLegendSymbol(colorIndex = 0) {
+    return chartContainer.querySelector(`.highcharts-legend-item.highcharts-color-${colorIndex}`);
+  }
+
+  describe('series pattern color', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should render a pattern element in the chart defs', () => {
+      expect(getDefsPatterns()).to.have.lengthOf(1);
+    });
+
+    it('should not set a fill attribute on the points (styled via CSS rule)', () => {
+      getSeriesPoints().forEach((point) => {
+        expect(point.getAttribute('fill') || '').to.not.contain('url(');
+      });
+    });
+
+    it('should resolve the computed point fill to the pattern', () => {
+      const patternId = getDefsPatterns()[0].getAttribute('id');
+      const points = getSeriesPoints();
+      expect(points).to.have.lengthOf(4);
+      points.forEach((point) => {
+        expect(getComputedStyle(point).fill).to.contain(patternId);
+      });
+    });
+
+    it('should resolve the computed legend symbol fill to the pattern', () => {
+      const patternId = getDefsPatterns()[0].getAttribute('id');
+      const legendSymbol = getLegendSymbol();
+      expect(legendSymbol).to.exist;
+      expect(getComputedStyle(legendSymbol).fill).to.contain(patternId);
+    });
+
+    it('should apply the explicit pattern color to the pattern path', () => {
+      const path = getDefsPatterns()[0].querySelector('path');
+      expect(getComputedStyle(path).stroke).to.equal('rgb(255, 0, 0)');
+    });
+  });
+
+  describe('non-styled mode', () => {
+    // In non-styled mode Highcharts' own pattern-fill module renders patterns
+    // natively; the Vaadin styled-mode bridge must stay out of the way.
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        chart: { styledMode: false },
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should render the pattern natively (highcharts-pattern def)', () => {
+      const patterns = getDefsPatterns();
+      expect(patterns.length).to.be.greaterThan(0);
+      const ids = patterns.map((pattern) => pattern.getAttribute('id'));
+      expect(ids.some((id) => id.startsWith('highcharts-pattern-'))).to.be.true;
+    });
+
+    it('should not create bridge defs or an injected stylesheet', () => {
+      const ids = getDefsPatterns().map((pattern) => pattern.getAttribute('id'));
+      expect(ids.some((id) => id.startsWith('vaadin-pattern-'))).to.be.false;
+      expect(chart.__patternSheet).to.not.exist;
+    });
+
+    it('should keep the native fill on the points', () => {
+      getSeriesPoints().forEach((point) => {
+        expect(point.getAttribute('fill') || '').to.contain('url(');
+        expect(getComputedStyle(point).fill).to.contain('url(');
+      });
+    });
+  });
+
+  describe('per-point pattern color', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [
+              5,
+              { y: 8, color: { pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#0000ff' } } },
+              3,
+              6,
+            ],
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should render a pattern only for the point that defines it', () => {
+      expect(getDefsPatterns()).to.have.lengthOf(1);
+    });
+
+    it('should use the fill-attribute fallback only on the configured point', () => {
+      const patternId = getDefsPatterns()[0].getAttribute('id');
+      const points = getSeriesPoints();
+      // The differing point falls back to the fill attribute since a class-level
+      // rule cannot distinguish points sharing the same color index.
+      expect(points[1].getAttribute('fill')).to.contain(`#${patternId}`);
+      expect(points[0].getAttribute('fill') || '').to.not.contain('url(');
+      expect(points[2].getAttribute('fill') || '').to.not.contain('url(');
+    });
+
+    it('should render the fallback point with the pattern fill', () => {
+      const patternId = getDefsPatterns()[0].getAttribute('id');
+      expect(getComputedStyle(getSeriesPoints()[1]).fill).to.contain(patternId);
+    });
+
+    it('should keep the non-patterned points on the theme color', () => {
+      const points = getSeriesPoints();
+      expect(getComputedStyle(points[0]).fill).to.not.contain('url(');
+      expect(getComputedStyle(points[2]).fill).to.not.contain('url(');
+    });
+
+    it('should apply the point pattern color to the pattern path', () => {
+      const path = getDefsPatterns()[0].querySelector('path');
+      expect(getComputedStyle(path).stroke).to.equal('rgb(0, 0, 255)');
+    });
+  });
+
+  describe('default pattern color', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.style.setProperty('--vaadin-charts-color-0', 'rgb(0, 255, 0)');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10 },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should follow the series color when no pattern color is set', () => {
+      const path = getDefsPatterns()[0].querySelector('path');
+      expect(getComputedStyle(path).stroke).to.equal('rgb(0, 255, 0)');
+    });
+  });
+
+  describe('updateConfiguration', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should update the pattern without leaking defs', async () => {
+      chart.updateConfiguration({
+        series: [
+          {
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#00ff00' },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+
+      const patterns = getDefsPatterns();
+      expect(patterns).to.have.lengthOf(1);
+      expect(getComputedStyle(patterns[0].querySelector('path')).stroke).to.equal('rgb(0, 255, 0)');
+      expect(getComputedStyle(getSeriesPoints()[0]).fill).to.contain(patterns[0].getAttribute('id'));
+    });
+  });
+
+  describe('without patterns', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [{ data: [5, 8, 3, 6] }],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should not create any pattern defs', () => {
+      expect(getDefsPatterns()).to.have.lengthOf(0);
+    });
+
+    it('should not inject any pattern CSS rules', () => {
+      expect(chart.__patternSheet).to.not.exist;
+    });
+
+    it('should keep the theme color on points', () => {
+      getSeriesPoints().forEach((point) => {
+        expect(getComputedStyle(point).fill).to.not.contain('url(');
+      });
+    });
+  });
+
+  describe('multiple series with different patterns', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' },
+            },
+          },
+          {
+            data: [4, 2, 7, 1],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#0000ff' },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should render exactly two distinct pattern defs', () => {
+      const patterns = getDefsPatterns();
+      expect(patterns).to.have.lengthOf(2);
+      const ids = patterns.map((pattern) => pattern.getAttribute('id'));
+      expect(ids[0]).to.not.equal(ids[1]);
+    });
+
+    it('should resolve a different pattern fill for each series', () => {
+      const firstFill = getComputedStyle(getSeriesPoints(0)[0]).fill;
+      const secondFill = getComputedStyle(getSeriesPoints(1)[0]).fill;
+      expect(firstFill).to.contain('url(');
+      expect(secondFill).to.contain('url(');
+      expect(firstFill).to.not.equal(secondFill);
+    });
+  });
+
+  describe('removing a series', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' },
+            },
+          },
+          {
+            data: [4, 2, 7, 1],
+            color: {
+              pattern: { id: 'my-custom-pattern', path: PATTERN_PATH, width: 10, height: 10, color: '#0000ff' },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should remove the def of a removed series with an explicit pattern id', async () => {
+      expect(getDefsPatterns()).to.have.lengthOf(2);
+      expect(chartContainer.querySelector('#my-custom-pattern')).to.exist;
+
+      const redraw = oneEvent(chart, 'chart-redraw');
+      chart.configuration.series[1].remove();
+      await redraw;
+
+      expect(getDefsPatterns()).to.have.lengthOf(1);
+      expect(chartContainer.querySelector('#my-custom-pattern')).to.not.exist;
+    });
+  });
+
+  describe('patternIndex', () => {
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: { patternIndex: 2 },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should render a def for a built-in pattern index', () => {
+      expect(getDefsPatterns()).to.have.lengthOf(1);
+    });
+
+    it('should resolve the built-in pattern fill on each point', () => {
+      const patternId = getDefsPatterns()[0].getAttribute('id');
+      getSeriesPoints().forEach((point) => {
+        expect(getComputedStyle(point).fill).to.contain(patternId);
+      });
+    });
+  });
+
+  describe('multiple charts', () => {
+    let secondChart, secondContainer;
+
+    beforeEach(async () => {
+      const config = {
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' },
+            },
+          },
+        ],
+      };
+
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration(config);
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+
+      secondChart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      secondChart.updateConfiguration(config);
+      await oneEvent(secondChart, 'chart-redraw');
+      secondContainer = secondChart.$.chart;
+    });
+
+    it('should render a def in each chart shadow root', () => {
+      expect(chartContainer.querySelectorAll('defs pattern')).to.have.lengthOf(1);
+      expect(secondContainer.querySelectorAll('defs pattern')).to.have.lengthOf(1);
+    });
+
+    it('should resolve each chart own def from its own points', () => {
+      const firstId = chartContainer.querySelector('defs pattern').getAttribute('id');
+      const secondId = secondContainer.querySelector('defs pattern').getAttribute('id');
+
+      const pointsIn = (container) =>
+        Array.from(container.querySelector('.highcharts-series').querySelectorAll('.highcharts-point'));
+
+      pointsIn(chartContainer).forEach((point) => {
+        expect(getComputedStyle(point).fill).to.contain(firstId);
+      });
+      pointsIn(secondContainer).forEach((point) => {
+        expect(getComputedStyle(point).fill).to.contain(secondId);
+      });
+    });
+  });
+
+  describe('image pattern stability', () => {
+    const IMAGE =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: {
+              pattern: { image: IMAGE },
+            },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should keep the same def across a resize', async () => {
+      const patternBefore = getDefsPatterns()[0];
+      const idBefore = patternBefore.getAttribute('id');
+
+      const redraw = oneEvent(chart, 'chart-redraw');
+      chart.configuration.setSize(400, 300);
+      await redraw;
+
+      const patternsAfter = getDefsPatterns();
+      expect(patternsAfter).to.have.lengthOf(1);
+      expect(patternsAfter[0].getAttribute('id')).to.equal(idBefore);
+      expect(patternsAfter[0]).to.equal(patternBefore);
+    });
+  });
+});

--- a/packages/charts/test/pattern-fill.test.js
+++ b/packages/charts/test/pattern-fill.test.js
@@ -228,6 +228,25 @@ describe('pattern fill', () => {
       expect(getComputedStyle(patterns[0].querySelector('path')).stroke).to.equal('rgb(0, 255, 0)');
       expect(getComputedStyle(getSeriesPoints()[0]).fill).to.contain(patterns[0].getAttribute('id'));
     });
+
+    it('should re-style a def re-added with the same pattern after removal', async () => {
+      // Remove the pattern (destroys the def, forgetting its styled/cssText caches)...
+      chart.updateConfiguration({ series: [{ color: '#123456' }] });
+      await oneEvent(chart, 'chart-redraw');
+      expect(getDefsPatterns()).to.have.lengthOf(0);
+
+      // ...then re-add the identical pattern: the recreated def must be re-styled and
+      // the CSS rule re-written (guards the styled-id / cssText caches).
+      chart.updateConfiguration({
+        series: [{ color: { pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' } } }],
+      });
+      await oneEvent(chart, 'chart-redraw');
+
+      const patterns = getDefsPatterns();
+      expect(patterns).to.have.lengthOf(1);
+      expect(getComputedStyle(patterns[0].querySelector('path')).stroke).to.equal('rgb(255, 0, 0)');
+      expect(getComputedStyle(getSeriesPoints()[0]).fill).to.contain(patterns[0].getAttribute('id'));
+    });
   });
 
   describe('without patterns', () => {

--- a/packages/charts/test/pattern-fill.test.js
+++ b/packages/charts/test/pattern-fill.test.js
@@ -20,6 +20,12 @@ describe('pattern fill', () => {
     return chartContainer.querySelector(`.highcharts-legend-item.highcharts-color-${colorIndex}`);
   }
 
+  function getPatternStyleText() {
+    // The bridge appends its rules to a <style> on the element shadow root, not the chart container.
+    const styleEl = chart.shadowRoot.querySelector('style[data-vaadin-pattern-fill]');
+    return styleEl ? styleEl.textContent : '';
+  }
+
   describe('series pattern color', () => {
     beforeEach(async () => {
       chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
@@ -39,6 +45,10 @@ describe('pattern fill', () => {
 
     it('should render a pattern element in the chart defs', () => {
       expect(getDefsPatterns()).to.have.lengthOf(1);
+    });
+
+    it('should inject a pattern CSS rule into the shadow-root style element', () => {
+      expect(getPatternStyleText()).to.contain('vaadin-pattern-');
     });
 
     it('should not set a fill attribute on the points (styled via CSS rule)', () => {
@@ -99,7 +109,7 @@ describe('pattern fill', () => {
     it('should not create bridge defs or an injected stylesheet', () => {
       const ids = getDefsPatterns().map((pattern) => pattern.getAttribute('id'));
       expect(ids.some((id) => id.startsWith('vaadin-pattern-'))).to.be.false;
-      expect(chart.__patternSheet).to.not.exist;
+      expect(getPatternStyleText()).to.not.contain('vaadin-pattern-');
     });
 
     it('should keep the native fill on the points', () => {
@@ -133,14 +143,14 @@ describe('pattern fill', () => {
       expect(getDefsPatterns()).to.have.lengthOf(1);
     });
 
-    it('should use the fill-attribute fallback only on the configured point', () => {
+    it('should use the inline-style fallback only on the configured point', () => {
       const patternId = getDefsPatterns()[0].getAttribute('id');
       const points = getSeriesPoints();
-      // The differing point falls back to the fill attribute since a class-level
+      // The differing point falls back to an inline fill style since a class-level
       // rule cannot distinguish points sharing the same color index.
-      expect(points[1].getAttribute('fill')).to.contain(`#${patternId}`);
-      expect(points[0].getAttribute('fill') || '').to.not.contain('url(');
-      expect(points[2].getAttribute('fill') || '').to.not.contain('url(');
+      expect(points[1].style.fill).to.contain(`#${patternId}`);
+      expect(points[0].style.fill || '').to.not.contain('url(');
+      expect(points[2].style.fill || '').to.not.contain('url(');
     });
 
     it('should render the fallback point with the pattern fill', () => {
@@ -235,7 +245,7 @@ describe('pattern fill', () => {
     });
 
     it('should not inject any pattern CSS rules', () => {
-      expect(chart.__patternSheet).to.not.exist;
+      expect(getPatternStyleText()).to.not.contain('vaadin-pattern-');
     });
 
     it('should keep the theme color on points', () => {
@@ -426,6 +436,102 @@ describe('pattern fill', () => {
       expect(patternsAfter).to.have.lengthOf(1);
       expect(patternsAfter[0].getAttribute('id')).to.equal(idBefore);
       expect(patternsAfter[0]).to.equal(patternBefore);
+    });
+  });
+
+  describe('non-patterned marker outline', () => {
+    // Regression: removing the color-N :not([fill^='url(']) guard must not let the series
+    // color win over the marker outline rule (both are now specificity 0,1,0, so source
+    // order decides and the later .highcharts-markers rule must win).
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="scatter"></vaadin-chart>');
+      chart.style.setProperty('--vaadin-charts-background', 'rgb(11, 22, 33)');
+      chart.style.setProperty('--vaadin-charts-color-0', 'rgb(200, 100, 50)');
+      chart.updateConfiguration({
+        series: [{ data: [5, 8, 3, 6] }],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should keep the background outline on markers, not the series color', () => {
+      const markers = chartContainer.querySelector('.highcharts-markers');
+      expect(markers).to.exist;
+      const stroke = getComputedStyle(markers).stroke;
+      expect(stroke).to.equal('rgb(11, 22, 33)');
+      expect(stroke).to.not.equal('rgb(200, 100, 50)');
+    });
+  });
+
+  describe('removing all patterns', () => {
+    // Regression: the stale-fill clear pass must run for every point even when no
+    // patterns remain, so a point never keeps an inline url() fill pointing at a
+    // destroyed def.
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.style.setProperty('--vaadin-charts-color-0', 'rgb(0, 128, 255)');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [
+              5,
+              { y: 8, color: { pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#0000ff' } } },
+              3,
+              6,
+            ],
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should clear the inline pattern fill and revert to the series color', async () => {
+      expect(getSeriesPoints()[1].style.fill).to.contain('url(');
+
+      // Override the point color with a solid value so no pattern remains (Highcharts
+      // merges point options, so a plain number would keep the old pattern color).
+      const redraw = oneEvent(chart, 'chart-redraw');
+      chart.updateConfiguration({ series: [{ data: [5, { y: 8, color: '#008000' }, 3, 6] }] });
+      await redraw;
+
+      getSeriesPoints().forEach((point) => {
+        expect(point.style.fill || '').to.not.contain('url(');
+        const fill = getComputedStyle(point).fill;
+        expect(fill).to.not.contain('url(');
+        expect(fill).to.equal('rgb(0, 128, 255)');
+      });
+      expect(getDefsPatterns()).to.have.lengthOf(0);
+    });
+  });
+
+  describe('distinct pattern ids', () => {
+    // Regression: two different pattern configs must hash to distinct ids (the old signed
+    // hash could collide once a negative value's hex digit was string-replaced).
+    beforeEach(async () => {
+      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
+      chart.updateConfiguration({
+        series: [
+          {
+            data: [5, 8, 3, 6],
+            color: { pattern: { path: PATTERN_PATH, width: 10, height: 10, color: '#ff0000' } },
+          },
+          {
+            data: [4, 2, 7, 1],
+            color: { pattern: { path: 'M 0 0 L 5 5', width: 8, height: 8, color: '#00ff00' } },
+          },
+        ],
+      });
+      await oneEvent(chart, 'chart-redraw');
+      chartContainer = chart.$.chart;
+    });
+
+    it('should generate two distinct vaadin-pattern ids', () => {
+      const ids = getDefsPatterns()
+        .map((pattern) => pattern.getAttribute('id'))
+        .filter((id) => id.startsWith('vaadin-pattern-'));
+      expect(ids).to.have.lengthOf(2);
+      expect(ids[0]).to.not.equal(ids[1]);
     });
   });
 });

--- a/packages/charts/test/pattern-fill.test.js
+++ b/packages/charts/test/pattern-fill.test.js
@@ -26,10 +26,16 @@ describe('pattern fill', () => {
     return styleEl ? styleEl.textContent : '';
   }
 
+  async function createChart(config, type = 'column') {
+    chart = fixtureSync(`<vaadin-chart type="${type}"></vaadin-chart>`);
+    chart.updateConfiguration(config);
+    await oneEvent(chart, 'chart-redraw');
+    chartContainer = chart.$.chart;
+  }
+
   describe('series pattern color', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -39,8 +45,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should render a pattern element in the chart defs', () => {
@@ -83,8 +87,7 @@ describe('pattern fill', () => {
     // In non-styled mode Highcharts' own pattern-fill module renders patterns
     // natively; the Vaadin styled-mode bridge must stay out of the way.
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         chart: { styledMode: false },
         series: [
           {
@@ -95,8 +98,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should render the pattern natively (highcharts-pattern def)', () => {
@@ -122,8 +123,7 @@ describe('pattern fill', () => {
 
   describe('per-point pattern color', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [
@@ -135,8 +135,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should render a pattern only for the point that defines it', () => {
@@ -196,8 +194,7 @@ describe('pattern fill', () => {
 
   describe('updateConfiguration', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -207,8 +204,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should update the pattern without leaking defs', async () => {
@@ -251,12 +246,9 @@ describe('pattern fill', () => {
 
   describe('without patterns', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [{ data: [5, 8, 3, 6] }],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should not create any pattern defs', () => {
@@ -276,8 +268,7 @@ describe('pattern fill', () => {
 
   describe('multiple series with different patterns', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -293,8 +284,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should render exactly two distinct pattern defs', () => {
@@ -315,8 +304,7 @@ describe('pattern fill', () => {
 
   describe('removing a series', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -332,8 +320,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should remove the def of a removed series with an explicit pattern id', async () => {
@@ -351,8 +337,7 @@ describe('pattern fill', () => {
 
   describe('patternIndex', () => {
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -360,8 +345,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should render a def for a built-in pattern index', () => {
@@ -428,8 +411,7 @@ describe('pattern fill', () => {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -439,8 +421,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should keep the same def across a resize', async () => {
@@ -528,8 +508,7 @@ describe('pattern fill', () => {
     // Regression: two different pattern configs must hash to distinct ids (the old signed
     // hash could collide once a negative value's hex digit was string-replaced).
     beforeEach(async () => {
-      chart = fixtureSync('<vaadin-chart type="column"></vaadin-chart>');
-      chart.updateConfiguration({
+      await createChart({
         series: [
           {
             data: [5, 8, 3, 6],
@@ -541,8 +520,6 @@ describe('pattern fill', () => {
           },
         ],
       });
-      await oneEvent(chart, 'chart-redraw');
-      chartContainer = chart.$.chart;
     });
 
     it('should generate two distinct vaadin-pattern ids', () => {


### PR DESCRIPTION
[Highcharts pattern fills](https://www.highcharts.com/docs/chart-design-and-style/pattern-fills) let series use SVG patterns instead of solid colors, which helps color-blind users tell series apart. The pattern-fill module ships with Highcharts (~8 KB) but was not enabled in `<vaadin-chart>`, and there was no way to use it.

- Register the Highcharts `pattern-fill` module.
- `<vaadin-chart>` runs Highcharts in styled mode, where color options (including patterns) are not applied directly — fills come from CSS classes. A new `PatternFillBridge` (`vaadin-chart-pattern-fill.js`) turns `color: { pattern: {...} }` / `{ patternIndex: N }` into a rendered pattern: it creates the `<pattern>` def and injects one shadow-scoped CSS rule per color index, so the point, its legend symbol and its tooltip swatch all get the pattern. A point whose pattern differs from its series uses a `fill` attribute.
- In non-styled mode Highcharts renders patterns itself, so the bridge does nothing.
- Theme color rules in the base styles now skip elements that already have a pattern `url()` fill, so they don't override it.

Known limitation (follow-up): server-side `exportChart` builds a fresh chart the bridge does not run on, so server-rendered SVGs don't include these patterns yet.

Part of #9990

🤖 Generated with Claude Code
