### PR TITLE
fix: use ARIA element references to link tooltip across shadow roots

### DIFF
--- a/packages/a11y-base/src/aria-element-reference.d.ts
+++ b/packages/a11y-base/src/aria-element-reference.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+/**
+ * Adds an element to the list of elements referenced by the given ARIA
+ * attribute on the target element, using ARIA element reflection properties
+ * (`ariaDescribedByElements`, `ariaLabelledByElements`). Unlike ID references,
+ * element references also work when the target element is in a shadow root
+ * and the referenced element is in a containing tree scope.
+ */
+export function addAriaElementReference(
+  target: HTMLElement,
+  attr: 'aria-describedby' | 'aria-labelledby',
+  element: HTMLElement,
+): void;
+
+/**
+ * Removes an element from the list of elements referenced by the given ARIA
+ * attribute on the target element. When the list becomes empty, the property
+ * is reset to `null` so that it no longer overrides the corresponding
+ * content attribute.
+ */
+export function removeAriaElementReference(
+  target: HTMLElement,
+  attr: 'aria-describedby' | 'aria-labelledby',
+  element: HTMLElement,
+): void;

--- a/packages/a11y-base/src/aria-element-reference.d.ts
+++ b/packages/a11y-base/src/aria-element-reference.d.ts
@@ -5,11 +5,9 @@
  */
 
 /**
- * Adds an element to the list of elements referenced by the given ARIA
- * attribute on the target element, using ARIA element reflection properties
- * (`ariaDescribedByElements`, `ariaLabelledByElements`). Unlike ID references,
- * element references also work when the target element is in a shadow root
- * and the referenced element is in a containing tree scope.
+ * Adds the element to the target's `ariaDescribedByElements` or
+ * `ariaLabelledByElements` property, based on the given attribute.
+ * Unlike ID references, element references also work across shadow roots.
  */
 export function addAriaElementReference(
   target: HTMLElement,
@@ -18,10 +16,10 @@ export function addAriaElementReference(
 ): void;
 
 /**
- * Removes an element from the list of elements referenced by the given ARIA
- * attribute on the target element. When the list becomes empty, the property
- * is reset to `null` so that it no longer overrides the corresponding
- * content attribute.
+ * Removes the element from the target's `ariaDescribedByElements` or
+ * `ariaLabelledByElements` property, based on the given attribute.
+ * When the last element is removed, the property is reset to `null`
+ * so it no longer overrides the content attribute.
  */
 export function removeAriaElementReference(
   target: HTMLElement,

--- a/packages/a11y-base/src/aria-element-reference.js
+++ b/packages/a11y-base/src/aria-element-reference.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright (c) 2000 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+const ARIA_REFERENCE_PROPERTIES = {
+  'aria-describedby': 'ariaDescribedByElements',
+  'aria-labelledby': 'ariaLabelledByElements',
+};
+
+/**
+ * Adds an element to the list of elements referenced by the given ARIA
+ * attribute on the target element, using ARIA element reflection properties
+ * (`ariaDescribedByElements`, `ariaLabelledByElements`). Unlike ID references,
+ * element references also work when the target element is in a shadow root
+ * and the referenced element is in a containing tree scope.
+ *
+ * @param {HTMLElement} target
+ * @param {string} attr the ARIA attribute, `aria-describedby` or `aria-labelledby`
+ * @param {HTMLElement} element the element to add to the reference list
+ */
+export function addAriaElementReference(target, attr, element) {
+  const property = ARIA_REFERENCE_PROPERTIES[attr];
+  if (!property) {
+    return;
+  }
+  const elements = new Set(target[property]);
+  elements.add(element);
+  target[property] = [...elements];
+}
+
+/**
+ * Removes an element from the list of elements referenced by the given ARIA
+ * attribute on the target element. When the list becomes empty, the property
+ * is reset to `null` so that it no longer overrides the corresponding
+ * content attribute.
+ *
+ * @param {HTMLElement} target
+ * @param {string} attr the ARIA attribute, `aria-describedby` or `aria-labelledby`
+ * @param {HTMLElement} element the element to remove from the reference list
+ */
+export function removeAriaElementReference(target, attr, element) {
+  const property = ARIA_REFERENCE_PROPERTIES[attr];
+  if (!property) {
+    return;
+  }
+  const elements = new Set(target[property]);
+  elements.delete(element);
+  target[property] = elements.size > 0 ? [...elements] : null;
+}

--- a/packages/a11y-base/src/aria-element-reference.js
+++ b/packages/a11y-base/src/aria-element-reference.js
@@ -10,41 +10,33 @@ const ARIA_REFERENCE_PROPERTIES = {
 };
 
 /**
- * Adds an element to the list of elements referenced by the given ARIA
- * attribute on the target element, using ARIA element reflection properties
- * (`ariaDescribedByElements`, `ariaLabelledByElements`). Unlike ID references,
- * element references also work when the target element is in a shadow root
- * and the referenced element is in a containing tree scope.
+ * Adds the element to the target's `ariaDescribedByElements` or
+ * `ariaLabelledByElements` property, based on the given attribute.
+ * Unlike ID references, element references also work across shadow roots.
  *
  * @param {HTMLElement} target
- * @param {string} attr the ARIA attribute, `aria-describedby` or `aria-labelledby`
- * @param {HTMLElement} element the element to add to the reference list
+ * @param {'aria-describedby' | 'aria-labelledby'} attr
+ * @param {HTMLElement} element
  */
 export function addAriaElementReference(target, attr, element) {
   const property = ARIA_REFERENCE_PROPERTIES[attr];
-  if (!property) {
-    return;
-  }
   const elements = new Set(target[property]);
   elements.add(element);
   target[property] = [...elements];
 }
 
 /**
- * Removes an element from the list of elements referenced by the given ARIA
- * attribute on the target element. When the list becomes empty, the property
- * is reset to `null` so that it no longer overrides the corresponding
- * content attribute.
+ * Removes the element from the target's `ariaDescribedByElements` or
+ * `ariaLabelledByElements` property, based on the given attribute.
+ * When the last element is removed, the property is reset to `null`
+ * so it no longer overrides the content attribute.
  *
  * @param {HTMLElement} target
- * @param {string} attr the ARIA attribute, `aria-describedby` or `aria-labelledby`
- * @param {HTMLElement} element the element to remove from the reference list
+ * @param {'aria-describedby' | 'aria-labelledby'} attr
+ * @param {HTMLElement} element
  */
 export function removeAriaElementReference(target, attr, element) {
   const property = ARIA_REFERENCE_PROPERTIES[attr];
-  if (!property) {
-    return;
-  }
   const elements = new Set(target[property]);
   elements.delete(element);
   target[property] = elements.size > 0 ? [...elements] : null;

--- a/packages/a11y-base/test/aria-element-reference.test.js
+++ b/packages/a11y-base/test/aria-element-reference.test.js
@@ -1,0 +1,74 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { addAriaElementReference, removeAriaElementReference } from '../src/aria-element-reference.js';
+
+describe('aria-element-reference', () => {
+  let container, target, element;
+
+  beforeEach(() => {
+    container = fixtureSync(`
+      <div>
+        <div id="target"></div>
+        <span id="element"></span>
+      </div>
+    `);
+    target = container.querySelector('#target');
+    element = container.querySelector('#element');
+  });
+
+  describe('addAriaElementReference', () => {
+    it('should add the element to ariaDescribedByElements', () => {
+      addAriaElementReference(target, 'aria-describedby', element);
+      expect(target.ariaDescribedByElements).to.eql([element]);
+    });
+
+    it('should add the element to ariaLabelledByElements', () => {
+      addAriaElementReference(target, 'aria-labelledby', element);
+      expect(target.ariaLabelledByElements).to.eql([element]);
+    });
+
+    it('should keep previously added element references', () => {
+      const element2 = document.createElement('span');
+      container.appendChild(element2);
+
+      addAriaElementReference(target, 'aria-describedby', element);
+      addAriaElementReference(target, 'aria-describedby', element2);
+
+      expect(target.ariaDescribedByElements).to.eql([element, element2]);
+    });
+
+    it('should not add the same element twice', () => {
+      addAriaElementReference(target, 'aria-describedby', element);
+      addAriaElementReference(target, 'aria-describedby', element);
+      expect(target.ariaDescribedByElements).to.eql([element]);
+    });
+  });
+
+  describe('removeAriaElementReference', () => {
+    it('should remove the element from ariaDescribedByElements', () => {
+      const element2 = document.createElement('span');
+      container.appendChild(element2);
+
+      addAriaElementReference(target, 'aria-describedby', element);
+      addAriaElementReference(target, 'aria-describedby', element2);
+
+      removeAriaElementReference(target, 'aria-describedby', element);
+
+      expect(target.ariaDescribedByElements).to.eql([element2]);
+    });
+
+    it('should remove the element from ariaLabelledByElements', () => {
+      addAriaElementReference(target, 'aria-labelledby', element);
+      removeAriaElementReference(target, 'aria-labelledby', element);
+      expect(target.ariaLabelledByElements).to.be.null;
+    });
+
+    it('should reset ariaDescribedByElements to null when removing the last element', () => {
+      addAriaElementReference(target, 'aria-describedby', element);
+      removeAriaElementReference(target, 'aria-describedby', element);
+
+      expect(target.ariaDescribedByElements).to.be.null;
+      expect(target.hasAttribute('aria-describedby')).to.be.false;
+    });
+  });
+});

--- a/packages/tooltip/src/vaadin-tooltip-aria-mixin.d.ts
+++ b/packages/tooltip/src/vaadin-tooltip-aria-mixin.d.ts
@@ -8,6 +8,10 @@ import type { Constructor } from '@open-wc/dedupe-mixin';
 /**
  * A mixin providing linking of the tooltip content to the tooltip target
  * elements using the `aria-describedby` or `aria-labelledby` attribute.
+ *
+ * Targets in the same root as the tooltip are linked by the content element
+ * ID. ID references only resolve within a single tree scope, so targets in
+ * other roots are linked with ARIA element references instead.
  */
 export declare function TooltipAriaMixin<T extends Constructor<HTMLElement>>(
   base: T,

--- a/packages/tooltip/src/vaadin-tooltip-aria-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-aria-mixin.js
@@ -16,9 +16,6 @@ import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component
  */
 export const TooltipAriaMixin = (superClass) =>
   class TooltipAriaMixinClass extends superClass {
-    // Added references are tracked so that they can be removed exactly as
-    // they were added: by the time `disconnectedCallback` runs, the tooltip
-    // root has already changed, so the references cannot be recomputed.
     #ariaReferences = [];
 
     static get properties() {
@@ -64,13 +61,13 @@ export const TooltipAriaMixin = (superClass) =>
     /** @protected */
     connectedCallback() {
       super.connectedCallback();
-      this.#updateAriaReferences();
+      this.#addAriaReferences();
     }
 
     /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      this.#updateAriaReferences();
+      this.#removeAriaReferences();
     }
 
     /** @protected */
@@ -82,32 +79,42 @@ export const TooltipAriaMixin = (superClass) =>
       }
     }
 
-    #updateAriaReferences() {
-      this.#ariaReferences.forEach(({ target, mode, content, byReference }) => {
-        if (byReference) {
-          removeAriaElementReference(target, mode, content);
-        } else {
-          removeValueFromAttribute(target, mode, content.id);
-        }
-      });
-      this.#ariaReferences = [];
-
-      const target = this._effectiveAriaTarget;
+    #addAriaReferences() {
       const mode = this.ariaLinkMode;
-      const content = this.__contentNode;
-      if (!this.isConnected || !content || !target || !mode || mode === 'none') {
+      const targets = this._effectiveAriaTarget;
+      const contentNode = this.__contentNode;
+      if (!contentNode || !targets || !mode || mode === 'none') {
         return;
       }
 
-      [target].flat().forEach((el) => {
-        const byReference = el.getRootNode() !== this.getRootNode();
+      [targets].flat().forEach((target) => {
+        const byReference = target.getRootNode() !== this.getRootNode();
         if (byReference) {
-          addAriaElementReference(el, mode, content);
+          addAriaElementReference(target, mode, contentNode);
         } else {
-          addValueToAttribute(el, mode, content.id);
+          addValueToAttribute(target, mode, contentNode.id);
         }
-        this.#ariaReferences.push({ target: el, mode, content, byReference });
+
+        this.#ariaReferences.push({ target, mode, byReference });
       });
+    }
+
+    #removeAriaReferences() {
+      const contentNode = this.__contentNode;
+
+      this.#ariaReferences.forEach(({ target, mode, byReference }) => {
+        if (byReference) {
+          removeAriaElementReference(target, mode, contentNode);
+        } else {
+          removeValueFromAttribute(target, mode, contentNode.id);
+        }
+      });
+      this.#ariaReferences = [];
+    }
+
+    #updateAriaReferences() {
+      this.#removeAriaReferences();
+      this.#addAriaReferences();
     }
 
     /** @private */

