### PR TITLE
test: add integration test to verify dialog / popover stacking order (CP: 25.1)

### DIFF
--- a/test/integration/dialog-popover.test.js
+++ b/test/integration/dialog-popover.test.js
@@ -1,6 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextFrame, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
+import {
+  fixtureSync,
+  middleOfNode,
+  mousedown,
+  nextFrame,
+  nextRender,
+  nextUpdate,
+  oneEvent,
+} from '@vaadin/testing-helpers';
 import './not-animated-styles.js';
 import '@vaadin/dialog/src/vaadin-dialog.js';
 import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -85,6 +93,49 @@ describe('popover in dialog', () => {
         expect(dialog.opened).to.be.true;
       });
     });
+  });
+});
+
+describe('popover stacking in modeless dialog', () => {
+  let dialog, content;
+
+  beforeEach(async () => {
+    dialog = fixtureSync(`
+      <vaadin-dialog modeless header-title="Title" top="50px" left="50px" width="400px" height="300px">
+        <button id="target">Open popover</button>
+        <vaadin-popover for="target" position="bottom-start" no-close-on-outside-click>
+          <div id="popover-content" style="width: 200px; height: 120px">Popover content</div>
+        </vaadin-popover>
+      </vaadin-dialog>
+    `);
+    dialog.opened = true;
+    await oneEvent(dialog.$.overlay, 'vaadin-overlay-open');
+
+    const popover = dialog.querySelector('vaadin-popover');
+    content = dialog.querySelector('#popover-content');
+    popover.opened = true;
+    await oneEvent(popover._overlayElement, 'vaadin-overlay-open');
+  });
+
+  afterEach(async () => {
+    dialog.opened = false;
+    await nextFrame();
+  });
+
+  it('should keep the popover rendered on top of the dialog on dialog header mousedown', () => {
+    const { x, y } = middleOfNode(content);
+
+    const dialogRect = dialog.$.overlay.$.overlay.getBoundingClientRect();
+    expect(x).to.be.within(dialogRect.left, dialogRect.right);
+    expect(y).to.be.within(dialogRect.top, dialogRect.bottom);
+
+    // Verify popover is rendered on top of the dialog to begin with.
+    // `elementFromPoint` reflects the actual rendered stacking order.
+    expect(content.contains(document.elementFromPoint(x, y))).to.be.true;
+
+    mousedown(dialog.$.overlay.shadowRoot.querySelector('[part="title"]'));
+
+    expect(content.contains(document.elementFromPoint(x, y))).to.be.true;
   });
 });
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12206 to branch 25.1.

---

> Adds an integration test that verifies that clicking a modeless dialog (which triggers `bringToFront`) with an opened popover does not move the dialog in front of the popover in the stacking order.
