### PR TITLE
refactor: move orientation property from ListMixin to tabs

### DIFF
--- a/packages/a11y-base/src/list-mixin.d.ts
+++ b/packages/a11y-base/src/list-mixin.d.ts
@@ -29,13 +29,6 @@ export declare class ListMixinClass {
   selected: number | null | undefined;
 
   /**
-   * Define how items are disposed in the dom.
-   * Possible values are: `horizontal|vertical`.
-   * It also changes navigation keys from left/right to up/down.
-   */
-  orientation: 'horizontal' | 'vertical';
-
-  /**
    * Used for mixin detection because `instanceof` does not work with mixins.
    */
   protected _hasVaadinListMixin: boolean;

--- a/packages/a11y-base/src/list-mixin.js
+++ b/packages/a11y-base/src/list-mixin.js
@@ -40,17 +40,6 @@ export const ListMixin = (superClass) =>
         },
 
         /**
-         * Define how items are disposed in the dom.
-         * Possible values are: `horizontal|vertical`.
-         * It also changes navigation keys from left/right to up/down.
-         */
-        orientation: {
-          type: String,
-          reflectToAttribute: true,
-          value: '',
-        },
-
-        /**
          * A read-only list of items from which a selection can be made.
          * It is populated from the elements passed to the light DOM,
          * and updated dynamically when adding or removing items.
@@ -74,7 +63,7 @@ export const ListMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['_enhanceItems(items, orientation, selected, disabled)'];
+      return ['_enhanceItems(items, selected, disabled)'];
     }
 
     constructor() {
@@ -159,18 +148,9 @@ export const ListMixin = (superClass) =>
     }
 
     /** @private */
