### PR TITLE
chore: add repro skill for triaging web component issues

### DIFF
--- a/.claude/skills/repro/SKILL.md
+++ b/.claude/skills/repro/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: repro
+description: Reproduce a Vaadin web component bug from a GitHub issue in vaadin/web-components. Builds a minimal dev-page reproduction, confirms the bug in a running browser with playwright-cli, points at the likely root cause, pushes a shareable repro/<issue> branch, and (after confirmation) posts a verification-pending summary comment on the issue.
+argument-hint: <issue-url>
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(gh:*), Bash(yarn:*), Bash(playwright-cli:*), Bash(npx:*), Bash(git:*), Bash(curl:*), Bash(lsof:*), Bash(kill:*)
+---
+
+You are a tester reproducing a Vaadin web component bug. Input `$0` is a GitHub issue URL in `vaadin/web-components`. Work the phases in order. **Never claim a bug is reproduced until you have seen it in a running browser.**
+
+Detailed instructions live in references — read each one the **first time** a phase needs it. They stay in context: on later runs in the same session, do not re-read them.
+
+| Reference | Covers |
+| --- | --- |
+| [`references/issue-analysis.md`](references/issue-analysis.md) | Phase 1 in full |
+| [`references/reproduce.md`](references/reproduce.md) | Phases 2–3: dev page, dev server, maintenance branches |
+| [`references/verify.md`](references/verify.md) | browser-observation discipline |
+| [`references/share.md`](references/share.md) | Phases 4–6 and cleanup |
+
+## Phase 0 — Setup (once per session)
+
+- Resolve `<ROOT>` = `git rev-parse --show-toplevel` (this web-components checkout). Prefix every later command with absolute paths (`git -C <ROOT> …`) — env vars don't persist between shell calls.
+- Optional sibling checkout, used only for root-cause pointers: `<FC_ROOT>` = `<dirname of ROOT>/flow-components` (the Flow integration layer). When absent, note it and read that source on GitHub instead (`gh api` / permalinks).
+- Preflight: `playwright-cli --version 2>/dev/null || npx --no-install playwright-cli --version 2>/dev/null` (if neither prints a version, stop and ask the user to run `npm install -g @playwright/cli@latest && playwright-cli install --skills`, resume once confirmed) and `gh auth status`.
+- Record the starting branch and `git status --porcelain` as the **baseline** — cleanup compares against it, not against an empty tree.
+
+Skip all of this when already done earlier in this session.
+
+## Phase 1 — Understand the bug
+
+Follow issue-analysis.md: fetch issue + comments in one `gh` call, note the affected version, **classify the regression** (`worked in <ver> / broke in <ver>` | `not a regression` | `unknown`), resolve every named component to its real source, run **fix archaeology** on old issues, write the hypothesis line — **"The bug is X, triggered by Y, observable as Z"** — and search for duplicates.
+
+## Phase 2 — Build the reproduction
+
+The smallest page that exercises the hypothesis, starting from the reporter's example, named after the issue (never overwrite an existing file): `dev/repro-<issue>.html` per reproduce.md. Give elements `id`s for playwright targeting, and prefer a **minimal pair**: the failing case plus a control that isolates the trigger.
+
+## Phase 3 — Run and reproduce
+
+1. Start the dev server in the background and confirm readiness per reproduce.md — pick the theme variant (`base` / `lumo` / `aura`) that matches the issue. The server does **not** hot-reload: after editing the page, reload it in the browser — no server restart needed.
+2. Drive the browser per verify.md. Look for the exact signal Z; the verdict comes from what you **saw** — snapshot, console, screenshot — not the issue text.
+3. **Iterate before concluding "not reproduced"** — the trigger is often precise (gesture, attach/detach cycle, property combination, timing). Record every attempted variation.
+4. Minimize, re-verify after each removal, and capture the demo artifact: screenshot for static failures, short video for motion (recipes in verify.md).
+
+## Phase 4 — Report
+
+Fill `assets/summary-template.md` → `<ROOT>/repro-<issue>-summary.md` with **every** field. Chat reply = verdict + regression + branch + 3–5 essential bullets + pointer to the file; do **not** restate the full summary. Details in share.md.
+
+## Phase 5 — Locate the root cause
+
+Point at the suspected cause as a **permalink pinned to a commit SHA** (format in share.md), searching the layer the evidence implicates — the component's `packages/<component>/src/`, shared mixins, or theme packages (repo layout is in the root CLAUDE.md). If the bug only manifests through the Flow integration, say so and point at `vaadin/flow-components` source (read it at `<FC_ROOT>` when present, otherwise on GitHub) — reproducing there is out of scope. Don't fix the bug unless asked.
+
+## Phase 6 — Decide the disposition (always ask)
+
+**End every run with an `AskUserQuestion` — never a prose "want me to…?".** Options per verdict are in share.md. Never close an issue yourself.
+
+## Cleanup
+
+Follow share.md. Not reproduced → no branch: archive the scaffold to your scratchpad, delete it from the repo.

