### PR TITLE
fix!: bring modeless dialog to front on top of its nested dialogs 

### DIFF
--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isNestedOverlayEvent } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
 
 export const DialogBaseMixin = (superClass) =>
   class DialogBaseMixin extends superClass {
@@ -203,13 +202,7 @@ export const DialogBaseMixin = (superClass) =>
       if (!this.modeless) {
         return;
       }
-      const overlay = this._overlayElement;
-      // Bring the dialog to the front on interaction, unless the event comes from the
-      // nested overlay (e.g. combo-box / popover) or the corresponding position target.
-      if (isNestedOverlayEvent(overlay, event)) {
-        return;
-      }
-      overlay.bringToFront();
+      this._overlayElement.bringToFront(event);
     }
 
     /** @private */

--- a/packages/dialog/src/vaadin-dialog-base-mixin.js
+++ b/packages/dialog/src/vaadin-dialog-base-mixin.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { isNestedOverlayEvent } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
 
 export const DialogBaseMixin = (superClass) =>
   class DialogBaseMixin extends superClass {
@@ -198,10 +199,17 @@ export const DialogBaseMixin = (superClass) =>
     }
 
     /** @private */
-    _bringOverlayToFront() {
-      if (this.modeless) {
-        this._overlayElement.bringToFront();
+    _bringOverlayToFront(event) {
+      if (!this.modeless) {
+        return;
       }
+      const overlay = this._overlayElement;
+      // Bring the dialog to the front on interaction, unless the event comes from the
+      // nested overlay (e.g. combo-box / popover) or the corresponding position target.
+      if (isNestedOverlayEvent(overlay, event)) {
+        return;
+      }
+      overlay.bringToFront();
     }
 
     /** @private */

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -7,6 +7,7 @@ import { html, LitElement } from 'lit';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
+import { getOverlaysOnTop, isNestedOverlay } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
 import { LumoInjectionMixin } from '@vaadin/vaadin-themable-mixin/lumo-injection-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { dialogOverlayStyles } from './styles/vaadin-dialog-overlay-base-styles.js';
@@ -54,6 +55,29 @@ export class DialogOverlay extends DialogOverlayMixin(
         </section>
       </div>
     `;
+  }
+
+  /**
+   * @param {Event} event
+   * @protected
+   * @override
+   */
+  bringToFront(event) {
+    if (event instanceof Event) {
+      const path = event.composedPath();
+
+      // Do not bring overlay to front if this method is called
+      // on event that originates from a nested dialog content.
+      const isNestedDialogEvent = getOverlaysOnTop(this).some(
+        (overlay) => path.includes(overlay) && isNestedOverlay(this, overlay) && overlay instanceof DialogOverlay,
+      );
+
+      if (isNestedDialogEvent) {
+        return;
+      }
+    }
+
+    super.bringToFront();
   }
 }
 

--- a/packages/dialog/test/draggable-resizable.test.js
+++ b/packages/dialog/test/draggable-resizable.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextFrame, nextRender, nextResize, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextResize, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './draggable-resizable-styles.js';
 import '../src/vaadin-dialog.js';
@@ -782,28 +782,22 @@ describe('nested draggable dialogs', () => {
   }
 
   beforeEach(async () => {
-    parentDialog = fixtureSync('<vaadin-dialog draggable opened></vaadin-dialog>');
+    parentDialog = fixtureSync(`
+      <vaadin-dialog modeless draggable header-title="Parent">
+        <div>Parent dialog content</div>
+        <vaadin-dialog modeless draggable header-title="Child">
+          <div>Child dialog content</div>
+        </vaadin-dialog>
+      </vaadin-dialog>
+    `);
     await nextRender();
-
-    parentDialog.headerTitle = 'Parent Dialog';
-    parentDialog.renderer = (root) => {
-      if (!root.firstChild) {
-        root.innerHTML = '<div>Parent dialog content</div>';
-
-        childDialog = document.createElement('vaadin-dialog');
-        childDialog.draggable = true;
-        childDialog.headerTitle = 'Child Dialog';
-        childDialog.renderer = (childRoot) => {
-          childRoot.innerHTML = '<div>Child dialog content</div>';
-        };
-        root.appendChild(childDialog);
-      }
-    };
-    await nextUpdate(parentDialog);
+    childDialog = parentDialog.querySelector('vaadin-dialog');
+    parentDialog.opened = true;
+    await oneEvent(parentDialog.$.overlay, 'vaadin-overlay-open');
 
     // Open the child dialog
     childDialog.opened = true;
-    await nextRender();
+    await oneEvent(childDialog.$.overlay, 'vaadin-overlay-open');
 
     parentContainer = parentDialog.$.overlay.$.resizerContainer;
     childContainer = childDialog.$.overlay.$.resizerContainer;
@@ -866,6 +860,27 @@ describe('nested draggable dialogs', () => {
     drag(childHeader, dx, dx);
 
     expect(spy.called).to.be.false;
+  });
+
+  it('should bring the parent dialog to front over the child when dragging the parent', () => {
+    expect(childDialog.$.overlay._last).to.be.true;
+
+    drag(parentHeader, dx, dx);
+
+    expect(parentDialog.$.overlay._last).to.be.true;
+    expect(childDialog.$.overlay._last).to.be.false;
+  });
+
+  it('should not bring the parent dialog to front when interacting with the child', () => {
+    // Bring the parent to the front first.
+    dispatchMouseEvent(parentHeader, 'mousedown');
+    expect(parentDialog.$.overlay._last).to.be.true;
+
+    // Interacting with the child brings the child to the front, not the parent.
+    dispatchMouseEvent(childHeader, 'mousedown');
+
+    expect(childDialog.$.overlay._last).to.be.true;
+    expect(parentDialog.$.overlay._last).to.be.false;
   });
 });
 

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -116,6 +116,11 @@ export const PositionMixin = (superClass) =>
     constructor() {
       super();
 
+      /**
+       * Used for mixin detection because `instanceof` does not work with mixins.
+       */
+      this._hasOverlayPositionMixin = true;
+
       this.__onScroll = this.__onScroll.bind(this);
       this._updatePosition = this._updatePosition.bind(this);
     }

--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -14,12 +14,22 @@ const attachedInstances = new Set();
 const getAttachedInstances = () => [...attachedInstances].filter((el) => !el.hasAttribute('closing'));
 
 /**
+ * Returns overlays shown on top of the given overlay.
+ * @private
+ */
+const getInstancesOnTop = (overlay) => {
+  const instances = getAttachedInstances();
+  const index = instances.indexOf(overlay);
+  // The overlay is not in the visible stack (e.g. mid-close), so nothing is "on top" of it.
+  return index === -1 ? [] : instances.slice(index + 1);
+};
+
+/**
  * Returns true if all the instances on top of the overlay are nested overlays.
  * @private
  */
 export const hasOnlyNestedOverlays = (overlay) => {
-  const instances = getAttachedInstances();
-  const next = instances[instances.indexOf(overlay) + 1];
+  const next = getInstancesOnTop(overlay)[0];
   if (!next) {
     return true;
   }
@@ -41,6 +51,30 @@ export const hasOnlyNestedOverlays = (overlay) => {
 export const isLastOverlay = (overlay, filter = (_overlay) => true) => {
   const filteredOverlays = getAttachedInstances().filter(filter);
   return overlay === filteredOverlays.pop();
+};
+
+/**
+ * Returns true if the event originates from one of the following:
+ * - nested overlay inside the given overlay (e.g. nested dialogs),
+ * - owner of a nested overlay (e.g. combo-box inside of dialog),
+ * - position target of a nested overlay (e.g. popover target).
+ *
+ * @param {HTMLElement} overlay
+ * @param {Event} event
+ * @return {boolean}
+ * @protected
+ */
+export const isNestedOverlayEvent = (overlay, event) => {
+  const path = event.composedPath();
+  const instances = getInstancesOnTop(overlay);
+
+  return instances.some(
+    (el) =>
+      (path.includes(el) ||
+        (el.owner && path.includes(el.owner)) ||
+        (el.positionTarget && path.includes(el.positionTarget))) &&
+      overlay._deepContains(el),
+  );
 };
 
 export const OverlayStackMixin = (superClass) =>
@@ -69,10 +103,9 @@ export const OverlayStackMixin = (superClass) =>
      * Brings the overlay as visually the frontmost one.
      */
     bringToFront() {
-      // If the overlay is the last one, or if all other overlays shown above
-      // are nested overlays (e.g. date-picker inside a dialog), do not call
-      // `showPopover()` unnecessarily to avoid scroll position being reset.
-      if (isLastOverlay(this) || hasOnlyNestedOverlays(this)) {
+      // Stacking order follows interaction order only, independent of nesting.
+      // Do not call `showPopover()` if the overlay is already the last one.
+      if (isLastOverlay(this)) {
         return;
       }
 

--- a/packages/overlay/src/vaadin-overlay-stack-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-stack-mixin.js
@@ -15,31 +15,25 @@ const getAttachedInstances = () => [...attachedInstances].filter((el) => !el.has
 
 /**
  * Returns overlays shown on top of the given overlay.
- * @private
+ * @param {HTMLElement} overlay
+ * @return {HTMLElement[]}
+ * @protected
  */
-const getInstancesOnTop = (overlay) => {
+export const getOverlaysOnTop = (overlay) => {
   const instances = getAttachedInstances();
   const index = instances.indexOf(overlay);
-  // The overlay is not in the visible stack (e.g. mid-close), so nothing is "on top" of it.
+  // The overlay is not in the visible stack (closing), so nothing is "on top" of it.
   return index === -1 ? [] : instances.slice(index + 1);
 };
 
 /**
- * Returns true if all the instances on top of the overlay are nested overlays.
- * @private
+ * Returns true if the given overlay is a child of a parent overlay.
+ * @param {HTMLElement} parent
+ * @param {HTMLElement} overlay
+ * @return {boolean}
+ * @protected
  */
-export const hasOnlyNestedOverlays = (overlay) => {
-  const next = getInstancesOnTop(overlay)[0];
-  if (!next) {
-    return true;
-  }
-
-  if (!overlay._deepContains(next)) {
-    return false;
-  }
-
-  return hasOnlyNestedOverlays(next);
-};
+export const isNestedOverlay = (parent, overlay) => parent._deepContains(overlay);
 
 /**
  * Returns true if the overlay is the last one in the opened overlays stack.
@@ -51,30 +45,6 @@ export const hasOnlyNestedOverlays = (overlay) => {
 export const isLastOverlay = (overlay, filter = (_overlay) => true) => {
   const filteredOverlays = getAttachedInstances().filter(filter);
   return overlay === filteredOverlays.pop();
-};
-
-/**
- * Returns true if the event originates from one of the following:
- * - nested overlay inside the given overlay (e.g. nested dialogs),
- * - owner of a nested overlay (e.g. combo-box inside of dialog),
- * - position target of a nested overlay (e.g. popover target).
- *
- * @param {HTMLElement} overlay
- * @param {Event} event
- * @return {boolean}
- * @protected
- */
-export const isNestedOverlayEvent = (overlay, event) => {
-  const path = event.composedPath();
-  const instances = getInstancesOnTop(overlay);
-
-  return instances.some(
-    (el) =>
-      (path.includes(el) ||
-        (el.owner && path.includes(el.owner)) ||
-        (el.positionTarget && path.includes(el.positionTarget))) &&
-      overlay._deepContains(el),
-  );
 };
 
 export const OverlayStackMixin = (superClass) =>
@@ -103,21 +73,28 @@ export const OverlayStackMixin = (superClass) =>
      * Brings the overlay as visually the frontmost one.
      */
     bringToFront() {
-      // Stacking order follows interaction order only, independent of nesting.
-      // Do not call `showPopover()` if the overlay is already the last one.
       if (isLastOverlay(this)) {
         return;
       }
 
-      // Update stacking order of native popover-based overlays
-      if (this.matches(':popover-open')) {
-        this.hidePopover();
-        this.showPopover();
+      const overlays = getOverlaysOnTop(this);
+      // Nested positioned overlays anchored must stay visually on top.
+      const nestedOverlays = overlays.filter((el) => el._hasOverlayPositionMixin && isNestedOverlay(this, el));
+
+      // If the only overlays on top are nested positioned overlays, this overlay is already
+      // effectively frontmost. Skip to avoid resetting scroll position via `showPopover()`.
+      if (nestedOverlays.length === overlays.length) {
+        return;
       }
 
-      // Update order of attached instances
-      this._removeAttachedInstance();
-      this._appendAttachedInstance();
+      [this, ...nestedOverlays].forEach((overlay) => {
+        if (overlay.matches(':popover-open')) {
+          overlay.hidePopover();
+          overlay.showPopover();
+        }
+        overlay._removeAttachedInstance();
+        overlay._appendAttachedInstance();
+      });
     }
 
     /** @protected */

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -240,22 +240,20 @@ describe('multiple overlays', () => {
       expect(frontmost).to.equal(modeless2);
     });
 
-    it('should not call showPopover on bringToFront if only nested overlay is open', () => {
-      modeless2.opened = true;
+    it('should bring the overlay to front even if a nested overlay is open above it', () => {
+      modeless1.opened = true;
       modeless2.opened = true;
 
       // Mimic nested overlays case
       modeless1.appendChild(modeless2);
 
-      const showSpy1 = sinon.spy(modeless1, 'showPopover');
-      const showSpy2 = sinon.spy(modeless2, 'showPopover');
-
       modeless1.bringToFront();
 
-      expect(showSpy1).to.be.not.called;
-      expect(showSpy2).to.be.not.called;
-
-      expect(modeless2._last).to.be.true;
+      // Stacking is decoupled from nesting: the overlay is brought to the front
+      // even over its own nested overlay.
+      expect(modeless1._last).to.be.true;
+      const frontmost = getFrontmostOverlayFromScreenCenter();
+      expect(frontmost).to.equal(modeless1);
     });
 
     it('should not call showPopover on bringToFront for the last open overlay', () => {

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -12,8 +12,9 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import {
-  hasOnlyNestedOverlays,
+  getOverlaysOnTop,
   isLastOverlay as isLastOverlayBase,
+  isNestedOverlay,
 } from '@vaadin/overlay/src/vaadin-overlay-stack-mixin.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import { PopoverFocusController } from './vaadin-popover-focus-controller.js';
@@ -157,6 +158,14 @@ const isLastOverlay = (overlay) => {
   const filter = (o) => o.localName !== 'vaadin-tooltip-overlay';
   return isLastOverlayBase(overlay, filter);
 };
+
+/**
+ * Returns true if all the overlays shown on top of the given overlay are nested inside it.
+ * @param {HTMLElement} overlay
+ * @return {boolean}
+ * @protected
+ */
+const hasOnlyNestedOverlays = (overlay) => getOverlaysOnTop(overlay).every((el) => isNestedOverlay(overlay, el));
 
 /**
  * `<vaadin-popover>` is a Web Component for creating overlays

--- a/test/integration/dialog-popover.test.js
+++ b/test/integration/dialog-popover.test.js
@@ -96,7 +96,7 @@ describe('popover in dialog', () => {
 });
 
 describe('popover stacking in modeless dialog', () => {
-  let dialog, content;
+  let dialog, popover, content;
 
   beforeEach(async () => {
     dialog = fixtureSync(`
@@ -110,7 +110,7 @@ describe('popover stacking in modeless dialog', () => {
     dialog.opened = true;
     await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
 
-    const popover = dialog.querySelector('vaadin-popover');
+    popover = dialog.querySelector('vaadin-popover');
     content = dialog.querySelector('#popover-content');
     popover.opened = true;
     await oneEvent(popover._overlayElement, 'vaadin-overlay-open');
@@ -136,34 +136,13 @@ describe('popover stacking in modeless dialog', () => {
 
     expect(content.contains(document.elementFromPoint(x, y))).to.be.true;
   });
-});
 
-describe('target-less popover stacking in modeless dialog', () => {
-  let dialog, popover;
+  it('should keep a target-less popover on top of the dialog on dialog header mousedown', async () => {
+    // A popover without a target is centered, so it may not overlap the dialog;
+    // assert stacking order directly instead of using `elementFromPoint`.
+    popover.target = null;
+    await nextUpdate(popover);
 
-  beforeEach(async () => {
-    dialog = fixtureSync(`
-      <vaadin-dialog modeless header-title="Title" top="50px" left="50px">
-        <vaadin-popover no-close-on-outside-click>
-          <div>Popover content</div>
-        </vaadin-popover>
-      </vaadin-dialog>
-    `);
-    dialog.opened = true;
-    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
-
-    popover = dialog.querySelector('vaadin-popover');
-    popover.opened = true;
-    await oneEvent(popover._overlayElement, 'vaadin-overlay-open');
-  });
-
-  afterEach(async () => {
-    dialog.opened = false;
-    await nextFrame();
-  });
-
-  it('should keep a target-less popover on top of the dialog on dialog header mousedown', () => {
-    // A popover without a target opens centered; it is still shown on top of the dialog.
     expect(popover._overlayElement._last).to.be.true;
 
     mousedown(dialog.$.overlay.shadowRoot.querySelector('[part="title"]'));

--- a/test/integration/dialog-popover.test.js
+++ b/test/integration/dialog-popover.test.js
@@ -138,6 +138,41 @@ describe('popover stacking in modeless dialog', () => {
   });
 });
 
+describe('target-less popover stacking in modeless dialog', () => {
+  let dialog, popover;
+
+  beforeEach(async () => {
+    dialog = fixtureSync(`
+      <vaadin-dialog modeless header-title="Title" top="50px" left="50px">
+        <vaadin-popover no-close-on-outside-click>
+          <div>Popover content</div>
+        </vaadin-popover>
+      </vaadin-dialog>
+    `);
+    dialog.opened = true;
+    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+
+    popover = dialog.querySelector('vaadin-popover');
+    popover.opened = true;
+    await oneEvent(popover._overlayElement, 'vaadin-overlay-open');
+  });
+
+  afterEach(async () => {
+    dialog.opened = false;
+    await nextFrame();
+  });
+
+  it('should keep a target-less popover on top of the dialog on dialog header mousedown', () => {
+    // A popover without a target opens centered; it is still shown on top of the dialog.
+    expect(popover._overlayElement._last).to.be.true;
+
+    mousedown(dialog.$.overlay.shadowRoot.querySelector('[part="title"]'));
+
+    expect(popover._overlayElement._last).to.be.true;
+    expect(dialog.$.overlay._last).to.be.false;
+  });
+});
+
 describe('dialog in popover', () => {
   let popover, target, button, dialog;
 


### PR DESCRIPTION
## Description

Depends on https://github.com/vaadin/web-components/pull/12202

Fixes https://github.com/vaadin/web-components/issues/12191

- Removed problematic check for `hasOnlyNestedOverlays` from `bringToFront()`
- Modified logic for modeless dialogs to use new `isNestedOverlayEvent()` helper

The new logic prevents bringing dialog to front on `mousedown` / `touchstart` in one of 3 cases:

- An event from a nested overlay content (= nested modeless dialog)
- An event from a nested overlay owner (= combo-box input / label)
- An event from a nested overlay position target (= popover target).

## Type of change

- Behavior altering fix

## Note

Here's a video of the "separate modeless dialog chains" case after the change:

https://github.com/user-attachments/assets/797c1d00-223f-46b6-9acd-34f4069c7c34

