### PR TITLE
fix!: use the crud dialog as the overlay owner

### DIFF
--- a/packages/crud/src/vaadin-crud-dialog-overlay.js
+++ b/packages/crud/src/vaadin-crud-dialog-overlay.js
@@ -40,8 +40,7 @@ class CrudDialogOverlay extends OverlayMixin(DirMixin(ThemableMixin(PolylitMixin
    * @override
    */
   get _focusRoot() {
-    // Do not use `owner` since that points to `vaadin-crud`
-    return this.getRootNode().host;
+    return this.owner;
   }
 
   /** @protected */

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -62,7 +62,7 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
     return html`
       <vaadin-crud-dialog-overlay
         id="overlay"
-        .owner="${this.crudElement}"
+        .owner="${this}"
         .opened="${this.opened}"
         @opened-changed="${this._onOverlayOpened}"
         @mousedown="${this._bringOverlayToFront}"

--- a/packages/crud/src/vaadin-crud-dialog.js
+++ b/packages/crud/src/vaadin-crud-dialog.js
@@ -50,10 +50,6 @@ class CrudDialog extends DialogBaseMixin(ThemePropertyMixin(PolylitMixin(LitElem
       fullscreen: {
         type: Boolean,
       },
-
-      crudElement: {
-        type: Object,
-      },
     };
   }
 

--- a/packages/crud/src/vaadin-crud.js
+++ b/packages/crud/src/vaadin-crud.js
@@ -261,7 +261,6 @@ class Crud extends CrudMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjecti
                 aria-label="${ifDefined(this.__dialogAriaLabel)}"
                 theme="${ifDefined(this._theme)}"
                 exportparts="backdrop, overlay, header, content, footer"
-                .crudElement="${this}"
                 .opened="${this.editorOpened}"
                 .fullscreen="${this._fullscreen}"
                 .noCloseOnOutsideClick="${this.__isDirty}"

--- a/packages/crud/test/crud.test.js
+++ b/packages/crud/test/crud.test.js
@@ -582,18 +582,23 @@ describe('crud', () => {
     });
   });
 
-  describe('exportparts', () => {
-    let dialog;
+  describe('overlay', () => {
+    let dialog, overlay;
 
     beforeEach(() => {
       crud = fixtureSync('<vaadin-crud style="width: 300px;"></vaadin-crud>');
       dialog = getDialogEditor(crud);
+      overlay = dialog.$.overlay;
+    });
+
+    it('should set owner property on the crud dialog overlay to dialog', () => {
+      expect(overlay.owner).to.equal(dialog);
     });
 
     it('should export all editor dialog overlay parts for styling', () => {
-      const parts = [...dialog.$.overlay.shadowRoot.querySelectorAll('[part]')].map((el) => el.getAttribute('part'));
+      const parts = [...overlay.shadowRoot.querySelectorAll('[part]')].map((el) => el.getAttribute('part'));
       const dialogExportParts = dialog.getAttribute('exportparts').split(', ');
-      const overlayExportParts = dialog.$.overlay.getAttribute('exportparts').split(', ');
+      const overlayExportParts = overlay.getAttribute('exportparts').split(', ');
 
       parts.forEach((part) => {
         expect(dialogExportParts).to.include(part);

--- a/packages/crud/test/dom/__snapshots__/crud.test.snap.js
+++ b/packages/crud/test/dom/__snapshots__/crud.test.snap.js
@@ -2,10 +2,7 @@
 export const snapshots = {};
 
 snapshots["vaadin-crud host default"] = 
-`<vaadin-crud
-  editor-position=""
-  with-backdrop=""
->
+`<vaadin-crud editor-position="">
   <vaadin-confirm-dialog
     aria-description="There are unsaved changes to this item."
     aria-label="Discard changes"
@@ -286,6 +283,7 @@ snapshots["vaadin-crud shadow default"] =
   id="dialog"
   role="dialog"
   tabindex="0"
+  with-backdrop=""
 >
   <slot
     name="header"


### PR DESCRIPTION
## Description

The overlay `owner` of the CRUD editor dialog points at the `vaadin-crud` element. It was set
that way in #9790, where `owner` was reused for passing the modality root. That usage was
removed in #10026, but the owner was left as it was.

`owner` is also where the overlay writes its state attributes, so they land on `vaadin-crud`
instead of on the dialog. The dialog styles already expect `opening` and `closing` on the
dialog element:

```css
:host([opened]),
:host([opening]),
:host([closing]) {
  display: block !important;
  position: fixed;
}
```

Those two selectors have never matched, because the attributes go somewhere else. With no
overlay animation the closing state lasts no time at all, so nothing was visible. Once a theme
sets `--vaadin-overlay-animation-duration`, the dialog is hidden for the whole closing
animation.

The dialog is now the owner, so the attributes reach the element whose styles use them.

## Type of change

- Behavior altering fix

## Note

`opening`, `closing`, `modeless` and `with-backdrop` are no longer set on `vaadin-crud`. They
are set on the internal dialog element inside its shadow root instead.

None of the four are documented for `vaadin-crud`: it declares only the `theme` attribute, and
`web-types.json` lists only its own properties. They were a side effect of the modality root
plumbing rather than a designed API, and no selector in this repository or in either theme
targets them.

The internal dialog element is not public API, so these states can no longer be styled from an
application stylesheet. Animating the CRUD editor dialog is unaffected, since that is done by
setting `--vaadin-overlay-animation-duration` on `vaadin-crud`, which is forwarded to the
overlay.

> [!WARNING]
> The `opening`, `closing`, `modeless` and `with-backdrop` attributes are no longer set on the
> `vaadin-crud` element. Styles that depend on them, for example
> `vaadin-crud[closing] { … }`, no longer apply and have no replacement, because the element
> that now carries them is internal.

Follow-up to #10026, Related to #12243

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