--- a/.claude/skills/repro/assets/summary-template.md
+++ b/.claude/skills/repro/assets/summary-template.md
@@ -1,0 +1,57 @@
+<!-- Edit any field. This file is committed on the `repro/<issue>` branch and posted as the issue comment. -->
+
+> [!WARNING]
+> **Automated reproduction — produced by the Claude Code `repro` skill. Needs human verification.**
+> The steps, verdict, and root-cause pointer below were generated automatically and must be confirmed by a human before being treated as authoritative.
+
+- **Verdict:** reproduced | not reproduced (fixed | addressed | obsolete API | unknown) | partially reproduced | works as designed (likely misuse) | duplicate of #N
+- **Hypothesis tested:** The bug is <X>, triggered by <Y>, observable as <Z>.
+- **Regression?:** worked in <ver> / broke in <ver> | not a regression (broken since introduction) | unknown
+- **Fixed by:** #PR (<one-line mechanism>) | broad rework (no single PR) | n/a
+- **Duplicate of:** <repo>#N (<open/closed; the issue the fixing PR closed, if any>) | none found
+- **Branch:** `repro/<issue>` — pushed to `vaadin/web-components`
+- **Reproduced on:** vaadin/web-components @ <version or branch>
+- **Present on main?:** yes (still broken) | no (fixed in <line>) | n/a
+- **Theme / Browser:** <base | Lumo | Aura> / <browser>
+- **Screenshot** (static bug): ![<caption>](https://raw.githubusercontent.com/vaadin/web-components/<commit-sha>/repro-<issue>.png) <!-- bare markdown, no backticks around it, or the image won't render -->
+- **Demo video** (motion bug): `repro-<issue>-<symptom>.webm` (on the branch; drag into the comment for inline playback)
+
+## Observed behavior
+
+<What actually happened — cite the DOM snapshot, console output, or screenshot.>
+
+## Expected behavior
+
+<From the issue.>
+
+## Steps to reproduce
+
+1. <step>
+2. <step>
+3. <step>
+
+## Reproduction
+
+How to run: start the dev server (`yarn start`, or `yarn start:lumo` / `yarn start:aura` for theme bugs) and open the page below.
+
+- **Route / page:** `http://localhost:8000/dev/repro-<issue>.html`
+- **Scaffold:** `dev/repro-<issue>.html` (committed on this branch)
+
+```
+<key markup / script — the minimal reproduction>
+```
+
+## Root cause (suspected)
+
+<short explanation of the problematic area>:
+
+https://github.com/vaadin/web-components/blob/<sha>/<path>#L<start>-L<end>
+
+## Duplicate
+
+<!-- Include when this issue duplicates another one — including an already-fixed issue discovered via the fixing PR; otherwise delete this section. -->
+Same bug as **<repo>#N** (<open/closed; fixed by #PR if known>): identical root cause and trigger. <One line on why they match.> Recommend closing this issue as a duplicate of #N, citing the fixing PR when known.
+
+## Notes
+
+<Anything else: version-specific findings, dead ends, related issues.>

--- a/.claude/skills/repro/references/issue-analysis.md
+++ b/.claude/skills/repro/references/issue-analysis.md
@@ -1,0 +1,51 @@
+# Phase 1 — Understanding the bug
+
+Tracker in scope: `vaadin/web-components`. The tracker doesn't decide the owning layer; the reproducing code path does.
+
+## 1. Fetch the issue
+
+One call (`gh issue view --comments` prints nothing non-interactively):
+
+```bash
+gh issue view <n> --repo vaadin/web-components --json number,title,state,body,labels,comments
+```
+
+- Keep any `--jq` simple — no nested double quotes inside a double-quoted command; build strings with `+`.
+- Read for a code example, reproduction steps, expected vs. actual behavior, and the theme in use.
+- A "works for me" / "could not reproduce" comment does **not** cancel the attempt — build and run it yourself, and mine the comment for variations (version, theme, browser, data set, exact gesture). Report not-reproduced only after genuine Phase 3 iteration.
+- **Fetch attached reproduction projects** — they can decide the verdict (misuse vs. bug). Zips linked as `github.com/.../files/...` download with `curl -sL`; linked repos read via `gh api "repos/<user>/<repo>/git/trees/HEAD?recursive=1" --jq '...'` and `gh api repos/<user>/<repo>/contents/<path> --jq .content | base64 -d`.
+
+## 2. Affected version + regression classification
+
+Note the affected version if stated. Check the current line (`version` in `packages/<component>/package.json`). If the bug is reportedly fixed in a newer line or the range is below the checkout, switch to the matching maintenance branch — see [reproduce.md](reproduce.md).
+
+**Classify the regression:** `worked in <ver> / broke in <ver>` when there is evidence of both ends; `not a regression` when broken since the feature shipped; `unknown` otherwise. Recorded in the report for the team — informational only.
+
+## 3. Resolve every named component to its real source — never assume markup or API from memory
+
+Tags, attributes, slots, and parts drift across versions; a wrong guess sends the reproduction at the wrong artifact. Find `packages/<name>/`, its element (`grep -rln "customElements.define\|static get is" packages/<name>/src`), the `@vaadin/<name>` import, and any existing `dev/<name>.html` — build from the real element and current API. Check the reported API still exists; a removed API trends the verdict toward "obsolete".
+
+## 4. Fix archaeology (issues more than ~2 years old)
+
+Old issues are often already fixed, the fix never linked back. Before scaffolding:
+
+1. Grep `packages/<component>/test/` for an existing regression test matching the symptom.
+2. `git log --oneline -S "<distinctive symbol or error string>" -- <suspect paths>` to find the fixing commit/PR; record `fixing PR: <#N | none found>` for the summary. Many fixes are broad reworks with no single greppable PR — "none found" is a normal answer.
+3. When a fixing PR is found, **resolve the issue it closed** — `gh pr view <n> --repo vaadin/web-components --json closingIssuesReferences,body`. That issue is usually the duplicate that got fixed while the triaged report stayed open; record it in the summary's `Duplicate of:` field.
+4. Before citing a candidate fixing PR, confirm it touched the relevant package — `git show <sha> --stat`. A matching title can mislead.
+
+A found fix does **not** skip browser verification, but it lets the page stay minimal and the report cite "duplicate of #N, fixed by #PR (with regression test)" — far more closeable than "could not reproduce".
+
+## 5. Intended behavior, then hypothesis
+
+Check what the component should do (docs, `src/` API, JSDoc contracts, tests), not just what the reporter expected — if it works as designed, the verdict is "works as designed (likely misuse)". Write one line: **"The bug is X, triggered by Y, observable as Z"**, where Z is the exact failure signal to look for.
+
+## 6. Duplicates
+
+Search open and closed issues for the component plus a distinctive symptom across the trackers:
+
+```bash
+gh search issues "<component> <distinctive token>" --repo vaadin/web-components --repo vaadin/flow-components --repo vaadin/flow
+```
+
+The Flow trackers are included on purpose — the same client bug is often reported through the Flow integration. Confirm a real match only after reproducing — same root cause, stack trace, and trigger, not a similar title. A confirmed match makes the verdict "duplicate of #N".

--- a/.claude/skills/repro/references/reproduce.md
+++ b/.claude/skills/repro/references/reproduce.md
@@ -1,0 +1,72 @@
+# Building and running the reproduction
+
+Work in `<ROOT>` (this web-components checkout): a monorepo of Lit-based packages under `packages/`. Run `yarn` commands from `<ROOT>` and write files under it — never rely on relative paths.
+
+## 1. Create the dev page
+
+Add `<ROOT>/dev/repro-<issue>.html`. The page must import `./common.js` (shared dev styles) and the component package, then place the markup that reproduces the bug:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repro #<issue></title>
+    <script type="module" src="./common.js"></script>
+    <script type="module">
+      import '@vaadin/<component>';
+    </script>
+  </head>
+  <body>
+    <!-- minimal markup that reproduces the bug -->
+    <vaadin-<component>></vaadin-<component>>
+  </body>
+</html>
+```
+
+- Copy tag names, slots, and attributes from an existing `dev/<component>.html` rather than recalling them (Phase 1 component resolution).
+- If the bug needs scripting (events, programmatic API), add it in the module `<script>` after the import. Give elements `id`s so playwright-cli can target them.
+- Prefer a **minimal pair**: the failing case plus a control next to it that isolates the trigger — it also feeds the root-cause analysis.
+- **Feature-flagged components** (newer components not yet enabled by default) must enable the flag *before* importing — copy the pattern from `dev/breadcrumbs.html`:
+  ```html
+  <script type="module">
+    window.Vaadin ||= {};
+    window.Vaadin.featureFlags ||= {};
+    window.Vaadin.featureFlags.<flagName> = true;
+    import '@vaadin/<component>';
+  </script>
+  ```
+
+## 2. Run the dev server
+
+Start it in the background, from `<ROOT>`. The default theme is `base`; use the theme-specific command for visual/theme bugs:
+
+```bash
+cd "<ROOT>" && yarn start           # base styles, port 8000
+cd "<ROOT>" && yarn start:lumo      # Lumo theme
+cd "<ROOT>" && yarn start:aura      # Aura theme
+```
+
+The server serves the repo root, so the page is at `http://localhost:8000/dev/repro-<issue>.html`. It is ready almost immediately — confirm with `curl -sf http://localhost:8000/dev/repro-<issue>.html >/dev/null && echo ready` before driving the browser. It does **not** hot-reload: after editing the page, reload it in the browser (`page.reload()` or re-`open`) — no server restart needed.
+
+If port 8000 is already in use, start on another port instead — `yarn start --port 8001` — and use that port in every URL.
+
+## 3. Maintenance branches
+
+Branches are named `<major>.<minor>` (e.g. `24.10`, `25.1`). The branch for "up to 24.10.x" is `24.10`.
+
+**Pick the newest line that still reproduces — not necessarily the reported minor.** A bug filed against an old minor almost always still reproduces up its major line. Start at the latest line of the reported major; drop to an older minor only if it doesn't reproduce there (then you've also learned the upper bound).
+
+Safety — never clobber the user's work:
+
+1. Record the starting branch: `git -C <ROOT> rev-parse --abbrev-ref HEAD`.
+2. Require a clean tree. If `git -C <ROOT> status --porcelain` is non-empty, stop and ask — do not stash or discard.
+3. Fetch and check out: `git -C <ROOT> fetch origin <major>.<minor> && git -C <ROOT> checkout <major>.<minor>`.
+4. **Run `yarn install` after every switch between version lines** (both directions — including switching back) — dependencies drift between lines and a stale `node_modules` produces misleading results.
+
+A **"version-specific" verdict needs evidence at both ends**: reproduce on the affected branch **and** confirm it does *not* reproduce on the current checkout. If it doesn't reproduce even on the affected branch, say so.
+
+## 4. Stop the server
+
+Stop the background `yarn start` task you started.

