### PR TITLE
fix: update sizer cell first/last-column state on column reorder

### DIFF
--- a/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
+++ b/packages/grid/src/vaadin-grid-dynamic-columns-mixin.js
@@ -145,7 +145,10 @@ export const DynamicColumnsMixin = (superClass) =>
 
     /** @protected */
     _updateFirstAndLastColumn() {
-      Array.from(this.shadowRoot.querySelectorAll('tr')).forEach((row) => this._updateFirstAndLastColumnForRow(row));
+      // The sizer is a <caption> element, so it isn't matched by the <tr> selector
+      [...this.shadowRoot.querySelectorAll('tr'), this.$.sizer].forEach((row) => {
+        this._updateFirstAndLastColumnForRow(row);
+      });
     }
 
     /**

--- a/packages/grid/test/column-reordering.test.js
+++ b/packages/grid/test/column-reordering.test.js
@@ -364,60 +364,6 @@ describe('reordering simple grid', () => {
       expectVisualOrder(grid, [3, 1, 2, 4]);
     });
 
-    it('should set first-column attribute on the cell', () => {
-      let cell = getCellByCellContent(headerContent[0]);
-      expect(cell.hasAttribute('first-column')).to.be.true;
-      cell = getContainerCell(grid.$.items, 0, 0);
-      expect(cell.hasAttribute('first-column')).to.be.true;
-    });
-
-    it('should add first-column to cell part attribute', () => {
-      let cell = getCellByCellContent(headerContent[0]);
-      expect(cell.getAttribute('part')).to.contain('first-column-cell');
-      cell = getContainerCell(grid.$.items, 0, 0);
-      expect(cell.getAttribute('part')).to.contain('first-column-cell');
-    });
-
-    it('should update first-column attribute on reordering', () => {
-      dragOver(headerContent[2], headerContent[0]);
-      const cell = getCellByCellContent(headerContent[2]);
-      expect(cell.hasAttribute('first-column')).to.be.true;
-    });
-
-    it('should update first-column attribute (details open)', () => {
-      grid.openItemDetails(getRows(grid.$.items)[0].item);
-      dragOver(headerContent[2], headerContent[0]);
-      const cell = getCellByCellContent(headerContent[2]);
-      expect(cell.hasAttribute('first-column')).to.be.true;
-    });
-
-    it('should set last-column attribute on the cell', () => {
-      let cell = getCellByCellContent(headerContent[3]);
-      expect(cell.hasAttribute('last-column')).to.be.true;
-      cell = getContainerCell(grid.$.items, 0, 3);
-      expect(cell.hasAttribute('last-column')).to.be.true;
-    });
-
-    it('should add last-column to cell part attribute', () => {
-      let cell = getCellByCellContent(headerContent[3]);
-      expect(cell.getAttribute('part')).to.contain('last-column-cell');
-      cell = getContainerCell(grid.$.items, 0, 3);
-      expect(cell.getAttribute('part')).to.contain('last-column-cell');
-    });
-
-    it('should update last-column attribute on reordering', () => {
-      dragOver(headerContent[2], headerContent[3]);
-      const cell = getCellByCellContent(headerContent[2]);
-      expect(cell.hasAttribute('last-column')).to.be.true;
-    });
-
-    it('should update last-column attribute (details open)', () => {
-      grid.openItemDetails(getRows(grid.$.items)[0].item);
-      dragOver(headerContent[2], headerContent[3]);
-      const cell = getCellByCellContent(headerContent[2]);
-      expect(cell.hasAttribute('last-column')).to.be.true;
-    });
-
     it('should set order to new column', async () => {
       dragAndDropOver(headerContent[0], headerContent[1]);
       const col = document.createElement('vaadin-grid-column');

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -2476,10 +2476,10 @@ snapshots["vaadin-grid column reordering reordered"] =
     part="row"
   >
     <td
-      class="body-cell cell last-column-cell reorder--cell"
+      class="body-cell cell first-column-cell reorder--cell"
+      first-column=""
       id="vaadin-grid-cell-1"
-      last-column=""
-      part="cell body-cell last-column-cell reorder--cell"
+      part="cell body-cell first-column-cell reorder--cell"
       reorder-status=""
       role="gridcell"
       style="width: 100px; flex-grow: 1;"
@@ -2489,10 +2489,10 @@ snapshots["vaadin-grid column reordering reordered"] =
       </slot>
     </td>
     <td
-      class="body-cell cell first-column-cell reorder--cell"
-      first-column=""
+      class="body-cell cell last-column-cell reorder--cell"
       id="vaadin-grid-cell-0"
-      part="cell body-cell first-column-cell reorder--cell"
+      last-column=""
+      part="cell body-cell last-column-cell reorder--cell"
       reorder-status=""
       role="gridcell"
       style="width: 100px; flex-grow: 1;"
@@ -2705,10 +2705,10 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
     part="row"
   >
     <td
-      class="body-cell cell last-column-cell reorder--cell"
+      class="body-cell cell first-column-cell reorder--cell"
+      first-column=""
       id="vaadin-grid-cell-1"
-      last-column=""
-      part="cell body-cell last-column-cell reorder--cell"
+      part="cell body-cell first-column-cell reorder--cell"
       reorder-status=""
       role="gridcell"
       style="width: 100px; flex-grow: 1;"
@@ -2718,10 +2718,10 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
       </slot>
     </td>
     <td
-      class="body-cell cell first-column-cell reorder--cell"
-      first-column=""
+      class="body-cell cell last-column-cell reorder--cell"
       id="vaadin-grid-cell-0"
-      part="cell body-cell first-column-cell reorder--cell"
+      last-column=""
+      part="cell body-cell last-column-cell reorder--cell"
       reorder-status=""
       role="gridcell"
       style="width: 100px; flex-grow: 1;"

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -2461,3 +2461,493 @@ snapshots["vaadin-grid hidden column group with group footer"] =
 `;
 /* end snapshot vaadin-grid hidden column group with group footer */
 
