### PR TITLE
refactor: render grid header and footer cell colspan declaratively

### DIFF
--- a/packages/grid/src/vaadin-grid-a11y-mixin.js
+++ b/packages/grid/src/vaadin-grid-a11y-mixin.js
@@ -153,15 +153,6 @@ export const A11yMixin = (superClass) =>
       });
     }
 
-    /**
-     * @param {!HTMLElement} cell
-     * @param {number} colspan
-     * @private
-     */
-    __a11yUpdateCellColspan(cell, colspan) {
-      cell.setAttribute('aria-colspan', Number(colspan));
-    }
-
     /** @private */
     __a11yUpdateSorters() {
       Array.from(this.querySelectorAll('vaadin-grid-sorter')).forEach((sorter) => {

--- a/packages/grid/src/vaadin-grid-column-group-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-group-mixin.js
@@ -57,7 +57,7 @@ export const GridColumnGroupMixin = (superClass) =>
         '_groupFrozenChanged(frozen, _rootColumns)',
         '_groupFrozenToEndChanged(frozenToEnd, _rootColumns)',
         '_groupHiddenChanged(hidden)',
-        '_colSpanChanged(_colSpan, _headerCell, _footerCell)',
+        '_colSpanChanged(_colSpan)',
         '_groupOrderChanged(_order, _rootColumns)',
         '_groupReorderStatusChanged(_reorderStatus, _rootColumns)',
         '_groupResizableChanged(resizable, _rootColumns)',
@@ -307,19 +307,8 @@ export const GridColumnGroupMixin = (superClass) =>
     }
 
     /** @private */
-    _colSpanChanged(colSpan, headerCell, footerCell) {
-      if (headerCell) {
-        headerCell.setAttribute('colspan', colSpan);
-        if (this._grid) {
-          this._grid.__a11yUpdateCellColspan(headerCell, colSpan);
-        }
-      }
-      if (footerCell) {
-        footerCell.setAttribute('colspan', colSpan);
-        if (this._grid) {
-          this._grid.__a11yUpdateCellColspan(footerCell, colSpan);
-        }
-      }
+    _colSpanChanged() {
+      this._grid?.__scheduleRenderHeaderFooter?.();
     }
 
     /**

--- a/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
@@ -5,6 +5,7 @@
  */
 import { html, nothing, render } from 'lit';
 import { cache } from 'lit/directives/cache.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
@@ -122,6 +123,8 @@ export const HeaderFooterRenderingMixin = (superClass) =>
                   @mousedown=${this.__onCellMouseDown}
                   @mouseenter=${this.__onCellMouseEnter}
                   @mouseleave=${this.__onCellMouseLeave}
+                  colspan="${ifDefined(column._colSpan)}"
+                  aria-colspan="${ifDefined(column._colSpan)}"
                   tabindex="-1"
                   ._column=${column}
                 >
@@ -181,6 +184,8 @@ export const HeaderFooterRenderingMixin = (superClass) =>
                   @mousedown=${this.__onCellMouseDown}
                   @mouseenter=${this.__onCellMouseEnter}
                   @mouseleave=${this.__onCellMouseLeave}
+                  colspan="${ifDefined(column._colSpan)}"
+                  aria-colspan="${ifDefined(column._colSpan)}"
                   tabindex="-1"
                   ._column=${column}
                 >

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -101,6 +101,7 @@ describe('column', () => {
 
       it('should not be bound to column-group header cells', () => {
         column.hidden = true;
+        flushGrid(grid);
 
         expect(getContainerCell(grid.$.header, 0, 0).style.display).to.eql('');
       });
@@ -109,6 +110,7 @@ describe('column', () => {
         expect(getContainerCell(grid.$.header, 0, 0).colSpan).to.eql(2);
 
         column.hidden = true;
+        flushGrid(grid);
 
         expect(getContainerCell(grid.$.header, 0, 0).colSpan).to.eql(1);
       });


### PR DESCRIPTION
This PR continues the migration of the imperatively applied header/footer cell state into Lit templates. The `colspan` and `aria-colspan` attributes of column group cells are now rendered as part of the header/footer templates instead of being set imperatively by `_colSpanChanged` and `__a11yUpdateCellColspan`.

Since `_colSpanChanged` now only schedules a header/footer re-render, colspan updates are applied asynchronously. The affected tests were updated to flush the grid before asserting.

Part of #10789