### PR TITLE
refactor: reorder shared component styles imports in Aura

### DIFF
--- a/packages/aura/aura.css
+++ b/packages/aura/aura.css
@@ -6,6 +6,10 @@
 @import './src/surface.css';
 @import './src/typography.css';
 
+@import './src/components/overlay.css';
+@import './src/components/item-overlay.css';
+@import './src/components/input-container.css';
+
 @import './src/components/accordion-details.css';
 @import './src/components/app-layout.css';
 @import './src/components/avatar.css';
@@ -21,8 +25,6 @@
 @import './src/components/dashboard.css';
 @import './src/components/dialog.css';
 @import './src/components/grid.css';
-@import './src/components/input-container.css';
-@import './src/components/item-overlay.css';
 @import './src/components/login.css';
 @import './src/components/markdown.css';
 @import './src/components/master-detail-layout.css';
@@ -31,7 +33,6 @@
 @import './src/components/message-list.css';
 @import './src/components/multi-select-combo-box.css';
 @import './src/components/notification.css';
-@import './src/components/overlay.css';
 @import './src/components/popover.css';
 @import './src/components/progress-bar.css';
 @import './src/components/rich-text-editor.css';


### PR DESCRIPTION
## Description

Extracted from https://github.com/vaadin/web-components/pull/12147.

Moved `overlay.css`, `item-overlay.css` and `input-container.css` above component files. These files contain shared foundation styles that component files may override, so they should not be placed in the alphabetical order.

## Type of change

- Refactor