### PR TITLE
fix: prevent default action of Enter key in login form

### DIFF
--- a/packages/login/src/vaadin-login-form-mixin.js
+++ b/packages/login/src/vaadin-login-form-mixin.js
@@ -189,6 +189,10 @@ export const LoginFormMixin = (superClass) =>
     /** @protected */
     _handleInputKeydown(e) {
       if (e.key === 'Enter') {
+        // Prevent default so that the browser does not apply the Enter activation
+        // behavior to an element that receives focus while this event is handled.
+        e.preventDefault();
+
         const { currentTarget: inputActive } = e;
         const nextInput = inputActive.id === 'vaadinLoginUsername' ? this._passwordField : this._userNameField;
         // eslint-disable-next-line no-restricted-syntax

--- a/packages/login/test/login-form.test.js
+++ b/packages/login/test/login-form.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { sendKeys } from '@vaadin/test-runner-commands';
 import { enter, fixtureSync, nextRender, nextUpdate, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-login-form.js';
@@ -248,6 +249,33 @@ describe('no autofocus', () => {
 
   it('should not focus the username field', () => {
     expect(document.activeElement).to.equal(activeElement);
+  });
+});
+
+describe('Enter key default action', () => {
+  let login, button, vaadinLoginPassword;
+
+  beforeEach(async () => {
+    const wrapper = fixtureSync(`
+      <div>
+        <vaadin-login-form no-autofocus></vaadin-login-form>
+        <button></button>
+      </div>
+    `);
+    [login, button] = wrapper.children;
+    await nextRender();
+    vaadinLoginPassword = fillUsernameAndPassword(login).vaadinLoginPassword;
+  });
+
+  it('should not activate an element focused while handling Enter keydown', async () => {
+    const clickSpy = sinon.spy();
+    button.addEventListener('click', clickSpy);
+    login.addEventListener('login', () => button.focus());
+
+    vaadinLoginPassword.focus();
+    await sendKeys({ press: 'Enter' });
+
+    expect(clickSpy).to.be.not.called;
   });
 });
 


### PR DESCRIPTION
Pressing <kbd>Enter</kbd> in the username or password field did submit the form, but the login overlay stayed open. What actually happened is that it closed and re-opened within the same key press.

The Enter keydown that triggers `submit()` was not default-prevented, so the browser applied the Enter activation behavior to whichever element was focused when the dispatch finished. Applications commonly move focus in the `login` listener, because the overlay does not restore focus on close. When focus goes to a native button, that button gets a click and re-opens the overlay.

## Reproduction

Using `dev/login-overlay.html`: type a username and a password, keep focus on the password field, press <kbd>Enter</kbd>. The overlay stays open. Clicking the **Log in** button closes it as expected.

The captured event sequence shows the redirected activation (all events trusted):

```
keydown  | INPUT#input-vaadin-password-field | Enter
keypress | BUTTON#open                       | Enter   <- focus already moved
click    | BUTTON#open                       |
keyup    | BUTTON#open                       | Enter
```

Focusing the password reveal button and pressing <kbd>Enter</kbd> worked, because `vaadin-password-field-button` is a custom element with no native Enter activation behavior to redirect.

## Changes

The regression test uses `sendKeys` instead of the `enter()` helper. A synthetic keyboard event does not carry the native activation behavior, so it cannot catch this.

Fixes #12272

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