--- a/.claude/skills/repro/references/share.md
+++ b/.claude/skills/repro/references/share.md
@@ -1,0 +1,86 @@
+# Phases 4–6 — Report, share, cleanup
+
+## 1. The report
+
+Copy [`assets/summary-template.md`](../assets/summary-template.md) to `<ROOT>/repro-<issue>-summary.md` and fill **every** field: observed vs. expected behavior, minimal steps, the inline reproduction, any screenshot/video. Cite only bug-relevant console output — never dev-server noise.
+
+**Chat reply is a digest, not a copy**: verdict + regression classification + branch (if pushed) + 3–5 bullets of what was observed, then point at the summary file. Don't restate the full summary in chat — the file is canonical and becomes the comment.
+
+Not reproduced: say so plainly and name the likely reason — fixed on `main` (cite the fixing PR from fix archaeology), version-specific, obsolete API, missing context. Don't force a positive result.
+
+## 2. End every run with a question — never prose
+
+The outward action is the user's; present it as an `AskUserQuestion` (2–4 options, recommended first), never a prose "want me to post…?":
+
+- **Reproduced:** `Push + post + label` · `Push branch only` · `Report only`.
+- **Not reproduced / fixed / duplicate:** the first option cites everything fix archaeology found — `Post close comment "Duplicate of #N, fixed by #PR"` (or just the PR / duplicate when only one is known); only when nothing was found offer the generic `Post "Could not reproduce using the latest Vaadin version. Closing as stale."`. Always include `Report only`.
+- **Reproduced but works-as-designed / already tracked by an enhancement:** `Report only` · `Push + post noting it`.
+
+Posting the comment is yours on approval; **closing the issue stays the user's action** unless they explicitly ask.
+
+## 3. Share the reproduction branch (reproduced only)
+
+Push from `<ROOT>`, under the `repro/` prefix so branches sort together.
+
+1. Note the starting branch: `git -C <ROOT> rev-parse --abbrev-ref HEAD`.
+2. Branch from the exact HEAD you reproduced on (e.g. a maintenance branch): `git -C <ROOT> checkout -b repro/<issue>`.
+3. **Stage only the files you created/edited** — scaffold, summary, demo screenshot/`*.webm` (copy from `/tmp` first). **Never `git add -A`.**
+   ```bash
+   git -C <ROOT> add dev/repro-<issue>.html repro-<issue>-summary.md repro-<issue>.png
+   git -C <ROOT> commit -m "test: reproduce #<issue> (<component>)"
+   ```
+4. Push: `git -C <ROOT> push -u origin repro/<issue>`. If the remote branch exists, use a suffix (`repro/<issue>-2`) rather than force-pushing.
+
+**Posting the comment** goes to a public upstream issue. **Show the rendered comment and get ONE explicit confirmation covering both the comment AND the `ai repro` label** — a separate label request after posting can be denied by permission tooling. Post via file input:
+
+```bash
+gh api repos/vaadin/web-components/issues/<issue>/comments -F body=@repro-<issue>-summary.md
+```
+
+Capture the returned `html_url`. Keep the `> [!WARNING]` disclaimer first. Then label (same confirmation): `gh issue edit <issue> --repo vaadin/web-components --add-label "ai repro"`.
+
+**Duplicate:** state it in the comment and recommend closing as a duplicate of #N (link both; note if #N is fixed). Surface the close command and run it only on explicit approval — never close yourself:
+
+```bash
+gh issue close <issue> --repo vaadin/web-components --reason "not planned" --comment "Duplicate of #N"
+```
+
+## 4. Screenshot embedding + permalinks
+
+Reference a committed screenshot by **commit SHA**, not branch name — a slashed branch name breaks raw URLs. Add to the summary before posting:
+
+```markdown
+![<caption>](https://raw.githubusercontent.com/vaadin/web-components/<commit-sha>/repro-<issue>.png)
+```
+
+where `<commit-sha>` is `git -C <ROOT> rev-parse HEAD`. A video can't embed via `gh` — surface the local `.webm` path so the approver can drag-drop it.
+
+Point at a suspected root cause as a **permalink pinned to a commit SHA**, not a bare `file:line`. On its own line it renders as an inline snippet:
+
+```
+https://github.com/vaadin/web-components/blob/<SHA>/<path>#L<start>-L<end>
+```
+
+Anchor it to the commit you reproduced on (`git -C <ROOT> rev-parse HEAD`); your branch leaves `src/` untouched, so line numbers match.
+
+## 5. Cleanup
+
+Stop the background `yarn start` task.
+
+**If it reproduced and you pushed `repro/<issue>`** — scaffold and summary are committed on that branch, so the working line is already clean. Just switch back:
+
+```bash
+git -C <ROOT> checkout <starting-branch>
+git -C <ROOT> branch -D repro/<issue>      # optional; preserved on the remote
+git -C <ROOT> branch -D <major>.<minor>    # drop any temp maintenance branch
+```
+
+**If it did not reproduce (no branch pushed)** — discard any tracked edits first, delete the untracked scaffold, then switch back:
+
+```bash
+rm -f <ROOT>/dev/repro-<issue>.html
+git -C <ROOT> checkout <starting-branch>
+git -C <ROOT> branch -D <major>.<minor>    # drop any temp maintenance branch
+```
+
+If you switched version lines during the session, run `yarn install` after switching back. Confirm `git -C <ROOT> status --porcelain` matches the Phase 0 baseline — your scaffold files gone, pre-existing entries untouched — and the repo is on the branch it started on. Delete any `/tmp` screenshot. Leave the pushed `repro/*` branches — they are the shared artifacts.

