### PR TITLE
feat: declare theme attribute via JSDoc for components supporting it

### DIFF
--- a/packages/accordion/src/vaadin-accordion-heading.js
+++ b/packages/accordion/src/vaadin-accordion-heading.js
@@ -60,6 +60,7 @@ import { accordionHeading } from './styles/vaadin-accordion-heading-base-styles.
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-accordion-heading
  * @extends HTMLElement
  */

--- a/packages/accordion/src/vaadin-accordion-panel.js
+++ b/packages/accordion/src/vaadin-accordion-panel.js
@@ -37,6 +37,7 @@ import { AccordionPanelMixin } from './vaadin-accordion-panel-mixin.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-accordion-panel
  * @extends HTMLElement
  */

--- a/packages/accordion/src/vaadin-accordion.js
+++ b/packages/accordion/src/vaadin-accordion.js
@@ -49,6 +49,7 @@ import { AccordionMixin } from './vaadin-accordion-mixin.js';
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-accordion
  * @extends HTMLElement
  */

--- a/packages/app-layout/src/vaadin-app-layout.js
+++ b/packages/app-layout/src/vaadin-app-layout.js
@@ -127,6 +127,7 @@ import { AppLayoutMixin } from './vaadin-app-layout-mixin.js';
  * @fires {CustomEvent} overlay-changed - Fired when the `overlay` property changes.
  * @fires {CustomEvent} primary-section-changed - Fired when the `primarySection` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-app-layout
  * @extends HTMLElement
  */

--- a/packages/app-layout/src/vaadin-drawer-toggle.js
+++ b/packages/app-layout/src/vaadin-drawer-toggle.js
@@ -55,6 +55,7 @@ import { drawerToggle } from './styles/vaadin-drawer-toggle-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-drawer-toggle
  * @extends HTMLElement
  */

--- a/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu-item.js
@@ -15,6 +15,7 @@ import { avatarGroupMenuItemStyles } from './styles/vaadin-avatar-group-menu-ite
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-avatar-group-menu-item
  * @extends HTMLElement
  * @protected

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.js
@@ -15,6 +15,7 @@ import { avatarGroupMenuStyles } from './styles/vaadin-avatar-group-menu-base-st
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-avatar-group-menu
  * @extends HTMLElement
  * @protected

--- a/packages/avatar-group/src/vaadin-avatar-group-overlay.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-overlay.js
@@ -16,6 +16,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-avatar-group>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-avatar-group-overlay
  * @extends HTMLElement
  * @private

