### PR TITLE
refactor: extract date builders into the date-picker helper

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -5,6 +5,45 @@
  */
 
 /**
+ * Create a date at midnight in local time. Unlike `new Date(year, month, day)`,
+ * this supports years below 100, which the constructor maps into the 20th
+ * century. The month is assigned before the day so that the initial day of month
+ * (1) always exists in the target month.
+ *
+ * @param {number} year
+ * @param {number} month Zero-based month, may be out of range to shift the year
+ * @param {number} day May be `0` to select the last day of the previous month
+ * @return {Date}
+ */
+export function createDate(year, month, day) {
+  const date = new Date(0, 0); // Wrong date (1900-01-01), but with midnight in local time
+  date.setFullYear(year);
+  date.setMonth(month);
+  date.setDate(day);
+  return date;
+}
+
+/**
+ * Get the first day of the month the given date is in.
+ *
+ * @param {!Date} date
+ * @return {Date}
+ */
+export function firstOfMonth(date) {
+  return createDate(date.getFullYear(), date.getMonth(), 1);
+}
+
+/**
+ * Get the last day of the month the given date is in.
+ *
+ * @param {!Date} date
+ * @return {Date}
+ */
+export function lastOfMonth(date) {
+  return createDate(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+/**
  * Get ISO 8601 week number for the given date.
  *
  * @param {!Date} date
@@ -185,11 +224,7 @@ export function parseDate(str) {
     return undefined;
   }
 
-  const date = new Date(0, 0); // Wrong date (1900-01-01), but with midnight in local time
-  date.setFullYear(parseInt(parts[1], 10));
-  date.setMonth(parseInt(parts[2], 10) - 1);
-  date.setDate(parseInt(parts[3], 10));
-  return date;
+  return createDate(parseInt(parts[1], 10), parseInt(parts[2], 10) - 1, parseInt(parts[3], 10));
 }
 
 /**

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -5,7 +5,14 @@
  */
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { addListener } from '@vaadin/component-base/src/gestures.js';
-import { dateAllowed, dateEquals, getISOWeekNumber, normalizeDate } from './vaadin-date-picker-helper.js';
+import {
+  dateAllowed,
+  dateEquals,
+  firstOfMonth,
+  getISOWeekNumber,
+  lastOfMonth,
+  normalizeDate,
+} from './vaadin-date-picker-helper.js';
 
 export const MonthCalendarMixin = (superClass) =>
   class MonthCalendarMixinClass extends FocusMixin(superClass) {
@@ -148,17 +155,8 @@ export const MonthCalendarMixin = (superClass) =>
      * @protected
      */
     __computeDisabled(month, minDate, maxDate) {
-      // First day of the month
-      const firstDate = new Date(0, 0);
-      firstDate.setFullYear(month.getFullYear());
-      firstDate.setMonth(month.getMonth());
-      firstDate.setDate(1);
-
-      // Last day of the month
-      const lastDate = new Date(0, 0);
-      lastDate.setFullYear(month.getFullYear());
-      lastDate.setMonth(month.getMonth() + 1);
-      lastDate.setDate(0);
+      const firstDate = firstOfMonth(month);
+      const lastDate = lastOfMonth(month);
 
       if (
         minDate &&


### PR DESCRIPTION
`new Date(year, month, day)` maps years below 100 into the 20th century, and the
date-picker supports years outside that range. The package therefore builds dates
by assigning the year with `setFullYear` instead.

That idiom was repeated in `parseDate` and in `__computeDisabled`, which also built
the first and last day of a month by hand. Keeping the rule for low years in
several places means a fix to one silently diverges from the rest.

`createDate`, `firstOfMonth` and `lastOfMonth` now live in
`vaadin-date-picker-helper.js`. They are internal, so there is no public API
change, and the values they produce are the same as before.

Part of #12041

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)