### PR TITLE
refactor: use # notation for private members in controllers

### DIFF
--- a/packages/a11y-base/src/aria-modal-controller.js
+++ b/packages/a11y-base/src/aria-modal-controller.js
@@ -13,6 +13,9 @@ import { hideOthers } from './aria-hidden.js';
  * consumer web component. This is done in to ensure the controller only does one thing.
  */
 export class AriaModalController {
+  /** @type {Function | null} */
+  #showOthers = null;
+
   /**
    * @param {HTMLElement} host
    */
@@ -42,7 +45,7 @@ export class AriaModalController {
    */
   showModal() {
     const targets = this.callback();
-    this.__showOthers = hideOthers(targets);
+    this.#showOthers = hideOthers(targets);
   }
 
   /**
@@ -50,9 +53,9 @@ export class AriaModalController {
    * controller hosts on the page activated by using `showModal()` call.
    */
   close() {
-    if (this.__showOthers) {
-      this.__showOthers();
-      this.__showOthers = null;
+    if (this.#showOthers) {
+      this.#showOthers();
+      this.#showOthers = null;
     }
   }
 }

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -10,9 +10,29 @@ import { removeAriaIDReference, restoreGeneratedAriaIDReference, setAriaIDRefere
  * either the component itself or slotted `<input>` element.
  */
 export class FieldAriaController {
+  /** @type {HTMLElement | undefined} */
+  #target;
+
+  /** @type {boolean} */
+  #required = false;
+
+  /** @type {string | null | undefined} */
+  #label;
+
+  /** @type {string | null | undefined} */
+  #labelId;
+
+  /** @type {string | null | undefined} */
+  #labelIdFromUser;
+
+  /** @type {string | null | undefined} */
+  #errorId;
+
+  /** @type {string | null | undefined} */
+  #helperId;
+
   constructor(host) {
     this.host = host;
-    this.__required = false;
   }
 
   /**
@@ -21,16 +41,16 @@ export class FieldAriaController {
    * @param {HTMLElement} target
    */
   setTarget(target) {
-    this.__target = target;
-    this.__setAriaRequiredAttribute(this.__required);
-    // We need to make sure that value in __labelId is stored
-    this.__setLabelIdToAriaAttribute(this.__labelId, this.__labelId);
-    if (this.__labelIdFromUser != null) {
-      this.__setLabelIdToAriaAttribute(this.__labelIdFromUser, this.__labelIdFromUser, true);
+    this.#target = target;
+    this.#setAriaRequiredAttribute(this.#required);
+    // We need to make sure that value in #labelId is stored
+    this.#setLabelIdToAriaAttribute(this.#labelId, this.#labelId);
+    if (this.#labelIdFromUser != null) {
+      this.#setLabelIdToAriaAttribute(this.#labelIdFromUser, this.#labelIdFromUser, true);
     }
-    this.__setErrorIdToAriaAttribute(this.__errorId);
-    this.__setHelperIdToAriaAttribute(this.__helperId);
-    this.setAriaLabel(this.__label);
+    this.#setErrorIdToAriaAttribute(this.#errorId);
+    this.#setHelperIdToAriaAttribute(this.#helperId);
+    this.setAriaLabel(this.#label);
   }
 
   /**
@@ -41,8 +61,8 @@ export class FieldAriaController {
    * @param {boolean} required
    */
   setRequired(required) {
-    this.__setAriaRequiredAttribute(required);
-    this.__required = required;
+    this.#setAriaRequiredAttribute(required);
+    this.#required = required;
   }
 
   /**
@@ -53,8 +73,8 @@ export class FieldAriaController {
    * @param {string | null | undefined} label
    */
   setAriaLabel(label) {
-    this.__setAriaLabelToAttribute(label);
-    this.__label = label;
+    this.#setAriaLabelToAttribute(label);
+    this.#label = label;
   }
 
   /**
@@ -66,12 +86,12 @@ export class FieldAriaController {
    * @param {string | null} labelId
    */
   setLabelId(labelId, fromUser = false) {
-    const oldLabelId = fromUser ? this.__labelIdFromUser : this.__labelId;
-    this.__setLabelIdToAriaAttribute(labelId, oldLabelId, fromUser);
+    const oldLabelId = fromUser ? this.#labelIdFromUser : this.#labelId;
+    this.#setLabelIdToAriaAttribute(labelId, oldLabelId, fromUser);
     if (fromUser) {
-      this.__labelIdFromUser = labelId;
+      this.#labelIdFromUser = labelId;
     } else {
-      this.__labelId = labelId;
+      this.#labelId = labelId;
     }
   }
 
@@ -85,8 +105,8 @@ export class FieldAriaController {
    * @param {string | null} errorId
    */
   setErrorId(errorId) {
-    this.__setErrorIdToAriaAttribute(errorId, this.__errorId);
-    this.__errorId = errorId;
+    this.#setErrorIdToAriaAttribute(errorId, this.#errorId);
+    this.#errorId = errorId;
   }
 
   /**
@@ -99,24 +119,23 @@ export class FieldAriaController {
    * @param {string | null} helperId
    */
   setHelperId(helperId) {
-    this.__setHelperIdToAriaAttribute(helperId, this.__helperId);
-    this.__helperId = helperId;
+    this.#setHelperIdToAriaAttribute(helperId, this.#helperId);
+    this.#helperId = helperId;
   }
 
   /**
    * @param {string | null | undefined} label
-   * @private
-   * */
-  __setAriaLabelToAttribute(label) {
-    if (!this.__target) {
+   */
+  #setAriaLabelToAttribute(label) {
+    if (!this.#target) {
       return;
     }
     if (label) {
-      removeAriaIDReference(this.__target, 'aria-labelledby');
-      this.__target.setAttribute('aria-label', label);
-    } else if (this.__label) {
-      restoreGeneratedAriaIDReference(this.__target, 'aria-labelledby');
-      this.__target.removeAttribute('aria-label');
+      removeAriaIDReference(this.#target, 'aria-labelledby');
+      this.#target.setAttribute('aria-label', label);
+    } else if (this.#label) {
+      restoreGeneratedAriaIDReference(this.#target, 'aria-labelledby');
+      this.#target.removeAttribute('aria-label');
     }
   }
 
@@ -124,48 +143,44 @@ export class FieldAriaController {
    * @param {string | null | undefined} labelId
    * @param {string | null | undefined} oldLabelId
    * @param {boolean | null | undefined} fromUser
-   * @private
    */
-  __setLabelIdToAriaAttribute(labelId, oldLabelId, fromUser) {
-    setAriaIDReference(this.__target, 'aria-labelledby', { newId: labelId, oldId: oldLabelId, fromUser });
+  #setLabelIdToAriaAttribute(labelId, oldLabelId, fromUser) {
+    setAriaIDReference(this.#target, 'aria-labelledby', { newId: labelId, oldId: oldLabelId, fromUser });
   }
 
   /**
    * @param {string | null | undefined} errorId
    * @param {string | null | undefined} oldErrorId
-   * @private
    */
-  __setErrorIdToAriaAttribute(errorId, oldErrorId) {
-    setAriaIDReference(this.__target, 'aria-describedby', { newId: errorId, oldId: oldErrorId, fromUser: false });
+  #setErrorIdToAriaAttribute(errorId, oldErrorId) {
+    setAriaIDReference(this.#target, 'aria-describedby', { newId: errorId, oldId: oldErrorId, fromUser: false });
   }
 
   /**
    * @param {string | null | undefined} helperId
    * @param {string | null | undefined} oldHelperId
-   * @private
    */
-  __setHelperIdToAriaAttribute(helperId, oldHelperId) {
-    setAriaIDReference(this.__target, 'aria-describedby', { newId: helperId, oldId: oldHelperId, fromUser: false });
+  #setHelperIdToAriaAttribute(helperId, oldHelperId) {
+    setAriaIDReference(this.#target, 'aria-describedby', { newId: helperId, oldId: oldHelperId, fromUser: false });
   }
 
   /**
    * @param {boolean} required
-   * @private
    */
-  __setAriaRequiredAttribute(required) {
-    if (!this.__target) {
+  #setAriaRequiredAttribute(required) {
+    if (!this.#target) {
       return;
     }
 
-    if (['input', 'textarea'].includes(this.__target.localName)) {
+    if (['input', 'textarea'].includes(this.#target.localName)) {
       // Native <input> or <textarea>, required is enough
       return;
     }
 
     if (required) {
-      this.__target.setAttribute('aria-required', 'true');
+      this.#target.setAttribute('aria-required', 'true');
     } else {
-      this.__target.removeAttribute('aria-required');
+      this.#target.removeAttribute('aria-required');
     }
   }
 }

--- a/packages/a11y-base/src/focus-trap-controller.d.ts
+++ b/packages/a11y-base/src/focus-trap-controller.d.ts
@@ -20,6 +20,11 @@ export class FocusTrapController implements ReactiveController {
    */
   host: HTMLElement;
 
+  /**
+   * A node for trapping focus in.
+   */
+  trapNode: HTMLElement | null;
+
   constructor(node: HTMLElement);
 
   hostConnected(): void;

--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -17,8 +17,8 @@ const instances = [];
 export function getActiveTrappingNode(element) {
   // Iterate backwards since instances are ordered outer-to-inner (push/pop)
   for (let i = instances.length - 1; i >= 0; i--) {
-    if (instances[i].__trapNode?.contains(element)) {
-      return instances[i].__trapNode;
+    if (instances[i].trapNode?.contains(element)) {
+      return instances[i].trapNode;
     }
   }
   return null;
@@ -29,6 +29,13 @@ export function getActiveTrappingNode(element) {
  */
 export class FocusTrapController {
   /**
+   * A node for trapping focus in.
+   *
+   * @type {HTMLElement | null}
+   */
+  trapNode = null;
+
+  /**
    * @param {HTMLElement} host
    */
   constructor(host) {
@@ -38,45 +45,33 @@ export class FocusTrapController {
      * @type {HTMLElement}
      */
     this.host = host;
-
-    /**
-     * A node for trapping focus in.
-     *
-     * @type {HTMLElement | null}
-     * @private
-     */
-    this.__trapNode = null;
-
-    this.__onKeyDown = this.__onKeyDown.bind(this);
   }
 
   /**
    * An array of tab-ordered focusable elements inside the trap node.
    *
    * @return {HTMLElement[]}
-   * @private
    */
-  get __focusableElements() {
-    return getTabbableElements(this.__trapNode);
+  get #focusableElements() {
+    return getTabbableElements(this.trapNode);
   }
 
   /**
    * The index of the element inside the trap node that currently has focus.
    *
    * @return {HTMLElement | undefined}
-   * @private
    */
-  get __focusedElementIndex() {
-    const focusableElements = this.__focusableElements;
+  get #focusedElementIndex() {
+    const focusableElements = this.#focusableElements;
     return focusableElements.indexOf(focusableElements.filter(isElementFocused).pop());
   }
 
   hostConnected() {
-    document.addEventListener('keydown', this.__onKeyDown);
+    document.addEventListener('keydown', this.#onKeyDown);
   }
 
   hostDisconnected() {
-    document.removeEventListener('keydown', this.__onKeyDown);
+    document.removeEventListener('keydown', this.#onKeyDown);
   }
 
   /**
@@ -94,17 +89,17 @@ export class FocusTrapController {
    * @param {HTMLElement} trapNode
    */
   trapFocus(trapNode) {
-    this.__trapNode = trapNode;
+    this.trapNode = trapNode;
 
-    if (this.__focusableElements.length === 0) {
-      this.__trapNode = null;
+    if (this.#focusableElements.length === 0) {
+      this.trapNode = null;
       throw new Error('The trap node should have at least one focusable descendant or be focusable itself.');
     }
 
     instances.push(this);
 
-    if (this.__focusedElementIndex === -1) {
-      this.__focusableElements[0].focus({ focusVisible: isKeyboardActive() });
+    if (this.#focusedElementIndex === -1) {
+      this.#focusableElements[0].focus({ focusVisible: isKeyboardActive() });
     }
   }
 
@@ -113,7 +108,7 @@ export class FocusTrapController {
    * so that it becomes possible to tab outside the trap node.
    */
   releaseFocus() {
-    this.__trapNode = null;
+    this.trapNode = null;
 
     instances.pop();
   }
@@ -127,10 +122,9 @@ export class FocusTrapController {
    * When no prev element to focus, the method moves focus to the last focusable element.
    *
    * @param {KeyboardEvent} event
-   * @private
    */
-  __onKeyDown(event) {
-    if (!this.__trapNode) {
+  #onKeyDown = (event) => {
+    if (!this.trapNode) {
       return;
     }
 
@@ -148,9 +142,9 @@ export class FocusTrapController {
       event.preventDefault();
 
       const backward = event.shiftKey;
-      this.__focusNextElement(backward);
+      this.#focusNextElement(backward);
     }
-  }
+  };
 
   /**
    * - Moves focus to the next focusable element if `backward === false`.
@@ -161,12 +155,11 @@ export class FocusTrapController {
    * If no focusable elements, the method returns immediately.
    *
    * @param {boolean} backward
-   * @private
    */
-  __focusNextElement(backward = false) {
-    const focusableElements = this.__focusableElements;
+  #focusNextElement(backward = false) {
+    const focusableElements = this.#focusableElements;
     const step = backward ? -1 : 1;
-    const currentIndex = this.__focusedElementIndex;
+    const currentIndex = this.#focusedElementIndex;
     const nextIndex = (focusableElements.length + currentIndex + step) % focusableElements.length;
     const element = focusableElements[nextIndex];
     element.focus({ focusVisible: true });

--- a/packages/component-base/src/media-query-controller.js
+++ b/packages/component-base/src/media-query-controller.js
@@ -8,6 +8,9 @@
  * A controller for listening on media query changes.
  */
 export class MediaQueryController {
+  /** @type {MediaQueryList | null} */
+  #mediaQuery = null;
+
   constructor(query, callback) {
     /**
      * The CSS media query to evaluate.
@@ -24,44 +27,39 @@ export class MediaQueryController {
      * @protected
      */
     this.callback = callback;
-
-    this._boundQueryHandler = this._queryHandler.bind(this);
   }
 
   hostConnected() {
-    this._removeListener();
+    this.#removeListener();
 
-    this._mediaQuery = window.matchMedia(this.query);
+    this.#mediaQuery = window.matchMedia(this.query);
 
-    this._addListener();
+    this.#addListener();
 
-    this._queryHandler(this._mediaQuery);
+    this.#queryHandler(this.#mediaQuery);
   }
 
   hostDisconnected() {
-    this._removeListener();
+    this.#removeListener();
   }
 
-  /** @private */
-  _addListener() {
-    if (this._mediaQuery) {
-      this._mediaQuery.addListener(this._boundQueryHandler);
+  #addListener() {
+    if (this.#mediaQuery) {
+      this.#mediaQuery.addListener(this.#queryHandler);
     }
   }
 
-  /** @private */
-  _removeListener() {
-    if (this._mediaQuery) {
-      this._mediaQuery.removeListener(this._boundQueryHandler);
+  #removeListener() {
+    if (this.#mediaQuery) {
+      this.#mediaQuery.removeListener(this.#queryHandler);
     }
 
-    this._mediaQuery = null;
+    this.#mediaQuery = null;
   }
 
-  /** @private */
-  _queryHandler(mediaQuery) {
+  #queryHandler = (mediaQuery) => {
     if (typeof this.callback === 'function') {
       this.callback(mediaQuery.matches);
     }
-  }
+  };
 }

--- a/packages/component-base/src/overflow-controller.js
+++ b/packages/component-base/src/overflow-controller.js
@@ -10,6 +10,15 @@
  * where content is overflowing. Supported values are: `top`, `bottom`, `start`, `end`.
  */
 export class OverflowController {
+  /** @type {ResizeObserver} */
+  #resizeObserver;
+
+  /** @type {MutationObserver} */
+  #childObserver;
+
+  /** @type {number} */
+  #resizeRaf;
+
   constructor(host, scrollTarget) {
     /**
      * The controller host element.
@@ -25,9 +34,6 @@ export class OverflowController {
      * @type {HTMLElement}
      */
     this.scrollTarget = scrollTarget || host;
-
-    /** @private */
-    this.__boundOnScroll = this.__onScroll.bind(this);
   }
 
   hostConnected() {
@@ -46,64 +52,60 @@ export class OverflowController {
   observe() {
     const { host } = this;
 
-    this.__resizeObserver = new ResizeObserver(() => this.__onResize());
-    this.__resizeObserver.observe(host);
+    this.#resizeObserver = new ResizeObserver(() => this.#onResize());
+    this.#resizeObserver.observe(host);
 
     // Observe initial children
     [...host.children].forEach((child) => {
-      this.__resizeObserver.observe(child);
+      this.#resizeObserver.observe(child);
     });
 
-    this.__childObserver = new MutationObserver((mutations) => {
+    this.#childObserver = new MutationObserver((mutations) => {
       mutations.forEach(({ addedNodes, removedNodes }) => {
         addedNodes.forEach((node) => {
           if (node.nodeType === Node.ELEMENT_NODE) {
-            this.__resizeObserver.observe(node);
+            this.#resizeObserver.observe(node);
           }
         });
 
         removedNodes.forEach((node) => {
           if (node.nodeType === Node.ELEMENT_NODE) {
-            this.__resizeObserver.unobserve(node);
+            this.#resizeObserver.unobserve(node);
           }
         });
 
         if (addedNodes.length === 0 && removedNodes.length > 0) {
-          this.__updateState({ sync: true });
+          this.#updateState({ sync: true });
         }
       });
     });
 
-    this.__childObserver.observe(host, { childList: true });
+    this.#childObserver.observe(host, { childList: true });
 
     // Update overflow attribute on scroll
-    this.scrollTarget.addEventListener('scroll', this.__boundOnScroll);
+    this.scrollTarget.addEventListener('scroll', this.#onScroll);
   }
 
-  /** @private */
-  __onResize() {
-    this.__updateState({ sync: false });
+  #onResize() {
+    this.#updateState({ sync: false });
   }
 
-  /** @private */
-  __onScroll() {
-    this.__updateState({ sync: true });
-  }
+  #onScroll = () => {
+    this.#updateState({ sync: true });
+  };
 
-  /** @private */
-  __updateState({ sync }) {
-    cancelAnimationFrame(this.__resizeRaf);
+  #updateState({ sync }) {
+    cancelAnimationFrame(this.#resizeRaf);
 
-    const state = this.__readState();
+    const state = this.#readState();
     if (sync) {
-      this.__writeState(state);
+      this.#writeState(state);
     } else {
-      this.__resizeRaf = requestAnimationFrame(() => this.__writeState(state));
+      this.#resizeRaf = requestAnimationFrame(() => this.#writeState(state));
     }
   }
 
-  /** @private */
-  __readState() {
+  #readState() {
     const target = this.scrollTarget;
 
     let overflow = '';
@@ -128,8 +130,7 @@ export class OverflowController {
     return { overflow: overflow.trim() };
   }
 
-  /** @private */
-  __writeState({ overflow }) {
+  #writeState({ overflow }) {
     if (overflow) {
       this.host.setAttribute('overflow', overflow);
     } else {

--- a/packages/component-base/src/slot-child-observe-controller.d.ts
+++ b/packages/component-base/src/slot-child-observe-controller.d.ts
@@ -25,4 +25,9 @@ export class SlotChildObserveController extends SlotController {
    * Override to update default node text on property change.
    */
   protected updateDefaultNode(node: Node): void;
+
+  /**
+   * Fire an event to notify the controller host about node changes.
+   */
+  protected _notifyChange(node: Node): void;
 }

--- a/packages/component-base/src/slot-child-observe-controller.js
+++ b/packages/component-base/src/slot-child-observe-controller.js
@@ -26,7 +26,7 @@ export class SlotChildObserveController extends SlotController {
    */
   initCustomNode(node) {
     this.#updateNodeId(node);
-    this.#notifyChange(node);
+    this._notifyChange(node);
   }
 
   /**
@@ -42,7 +42,7 @@ export class SlotChildObserveController extends SlotController {
 
     // Custom node is added to the slot
     if (node && node !== this.defaultNode) {
-      this.#notifyChange(node);
+      this._notifyChange(node);
     } else {
       this.restoreDefaultNode();
       this.updateDefaultNode(this.node);
@@ -83,7 +83,7 @@ export class SlotChildObserveController extends SlotController {
    * @protected
    */
   updateDefaultNode(node) {
-    this.#notifyChange(node);
+    this._notifyChange(node);
   }
 
   /**
@@ -115,7 +115,7 @@ export class SlotChildObserveController extends SlotController {
           }
         } else if (isCurrentNodeMutation || target.parentElement === this.node) {
           // Node text content has changed.
-          this.#notifyChange(this.node);
+          this._notifyChange(this.node);
         }
       });
     });
@@ -152,8 +152,9 @@ export class SlotChildObserveController extends SlotController {
    * Fire an event to notify the controller host about node changes.
    *
    * @param {Node} node
+   * @protected
    */
-  #notifyChange(node) {
+  _notifyChange(node) {
     this.dispatchEvent(
       new CustomEvent('slot-content-changed', {
         detail: { hasContent: this.#hasContent(node), node },

--- a/packages/component-base/src/slot-child-observe-controller.js
+++ b/packages/component-base/src/slot-child-observe-controller.js
@@ -10,6 +10,9 @@ import { SlotController } from './slot-controller.js';
  * and the text content, and fires an event to notify host element about those.
  */
 export class SlotChildObserveController extends SlotController {
+  /** @type {MutationObserver} */
+  #nodeObserver;
+
   constructor(host, slot, tagName, config = {}) {
     super(host, slot, tagName, { ...config, useUniqueId: true });
   }
@@ -22,8 +25,8 @@ export class SlotChildObserveController extends SlotController {
    * @override
    */
   initCustomNode(node) {
-    this.__updateNodeId(node);
-    this.__notifyChange(node);
+    this.#updateNodeId(node);
+    this.#notifyChange(node);
   }
 
   /**
@@ -39,7 +42,7 @@ export class SlotChildObserveController extends SlotController {
 
     // Custom node is added to the slot
     if (node && node !== this.defaultNode) {
-      this.__notifyChange(node);
+      this.#notifyChange(node);
     } else {
       this.restoreDefaultNode();
       this.updateDefaultNode(this.node);
@@ -58,7 +61,7 @@ export class SlotChildObserveController extends SlotController {
     const node = super.attachDefaultNode();
 
     if (node) {
-      this.__updateNodeId(node);
+      this.#updateNodeId(node);
     }
 
     return node;
@@ -80,7 +83,7 @@ export class SlotChildObserveController extends SlotController {
    * @protected
    */
   updateDefaultNode(node) {
-    this.__notifyChange(node);
+    this.#notifyChange(node);
   }
 
   /**
@@ -92,11 +95,11 @@ export class SlotChildObserveController extends SlotController {
    */
   observeNode(node) {
     // Stop observing the previous node, if any.
-    if (this.__nodeObserver) {
-      this.__nodeObserver.disconnect();
+    if (this.#nodeObserver) {
+      this.#nodeObserver.disconnect();
     }
 
-    this.__nodeObserver = new MutationObserver((mutations) => {
+    this.#nodeObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         const target = mutation.target;
 
@@ -108,17 +111,17 @@ export class SlotChildObserveController extends SlotController {
           // We use attributeFilter to only observe ID mutation,
           // no need to check for attribute name separately.
           if (isCurrentNodeMutation) {
-            this.__updateNodeId(target);
+            this.#updateNodeId(target);
           }
         } else if (isCurrentNodeMutation || target.parentElement === this.node) {
           // Node text content has changed.
-          this.__notifyChange(this.node);
+          this.#notifyChange(this.node);
         }
       });
     });
 
     // Observe changes to node ID attribute, text content and children.
-    this.__nodeObserver.observe(node, {
+    this.#nodeObserver.observe(node, {
       attributes: true,
       attributeFilter: ['id'],
       childList: true,
@@ -133,9 +136,8 @@ export class SlotChildObserveController extends SlotController {
    *
    * @param {Node} node
    * @return {boolean}
-   * @private
    */
-  __hasContent(node) {
+  #hasContent(node) {
     if (!node) {
       return false;
     }
@@ -150,12 +152,11 @@ export class SlotChildObserveController extends SlotController {
    * Fire an event to notify the controller host about node changes.
    *
    * @param {Node} node
-   * @private
    */
-  __notifyChange(node) {
+  #notifyChange(node) {
     this.dispatchEvent(
       new CustomEvent('slot-content-changed', {
-        detail: { hasContent: this.__hasContent(node), node },
+        detail: { hasContent: this.#hasContent(node), node },
       }),
     );
   }
@@ -164,9 +165,8 @@ export class SlotChildObserveController extends SlotController {
    * Set default ID on the node in case it is an HTML element.
    *
    * @param {Node} node
-   * @private
    */
-  __updateNodeId(node) {
+  #updateNodeId(node) {
     // When in multiple mode, only set ID attribute on the element in default slot.
     const isFirstNode = !this.nodes || node === this.nodes[0];
     if (node.nodeType === Node.ELEMENT_NODE && (!this.multiple || isFirstNode) && !node.id) {

--- a/packages/component-base/src/slot-controller.js
+++ b/packages/component-base/src/slot-controller.js
@@ -202,7 +202,8 @@ export class SlotController extends EventTarget {
     const selector = slotName === '' ? 'slot:not([name])' : `slot[name=${slotName}]`;
     const slot = this.host.shadowRoot.querySelector(selector);
 
-    this.__slotObserver = new SlotObserver(slot, ({ addedNodes, removedNodes }) => {
+    // eslint-disable-next-line no-new
+    new SlotObserver(slot, ({ addedNodes, removedNodes }) => {
       const current = this.multiple ? this.nodes : [this.node];
 
       // Calling `slot.assignedNodes()` includes whitespace text nodes in case of default slot:

--- a/packages/component-base/src/tooltip-controller.js
+++ b/packages/component-base/src/tooltip-controller.js
@@ -14,7 +14,6 @@ export class TooltipController extends SlotController {
     super(host, 'tooltip');
 
     this.setTarget(host);
-    this.__onContentChange = this.__onContentChange.bind(this);
   }
 
   /**
@@ -50,8 +49,8 @@ export class TooltipController extends SlotController {
     if (!this.manual) {
       this.host.setAttribute('has-tooltip', '');
     }
-    this.__notifyChange(tooltipNode);
-    tooltipNode.addEventListener('content-changed', this.__onContentChange);
+    this.#notifyChange(tooltipNode);
+    tooltipNode.addEventListener('content-changed', this.#onContentChange);
   }
 
   /**
@@ -65,8 +64,8 @@ export class TooltipController extends SlotController {
     if (!this.manual) {
       this.host.removeAttribute('has-tooltip');
     }
-    tooltipNode.removeEventListener('content-changed', this.__onContentChange);
-    this.__notifyChange(null);
+    tooltipNode.removeEventListener('content-changed', this.#onContentChange);
+    this.#notifyChange(null);
   }
 
   /**
@@ -179,13 +178,11 @@ export class TooltipController extends SlotController {
     }
   }
 
-  /** @private */
-  __onContentChange(event) {
-    this.__notifyChange(event.target);
-  }
+  #onContentChange = (event) => {
+    this.#notifyChange(event.target);
+  };
 
-  /** @private */
-  __notifyChange(node) {
+  #notifyChange(node) {
     this.dispatchEvent(new CustomEvent('tooltip-changed', { detail: { node } }));
   }
 }

--- a/packages/details/src/summary-controller.js
+++ b/packages/details/src/summary-controller.js
@@ -24,7 +24,7 @@ export class SummaryController extends SlotChildObserveController {
     super.initSingle();
 
     if (this.node && this.node === this.defaultNode) {
-      this.__notifyChange(this.node);
+      this._notifyChange(this.node);
     }
   }
 

--- a/packages/field-base/src/labelled-input-controller.js
+++ b/packages/field-base/src/labelled-input-controller.js
@@ -10,23 +10,21 @@
 export class LabelledInputController {
   constructor(input, labelController) {
     this.input = input;
-    this.__preventDuplicateLabelClick = this.__preventDuplicateLabelClick.bind(this);
 
     labelController.addEventListener('slot-content-changed', (event) => {
-      this.__initLabel(event.detail.node);
+      this.#initLabel(event.detail.node);
     });
 
     // Initialize the default label element
-    this.__initLabel(labelController.node);
+    this.#initLabel(labelController.node);
   }
 
   /**
    * @param {HTMLElement} label
-   * @private
    */
-  __initLabel(label) {
+  #initLabel(label) {
     if (label) {
-      label.addEventListener('click', this.__preventDuplicateLabelClick);
+      label.addEventListener('click', this.#preventDuplicateLabelClick);
 
       if (this.input) {
         label.setAttribute('for', this.input.id);
@@ -40,13 +38,12 @@ export class LabelledInputController {
    * This results in two click events arriving at the host, but we only want one.
    * This method prevents the duplicate click and ensures the correct isTrusted event
    * with the correct event.target arrives at the host.
-   * @private
    */
-  __preventDuplicateLabelClick() {
+  #preventDuplicateLabelClick = () => {
     const inputClickHandler = (e) => {
       e.stopImmediatePropagation();
       this.input.removeEventListener('click', inputClickHandler);
     };
     this.input.addEventListener('click', inputClickHandler);
-  }
+  };
 }

--- a/packages/field-base/src/virtual-keyboard-controller.js
+++ b/packages/field-base/src/virtual-keyboard-controller.js
@@ -18,19 +18,18 @@ export class VirtualKeyboardController {
     host.addEventListener('opened-changed', () => {
       if (!host.opened) {
         // Prevent opening the virtual keyboard when the input gets re-focused on dropdown close
-        this.__setVirtualKeyboardEnabled(false);
+        this.#setVirtualKeyboardEnabled(false);
       }
     });
 
     // Re-enable virtual keyboard on blur, so it gets opened when the field is focused again
-    host.addEventListener('blur', () => this.__setVirtualKeyboardEnabled(true));
+    host.addEventListener('blur', () => this.#setVirtualKeyboardEnabled(true));
 
     // Re-enable the virtual keyboard whenever the field is touched
-    host.addEventListener('touchstart', () => this.__setVirtualKeyboardEnabled(true));
+    host.addEventListener('touchstart', () => this.#setVirtualKeyboardEnabled(true));
   }
 
-  /** @private */
-  __setVirtualKeyboardEnabled(value) {
+  #setVirtualKeyboardEnabled(value) {
     if (this.host.inputElement) {
       this.host.inputElement.inputMode = value ? '' : 'none';
     }


### PR DESCRIPTION
The controllers in `component-base`, `a11y-base`, and `field-base` still use the `__name` convention for private state and methods. Native `#` private members are already used in other parts of the repo (`DataProviderController`, `UploadManager`, `TooltipAriaMixin`) and make the members actually inaccessible from outside the class.

Non-obvious changes:

- `FocusTrapController.trapNode` is now a public field (also added to the `.d.ts`): `getActiveTrappingNode()` is a module-level function that needs to read the trap node of controller instances, which is not possible with a `#` field.
- `SlotController` no longer stores the created `SlotObserver`: the reference was never read anywhere (`no-unused-private-class-members` caught this after the rename), and the observer is kept alive by the `slotchange` listener it adds to the slot.
- Handlers that were bound with `.bind(this)` in the constructor are now arrow function fields.

---

🤖 Generated with Claude Code