### PR TITLE
fix: apply Aura MDL detail inset with inset properties

### DIFF
--- a/packages/aura/src/components/master-detail-layout.css
+++ b/packages/aura/src/components/master-detail-layout.css
@@ -28,12 +28,23 @@ vaadin-master-detail-layout[has-detail][overlay]::part(detail) {
     var(--aura-overlay-shadow)
   );
   --_inset: var(--aura-master-detail-layout-detail-inset, round(var(--aura-app-layout-inset) / 1.5, 1px));
-  margin: var(--_inset);
   border-radius: clamp(
     0px,
     var(--_inset) * 1000,
     max(var(--vaadin-radius-m), var(--vaadin-radius-l) - round(var(--_inset) / 2, 1px))
   );
+}
+
+/* Use inset properties instead of `margin` because Chromium 150+ does not re-resolve the auto
+block size when only margin changes. See https://issues.chromium.org/issues/539404705 */
+vaadin-master-detail-layout[has-detail][overlay][orientation='horizontal']::part(detail) {
+  inset-block: var(--_inset);
+  inset-inline-end: var(--_inset);
+}
+
+vaadin-master-detail-layout[has-detail][overlay][orientation='vertical']::part(detail) {
+  inset-inline: var(--_inset);
+  inset-block-end: var(--_inset);
 }
 
 vaadin-master-detail-layout[has-detail][overlay][overlay-containment='page']::part(detail) {


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12234

Chromium 150+ does not re-resolve the auto block size of an absolutely positioned box with `inset-block: 0` when only its margin changes. The overlay detail part relied on that, so changing the inset at runtime left a stale height: with a smaller inset a gap appeared at the bottom, and with a larger one the detail overflowed the layout.

See https://issues.chromium.org/issues/539404705

## Type of change

- Bugfix