### PR TITLE
feat: add DateMetadataController to resolve date metadata on demand

### DIFF
--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -32,17 +32,24 @@ One function returns all of a date's metadata, rather than a generator per conce
 query answers everything instead of making a pass per concern. Only the disabled state is read today;
 further metadata extends the same entry shape.
 
-### Ranges and prefetch
+### Ranges and blocks
 
-`ensureRangeLoaded(start, end)` expands the requested range by `PREFETCH_MONTHS` (6) on each side, so
-scrolling a few months either way does not trigger a request. Months already loaded or in flight are
-skipped, and the months left over are loaded with a **single call**, narrowed to the first and last of
-them.
+`ensureRangeLoaded(start, end)` rounds the requested range out to whole blocks of `BLOCK_MONTHS` (12).
+Months already loaded or in flight are skipped, and the months left over are loaded with a **single
+call**, narrowed to the first and last of them.
 
-Narrowing keeps the common case tight: after scrolling, the missing months sit at one edge of the range,
-so the call asks for those and not for the year already in cache. When an answered month falls between
-two missing ones, the range covers it rather than splitting into a call per gap — one round trip for a
-slightly wider range.
+Blocks are counted from January of year 0, so one block is exactly one calendar year. Rounding out to a
+block rather than centring a buffer on the request is what makes navigating cheap: a buffer moves with
+the request, so stepping forward one month leaves one new month missing at the far edge, and one missing
+month is one more request — stepping through a year that way costs a request per month. Inside a block
+there is nothing missing, so it costs nothing. Debouncing does not cover this on its own, since deliberate
+month-at-a-time navigation is slower than any debounce window.
+
+Fixed blocks also mean every caller asks for the same ranges, which a server can cache. Ranges centred on
+wherever the user happens to be looking are all slightly different, so they cannot be.
+
+Narrowing keeps the call to what is missing: when an answered block falls between two missing ones, the
+range covers it rather than splitting into a call per gap — one round trip for a slightly wider range.
 
 A call marks as pending, and later writes, only the months it is loading — never the ones its range
 merely covers. An answered month keeps its metadata while the wider reply is in flight, so a date known

--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -1,0 +1,148 @@
+# Date Picker — Architecture
+
+Notes on the parts of `<vaadin-date-picker>` whose design is not obvious from the code. Currently
+covers date metadata resolution.
+
+## Date metadata
+
+`isDateDisabled` answers one date at a time and synchronously, which cannot be backed by a server. The
+`dateMetadataProvider` is the asynchronous, batched counterpart: it is called for a **range** of dates
+and may return a promise, so the answer can come from a backend.
+
+`DateMetadataController` decides which ranges to request, caches answers, and notifies consumers.
+
+> The controller is not wired into the component yet. Paragraphs marked _planned_ describe the
+> integration it is built for, which lands separately.
+
+### Where the cache lives
+
+The cache is owned by the date-picker element rather than by the overlay content, because the overlay
+content is created lazily on first open. Keeping the cache on the element means it survives opening and
+closing the overlay.
+
+The month calendars therefore read a controller they do not own, which is why change notification is
+explicit rather than a property assignment (see _Notification_).
+
+_Planned:_ validating a value that was set or typed without ever opening the overlay needs the metadata
+too, which is only possible with the cache on the element. Validation does not consult the provider yet.
+
+### One provider for all metadata
+
+One function returns all of a date's metadata, rather than a generator per concern, so a single backend
+query answers everything instead of making a pass per concern. Only the disabled state is read today;
+further metadata extends the same entry shape.
+
+### Ranges and prefetch
+
+`ensureRangeLoaded(start, end)` expands the requested range by `PREFETCH_MONTHS` (6) on each side, so
+scrolling a few months either way does not trigger a request. Months already loaded or in flight are
+skipped, and the months left over are loaded with a **single call**, narrowed to the first and last of
+them.
+
+Narrowing keeps the common case tight: after scrolling, the missing months sit at one edge of the range,
+so the call asks for those and not for the year already in cache. When an answered month falls between
+two missing ones, the range covers it rather than splitting into a call per gap — one round trip for a
+slightly wider range.
+
+A call marks as pending, and later writes, only the months it is loading — never the ones its range
+merely covers. An answered month keeps its metadata while the wider reply is in flight, so a date known
+to be disabled cannot go back to being selectable partway through a scroll.
+
+A month is either fully resolved or not resolved at all, and only being loaded resolves it. Metadata the
+provider volunteers for any other month is dropped, including for a month the range covered, so a
+month's own answer is the only thing that can decide its dates.
+
+Each call that finds a missing month issues its own request; the controller does not coalesce calls. A
+caller that loads on scroll debounces instead.
+
+### One record per month
+
+Whether a month is still pending and what it holds are kept in the same record, so the two cannot
+disagree, and `isLoading()` is derived by looking for a pending month rather than counted separately.
+
+A month has no record until it is loaded, so it is pending, resolved, or absent. That makes what is
+absent exactly what needs loading, and it is why a failure removes the months it covered rather than
+marking them.
+
+Resolving a month writes a fresh record, so its entries replace the previous ones rather than merging
+into them: a month's own answer is complete by definition. A resolved month is currently only
+re-requested after `clearCache()`, which drops it first, so replace and merge are not distinguishable
+through the API — replacing is what keeps that true if a per-month refresh is added.
+
+### Only known-disabled dates are disabled
+
+The controller's `isDateDisabled` is true when the date's month is resolved **and** its metadata says so. A
+date whose month is still being fetched is not disabled, and is re-checked when the month resolves.
+
+Being optimistic and correcting afterwards keeps rendering, selection and validation consistent with
+each other, since they all read the same predicate. Treating an unresolved date as unusable would
+instead make the whole visible calendar go dead while a slow provider answers, and report a value
+invalid on every fresh load before anything is known about it.
+
+_Planned:_ dates in a month that is still loading render with a `pending` part while a loading indicator
+is shown, but they stay selectable.
+
+### Notification
+
+**Subscribers are invalidated synchronously** with `requestUpdate()`. A subscriber must render from its
+bindings: `requestUpdate()` leaves the changed properties empty, so `PolylitMixin` does not re-run
+observers, and state applied imperatively from an observer is refreshed from the host callback instead. A
+subscriber must also not be the element whose own observer triggered the load, or it invalidates itself
+mid-update.
+
+There is no `unsubscribe`: a subscriber is retained for the controller's lifetime. _Planned:_ the month
+scroller creates its pool of calendars once and afterwards only reassigns which month each one shows, so
+every subscriber lives as long as the controller's host.
+
+**The host callback is deferred by one microtask and coalesced.** Loads are triggered from observers
+that run inside a Lit update, and the host reacts by writing reactive state of its own. Writing reactive
+state during an update logs Lit's `change-in-update` warning and makes `updateComplete` resolve to
+`false`, a source of one-tick-late test failures. Coalescing then means that starting several requests in
+one task, or several of them resolving in one task, costs one callback rather than one per month range.
+
+The provider's answer is awaited whether it is a promise or a plain array, so a request always resolves in
+a later task than it started in, and a provider's failure is contained in one place.
+
+### Request lifetime
+
+Requests carry a generation counter that only `clearCache()` advances. An answer from a superseded generation
+is discarded; one from the current generation is applied even if the host was detached meanwhile, since
+discarding it would only re-fetch the same range.
+
+There is therefore no disconnect handling. `hostConnected()` re-notifies instead, because notifications
+are skipped while the host is disconnected and state that resolved in the meantime would never reach it.
+
+### Failures fail open
+
+A provider that throws or rejects is treated as no metadata for those months: the error is logged, the
+months are dropped from the cache, and nothing is disabled. Dropping them is what stops them from
+rendering as perpetually pending, and the error must not escape the scroll or render path that triggered
+the load. Applying a result is kept outside that error handling, so an exception from a subscriber is not
+reported as a provider failure.
+
+A result that is not an array, and an entry that does not describe a real date, are reported rather than
+ignored, since ignoring them would present a provider bug as "nothing is disabled". Entries are checked by
+rebuilding the date and comparing it back, which catches a month outside 0–11, a day outside its month and
+February 30 alike — each would otherwise be stored under a key that no lookup can produce. A month given
+1-based cannot be caught this way, since it is a valid month number, so the 0-based contract is stated on
+the provider type instead.
+
+Both of those are mistakes in how the provider is written rather than runtime failures, so they are warned
+about once rather than once per request, which would otherwise repeat on every scroll. The trade is that
+the message states the contract instead of naming the offending entry.
+
+A month that failed is left absent rather than recorded as empty, so the next range request asks about it
+again. Recording a failure as an empty month would cache "nothing is disabled" as authoritative for the
+rest of the session, and treating an empty month as a failure would re-request every month a provider
+reports nothing for, which for most providers is most months. A transient failure therefore heals on the
+next scroll or reopen. Asking again marks the month pending, which is what makes it render as pending
+while the retry is in flight rather than showing a spinner over dates that look settled.
+
+A promise that never settles cannot be recovered from: its months stay pending, so they keep rendering as
+pending and `isLoading()` stays true, until the cache is cleared.
+
+### Provider identity
+
+`setProvider` compares by reference and normalizes a missing provider to `null`, so a host forwarding an
+unset property as `undefined` does not look like a change. Assigning a new function resets the cache, so
+callers keep a stable reference rather than passing a fresh function on every update.

--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -1,167 +1,165 @@
 # Date Picker — Architecture
 
-Notes on the parts of `<vaadin-date-picker>` whose design is not obvious from the code. Currently
-covers date metadata resolution.
+Notes on the parts of `<vaadin-date-picker>` whose design is not obvious from the code. Currently covers
+date metadata resolution: `DateMetadataController` decides which ranges to request, caches the answers, and
+notifies whoever reads them.
 
-## Date metadata
+> The controller is not wired into the component yet. Paragraphs marked _planned_ describe the integration
+> it is built for, which lands separately.
 
-`isDateDisabled` answers one date at a time and synchronously, which cannot be backed by a server. The
-`dateMetadataProvider` is the asynchronous, batched counterpart: it is called for a **range** of dates
-and may return a promise, so the answer can come from a backend.
+## What the provider is for
 
-`DateMetadataController` decides which ranges to request, caches answers, and notifies consumers.
+`isDateDisabled` answers one date at a time and synchronously, which cannot be backed by a server.
+`dateMetadataProvider` is its asynchronous, batched counterpart: it is called for a **range** of dates and
+may return a promise, so the answer can come from a backend.
 
-> The controller is not wired into the component yet. Paragraphs marked _planned_ describe the
-> integration it is built for, which lands separately.
+One function returns all of a date's metadata, rather than a generator per concern. A single backend query
+can then answer everything instead of making a pass per concern. Only the disabled state is read today;
+further metadata extends the same entry shape.
 
-### Where the cache lives
+`setProvider` compares by reference, and normalizes a missing provider to `null` so that a host forwarding
+an unset property as `undefined` does not look like a change. Assigning a new function resets the cache.
+Callers are expected to keep a stable reference instead of passing a fresh function on every update.
 
-The cache is owned by the date-picker element rather than by the overlay content, because the overlay
-content is created lazily on first open. Keeping the cache on the element means it survives opening and
-closing the overlay.
+## Where the cache lives
 
