### PR TITLE
test: use not-animated-styles in confirm-dialog visual tests

### DIFF
--- a/packages/confirm-dialog/test/visual/aura/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/visual/aura/confirm-dialog.test.js
@@ -1,6 +1,7 @@
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
 import '@vaadin/aura/aura.css';
+import '../../not-animated-styles.css';
 import '../../../vaadin-confirm-dialog.js';
 
 describe('confirm-dialog', () => {

--- a/packages/confirm-dialog/test/visual/base/confirm-dialog.test.js
+++ b/packages/confirm-dialog/test/visual/base/confirm-dialog.test.js
@@ -1,5 +1,6 @@
 import { fixtureSync, oneEvent } from '@vaadin/testing-helpers';
 import { visualDiff } from '@web/test-runner-visual-regression';
+import '../../not-animated-styles.css';
 import '../../../src/vaadin-confirm-dialog.js';
 
 describe('confirm-dialog', () => {


### PR DESCRIPTION
## Description

Added missing `not-animated-styles.css` to confirm-dialog base & Aura visual tests.

Note: base styles have no animations but e.g. dialog visual tests still import this file.

Pre-requisite for https://github.com/vaadin/web-components/pull/12147

## Type of change

- Test