--- a/packages/tooltip/src/vaadin-tooltip-aria-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-aria-mixin.js
@@ -3,14 +3,24 @@
  * Copyright (c) 2026 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { addAriaElementReference, removeAriaElementReference } from '@vaadin/a11y-base/src/aria-element-reference.js';
 import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 
 /**
  * A mixin providing linking of the tooltip content to the tooltip target
  * elements using the `aria-describedby` or `aria-labelledby` attribute.
+ *
+ * Targets in the same root as the tooltip are linked by the content element
+ * ID. ID references only resolve within a single tree scope, so targets in
+ * other roots are linked with ARIA element references instead.
  */
 export const TooltipAriaMixin = (superClass) =>
   class TooltipAriaMixinClass extends superClass {
+    // Added references are tracked so that they can be removed exactly as
+    // they were added: by the time `disconnectedCallback` runs, the tooltip
+    // root has already changed, so the references cannot be recomputed.
+    #ariaReferences = [];
+
     static get properties() {
       return {
         /**
@@ -52,40 +62,51 @@ export const TooltipAriaMixin = (superClass) =>
     }
 
     /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+      this.#updateAriaReferences();
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.#updateAriaReferences();
+    }
+
+    /** @protected */
     updated(props) {
       super.updated(props);
 
-      const ariaTargetChanged = props.has('_effectiveAriaTarget');
-      const ariaLinkModeChanged = props.has('ariaLinkMode');
-
-      if (ariaTargetChanged || ariaLinkModeChanged) {
-        const oldTarget = ariaTargetChanged ? props.get('_effectiveAriaTarget') : this._effectiveAriaTarget;
-        const oldMode = ariaLinkModeChanged ? props.get('ariaLinkMode') : this.ariaLinkMode;
-        this.#removeAriaReferences(oldTarget, oldMode);
-
-        const newTarget = this._effectiveAriaTarget;
-        const newMode = this.ariaLinkMode;
-        this.#addAriaReferences(newTarget, newMode);
+      if (props.has('_effectiveAriaTarget') || props.has('ariaLinkMode')) {
+        this.#updateAriaReferences();
       }
     }
 
-    #addAriaReferences(target, mode) {
-      if (!target || !mode || mode === 'none') {
-        return;
-      }
-
-      [target].flat().forEach((el) => {
-        addValueToAttribute(el, mode, this._uniqueId);
+    #updateAriaReferences() {
+      this.#ariaReferences.forEach(({ target, mode, content, byReference }) => {
+        if (byReference) {
+          removeAriaElementReference(target, mode, content);
+        } else {
+          removeValueFromAttribute(target, mode, content.id);
+        }
       });
-    }
+      this.#ariaReferences = [];
 
-    #removeAriaReferences(target, mode) {
-      if (!target || !mode || mode === 'none') {
+      const target = this._effectiveAriaTarget;
+      const mode = this.ariaLinkMode;
+      const content = this.__contentNode;
+      if (!this.isConnected || !content || !target || !mode || mode === 'none') {
         return;
       }
 
       [target].flat().forEach((el) => {
-        removeValueFromAttribute(el, mode, this._uniqueId);
+        const byReference = el.getRootNode() !== this.getRootNode();
+        if (byReference) {
+          addAriaElementReference(el, mode, content);
+        } else {
+          addValueToAttribute(el, mode, content.id);
+        }
+        this.#ariaReferences.push({ target: el, mode, content, byReference });
       });
     }
 

--- a/packages/tooltip/test/tooltip-target.test.js
+++ b/packages/tooltip/test/tooltip-target.test.js
@@ -64,6 +64,26 @@ describe('tooltip target', () => {
       await nextUpdate(tooltip);
       expect(target.getAttribute('aria-describedby')).to.equal('foo');
     });
+
+    it('should remove aria-describedby when the tooltip is detached', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.remove();
+
+      expect(target.hasAttribute('aria-describedby')).to.be.false;
+    });
+
+    it('should restore aria-describedby when the tooltip is reattached', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      const parent = tooltip.parentElement;
+      tooltip.remove();
+      parent.appendChild(tooltip);
+
+      expect(target.getAttribute('aria-describedby')).to.equal(contentNode.id);
+    });
   });
 
   describe('ariaTarget', () => {
@@ -245,6 +265,94 @@ describe('tooltip target', () => {
 
       expect(target.getAttribute('aria-describedby')).to.equal('foo');
       expect(target.getAttribute('aria-labelledby')).to.equal(contentNode.id);
+    });
+  });
+
+  describe('ariaTarget in a shadow root', () => {
+    let host, target;
+
+    beforeEach(() => {
+      host = fixtureSync('<div></div>');
+      host.attachShadow({ mode: 'open' });
+
+      target = document.createElement('input');
+      host.shadowRoot.appendChild(target);
+    });
+
+    it('should link the target using ariaDescribedByElements', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      expect(target.ariaDescribedByElements).to.eql([contentNode]);
+    });
+
+    it('should remove the element reference when clearing target', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.target = null;
+      await nextUpdate(tooltip);
+
+      expect(target.ariaDescribedByElements).to.be.null;
+    });
+
+    it('should use ariaLabelledByElements when ariaLinkMode is set to aria-labelledby', async () => {
+      tooltip.ariaLinkMode = 'aria-labelledby';
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      expect(target.ariaLabelledByElements).to.eql([contentNode]);
+      expect(target.ariaDescribedByElements).to.be.null;
+    });
+
+    it('should update element references when ariaLinkMode changes', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.ariaLinkMode = 'aria-labelledby';
+      await nextUpdate(tooltip);
+
+      expect(target.ariaDescribedByElements).to.be.null;
+      expect(target.ariaLabelledByElements).to.eql([contentNode]);
+    });
+
+    it('should not set element references when ariaLinkMode is none', async () => {
+      tooltip.ariaLinkMode = 'none';
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      expect(target.ariaDescribedByElements).to.be.null;
+      expect(target.ariaLabelledByElements).to.be.null;
+    });
+
+    it('should remove element references when ariaLinkMode is set to none', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.ariaLinkMode = 'none';
+      await nextUpdate(tooltip);
+
+      expect(target.ariaDescribedByElements).to.be.null;
+    });
+
+    it('should remove element references when the tooltip is detached', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      tooltip.remove();
+
+      expect(target.ariaDescribedByElements).to.be.null;
+    });
+
+    it('should restore element references when the tooltip is reattached', async () => {
+      tooltip.target = target;
+      await nextUpdate(tooltip);
+
+      const parent = tooltip.parentElement;
+      tooltip.remove();
+      parent.appendChild(tooltip);
+
+      expect(target.ariaDescribedByElements).to.eql([contentNode]);
     });
   });
 


### PR DESCRIPTION
ID-based `aria-describedby` / `aria-labelledby` references only resolve within a single tree scope. When the tooltip target is in a different root than the tooltip content, for example a grid cell in shadow DOM while the slotted tooltip content is in light DOM, the reference does not resolve and screen readers do not announce the tooltip.

This change links such targets using ARIA element reflection properties (`ariaDescribedByElements`, `ariaLabelledByElements`), which work across shadow roots as long as the content node is in a containing tree scope. These properties are supported by all browsers we test against.

Targets in the same root are still linked by ID. Element references override the `aria-describedby` / `aria-labelledby` attributes, so using them everywhere would conflict with other code that manages these attributes as a list of ID tokens.

Fixes #11973