### PR TITLE
refactor: deprecate renderer and contextMenuRenderer in context-menu

### DIFF
--- a/packages/context-menu/src/lit/renderer-directives.d.ts
+++ b/packages/context-menu/src/lit/renderer-directives.d.ts
@@ -52,6 +52,7 @@ export class ContextMenuRendererDirective extends LitRendererDirective<ContextMe
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Use a slotted `<vaadin-context-menu-list-box>` or the `items` property instead
  */
 export declare function contextMenuRenderer(
   renderer: ContextMenuLitRenderer,

--- a/packages/context-menu/src/lit/renderer-directives.js
+++ b/packages/context-menu/src/lit/renderer-directives.js
@@ -56,5 +56,6 @@ export class ContextMenuRendererDirective extends LitRendererDirective {
  * @param renderer the renderer callback that returns a Lit template.
  * @param dependencies a single dependency or an array of dependencies
  *                     which trigger a re-render when changed.
+ * @deprecated Use a slotted `<vaadin-context-menu-list-box>` or the `items` property instead
  */
 export const contextMenuRenderer = directive(ContextMenuRendererDirective);

--- a/packages/context-menu/src/vaadin-context-menu-mixin.d.ts
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.d.ts
@@ -52,6 +52,8 @@ export declare class ContextMenuMixinClass {
    * - `context` The object with the menu context, contains:
    *   - `context.target`  the target of the menu opening event,
    *   - `context.detail` the menu opening event detail.
+   *
+   * @deprecated Use a slotted `<vaadin-context-menu-list-box>` or the `items` property instead
    */
   renderer: ContextMenuRenderer | null | undefined;
 

--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -81,6 +81,7 @@ export const ContextMenuMixin = (superClass) =>
          *   - `context.target`  the target of the menu opening event,
          *   - `context.detail` the menu opening event detail.
          * @type {ContextMenuRenderer | undefined}
+         * @deprecated Use a slotted `<vaadin-context-menu-list-box>` or the `items` property instead
          */
         renderer: {
           type: Function,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/vaadin/web-components/pull/12172

Deprecated `renderer` property and `contextMenuRenderer` Lit directive for removal.

Let's consider deprecating `requestContentUpdate()` separately as it might be useful with `items`: https://github.com/vaadin/web-components/issues/5400

## Type of change

- Deprecation