### PR TITLE
feat: support left and right in grid column text-align

### DIFF
--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -70,8 +70,7 @@ export declare class ColumnBaseMixinClass<TItem, Column extends ColumnBaseMixinC
   header: string | null | undefined;
 
   /**
-   * Aligns the columns cell content horizontally by setting the CSS
-   * `text-align` property on the cell content.
+   * Aligns the columns cell content horizontally.
    *
    * @attr {start|center|end|left|right} text-align
    */

--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -12,7 +12,7 @@ export type GridBodyRenderer<TItem, Column extends GridColumnMixin<TItem, Column
   model: GridItemModel<TItem>,
 ) => void;
 
-export type GridColumnTextAlign = 'center' | 'end' | 'justify' | 'left' | 'right' | 'start' | null;
+export type GridColumnTextAlign = 'center' | 'end' | 'left' | 'right' | 'start' | null;
 
 export type GridHeaderFooterRenderer<TItem, Column extends ColumnBaseMixinClass<TItem, Column>> = (
   root: HTMLElement,
@@ -72,8 +72,8 @@ export declare class ColumnBaseMixinClass<TItem, Column extends ColumnBaseMixinC
   /**
    * Aligns the columns cell content horizontally by setting the CSS
    * `text-align` property on the cell content.
-   * Supported values: "start", "center", "end", "left", "right" and "justify".
-   * @attr {start|center|end|left|right|justify} text-align
+   *
+   * @attr {start|center|end|left|right} text-align
    */
   textAlign: GridColumnTextAlign | null | undefined;
 

--- a/packages/grid/src/vaadin-grid-column-mixin.d.ts
+++ b/packages/grid/src/vaadin-grid-column-mixin.d.ts
@@ -12,7 +12,7 @@ export type GridBodyRenderer<TItem, Column extends GridColumnMixin<TItem, Column
   model: GridItemModel<TItem>,
 ) => void;
 