-The month calendars therefore read a controller they do not own, which is why change notification is
-explicit rather than a property assignment (see _Notification_).
+The date-picker element owns the controller, not the overlay content — which exists only once the overlay
+has been opened. Keeping it on the element is what makes the cache survive opening and closing.
+
+The month calendars therefore read a controller they do not own. That is why change notification is
+explicit rather than a property assignment (see [How consumers are notified](#how-consumers-are-notified)).
 
 _Planned:_ validating a value that was set or typed without ever opening the overlay needs the metadata
 too, which is only possible with the cache on the element. Validation does not consult the provider yet.
 
-### One provider for all metadata
+## Which months are requested
 
-One function returns all of a date's metadata, rather than a generator per concern, so a single backend
-query answers everything instead of making a pass per concern. Only the disabled state is read today;
-further metadata extends the same entry shape.
+`ensureRangeLoaded(start, end)` rounds the requested range out to whole blocks of `BLOCK_MONTHS` (12),
+skips the months already loaded or in flight, and asks for what is left with a **single call**, narrowed to
+the first and last of them.
 
-### Ranges and blocks
+Blocks are counted from January of year 0, so one block is exactly one calendar year. A month is rounded
+**down** to its block and never towards zero, which keeps a date before year 0 in the block it belongs to.
 
-`ensureRangeLoaded(start, end)` rounds the requested range out to whole blocks of `BLOCK_MONTHS` (12).
-Months already loaded or in flight are skipped, and the months left over are loaded with a **single
-call**, narrowed to the first and last of them.
+Rounding out to a block is what makes navigating cheap. A buffer centred on the request travels with it and
+never gets ahead of the user: step forward one month and one new month falls off the far edge, which is one
+more request. Stepping through a year that way costs a request per month. Inside a block nothing is
+missing, so it costs nothing.
 
-Blocks are counted from January of year 0, so one block is exactly one calendar year. Rounding out to a
-block rather than centring a buffer on the request is what makes navigating cheap: a buffer moves with
-the request, so stepping forward one month leaves one new month missing at the far edge, and one missing
-month is one more request — stepping through a year that way costs a request per month. Inside a block
-there is nothing missing, so it costs nothing. Debouncing does not cover this on its own, since deliberate
-month-at-a-time navigation is slower than any debounce window.
+Fixed blocks have a second benefit. Every caller asks for the same ranges, which a server can cache; ranges
+centred on wherever the user happens to be looking are all slightly different, and cannot be.
 
-Fixed blocks also mean every caller asks for the same ranges, which a server can cache. Ranges centred on
-wherever the user happens to be looking are all slightly different, so they cannot be.
+Narrowing keeps a call to what is missing. When an answered block sits between two missing ones, the range
+covers it instead of splitting into a call per gap — one round trip for a slightly wider range.
 
-A month is rounded **down** to its block, not towards zero, so that a date before year 0 lands in the
-block it belongs to rather than the one after it.
+The controller does not coalesce calls: each one that finds a missing month issues its own request, so a
+caller that loads while the user navigates has to debounce. That covers a fast scroll, where many positions
+pass in a single gesture. It does nothing for deliberate month-at-a-time stepping, which is slower than any
+window worth setting — block alignment is what covers that.
 
-Narrowing keeps the call to what is missing: when an answered block falls between two missing ones, the
-range covers it rather than splitting into a call per gap — one round trip for a slightly wider range.
+## What the cache holds
 
-A call marks as pending, and later writes, only the months it is loading — never the ones its range
-merely covers. An answered month keeps its metadata while the wider reply is in flight, so a date known
-to be disabled cannot go back to being selectable partway through a scroll.
+A month is pending, resolved, or absent, and has no record at all until it is loaded. Absent is therefore
+exactly what needs loading, which is also why a failure removes the months it covered instead of marking
+them.
 
-A month is either fully resolved or not resolved at all, and only being loaded resolves it. Metadata the
-provider volunteers for any other month is dropped, including for a month the range covered, so a
-month's own answer is the only thing that can decide its dates.
+Whether a month is still pending and what it holds live in the same record, so the two cannot disagree.
+`isLoading()` is derived by looking for a pending month rather than counted separately, for the same
+reason.
 
-Each call that finds a missing month issues its own request; the controller does not coalesce calls. A
-caller that loads on scroll debounces instead.
+Every pending month shares one frozen record, because a month being fetched has nothing of its own to hold:
+only a resolved month is ever read for entries. Anything that had to be remembered per month while in
+flight would need a record per month again.
 
-### One record per month
+A call marks as pending, and later writes, only the months it is loading — never the ones its range merely
+covers. An answered month keeps its metadata while the wider reply is in flight, which is what stops a date
+known to be disabled from turning selectable again partway through a scroll.
 
-Whether a month is still pending and what it holds are kept in the same record, so the two cannot
-disagree, and `isLoading()` is derived by looking for a pending month rather than counted separately.
+Only being loaded resolves a month. Metadata the provider volunteers for any other month is dropped,
+including for a month the range covered, leaving a month's own answer as the only thing that can decide its
+dates.
 
-A month has no record until it is loaded, so it is pending, resolved, or absent. That makes what is
-absent exactly what needs loading, and it is why a failure removes the months it covered rather than
-marking them.
+Resolving a month writes a fresh record, replacing its entries rather than merging into them: a month's own
+answer is complete by definition. Today a resolved month is only re-requested after `clearCache()`, which
+drops it first, so replace and merge cannot be told apart through the API. Replacing is what keeps that
+true if a per-month refresh is ever added.
 
-Every pending month shares one frozen record, because a month being fetched has nothing of its own to
-hold: only a resolved month is ever read for entries. Anything that has to be remembered per month while
-it is in flight would need a record per month again.
-
-Resolving a month writes a fresh record, so its entries replace the previous ones rather than merging
-into them: a month's own answer is complete by definition. A resolved month is currently only
-re-requested after `clearCache()`, which drops it first, so replace and merge are not distinguishable
-through the API — replacing is what keeps that true if a per-month refresh is added.
-
-### Only known-disabled dates are disabled
+## Which dates count as disabled
 
 The controller's `isDateDisabled` is true when the date's month is resolved **and** its metadata says so. A
-date whose month is still being fetched is not disabled, and is re-checked when the month resolves.
+date whose month is still being fetched is not disabled; it is re-checked when the month resolves.
 
-Being optimistic and correcting afterwards keeps rendering, selection and validation consistent with
-each other, since they all read the same predicate. Treating an unresolved date as unusable would
-instead make the whole visible calendar go dead while a slow provider answers, and report a value
-invalid on every fresh load before anything is known about it.
+Being optimistic and correcting afterwards keeps rendering, selection and validation consistent with each
+other, because all three read the same predicate. The alternative — treating an unresolved date as unusable
+— would make the whole visible calendar go dead while a slow provider answers, and report a value invalid
+on every fresh load, before anything is known about it.
 
-_Planned:_ dates in a month that is still loading render with a `pending` part while a loading indicator
-is shown, but they stay selectable.
+_Planned:_ dates in a month that is still loading render with a `pending` part while a loading indicator is
+shown, but they stay selectable.
 
-### Notification
+## How consumers are notified
 
-**Subscribers are invalidated synchronously** with `requestUpdate()`. A subscriber must render from its
+**Subscribers are invalidated synchronously** with `requestUpdate()`. A subscriber has to render from its
 bindings: `requestUpdate()` leaves the changed properties empty, so `PolylitMixin` does not re-run
 observers, and state applied imperatively from an observer is refreshed from the host callback instead. A
-subscriber must also not be the element whose own observer triggered the load, or it invalidates itself
+subscriber also must not be the element whose own observer triggered the load, or it invalidates itself
 mid-update.
 
-There is no `unsubscribe`: a subscriber is retained for the controller's lifetime. _Planned:_ the month
+There is no `unsubscribe`; a subscriber is retained for the controller's lifetime. _Planned:_ the month
 scroller creates its pool of calendars once and afterwards only reassigns which month each one shows, so
 every subscriber lives as long as the controller's host.
 
-**The host callback is deferred by one microtask and coalesced.** Loads are triggered from observers
-that run inside a Lit update, and the host reacts by writing reactive state of its own. Writing reactive
-state during an update logs Lit's `change-in-update` warning and makes `updateComplete` resolve to
-`false`, a source of one-tick-late test failures. Coalescing then means that starting several requests in
-one task, or several of them resolving in one task, costs one callback rather than one per month range.
+**The host callback is deferred by one microtask, and coalesced.** Loads are triggered from observers that
+run inside a Lit update, and the host reacts by writing reactive state of its own. Writing reactive state
+during an update logs Lit's `change-in-update` warning and makes `updateComplete` resolve to `false`, which
+is a source of one-tick-late test failures. Coalescing then means that several requests starting in one
+task, or several of them resolving in one task, cost one callback instead of one per month range.
 
-The provider's answer is awaited whether it is a promise or a plain array, so a request always resolves in
-a later task than it started in, and a provider's failure is contained in one place.
+The provider's answer is awaited whether it is a promise or a plain array. A request therefore always
+resolves in a later task than the one it started in, and a provider's failure is contained in one place.
 
-### Request lifetime
+## How long a request lives
 
-Requests carry a generation counter that only `clearCache()` advances. An answer from a superseded generation
-is discarded; one from the current generation is applied even if the host was detached meanwhile, since
-discarding it would only re-fetch the same range.
+Requests carry a generation counter that only `clearCache()` advances. An answer from a superseded
+generation is discarded. An answer from the current generation is applied even if the host was detached
+meanwhile, since discarding it would only re-fetch the same range.
 
-There is therefore no disconnect handling. `hostConnected()` re-notifies instead, because notifications
-are skipped while the host is disconnected and state that resolved in the meantime would never reach it.
+There is therefore no disconnect handling. `hostConnected()` re-notifies instead, because notifications are
+skipped while the host is disconnected, and state that resolved in the meantime would never reach it.
 
-### Failures fail open
+## What happens when the provider fails
 
 A provider that throws or rejects is treated as no metadata for those months: the error is logged, the
-months are dropped from the cache, and nothing is disabled. Dropping them is what stops them from
-rendering as perpetually pending, and the error must not escape the scroll or render path that triggered
-the load. Applying a result is kept outside that error handling, so an exception from a subscriber is not
-reported as a provider failure.
+months are dropped from the cache, and nothing is disabled. Dropping months prevents them from rendering
+as stuck in pending state. The error itself must not escape the scroll or render path that triggered the load.
+Applying a result is kept outside that error handling, so an exception from a subscriber is not reported as
+a provider failure.
 
-A result that is not an array, and an entry that does not describe a real date, are reported rather than
-ignored, since ignoring them would present a provider bug as "nothing is disabled". Entries are checked by
-rebuilding the date and comparing it back, which catches a month outside 0–11, a day outside its month and
-February 30 alike — each would otherwise be stored under a key that no lookup can produce. A month given
-1-based cannot be caught this way, since it is a valid month number, so the 0-based contract is stated on
-the provider type instead.
+A failed month is left absent instead of being recorded as empty, so the next range request asks about it
+again and a transient failure heals on the next scroll or reopen. Recording it as empty would cache
+"nothing is disabled" as authoritative for the rest of the session; treating an empty month as a failure
+would re-request every month a provider reports nothing for, which for most providers is most months.
+Asking again marks the month pending, which is what makes it render as pending while the retry is in flight
+rather than showing a spinner over dates that look settled.
 
-The three fields are type-checked before that, which is not redundant: a value that cannot be coerced to a
-number, a bigint say, throws while the date is being rebuilt. Since the answer is applied inside the
-error handling above, one such entry would otherwise discard the whole range and have it requested again
-on every navigation, instead of costing only itself.
-
-Both of those are mistakes in how the provider is written rather than runtime failures, so they are warned
-about once rather than once per request, which would otherwise repeat on every scroll. The trade is that
-the message states the contract instead of naming the offending entry.
-
-A month that failed is left absent rather than recorded as empty, so the next range request asks about it
-again. Recording a failure as an empty month would cache "nothing is disabled" as authoritative for the
-rest of the session, and treating an empty month as a failure would re-request every month a provider
-reports nothing for, which for most providers is most months. A transient failure therefore heals on the
-next scroll or reopen. Asking again marks the month pending, which is what makes it render as pending
-while the retry is in flight rather than showing a spinner over dates that look settled.
-
-A promise that never settles cannot be recovered from: its months stay pending, so they keep rendering as
+A promise that never settles cannot be recovered from. Its months stay pending, so they keep rendering as
 pending and `isLoading()` stays true, until the cache is cleared.
 
-### Provider identity
+### When the provider is written wrong
 
-`setProvider` compares by reference and normalizes a missing provider to `null`, so a host forwarding an
-unset property as `undefined` does not look like a change. Assigning a new function resets the cache, so
-callers keep a stable reference rather than passing a fresh function on every update.
+A result that is not an array, and an entry that does not describe a real date, are reported rather than
+ignored: ignoring them would present a provider bug as "nothing is disabled".
+
+Entries are checked by rebuilding the date and comparing it back, which catches a month outside 0–11, a day
+outside its month, and February 30 alike — each would otherwise be stored under a key that no lookup can
+produce. A month given 1-based cannot be caught this way, being a valid month number, so the 0-based
+contract is stated on the provider type instead.
+
+The three fields are type-checked before that, which is not redundant. A value that cannot be coerced to a
+number (e.g. bigint) throws while the date is being rebuilt; because the answer is applied inside the
+error handling above, one such entry would discard the whole range and have it requested again on every
+navigation, instead of costing only itself.
+
+Both are mistakes in how the provider is written rather than runtime failures, so they are warned about
+once instead of once per request, which would otherwise repeat on every scroll. The trade is that the
+message states the contract instead of naming the offending entry.

--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -48,6 +48,9 @@ month-at-a-time navigation is slower than any debounce window.
 Fixed blocks also mean every caller asks for the same ranges, which a server can cache. Ranges centred on
 wherever the user happens to be looking are all slightly different, so they cannot be.
 
+A month is rounded **down** to its block, not towards zero, so that a date before year 0 lands in the
+block it belongs to rather than the one after it.
+
 Narrowing keeps the call to what is missing: when an answered block falls between two missing ones, the
 range covers it rather than splitting into a call per gap — one round trip for a slightly wider range.
 
@@ -70,6 +73,10 @@ disagree, and `isLoading()` is derived by looking for a pending month rather tha
 A month has no record until it is loaded, so it is pending, resolved, or absent. That makes what is
 absent exactly what needs loading, and it is why a failure removes the months it covered rather than
 marking them.
+
+Every pending month shares one frozen record, because a month being fetched has nothing of its own to
+hold: only a resolved month is ever read for entries. Anything that has to be remembered per month while
+it is in flight would need a record per month again.
 
 Resolving a month writes a fresh record, so its entries replace the previous ones rather than merging
 into them: a month's own answer is complete by definition. A resolved month is currently only
@@ -133,6 +140,11 @@ rebuilding the date and comparing it back, which catches a month outside 0–11,
 February 30 alike — each would otherwise be stored under a key that no lookup can produce. A month given
 1-based cannot be caught this way, since it is a valid month number, so the 0-based contract is stated on
 the provider type instead.
+
+The three fields are type-checked before that, which is not redundant: a value that cannot be coerced to a
+number, a bigint say, throws while the date is being rebuilt. Since the answer is applied inside the
+error handling above, one such entry would otherwise discard the whole range and have it requested again
+on every navigation, instead of costing only itself.
 
 Both of those are mistakes in how the provider is written rather than runtime failures, so they are warned
 about once rather than once per request, which would otherwise repeat on every scroll. The trade is that

--- a/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import type { ReactiveController, ReactiveControllerHost, ReactiveElement } from 'lit';
+import type { DatePickerDateMetadata, DatePickerDateMetadataProvider } from './vaadin-date-picker-mixin.js';
+
+/**
+ * A reactive controller that resolves the metadata (currently the disabled state)
+ * for the dates shown by the date-picker's `dateMetadataProvider`.
+ *
+ * The provider is called for a range of months and may return an array
+ * synchronously or a `Promise`, so results from a server (Flow) or a remote
+ * availability service can be awaited. Each returned entry is a `DatePickerDate`
+ * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
+ *
+ * A month is either resolved or not resolved at all, and only a month's own answer
+ * decides its dates. A date in a month that has not resolved yet is not disabled.
+ *
+ * See `ARCHITECTURE.md` for the reasoning behind the caching, notification and
+ * failure behavior.
+ */
+export class DateMetadataController implements ReactiveController {
+  /**
+   * The controller host element.
+   */
+  host: HTMLElement & ReactiveControllerHost;
+
+  /**
+   * The provider function, or `null` when none is set.
+   */
+  provider: DatePickerDateMetadataProvider | null;
+
+  constructor(host: HTMLElement & ReactiveControllerHost, onChange?: () => void);
+
+  hostConnected(): void;
+
+  /**
+   * Registers an element to be re-rendered whenever the resolved metadata or the
+   * loading state changes.
+   *
+   * The element must render from its bindings: it is invalidated with
+   * `requestUpdate()`, which leaves the changed properties empty, so `PolylitMixin`
+   * does not re-run observers. State applied imperatively from an observer has to be
+   * refreshed from the host callback instead.
+   *
+   * The element must also not be the one whose own observer triggers a load, or it
+   * invalidates itself mid-update.
+   *
+   * There is no `unsubscribe`: a subscriber is retained for the controller's lifetime.
+   */
+  subscribe(element: ReactiveElement): void;
+
+  /**
+   * Whether any month range is currently being fetched.
+   */
+  isLoading(): boolean;
+
+  /**
+   * Sets the provider function and clears the cache. Compared by reference, so a
+   * missing provider is normalized to `null` and passing the same provider again is
+   * a no-op. Callers should keep a stable provider reference.
+   */
+  setProvider(provider: DatePickerDateMetadataProvider | null | undefined): void;
+
+  /**
+   * Clears the cache and invalidates any in-flight requests.
+   */
+  clearCache(): void;
+
+  /**
+   * Whether the provider has answered for the month containing the given date.
+   * A month whose request failed is not loaded and will be requested again.
+   */
+  isMonthLoaded(date: Date | null | undefined): boolean;
+
+  /**
+   * The metadata resolved for the given date, or `undefined` when the date has
+   * no metadata or its month has not been resolved yet. Returns the entry the
+   * provider supplied, which the caller must not modify.
+   */
+  getMetadata(date: Date | null | undefined): DatePickerDateMetadata | undefined;
+
+  /**
+   * Whether the given date is disabled by its metadata. Only returns `true` for
+   * dates in an already-resolved month, and does not consider `min`, `max` or the
+   * date-picker's `isDateDisabled` property.
+   */
+  isDateDisabled(date: Date | null | undefined): boolean;
+
+  /**
+   * Ensures the provider has been consulted for the inclusive range between the
+   * given dates, expanded by a prefetch buffer of months on each side. Months
+   * already loaded or in flight are skipped, and the ones left over are requested
+   * with a single call.
+   *
+   * Each call that finds a missing month issues its own request, so a caller that
+   * loads on scroll is expected to debounce.
+   */
+  ensureRangeLoaded(startDate: Date | null | undefined, endDate: Date | null | undefined): void;
+}

--- a/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
@@ -14,6 +14,9 @@ import type { DatePickerDateMetadata, DatePickerDateMetadataProvider } from './v
  * synchronously or a `Promise`, so results from a server (Flow) or a remote
  * availability service can be awaited. Each returned entry is a `DatePickerDate`
  * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
+ *
+ * `ARCHITECTURE.md` in this package records the reasoning behind the request,
+ * caching, notification and failure behavior.
  */
 export class DateMetadataController implements ReactiveController {
   /**
@@ -32,17 +35,9 @@ export class DateMetadataController implements ReactiveController {
 
   /**
    * Registers an element to be re-rendered whenever the resolved metadata or the
-   * loading state changes.
-   *
-   * The element must render from its bindings: it is invalidated with
-   * `requestUpdate()`, which leaves the changed properties empty, so `PolylitMixin`
-   * does not re-run observers. State applied imperatively from an observer has to be
-   * refreshed from the host callback instead.
-   *
-   * The element must also not be the one whose own observer triggers a load, or it
-   * invalidates itself mid-update.
-   *
-   * There is no `unsubscribe`: a subscriber is retained for the controller's lifetime.
+   * loading state changes. The element must render from its bindings, and must not be
+   * the one whose own observer triggers a load. It stays registered for the
+   * controller's lifetime.
    */
   subscribe(element: ReactiveElement): void;
 
@@ -52,9 +47,8 @@ export class DateMetadataController implements ReactiveController {
   isLoading(): boolean;
 
   /**
-   * Sets the provider function and clears the cache. Compared by reference, so a
-   * missing provider is normalized to `null` and passing the same provider again is
-   * a no-op. Callers should keep a stable provider reference.
+   * Sets the provider function and clears the cache. Passing the same provider again
+   * is a no-op, so callers should keep a stable reference.
    */
   setProvider(provider: DatePickerDateMetadataProvider | null | undefined): void;
 
@@ -86,9 +80,8 @@ export class DateMetadataController implements ReactiveController {
    * given dates, rounded out to whole blocks of months. Months already loaded or in
    * flight are skipped, and the ones left over are requested with a single call.
    *
-   * A range inside one block costs nothing once that block is loaded, so moving
-   * around within it does not re-request. Each call that does find a missing month
-   * issues its own request, so a caller that loads on scroll should still debounce.
+   * Each call that finds a missing month issues its own request, so a caller that
+   * loads on scroll should debounce.
    */
   ensureRangeLoaded(startDate: Date | null | undefined, endDate: Date | null | undefined): void;
 }

--- a/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
@@ -14,12 +14,6 @@ import type { DatePickerDateMetadata, DatePickerDateMetadataProvider } from './v
  * synchronously or a `Promise`, so results from a server (Flow) or a remote
  * availability service can be awaited. Each returned entry is a `DatePickerDate`
  * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
- *
- * A month is either resolved or not resolved at all, and only a month's own answer
- * decides its dates. A date in a month that has not resolved yet is not disabled.
- *
- * See `ARCHITECTURE.md` for the reasoning behind the caching, notification and
- * failure behavior.
  */
 export class DateMetadataController implements ReactiveController {
   /**
@@ -83,9 +77,7 @@ export class DateMetadataController implements ReactiveController {
   getMetadata(date: Date | null | undefined): DatePickerDateMetadata | undefined;
 
   /**
-   * Whether the given date is disabled by its metadata. Only returns `true` for
-   * dates in an already-resolved month, and does not consider `min`, `max` or the
-   * date-picker's `isDateDisabled` property.
+   * Whether the given date is disabled by its metadata.
    */
   isDateDisabled(date: Date | null | undefined): boolean;
 

--- a/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.d.ts
@@ -91,12 +91,12 @@ export class DateMetadataController implements ReactiveController {
 
   /**
    * Ensures the provider has been consulted for the inclusive range between the
-   * given dates, expanded by a prefetch buffer of months on each side. Months
-   * already loaded or in flight are skipped, and the ones left over are requested
-   * with a single call.
+   * given dates, rounded out to whole blocks of months. Months already loaded or in
+   * flight are skipped, and the ones left over are requested with a single call.
    *
-   * Each call that finds a missing month issues its own request, so a caller that
-   * loads on scroll is expected to debounce.
+   * A range inside one block costs nothing once that block is loaded, so moving
+   * around within it does not re-request. Each call that does find a missing month
+   * issues its own request, so a caller that loads on scroll should still debounce.
    */
   ensureRangeLoaded(startDate: Date | null | undefined, endDate: Date | null | undefined): void;
 }

--- a/packages/date-picker/src/vaadin-date-metadata-controller.js
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.js
@@ -1,0 +1,288 @@
+/**
+ * @license
+ * Copyright (c) 2016 - 2026 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+import { microTask } from '@vaadin/component-base/src/async.js';
+import { Debouncer } from '@vaadin/component-base/src/debounce.js';
+import { issueWarning } from '@vaadin/component-base/src/warnings.js';
+import {
+  createDate,
+  extractDateParts,
+  lastOfMonth,
+  monthDate,
+  monthIndex,
+  monthIndexOf,
+} from './vaadin-date-picker-helper.js';
+
+// Months fetched on each side of the requested range, so scrolling a little does not re-request.
+const PREFETCH_MONTHS = 6;
+
+// Shared, because a pending month has no entries to hold: `#resolvedMonth` only answers for a
+// month that has resolved.
+const PENDING_MONTH = Object.freeze({ pending: true });
+
+// Entries are keyed by the month and day they name, so anything that is not a real date would
+// silently produce a key that no lookup can ever match. Rebuilding the date and comparing it back
+// catches a month outside 0-11, a day outside its month, and February 30 alike.
+function isValidEntry(entry) {
+  if (!entry || !Number.isInteger(entry.year) || !Number.isInteger(entry.month) || !Number.isInteger(entry.day)) {
+    return false;
+  }
+  const date = createDate(entry.year, entry.month, entry.day);
+  return date.getFullYear() === entry.year && date.getMonth() === entry.month && date.getDate() === entry.day;
+}
+
+// One fresh bucket per month being loaded, so a month's own answer replaces its entries, and an
+// entry for any other month is dropped, including one the range covered but did not load.
+function groupEntriesByMonth(months, entries) {
+  const result = new Map(months.map((month) => [month, new Map()]));
+
+  if (Array.isArray(entries)) {
+    entries.forEach((entry) => {
+      if (isValidEntry(entry)) {
+        result.get(monthIndexOf(entry.year, entry.month))?.set(entry.day, entry);
+      } else {
+        issueWarning('Ignored `dateMetadataProvider` entries with an invalid year, month (0-11) or day.');
+      }
+    });
+  } else if (entries != null) {
+    issueWarning('Expected `dateMetadataProvider` to return an array of date metadata objects.');
+  }
+
+  return result;
+}
+
+/**
+ * A reactive controller that resolves the metadata (currently the disabled state)
+ * for the dates shown by the date-picker's `dateMetadataProvider`.
+ *
+ * The provider is called for a range of months and may return an array
+ * synchronously or a `Promise`, so results from a server (Flow) or a remote
+ * availability service can be awaited. Each returned entry is a `DatePickerDate`
+ * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
+ *
+ * A month is either resolved or not resolved at all, and only a month's own answer
+ * decides its dates. A date in a month that has not resolved yet is not disabled.
+ *
+ * See `ARCHITECTURE.md` for the reasoning behind the caching, notification and
+ * failure behavior.
+ */
+export class DateMetadataController {
+  /**
+   * The controller host element.
+   * @type {import('lit').ReactiveControllerHost & HTMLElement}
+   */
+  host;
+
+  /**
+   * The provider function, or `null` when none is set.
+   * @type {Function | null}
+   */
+  provider = null;
+
+  /** @type {(() => void) | undefined} */
+  #onChange;
+
+  /**
+   * What is known about each month, keyed by month index: a shared marker while its request is in
+   * flight, or a record holding the resolved entries by day. A month is absent until it is loaded,
+   * and absent again if its request failed.
+   * @type {Map<number, { pending: boolean, entries?: Map<number, object> }>}
+   */
+  #months = new Map();
+
+  /** @type {Set<import('lit').ReactiveElement>} */
+  #subscribers = new Set();
+
+  #requestId = 0;
+
+  /** @type {import('@vaadin/component-base/src/debounce.js').Debouncer} */
+  #notifyDebouncer;
+
+  constructor(host, onChange) {
+    this.host = host;
+    this.#onChange = onChange;
+  }
+
+  hostConnected() {
+    // Changes that resolved while the host was detached were not reported to it,
+    // so re-report the current state now that it can act on it again.
+    this.#notify();
+  }
+
+  /**
+   * Registers an element to be re-rendered whenever the resolved metadata or the
+   * loading state changes.
+   *
+   * The element must render from its bindings: it is invalidated with
+   * `requestUpdate()`, which leaves the changed properties empty, so `PolylitMixin`
+   * does not re-run observers. State applied imperatively from an observer has to be
+   * refreshed from the host callback instead.
+   *
+   * The element must also not be the one whose own observer triggers a load, or it
+   * invalidates itself mid-update.
+   *
+   * There is no `unsubscribe`: a subscriber is retained for the controller's lifetime.
+   *
+   * @param {import('lit').ReactiveElement} element
+   */
+  subscribe(element) {
+    this.#subscribers.add(element);
+  }
+
+  /**
+   * Whether any month range is currently being fetched.
+   * @return {boolean}
+   */
+  isLoading() {
+    for (const { pending } of this.#months.values()) {
+      if (pending) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Sets the provider function and clears the cache. Compared by reference, so a
+   * missing provider is normalized to `null` and passing the same provider again is
+   * a no-op. Callers should keep a stable provider reference.
+   *
+   * @param {Function | null | undefined} provider
+   */
+  setProvider(provider) {
+    const next = provider ?? null;
+    if (this.provider === next) {
+      return;
+    }
+    this.provider = next;
+    this.clearCache();
+  }
+
+  /**
+   * Clears the cache and invalidates any in-flight requests.
+   */
+  clearCache() {
+    this.#months.clear();
+    this.#requestId += 1;
+    this.#notify();
+  }
+
+  /**
+   * Whether the provider has answered for the month containing the given date.
+   * A month whose request failed is not loaded and will be requested again.
+   * @param {Date | null | undefined} date
+   * @return {boolean}
+   */
+  isMonthLoaded(date) {
+    return !!this.#resolvedMonth(date);
+  }
+
+  /**
+   * The metadata resolved for the given date, or `undefined` when the date has
+   * no metadata or its month has not been resolved yet. Returns the entry the
+   * provider supplied, which the caller must not modify.
+   * @param {Date | null | undefined} date
+   * @return {object | undefined}
+   */
+  getMetadata(date) {
+    return this.#resolvedMonth(date)?.entries.get(date.getDate());
+  }
+
+  /**
+   * Whether the given date is disabled by its metadata. Only returns `true` for
+   * dates in an already-resolved month, and does not consider `min`, `max` or the
+   * date-picker's `isDateDisabled` property.
+   * @param {Date | null | undefined} date
+   * @return {boolean}
+   */
+  isDateDisabled(date) {
+    return !!this.getMetadata(date)?.disabled;
+  }
+
+  /**
+   * Ensures the provider has been consulted for the inclusive range between the
+   * given dates, expanded by a prefetch buffer of months on each side. Months
+   * already loaded or in flight are skipped, and the ones left over are requested
+   * with a single call.
+   *
+   * Each call that finds a missing month issues its own request, so a caller that
+   * loads on scroll is expected to debounce.
+   *
+   * @param {Date | null | undefined} startDate
+   * @param {Date | null | undefined} endDate
+   */
+  ensureRangeLoaded(startDate, endDate) {
+    if (!this.provider || !startDate || !endDate) {
+      return;
+    }
+
+    const first = monthIndex(startDate) - PREFETCH_MONTHS;
+    const last = monthIndex(endDate) + PREFETCH_MONTHS;
+
+    const months = [];
+    for (let month = first; month <= last; month++) {
+      if (!this.#months.has(month)) {
+        months.push(month);
+      }
+    }
+
+    if (months.length > 0) {
+      this.#loadMonths(months);
+    }
+  }
+
+  #resolvedMonth(date) {
+    const month = date && this.#months.get(monthIndex(date));
+    return month && !month.pending ? month : undefined;
+  }
+
+  async #loadMonths(months) {
+    const requestId = this.#requestId;
+    months.forEach((month) => this.#months.set(month, PENDING_MONTH));
+    this.#notify();
+
+    const range = {
+      start: extractDateParts(monthDate(months[0])),
+      end: extractDateParts(lastOfMonth(monthDate(months.at(-1)))),
+    };
+
+    let entries;
+    try {
+      const data = await this.provider(range);
+      entries = groupEntriesByMonth(months, data);
+    } catch (error) {
+      console.error(error);
+    }
+
+    // Ignore an answer from before the last `clearCache()`, e.g. because the provider changed.
+    if (requestId !== this.#requestId) {
+      return;
+    }
+
+    months.forEach((month) => {
+      if (entries) {
+        this.#months.set(month, { pending: false, entries: entries.get(month) });
+      } else {
+        // Left absent rather than recorded as empty, so the next range request asks again.
+        this.#months.delete(month);
+      }
+    });
+
+    this.#notify();
+  }
+
+  #notify() {
+    // Subscribers re-render from their bindings, so invalidate them synchronously.
+    this.#subscribers.forEach((element) => element.requestUpdate());
+
+    if (this.#onChange) {
+      this.#notifyDebouncer = Debouncer.debounce(this.#notifyDebouncer, microTask, () => {
+        if (this.host.isConnected) {
+          this.#onChange();
+        }
+      });
+    }
+  }
+}

--- a/packages/date-picker/src/vaadin-date-metadata-controller.js
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.js
@@ -74,12 +74,6 @@ function groupEntriesByMonth(months, entries) {
  * synchronously or a `Promise`, so results from a server (Flow) or a remote
  * availability service can be awaited. Each returned entry is a `DatePickerDate`
  * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
- *
- * A month is either resolved or not resolved at all, and only a month's own answer
- * decides its dates. A date in a month that has not resolved yet is not disabled.
- *
- * See `ARCHITECTURE.md` for the reasoning behind the caching, notification and
- * failure behavior.
  */
 export class DateMetadataController {
   /**
@@ -204,9 +198,7 @@ export class DateMetadataController {
   }
 
   /**
-   * Whether the given date is disabled by its metadata. Only returns `true` for
-   * dates in an already-resolved month, and does not consider `min`, `max` or the
-   * date-picker's `isDateDisabled` property.
+   * Whether the given date is disabled by its metadata.
    * @param {Date | null | undefined} date
    * @return {boolean}
    */

--- a/packages/date-picker/src/vaadin-date-metadata-controller.js
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.js
@@ -15,8 +15,21 @@ import {
   monthIndexOf,
 } from './vaadin-date-picker-helper.js';
 
-// Months fetched on each side of the requested range, so scrolling a little does not re-request.
-const PREFETCH_MONTHS = 6;
+// Months are fetched in fixed blocks rather than in a buffer centred on what was asked for. A
+// buffer moves with the request, so it never gets ahead of the user: stepping forward one month
+// leaves one new month missing at the far edge, and that is one more request. Rounding out to a
+// block instead means stepping around inside it asks for nothing.
+//
+// Counted from January of year 0, a block is exactly one calendar year, which also means every
+// caller asks for the same ranges, so a server can cache the answers. Ranges centred on wherever
+// the user happens to be looking are all slightly different and cannot be.
+const BLOCK_MONTHS = 12;
+
+// `Math.floor`, not `Math.trunc`, so a month before year 0 rounds down to the start of its block
+// rather than towards zero, which would land in the block after it.
+function blockStart(month) {
+  return Math.floor(month / BLOCK_MONTHS) * BLOCK_MONTHS;
+}
 
 // Shared, because a pending month has no entries to hold: `#resolvedMonth` only answers for a
 // month that has resolved.
@@ -203,12 +216,12 @@ export class DateMetadataController {
 
   /**
    * Ensures the provider has been consulted for the inclusive range between the
-   * given dates, expanded by a prefetch buffer of months on each side. Months
-   * already loaded or in flight are skipped, and the ones left over are requested
-   * with a single call.
+   * given dates, rounded out to whole blocks of months. Months already loaded or in
+   * flight are skipped, and the ones left over are requested with a single call.
    *
-   * Each call that finds a missing month issues its own request, so a caller that
-   * loads on scroll is expected to debounce.
+   * A range inside one block costs nothing once that block is loaded, so moving
+   * around within it does not re-request. Each call that does find a missing month
+   * issues its own request, so a caller that loads on scroll should still debounce.
    *
    * @param {Date | null | undefined} startDate
    * @param {Date | null | undefined} endDate
@@ -218,8 +231,8 @@ export class DateMetadataController {
       return;
     }
 
-    const first = monthIndex(startDate) - PREFETCH_MONTHS;
-    const last = monthIndex(endDate) + PREFETCH_MONTHS;
+    const first = blockStart(monthIndex(startDate));
+    const last = blockStart(monthIndex(endDate)) + BLOCK_MONTHS - 1;
 
     const months = [];
     for (let month = first; month <= last; month++) {

--- a/packages/date-picker/src/vaadin-date-metadata-controller.js
+++ b/packages/date-picker/src/vaadin-date-metadata-controller.js
@@ -15,29 +15,15 @@ import {
   monthIndexOf,
 } from './vaadin-date-picker-helper.js';
 
-// Months are fetched in fixed blocks rather than in a buffer centred on what was asked for. A
-// buffer moves with the request, so it never gets ahead of the user: stepping forward one month
-// leaves one new month missing at the far edge, and that is one more request. Rounding out to a
-// block instead means stepping around inside it asks for nothing.
-//
-// Counted from January of year 0, a block is exactly one calendar year, which also means every
-// caller asks for the same ranges, so a server can cache the answers. Ranges centred on wherever
-// the user happens to be looking are all slightly different and cannot be.
+// Counted from January of year 0, so a block is one calendar year.
 const BLOCK_MONTHS = 12;
 
-// `Math.floor`, not `Math.trunc`, so a month before year 0 rounds down to the start of its block
-// rather than towards zero, which would land in the block after it.
 function blockStart(month) {
   return Math.floor(month / BLOCK_MONTHS) * BLOCK_MONTHS;
 }
 
-// Shared, because a pending month has no entries to hold: `#resolvedMonth` only answers for a
-// month that has resolved.
 const PENDING_MONTH = Object.freeze({ pending: true });
 
-// Entries are keyed by the month and day they name, so anything that is not a real date would
-// silently produce a key that no lookup can ever match. Rebuilding the date and comparing it back
-// catches a month outside 0-11, a day outside its month, and February 30 alike.
 function isValidEntry(entry) {
   if (!entry || !Number.isInteger(entry.year) || !Number.isInteger(entry.month) || !Number.isInteger(entry.day)) {
     return false;
@@ -46,8 +32,6 @@ function isValidEntry(entry) {
   return date.getFullYear() === entry.year && date.getMonth() === entry.month && date.getDate() === entry.day;
 }
 
-// One fresh bucket per month being loaded, so a month's own answer replaces its entries, and an
-// entry for any other month is dropped, including one the range covered but did not load.
 function groupEntriesByMonth(months, entries) {
   const result = new Map(months.map((month) => [month, new Map()]));
 
@@ -74,6 +58,9 @@ function groupEntriesByMonth(months, entries) {
  * synchronously or a `Promise`, so results from a server (Flow) or a remote
  * availability service can be awaited. Each returned entry is a `DatePickerDate`
  * extended with metadata fields, e.g. `{ year, month, day, disabled: true }`.
+ *
+ * `ARCHITECTURE.md` in this package records the reasoning behind the request,
+ * caching, notification and failure behavior.
  */
 export class DateMetadataController {
   /**
@@ -113,24 +100,14 @@ export class DateMetadataController {
   }
 
   hostConnected() {
-    // Changes that resolved while the host was detached were not reported to it,
-    // so re-report the current state now that it can act on it again.
     this.#notify();
   }
 
   /**
    * Registers an element to be re-rendered whenever the resolved metadata or the
-   * loading state changes.
-   *
-   * The element must render from its bindings: it is invalidated with
-   * `requestUpdate()`, which leaves the changed properties empty, so `PolylitMixin`
-   * does not re-run observers. State applied imperatively from an observer has to be
-   * refreshed from the host callback instead.
-   *
-   * The element must also not be the one whose own observer triggers a load, or it
-   * invalidates itself mid-update.
-   *
-   * There is no `unsubscribe`: a subscriber is retained for the controller's lifetime.
+   * loading state changes. The element must render from its bindings, and must not be
+   * the one whose own observer triggers a load. It stays registered for the
+   * controller's lifetime.
    *
    * @param {import('lit').ReactiveElement} element
    */
@@ -152,9 +129,8 @@ export class DateMetadataController {
   }
 
   /**
-   * Sets the provider function and clears the cache. Compared by reference, so a
-   * missing provider is normalized to `null` and passing the same provider again is
-   * a no-op. Callers should keep a stable provider reference.
+   * Sets the provider function and clears the cache. Passing the same provider again
+   * is a no-op, so callers should keep a stable reference.
    *
    * @param {Function | null | undefined} provider
    */
@@ -211,9 +187,8 @@ export class DateMetadataController {
    * given dates, rounded out to whole blocks of months. Months already loaded or in
    * flight are skipped, and the ones left over are requested with a single call.
    *
-   * A range inside one block costs nothing once that block is loaded, so moving
-   * around within it does not re-request. Each call that does find a missing month
-   * issues its own request, so a caller that loads on scroll should still debounce.
+   * Each call that finds a missing month issues its own request, so a caller that
+   * loads on scroll should debounce.
    *
    * @param {Date | null | undefined} startDate
    * @param {Date | null | undefined} endDate
@@ -261,7 +236,6 @@ export class DateMetadataController {
       console.error(error);
     }
 
-    // Ignore an answer from before the last `clearCache()`, e.g. because the provider changed.
     if (requestId !== this.#requestId) {
       return;
     }
@@ -270,7 +244,6 @@ export class DateMetadataController {
       if (entries) {
         this.#months.set(month, { pending: false, entries: entries.get(month) });
       } else {
-        // Left absent rather than recorded as empty, so the next range request asks again.
         this.#months.delete(month);
       }
     });
@@ -279,7 +252,6 @@ export class DateMetadataController {
   }
 
   #notify() {
-    // Subscribers re-render from their bindings, so invalidate them synchronously.
     this.#subscribers.forEach((element) => element.requestUpdate());
 
     if (this.#onChange) {

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -18,6 +18,39 @@ export interface DatePickerDate {
   year: number;
 }
 
+/**
+ * A range of dates the provider is asked about. Always covers whole months: `start` is the first
+ * day of a month and `end` the last day of a month, so a provider may group its query by month.
+ */
+export interface DatePickerDateRange {
+  /**
+   * The first date of the range (inclusive).
+   */
+  start: DatePickerDate;
+  /**
+   * The last date of the range (inclusive).
+   */
+  end: DatePickerDate;
+}
+
+/**
+ * Metadata resolved on demand for a single date.
+ */
+export interface DatePickerDateMetadata extends DatePickerDate {
+  /**
+   * Whether the date cannot be selected.
+   */
+  disabled?: boolean;
+}
+
+/**
+ * A function called with the range of dates the calendar is about to show, returning or resolving
+ * with the metadata for the dates in that range.
+ */
+export type DatePickerDateMetadataProvider = (
+  range: DatePickerDateRange,
+) => DatePickerDateMetadata[] | Promise<DatePickerDateMetadata[] | null | undefined> | null | undefined;
+
 export interface DatePickerI18n {
   /**
    * An array with the full names of months starting

--- a/packages/date-picker/src/vaadin-date-picker.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker.d.ts
@@ -7,7 +7,13 @@ import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { InputControlMixin } from '@vaadin/field-base/src/input-control-mixin.js';
 import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
-export { DatePickerDate, DatePickerI18n } from './vaadin-date-picker-mixin.js';
+export {
+  DatePickerDate,
+  DatePickerDateMetadata,
+  DatePickerDateMetadataProvider,
+  DatePickerDateRange,
+  DatePickerI18n,
+} from './vaadin-date-picker-mixin.js';
 
 /**
  * Fired when the user commits a value change.

--- a/packages/date-picker/test/date-metadata-controller.test.js
+++ b/packages/date-picker/test/date-metadata-controller.test.js
@@ -8,7 +8,7 @@ import { createDate } from '../src/vaadin-date-picker-helper.js';
 describe('DateMetadataController', () => {
   let controller, host, onChange;
 
-  // Most tests care about a single month, which the controller expands by the prefetch buffer.
+  // Most tests care about a single month, which the controller rounds out to a whole block.
   function loadMonth(year, month) {
     const date = createDate(year, month, 1);
     controller.ensureRangeLoaded(date, date);
@@ -26,16 +26,28 @@ describe('DateMetadataController', () => {
     controller = new DateMetadataController(host, onChange);
   });
 
-  it('should call the provider once for a range covering the prefetch window', () => {
+  it('should call the provider once for the whole block the range falls in', () => {
     const provider = stubProvider();
 
     loadMonth(2023, 2); // March 2023
 
     expect(provider).to.be.calledOnce;
-    // March 2023 ± 6 months = Sept 2022 (month 8) through Sept 2023.
+    // A block is one calendar year, so asking about March 2023 asks about all of 2023.
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2022, month: 8, day: 1 },
-      end: { year: 2023, month: 8, day: 30 },
+      start: { year: 2023, month: 0, day: 1 },
+      end: { year: 2023, month: 11, day: 31 },
+    });
+  });
+
+  it('should round a block down for a year before 0', () => {
+    const provider = stubProvider();
+
+    controller.ensureRangeLoaded(createDate(-1, 5, 10), createDate(-1, 5, 10));
+
+    // Rounding towards zero instead of down would land in the block after this one.
+    expect(provider.firstCall.args[0]).to.eql({
+      start: { year: -1, month: 0, day: 1 },
+      end: { year: -1, month: 11, day: 31 },
     });
   });
 
@@ -67,32 +79,48 @@ describe('DateMetadataController', () => {
   it('should not call the provider again for months within the loaded window', async () => {
     const provider = stubProvider();
 
-    // Load a wide span first (Jan..Dec 2023 → window Jul 2022..Jun 2024).
+    // Load a whole year first.
     controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2023, 11, 1));
     await aTimeout(0);
     provider.resetHistory();
 
-    // Re-request months whose full prefetch window is already covered.
+    // Re-request months the loaded block already covers.
     controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2023, 11, 1));
-    loadMonth(2023, 5); // June, window Dec22..Dec23
+    loadMonth(2023, 5);
 
     expect(provider).to.not.be.called;
   });
 
-  it('should fetch only the new months when scrolling one month forward', async () => {
+  it('should not fetch again when moving within the loaded block', async () => {
     const provider = stubProvider();
 
-    loadMonth(2023, 2); // window Sep22..Sep23
+    loadMonth(2023, 2);
     await aTimeout(0);
     provider.resetHistory();
 
-    loadMonth(2023, 3); // window Oct22..Oct23
+    // Stepping through the rest of the year stays inside the block that is already loaded, which is
+    // the point of aligning them: a buffer centred on the request would ask for a month per step.
+    for (let month = 3; month <= 11; month++) {
+      loadMonth(2023, month);
+    }
 
-    // Only the single new trailing month (Oct 2023) should be fetched.
+    expect(provider).to.not.be.called;
+  });
+
+  it('should fetch the next block when the range reaches into it', async () => {
+    const provider = stubProvider();
+
+    loadMonth(2023, 2);
+    await aTimeout(0);
+    provider.resetHistory();
+
+    controller.ensureRangeLoaded(createDate(2023, 11, 1), createDate(2024, 0, 1));
+
+    // 2023 is already loaded, so only the block it reaches into is requested.
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2023, month: 9, day: 1 },
-      end: { year: 2023, month: 9, day: 31 },
+      start: { year: 2024, month: 0, day: 1 },
+      end: { year: 2024, month: 11, day: 31 },
     });
   });
 
@@ -107,8 +135,8 @@ describe('DateMetadataController', () => {
 
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2024, month: 8, day: 1 },
-      end: { year: 2025, month: 8, day: 30 },
+      start: { year: 2025, month: 0, day: 1 },
+      end: { year: 2025, month: 11, day: 31 },
     });
   });
 
@@ -144,39 +172,37 @@ describe('DateMetadataController', () => {
   it('should narrow the range to the months that are missing', async () => {
     const provider = stubProvider();
 
-    // Load two windows far apart, leaving a gap of unloaded months between them.
-    loadMonth(2023, 0); // Jul 2022 - Jul 2023
-    loadMonth(2025, 0); // Jul 2024 - Jul 2025
+    // Load two blocks with an unloaded one between them.
+    loadMonth(2023, 0);
+    loadMonth(2025, 0);
     await aTimeout(0);
     provider.resetHistory();
 
-    // A range spanning both windows plus the gap. It is narrowed to the months still missing:
-    // August 2023 (first month after the earlier window) through June 2024 (last month before the
-    // later one).
+    // A range covering the first block and the gap. It is narrowed to the block still missing.
     controller.ensureRangeLoaded(new Date(2023, 6, 1), new Date(2024, 6, 1));
 
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2023, month: 7, day: 1 },
-      end: { year: 2024, month: 5, day: 30 },
+      start: { year: 2024, month: 0, day: 1 },
+      end: { year: 2024, month: 11, day: 31 },
     });
   });
 
   it('should request one range when the missing months are not consecutive', async () => {
     const provider = stubProvider();
 
-    // Load a window in the middle, so a wider range around it leaves a gap on either side.
-    loadMonth(2023, 6); // Jan 2023 - Jan 2024
+    // Load a block in the middle, so a wider range leaves a missing one on either side.
+    loadMonth(2024, 6);
     await aTimeout(0);
     provider.resetHistory();
 
-    // Jul 2022 - Jul 2024. The answered middle is covered by the range rather than splitting it.
-    controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2024, 0, 1));
+    // The answered block in the middle is covered by the range rather than splitting it in two.
+    controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2025, 0, 1));
 
     expect(provider).to.be.calledOnce;
     expect(provider.firstCall.args[0]).to.eql({
-      start: { year: 2022, month: 6, day: 1 },
-      end: { year: 2024, month: 6, day: 31 },
+      start: { year: 2023, month: 0, day: 1 },
+      end: { year: 2025, month: 11, day: 31 },
     });
   });
 
@@ -529,7 +555,7 @@ describe('DateMetadataController', () => {
 
       expect(provider.firstCall.args[0]).to.eql({
         start: { year: 50, month: 0, day: 1 },
-        end: { year: 51, month: 0, day: 31 },
+        end: { year: 50, month: 11, day: 31 },
       });
       expect(controller.isMonthLoaded(createDate(50, 6, 1))).to.be.true;
       expect(controller.isDateDisabled(createDate(50, 6, 15))).to.be.true;
@@ -700,13 +726,14 @@ describe('DateMetadataController', () => {
 
       loadMonth(2023, 2);
       loadMonth(2023, 2);
-      loadMonth(2023, 3); // overlapping window
+      loadMonth(2023, 8); // same block
+      loadMonth(2024, 3); // the next one
 
-      // The second call is fully covered by the pending months; the third adds only Oct 2023.
+      // Everything in the pending block is skipped; only the next block is a second call.
       expect(provider).to.be.calledTwice;
       expect(provider.secondCall.args[0]).to.eql({
-        start: { year: 2023, month: 9, day: 1 },
-        end: { year: 2023, month: 9, day: 31 },
+        start: { year: 2024, month: 0, day: 1 },
+        end: { year: 2024, month: 11, day: 31 },
       });
     });
 
@@ -728,18 +755,18 @@ describe('DateMetadataController', () => {
     });
   });
 
-  describe('month lengths', () => {
-    [
-      { name: 'a leap February', year: 2023, end: { year: 2024, month: 1, day: 29 } },
-      { name: 'a non-leap February', year: 2022, end: { year: 2023, month: 1, day: 28 } },
-    ].forEach(({ name, year, end }) => {
-      it(`should end the range on the last day of ${name}`, () => {
+  describe('block bounds', () => {
+    [2022, 2023, 2024].forEach((year) => {
+      it(`should cover ${year} whichever month of it is asked about`, () => {
         const provider = stubProvider();
 
-        // August + 6 months = February of the next year.
         loadMonth(year, 7);
 
-        expect(provider.firstCall.args[0].end).to.eql(end);
+        // A block ends on 31 December, so a leap year does not change where the range ends.
+        expect(provider.firstCall.args[0]).to.eql({
+          start: { year, month: 0, day: 1 },
+          end: { year, month: 11, day: 31 },
+        });
       });
     });
   });

--- a/packages/date-picker/test/date-metadata-controller.test.js
+++ b/packages/date-picker/test/date-metadata-controller.test.js
@@ -1,0 +1,746 @@
+import { expect } from '@vaadin/chai-plugins';
+import { aTimeout } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import { clearWarnings } from '@vaadin/component-base/src/warnings.js';
+import { DateMetadataController } from '../src/vaadin-date-metadata-controller.js';
+import { createDate } from '../src/vaadin-date-picker-helper.js';
+
+describe('DateMetadataController', () => {
+  let controller, host, onChange;
+
+  // Most tests care about a single month, which the controller expands by the prefetch buffer.
+  function loadMonth(year, month) {
+    const date = createDate(year, month, 1);
+    controller.ensureRangeLoaded(date, date);
+  }
+
+  function stubProvider(result = []) {
+    const provider = sinon.stub().returns(result);
+    controller.setProvider(provider);
+    return provider;
+  }
+
+  beforeEach(() => {
+    onChange = sinon.spy();
+    host = { isConnected: true };
+    controller = new DateMetadataController(host, onChange);
+  });
+
+  it('should call the provider once for a range covering the prefetch window', () => {
+    const provider = stubProvider();
+
+    loadMonth(2023, 2); // March 2023
+
+    expect(provider).to.be.calledOnce;
+    // March 2023 ± 6 months = Sept 2022 (month 8) through Sept 2023.
+    expect(provider.firstCall.args[0]).to.eql({
+      start: { year: 2022, month: 8, day: 1 },
+      end: { year: 2023, month: 8, day: 30 },
+    });
+  });
+
+  it('should mark the requested months as loaded and expose disabled dates', async () => {
+    controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+    loadMonth(2023, 2);
+    await aTimeout(0);
+
+    expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
+    expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+    expect(controller.isDateDisabled(new Date(2023, 2, 16))).to.be.false;
+    expect(controller.isLoading()).to.be.false;
+  });
+
+  it('should return the entry the provider supplied', async () => {
+    controller.setProvider(() => [
+      { year: 2023, month: 2, day: 10, occupancy: 'high' },
+      { year: 2023, month: 2, day: 15, disabled: true },
+    ]);
+    loadMonth(2023, 2);
+    await aTimeout(0);
+
+    expect(controller.getMetadata(new Date(2023, 2, 10))).to.include({ occupancy: 'high' });
+    expect(controller.getMetadata(new Date(2023, 2, 15))).to.include({ disabled: true });
+    expect(controller.isDateDisabled(new Date(2023, 2, 10))).to.be.false;
+    expect(controller.getMetadata(new Date(2023, 2, 11))).to.be.undefined;
+  });
+
+  it('should not call the provider again for months within the loaded window', async () => {
+    const provider = stubProvider();
+
+    // Load a wide span first (Jan..Dec 2023 → window Jul 2022..Jun 2024).
+    controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2023, 11, 1));
+    await aTimeout(0);
+    provider.resetHistory();
+
+    // Re-request months whose full prefetch window is already covered.
+    controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2023, 11, 1));
+    loadMonth(2023, 5); // June, window Dec22..Dec23
+
+    expect(provider).to.not.be.called;
+  });
+
+  it('should fetch only the new months when scrolling one month forward', async () => {
+    const provider = stubProvider();
+
+    loadMonth(2023, 2); // window Sep22..Sep23
+    await aTimeout(0);
+    provider.resetHistory();
+
+    loadMonth(2023, 3); // window Oct22..Oct23
+
+    // Only the single new trailing month (Oct 2023) should be fetched.
+    expect(provider).to.be.calledOnce;
+    expect(provider.firstCall.args[0]).to.eql({
+      start: { year: 2023, month: 9, day: 1 },
+      end: { year: 2023, month: 9, day: 31 },
+    });
+  });
+
+  it('should fetch again for a range far outside the loaded window', async () => {
+    const provider = stubProvider();
+
+    loadMonth(2023, 2);
+    await aTimeout(0);
+    provider.resetHistory();
+
+    loadMonth(2025, 2);
+
+    expect(provider).to.be.calledOnce;
+    expect(provider.firstCall.args[0]).to.eql({
+      start: { year: 2024, month: 8, day: 1 },
+      end: { year: 2025, month: 8, day: 30 },
+    });
+  });
+
+  it('should clear the cache when the provider changes', async () => {
+    controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+    loadMonth(2023, 2);
+    await aTimeout(0);
+    expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+
+    controller.setProvider(() => []);
+    expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
+    expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
+  });
+
+  it('should ignore an async result that resolves after a reset', async () => {
+    let resolveStale;
+    controller.setProvider(
+      () =>
+        new Promise((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+    loadMonth(2023, 2);
+
+    // Provider changes (reset) before the first request resolves.
+    controller.setProvider(() => []);
+    resolveStale([{ year: 2023, month: 2, day: 15, disabled: true }]);
+    await aTimeout(0);
+
+    expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
+  });
+
+  it('should narrow the range to the months that are missing', async () => {
+    const provider = stubProvider();
+
+    // Load two windows far apart, leaving a gap of unloaded months between them.
+    loadMonth(2023, 0); // Jul 2022 - Jul 2023
+    loadMonth(2025, 0); // Jul 2024 - Jul 2025
+    await aTimeout(0);
+    provider.resetHistory();
+
+    // A range spanning both windows plus the gap. It is narrowed to the months still missing:
+    // August 2023 (first month after the earlier window) through June 2024 (last month before the
+    // later one).
+    controller.ensureRangeLoaded(new Date(2023, 6, 1), new Date(2024, 6, 1));
+
+    expect(provider).to.be.calledOnce;
+    expect(provider.firstCall.args[0]).to.eql({
+      start: { year: 2023, month: 7, day: 1 },
+      end: { year: 2024, month: 5, day: 30 },
+    });
+  });
+
+  it('should request one range when the missing months are not consecutive', async () => {
+    const provider = stubProvider();
+
+    // Load a window in the middle, so a wider range around it leaves a gap on either side.
+    loadMonth(2023, 6); // Jan 2023 - Jan 2024
+    await aTimeout(0);
+    provider.resetHistory();
+
+    // Jul 2022 - Jul 2024. The answered middle is covered by the range rather than splitting it.
+    controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2024, 0, 1));
+
+    expect(provider).to.be.calledOnce;
+    expect(provider.firstCall.args[0]).to.eql({
+      start: { year: 2022, month: 6, day: 1 },
+      end: { year: 2024, month: 6, day: 31 },
+    });
+  });
+
+  it('should keep the metadata of an answered month covered by a wider range', async () => {
+    // The same provider throughout, so the cache is not dropped: it answers the first request and
+    // leaves the second one in flight.
+    let answered = false;
+    controller.setProvider(() => {
+      if (answered) {
+        return new Promise(() => {});
+      }
+      answered = true;
+      return [{ year: 2023, month: 6, day: 15, disabled: true }];
+    });
+
+    loadMonth(2023, 6); // Jan 2023 - Jan 2024
+    await aTimeout(0);
+    expect(controller.isDateDisabled(new Date(2023, 6, 15))).to.be.true;
+
+    // Jul 2022 - Jul 2024, so months are missing on either side of the answered block. The range
+    // covers the answered months, but only the missing ones are loaded, so what is already known
+    // stays known instead of dropping back to pending until the reply arrives.
+    controller.ensureRangeLoaded(new Date(2023, 0, 1), new Date(2024, 0, 1));
+
+    expect(controller.isMonthLoaded(new Date(2023, 6, 15))).to.be.true;
+    expect(controller.isDateDisabled(new Date(2023, 6, 15))).to.be.true;
+  });
+
+  describe('async provider', () => {
+    let resolveProvider, provider;
+
+    beforeEach(() => {
+      provider = sinon.stub().returns(
+        new Promise((resolve) => {
+          resolveProvider = resolve;
+        }),
+      );
+      controller.setProvider(provider);
+    });
+
+    it('should be loading until the promise resolves', async () => {
+      loadMonth(2023, 2);
+      expect(controller.isLoading()).to.be.true;
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
+
+      resolveProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      await aTimeout(0);
+
+      expect(controller.isLoading()).to.be.false;
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+    });
+
+    it('should notify the host when loading starts and finishes', async () => {
+      onChange.resetHistory();
+      loadMonth(2023, 2);
+      // The host callback is deferred to a microtask so it never runs during an update.
+      await Promise.resolve();
+      expect(onChange).to.be.called;
+
+      onChange.resetHistory();
+      resolveProvider([]);
+      await aTimeout(0);
+      expect(onChange).to.be.called;
+    });
+  });
+
+  describe('nullish dates', () => {
+    beforeEach(async () => {
+      controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+      loadMonth(2023, 2);
+      await aTimeout(0);
+    });
+
+    [null, undefined].forEach((value) => {
+      it(`should answer the lookups for ${value}`, () => {
+        expect(controller.isMonthLoaded(value)).to.be.false;
+        expect(controller.getMetadata(value)).to.be.undefined;
+        expect(controller.isDateDisabled(value)).to.be.false;
+      });
+
+      it(`should not request a range bounded by ${value}`, () => {
+        const provider = stubProvider();
+
+        controller.ensureRangeLoaded(value, new Date(2030, 0, 1));
+        controller.ensureRangeLoaded(new Date(2030, 0, 1), value);
+
+        expect(provider).to.not.be.called;
+      });
+    });
+  });
+
+  describe('failing provider', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'error');
+      sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      console.error.restore();
+      console.warn.restore();
+      clearWarnings();
+    });
+
+    it('should treat a throwing provider as no metadata', () => {
+      controller.setProvider(() => {
+        throw new Error('provider failed');
+      });
+
+      expect(() => loadMonth(2023, 2)).to.not.throw();
+      expect(controller.isLoading()).to.be.false;
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
+      // Failing open: a failure must not leave the dates disabled.
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
+      expect(console.error).to.be.called;
+    });
+
+    it('should treat a rejecting provider as no metadata', async () => {
+      controller.setProvider(() => Promise.reject(new Error('provider failed')));
+
+      loadMonth(2023, 2);
+      await aTimeout(0);
+
+      expect(controller.isLoading()).to.be.false;
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
+      expect(console.error).to.be.called;
+    });
+
+    it('should treat a non-array result as no metadata and warn about it', async () => {
+      controller.setProvider(() => ({ dates: [] }));
+
+      loadMonth(2023, 2);
+      await aTimeout(0);
+
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
+      expect(console.warn).to.be.calledOnce;
+      expect(console.warn.firstCall.args[0]).to.contain('array');
+    });
+
+    it('should accept an empty result without warning', async () => {
+      controller.setProvider(() => undefined);
+
+      loadMonth(2023, 2);
+      await aTimeout(0);
+
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
+      expect(console.warn).to.not.be.called;
+    });
+
+    it('should request an update on subscribed elements when a request fails', async () => {
+      const element = { requestUpdate: sinon.spy() };
+      controller.subscribe(element);
+      controller.setProvider(() => Promise.reject(new Error('provider failed')));
+      loadMonth(2023, 2);
+      element.requestUpdate.resetHistory();
+
+      await aTimeout(0);
+
+      expect(element.requestUpdate).to.be.called;
+    });
+
+    it('should report a month being retried as loading', () => {
+      // A failed month is not loading, since nothing is in flight for it. Once the retry starts it
+      // is genuinely being fetched again, so it must report as loading rather than as settled.
+      let attempt = 0;
+      controller.setProvider(() => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error('provider failed');
+        }
+        return new Promise(() => {});
+      });
+
+      loadMonth(2023, 2);
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
+      expect(controller.isLoading()).to.be.false;
+
+      loadMonth(2023, 2);
+
+      expect(controller.isLoading()).to.be.true;
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.false;
+    });
+
+    it('should request a failed month again on the next range request', async () => {
+      // A transient failure must not be cached as an authoritative "nothing is disabled".
+      let fail = true;
+      const provider = sinon.spy(() => {
+        if (fail) {
+          throw new Error('provider failed');
+        }
+        return [{ year: 2023, month: 2, day: 15, disabled: true }];
+      });
+      controller.setProvider(provider);
+      loadMonth(2023, 2);
+      provider.resetHistory();
+
+      fail = false;
+      loadMonth(2023, 2);
+      await aTimeout(0);
+
+      expect(provider).to.be.called;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+    });
+
+    it('should stop re-requesting a month once it resolves', async () => {
+      const provider = sinon.stub();
+      provider.onFirstCall().throws(new Error('provider failed'));
+      provider.returns([]);
+      controller.setProvider(provider);
+      loadMonth(2023, 2);
+      loadMonth(2023, 2);
+      await aTimeout(0);
+      provider.resetHistory();
+
+      loadMonth(2023, 2);
+
+      expect(provider).to.not.be.called;
+    });
+  });
+
+  describe('subscribers', () => {
+    let element;
+
+    beforeEach(() => {
+      element = { requestUpdate: sinon.spy() };
+      controller.subscribe(element);
+    });
+
+    it('should request an update when the cache is cleared', () => {
+      controller.clearCache();
+
+      expect(element.requestUpdate).to.be.called;
+    });
+
+    it('should request an update when a load starts', () => {
+      controller.setProvider(() => new Promise(() => {}));
+      element.requestUpdate.resetHistory();
+
+      loadMonth(2023, 2);
+
+      expect(element.requestUpdate).to.be.called;
+    });
+
+    it('should request an update when a month resolves', async () => {
+      let resolveProvider;
+      controller.setProvider(
+        () =>
+          new Promise((resolve) => {
+            resolveProvider = resolve;
+          }),
+      );
+      loadMonth(2023, 2);
+      element.requestUpdate.resetHistory();
+
+      resolveProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      await aTimeout(0);
+
+      expect(element.requestUpdate).to.be.called;
+    });
+
+    it('should only register an element once', () => {
+      controller.subscribe(element);
+
+      controller.clearCache();
+
+      expect(element.requestUpdate).to.be.calledOnce;
+    });
+
+    it('should request an update synchronously, before the host callback', () => {
+      onChange.resetHistory();
+
+      controller.clearCache();
+
+      // Subscribers are invalidated in the same task; the host callback is deferred.
+      expect(element.requestUpdate).to.be.called;
+      expect(onChange).to.not.be.called;
+    });
+  });
+
+  describe('detached host', () => {
+    it('should keep the resolved cache when the host reconnects', async () => {
+      const provider = stubProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      loadMonth(2023, 2);
+      await aTimeout(0);
+      provider.resetHistory();
+
+      controller.hostConnected();
+
+      loadMonth(2023, 2);
+
+      expect(provider).to.not.be.called;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+    });
+
+    it('should still apply a request that resolves while detached', async () => {
+      let resolveProvider;
+      controller.setProvider(
+        () =>
+          new Promise((resolve) => {
+            resolveProvider = resolve;
+          }),
+      );
+      loadMonth(2023, 2);
+
+      // Detached while the request is on its way: discarding the answer would only re-fetch the
+      // same range once the host came back.
+      host.isConnected = false;
+      resolveProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      await aTimeout(0);
+
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+    });
+
+    it('should not notify the host while it is disconnected', async () => {
+      host.isConnected = false;
+      controller.setProvider(() => []);
+      onChange.resetHistory();
+
+      loadMonth(2023, 2);
+      await aTimeout(0);
+
+      expect(onChange).to.not.be.called;
+    });
+
+    it('should report the current state again once the host is reconnected', async () => {
+      host.isConnected = false;
+      controller.setProvider(() => [{ year: 2023, month: 2, day: 15, disabled: true }]);
+      // Resolves while detached, so the host is never told about it.
+      loadMonth(2023, 2);
+      await aTimeout(0);
+      expect(onChange).to.not.be.called;
+
+      host.isConnected = true;
+      controller.hostConnected();
+      await aTimeout(0);
+
+      expect(onChange).to.be.called;
+    });
+  });
+
+  describe('years below 100', () => {
+    it('should resolve metadata for a year below 100', async () => {
+      const provider = stubProvider([{ year: 50, month: 6, day: 15, disabled: true }]);
+
+      loadMonth(50, 6);
+      await aTimeout(0);
+
+      expect(provider.firstCall.args[0]).to.eql({
+        start: { year: 50, month: 0, day: 1 },
+        end: { year: 51, month: 0, day: 31 },
+      });
+      expect(controller.isMonthLoaded(createDate(50, 6, 1))).to.be.true;
+      expect(controller.isDateDisabled(createDate(50, 6, 15))).to.be.true;
+      expect(controller.isDateDisabled(createDate(50, 6, 16))).to.be.false;
+    });
+  });
+
+  describe('entries outside the requested range', () => {
+    // A month is only resolved by being requested, so metadata the provider volunteers for other
+    // months must not be trusted before that month is loaded in its own right.
+    beforeEach(async () => {
+      controller.setProvider(() => [
+        { year: 2023, month: 2, day: 15, disabled: true },
+        { year: 2024, month: 0, day: 5, disabled: true },
+      ]);
+      loadMonth(2023, 2); // Sep 2022 - Sep 2023
+      await aTimeout(0);
+    });
+
+    it('should not report a date in an unresolved month as disabled', () => {
+      expect(controller.isMonthLoaded(new Date(2024, 0, 1))).to.be.false;
+      expect(controller.isDateDisabled(new Date(2024, 0, 5))).to.be.false;
+      expect(controller.getMetadata(new Date(2024, 0, 5))).to.be.undefined;
+    });
+
+    it('should report the date once its month is resolved', async () => {
+      loadMonth(2024, 0);
+      await aTimeout(0);
+
+      expect(controller.isMonthLoaded(new Date(2024, 0, 1))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2024, 0, 5))).to.be.true;
+    });
+  });
+
+  describe('a resolved month keeps its own answer', () => {
+    it('should not let a later request override an already resolved month', async () => {
+      // March 2026 is asked about and answered clean. A later request for an unrelated range
+      // volunteers a March date as disabled. March already gave its own answer, so it wins.
+      let call = 0;
+      controller.setProvider(() => {
+        call += 1;
+        return call === 1 ? [] : [{ year: 2026, month: 2, day: 10, disabled: true }];
+      });
+      loadMonth(2026, 2);
+      await aTimeout(0);
+      expect(controller.isMonthLoaded(new Date(2026, 2, 1))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2026, 2, 10))).to.be.false;
+
+      loadMonth(2030, 5);
+      await aTimeout(0);
+
+      expect(controller.isDateDisabled(new Date(2026, 2, 10))).to.be.false;
+    });
+  });
+
+  describe('entries that are not a real date', () => {
+    beforeEach(() => {
+      sinon.stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      console.warn.restore();
+      clearWarnings();
+    });
+
+    [
+      { name: 'a missing date', entry: { disabled: true } },
+      { name: 'a non-integer day', entry: { year: 2024, month: 0, day: '15' } },
+      { name: 'a month above 11', entry: { year: 2024, month: 12, day: 15 } },
+      { name: 'a negative month', entry: { year: 2024, month: -1, day: 15 } },
+      { name: 'a day above the month length', entry: { year: 2024, month: 0, day: 32 } },
+      { name: 'a zero day', entry: { year: 2024, month: 0, day: 0 } },
+      { name: 'a day that does not exist in that month', entry: { year: 2023, month: 1, day: 29 } },
+      // Throws when coerced to a number, rather than merely describing no real date.
+      { name: 'a bigint month', entry: { year: 2024, month: 0n, day: 15 } },
+    ].forEach(({ name, entry }) => {
+      it(`should warn about and ignore ${name}`, async () => {
+        controller.setProvider(() => [entry, { year: 2024, month: 0, day: 20, disabled: true }]);
+        loadMonth(2024, 0);
+        await aTimeout(0);
+
+        expect(console.warn).to.be.calledOnce;
+        expect(controller.isDateDisabled(new Date(2024, 0, 20))).to.be.true;
+      });
+    });
+
+    it('should accept the last day of a leap February', async () => {
+      controller.setProvider(() => [{ year: 2024, month: 1, day: 29, disabled: true }]);
+      loadMonth(2024, 1);
+      await aTimeout(0);
+
+      expect(console.warn).to.not.be.called;
+      expect(controller.isDateDisabled(new Date(2024, 1, 29))).to.be.true;
+    });
+
+    it('should warn only once however many requests return invalid entries', async () => {
+      controller.setProvider(() => [{ disabled: true }]);
+      loadMonth(2024, 0);
+      loadMonth(2030, 0);
+      await aTimeout(0);
+
+      expect(console.warn).to.be.calledOnce;
+    });
+
+    it('should not warn for a well-formed result', async () => {
+      controller.setProvider(() => [{ year: 2024, month: 0, day: 15, disabled: true }]);
+      loadMonth(2024, 0);
+      await aTimeout(0);
+
+      expect(console.warn).to.not.be.called;
+    });
+  });
+
+  describe('re-resolving a month', () => {
+    it('should answer from the provider again after the cache is cleared', async () => {
+      let disabledDay = 15;
+      controller.setProvider(() => [{ year: 2023, month: 2, day: disabledDay, disabled: true }]);
+      loadMonth(2023, 2);
+      await aTimeout(0);
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+
+      // The same month is asked about again and answers differently: the 15th is free, the 16th is
+      // not. Nothing from the dropped answer may survive into the new one.
+      disabledDay = 16;
+      controller.clearCache();
+      loadMonth(2023, 2);
+      await aTimeout(0);
+
+      expect(controller.isDateDisabled(new Date(2023, 2, 16))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.false;
+    });
+  });
+
+  describe('provider identity', () => {
+    it('should not reset the cache when the same provider is set again', async () => {
+      const provider = stubProvider([{ year: 2023, month: 2, day: 15, disabled: true }]);
+      loadMonth(2023, 2);
+      await aTimeout(0);
+      provider.resetHistory();
+      onChange.resetHistory();
+
+      controller.setProvider(provider);
+      // The host callback is deferred, so a cache reset would only be reported a microtask later.
+      await aTimeout(0);
+
+      expect(controller.isMonthLoaded(new Date(2023, 2, 1))).to.be.true;
+      expect(controller.isDateDisabled(new Date(2023, 2, 15))).to.be.true;
+      expect(provider).to.not.be.called;
+      expect(onChange).to.not.be.called;
+    });
+
+    it('should not reset the cache when an unset provider is forwarded as undefined', async () => {
+      // The initial value is `null`, so a host that forwards an unset property as `undefined` must
+      // not be treated as a change.
+      onChange.resetHistory();
+
+      controller.setProvider(undefined);
+      await aTimeout(0);
+
+      expect(controller.provider).to.be.null;
+      expect(onChange).to.not.be.called;
+    });
+  });
+
+  describe('pending requests', () => {
+    it('should not request the same months twice while a request is in flight', () => {
+      const provider = stubProvider(new Promise(() => {}));
+
+      loadMonth(2023, 2);
+      loadMonth(2023, 2);
+      loadMonth(2023, 3); // overlapping window
+
+      // The second call is fully covered by the pending months; the third adds only Oct 2023.
+      expect(provider).to.be.calledTwice;
+      expect(provider.secondCall.args[0]).to.eql({
+        start: { year: 2023, month: 9, day: 1 },
+        end: { year: 2023, month: 9, day: 31 },
+      });
+    });
+
+    it('should notify the host once per batch of changes in the same task', async () => {
+      controller.setProvider(() => []);
+      loadMonth(2023, 6);
+      await aTimeout(0);
+      onChange.resetHistory();
+
+      // Dropping the cache and starting two requests are three changes in one task, reported once.
+      controller.clearCache();
+      loadMonth(2020, 0);
+      loadMonth(2030, 0);
+
+      await aTimeout(0);
+
+      // Once for the three changes above, and once for both requests resolving.
+      expect(onChange).to.be.calledTwice;
+    });
+  });
+
+  describe('month lengths', () => {
+    [
+      { name: 'a leap February', year: 2023, end: { year: 2024, month: 1, day: 29 } },
+      { name: 'a non-leap February', year: 2022, end: { year: 2023, month: 1, day: 28 } },
+    ].forEach(({ name, year, end }) => {
+      it(`should end the range on the last day of ${name}`, () => {
+        const provider = stubProvider();
+
+        // August + 6 months = February of the next year.
+        loadMonth(year, 7);
+
+        expect(provider.firstCall.args[0].end).to.eql(end);
+      });
+    });
+  });
+});

--- a/packages/date-picker/test/typings/date-picker.types.ts
+++ b/packages/date-picker/test/typings/date-picker.types.ts
@@ -11,7 +11,14 @@ import type { InputMixinClass } from '@vaadin/field-base/src/input-mixin.js';
 import type { LabelMixinClass } from '@vaadin/field-base/src/label-mixin.js';
 import type { ValidateMixinClass } from '@vaadin/field-base/src/validate-mixin.js';
 import type { ThemableMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
-import type { DatePickerDate, DatePickerI18n, DatePickerMixinClass } from '../../src/vaadin-date-picker-mixin.js';
+import type {
+  DatePickerDate,
+  DatePickerDateMetadata,
+  DatePickerDateMetadataProvider,
+  DatePickerDateRange,
+  DatePickerI18n,
+  DatePickerMixinClass,
+} from '../../src/vaadin-date-picker-mixin.js';
 import type {
   DatePicker,
   DatePickerChangeEvent,
@@ -82,6 +89,17 @@ assertType<string | null | undefined>(datePicker.initialPosition);
 // I18n
 assertType<DatePickerI18n>({});
 assertType<DatePickerI18n>({ cancel: 'cancel' });
+
+// Date metadata
+assertType<DatePickerDateRange>({ start: { year: 2024, month: 0, day: 1 }, end: { year: 2024, month: 0, day: 31 } });
+assertType<DatePickerDateMetadata>({ year: 2024, month: 0, day: 1 });
+assertType<DatePickerDateMetadata>({ year: 2024, month: 0, day: 1, disabled: true });
+assertType<DatePickerDateMetadataProvider>((range) => {
+  assertType<DatePickerDate>(range.start);
+  assertType<DatePickerDate>(range.end);
+  return [];
+});
+assertType<DatePickerDateMetadataProvider>(async () => await Promise.resolve([]));
 
 // DatePicker mixins
 assertType<ElementMixinClass>(datePicker);


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12041

Depends on https://github.com/vaadin/web-components/pull/12242

Added initial `DateMetadataController` implementation and tests. Integration will be done in a follow-up PR.

## Type of change

- Feature

## Note

Here's a list of notable changes vs the initial implementation:

- **Subscription-based change notification**. Consumers register with `subscribe()` and are invalidated synchronously with `requestUpdate()`, replacing the `_dateMetadataVersion` counter passed to overlay content / calendars.
- **Host callback is deferred by one microtask** - see reasoning in `ARCHITECTURE.md`. A synchronous provider also notified twice per load, once on start and once on resolve.
- **Dates are built with `setFullYear`**. Using `new Date(year, ...)` maps years 0–99 into the 20th century, so the month keys written while loading never matched the keys read back. Every date in those years stayed permanently blocked.
- **Resolving a month replaces metadata instead of merging**. Metadata is grouped by month, so a date that the provider stops reporting as disabled actually becomes selectable again. Merging also blocks a per-month cache refresh.
- **In-flight requests survive the host being detached**. Only `reset()` invalidates them, so moving the field in the DOM no longer discards work already on its way and re-fetches the same range. `hostConnected()` re-reports the current state, because notifications are skipped while disconnected and would otherwise never reach the host — which previously left loading stuck.
- **`setProvider()` normalizes a missing provider to null**. A host forwarding an unset property as undefined no longer looks like a change, which had reset the cache and notified on every picker using no provider.
- **A provider result that is neither an array nor empty is logged**, consistent with the throw and reject paths, instead of silently presenting a provider bug as "nothing is disabled".
- **`isMonthLoaded` accepts a nullish date**, like the other lookups.
- Private state and methods use # notation, following #12217.
- Typings match the runtime: isConnected on the host, optional onChange, nullable date parameters, plus subscribe and hostConnected.
- More tests added covering a throwing, rejecting and non-array provider, non-consecutive month grouping, detach and reconnect, subscriber semantics and notification ordering, coalescing asserted by call count, leap and non-leap February range ends, and years below 100.
- ARCHITECTURE.md records the reasoning behind these decisions next to the code.