### PR TITLE
refactor: align exporting component classes in src folders

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox.js
+++ b/packages/checkbox/src/vaadin-checkbox.js
@@ -88,7 +88,7 @@ import { CheckboxMixin } from './vaadin-checkbox-mixin.js';
  * @customElement vaadin-checkbox
  * @extends HTMLElement
  */
-export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
+class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-checkbox';
   }
@@ -168,3 +168,5 @@ export class Checkbox extends CheckboxMixin(ElementMixin(ThemableMixin(PolylitMi
 }
 
 defineCustomElement(Checkbox);
+
+export { Checkbox };

--- a/packages/combo-box/src/vaadin-combo-box-item.js
+++ b/packages/combo-box/src/vaadin-combo-box-item.js
@@ -38,9 +38,7 @@ import { ComboBoxItemMixin } from './vaadin-combo-box-item-mixin.js';
  * @customElement vaadin-combo-box-item
  * @private
  */
-export class ComboBoxItem extends ComboBoxItemMixin(
-  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
-) {
+class ComboBoxItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-combo-box-item';
   }
@@ -61,3 +59,5 @@ export class ComboBoxItem extends ComboBoxItemMixin(
 }
 
 defineCustomElement(ComboBoxItem);
+
+export { ComboBoxItem };

--- a/packages/combo-box/src/vaadin-combo-box-overlay.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay.js
@@ -22,7 +22,7 @@ import { ComboBoxOverlayMixin } from './vaadin-combo-box-overlay-mixin.js';
  * @extends HTMLElement
  * @private
  */
-export class ComboBoxOverlay extends ComboBoxOverlayMixin(
+class ComboBoxOverlay extends ComboBoxOverlayMixin(
   OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
@@ -45,3 +45,5 @@ export class ComboBoxOverlay extends ComboBoxOverlayMixin(
 }
 
 defineCustomElement(ComboBoxOverlay);
+
+export { ComboBoxOverlay };

--- a/packages/combo-box/src/vaadin-combo-box-scroller.js
+++ b/packages/combo-box/src/vaadin-combo-box-scroller.js
@@ -16,7 +16,7 @@ import { ComboBoxScrollerMixin } from './vaadin-combo-box-scroller-mixin.js';
  * @extends HTMLElement
  * @private
  */
-export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {
+class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {
   static get is() {
     return 'vaadin-combo-box-scroller';
   }
@@ -36,3 +36,5 @@ export class ComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElem
 }
 
 defineCustomElement(ComboBoxScroller);
+
+export { ComboBoxScroller };

--- a/packages/context-menu/src/vaadin-context-menu-overlay.js
+++ b/packages/context-menu/src/vaadin-context-menu-overlay.js
@@ -21,7 +21,7 @@ import { MenuOverlayMixin } from './vaadin-menu-overlay-mixin.js';
  * @extends HTMLElement
  * @protected
  */
-export class ContextMenuOverlay extends MenuOverlayMixin(
+class ContextMenuOverlay extends MenuOverlayMixin(
   OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
@@ -105,3 +105,5 @@ export class ContextMenuOverlay extends MenuOverlayMixin(
 }
 
 defineCustomElement(ContextMenuOverlay);
+
+export { ContextMenuOverlay };

--- a/packages/context-menu/src/vaadin-context-menu.js
+++ b/packages/context-menu/src/vaadin-context-menu.js
@@ -362,4 +362,5 @@ class ContextMenu extends ContextMenuMixin(ElementMixin(ThemePropertyMixin(Polyl
 }
 
 defineCustomElement(ContextMenu);
+
 export { ContextMenu };

--- a/packages/date-picker/src/vaadin-date-picker-year.js
+++ b/packages/date-picker/src/vaadin-date-picker-year.js
@@ -18,7 +18,7 @@ import { datePickerYearStyles } from './styles/vaadin-date-picker-year-base-styl
  * @extends HTMLElement
  * @private
  */
-export class DatePickerYear extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
+class DatePickerYear extends ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))) {
   static get is() {
     return 'vaadin-date-picker-year';
   }
@@ -64,3 +64,5 @@ export class DatePickerYear extends ThemableMixin(PolylitMixin(LumoInjectionMixi
 }
 
 defineCustomElement(DatePickerYear);
+
+export { DatePickerYear };

--- a/packages/dialog/src/vaadin-dialog-overlay.js
+++ b/packages/dialog/src/vaadin-dialog-overlay.js
@@ -21,9 +21,7 @@ import { DialogOverlayMixin } from './vaadin-dialog-overlay-mixin.js';
  * @extends HTMLElement
  * @private
  */
-export class DialogOverlay extends DialogOverlayMixin(
-  DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
-) {
+class DialogOverlay extends DialogOverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-dialog-overlay';
   }
@@ -83,3 +81,5 @@ export class DialogOverlay extends DialogOverlayMixin(
 }
 
 defineCustomElement(DialogOverlay);
+
+export { DialogOverlay };

--- a/packages/email-field/src/vaadin-email-field.js
+++ b/packages/email-field/src/vaadin-email-field.js
@@ -96,7 +96,7 @@ import { emailFieldStyles } from './styles/vaadin-email-field-base-styles.js';
  * @customElement vaadin-email-field
  * @extends TextField
  */
-export class EmailField extends TextField {
+class EmailField extends TextField {
   static get is() {
     return 'vaadin-email-field';
   }
@@ -128,3 +128,5 @@ export class EmailField extends TextField {
 }
 
 defineCustomElement(EmailField);
+
+export { EmailField };

--- a/packages/field-highlighter/src/vaadin-field-highlighter.js
+++ b/packages/field-highlighter/src/vaadin-field-highlighter.js
@@ -155,7 +155,7 @@ export class FieldHighlighterController {
  *
  * @customElement vaadin-field-highlighter
  */
-export class FieldHighlighter extends HTMLElement {
+class FieldHighlighter extends HTMLElement {
   static get is() {
     return 'vaadin-field-highlighter';
   }
@@ -194,3 +194,5 @@ export class FieldHighlighter extends HTMLElement {
 }
 
 defineCustomElement(FieldHighlighter);
+
+export { FieldHighlighter };

--- a/packages/field-highlighter/src/vaadin-field-outline.js
+++ b/packages/field-highlighter/src/vaadin-field-outline.js
@@ -17,7 +17,7 @@ import { fieldOutlineStyles } from './styles/vaadin-field-outline-base-styles.js
  * @extends HTMLElement
  * @private
  */
-export class FieldOutline extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
+class FieldOutline extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-field-outline';
   }
@@ -72,3 +72,5 @@ export class FieldOutline extends ThemableMixin(DirMixin(PolylitMixin(LumoInject
 }
 
 defineCustomElement(FieldOutline);
+
+export { FieldOutline };

--- a/packages/field-highlighter/src/vaadin-user-tag.js
+++ b/packages/field-highlighter/src/vaadin-user-tag.js
@@ -18,7 +18,7 @@ import { userTagStyles } from './styles/vaadin-user-tag-base-styles.js';
  * @extends HTMLElement
  * @private
  */
-export class UserTag extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
+class UserTag extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-user-tag';
   }
@@ -94,3 +94,5 @@ export class UserTag extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMi
 }
 
 defineCustomElement(UserTag);
+
+export { UserTag };

--- a/packages/field-highlighter/src/vaadin-user-tags.js
+++ b/packages/field-highlighter/src/vaadin-user-tags.js
@@ -28,7 +28,7 @@ const listenOnce = (elem, type) => {
  * @extends HTMLElement
  * @private
  */
-export class UserTags extends PolylitMixin(LitElement) {
+class UserTags extends PolylitMixin(LitElement) {
   static get is() {
     return 'vaadin-user-tags';
   }
@@ -442,3 +442,5 @@ export class UserTags extends PolylitMixin(LitElement) {
 }
 
 defineCustomElement(UserTags);
+
+export { UserTags };

--- a/packages/input-container/src/vaadin-input-container.js
+++ b/packages/input-container/src/vaadin-input-container.js
@@ -16,7 +16,7 @@ import { inputContainerStyles } from './styles/vaadin-input-container-base-style
  * @customElement vaadin-input-container
  * @extends HTMLElement
  */
-export class InputContainer extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
+class InputContainer extends ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-input-container';
   }
@@ -87,3 +87,5 @@ export class InputContainer extends ThemableMixin(DirMixin(PolylitMixin(LumoInje
 }
 
 defineCustomElement(InputContainer);
+
+export { InputContainer };

--- a/packages/integer-field/src/vaadin-integer-field.js
+++ b/packages/integer-field/src/vaadin-integer-field.js
@@ -115,7 +115,7 @@ import { NumberField } from '@vaadin/number-field/src/vaadin-number-field.js';
  * @customElement vaadin-integer-field
  * @extends NumberField
  */
-export class IntegerField extends NumberField {
+class IntegerField extends NumberField {
   static get is() {
     return 'vaadin-integer-field';
   }
@@ -175,3 +175,5 @@ export class IntegerField extends NumberField {
 }
 
 defineCustomElement(IntegerField);
+
+export { IntegerField };

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -21,7 +21,7 @@ import { menuBarOverlayStyles } from './styles/vaadin-menu-bar-overlay-base-styl
  * @extends HTMLElement
  * @protected
  */
-export class MenuBarOverlay extends MenuOverlayMixin(
+class MenuBarOverlay extends MenuOverlayMixin(
   OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
@@ -51,3 +51,5 @@ export class MenuBarOverlay extends MenuOverlayMixin(
 }
 
 defineCustomElement(MenuBarOverlay);
+
+export { MenuBarOverlay };

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-item.js
@@ -38,7 +38,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @customElement vaadin-multi-select-combo-box-item
  * @private
  */
-export class MultiSelectComboBoxItem extends ComboBoxItemMixin(
+class MultiSelectComboBoxItem extends ComboBoxItemMixin(
   ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
 ) {
   static get is() {
@@ -61,3 +61,5 @@ export class MultiSelectComboBoxItem extends ComboBoxItemMixin(
 }
 
 defineCustomElement(MultiSelectComboBoxItem);
+
+export { MultiSelectComboBoxItem };

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-scroller.js
@@ -17,7 +17,7 @@ import { multiSelectComboBoxScrollerStyles } from './styles/vaadin-multi-select-
  * @extends HTMLElement
  * @private
  */
-export class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {
+class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {
   static get is() {
     return 'vaadin-multi-select-combo-box-scroller';
   }
@@ -72,3 +72,5 @@ export class MultiSelectComboBoxScroller extends ComboBoxScrollerMixin(PolylitMi
 }
 
 defineCustomElement(MultiSelectComboBoxScroller);
+
+export { MultiSelectComboBoxScroller };

--- a/packages/password-field/src/vaadin-password-field.js
+++ b/packages/password-field/src/vaadin-password-field.js
@@ -101,7 +101,7 @@ import { PasswordFieldMixin } from './vaadin-password-field-mixin.js';
  * @customElement vaadin-password-field
  * @extends TextField
  */
-export class PasswordField extends PasswordFieldMixin(TextField) {
+class PasswordField extends PasswordFieldMixin(TextField) {
   static get is() {
     return 'vaadin-password-field';
   }
@@ -125,3 +125,5 @@ export class PasswordField extends PasswordFieldMixin(TextField) {
 }
 
 defineCustomElement(PasswordField);
+
+export { PasswordField };

--- a/packages/select/src/vaadin-select-overlay.js
+++ b/packages/select/src/vaadin-select-overlay.js
@@ -20,7 +20,7 @@ import { SelectOverlayMixin } from './vaadin-select-overlay-mixin.js';
  * @extends HTMLElement
  * @private
  */
-export class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
+class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement)))) {
   static get is() {
     return 'vaadin-select-overlay';
   }
@@ -52,3 +52,5 @@ export class SelectOverlay extends SelectOverlayMixin(ThemableMixin(PolylitMixin
 }
 
 defineCustomElement(SelectOverlay);
+
+export { SelectOverlay };

--- a/packages/text-area/src/vaadin-text-area.js
+++ b/packages/text-area/src/vaadin-text-area.js
@@ -120,7 +120,7 @@ import { TextAreaMixin } from './vaadin-text-area-mixin.js';
  * @customElement vaadin-text-area
  * @extends HTMLElement
  */
-export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
+class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-text-area';
   }
@@ -177,3 +177,5 @@ export class TextArea extends TextAreaMixin(ThemableMixin(ElementMixin(PolylitMi
 }
 
 defineCustomElement(TextArea);
+
+export { TextArea };

--- a/packages/text-field/src/vaadin-text-field.js
+++ b/packages/text-field/src/vaadin-text-field.js
@@ -119,9 +119,7 @@ import { TextFieldMixin } from './vaadin-text-field-mixin.js';
  * @customElement vaadin-text-field
  * @extends HTMLElement
  */
-export class TextField extends TextFieldMixin(
-  ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
-) {
+class TextField extends TextFieldMixin(ThemableMixin(ElementMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-text-field';
   }
@@ -183,3 +181,5 @@ export class TextField extends TextFieldMixin(
 }
 
 defineCustomElement(TextField);
+
+export { TextField };

--- a/packages/time-picker/src/vaadin-time-picker-item.js
+++ b/packages/time-picker/src/vaadin-time-picker-item.js
@@ -38,9 +38,7 @@ import { ThemableMixin } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mix
  * @customElement vaadin-time-picker-item
  * @private
  */
-export class TimePickerItem extends ComboBoxItemMixin(
-  ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement)))),
-) {
+class TimePickerItem extends ComboBoxItemMixin(ThemableMixin(DirMixin(PolylitMixin(LumoInjectionMixin(LitElement))))) {
   static get is() {
     return 'vaadin-time-picker-item';
   }
@@ -61,3 +59,5 @@ export class TimePickerItem extends ComboBoxItemMixin(
 }
 
 defineCustomElement(TimePickerItem);
+
+export { TimePickerItem };

--- a/packages/time-picker/src/vaadin-time-picker-overlay.js
+++ b/packages/time-picker/src/vaadin-time-picker-overlay.js
@@ -21,7 +21,7 @@ import { timePickerOverlayStyles } from './styles/vaadin-time-picker-overlay-bas
  * @private
  * @attr {string} theme - The theme variants to apply to the component.
  */
-export class TimePickerOverlay extends ComboBoxOverlayMixin(
+class TimePickerOverlay extends ComboBoxOverlayMixin(
   OverlayMixin(DirMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(LitElement))))),
 ) {
   static get is() {
@@ -45,3 +45,5 @@ export class TimePickerOverlay extends ComboBoxOverlayMixin(
 }
 
 defineCustomElement(TimePickerOverlay);
+
+export { TimePickerOverlay };

--- a/packages/time-picker/src/vaadin-time-picker-scroller.js
+++ b/packages/time-picker/src/vaadin-time-picker-scroller.js
@@ -16,7 +16,7 @@ import { timePickerScrollerStyles } from './styles/vaadin-time-picker-scroller-b
  * @extends HTMLElement
  * @private
  */
-export class TimePickerScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {
+class TimePickerScroller extends ComboBoxScrollerMixin(PolylitMixin(LitElement)) {
   static get is() {
     return 'vaadin-time-picker-scroller';
   }
@@ -36,3 +36,5 @@ export class TimePickerScroller extends ComboBoxScrollerMixin(PolylitMixin(LitEl
 }
 
 defineCustomElement(TimePickerScroller);
+
+export { TimePickerScroller };


### PR DESCRIPTION
## Description

Closes https://github.com/vaadin/web-components/issues/6931

Related to https://github.com/vaadin/web-components/pull/12254

Updated code style to be consistent across all custom elements so this can be removed:

> Most packages declare the class and export it at the bottom of the file (`export { Button };`) instead of using `export class`.

## Type of change

- Refactor