### PR TITLE
fix: clean up notification card state when it does not animate

### DIFF
--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -39,6 +39,7 @@
     "@open-wc/dedupe-mixin": "^1.3.0",
     "@vaadin/component-base": "25.3.0-alpha8",
     "@vaadin/lit-renderer": "25.3.0-alpha8",
+    "@vaadin/overlay": "25.3.0-alpha8",
     "@vaadin/vaadin-themable-mixin": "25.3.0-alpha8",
     "lit": "^3.0.0"
   },

--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -7,6 +7,7 @@ import { render } from 'lit';
 import { isTemplateResult } from 'lit/directive-helpers.js';
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
+import { shouldAnimate } from '@vaadin/overlay/src/vaadin-overlay-utils.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 /**
@@ -349,8 +350,12 @@ export const NotificationMixin = (superClass) =>
 
         this._card.setAttribute('opening', '');
         this._appendNotificationCard();
-        this.__animationEndListener = () => this.__cleanUpOpeningClosingState();
-        this._card.addEventListener('animationend', this.__animationEndListener);
+        if (shouldAnimate(this._card)) {
+          this.__animationEndListener = () => this.__cleanUpOpeningClosingState();
+          this._card.addEventListener('animationend', this.__animationEndListener);
+        } else {
+          this.__cleanUpOpeningClosingState();
+        }
         this._didAnimateNotificationAppend = true;
       } else {
         this._didAnimateNotificationAppend = false;
@@ -409,8 +414,7 @@ export const NotificationMixin = (superClass) =>
       this.__cleanUpOpeningClosingState();
 
       this._card.setAttribute('closing', '');
-      const name = getComputedStyle(this._card).getPropertyValue('animation-name');
-      if (name && name !== 'none') {
+      if (shouldAnimate(this._card)) {
         this.__animationEndListener = () => {
           this._removeNotificationCard();
           this.__cleanUpOpeningClosingState();

--- a/packages/notification/test/animation.test.js
+++ b/packages/notification/test/animation.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import './animation-test-styles.js';
 import '../src/vaadin-notification.js';
 
@@ -124,5 +125,47 @@ describe('animated notifications', () => {
         expect(container.parentNode).to.not.equal(document.body);
       });
     });
+  });
+});
+
+describe('notification that does not animate', () => {
+  let notification, card;
+
+  beforeEach(async () => {
+    notification = fixtureSync('<vaadin-notification duration="-1"></vaadin-notification>');
+    notification.renderer = (root) => {
+      root.textContent = 'Notification';
+    };
+    await nextFrame();
+    card = notification._card;
+  });
+
+  afterEach(async () => {
+    notification.close();
+    // Wait for the notification container to be removed
+    while (document.querySelector('body > vaadin-notification-container')) {
+      await aTimeout(1);
+    }
+  });
+
+  it('should remove the opening attribute without waiting for animationend', () => {
+    card.style.animation = 'none';
+    notification.open();
+
+    expect(card.hasAttribute('opening')).to.be.false;
+  });
+
+  it('should remove a card that is not rendered but has an animation name', () => {
+    const closedSpy = sinon.spy();
+    notification.addEventListener('closed', closedSpy);
+
+    notification.open();
+    // The card has an animation name from `:host([closing])`, but a card that is
+    // not rendered never fires `animationend`.
+    card.style.display = 'none';
+    notification.close();
+
+    expect(card.parentNode).to.be.not.ok;
+    expect(closedSpy).to.be.calledOnce;
   });
 });

--- a/packages/notification/test/dom/__snapshots__/notification.test.snap.js
+++ b/packages/notification/test/dom/__snapshots__/notification.test.snap.js
@@ -4,7 +4,6 @@ export const snapshots = {};
 snapshots["vaadin-notification card"] = 
 `<vaadin-notification-card
   aria-live="polite"
-  opening=""
   role="alert"
   slot="bottom-start"
 >
@@ -16,7 +15,6 @@ snapshots["vaadin-notification card"] =
 snapshots["vaadin-notification card theme"] = 
 `<vaadin-notification-card
   aria-live="polite"
-  opening=""
   role="alert"
   slot="bottom-start"
   theme="custom"
@@ -30,7 +28,6 @@ snapshots["vaadin-notification card class"] =
 `<vaadin-notification-card
   aria-live="polite"
   class="custom"
-  opening=""
   role="alert"
   slot="bottom-start"
 >
@@ -42,7 +39,6 @@ snapshots["vaadin-notification card class"] =
 snapshots["vaadin-notification assertive"] = 
 `<vaadin-notification-card
   aria-live="assertive"
