### PR TITLE
refactor: rename _trapFocus and _focusTrapRoot

### DIFF
--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -88,11 +88,11 @@ class ConfirmDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMi
   }
 
   /**
-   * Override method from OverlayFocusMixin to use owner as focus trap root
+   * Override method from OverlayFocusMixin to use owner as focus root
    * @protected
    * @override
    */
-  get _focusTrapRoot() {
+  get _focusRoot() {
     return this.owner;
   }
 }

--- a/packages/crud/src/vaadin-crud-dialog-overlay.js
+++ b/packages/crud/src/vaadin-crud-dialog-overlay.js
@@ -34,11 +34,11 @@ class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin
   }
 
   /**
-   * Override method from OverlayFocusMixin to use dialog as focus trap root
+   * Override method from OverlayFocusMixin to use dialog as focus root
    * @protected
    * @override
    */
-  get _focusTrapRoot() {
+  get _focusRoot() {
     // Do not use `owner` since that points to `vaadin-crud`
     return this.getRootNode().host;
   }

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -32,11 +32,11 @@ export class DialogOverlay extends DialogOverlayMixin(
   }
 
   /**
-   * Override method from OverlayFocusMixin to use owner as focus trap root
+   * Override method from OverlayFocusMixin to use owner as focus root
    * @protected
    * @override
    */
-  get _focusTrapRoot() {
+  get _focusRoot() {
     return this.owner;
   }
 

--- a/packages/login/src/vaadin-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-login-overlay-wrapper.js
@@ -39,11 +39,11 @@ class LoginOverlayWrapper extends OverlayMixin(DirMixin(ThemableMixin(PolylitMix
   }
 
   /**
-   * Override method from OverlayFocusMixin to use owner as focus trap root
+   * Override method from OverlayFocusMixin to use owner as focus root
    * @protected
    * @override
    */
-  get _focusTrapRoot() {
+  get _focusRoot() {
     return this.owner;
   }
 

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.d.ts
@@ -40,9 +40,10 @@ export declare class OverlayFocusMixinClass {
   protected _saveFocus(): void;
 
   /**
-   * Trap focus within the overlay after opening has completed.
+   * Sets up focus after the overlay opening has completed: traps focus
+   * within the overlay if `focusTrap` is enabled.
    */
-  protected _trapFocus(): void;
+  protected _initFocus(): void;
 
   /**
    * Returns true if focus is still inside the overlay or on the body element,

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -66,11 +66,11 @@ export const OverlayFocusMixin = (superClass) =>
     }
 
     /**
-     * Override to specify another element used as a focus trap root,
+     * Override to specify another element used as a focus root,
      * e.g. the overlay's owner element, rather than overlay part.
      * @protected
      */
-    get _focusTrapRoot() {
+    get _focusRoot() {
       return this.$.overlay;
     }
 
@@ -103,13 +103,14 @@ export const OverlayFocusMixin = (superClass) =>
     }
 
     /**
-     * Trap focus within the overlay after opening has completed.
+     * Sets up focus after the overlay opening has completed: traps focus
+     * within the overlay if `focusTrap` is enabled.
      *
      * @protected
      */
-    _trapFocus() {
-      if (this.focusTrap && !isElementHidden(this._focusTrapRoot)) {
-        this.__focusTrapController.trapFocus(this._focusTrapRoot);
+    _initFocus() {
+      if (this.focusTrap && !isElementHidden(this._focusRoot)) {
+        this.__focusTrapController.trapFocus(this._focusRoot);
       }
     }
 

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -359,7 +359,7 @@ export const OverlayMixin = (superClass) =>
 
         this.__scheduledOpen = requestAnimationFrame(() => {
           setTimeout(() => {
-            this._trapFocus();
+            this._initFocus();
 
             // Dispatch the event on the overlay. Not using composed, as propagating the event through shadow roots
             // could have side effects when nesting overlays
@@ -574,7 +574,7 @@ export const OverlayMixin = (superClass) =>
       }
 
       // Only close modeless overlay on Esc press when it contains focus
-      if (!this._shouldAddGlobalListeners() && !event.composedPath().includes(this._focusTrapRoot)) {
+      if (!this._shouldAddGlobalListeners() && !event.composedPath().includes(this._focusRoot)) {
         return;
       }
 

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -78,11 +78,11 @@ class PopoverOverlay extends PopoverOverlayMixin(
   }
 
   /**
-   * Override method from OverlayFocusMixin to use owner as focus trap root
+   * Override method from OverlayFocusMixin to use owner as focus root
    * @protected
    * @override
    */
-  get _focusTrapRoot() {
+  get _focusRoot() {
     return this.owner;
   }
 

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
@@ -170,11 +170,11 @@ class RichTextEditorPopupOverlay extends PositionMixin(
   }
 
   /**
-   * Override method from OverlayFocusMixin to use owner as focus trap root
+   * Override method from OverlayFocusMixin to use owner as focus root
    * @protected
    * @override
    */
-  get _focusTrapRoot() {
+  get _focusRoot() {
     return this.owner;
   }
 }


### PR DESCRIPTION
Prepares for letting modeless overlays move focus into the overlay on open without trapping it. With that change, the focus root and the open hook are no longer used only for the focus trap, so the current names become misleading:

- `_focusTrapRoot` is renamed to `_focusRoot` (including the overrides in confirm-dialog, crud, dialog, login, popover, and rich-text-editor)
- `_trapFocus` is renamed to `_initFocus`, pairing with the existing `_resetFocus`

Part of https://github.com/vaadin/web-components/issues/11971