-export type GridColumnTextAlign = 'center' | 'end' | 'start' | null;
+export type GridColumnTextAlign = 'center' | 'end' | 'justify' | 'left' | 'right' | 'start' | null;
 
 export type GridHeaderFooterRenderer<TItem, Column extends ColumnBaseMixinClass<TItem, Column>> = (
   root: HTMLElement,
@@ -70,9 +70,10 @@ export declare class ColumnBaseMixinClass<TItem, Column extends ColumnBaseMixinC
   header: string | null | undefined;
 
   /**
-   * Aligns the columns cell content horizontally.
-   * Supported values: "start", "center" and "end".
-   * @attr {start|center|end} text-align
+   * Aligns the columns cell content horizontally by setting the CSS
+   * `text-align` property on the cell content.
+   * Supported values: "start", "center", "end", "left", "right" and "justify".
+   * @attr {start|center|end|left|right|justify} text-align
    */
   textAlign: GridColumnTextAlign | null | undefined;
 

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -92,8 +92,7 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * Aligns the columns cell content horizontally by setting the CSS
-         * `text-align` property on the cell content.
+         * Aligns the columns cell content horizontally.
          *
          * @attr {start|center|end|left|right} text-align
          */

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -94,8 +94,8 @@ export const ColumnBaseMixin = (superClass) =>
         /**
          * Aligns the columns cell content horizontally by setting the CSS
          * `text-align` property on the cell content.
-         * Supported values: "start", "center", "end", "left", "right" and "justify".
-         * @attr {start|center|end|left|right|justify} text-align
+         *
+         * @attr {start|center|end|left|right} text-align
          */
         textAlign: {
           type: String,

--- a/packages/grid/src/vaadin-grid-column-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-mixin.js
@@ -92,9 +92,10 @@ export const ColumnBaseMixin = (superClass) =>
         },
 
         /**
-         * Aligns the columns cell content horizontally.
-         * Supported values: "start", "center" and "end".
-         * @attr {start|center|end} text-align
+         * Aligns the columns cell content horizontally by setting the CSS
+         * `text-align` property on the cell content.
+         * Supported values: "start", "center", "end", "left", "right" and "justify".
+         * @attr {start|center|end|left|right|justify} text-align
          */
         textAlign: {
           type: String,
@@ -510,10 +511,6 @@ export const ColumnBaseMixin = (superClass) =>
     /** @private */
     _textAlignChanged(textAlign) {
       if (textAlign === undefined || this._grid === undefined) {
-        return;
-      }
-      if (['start', 'end', 'center'].indexOf(textAlign) === -1) {
-        console.warn('textAlign can only be set as "start", "end" or "center"');
         return;
       }
 

--- a/packages/grid/test/column.test.js
+++ b/packages/grid/test/column.test.js
@@ -395,55 +395,6 @@ describe('column', () => {
         expect(spy.callCount).to.equal(callCount);
       });
     });
-
-    describe('Text align', () => {
-      it('should align visually to right', () => {
-        emptyColumn.textAlign = 'end';
-        expect(getComputedStyle(getHeaderCellContent(grid, 1, 2)).textAlign).to.be.oneOf(['end', 'right']);
-        expect(getComputedStyle(getBodyCellContent(grid, 0, 2)).textAlign).to.be.oneOf(['end', 'right']);
-        expect(getComputedStyle(getContainerCellContent(grid.$.footer, 0, 2)).textAlign).to.be.oneOf(['end', 'right']);
-      });
-
-      it('should align visually to left', () => {
-        grid.style.direction = 'rtl';
-        emptyColumn.textAlign = 'end';
-        expect(getComputedStyle(getHeaderCellContent(grid, 1, 2)).textAlign).to.be.oneOf(['end', 'left']);
-        expect(getComputedStyle(getBodyCellContent(grid, 0, 2)).textAlign).to.be.oneOf(['end', 'left']);
-        expect(getComputedStyle(getContainerCellContent(grid.$.footer, 0, 2)).textAlign).to.be.oneOf(['end', 'left']);
-      });
-
-      it('should align visually to center', () => {
-        emptyColumn.textAlign = 'center';
-        expect(getComputedStyle(getHeaderCellContent(grid, 1, 2)).textAlign).to.equal('center');
-        expect(getComputedStyle(getBodyCellContent(grid, 0, 2)).textAlign).to.equal('center');
-        expect(getComputedStyle(getContainerCellContent(grid.$.footer, 0, 2)).textAlign).to.equal('center');
-      });
-
-      describe('warnings', () => {
-        beforeEach(() => {
-          sinon.stub(console, 'warn');
-        });
-
-        afterEach(() => {
-          console.warn.restore();
-        });
-
-        it('should warn about invalid text-align value', () => {
-          emptyColumn.textAlign = 'right';
-          expect(console.warn.callCount).to.equal(1);
-        });
-
-        it('should not warn about valid text-align value', () => {
-          emptyColumn.textAlign = 'center';
-          expect(console.warn.callCount).to.equal(0);
-        });
-
-        it('invalid value should not change the effective value', () => {
-          emptyColumn.textAlign = 'right';
-          expect(getComputedStyle(getBodyCellContent(grid, 0, 2)).textAlign).not.to.equal('right');
-        });
-      });
-    });
   });
 
   describe('observing', () => {

--- a/packages/grid/test/dom/__snapshots__/grid.test.snap.js
+++ b/packages/grid/test/dom/__snapshots__/grid.test.snap.js
@@ -2951,3 +2951,59 @@ snapshots["vaadin-grid column reordering reordered details opened"] =
 `;
 /* end snapshot vaadin-grid column reordering reordered details opened */
 
+snapshots["vaadin-grid column text align default"] = 
+`<vaadin-grid style="">
+  <vaadin-grid-column
+    path="name.first"
+    text-align="right"
+  >
+  </vaadin-grid-column>
+  <vaadin-grid-column path="name.last">
+  </vaadin-grid-column>
+  <vaadin-grid-cell-content
+    slot="vaadin-grid-header-cell-content-0-36"
+    style="text-align: right;"
+  >
+    Header
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-header-cell-content-0-37">
+    Header
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content
+    slot="vaadin-grid-footer-cell-content-0-36"
+    style="text-align: right;"
+  >
+    Footer
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-footer-cell-content-0-37">
+    Footer
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content
+    slot="vaadin-grid-cell-content-0"
+    style="text-align: right;"
+  >
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-1">
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content
+    slot="vaadin-grid-cell-content-2"
+    style="text-align: right;"
+  >
+    Laura
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-3">
+    Arnaud
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content
+    slot="vaadin-grid-cell-content-4"
+    style="text-align: right;"
+  >
+    Fabien
+  </vaadin-grid-cell-content>
+  <vaadin-grid-cell-content slot="vaadin-grid-cell-content-5">
+    Le gall
+  </vaadin-grid-cell-content>
+</vaadin-grid>
+`;
+/* end snapshot vaadin-grid column text align default */
+

--- a/packages/grid/test/dom/grid.test.js
+++ b/packages/grid/test/dom/grid.test.js
@@ -168,4 +168,29 @@ describe('vaadin-grid', () => {
       await expect(grid.$.table).dom.to.equalSnapshot();
     });
   });
+
+  describe('column text align', () => {
+    beforeEach(async () => {
+      grid = fixtureSync(`
+        <vaadin-grid>
+          <vaadin-grid-column path="name.first" text-align="right"></vaadin-grid-column>
+          <vaadin-grid-column path="name.last"></vaadin-grid-column>
+        </vaadin-grid>
+      `);
+      grid.querySelectorAll('vaadin-grid-column').forEach((column) => {
+        column.headerRenderer = (root) => {
+          root.textContent = 'Header';
+        };
+        column.footerRenderer = (root) => {
+          root.textContent = 'Footer';
+        };
+      });
+      grid.items = users.slice(0, 2);
+      await nextFrame();
+    });
+
+    it('default', async () => {
+      await expect(grid).dom.to.equalSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
The grid column `textAlign` property previously accepted only `start`, `center`, and `end`, rejecting any other value with a console warning. This restriction was introduced in 2018 to support mapping `start`/`end` to `left`/`right` based on direction, which was necessary back then because browsers didn't yet support the logical values. That mapping was removed in #10165, but the check remained.

This PR removes the check. The value now passes straight through to the cell content's CSS text-align property, so any value supported by the browser can be used, and invalid ones are simply ignored.

Removing the check also makes `textAlign = null` reset the alignment, since previously `null` didn't pass the allowlist and alignment couldn't be cleared.

Part of https://github.com/vaadin/web-components/issues/10789, vaadin/flow-components#2879