-    _enhanceItems(items, orientation, selected, disabled) {
+    _enhanceItems(items, selected, disabled) {
       if (!disabled) {
         if (items) {
-          this.setAttribute('aria-orientation', orientation || 'vertical');
-          items.forEach((item) => {
-            if (orientation) {
-              item.setAttribute('orientation', orientation);
-            } else {
-              item.removeAttribute('orientation');
-            }
-          });
-
           // When selected is set to -1, focus the first available item.
           this._setFocusable(selected < 0 || !selected ? 0 : selected);
 

--- a/packages/a11y-base/test/list-mixin.test.js
+++ b/packages/a11y-base/test/list-mixin.test.js
@@ -43,6 +43,18 @@ describe('ListMixin', () => {
     `,
     (Base) =>
       class extends ListMixin(PolylitMixin(Base)) {
+        static get properties() {
+          return {
+            // `orientation` is no longer defined by `ListMixin`. Define it here
+            // to keep testing the orientation-dependent behavior of the mixin.
+            orientation: {
+              type: String,
+              reflectToAttribute: true,
+              value: '',
+            },
+          };
+        }
+
         get _scrollerElement() {
           return this.$.scroll;
         }
@@ -566,59 +578,6 @@ describe('ListMixin', () => {
         </${listTag}>
       `);
       await nextRender();
-    });
-
-    it('should set aria-orientation attribute to vertical by default', () => {
-      expect(list.getAttribute('aria-orientation')).to.be.equal('vertical');
-    });
-
-    it('should set aria-orientation attribute to horizontal when orientation is set', async () => {
-      list.orientation = 'horizontal';
-      await nextUpdate(list);
-      expect(list.getAttribute('aria-orientation')).to.be.equal('horizontal');
-    });
-
-    it('should set aria-orientation attribute to horizontal when orientation is set', async () => {
-      list.orientation = 'vertical';
-      await nextUpdate(list);
-      expect(list.getAttribute('aria-orientation')).to.be.equal('vertical');
-    });
-
-    it('should not have orientation attribute on each item if orientation is not set', () => {
-      list.querySelectorAll(itemTag).forEach((item) => {
-        expect(item.hasAttribute('orientation')).to.be.false;
-      });
-    });
-
-    it('should have orientation attribute on each item', async () => {
-      list.orientation = 'horizontal';
-      await nextUpdate(list);
-      list.querySelectorAll(itemTag).forEach((item) => {
-        expect(item.getAttribute('orientation')).to.be.equal('horizontal');
-      });
-    });
-
-    it('should change orientation attribute on each item', async () => {
-      list.orientation = 'horizontal';
-      await nextUpdate(list);
-
-      list.orientation = 'vertical';
-      await nextUpdate(list);
-
-      list.querySelectorAll(itemTag).forEach((item) => {
-        expect(item.getAttribute('orientation')).to.be.equal('vertical');
-      });
-    });
-
-    it('should have vertical attribute on newly added item', async () => {
-      list.orientation = 'vertical';
-      await nextUpdate(list);
-
-      const item = document.createElement(itemTag);
-      item.textContent = 'foo';
-      list.appendChild(item);
-      await nextRender();
-      expect(item.hasAttribute('orientation')).to.be.true;
     });
 
     it('should have a protected boolean property to check vertical orientation', async () => {

--- a/packages/avatar-group/src/vaadin-avatar-group-menu.js
+++ b/packages/avatar-group/src/vaadin-avatar-group-menu.js
@@ -29,17 +29,6 @@ class AvatarGroupMenu extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(Lumo
     return avatarGroupMenuStyles;
   }
 
-  static get properties() {
-    return {
-      // We don't need to define this property since super default is vertical,
-      // but we don't want it to be modified, or be shown in the API docs.
-      /** @private */
-      orientation: {
-        readOnly: true,
-      },
-    };
-  }
-
   /**
    * @return {!HTMLElement}
    * @protected

--- a/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
+++ b/packages/avatar-group/test/dom/__snapshots__/avatar-group.test.snap.js
@@ -35,7 +35,6 @@ snapshots["vaadin-avatar-group default"] =
 snapshots["vaadin-avatar-group items"] = 
 `<vaadin-avatar-group aria-label="Currently 2 active users">
   <vaadin-avatar-group-menu
-    aria-orientation="vertical"
     role="menu"
     slot="overlay"
   >
@@ -121,7 +120,6 @@ snapshots["vaadin-avatar-group theme"] =
   theme="small"
 >
   <vaadin-avatar-group-menu
-    aria-orientation="vertical"
     role="menu"
     slot="overlay"
   >
@@ -212,7 +210,6 @@ snapshots["vaadin-avatar-group opened default"] =
   top-aligned=""
 >
   <vaadin-avatar-group-menu
-    aria-orientation="vertical"
     role="menu"
     slot="overlay"
   >

--- a/packages/context-menu/src/vaadin-context-menu-list-box.js
+++ b/packages/context-menu/src/vaadin-context-menu-list-box.js
@@ -47,18 +47,6 @@ class ContextMenuListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(L
     return listBoxStyles;
   }
 
-  static get properties() {
-    return {
-      // We don't need to define this property since super default is vertical,
-      // but we don't want it to be modified, or be shown in the API docs.
-      /** @private */
-      orientation: {
-        type: String,
-        readOnly: true,
-      },
-    };
-  }
-
   /**
    * @return {!HTMLElement}
    * @protected

--- a/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
+++ b/packages/context-menu/test/dom/__snapshots__/context-menu.test.snap.js
@@ -7,10 +7,7 @@ snapshots["context-menu items"] =
     Target
   </div>
   <div slot="overlay">
-    <vaadin-context-menu-list-box
-      aria-orientation="vertical"
-      role="menu"
-    >
+    <vaadin-context-menu-list-box role="menu">
       <vaadin-context-menu-item
         aria-haspopup="false"
         aria-selected="false"
@@ -74,10 +71,7 @@ snapshots["context-menu items nested"] =
   top-aligned=""
 >
   <div slot="overlay">
-    <vaadin-context-menu-list-box
-      aria-orientation="vertical"
-      role="menu"
-    >
+    <vaadin-context-menu-list-box role="menu">
       <vaadin-context-menu-item
         aria-haspopup="false"
         aria-selected="false"
@@ -108,10 +102,7 @@ snapshots["context-menu items nested"] =
     top-aligned=""
   >
     <div slot="overlay">
-      <vaadin-context-menu-list-box
-        aria-orientation="vertical"
-        role="menu"
-      >
+      <vaadin-context-menu-list-box role="menu">
         <vaadin-context-menu-item
           aria-haspopup="false"
           aria-selected="false"

--- a/packages/list-box/src/vaadin-list-box.js
+++ b/packages/list-box/src/vaadin-list-box.js
@@ -58,17 +58,6 @@ class ListBox extends ElementMixin(MultiSelectListMixin(ThemableMixin(PolylitMix
     return listBoxStyles;
   }
 
-  static get properties() {
-    return {
-      // We don't need to define this property since super default is vertical,
-      // but we don't want it to be modified, or be shown in the API docs.
-      /** @private */
-      orientation: {
-        readOnly: true,
-      },
-    };
-  }
-
   /** @protected */
   render() {
     return html`

--- a/packages/list-box/test/multi-select-list-mixin.test.js
+++ b/packages/list-box/test/multi-select-list-mixin.test.js
@@ -29,6 +29,18 @@ describe('MultiSelectListMixin', () => {
     `,
     (Base) =>
       class extends MultiSelectListMixin(PolylitMixin(Base)) {
+        static get properties() {
+          return {
+            // `orientation` is no longer defined by `ListMixin`. Define it here
+            // to keep testing the orientation-dependent behavior of the mixin.
+            orientation: {
+              type: String,
+              reflectToAttribute: true,
+              value: '',
+            },
+          };
+        }
+
         get _scrollerElement() {
           return this.$.scroll;
         }

--- a/packages/menu-bar/src/vaadin-menu-bar-list-box.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-list-box.js
@@ -29,18 +29,6 @@ class MenuBarListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoI
     return listBoxStyles;
   }
 
-  static get properties() {
-    return {
-      // We don't need to define this property since super default is vertical,
-      // but we don't want it to be modified, or be shown in the API docs.
-      /** @private */
-      orientation: {
-        type: String,
-        readOnly: true,
-      },
-    };
-  }
-
   /**
    * @return {!HTMLElement}
    * @protected

--- a/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
+++ b/packages/menu-bar/test/dom/__snapshots__/menu-bar.test.snap.js
@@ -82,10 +82,7 @@ snapshots["menu-bar opened"] =
       slot="overlay"
       style="display: contents;"
     >
-      <vaadin-menu-bar-list-box
-        aria-orientation="vertical"
-        role="menu"
-      >
+      <vaadin-menu-bar-list-box role="menu">
         <vaadin-menu-bar-item
           aria-haspopup="false"
           aria-selected="false"

--- a/packages/select/src/vaadin-select-list-box.js
+++ b/packages/select/src/vaadin-select-list-box.js
@@ -47,17 +47,6 @@ class SelectListBox extends ListMixin(ThemableMixin(DirMixin(PolylitMixin(LumoIn
     return listBoxStyles;
   }
 
-  static get properties() {
-    return {
-      // We don't need to define this property since super default is vertical,
-      // but we don't want it to be modified, or be shown in the API docs.
-      /** @private */
-      orientation: {
-        readOnly: true,
-      },
-    };
-  }
-
   /**
    * @return {!HTMLElement}
    * @protected

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -4,10 +4,7 @@ export const snapshots = {};
 snapshots["vaadin-select host default"] = 
 `<vaadin-select>
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -55,10 +52,7 @@ snapshots["vaadin-select host default"] =
 snapshots["vaadin-select host label"] = 
 `<vaadin-select has-label="">
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -108,10 +102,7 @@ snapshots["vaadin-select host label"] =
 snapshots["vaadin-select host placeholder"] = 
 `<vaadin-select>
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -167,10 +158,7 @@ snapshots["vaadin-select host disabled"] =
   disabled=""
 >
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -220,10 +208,7 @@ snapshots["vaadin-select host disabled"] =
 snapshots["vaadin-select host required"] = 
 `<vaadin-select required="">
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -273,7 +258,6 @@ snapshots["vaadin-select host value"] =
 `<vaadin-select has-value="">
   <div slot="overlay">
     <vaadin-select-list-box
-      aria-orientation="vertical"
       role="listbox"
       selected="0"
     >
@@ -332,10 +316,7 @@ snapshots["vaadin-select host value"] =
 snapshots["vaadin-select host helper"] = 
 `<vaadin-select has-helper="">
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -393,10 +374,7 @@ snapshots["vaadin-select host phone"] =
   with-backdrop=""
 >
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -447,10 +425,7 @@ snapshots["vaadin-select host error"] =
   invalid=""
 >
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         role="option"
@@ -505,10 +480,7 @@ snapshots["vaadin-select host opened default"] =
   top-aligned=""
 >
   <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
+    <vaadin-select-list-box role="listbox">
       <vaadin-select-item
         aria-selected="false"
         focused=""

--- a/packages/tabs/src/vaadin-tabs-mixin.js
+++ b/packages/tabs/src/vaadin-tabs-mixin.js
@@ -33,7 +33,7 @@ export const TabsMixin = (superClass) =>
     }
 
     static get observers() {
-      return ['__tabsItemsChanged(items)'];
+      return ['__tabsItemsChanged(items)', '__updateOrientation(items, orientation)'];
     }
 
     constructor() {
@@ -82,6 +82,24 @@ export const TabsMixin = (superClass) =>
      */
     _onResize() {
       this._updateOverflow();
+    }
+
+    /**
+     * Set `aria-orientation` on the host and `orientation` attribute on the
+     * items based on the current `orientation` value.
+     * @private
+     */
+    __updateOrientation(items, orientation) {
+      if (items) {
+        this.setAttribute('aria-orientation', orientation || 'vertical');
+        items.forEach((item) => {
+          if (orientation) {
+            item.setAttribute('orientation', orientation);
+          } else {
+            item.removeAttribute('orientation');
+          }
+        });
+      }
     }
 
     /** @private */

