### PR TITLE
fix: reset login overlay fields and disabled state on close

### DIFF
--- a/packages/login/src/vaadin-login-overlay-mixin.js
+++ b/packages/login/src/vaadin-login-overlay-mixin.js
@@ -86,7 +86,7 @@ export const LoginOverlayMixin = (superClass) =>
       }
 
       if (props.has('opened')) {
-        this._openedChanged(this.opened);
+        this._openedChanged(this.opened, props.get('opened'));
       }
     }
 

--- a/packages/login/test/login-overlay.test.js
+++ b/packages/login/test/login-overlay.test.js
@@ -304,6 +304,57 @@ describe('title slot', () => {
   });
 });
 
+describe('reset on close', () => {
+  let login, vaadinLoginUsername, vaadinLoginPassword;
+
+  beforeEach(async () => {
+    login = fixtureSync('<vaadin-login-overlay opened></vaadin-login-overlay>');
+    await nextRender();
+    ({ vaadinLoginUsername, vaadinLoginPassword } = fillUsernameAndPassword(login));
+  });
+
+  it('should clear the username and password fields when closing the overlay', async () => {
+    login.opened = false;
+    await nextUpdate(login);
+
+    expect(vaadinLoginUsername.value).to.equal('');
+    expect(vaadinLoginPassword.value).to.equal('');
+  });
+
+  it('should enable the submit button when closing the overlay after submit', async () => {
+    const submit = login.querySelector('vaadin-button[slot="submit"]');
+    submit.click();
+    await nextRender();
+    expect(submit.disabled).to.be.true;
+
+    login.opened = false;
+    await nextRender();
+    expect(submit.disabled).to.be.false;
+  });
+
+  it('should not clear the username and password fields when opening the overlay', async () => {
+    login.opened = false;
+    await nextUpdate(login);
+
+    fillUsernameAndPassword(login);
+    login.opened = true;
+    await nextUpdate(login);
+
+    expect(vaadinLoginUsername.value).to.equal('username');
+    expect(vaadinLoginPassword.value).to.equal('password');
+  });
+});
+
+describe('initially closed', () => {
+  it('should not enable the submit button when disabled is set before attaching', async () => {
+    const login = fixtureSync('<vaadin-login-overlay disabled></vaadin-login-overlay>');
+    await nextRender();
+
+    expect(login.disabled).to.be.true;
+    expect(login.querySelector('vaadin-button[slot="submit"]').disabled).to.be.true;
+  });
+});
+
 describe('detach and re-attach', () => {
   let login;
 


### PR DESCRIPTION
Closing the login overlay is supposed to clear the username and password fields and re-enable the form, so that reopening it starts from a clean state. That has not worked since 25.0.0.

`_openedChanged(opened, oldOpened)` is called from `updated()` with a single argument, so `oldOpened` is always `undefined` and the whole reset branch is dead code. Before #9794 this was a Polymer observer (`_onOpenedChange`) that read `this.opened` directly and needed no previous value.

## Reproduction

Using `dev/login-overlay.html`: type a username and a password, click **Log in**, then reopen the overlay. The old values are still there and the **Log in** button stays disabled. Measured right after closing:

```js
{ opened: false, disabled: true, username: 'user', password: 'pass' }
```

Expected `disabled: false` and empty fields. This is why the dev page has to set `login.disabled = false` before reopening.

## Changes

The previous value comes from the changed properties map, so the reset only runs on a real open → closed transition. Reading `!opened` instead would also run it on the first render and would reset `disabled` when it is set before the element is attached — `initially closed > should not enable the submit button when disabled is set before attaching` covers that.

Clearing the fields also applies when the element is removed from the DOM while open, which matches the behavior in 24.x.

Related to #12272

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
