### PR TITLE
test: restore ITs for nested overlays shown on top of modeless dialog (CP: 25.1)

### DIFF
--- a/test/integration/dialog-combo-box.test.js
+++ b/test/integration/dialog-combo-box.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextUpdate, oneEvent, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextRender, nextUpdate, oneEvent, outsideClick } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/combo-box';
 import '@vaadin/dialog';
@@ -9,11 +9,12 @@ describe('combo-box in dialog', () => {
   let dialog, comboBox;
 
   beforeEach(async () => {
-    dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
+    dialog = fixtureSync(`
+      <vaadin-dialog>
+        <vaadin-combo-box></vaadin-combo-box>
+      </vaadin-dialog>
+    `);
     await nextUpdate(dialog);
-    dialog.renderer = (root) => {
-      root.innerHTML = '<vaadin-combo-box></vaadin-combo-box>';
-    };
     dialog.opened = true;
     await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
     comboBox = dialog.querySelector('vaadin-combo-box');
@@ -21,7 +22,7 @@ describe('combo-box in dialog', () => {
     comboBox.inputElement.focus();
   });
 
-  describe('opened', () => {
+  describe('default', () => {
     beforeEach(async () => {
       comboBox.open();
       await nextUpdate(comboBox);
@@ -68,6 +69,30 @@ describe('combo-box in dialog', () => {
       await sendKeys({ press: 'Escape' });
 
       expect(dialog.opened).to.be.false;
+    });
+  });
+
+  describe('modeless', () => {
+    beforeEach(async () => {
+      dialog.modeless = true;
+      await nextUpdate(dialog);
+
+      comboBox.open();
+      await nextRender();
+    });
+
+    it('should keep the combo-box overlay on top of dialog on input mousedown', () => {
+      mousedown(comboBox.inputElement);
+
+      expect(comboBox.$.overlay._last).to.be.true;
+      expect(dialog.$.overlay._last).to.be.false;
+    });
+
+    it('should keep the combo-box overlay on top of dialog on label mousedown', () => {
+      mousedown(comboBox._labelNode);
+
+      expect(comboBox.$.overlay._last).to.be.true;
+      expect(dialog.$.overlay._last).to.be.false;
     });
   });
 });

--- a/test/integration/dialog-date-picker.test.js
+++ b/test/integration/dialog-date-picker.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextFrame, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './not-animated-styles.js';
 import '@vaadin/date-picker/src/vaadin-date-picker.js';
@@ -11,12 +11,13 @@ describe('date-picker in dialog', () => {
   let dialog, datePicker;
 
   beforeEach(async () => {
-    dialog = fixtureSync('<vaadin-dialog></vaadin-dialog>');
-    dialog.renderer = (root) => {
-      root.innerHTML = '<vaadin-date-picker></vaadin-date-picker>';
-    };
+    dialog = fixtureSync(`
+      <vaadin-dialog>
+        <vaadin-date-picker></vaadin-date-picker>
+      </vaadin-dialog>
+    `);
     dialog.opened = true;
-    await nextFrame();
+    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
     datePicker = dialog.querySelector('vaadin-date-picker');
   });
 
@@ -116,6 +117,30 @@ describe('date-picker in dialog', () => {
 
       expect(datePicker.opened).to.be.false;
       expect(dialog.opened).to.be.true;
+    });
+  });
+
+  describe('modeless', () => {
+    beforeEach(async () => {
+      dialog.modeless = true;
+      await nextUpdate(dialog);
+
+      await open(datePicker);
+      await nextRender();
+    });
+
+    it('should keep the date-picker overlay on top of dialog on input mousedown', () => {
+      mousedown(datePicker.inputElement);
+
+      expect(datePicker.$.overlay._last).to.be.true;
+      expect(dialog.$.overlay._last).to.be.false;
+    });
+
+    it('should keep the date-picker overlay on top of dialog on label mousedown', () => {
+      mousedown(datePicker._labelNode);
+
+      expect(datePicker.$.overlay._last).to.be.true;
+      expect(dialog.$.overlay._last).to.be.false;
     });
   });
 });

--- a/test/integration/dialog-select.test.js
+++ b/test/integration/dialog-select.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, mousedown, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/dialog/src/vaadin-dialog.js';
 import '@vaadin/select/src/vaadin-select.js';
@@ -9,13 +9,11 @@ describe('select in dialog', () => {
   let dialog, select;
 
   beforeEach(async () => {
-    dialog = fixtureSync('<vaadin-dialog modeless></vaadin-dialog>');
-    dialog.headerTitle = 'Title';
-    dialog.renderer = (root) => {
-      if (!root.firstChild) {
-        root.innerHTML = '<vaadin-select></vaadin-select>';
-      }
-    };
+    dialog = fixtureSync(`
+      <vaadin-dialog modeless header-title="Title">
+        <vaadin-select no-vertical-overlap></vaadin-select>
+      </vaadin-dialog>
+    `);
     dialog.opened = true;
     await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
     select = dialog.querySelector('vaadin-select');
@@ -23,6 +21,8 @@ describe('select in dialog', () => {
       { label: 'Option 1', value: 'value-1' },
       { label: 'Option 2', value: 'value-2' },
     ];
+    select.opened = true;
+    await nextRender();
   });
 
   afterEach(async () => {
@@ -30,9 +30,6 @@ describe('select in dialog', () => {
   });
 
   it('should close the select on dialog header title click', async () => {
-    select.opened = true;
-    await nextRender();
-
     // Use title slot part instead of the actual slotted title HTML element,
     // since `getBoundingClientRect()` for the latter returns 0 coordinates.
     const title = dialog.$.overlay.shadowRoot.querySelector('[part="title"]');
@@ -40,5 +37,19 @@ describe('select in dialog', () => {
     await sendMouseToElement({ type: 'click', element: title });
 
     expect(select.opened).to.be.false;
+  });
+
+  it('should keep the select overlay on top of dialog on select mousedown', () => {
+    mousedown(select.focusElement);
+
+    expect(select.$.overlay._last).to.be.true;
+    expect(dialog.$.overlay._last).to.be.false;
+  });
+
+  it('should keep the select overlay on top of dialog on label mousedown', () => {
+    mousedown(select._labelNode);
+
+    expect(select.$.overlay._last).to.be.true;
+    expect(dialog.$.overlay._last).to.be.false;
   });
 });


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12202 to branch 25.1.

---

> ## Description
> 
> Restored ITs that were previously removed in following PRs:
> 
> - https://github.com/vaadin/web-components/pull/9815
> - https://github.com/vaadin/web-components/pull/9762
> 
> Also added the corresponding test to `dialog-select.test.js`.
> 
> ## Type of change
> 
> - Test
> 
> ## Note
> 
> These tests are needed to verify the existing `bringToFront()` behavior:
> 
> https://github.com/vaadin/web-components/blob/aabb31bfca1e019ce73c7d818b76939c466330c2/packages/overlay/src/vaadin-overlay-stack-mixin.js#L71-L76
> 
> 
> Removing `hasOnlyNestedOverlays(this)` from the check above fails passes ITs on `main` without them.
> I'm going to create another PR with a behavior altering fix using different logic where ITs must still pass.
