### PR TITLE
fix: update scroll container height on virtualizer size change

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -22,7 +22,6 @@ export class IronListAdapter {
     reorderElements,
     elementsContainer,
     __disableHeightPlaceholder,
-    __alwaysUpdateScrollerSize,
   }) {
     this.isAttached = true;
     this._vidxOffset = 0;
@@ -37,12 +36,6 @@ export class IronListAdapter {
     // (see __afterElementsUpdated) for components that always render virtual
     // elements with a non-zero height. Not for public use.
     this.__disableHeightPlaceholder = __disableHeightPlaceholder ?? false;
-
-    // Internal option: a predicate that, when it returns true, makes the scroller
-    // height always be applied instead of amortized (see `_updateScrollerSize`).
-    // Used by components whose height tracks the content exactly (e.g. the grid's
-    // `allRowsVisible` mode). Not for public use.
-    this.__alwaysUpdateScrollerSize = __alwaysUpdateScrollerSize;
 
     // Iron-list uses this value to determine how many pages of elements to render
     this._maxPages = 1.3;
@@ -221,11 +214,6 @@ export class IronListAdapter {
     });
 
     this.__afterElementsUpdated(updatedElements);
-  }
-
-  /** @override */
-  _updateScrollerSize(forceUpdate) {
-    super._updateScrollerSize(forceUpdate || !!this.__alwaysUpdateScrollerSize?.());
   }
 
   /**
@@ -425,6 +413,8 @@ export class IronListAdapter {
     if (!this.elementsContainer.children.length) {
       requestAnimationFrame(() => this._resizeHandler());
     }
+
+    this._updateScrollerSize(true);
 
     // Re-render items once the scroll position has been restored.
     // This call also updates the cached scrollTarget height and

--- a/packages/component-base/test/virtualizer.test.js
+++ b/packages/component-base/test/virtualizer.test.js
@@ -234,6 +234,14 @@ describe('virtualizer', () => {
     expect(item.getBoundingClientRect().top).to.be.closeTo(scrollTarget.getBoundingClientRect().top - 10, 1);
   });
 
+  it('should update scroll container height on size change', () => {
+    virtualizer.size += 5;
+    expect(elementsContainer.offsetHeight).to.equal(virtualizer.size * 30);
+
+    virtualizer.size -= 5;
+    expect(elementsContainer.offsetHeight).to.equal(virtualizer.size * 30);
+  });
+
   it('should not call updateElement when size increase does not affect visible indexes', () => {
     const updateElement = sinon.spy((el, index) => {
       el.textContent = `item-${index}`;

--- a/packages/grid/src/vaadin-grid-mixin.js
+++ b/packages/grid/src/vaadin-grid-mixin.js
@@ -247,13 +247,6 @@ export const GridMixin = (superClass) =>
         // otherwise be triggered by this logic because it reads the row height
         // right after updating the rows' content.
         __disableHeightPlaceholder: true,
-        // The virtualizer amortizes scroller height updates to avoid reflows while
-        // scrolling. In `allRowsVisible` mode the grid has no scrolling and its
-        // height must track the content exactly, so tell the virtualizer to always
-        // apply the scroller height. Otherwise the items container can be left at a
-        // stale, too-small height and clip rows when the grid grows (e.g. when
-        // expanding a tree grid from a small size).
-        __alwaysUpdateScrollerSize: () => this.allRowsVisible,
       });
 
       this._tooltipController = new TooltipController(this);


### PR DESCRIPTION
When the virtualizer size changes, the scroll container height needs to be updated. This used to happen reliably only because the virtualizer called `scrollToIndex` unconditionally in that situation, and that call force-updated the height as a side effect. However, that call was made conditional in https://github.com/vaadin/web-components/pull/11196, and no longer happens when no scroll position needs to be restored. Without it, the amortization logic in `_updateScrollerSize` can skip the height update if the change is smaller than the viewport, so the scroll container ends up with a stale height.

This PR fixes that by making the size setter force the height update with an explicit `_updateScrollerSize(true)` call. This also covers the `allRowsVisible` growth scenario from #12146, so the complexity introduced there is no longer needed and has been removed. The regression tests from that PR still pass.

Fixes vaadin/flow-components#9802