+snapshots["vaadin-grid column reordering reordered"] = 
+`<table
+  aria-colcount="2"
+  aria-multiselectable="true"
+  aria-rowcount="3"
+  has-header=""
+  id="table"
+  role="treegrid"
+  tabindex="0"
+>
+  <caption
+    id="sizer"
+    part="row"
+  >
+    <td
+      class="body-cell cell last-column-cell reorder--cell"
+      id="vaadin-grid-cell-1"
+      last-column=""
+      part="cell body-cell last-column-cell reorder--cell"
+      reorder-status=""
+      role="gridcell"
+      style="width: 100px; flex-grow: 1;"
+      tabindex="-1"
+    >
+      <slot name="vaadin-grid-cell-content-1">
+      </slot>
+    </td>
+    <td
+      class="body-cell cell first-column-cell reorder--cell"
+      first-column=""
+      id="vaadin-grid-cell-0"
+      part="cell body-cell first-column-cell reorder--cell"
+      reorder-status=""
+      role="gridcell"
+      style="width: 100px; flex-grow: 1;"
+      tabindex="-1"
+    >
+      <slot name="vaadin-grid-cell-content-0">
+      </slot>
+    </td>
+  </caption>
+  <thead
+    id="header"
+    role="rowgroup"
+    style="transform: translate(0px, 0px);"
+  >
+    <tr
+      aria-rowindex="1"
+      class="first-header-row header-row last-header-row row"
+      part="row header-row first-header-row last-header-row"
+      role="row"
+      style="--_grid-horizontal-scroll-position: 0px;"
+      tabindex="-1"
+    >
+      <th
+        class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell reorder--cell"
+        first-column=""
+        part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="columnheader"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-header-cell-content-0-33">
+        </slot>
+      </th>
+      <th
+        class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell reorder--cell"
+        last-column=""
+        part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="columnheader"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="0"
+      >
+        <slot name="vaadin-grid-header-cell-content-0-32">
+        </slot>
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    id="items"
+    role="rowgroup"
+    style="transform: translate(0px, 0px); height: 72px;"
+  >
+    <tr
+      aria-rowindex="2"
+      aria-selected="false"
+      class="body-row drag-disabled-row drop-disabled-row even-row first-row row"
+      drag-disabled=""
+      drop-disabled=""
+      even=""
+      first=""
+      part="row body-row first-row even-row drag-disabled-row drop-disabled-row"
+      role="row"
+      style="position: absolute; transform: translateY(0px);"
+      tabindex="-1"
+    >
+      <td
+        aria-selected="false"
+        class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell reorder--cell"
+        first-column=""
+        id="vaadin-grid-cell-3"
+        part="cell body-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-3">
+        </slot>
+      </td>
+      <td
+        aria-selected="false"
+        class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell reorder--cell"
+        id="vaadin-grid-cell-2"
+        last-column=""
+        part="cell body-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="0"
+      >
+        <slot name="vaadin-grid-cell-content-2">
+        </slot>
+      </td>
+    </tr>
+    <tr
+      aria-rowindex="3"
+      aria-selected="false"
+      class="body-row drag-disabled-row drop-disabled-row last-row odd-row row"
+      drag-disabled=""
+      drop-disabled=""
+      last=""
+      odd=""
+      part="row body-row last-row odd-row drag-disabled-row drop-disabled-row"
+      role="row"
+      style="position: absolute; transform: translateY(36px);"
+      tabindex="-1"
+    >
+      <td
+        aria-selected="false"
+        class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell reorder--cell"
+        first-column=""
+        id="vaadin-grid-cell-5"
+        part="cell body-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-5">
+        </slot>
+      </td>
+      <td
+        aria-selected="false"
+        class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell reorder--cell"
+        id="vaadin-grid-cell-4"
+        last-column=""
+        part="cell body-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-4">
+        </slot>
+      </td>
+    </tr>
+  </tbody>
+  <tbody id="emptystatebody">
+    <tr id="emptystaterow">
+      <td
+        class="empty-state"
+        id="emptystatecell"
+        part="empty-state"
+        tabindex="0"
+      >
+        <slot
+          id="emptystateslot"
+          name="empty-state"
+        >
+        </slot>
+      </td>
+    </tr>
+  </tbody>
+  <tfoot
+    id="footer"
+    role="rowgroup"
+    style="transform: translate(0px, 0px);"
+  >
+    <tr
+      aria-rowindex="4"
+      class="footer-row row"
+      hidden=""
+      part="row footer-row"
+      role="row"
+      tabindex="-1"
+    >
+      <td
+        class="cell first-column-cell footer-cell reorder--cell"
+        first-column=""
+        part="cell footer-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-footer-cell-content-0-33">
+        </slot>
+      </td>
+      <td
+        class="cell footer-cell last-column-cell reorder--cell"
+        last-column=""
+        part="cell footer-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-footer-cell-content-0-32">
+        </slot>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+`;
+/* end snapshot vaadin-grid column reordering reordered */
+
+snapshots["vaadin-grid column reordering reordered details opened"] = 
+`<table
+  aria-colcount="2"
+  aria-multiselectable="true"
+  aria-rowcount="3"
+  has-header=""
+  id="table"
+  role="treegrid"
+  tabindex="0"
+>
+  <caption
+    id="sizer"
+    part="row"
+  >
+    <td
+      class="body-cell cell last-column-cell reorder--cell"
+      id="vaadin-grid-cell-1"
+      last-column=""
+      part="cell body-cell last-column-cell reorder--cell"
+      reorder-status=""
+      role="gridcell"
+      style="width: 100px; flex-grow: 1;"
+      tabindex="-1"
+    >
+      <slot name="vaadin-grid-cell-content-1">
+      </slot>
+    </td>
+    <td
+      class="body-cell cell first-column-cell reorder--cell"
+      first-column=""
+      id="vaadin-grid-cell-0"
+      part="cell body-cell first-column-cell reorder--cell"
+      reorder-status=""
+      role="gridcell"
+      style="width: 100px; flex-grow: 1;"
+      tabindex="-1"
+    >
+      <slot name="vaadin-grid-cell-content-0">
+      </slot>
+    </td>
+  </caption>
+  <thead
+    id="header"
+    role="rowgroup"
+    style="transform: translate(0px, 0px);"
+  >
+    <tr
+      aria-rowindex="1"
+      class="first-header-row header-row last-header-row row"
+      part="row header-row first-header-row last-header-row"
+      role="row"
+      style="--_grid-horizontal-scroll-position: 0px;"
+      tabindex="-1"
+    >
+      <th
+        class="cell first-column-cell first-header-row-cell header-cell last-header-row-cell reorder--cell"
+        first-column=""
+        part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="columnheader"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-header-cell-content-0-35">
+        </slot>
+      </th>
+      <th
+        class="cell first-header-row-cell header-cell last-column-cell last-header-row-cell reorder--cell"
+        last-column=""
+        part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="columnheader"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="0"
+      >
+        <slot name="vaadin-grid-header-cell-content-0-34">
+        </slot>
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    id="items"
+    role="rowgroup"
+    style="transform: translate(0px, 0px); height: 108px;"
+  >
+    <tr
+      aria-rowindex="2"
+      aria-selected="false"
+      class="body-row details-opened-row drag-disabled-row drop-disabled-row even-row first-row row"
+      details-opened=""
+      drag-disabled=""
+      drop-disabled=""
+      even=""
+      first=""
+      part="row body-row first-row even-row drag-disabled-row drop-disabled-row details-opened-row"
+      role="row"
+      style="position: absolute; transform: translateY(0px); padding-bottom: 36px;"
+      tabindex="-1"
+    >
+      <td
+        aria-controls="vaadin-grid-cell-6"
+        aria-selected="false"
+        class="body-cell cell details-opened-row-cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-column-cell first-row-cell reorder--cell"
+        first-column=""
+        id="vaadin-grid-cell-3"
+        part="cell body-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell details-opened-row-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-3">
+        </slot>
+      </td>
+      <td
+        aria-controls="vaadin-grid-cell-6"
+        aria-selected="false"
+        class="body-cell cell details-opened-row-cell drag-disabled-row-cell drop-disabled-row-cell even-row-cell first-row-cell last-column-cell reorder--cell"
+        id="vaadin-grid-cell-2"
+        last-column=""
+        part="cell body-cell first-row-cell even-row-cell drag-disabled-row-cell drop-disabled-row-cell details-opened-row-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="0"
+      >
+        <slot name="vaadin-grid-cell-content-2">
+        </slot>
+      </td>
+      <td
+        aria-selected="false"
+        class="cell details-cell"
+        frozen=""
+        id="vaadin-grid-cell-6"
+        part="cell details-cell"
+        role="gridcell"
+        style="transform: translate(0px, 0px);"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-6">
+        </slot>
+      </td>
+    </tr>
+    <tr
+      aria-rowindex="3"
+      aria-selected="false"
+      class="body-row drag-disabled-row drop-disabled-row last-row odd-row row"
+      drag-disabled=""
+      drop-disabled=""
+      last=""
+      odd=""
+      part="row body-row last-row odd-row drag-disabled-row drop-disabled-row"
+      role="row"
+      style="position: absolute; transform: translateY(72px);"
+      tabindex="-1"
+    >
+      <td
+        aria-controls="vaadin-grid-cell-7"
+        aria-selected="false"
+        class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell last-row-cell odd-row-cell reorder--cell"
+        first-column=""
+        id="vaadin-grid-cell-5"
+        part="cell body-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-5">
+        </slot>
+      </td>
+      <td
+        aria-controls="vaadin-grid-cell-7"
+        aria-selected="false"
+        class="body-cell cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell last-row-cell odd-row-cell reorder--cell"
+        id="vaadin-grid-cell-4"
+        last-column=""
+        part="cell body-cell last-row-cell odd-row-cell drag-disabled-row-cell drop-disabled-row-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-4">
+        </slot>
+      </td>
+      <td
+        aria-selected="false"
+        class="cell details-cell"
+        frozen=""
+        hidden=""
+        id="vaadin-grid-cell-7"
+        part="cell details-cell"
+        role="gridcell"
+        style="transform: translate(0px, 0px);"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-cell-content-7">
+        </slot>
+      </td>
+    </tr>
+  </tbody>
+  <tbody id="emptystatebody">
+    <tr id="emptystaterow">
+      <td
+        class="empty-state"
+        id="emptystatecell"
+        part="empty-state"
+        tabindex="0"
+      >
+        <slot
+          id="emptystateslot"
+          name="empty-state"
+        >
+        </slot>
+      </td>
+    </tr>
+  </tbody>
+  <tfoot
+    id="footer"
+    role="rowgroup"
+    style="transform: translate(0px, 0px);"
+  >
+    <tr
+      aria-rowindex="4"
+      class="footer-row row"
+      hidden=""
+      part="row footer-row"
+      role="row"
+      tabindex="-1"
+    >
+      <td
+        class="cell first-column-cell footer-cell reorder--cell"
+        first-column=""
+        part="cell footer-cell first-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-footer-cell-content-0-35">
+        </slot>
+      </td>
+      <td
+        class="cell footer-cell last-column-cell reorder--cell"
+        last-column=""
+        part="cell footer-cell last-column-cell reorder--cell"
+        reorder-status=""
+        role="gridcell"
+        style="width: 100px; flex-grow: 1;"
+        tabindex="-1"
+      >
+        <slot name="vaadin-grid-footer-cell-content-0-34">
+        </slot>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+`;
+/* end snapshot vaadin-grid column reordering reordered details opened */
+

