### PR TITLE
refactor: reuse date helpers for month arithmetic

### DIFF
--- a/packages/date-picker/src/vaadin-date-picker-helper.js
+++ b/packages/date-picker/src/vaadin-date-picker-helper.js
@@ -44,6 +44,40 @@ export function lastOfMonth(date) {
 }
 
 /**
+ * Get the index of a month, counted from January of year 0. Reduces a month to a single
+ * integer, so a lookup builds no key and two months are adjacent when their indexes are.
+ *
+ * @param {number} year
+ * @param {number} month Zero-based month
+ * @return {number}
+ */
+export function monthIndexOf(year, month) {
+  return year * 12 + month;
+}
+
+/**
+ * Get the index of the month the given date is in.
+ *
+ * @param {!Date} date
+ * @return {number}
+ */
+export function monthIndex(date) {
+  return monthIndexOf(date.getFullYear(), date.getMonth());
+}
+
+/**
+ * Get the first day of the month with the given index, inverting `monthIndexOf`. Counting from
+ * January of year 0 also inverts negative indexes, since `createDate` normalizes a month outside
+ * 0-11 into the year.
+ *
+ * @param {number} index
+ * @return {Date}
+ */
+export function monthDate(index) {
+  return createDate(0, index, 1);
+}
+
+/**
  * Get ISO 8601 week number for the given date.
  *
  * @param {!Date} date

--- a/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-overlay-content-mixin.js
@@ -8,7 +8,16 @@ import { Debouncer } from '@vaadin/component-base/src/debounce.js';
 import { addListener } from '@vaadin/component-base/src/gestures.js';
 import { MediaQueryController } from '@vaadin/component-base/src/media-query-controller.js';
 import { SlotController } from '@vaadin/component-base/src/slot-controller.js';
-import { dateAfterXMonths, dateAllowed, dateEquals, getClosestDate } from './vaadin-date-picker-helper.js';
+import {
+  createDate,
+  dateAfterXMonths,
+  dateAllowed,
+  dateEquals,
+  firstOfMonth,
+  getClosestDate,
+  lastOfMonth,
+  monthIndex,
+} from './vaadin-date-picker-helper.js';
 
 export const DatePickerOverlayContentMixin = (superClass) =>
   class DatePickerOverlayContentMixin extends superClass {
@@ -440,11 +449,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
      * @private
      */
     _calculateWeekScrollOffset(date) {
-      // Get first day of month
-      const temp = new Date(0, 0);
-      temp.setFullYear(date.getFullYear());
-      temp.setMonth(date.getMonth());
-      temp.setDate(1);
+      const temp = firstOfMonth(date);
       // Determine week (=row index) of date within the month
       let week = 0;
       while (temp.getDate() < date.getDate()) {
@@ -644,8 +649,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _differenceInMonths(date1, date2) {
-      const months = (date1.getFullYear() - date2.getFullYear()) * 12;
-      return months - date2.getMonth() + date1.getMonth();
+      return monthIndex(date1) - monthIndex(date2);
     }
 
     /** @private */
@@ -873,13 +877,11 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _getDateDiff(months, days) {
-      const date = new Date(0, 0);
-      date.setFullYear(this.focusedDate.getFullYear());
-      date.setMonth(this.focusedDate.getMonth() + months);
-      if (days) {
-        date.setDate(this.focusedDate.getDate() + days);
-      }
-      return date;
+      return createDate(
+        this.focusedDate.getFullYear(),
+        this.focusedDate.getMonth() + months,
+        days ? this.focusedDate.getDate() + days : 1,
+      );
     }
 
     /** @private */
@@ -909,16 +911,7 @@ export const DatePickerOverlayContentMixin = (superClass) =>
 
     /** @private */
     _moveFocusInsideMonth(focusedDate, property) {
-      const dateToFocus = new Date(0, 0);
-      dateToFocus.setFullYear(focusedDate.getFullYear());
-
-      if (property === 'minDate') {
-        dateToFocus.setMonth(focusedDate.getMonth());
-        dateToFocus.setDate(1);
-      } else {
-        dateToFocus.setMonth(focusedDate.getMonth() + 1);
-        dateToFocus.setDate(0);
-      }
+      const dateToFocus = property === 'minDate' ? firstOfMonth(focusedDate) : lastOfMonth(focusedDate);
 
       if (this._dateAllowed(dateToFocus)) {
         this.focusDate(dateToFocus);
@@ -944,10 +937,6 @@ export const DatePickerOverlayContentMixin = (superClass) =>
     /** @private */
     _getTodayMidnight() {
       const today = new Date();
-      const todayMidnight = new Date(0, 0);
-      todayMidnight.setFullYear(today.getFullYear());
-      todayMidnight.setMonth(today.getMonth());
-      todayMidnight.setDate(today.getDate());
-      return todayMidnight;
+      return createDate(today.getFullYear(), today.getMonth(), today.getDate());
     }
   };

--- a/packages/date-picker/src/vaadin-month-calendar-mixin.js
+++ b/packages/date-picker/src/vaadin-month-calendar-mixin.js
@@ -251,11 +251,7 @@ export const MonthCalendarMixin = (superClass) =>
       if (month === undefined || i18n === undefined) {
         return [];
       }
-      // First day of the month (at midnight).
-      const date = new Date(0, 0);
-      date.setFullYear(month.getFullYear());
-      date.setMonth(month.getMonth());
-      date.setDate(1);
+      const date = firstOfMonth(month);
 
       // Rewind to first day of the week.
       while (date.getDay() !== i18n.firstDayOfWeek) {


### PR DESCRIPTION
`vaadin-date-picker-helper.js` already wraps the `new Date(0, 0)` plus `setFullYear` idiom needed to build a local-midnight date that also works for years below 100. Five places in the date-picker still inlined that idiom by hand instead of calling `createDate`, `firstOfMonth` or `lastOfMonth`.

Month arithmetic has the same problem in the other direction: reducing a month to a single integer is useful in more than one place, but there was no helper for it, so `_differenceInMonths` spelled the arithmetic out.

## Changes

`monthIndexOf`, `monthIndex` and `monthDate` are new. They convert a month to an integer counted from January of year 0 and back. Counting from year 0 means `monthDate` also inverts negative indexes, because `createDate` normalizes a month outside 0-11 into the year.

`_differenceInMonths` becomes `monthIndex(date1) - monthIndex(date2)`, which is the same value: `(y1 - y2) * 12 - m2 + m1` expands to `(y1 * 12 + m1) - (y2 * 12 + m2)`.

The five inlined dates now call the existing helpers:

| Method | Now uses |
| --- | --- |
| `__computeDays` (month calendar) | `firstOfMonth` |
| `_calculateWeekScrollOffset` | `firstOfMonth` |
| `_moveFocusInsideMonth` | `firstOfMonth` / `lastOfMonth` |
| `_getDateDiff` | `createDate` |
| `_getTodayMidnight` | `createDate` |

All six are behaviour-preserving. The one that is not obvious is `_getDateDiff`: when called without a day offset it never assigned the day, leaving it at the 1 that `new Date(0, 0)` starts from, so the replacement passes `1` explicitly. `createDate` assigns the month before the day exactly as the inlined versions did, so a day-31 source landing in a 30-day month behaves the same.

The fractional scroller positions in `_repositionYearScroller`, `_repositionMonthScroller` and the `yearDelta * 12` offset are left alone: those are positions relative to `_originDate` and may be fractional, so they are not month indexes.

`monthIndex` and `monthDate` are also what the upcoming `dateMetadataProvider` work needs, which is why they land here rather than inside that feature.

## Testing

Verified equivalence numerically before converting: 40,824 cases for the `createDate` family and 5,040 month pairs for `monthIndex`, no mismatches, covering negative years, leap Februaries and day-31 sources in shorter months.

Existing suites cover the touched paths (scroll positioning, keyboard navigation, calendar rendering): 419 date-picker and 250 date-time-picker tests, 25 snapshot tests, 17 base visual tests, plus lint and types.

Related to #12242

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)