--- a/.claude/skills/repro/references/verify.md
+++ b/.claude/skills/repro/references/verify.md
@@ -1,0 +1,41 @@
+# Observing the bug in the browser
+
+Core discipline: **never claim a bug reproduced until you have seen the signal in a running browser.** A git diff, an issue comment, or a listening port is not evidence.
+
+## Drive the browser
+
+```bash
+playwright-cli open http://localhost:8000/dev/repro-<issue>.html
+playwright-cli snapshot
+# ... click / type / press to follow the repro steps ...
+playwright-cli console          # check for JS errors
+playwright-cli screenshot --filename=/tmp/repro-<issue>.png   # for visual bugs
+playwright-cli close
+```
+
+Prefer locators (`page.locator('#id')`) over coordinate clicks — locators pierce open shadow DOM, auto-wait, and auto-scroll; `page.mouse.click(x, y)` into nested shadow roots or overlays lands on the wrong element and yields garbage.
+
+## run-code, eval, snapshots
+
+- **`run-code` takes a function** `async (page) => {…}`; do DOM work inside `page.evaluate(() => {…})`. The outer scope has `page` only — no `document`/`window`/`setTimeout`; wait with `page.waitForTimeout(ms)`.
+- The script is echoed back and `console.log` is **not** captured — keep it terse and `return` a JSON string of the measurements. `--raw eval "() => …"` is for one-liners only: nested quotes inside it can fail silently (empty output) — move anything non-trivial into a file and run `run-code --filename`.
+- **`open <url>` once per session before any `run-code`** — a fresh CLI session errors *"browser is not open"*. `open` auto-prints a snapshot; otherwise navigate with `page.goto(...)` inside `run-code` and read values with `eval`. Snapshot only to discover structure/refs.
+
+## Filter dev-server noise
+
+Ignore dev-environment noise — a favicon 404 and the Lit dev-mode warning always appear under `yarn start` and belong to no bug. Don't cite them; if nothing else appears, say the console is clean.
+
+## Inspect the real DOM before asserting
+
+Components render into shadow DOM and slot into light DOM; "hidden" is rarely a `hidden` attribute — it may be a slot, a `part`, `display: none`, or a property. Don't guess a selector; dump the structure once, then build the check from what you see:
+
+```bash
+playwright-cli --raw eval "() => document.querySelector('vaadin-<component>').shadowRoot.innerHTML.replace(/\s+/g,' ').slice(0,800)"
+```
+
+Prefer the component's own state (a public/observed property, computed style, `offsetWidth > 0`) over the bare `hidden` attribute.
+
+## General gotchas
+
+- After setting a property/attribute on a Lit-based component, wait a frame before asserting computed styles — a same-tick `getComputedStyle` read shows the stale style.
+- Items of overlay components (combo-box, select, menu-bar) exist in the DOM only while the overlay is open and after data arrives; drive selection via the input (type + Enter) or wait for items.


### PR DESCRIPTION
## Description

Added new skill `.claude/skills/repro` that reproduces a bug from a `vaadin/web-components` issue URL: builds a minimal `dev/repro-<issue>.html` page, confirms the bug in a running browser via playwright-cli, points at the likely root cause, pushes a shareable `repro/<issue>` branch and (after confirmation) posts a summary comment on the issue.

```sh
/repro https://github.com/vaadin/web-components/issues/1488
```

Mirrors the flow-components skill (vaadin/flow-components#9752), adapted for the web-dev-server workflow: dev-page scaffold instead of an integration-test View, `yarn start` / `start:lumo` / `start:aura` theme variants, and no server-restart discipline.

## Type of change

- Internal change

## Note

- Requires [`playwright-cli`](https://github.com/microsoft/playwright-cli#installation) to be installed (including `ffmpeg` to record reproduction videos)
- Invocable only explicitly via `/repro` (`disable-model-invocation: true`), so the `claude` workflow won't auto-pick it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
