### PR TITLE
fix: do not open context menu on short tap on touch devices

### DIFF
--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -7,6 +7,11 @@ import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { isFirefox, isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { prevent, register } from '@vaadin/component-base/src/gestures.js';
 
+// A `contextmenu` caused by a selection change on touch focus (e.g. with `autoselect`) is
+// dispatched in the same input turn as the tap, measured at ~80 ms after `touchstart`. A long
+// press needs the finger held for 500 ms or more, which platform settings can shorten.
+const SELECTION_CONTEXTMENU_MAX_DELAY = 200;
+
 register({
   name: 'vaadin-contextmenu',
   deps: ['touchstart', 'touchmove', 'touchend', 'contextmenu'],
@@ -20,6 +25,9 @@ register({
   info: {
     sourceEvent: null,
   },
+
+  // Not part of `info`, which `reset()` clears when the `contextmenu` handling starts.
+  _touchStartTime: null,
 
   reset() {
     this.info.sourceEvent = null;
@@ -48,6 +56,8 @@ register({
 
   touchstart(e) {
     this._setSourceEvent(e);
+
+    this._touchStartTime = performance.now();
 
     this.info.touchStartCoords = {
       x: e.changedTouches[0].clientX,
@@ -92,6 +102,18 @@ register({
   },
 
   contextmenu(e) {
+    // Ignore a `contextmenu` that fires too soon after `touchstart` to be a long press. On
+    // touch, changing the text selection on focus (e.g. with `autoselect`) makes the browser
+    // fire `contextmenu` as a side effect of the tap itself. Mouse and keyboard events do
+    // not follow a touch this closely in practice.
+    //
+    // Uses `performance.now()` rather than `e.timeStamp`: on Android, the `contextmenu` of a
+    // long press carries the timestamp of the touch that started it, so `e.timeStamp` would
+    // report no elapsed time and suppress every long press.
+    if (this._touchStartTime !== null && performance.now() - this._touchStartTime < SELECTION_CONTEXTMENU_MAX_DELAY) {
+      return;
+    }
+
     if (!e.shiftKey) {
       this._setSourceEvent(e);
       if (isFirefox && isKeyboardActive()) {

--- a/packages/context-menu/src/vaadin-contextmenu-event.js
+++ b/packages/context-menu/src/vaadin-contextmenu-event.js
@@ -26,7 +26,8 @@ register({
     sourceEvent: null,
   },
 
-  // Not part of `info`, which `reset()` clears when the `contextmenu` handling starts.
+  // Deliberately not cleared in `reset()`: it runs when the `contextmenu` handling starts,
+  // which is exactly when this value is needed.
   _touchStartTime: null,
 
   reset() {

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -79,6 +79,8 @@ describe('mobile support', () => {
       clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
       spy = sinon.spy();
       menu.listenOn.addEventListener('vaadin-contextmenu', spy);
+      // `tap` is not registered on the target, so nothing resets its state between tests.
+      gestures.tap.reset();
     });
 
     afterEach(() => {
@@ -94,13 +96,23 @@ describe('mobile support', () => {
       target.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true }));
 
       expect(spy).to.be.not.called;
+      // The tap itself must still reach the target, e.g. to focus the field.
+      expect(gestures.tap.info.prevent).to.be.false;
     });
 
-    it('should fire on `contextmenu` during a long press', async () => {
+    it('should not fire on `contextmenu` just below the threshold', async () => {
+      touchstart(target);
+      await clock.tickAsync(199);
+      target.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true }));
+
+      expect(spy).to.be.not.called;
+    });
+
+    it('should fire on `contextmenu` once the threshold has passed', async () => {
       // Platforms fire `contextmenu` after holding for 500 ms or more, but the finger only
       // has to be down for longer than the text selection side effect takes.
       touchstart(target);
-      await clock.tickAsync(250);
+      await clock.tickAsync(200);
       target.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true }));
 
       expect(spy).to.be.calledOnce;

--- a/packages/context-menu/test/touch.test.js
+++ b/packages/context-menu/test/touch.test.js
@@ -72,6 +72,52 @@ describe('mobile support', () => {
     target.dispatchEvent(ev);
   });
 
+  describe('long press duration', () => {
+    let clock, spy;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+      spy = sinon.spy();
+      menu.listenOn.addEventListener('vaadin-contextmenu', spy);
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should not fire on `contextmenu` right after a short tap', async () => {
+      // A short tap that focuses a field with `autoselect` makes the browser fire
+      // `contextmenu` as a side effect of selecting the text.
+      touchstart(target);
+      touchend(target);
+      await clock.tickAsync(80);
+      target.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true }));
+
+      expect(spy).to.be.not.called;
+    });
+
+    it('should fire on `contextmenu` during a long press', async () => {
+      // Platforms fire `contextmenu` after holding for 500 ms or more, but the finger only
+      // has to be down for longer than the text selection side effect takes.
+      touchstart(target);
+      await clock.tickAsync(250);
+      target.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true }));
+
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire on `contextmenu` once the touch has ended', async () => {
+      // Covers both platforms that only fire `contextmenu` after the finger is lifted,
+      // and a mouse or keyboard triggered `contextmenu` following an unrelated tap.
+      touchstart(target);
+      touchend(target);
+      await clock.tickAsync(1000);
+      target.dispatchEvent(new CustomEvent('contextmenu', { bubbles: true }));
+
+      expect(spy).to.be.calledOnce;
+    });
+  });
+
   (isIOS ? describe : describe.skip)('iOS touch', () => {
     describe('timings', () => {
       let clock;


### PR DESCRIPTION
On touch devices, a text field with `autoselect` that is the target of a
context menu opened the menu on a plain short tap, instead of only on a long
press. Focusing the field selects its text, and the browser fires a native
`contextmenu` event as a side effect of that selection. The gesture
recognizer turned every `contextmenu` event into a request to open the menu,
so it could not tell a real long press from the selection side effect.

```html
<vaadin-text-field autoselect value="AAA"></vaadin-text-field>
<vaadin-context-menu></vaadin-context-menu>

<script>
  const menu = document.querySelector('vaadin-context-menu');
  menu.listenOn = document.querySelector('vaadin-text-field');
  menu.items = [{ text: 'Item' }];
</script>
```

Tap the field on an Android device: the menu opens without any long press.

The recognizer now stores the time of `touchstart` and ignores a
`contextmenu` event that arrives less than 200 ms later. On a real Pixel the
selection side effect arrives about 80 ms after `touchstart`, while a long
press needs the finger held for 500 ms or more, so the two are far apart.
The threshold is kept well below the platform long press delay because
Android lets that delay be shortened in the accessibility settings.

The elapsed time is measured with `performance.now()` instead of
`e.timeStamp`. On Android the `contextmenu` event of a long press carries the
timestamp of the touch that started it, so `e.timeStamp` reports no elapsed
time and would suppress every long press.

Verified on a real Android device: a short tap only focuses the field, a long
press opens the menu, and a long press on a non-text target still opens it.

Fixes #12201

---

🤖 Generated with Claude Code
