### PR TITLE
refactor: rename ColumnRenderingMixin to HeaderFooterRenderingMixin

### DIFF
--- a/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
@@ -46,10 +46,10 @@ function isFooterRowVisible(columns, level, columnTree) {
 }
 
 /**
- * A mixin providing rendering of rows based on the column tree.
+ * A mixin providing rendering of header and footer rows based on the column tree.
  */
-export const ColumnRenderingMixin = (superClass) =>
-  class ColumnRenderingMixin extends superClass {
+export const HeaderFooterRenderingMixin = (superClass) =>
+  class HeaderFooterRenderingMixin extends superClass {
     /** @private */
     __scheduleRenderHeaderFooter() {
       this.__renderHeaderFooterDebouncer = Debouncer.debounce(this.__renderHeaderFooterDebouncer, microTask, () => {

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -13,7 +13,6 @@ import { A11yMixin } from './vaadin-grid-a11y-mixin.js';
 import { ActiveItemMixin } from './vaadin-grid-active-item-mixin.js';
 import { ArrayDataProviderMixin } from './vaadin-grid-array-data-provider-mixin.js';
 import { ColumnAutoWidthMixin } from './vaadin-grid-column-auto-width-mixin.js';
-import { ColumnRenderingMixin } from './vaadin-grid-column-rendering-mixin.js';
 import { ColumnReorderingMixin } from './vaadin-grid-column-reordering-mixin.js';
 import { ColumnResizingMixin } from './vaadin-grid-column-resizing-mixin.js';
 import { DataProviderMixin } from './vaadin-grid-data-provider-mixin.js';
@@ -21,6 +20,7 @@ import { DragAndDropMixin } from './vaadin-grid-drag-and-drop-mixin.js';
 import { DynamicColumnsMixin } from './vaadin-grid-dynamic-columns-mixin.js';
 import { EventContextMixin } from './vaadin-grid-event-context-mixin.js';
 import { FilterMixin } from './vaadin-grid-filter-mixin.js';
+import { HeaderFooterRenderingMixin } from './vaadin-grid-header-footer-rendering-mixin.js';
 import {
   getBodyRowCells,
   getClosestCell,
@@ -47,7 +47,7 @@ export const GridMixin = (superClass) =>
     ArrayDataProviderMixin(
       DataProviderMixin(
         DynamicColumnsMixin(
-          ColumnRenderingMixin(
+          HeaderFooterRenderingMixin(
             ActiveItemMixin(
               ScrollMixin(
                 SelectionMixin(


### PR DESCRIPTION
The mixin was originally intended as a place for rendering both header/footer rows and body rows based on the column tree. However, header and footer rendering alone already turned out to be a large piece, so it makes sense to keep it in a dedicated mixin instead. This PR renames the mixin to `HeaderFooterRenderingMixin` to reflect that scope. Body row rendering can later get its own mixin.

Part of https://github.com/vaadin/web-components/issues/10789