--- a/packages/grid/test/dom/grid.test.js
+++ b/packages/grid/test/dom/grid.test.js
@@ -3,6 +3,7 @@ import { fixtureSync, nextFrame } from '@vaadin/testing-helpers';
 import '../grid-test-styles.js';
 import '../../vaadin-grid.js';
 import '../../vaadin-grid-column-group.js';
+import { dragAndDropOver, getHeaderCellContent } from '../helpers.js';
 import { users } from '../visual/users.js';
 
 describe('vaadin-grid', () => {
@@ -135,6 +136,36 @@ describe('vaadin-grid', () => {
       };
       await nextFrame();
       await expect(grid).shadowDom.to.equalSnapshot();
+    });
+  });
+
+  describe('column reordering', () => {
+    beforeEach(async () => {
+      grid = fixtureSync(`
+        <vaadin-grid column-reordering-allowed>
+          <vaadin-grid-column path="name.first"></vaadin-grid-column>
+          <vaadin-grid-column path="name.last"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      grid.items = users.slice(0, 2);
+      await nextFrame();
+    });
+
+    it('reordered', async () => {
+      dragAndDropOver(getHeaderCellContent(grid, 0, 0), getHeaderCellContent(grid, 0, 1));
+      await nextFrame();
+      await expect(grid.$.table).dom.to.equalSnapshot();
+    });
+
+    it('reordered details opened', async () => {
+      grid.rowDetailsRenderer = (root) => {
+        root.textContent = 'Details';
+      };
+      grid.detailsOpenedItems = [grid.items[0]];
+      await nextFrame();
+      dragAndDropOver(getHeaderCellContent(grid, 0, 0), getHeaderCellContent(grid, 0, 1));
+      await nextFrame();
+      await expect(grid.$.table).dom.to.equalSnapshot();
     });
   });
 });


### PR DESCRIPTION
After reordering columns, the sizer cells keep their old `first-column` / `last-column` attributes. `_updateFirstAndLastColumn` only queries `tr` elements, and the sizer is a `caption` element, so it is never updated on reorder.

This was found while extending test coverage: the column reordering tests only checked the `first-column` / `last-column` attributes on header cells after reordering. Body and sizer cells were only checked in the initial state, and they are updated through a different code path than header and footer cells, so a regression there would not have been caught.

The attribute assertions in `column-reordering.test.js` are replaced with DOM snapshot tests that capture the state of all sections (header, body, footer, sizer) after reordering, including all cell attributes and `part` names.

Part of https://github.com/vaadin/web-components/issues/10789