--- a/packages/tabs/test/tabs.test.js
+++ b/packages/tabs/test/tabs.test.js
@@ -90,6 +90,40 @@ describe('tabs', () => {
       expect(tabs.getAttribute('role')).to.equal('tablist');
     });
   });
+
+  describe('orientation', () => {
+    it('should set aria-orientation attribute to horizontal by default', () => {
+      expect(tabs.getAttribute('aria-orientation')).to.equal('horizontal');
+    });
+
+    it('should set aria-orientation attribute to vertical when orientation is set', async () => {
+      tabs.orientation = 'vertical';
+      await nextUpdate(tabs);
+      expect(tabs.getAttribute('aria-orientation')).to.equal('vertical');
+    });
+
+    it('should set orientation attribute on each item', () => {
+      tabs.items.forEach((item) => {
+        expect(item.getAttribute('orientation')).to.equal('horizontal');
+      });
+    });
+
+    it('should change orientation attribute on each item', async () => {
+      tabs.orientation = 'vertical';
+      await nextUpdate(tabs);
+      tabs.items.forEach((item) => {
+        expect(item.getAttribute('orientation')).to.equal('vertical');
+      });
+    });
+
+    it('should set orientation attribute on newly added item', async () => {
+      const item = document.createElement('vaadin-tab');
+      item.textContent = 'New';
+      tabs.appendChild(item);
+      await nextRender();
+      expect(item.getAttribute('orientation')).to.equal('horizontal');
+    });
+  });
 });
 
 describe('flex child tabs', () => {


### PR DESCRIPTION
## Description

Fixes #12224

Due to historical reasons, `orientation` was defined in `ListMixin` but only used by `tabs`. All other components using the mixin overrode it as private read-only.

This PR moves the `orientation` property and the `aria-orientation` / item `orientation` attribute logic from `ListMixin` into `TabsMixin`, and removes the overrides from `vaadin-list-box` and 4 related components.

## Note

For [`listbox`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listbox_role) and [`menu`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role) roles the default orientation is vertical, so the removed `aria-orientation="vertical"` attribute keeps the same semantics (DOM snapshots updated accordingly).

---

🤖 Generated with [Claude Code](https://claude.ai/code)