-  opening=""
   role="alert"
   slot="bottom-start"
 >

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -6,7 +6,7 @@
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
-import { setOverlayStateAttribute } from './vaadin-overlay-utils.js';
+import { setOverlayStateAttribute, shouldAnimate } from './vaadin-overlay-utils.js';
 
 export const OverlayMixin = (superClass) =>
   class OverlayMixin extends OverlayFocusMixin(OverlayStackMixin(superClass)) {
@@ -405,14 +405,7 @@ export const OverlayMixin = (superClass) =>
      * @private
      */
     _shouldAnimate() {
-      const style = getComputedStyle(this);
-      const name = style.getPropertyValue('animation-name');
-      const hasDuration = style
-        .getPropertyValue('animation-duration')
-        .split(',')
-        .some((duration) => parseFloat(duration) > 0);
-      const hidden = style.getPropertyValue('display') === 'none';
-      return !hidden && name && name !== 'none' && hasDuration;
+      return shouldAnimate(this);
     }
 
     /**

--- a/packages/overlay/src/vaadin-overlay-utils.d.ts
+++ b/packages/overlay/src/vaadin-overlay-utils.d.ts
@@ -13,6 +13,13 @@
 export function observeMove(element: HTMLElement, callback: () => void): () => void;
 
 /**
+ * Detect whether an animation runs on the given element, so that its end can be
+ * awaited before the element is hidden or removed. An element that is not rendered,
+ * has no animation name, or has a zero duration does not fire `animationend`.
+ */
+export function shouldAnimate(element: HTMLElement): boolean;
+
+/**
  * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state attributes
  * in the light DOM in case the overlay is in the shadow DOM of its owner.
  */

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -86,6 +86,24 @@ export function observeMove(element, callback) {
 }
 
 /**
+ * Detect whether an animation runs on the given element, so that its end can be
+ * awaited before the element is hidden or removed. An element that is not rendered,
+ * has no animation name, or has a zero duration does not fire `animationend`.
+ *
+ * @param {HTMLElement} element
+ * @return {boolean}
+ */
+export function shouldAnimate(element) {
+  const style = getComputedStyle(element);
+  const name = style.getPropertyValue('animation-name');
+  const hasDuration = style
+    .getPropertyValue('animation-duration')
+    .split(',')
+    .some((duration) => parseFloat(duration) > 0);
+  return style.getPropertyValue('display') !== 'none' && name && name !== 'none' && hasDuration;
+}
+
+/**
  * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state attributes
  * in the light DOM in case the overlay is in the shadow DOM of its owner.
  * @param {HTMLElement} overlay The overlay element on which to toggle the attribute.

--- a/packages/overlay/test/utils.test.js
+++ b/packages/overlay/test/utils.test.js
@@ -1,0 +1,33 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync } from '@vaadin/testing-helpers';
+import { shouldAnimate } from '../src/vaadin-overlay-utils.js';
+
+describe('shouldAnimate', () => {
+  let element;
+
+  beforeEach(() => {
+    element = fixtureSync('<div></div>');
+  });
+
+  it('should return false when the element is not rendered', () => {
+    element.style.animation = 'foo 1s';
+    element.style.display = 'none';
+    expect(shouldAnimate(element)).to.be.false;
+  });
+
+  it('should return false when the element has no animation name', () => {
+    element.style.animationDuration = '1s';
+    expect(shouldAnimate(element)).to.be.false;
+  });
+
+  it('should return false when the animation duration is zero', () => {
+    element.style.animation = 'foo 0s';
+    expect(shouldAnimate(element)).to.be.false;
+  });
+
+  it('should return true when one of the animation durations is not zero', () => {
+    element.style.animationName = 'foo, bar';
+    element.style.animationDuration = '0s, 1s';
+    expect(shouldAnimate(element)).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description

`vaadin-notification` decided whether to wait for an animation by looking only at
`animation-name`. That is not enough: an element that is not rendered, or whose animation has a
zero duration, never fires `animationend`. When that happened while closing, the card kept
waiting for an event that never arrived, so it stayed in the DOM and `closed` was never
dispatched. Opening had no check at all, so the `opening` attribute was left on the card
whenever no animation ran.

`vaadin-overlay` already did this correctly, checking the animation name, the duration and
`display`. This moves that check into a shared `shouldAnimate()` helper in the overlay package
and uses it in both places, so the two components cannot drift apart again. `@vaadin/overlay`
is added to the notification dependencies for the import.

Four notification DOM snapshots lose an `opening=""` attribute. The cards in those tests never
animate, so the baseline had recorded the attribute that was left behind.

## Reproduction

```js
const notification = document.querySelector('vaadin-notification');
notification.open();
// Hide the card, for example because an ancestor is hidden.
notification._card.style.display = 'none';
notification.close();
// The card is still in the DOM and no `closed` event was fired.
```

## Type of change

- [x] Bugfix
- [ ] Feature

## Note

Extracted from #12120, where the same helper is needed because the overlay animation styles give
every card an animation name. The fix stands on its own, so it is proposed separately and does
not depend on that PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
