### PR TITLE
refactor!: render grid header and footer cell styles declaratively

### DIFF
--- a/packages/grid/src/directives/cell-content-directive.js
+++ b/packages/grid/src/directives/cell-content-directive.js
@@ -12,10 +12,11 @@ import { AsyncDirective, directive } from 'lit/async-directive.js';
 class CellContentDirective extends AsyncDirective {
   #cell;
 
-  update(part, [grid, slotName]) {
+  update(part, [grid, slotName, { textAlign } = {}]) {
     this.#cell = part.parentNode;
     this.#cell._content ??= document.createElement('vaadin-grid-cell-content');
     this.#cell._content.slot = slotName;
+    this.#cell._content.style.textAlign = textAlign ?? '';
 
     if (!grid.contains(this.#cell._content)) {
       grid.appendChild(this.#cell._content);

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -261,11 +261,11 @@ export const ColumnBaseMixin = (superClass) =>
 
     static get observers() {
       return [
-        '_widthChanged(width, _headerCell, _footerCell, _cells)',
+        '_widthChanged(width, _cells)',
         '_frozenChanged(frozen, _headerCell, _footerCell, _cells)',
         '_frozenToEndChanged(frozenToEnd, _headerCell, _footerCell, _cells)',
-        '_flexGrowChanged(flexGrow, _headerCell, _footerCell, _cells)',
-        '_textAlignChanged(textAlign, _cells, _headerCell, _footerCell)',
+        '_flexGrowChanged(flexGrow, _cells)',
+        '_textAlignChanged(textAlign, _cells)',
         '_lastFrozenChanged(_lastFrozen)',
         '_firstFrozenToEndChanged(_firstFrozenToEnd)',
         '_onRendererOrBindingChanged(_renderer, _cells, _bodyContentHidden, path)',
@@ -382,7 +382,9 @@ export const ColumnBaseMixin = (superClass) =>
         this.parentElement._columnPropChanged('flexGrow');
       }
 
-      this._allCells.forEach((cell) => {
+      this._grid?.__scheduleRenderHeaderFooter?.();
+
+      this._cells?.forEach((cell) => {
         cell.style.flexGrow = flexGrow;
       });
     }
@@ -393,7 +395,9 @@ export const ColumnBaseMixin = (superClass) =>
         this.parentElement._columnPropChanged('width');
       }
 
-      this._allCells.forEach((cell) => {
+      this._grid?.__scheduleRenderHeaderFooter?.();
+
+      this._cells?.forEach((cell) => {
         cell.style.width = width;
       });
     }
@@ -513,7 +517,9 @@ export const ColumnBaseMixin = (superClass) =>
         return;
       }
 
-      this._allCells.forEach((cell) => {
+      this._grid.__scheduleRenderHeaderFooter?.();
+
+      this._cells?.forEach((cell) => {
         cell._content.style.textAlign = textAlign;
       });
     }

--- a/packages/grid/src/vaadin-grid-column-resizing-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-resizing-mixin.js
@@ -98,6 +98,10 @@ export const ColumnResizingMixin = (superClass) =>
           cell._column.flexGrow = 0;
         });
 
+        // Flush the scheduled header/footer render to apply the new widths
+        // to the cells before measuring the layout below
+        this.__renderHeaderFooterDebouncer?.flush();
+
         const cellFrozenToEnd = this._frozenToEndCells[0];
 
         // When handle moves below the cell frozen to end, scroll into view.

--- a/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
+++ b/packages/grid/src/vaadin-grid-header-footer-rendering-mixin.js
@@ -8,6 +8,7 @@ import { cache } from 'lit/directives/cache.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { styleMap } from 'lit/directives/style-map.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { partMap } from '@vaadin/component-base/src/directives/part-map.js';
@@ -133,6 +134,10 @@ export const HeaderFooterRenderingMixin = (superClass) =>
                   role="columnheader"
                   part="cell header-cell${partMap(cellParts)}"
                   class="cell header-cell${classMap(cellParts)}"
+                  style="${styleMap({
+                    width: column.width,
+                    'flex-grow': column.flexGrow,
+                  })}"
                   ?first-column="${isFirstCell}"
                   ?last-column="${isLastCell}"
                   @keydown="${this.__onCellKeyDown}"
@@ -144,7 +149,9 @@ export const HeaderFooterRenderingMixin = (superClass) =>
                   tabindex="-1"
                   ._column=${column}
                 >
-                  ${cellContent(this, `vaadin-grid-header-cell-content-${level}-${column._id}`)}
+                  ${cellContent(this, `vaadin-grid-header-cell-content-${level}-${column._id}`, {
+                    textAlign: column.textAlign,
+                  })}
                   ${column.resizable ? html`<div part="resize-handle" class="resize-handle"></div>` : nothing}
                 </th>
               `);
@@ -208,6 +215,10 @@ export const HeaderFooterRenderingMixin = (superClass) =>
                   role="gridcell"
                   part="cell footer-cell${partMap(cellParts)}"
                   class="cell footer-cell${classMap(cellParts)}"
+                  style="${styleMap({
+                    width: column.width,
+                    'flex-grow': column.flexGrow,
+                  })}"
                   ?first-column="${isFirstCell}"
                   ?last-column="${isLastCell}"
                   @keydown="${this.__onCellKeyDown}"
@@ -219,7 +230,9 @@ export const HeaderFooterRenderingMixin = (superClass) =>
                   tabindex="-1"
                   ._column=${column}
                 >
-                  ${cellContent(this, `vaadin-grid-footer-cell-content-${level}-${column._id}`)}
+                  ${cellContent(this, `vaadin-grid-footer-cell-content-${level}-${column._id}`, {
+                    textAlign: column.textAlign,
+                  })}
                 </td>
               `);
             },

--- a/packages/grid/test/column-groups.test.js
+++ b/packages/grid/test/column-groups.test.js
@@ -136,6 +136,7 @@ describe('column groups', () => {
 
       it('should align visually to right', () => {
         emptyGroup.textAlign = 'end';
+        flushGrid(grid);
         expect(getComputedStyle(getContainerCellContent(grid.$.header, 0, 1)).textAlign).to.be.oneOf(['end', 'right']);
         expect(getComputedStyle(getContainerCellContent(grid.$.footer, 1, 1)).textAlign).to.be.oneOf(['end', 'right']);
       });
@@ -143,12 +144,14 @@ describe('column groups', () => {
       it('should align visually to left', () => {
         grid.style.direction = 'rtl';
         emptyGroup.textAlign = 'end';
+        flushGrid(grid);
         expect(getComputedStyle(getContainerCellContent(grid.$.header, 0, 1)).textAlign).to.be.oneOf(['end', 'left']);
         expect(getComputedStyle(getContainerCellContent(grid.$.footer, 1, 1)).textAlign).to.be.oneOf(['end', 'left']);
       });
 
       it('should align visually to center', () => {
         emptyGroup.textAlign = 'center';
+        flushGrid(grid);
         expect(getComputedStyle(getContainerCellContent(grid.$.header, 0, 1)).textAlign).to.equal('center');
         expect(getComputedStyle(getContainerCellContent(grid.$.footer, 1, 1)).textAlign).to.equal('center');
       });
@@ -183,6 +186,7 @@ describe('column groups', () => {
 
       expect(cellGroup0.style.flexGrow).to.equal('2');
       cellHeader1._column.flexGrow = 3;
+      flushGrid(grid);
       expect(cellGroup0.style.flexGrow).to.equal('4');
     });
 

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -49,6 +49,7 @@ describe('column', () => {
 
       it('should be bound to header cells', () => {
         column.flexGrow = 2;
+        flushGrid(grid);
 
         const header = grid.$.header;
 
@@ -64,6 +65,7 @@ describe('column', () => {
 
       it('should be bound to footer cells', () => {
         column.flexGrow = 2;
+        flushGrid(grid);
 
         expect(getContainerCell(grid.$.footer, 0, 0).style.flexGrow).to.eql('2');
       });
@@ -76,6 +78,7 @@ describe('column', () => {
 
       it('should be bound to header cells', () => {
         column.width = '20%';
+        flushGrid(grid);
 
         const width = getContainerCell(grid.$.header, 0, 0).style.width;
         expect(width).to.be.oneOf(['calc(20% + 100px)', 'calc(100px + 20%)']);
@@ -89,6 +92,7 @@ describe('column', () => {
 
       it('should be bound to footer cells', () => {
         column.width = '200px';
+        flushGrid(grid);
 
         expect(getContainerCell(grid.$.footer, 0, 0).style.width).to.eql('200px');
       });

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -102,7 +102,7 @@ snapshots["vaadin-grid basic shadow default"] =
           first-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-0-2">
@@ -113,7 +113,7 @@ snapshots["vaadin-grid basic shadow default"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-3">
@@ -241,7 +241,7 @@ snapshots["vaadin-grid basic shadow default"] =
           first-column=""
           part="cell footer-cell first-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-2">
@@ -252,7 +252,7 @@ snapshots["vaadin-grid basic shadow default"] =
           last-column=""
           part="cell footer-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-3">
@@ -342,7 +342,7 @@ snapshots["vaadin-grid basic shadow selected"] =
           first-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-0-4">
@@ -353,7 +353,7 @@ snapshots["vaadin-grid basic shadow selected"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-5">
@@ -482,7 +482,7 @@ snapshots["vaadin-grid basic shadow selected"] =
           first-column=""
           part="cell footer-cell first-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-4">
@@ -493,7 +493,7 @@ snapshots["vaadin-grid basic shadow selected"] =
           last-column=""
           part="cell footer-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-5">
@@ -583,7 +583,7 @@ snapshots["vaadin-grid basic shadow details opened"] =
           first-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-0-6">
@@ -594,7 +594,7 @@ snapshots["vaadin-grid basic shadow details opened"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-7">
@@ -722,7 +722,7 @@ snapshots["vaadin-grid basic shadow details opened"] =
           first-column=""
           part="cell footer-cell first-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-6">
@@ -733,7 +733,7 @@ snapshots["vaadin-grid basic shadow details opened"] =
           last-column=""
           part="cell footer-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-7">
@@ -813,7 +813,7 @@ snapshots["vaadin-grid basic shadow hidden column"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-0-9">
@@ -918,7 +918,7 @@ snapshots["vaadin-grid basic shadow hidden column"] =
           last-column=""
           part="cell footer-cell last-column-cell first-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-9">
@@ -998,7 +998,7 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-0-11">
@@ -1104,7 +1104,7 @@ snapshots["vaadin-grid basic shadow hidden column selected"] =
           last-column=""
           part="cell footer-cell last-column-cell first-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-11">
@@ -1195,7 +1195,7 @@ snapshots["vaadin-grid basic shadow with footer"] =
           first-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-0-12">
@@ -1206,7 +1206,7 @@ snapshots["vaadin-grid basic shadow with footer"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-13">
@@ -1333,7 +1333,7 @@ snapshots["vaadin-grid basic shadow with footer"] =
           first-column=""
           part="cell footer-cell first-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-footer-cell-content-0-12">
@@ -1344,7 +1344,7 @@ snapshots["vaadin-grid basic shadow with footer"] =
           last-column=""
           part="cell footer-cell last-column-cell first-footer-row-cell last-footer-row-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-13">
@@ -1438,7 +1438,7 @@ snapshots["vaadin-grid column groups default"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
-          style="width: calc(200px); flex-grow: 2;"
+          style="width:calc(100px + 100px);flex-grow:2;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-14">
@@ -1458,7 +1458,7 @@ snapshots["vaadin-grid column groups default"] =
           first-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-1-15">
@@ -1469,7 +1469,7 @@ snapshots["vaadin-grid column groups default"] =
           last-column=""
           part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-1-16">
@@ -1597,7 +1597,7 @@ snapshots["vaadin-grid column groups default"] =
           first-column=""
           part="cell footer-cell first-footer-row-cell last-footer-row-cell first-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-footer-cell-content-1-15">
@@ -1608,7 +1608,7 @@ snapshots["vaadin-grid column groups default"] =
           last-column=""
           part="cell footer-cell first-footer-row-cell last-footer-row-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-1-16">
@@ -1631,7 +1631,7 @@ snapshots["vaadin-grid column groups default"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
-          style="width: calc(200px); flex-grow: 2;"
+          style="width:calc(100px + 100px);flex-grow:2;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-14">
@@ -1677,7 +1677,7 @@ snapshots["vaadin-grid column groups with header"] =
       last-column=""
       part="cell header-cell first-column-cell last-column-cell first-header-row-cell"
       role="columnheader"
-      style="width: calc(200px); flex-grow: 2;"
+      style="width:calc(100px + 100px);flex-grow:2;"
       tabindex="-1"
     >
       <slot name="vaadin-grid-header-cell-content-0-17">
@@ -1697,7 +1697,7 @@ snapshots["vaadin-grid column groups with header"] =
       first-column=""
       part="cell header-cell last-header-row-cell first-column-cell"
       role="columnheader"
-      style="width: 100px; flex-grow: 1;"
+      style="width:100px;flex-grow:1;"
       tabindex="0"
     >
       <slot name="vaadin-grid-header-cell-content-1-18">
@@ -1708,7 +1708,7 @@ snapshots["vaadin-grid column groups with header"] =
       last-column=""
       part="cell header-cell last-header-row-cell last-column-cell"
       role="columnheader"
-      style="width: 100px; flex-grow: 1;"
+      style="width:100px;flex-grow:1;"
       tabindex="-1"
     >
       <slot name="vaadin-grid-header-cell-content-1-19">
@@ -1738,7 +1738,7 @@ snapshots["vaadin-grid column groups with footer"] =
       first-column=""
       part="cell footer-cell first-footer-row-cell first-column-cell"
       role="gridcell"
-      style="width: 100px; flex-grow: 1;"
+      style="width:100px;flex-grow:1;"
       tabindex="0"
     >
       <slot name="vaadin-grid-footer-cell-content-1-21">
@@ -1749,7 +1749,7 @@ snapshots["vaadin-grid column groups with footer"] =
       last-column=""
       part="cell footer-cell first-footer-row-cell last-column-cell"
       role="gridcell"
-      style="width: 100px; flex-grow: 1;"
+      style="width:100px;flex-grow:1;"
       tabindex="-1"
     >
       <slot name="vaadin-grid-footer-cell-content-1-22">
@@ -1771,7 +1771,7 @@ snapshots["vaadin-grid column groups with footer"] =
       last-column=""
       part="cell footer-cell first-column-cell last-column-cell last-footer-row-cell"
       role="gridcell"
-      style="width: calc(200px); flex-grow: 2;"
+      style="width:calc(100px + 100px);flex-grow:2;"
       tabindex="-1"
     >
       <slot name="vaadin-grid-footer-cell-content-0-20">
@@ -1836,7 +1836,7 @@ snapshots["vaadin-grid hidden column group with group header"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell "
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-23">
@@ -1857,7 +1857,7 @@ snapshots["vaadin-grid hidden column group with group header"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-1-23">
@@ -1962,7 +1962,7 @@ snapshots["vaadin-grid hidden column group with group header"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-1-23">
@@ -1983,7 +1983,7 @@ snapshots["vaadin-grid hidden column group with group header"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell "
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-23">
@@ -2063,7 +2063,7 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell "
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-26">
@@ -2084,7 +2084,7 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell first-header-row-cell last-header-row-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="0"
         >
           <slot name="vaadin-grid-header-cell-content-1-26">
@@ -2189,7 +2189,7 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-1-26">
@@ -2210,7 +2210,7 @@ snapshots["vaadin-grid hidden column group with group and column header"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell "
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-26">
@@ -2289,7 +2289,7 @@ snapshots["vaadin-grid hidden column group with group footer"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell "
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-0-29">
@@ -2310,7 +2310,7 @@ snapshots["vaadin-grid hidden column group with group footer"] =
           last-column=""
           part="cell header-cell first-column-cell last-column-cell"
           role="columnheader"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-header-cell-content-1-29">
@@ -2415,7 +2415,7 @@ snapshots["vaadin-grid hidden column group with group footer"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell"
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-1-29">
@@ -2436,7 +2436,7 @@ snapshots["vaadin-grid hidden column group with group footer"] =
           last-column=""
           part="cell footer-cell first-column-cell last-column-cell "
           role="gridcell"
-          style="width: 100px; flex-grow: 1;"
+          style="width:100px;flex-grow:1;"
           tabindex="-1"
         >
           <slot name="vaadin-grid-footer-cell-content-0-29">
@@ -2521,7 +2521,7 @@ snapshots["vaadin-grid column reordering reordered"] =
         part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell reorder--cell"
         reorder-status=""
         role="columnheader"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="-1"
       >
         <slot name="vaadin-grid-header-cell-content-0-33">
@@ -2533,7 +2533,7 @@ snapshots["vaadin-grid column reordering reordered"] =
         part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell reorder--cell"
         reorder-status=""
         role="columnheader"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="0"
       >
         <slot name="vaadin-grid-header-cell-content-0-32">
@@ -2666,7 +2666,7 @@ snapshots["vaadin-grid column reordering reordered"] =
         part="cell footer-cell first-column-cell reorder--cell"
         reorder-status=""
         role="gridcell"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="-1"
       >
         <slot name="vaadin-grid-footer-cell-content-0-33">
@@ -2678,7 +2678,7 @@ snapshots["vaadin-grid column reordering reordered"] =
         part="cell footer-cell last-column-cell reorder--cell"
         reorder-status=""
         role="gridcell"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="-1"
       >
         <slot name="vaadin-grid-footer-cell-content-0-32">
@@ -2750,7 +2750,7 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
         part="cell header-cell first-header-row-cell last-header-row-cell first-column-cell reorder--cell"
         reorder-status=""
         role="columnheader"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="-1"
       >
         <slot name="vaadin-grid-header-cell-content-0-35">
@@ -2762,7 +2762,7 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
         part="cell header-cell first-header-row-cell last-header-row-cell last-column-cell reorder--cell"
         reorder-status=""
         role="columnheader"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="0"
       >
         <slot name="vaadin-grid-header-cell-content-0-34">
@@ -2927,7 +2927,7 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
         part="cell footer-cell first-column-cell reorder--cell"
         reorder-status=""
         role="gridcell"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="-1"
       >
         <slot name="vaadin-grid-footer-cell-content-0-35">
@@ -2939,7 +2939,7 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
         part="cell footer-cell last-column-cell reorder--cell"
         reorder-status=""
         role="gridcell"
-        style="width: 100px; flex-grow: 1;"
+        style="width:100px;flex-grow:1;"
         tabindex="-1"
       >
         <slot name="vaadin-grid-footer-cell-content-0-34">

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -357,6 +357,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
             grid._columnTree[0][i].width = '10px';
             grid._columnTree[0][i].flexGrow = 0;
           }
+          flushGrid(grid);
 
           const finalBoundingClientRect = getRowCells(containerRows[0])[2].getBoundingClientRect();
           expect(finalBoundingClientRect.x).to.equal(initBoundingClientRect.x);
@@ -376,6 +377,7 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
             grid._columnTree[0][i].width = '10px';
             grid._columnTree[0][i].flexGrow = 0;
           }
+          flushGrid(grid);
 
           const boundingClientRect = getRowCells(containerRows[0])[2].getBoundingClientRect();
           let xCoordinate;


### PR DESCRIPTION
This PR continues the migration of the imperatively applied header/footer cell state into Lit templates. The header/footer templates now render the cell `width`, `flex-grow`, and `text-align` styles themselves, so the corresponding column observers only style body cells and schedule a re-render.

> [!WARNING]
> Setting `width`, `flexGrow`, or `textAlign` on a column now updates header and footer cells asynchronously, in a scheduled microtask. Code that changes these properties and measures header/footer cells right after needs to wait for the update to be applied. Body cells are still updated synchronously.

Part of #10789