--- a/packages/avatar-group/src/vaadin-avatar-group.js
+++ b/packages/avatar-group/src/vaadin-avatar-group.js
@@ -65,6 +65,7 @@ import { AvatarGroupMixin } from './vaadin-avatar-group-mixin.js';
  * - `<vaadin-avatar-group-menu>` - has the same API as [`<vaadin-list-box>`](#/elements/vaadin-list-box).
  * - `<vaadin-avatar-group-menu-item>` - has the same API as [`<vaadin-item>`](#/elements/vaadin-item).
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-avatar-group
  * @extends HTMLElement
  */

--- a/packages/avatar/src/vaadin-avatar.js
+++ b/packages/avatar/src/vaadin-avatar.js
@@ -54,6 +54,7 @@ import { AvatarMixin } from './vaadin-avatar-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-avatar
  * @extends HTMLElement
  */

--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -65,6 +65,7 @@ import { badgeStyles } from './styles/vaadin-badge-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-badge
  * @extends HTMLElement
  */

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -50,6 +50,7 @@ import { breadcrumbsItemStyles } from './styles/vaadin-breadcrumbs-item-base-sty
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-breadcrumbs-item
  * @extends HTMLElement
  */

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.js
@@ -66,6 +66,7 @@ const DEFAULT_I18N = {
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-breadcrumbs
  * @extends HTMLElement
  */

--- a/packages/button/src/vaadin-button.js
+++ b/packages/button/src/vaadin-button.js
@@ -60,6 +60,7 @@ import { ButtonMixin } from './vaadin-button-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-button
  * @extends HTMLElement
  */

--- a/packages/card/src/vaadin-card.js
+++ b/packages/card/src/vaadin-card.js
@@ -61,6 +61,7 @@ import { TitleController } from './title-controller.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-card
  * @extends HTMLElement
  */

--- a/packages/charts/src/vaadin-chart.js
+++ b/packages/charts/src/vaadin-chart.js
@@ -149,6 +149,7 @@ import { ChartMixin } from './vaadin-chart-mixin.js';
  * @fires {CustomEvent} xaxes-extremes-set - Fired when the minimum and maximum is set for the X axis.
  * @fires {CustomEvent} yaxes-extremes-set - Fired when the minimum and maximum is set for the Y axis.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-chart
  * @extends HTMLElement
  */

--- a/packages/checkbox-group/src/vaadin-checkbox-group.js
+++ b/packages/checkbox-group/src/vaadin-checkbox-group.js
@@ -76,6 +76,7 @@ import { CheckboxGroupMixin } from './vaadin-checkbox-group-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-checkbox-group
  * @extends HTMLElement
  */

--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -84,6 +84,7 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-checkbox
  * @extends HTMLElement
  */

--- a/packages/combo-box/src/vaadin-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-combo-box-item.js
@@ -34,6 +34,7 @@ import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-combo-box-item
  * @private
  */

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -17,6 +17,7 @@ import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-combo-box>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-combo-box-overlay
  * @extends HTMLElement
  * @private

--- a/packages/combo-box/src/vaadin-combo-box.js
+++ b/packages/combo-box/src/vaadin-combo-box.js
@@ -161,6 +161,7 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
  * @fires {CustomEvent} vaadin-combo-box-dropdown-opened - Fired after the `vaadin-combo-box-overlay` opens.
  * @fires {CustomEvent} vaadin-combo-box-dropdown-closed - Fired after the `vaadin-combo-box-overlay` closes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-combo-box
  * @extends HTMLElement
  */

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog-overlay.js
@@ -15,6 +15,7 @@ import { confirmDialogOverlayStyles } from './styles/vaadin-confirm-dialog-overl
 /**
  * An element used internally by `<vaadin-confirm-dialog>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-confirm-dialog-overlay
  * @extends HTMLElement
  * @private

--- a/packages/confirm-dialog/src/vaadin-confirm-dialog.js
+++ b/packages/confirm-dialog/src/vaadin-confirm-dialog.js
@@ -78,6 +78,7 @@ import { ConfirmDialogMixin } from './vaadin-confirm-dialog-mixin.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the confirm dialog is closed.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-confirm-dialog
  * @extends HTMLElement
  */

--- a/packages/context-menu/src/vaadin-context-menu-item.js
+++ b/packages/context-menu/src/vaadin-context-menu-item.js
@@ -47,6 +47,7 @@ import { contextMenuItemStyles } from './styles/vaadin-context-menu-item-base-st
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-context-menu-item
  * @extends HTMLElement
  */

--- a/packages/context-menu/src/vaadin-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.js
@@ -34,6 +34,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-context-menu-list-box
  * @extends HTMLElement
  */

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -16,6 +16,7 @@ import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-context-menu>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-context-menu-overlay
  * @extends HTMLElement
  * @protected

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -254,6 +254,7 @@ import { ContextMenuMixin } from './vaadin-context-menu-mixin.js';
  * @fires {CustomEvent} close-all-menus - Fired when all menus should close, e.g., after pressing Tab or on submenu close.
  * @fires {CustomEvent} items-outside-click - Fired when a click happens outside any open sub-menus.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-context-menu
  * @extends HTMLElement
  */

--- a/packages/crud/src/vaadin-crud-dialog-overlay.js
+++ b/packages/crud/src/vaadin-crud-dialog-overlay.js
@@ -20,6 +20,7 @@ import { crudDialogOverlayStyles } from './styles/vaadin-crud-dialog-overlay-bas
 /**
  * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-crud-dialog-overlay
  * @extends HTMLElement
  * @private

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -18,6 +18,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 /**
  * An element used internally by `<vaadin-crud>`. Not intended to be used separately.
  * @private
+ * @attr {string} theme - The theme variants to apply to the component.
  */
 class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElement))) {
   static get is() {

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -194,6 +194,7 @@ import { CrudMixin } from './vaadin-crud-mixin.js';
  * @fires {CustomEvent} save - Fired when user wants to save a new or an existing item. If the default is prevented, no action is performed: the items array is not modified and the dialog is not closed.
  * @fires {CustomEvent} cancel - Fired when user discards edition. If the default is prevented, no action is performed; the listener is responsible for closing the dialog and resetting the item and grid.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-crud
  * @extends HTMLElement
  */

--- a/packages/custom-field/src/vaadin-custom-field.js
+++ b/packages/custom-field/src/vaadin-custom-field.js
@@ -75,6 +75,7 @@ import { CustomFieldMixin } from './vaadin-custom-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-custom-field
  * @extends HTMLElement
  */

--- a/packages/dashboard/src/vaadin-dashboard-button.js
+++ b/packages/dashboard/src/vaadin-dashboard-button.js
@@ -20,6 +20,7 @@ import { dashboardButtonStyles } from './styles/vaadin-dashboard-button-base-sty
 /**
  * An element used internally by `<vaadin-dashboard>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dashboard-button
  * @extends HTMLElement
  * @protected

--- a/packages/dashboard/src/vaadin-dashboard-layout.js
+++ b/packages/dashboard/src/vaadin-dashboard-layout.js
@@ -51,6 +51,7 @@ import { DashboardLayoutMixin } from './vaadin-dashboard-layout-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dashboard-layout
  * @extends HTMLElement
  */

--- a/packages/dashboard/src/vaadin-dashboard-section.js
+++ b/packages/dashboard/src/vaadin-dashboard-section.js
@@ -63,6 +63,7 @@ import { DashboardItemMixin, getDefaultI18n } from './vaadin-dashboard-item-mixi
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dashboard-section
  * @extends HTMLElement
  */

--- a/packages/dashboard/src/vaadin-dashboard-widget.js
+++ b/packages/dashboard/src/vaadin-dashboard-widget.js
@@ -97,6 +97,7 @@ import { DashboardSection } from './vaadin-dashboard-section.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dashboard-widget
  * @extends HTMLElement
  */

--- a/packages/dashboard/src/vaadin-dashboard.js
+++ b/packages/dashboard/src/vaadin-dashboard.js
@@ -101,6 +101,7 @@ const DEFAULT_I18N = getDefaultI18n();
  * @fires {CustomEvent} dashboard-item-move-mode-changed - Fired when an item move mode changed
  * @fires {CustomEvent} dashboard-item-resize-mode-changed - Fired when an item resize mode changed
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dashboard
  * @extends HTMLElement
  */

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content.js
@@ -18,6 +18,7 @@ import { overlayContentStyles } from './styles/vaadin-date-picker-overlay-conten
 import { DatePickerOverlayContentMixin } from './vaadin-date-picker-overlay-content-mixin.js';
 
 /**
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-date-picker-overlay-content
  * @extends HTMLElement
  * @private

--- a/packages/date-picker/src/vaadin-date-picker-overlay.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay.js
@@ -16,6 +16,7 @@ import { DatePickerOverlayMixin } from './vaadin-date-picker-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-date-picker-overlay
  * @extends HTMLElement
  * @private

--- a/packages/date-picker/src/vaadin-date-picker-year.js
+++ b/packages/date-picker/src/vaadin-date-picker-year.js
@@ -13,6 +13,7 @@ import { datePickerYearStyles } from './styles/vaadin-date-picker-year-base-styl
 /**
  * An element used internally by `<vaadin-date-picker>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-date-picker-year
  * @extends HTMLElement
  * @private

--- a/packages/date-picker/src/vaadin-date-picker.js
+++ b/packages/date-picker/src/vaadin-date-picker.js
@@ -150,6 +150,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-date-picker
  * @extends HTMLElement
  */

--- a/packages/date-picker/src/vaadin-month-calendar.js
+++ b/packages/date-picker/src/vaadin-month-calendar.js
@@ -12,6 +12,7 @@ import { monthCalendarStyles } from './styles/vaadin-month-calendar-base-styles.
 import { MonthCalendarMixin } from './vaadin-month-calendar-mixin.js';
 
 /**
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-month-calendar
  * @extends HTMLElement
  * @private

--- a/packages/date-time-picker/src/vaadin-date-time-picker.js
+++ b/packages/date-time-picker/src/vaadin-date-time-picker.js
@@ -112,6 +112,7 @@ import { DateTimePickerMixin } from './vaadin-date-time-picker-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-date-time-picker
  * @extends HTMLElement
  */

--- a/packages/details/src/vaadin-details-summary.js
+++ b/packages/details/src/vaadin-details-summary.js
@@ -51,6 +51,7 @@ import { detailsSummary } from './styles/vaadin-details-summary-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-details-summary
  * @extends HTMLElement
  */

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -47,6 +47,7 @@ import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
  *
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-details
  * @extends HTMLElement
  */

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -16,6 +16,7 @@ import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-dialog>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dialog-overlay
  * @extends HTMLElement
  * @private

--- a/packages/dialog/src/vaadin-dialog.js
+++ b/packages/dialog/src/vaadin-dialog.js
@@ -116,6 +116,7 @@ export { DialogOverlay } from './vaadin-dialog-overlay.js';
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the dialog is closed.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-dialog
  * @extends HTMLElement
  */

--- a/packages/form-layout/src/vaadin-form-item.js
+++ b/packages/form-layout/src/vaadin-form-item.js
@@ -86,6 +86,7 @@ import { FormItemMixin } from './vaadin-form-item-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-form-item
  * @extends HTMLElement
  */

--- a/packages/form-layout/src/vaadin-form-layout.js
+++ b/packages/form-layout/src/vaadin-form-layout.js
@@ -198,6 +198,7 @@ import { FormLayoutMixin } from './vaadin-form-layout-mixin.js';
  * `--vaadin-form-layout-label-width` | Width of the label when labels are displayed aside | `8em`
  * `--vaadin-form-layout-label-spacing` | Length of the spacing between the label and the input when labels are displayed aside | `1em`
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-form-layout
  * @extends HTMLElement
  */

--- a/packages/form-layout/src/vaadin-form-row.js
+++ b/packages/form-layout/src/vaadin-form-row.js
@@ -17,6 +17,7 @@ import { formRowStyles } from './styles/vaadin-form-row-base-styles.js';
  * the available columns wrap to a new row, which then remains reserved
  * exclusively for the fields of that `<vaadin-form-row>` element.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-form-row
  * @extends HTMLElement
  */

--- a/packages/grid/src/vaadin-grid-filter.js
+++ b/packages/grid/src/vaadin-grid-filter.js
@@ -37,6 +37,7 @@ import { GridFilterElementMixin } from './vaadin-grid-filter-element-mixin.js';
  *
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-grid-filter
  * @extends HTMLElement
  */

--- a/packages/grid/src/vaadin-grid-sorter.js
+++ b/packages/grid/src/vaadin-grid-sorter.js
@@ -51,6 +51,7 @@ import { GridSorterMixin } from './vaadin-grid-sorter-mixin.js';
  * @fires {CustomEvent} direction-changed - Fired when the `direction` property changes.
  * @fires {CustomEvent} sorter-changed - Fired when the `path` or `direction` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-grid-sorter
  * @extends HTMLElement
  */

--- a/packages/grid/src/vaadin-grid-tree-toggle.js
+++ b/packages/grid/src/vaadin-grid-tree-toggle.js
@@ -59,6 +59,7 @@ import { GridTreeToggleMixin } from './vaadin-grid-tree-toggle-mixin.js';
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-grid-tree-toggle
  * @extends HTMLElement
  */

--- a/packages/grid/src/vaadin-grid.js
+++ b/packages/grid/src/vaadin-grid.js
@@ -274,6 +274,7 @@ const DEFAULT_I18N = {
  * @fires {CustomEvent} size-changed - Fired when the `size` property changes.
  * @fires {CustomEvent} item-toggle - Fired when the user selects or deselects an item through the selection column.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-grid
  * @extends HTMLElement
  */

--- a/packages/horizontal-layout/src/vaadin-horizontal-layout.js
+++ b/packages/horizontal-layout/src/vaadin-horizontal-layout.js
@@ -55,6 +55,7 @@ import { HorizontalLayoutMixin } from './vaadin-horizontal-layout-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-horizontal-layout
  * @extends HTMLElement
  */

--- a/packages/icon/src/vaadin-icon.js
+++ b/packages/icon/src/vaadin-icon.js
@@ -72,6 +72,7 @@ import { ensureSvgLiteral } from './vaadin-icon-svg.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-icon
  * @extends HTMLElement
  */

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -12,6 +12,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 import { inputContainerStyles } from './styles/vaadin-input-container-base-styles.js';
 
 /**
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-input-container
  * @extends HTMLElement
  */

--- a/packages/item/src/vaadin-item.js
+++ b/packages/item/src/vaadin-item.js
@@ -61,6 +61,7 @@ import { ItemMixin } from './vaadin-item-mixin.js';
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @prop {string} label - String that can be set to visually represent the selected item in `vaadin-select`.
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-item
  * @extends HTMLElement
  */

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -45,6 +45,7 @@ import { MultiSelectListMixin } from './vaadin-multi-select-list-mixin.js';
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes. Not fired in multiple selection mode.
  * @fires {CustomEvent} selected-values-changed - Fired when the `selectedValues` property changes. Not fired in single selection mode.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-list-box
  * @extends HTMLElement
  */

--- a/packages/login/src/vaadin-login-form-wrapper.js
+++ b/packages/login/src/vaadin-login-form-wrapper.js
@@ -15,6 +15,7 @@ import { loginFormWrapperStyles } from './styles/vaadin-login-form-wrapper-base-
  *
  * @extends HTMLElement
  * @private
+ * @attr {string} theme - The theme variants to apply to the component.
  */
 class LoginFormWrapper extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {

--- a/packages/login/src/vaadin-login-form.js
+++ b/packages/login/src/vaadin-login-form.js
@@ -65,6 +65,7 @@ import { LoginFormMixin } from './vaadin-login-form-mixin.js';
  * @fires {CustomEvent} forgot-password - Fired when user clicks on the "Forgot password" button.
  * @fires {CustomEvent} login - Fired when a user submits the login form. The event detail contains `username` and `password`.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-login-form
  * @extends HTMLElement
  */

--- a/packages/login/src/vaadin-login-overlay-wrapper.js
+++ b/packages/login/src/vaadin-login-overlay-wrapper.js
@@ -17,6 +17,7 @@ import { loginOverlayWrapperStyles } from './styles/vaadin-login-overlay-wrapper
  *
  * @extends HTMLElement
  * @private
+ * @attr {string} theme - The theme variants to apply to the component.
  */
 class LoginOverlayWrapper extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {

--- a/packages/login/src/vaadin-login-overlay.js
+++ b/packages/login/src/vaadin-login-overlay.js
@@ -74,6 +74,7 @@ import { LoginOverlayMixin } from './vaadin-login-overlay-mixin.js';
  * @fires {CustomEvent} login - Fired when a user submits the login form. The event detail contains `username` and `password`.
  * @fires {CustomEvent} closed - Fired when the overlay is closed.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-login-overlay
  * @extends HTMLElement
  */

--- a/packages/map/src/vaadin-map.js
+++ b/packages/map/src/vaadin-map.js
@@ -50,6 +50,7 @@ import { MapMixin } from './vaadin-map-mixin.js';
  * </script>
  * ```
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-map
  * @extends HTMLElement
  */

--- a/packages/markdown/src/vaadin-markdown.js
+++ b/packages/markdown/src/vaadin-markdown.js
@@ -24,6 +24,7 @@ import { markdownSlotStyles } from './styles/vaadin-markdown-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-markdown
  * @extends HTMLElement
  */

--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -88,6 +88,7 @@ import {
  * @fires {CustomEvent} backdrop-click - Fired when the user clicks the backdrop in the overlay mode.
  * @fires {CustomEvent} detail-escape-press - Fired when the user presses Escape in the detail area.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-master-detail-layout
  * @extends HTMLElement
  */

--- a/packages/menu-bar/src/vaadin-menu-bar-item.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-item.js
@@ -15,6 +15,7 @@ import { menuBarItemStyles } from './styles/vaadin-menu-bar-item-base-styles.js'
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-menu-bar-item
  * @extends HTMLElement
  * @protected

--- a/packages/menu-bar/src/vaadin-menu-bar-list-box.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-list-box.js
@@ -15,6 +15,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-menu-bar-list-box
  * @extends HTMLElement
  * @protected

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -16,6 +16,7 @@ import { menuBarOverlayStyles } from './styles/vaadin-menu-bar-overlay-base-styl
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-menu-bar-overlay
  * @extends HTMLElement
  * @protected

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -16,6 +16,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 /**
  * An element used internally by `<vaadin-menu-bar>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-menu-bar-submenu
  * @extends HTMLElement
  * @protected

--- a/packages/menu-bar/src/vaadin-menu-bar.js
+++ b/packages/menu-bar/src/vaadin-menu-bar.js
@@ -67,6 +67,7 @@ import { MenuBarMixin } from './vaadin-menu-bar-mixin.js';
  *
  * @fires {CustomEvent<boolean>} item-selected - Fired when a submenu item or menu bar button without children is clicked.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-menu-bar
  * @extends HTMLElement
  */

--- a/packages/message-input/src/vaadin-message-input-button.js
+++ b/packages/message-input/src/vaadin-message-input-button.js
@@ -16,6 +16,7 @@ import { messageInputButtonStyles } from './styles/vaadin-message-input-button-s
 /**
  * An element used internally by `<vaadin-message-input>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-message-input-button
  * @extends HTMLElement
  * @private

--- a/packages/message-input/src/vaadin-message-input.js
+++ b/packages/message-input/src/vaadin-message-input.js
@@ -47,6 +47,7 @@ import { MessageInputMixin } from './vaadin-message-input-mixin.js';
  *
  * @fires {CustomEvent} submit - Fired when a new message is submitted, either by clicking the "send" button, or pressing the Enter key.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-message-input
  * @extends HTMLElement
  */

--- a/packages/message-list/src/vaadin-message-list.js
+++ b/packages/message-list/src/vaadin-message-list.js
@@ -47,6 +47,7 @@ import { MessageListMixin } from './vaadin-message-list-mixin.js';
  *
  * @fires {CustomEvent} attachment-click - Fired when an attachment is clicked.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-message-list
  * @extends HTMLElement
  */

--- a/packages/message-list/src/vaadin-message.js
+++ b/packages/message-list/src/vaadin-message.js
@@ -83,6 +83,7 @@ import { MessageMixin } from './vaadin-message-mixin.js';
  *
  * @fires {CustomEvent} attachment-click - Fired when an attachment is clicked.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-message
  * @extends HTMLElement
  */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-chip.js
@@ -24,6 +24,7 @@ import { multiSelectComboBoxChipStyles } from './styles/vaadin-multi-select-comb
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-multi-select-combo-box-chip
  * @extends HTMLElement
  * @private

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
@@ -34,6 +34,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-multi-select-combo-box-item
  * @private
  */

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-overlay.js
@@ -17,6 +17,7 @@ import { multiSelectComboBoxOverlayStyles } from './styles/vaadin-multi-select-c
 /**
  * An element used internally by `<vaadin-multi-select-combo-box>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-multi-select-combo-box-overlay
  * @extends HTMLElement
  * @private

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box.js
@@ -96,6 +96,7 @@ import { MultiSelectComboBoxMixin } from './vaadin-multi-select-combo-box-mixin.
  * @fires {CustomEvent} selected-items-changed - Fired when the `selectedItems` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-multi-select-combo-box
  * @extends HTMLElement
  */

--- a/packages/notification/src/vaadin-notification.js
+++ b/packages/notification/src/vaadin-notification.js
@@ -17,6 +17,7 @@ import { NotificationContainerMixin, NotificationMixin } from './vaadin-notifica
 /**
  * An element used internally by `<vaadin-notification>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-notification-container
  * @extends HTMLElement
  * @private
@@ -55,6 +56,7 @@ class NotificationContainer extends NotificationContainerMixin(
 /**
  * An element used internally by `<vaadin-notification>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-notification-card
  * @extends HTMLElement
  * @private
@@ -147,6 +149,7 @@ class NotificationCard extends ThemableMixin(PolylitMixin(LumoInjectionMixin(Lit
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the notification is closed.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-notification
  * @extends HTMLElement
  */

--- a/packages/number-field/src/vaadin-number-field.js
+++ b/packages/number-field/src/vaadin-number-field.js
@@ -123,6 +123,7 @@ import { NumberFieldMixin } from './vaadin-number-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-number-field
  * @extends HTMLElement
  */

--- a/packages/password-field/src/vaadin-password-field-button.js
+++ b/packages/password-field/src/vaadin-password-field-button.js
@@ -15,6 +15,7 @@ import { passwordFieldButton } from './styles/vaadin-password-field-button-base-
 /**
  * An element used internally by `<vaadin-password-field>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-password-field-button
  * @extends HTMLElement
  * @private

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -16,6 +16,7 @@ import { PopoverOverlayMixin } from './vaadin-popover-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-popover>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-popover-overlay
  * @extends HTMLElement
  * @private

--- a/packages/popover/src/vaadin-popover.js
+++ b/packages/popover/src/vaadin-popover.js
@@ -216,6 +216,7 @@ const hasOnlyNestedOverlays = (overlay) => getOverlaysOnTop(overlay).every((el) 
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} closed - Fired when the popover is closed.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-popover
  * @extends HTMLElement
  */

--- a/packages/progress-bar/src/vaadin-progress-bar.js
+++ b/packages/progress-bar/src/vaadin-progress-bar.js
@@ -51,6 +51,7 @@ import { ProgressMixin } from './vaadin-progress-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-progress-bar
  * @extends HTMLElement
  */

--- a/packages/radio-group/src/vaadin-radio-button.js
+++ b/packages/radio-group/src/vaadin-radio-button.js
@@ -63,6 +63,7 @@ import { RadioButtonMixin } from './vaadin-radio-button-mixin.js';
  *
  * @fires {CustomEvent} checked-changed - Fired when the `checked` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-radio-button
  * @extends HTMLElement
  */

--- a/packages/radio-group/src/vaadin-radio-group.js
+++ b/packages/radio-group/src/vaadin-radio-group.js
@@ -75,6 +75,7 @@ import { RadioGroupMixin } from './vaadin-radio-group-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-radio-group
  * @extends HTMLElement
  */

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor-popup.js
@@ -134,6 +134,7 @@ export { RichTextEditorPopup };
 /**
  * An element used internally by `<vaadin-rich-text-editor>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-rich-text-editor-popup-overlay
  * @extends HTMLElement
  * @private

--- a/packages/rich-text-editor/src/vaadin-rich-text-editor.js
+++ b/packages/rich-text-editor/src/vaadin-rich-text-editor.js
@@ -115,6 +115,7 @@ import { RichTextEditorMixin } from './vaadin-rich-text-editor-mixin.js';
  * @fires {CustomEvent} html-value-changed - Fired when the `htmlValue` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-rich-text-editor
  * @extends HTMLElement
  */

--- a/packages/scroller/src/vaadin-scroller.js
+++ b/packages/scroller/src/vaadin-scroller.js
@@ -55,6 +55,7 @@ import { ScrollerMixin } from './vaadin-scroller-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-scroller
  * @extends HTMLElement
  */

--- a/packages/select/src/vaadin-select-item.js
+++ b/packages/select/src/vaadin-select-item.js
@@ -48,6 +48,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
  * @prop {string} label - String that can be set to visually represent the selected item in `vaadin-select`.
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-select-item
  * @extends HTMLElement
  */

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -34,6 +34,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-select-list-box
  * @extends HTMLElement
  */

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -15,6 +15,7 @@ import { SelectOverlayMixin } from './vaadin-select-overlay-mixin.js';
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-select-overlay
  * @extends HTMLElement
  * @private

--- a/packages/select/src/vaadin-select-value-button.js
+++ b/packages/select/src/vaadin-select-value-button.js
@@ -14,6 +14,7 @@ import { valueButton } from './styles/vaadin-select-value-button-base-styles.js'
 /**
  * An element used internally by `<vaadin-select>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-select-value-button
  * @extends HTMLElement
  * @protected

--- a/packages/select/src/vaadin-select.js
+++ b/packages/select/src/vaadin-select.js
@@ -150,6 +150,7 @@ import { SelectBaseMixin } from './vaadin-select-base-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-select
  * @extends HTMLElement
  */

--- a/packages/side-nav/src/vaadin-side-nav-item.js
+++ b/packages/side-nav/src/vaadin-side-nav-item.js
@@ -91,6 +91,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @fires {CustomEvent} expanded-changed - Fired when the `expanded` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-side-nav-item
  * @extends HTMLElement
  */

--- a/packages/side-nav/src/vaadin-side-nav.js
+++ b/packages/side-nav/src/vaadin-side-nav.js
@@ -78,6 +78,7 @@ import { SideNavChildrenMixin } from './vaadin-side-nav-children-mixin.js';
  *
  * @fires {CustomEvent} collapsed-changed - Fired when the `collapsed` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-side-nav
  * @extends HTMLElement
  */

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -123,6 +123,7 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-range-slider
  * @extends HTMLElement
  */

--- a/packages/slider/src/vaadin-slider-bubble-overlay.js
+++ b/packages/slider/src/vaadin-slider-bubble-overlay.js
@@ -16,6 +16,7 @@ import { sliderBubbleOverlayStyles } from './styles/vaadin-slider-bubble-overlay
 /**
  * An element used internally by `<vaadin-slider>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-slider-bubble-overlay
  * @extends HTMLElement
  * @private

--- a/packages/slider/src/vaadin-slider-bubble.js
+++ b/packages/slider/src/vaadin-slider-bubble.js
@@ -13,6 +13,7 @@ import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-p
 /**
  * An element used internally by `<vaadin-slider>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-slider-bubble
  * @extends HTMLElement
  * @private

--- a/packages/slider/src/vaadin-slider.js
+++ b/packages/slider/src/vaadin-slider.js
@@ -118,6 +118,7 @@ import { SliderMixin } from './vaadin-slider-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-slider
  * @extends HTMLElement
  */

--- a/packages/split-layout/src/vaadin-split-layout.js
+++ b/packages/split-layout/src/vaadin-split-layout.js
@@ -186,6 +186,7 @@ const DEFAULT_I18N = {
  *
  * @fires {Event} splitter-dragend - Fired after resizing the splitter via pointer or keyboard has ended.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-split-layout
  * @extends HTMLElement
  */

--- a/packages/switch/src/vaadin-switch.js
+++ b/packages/switch/src/vaadin-switch.js
@@ -91,6 +91,7 @@ import { switchStyles } from './styles/vaadin-switch-base-styles.js';
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-switch
  * @extends HTMLElement
  */

--- a/packages/tabs/src/vaadin-tab.js
+++ b/packages/tabs/src/vaadin-tab.js
@@ -47,6 +47,7 @@ import { tabStyles } from './styles/vaadin-tab-base-styles.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-tab
  * @extends HTMLElement
  */

--- a/packages/tabs/src/vaadin-tabs.js
+++ b/packages/tabs/src/vaadin-tabs.js
@@ -60,6 +60,7 @@ import { TabsMixin } from './vaadin-tabs-mixin.js';
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-tabs
  * @extends HTMLElement
  */

--- a/packages/tabsheet/src/vaadin-tabsheet.js
+++ b/packages/tabsheet/src/vaadin-tabsheet.js
@@ -66,6 +66,7 @@ import { TabSheetMixin } from './vaadin-tabsheet-mixin.js';
  * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
  * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-tabsheet
  * @extends HTMLElement
  */

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -116,6 +116,7 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-text-area
  * @extends HTMLElement
  */

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -115,6 +115,7 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-text-field
  * @extends HTMLElement
  */

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -34,6 +34,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-time-picker-item
  * @private
  */

--- a/packages/time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.js
@@ -19,6 +19,7 @@ import { timePickerOverlayStyles } from './styles/vaadin-time-picker-overlay-bas
  *
  * @extends HTMLElement
  * @private
+ * @attr {string} theme - The theme variants to apply to the component.
  */
 export class TimePickerOverlay extends ComboBoxOverlayMixin(
   OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),

--- a/packages/time-picker/src/vaadin-time-picker.js
+++ b/packages/time-picker/src/vaadin-time-picker.js
@@ -103,6 +103,7 @@ import { TimePickerMixin } from './vaadin-time-picker-mixin.js';
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  * @fires {CustomEvent} validated - Fired whenever the field is validated.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-time-picker
  * @extends HTMLElement
  */

--- a/packages/tooltip/src/vaadin-tooltip-overlay.js
+++ b/packages/tooltip/src/vaadin-tooltip-overlay.js
@@ -16,6 +16,7 @@ import { tooltipOverlayStyles } from './styles/vaadin-tooltip-overlay-base-style
 /**
  * An element used internally by `<vaadin-tooltip>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-tooltip-overlay
  * @extends HTMLElement
  * @private

--- a/packages/tooltip/src/vaadin-tooltip.js
+++ b/packages/tooltip/src/vaadin-tooltip.js
@@ -73,6 +73,7 @@ import { TooltipMixin } from './vaadin-tooltip-mixin.js';
  *
  * @fires {CustomEvent} content-changed - Fired when the tooltip text content is changed.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-tooltip
  * @extends HTMLElement
  */

--- a/packages/upload/src/vaadin-upload-button.js
+++ b/packages/upload/src/vaadin-upload-button.js
@@ -70,6 +70,7 @@ import { UploadManager } from './vaadin-upload-manager.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-upload-button
  * @extends HTMLElement
  */

--- a/packages/upload/src/vaadin-upload-drop-zone.js
+++ b/packages/upload/src/vaadin-upload-drop-zone.js
@@ -47,6 +47,7 @@ import { UploadManager } from './vaadin-upload-manager.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-upload-drop-zone
  * @extends HTMLElement
  */

--- a/packages/upload/src/vaadin-upload-file-list.js
+++ b/packages/upload/src/vaadin-upload-file-list.js
@@ -75,6 +75,7 @@ import { UploadFileListMixin } from './vaadin-upload-file-list-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-upload-file-list
  * @extends HTMLElement
  */

--- a/packages/upload/src/vaadin-upload-file.js
+++ b/packages/upload/src/vaadin-upload-file.js
@@ -81,6 +81,7 @@ import { UploadFileMixin } from './vaadin-upload-file-mixin.js';
  * @fires {CustomEvent} file-retry - Fired when the retry button is pressed to request retrying the upload of this file.
  * @fires {CustomEvent} file-start - Fired when the start button is pressed to request starting the upload of this file.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-upload-file
  * @extends HTMLElement
  */

--- a/packages/upload/src/vaadin-upload-icon.js
+++ b/packages/upload/src/vaadin-upload-icon.js
@@ -12,6 +12,7 @@ import { uploadIconStyles } from './styles/vaadin-upload-icon-base-styles.js';
 /**
  * An element used internally by `<vaadin-upload>`. Not intended to be used separately.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-upload-icon
  * @extends HTMLElement
  * @private

--- a/packages/upload/src/vaadin-upload.js
+++ b/packages/upload/src/vaadin-upload.js
@@ -102,6 +102,7 @@ import { UploadMixin } from './vaadin-upload-mixin.js';
  * @fires {CustomEvent} upload-retry - Fired when retry upload is requested. If the default is prevented, the retry is not performed.
  * @fires {CustomEvent} upload-abort - Fired when upload abort is requested. If the default is prevented, the upload is not aborted.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-upload
  * @extends HTMLElement
  */

--- a/packages/vertical-layout/src/vaadin-vertical-layout.js
+++ b/packages/vertical-layout/src/vaadin-vertical-layout.js
@@ -44,6 +44,7 @@ import { verticalLayoutStyles } from './styles/vaadin-vertical-layout-base-style
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-vertical-layout
  * @extends HTMLElement
  */

--- a/packages/virtual-list/src/vaadin-virtual-list.js
+++ b/packages/virtual-list/src/vaadin-virtual-list.js
@@ -57,6 +57,7 @@ import { VirtualListMixin } from './vaadin-virtual-list-mixin.js';
  *
  * See [Styling Components](https://vaadin.com/docs/latest/styling/styling-components) documentation.
  *
+ * @attr {string} theme - The theme variants to apply to the component.
  * @customElement vaadin-virtual-list
  * @extends HTMLElement
  */

--- a/scripts/buildWebtypes.js
+++ b/scripts/buildWebtypes.js
@@ -21,16 +21,6 @@ const blacklistedPackages = [
   /^aura/u,
 ];
 
-// Additional attributes that will be added to all components
-const additionalAttributes = [
-  // Theme attribute is not properly declared at the moment
-  {
-    name: 'theme',
-    description: 'The theme variants to apply to the component.',
-    type: 'string | null | undefined',
-  },
-];
-
 /**
  * Get packages using lerna, excluding blacklisted packages
  */
@@ -153,7 +143,7 @@ function getPublicWritableProperties(elementDeclaration) {
 function createPlainElementDefinition(packageJson, elementDeclaration) {
   const readonlyFields = new Set((elementDeclaration.members || []).filter((m) => m.readonly).map((m) => m.name));
   const elementAttributes = elementDeclaration.attributes || [];
-  const attributes = [...elementAttributes, ...additionalAttributes]
+  const attributes = elementAttributes
     .filter((attribute) => isWritablePrimitiveAttribute(attribute))
     .filter((attribute) => !readonlyFields.has(attribute.fieldName))
     .sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
The `theme` attribute was added to web-types by a hardcoded list in `buildWebtypes.js` that applied it to every component, including ones that don't support it (e.g. `vaadin-grid-column`). It was also missing from `custom-elements.json`, since `ThemePropertyMixin` observes the attribute without declaring a property.

The attribute is now declared with a class-level `@attr` JSDoc tag on each element class that composes `ThemableMixin` / `ThemePropertyMixin`, or supports `theme` through CSS only (`vaadin-switch`, `vaadin-breadcrumbs`). Subclasses such as `vaadin-password-field` and `vaadin-grid-pro` inherit the attribute through CEM inheritance resolution.

The following components no longer list `theme` in web-types:

- `vaadin-board`, `vaadin-board-row`
- `vaadin-chart-series`
- `vaadin-crud-edit-column`
- `vaadin-grid-column`, `vaadin-grid-column-group`, `vaadin-grid-filter-column`, `vaadin-grid-selection-column`, `vaadin-grid-sort-column`, `vaadin-grid-tree-column`
- `vaadin-grid-pro-edit-column`
- `vaadin-iconset`

Part of #1582

---

🤖 Generated with Claude Code