### PR TITLE
refactor: compute field ARIA id references from field state

### DIFF
--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -76,17 +76,17 @@ export const FieldMixin = (superclass) =>
       this._errorController = new ErrorController(this);
 
       this._labelController.addEventListener('slot-content-changed', () => {
-        this.#syncFieldAriaControllerLabelId();
+        this.__syncFieldAriaControllerLabelId();
       });
 
       this._errorController.addEventListener('slot-content-changed', (event) => {
         this.toggleAttribute('has-error-message', event.detail.hasContent);
-        this.#syncFieldAriaControllerErrorId();
+        this.__syncFieldAriaControllerErrorId();
       });
 
       this._helperController.addEventListener('slot-content-changed', (event) => {
         this.toggleAttribute('has-helper', event.detail.hasContent);
-        this.#syncFieldAriaControllerHelperId();
+        this.__syncFieldAriaControllerHelperId();
       });
     }
 
@@ -121,8 +121,12 @@ export const FieldMixin = (superclass) =>
     }
 
     /** @protected */
-    _accessibleNameRefChanged() {
-      this.#syncFieldAriaControllerLabelId();
+    _accessibleNameRefChanged(accessibleNameRef, oldAccessibleNameRef) {
+      if (!accessibleNameRef && oldAccessibleNameRef) {
+        // Remove the user-provided id and restore ids stored by the controller.
+        this._fieldAriaController.setLabelId(null, true);
+      }
+      this.__syncFieldAriaControllerLabelId();
     }
 
     /**
@@ -165,19 +169,11 @@ export const FieldMixin = (superclass) =>
      */
     _invalidChanged(invalid) {
       this._errorController.setInvalid(invalid);
-
-      // This timeout is needed to prevent NVDA from announcing the error message twice:
-      // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
-      // 2. Once linking the error ID with the ARIA target here (unwanted).
-      // Related issue: https://github.com/vaadin/web-components/issues/3061.
-      setTimeout(() => {
-        // Error message ID needs to be dynamically added / removed based on the validity
-        // Otherwise assistive technologies would announce the error, even if we hide it.
-        this.#syncFieldAriaControllerErrorId();
-      });
+      this.__syncFieldAriaControllerErrorId();
     }
 
-    #syncFieldAriaControllerHelperId() {
+    /** @private */
+    __syncFieldAriaControllerHelperId() {
       if (this.hasAttribute('has-helper')) {
         this._fieldAriaController.setHelperId(this._helperNode?.id);
       } else {
@@ -185,17 +181,27 @@ export const FieldMixin = (superclass) =>
       }
     }
 
-    #syncFieldAriaControllerErrorId() {
-      if (this.invalid) {
-        this._fieldAriaController.setErrorId(this._errorNode?.id);
-      } else {
-        this._fieldAriaController.setErrorId(null);
-      }
+    /** @private */
+    __syncFieldAriaControllerErrorId() {
+      // This timeout is needed to prevent NVDA from announcing the error message twice:
+      // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
+      // 2. Once linking the error ID with the ARIA target here (unwanted).
+      // Related issue: https://github.com/vaadin/web-components/issues/3061.
+      setTimeout(() => {
+        // Error message ID needs to be dynamically added / removed based on the validity
+        // Otherwise assistive technologies would announce the error, even if we hide it.
+        if (this.invalid) {
+          this._fieldAriaController.setErrorId(this._errorNode?.id);
+        } else {
+          this._fieldAriaController.setErrorId(null);
+        }
+      });
     }
 
-    #syncFieldAriaControllerLabelId() {
+    /** @private */
+    __syncFieldAriaControllerLabelId() {
       if (this.accessibleNameRef) {
-        this._fieldAriaController.setLabelId(this.accessibleNameRef);
+        this._fieldAriaController.setLabelId(this.accessibleNameRef, true);
       } else if (this.hasAttribute('has-label')) {
         // Label ID should be only added when the label content is present.
         // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -75,19 +75,18 @@ export const FieldMixin = (superclass) =>
       this._helperController = new HelperController(this);
       this._errorController = new ErrorController(this);
 
-      this._errorController.addEventListener('slot-content-changed', (event) => {
-        this.toggleAttribute('has-error-message', event.detail.hasContent);
+      this._labelController.addEventListener('slot-content-changed', () => {
+        this.#syncFieldAriaControllerLabelId();
       });
 
-      this._labelController.addEventListener('slot-content-changed', (event) => {
-        const { hasContent, node } = event.detail;
-        this.__labelChanged(hasContent, node);
+      this._errorController.addEventListener('slot-content-changed', (event) => {
+        this.toggleAttribute('has-error-message', event.detail.hasContent);
+        this.#syncFieldAriaControllerErrorId();
       });
 
       this._helperController.addEventListener('slot-content-changed', (event) => {
-        const { hasContent, node } = event.detail;
-        this.toggleAttribute('has-helper', hasContent);
-        this.__helperChanged(hasContent, node);
+        this.toggleAttribute('has-helper', event.detail.hasContent);
+        this.#syncFieldAriaControllerHelperId();
       });
     }
 
@@ -116,34 +115,14 @@ export const FieldMixin = (superclass) =>
       this.addController(this._errorController);
     }
 
-    /** @private */
-    __helperChanged(hasHelper, helperNode) {
-      if (hasHelper) {
-        this._fieldAriaController.setHelperId(helperNode.id);
-      } else {
-        this._fieldAriaController.setHelperId(null);
-      }
-    }
-
     /** @protected */
     _accessibleNameChanged(accessibleName) {
       this._fieldAriaController.setAriaLabel(accessibleName);
     }
 
     /** @protected */
-    _accessibleNameRefChanged(accessibleNameRef) {
-      this._fieldAriaController.setLabelId(accessibleNameRef, true);
-    }
-
-    /** @private */
-    __labelChanged(hasLabel, labelNode) {
-      // Label ID should be only added when the label content is present.
-      // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.
-      if (hasLabel) {
-        this._fieldAriaController.setLabelId(labelNode.id);
-      } else {
-        this._fieldAriaController.setLabelId(null);
-      }
+    _accessibleNameRefChanged() {
+      this.#syncFieldAriaControllerLabelId();
     }
 
     /**
@@ -194,12 +173,35 @@ export const FieldMixin = (superclass) =>
       setTimeout(() => {
         // Error message ID needs to be dynamically added / removed based on the validity
         // Otherwise assistive technologies would announce the error, even if we hide it.
-        if (invalid) {
-          const node = this._errorNode;
-          this._fieldAriaController.setErrorId(node?.id);
-        } else {
-          this._fieldAriaController.setErrorId(null);
-        }
+        this.#syncFieldAriaControllerErrorId();
       });
+    }
+
+    #syncFieldAriaControllerHelperId() {
+      if (this.hasAttribute('has-helper')) {
+        this._fieldAriaController.setHelperId(this._helperNode?.id);
+      } else {
+        this._fieldAriaController.setHelperId(null);
+      }
+    }
+
+    #syncFieldAriaControllerErrorId() {
+      if (this.invalid) {
+        this._fieldAriaController.setErrorId(this._errorNode?.id);
+      } else {
+        this._fieldAriaController.setErrorId(null);
+      }
+    }
+
+    #syncFieldAriaControllerLabelId() {
+      if (this.accessibleNameRef) {
+        this._fieldAriaController.setLabelId(this.accessibleNameRef);
+      } else if (this.hasAttribute('has-label')) {
+        // Label ID should be only added when the label content is present.
+        // Otherwise, it may conflict with an `aria-label` attribute possibly added by the user.
+        this._fieldAriaController.setLabelId(this._labelNode?.id);
+      } else {
+        this._fieldAriaController.setLabelId(null);
+      }
     }
   };

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -833,6 +833,14 @@ describe('FieldMixin', () => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
 
+      it('should set aria-labelledby when accessible-name is defined before accessible-name-ref', async () => {
+        element.accessibleName = 'accessible name';
+        await nextUpdate(element);
+        element.accessibleNameRef = 'accessible-name-ref-0';
+        await nextUpdate(element);
+        expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
+      });
+
       it('should change aria-labelledby if accessible-name-ref is changed', async () => {
         element.accessibleNameRef = 'accessible-name-ref-0';
         await nextUpdate(element);

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2017 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { setAriaIDReference } from '@vaadin/a11y-base/src/aria-id-reference.js';
 import { DelegateFocusMixin } from '@vaadin/a11y-base/src/delegate-focus-mixin.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { DelegateStateMixin } from '@vaadin/component-base/src/delegate-state-mixin.js';
@@ -168,6 +167,10 @@ export const SelectBaseMixin = (superClass) =>
       this._itemId = `value-${this.localName}-${generateUniqueId()}`;
       this._srLabelController = new LabelController(this);
       this._srLabelController.slotName = 'sr-label';
+
+      this._labelController.addEventListener('slot-content-changed', () => {
+        this.#syncFieldAriaControllerLabelId();
+      });
     }
 
     /** @protected */
@@ -541,39 +544,19 @@ export const SelectBaseMixin = (superClass) =>
     /**
      * @param {string} accessibleName
      * @protected
+     * @override
      */
     _accessibleNameChanged(accessibleName) {
       this._srLabelController.setLabel(accessibleName);
-      this._setCustomAriaLabelledBy(accessibleName ? this._srLabelController.defaultId : null);
+      this.#syncFieldAriaControllerLabelId();
     }
 
     /**
-     * @param {string} accessibleNameRef
      * @protected
+     * @override
      */
-    _accessibleNameRefChanged(accessibleNameRef) {
-      this._setCustomAriaLabelledBy(accessibleNameRef);
-    }
-
-    /**
-     * @param {string} ariaLabelledby
-     * @private
-     */
-    _setCustomAriaLabelledBy(ariaLabelledby) {
-      const labelId = this._getLabelIdWithItemId(ariaLabelledby);
-      this._fieldAriaController.setLabelId(labelId, true);
-    }
-
-    /**
-     * @param {string | null} labelId
-     * @returns string | null
-     * @private
-     */
-    _getLabelIdWithItemId(labelId) {
-      const selected = this._items ? this._items[this._menuElement.selected] : false;
-      const itemId = selected || this.placeholder ? this._itemId : '';
-
-      return labelId ? `${labelId} ${itemId}`.trim() : null;
+    _accessibleNameRefChanged() {
+      this.#syncFieldAriaControllerLabelId();
     }
 
     /** @private */
@@ -607,13 +590,7 @@ export const SelectBaseMixin = (superClass) =>
         delete this._selectedChanging;
       }
 
-      const labelledIdReferenceConfig =
-        selected || this.placeholder ? { newId: this._itemId } : { oldId: this._itemId };
-
-      setAriaIDReference(valueButton, 'aria-labelledby', labelledIdReferenceConfig);
-      if (this.accessibleName || this.accessibleNameRef) {
-        this._setCustomAriaLabelledBy(this.accessibleNameRef || this._srLabelController.defaultId);
-      }
+      this.#syncFieldAriaControllerLabelId();
     }
 
     /** @private */
@@ -708,5 +685,26 @@ export const SelectBaseMixin = (superClass) =>
       this._requestValidation();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
       this.__dispatchChangePending = false;
+    }
+
+    #syncFieldAriaControllerLabelId() {
+      let labelId;
+      if (this.accessibleNameRef) {
+        labelId = this.accessibleNameRef;
+      } else if (this.accessibleName) {
+        labelId = this._srLabelController.defaultId;
+      } else if (this.hasAttribute('has-label')) {
+        labelId = this._labelNode?.id;
+      }
+
+      const selectedItem = this._items?.[this._menuElement.selected];
+      const itemId = selectedItem || this.placeholder ? this._itemId : null;
+
+      const ids = [labelId, itemId].filter(Boolean);
+      if (ids.length > 0) {
+        this._fieldAriaController.setLabelId(ids.join(' '), true);
+      } else {
+        this._fieldAriaController.setLabelId(null, true);
+      }
     }
   };

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -167,10 +167,6 @@ export const SelectBaseMixin = (superClass) =>
       this._itemId = `value-${this.localName}-${generateUniqueId()}`;
       this._srLabelController = new LabelController(this);
       this._srLabelController.slotName = 'sr-label';
-
-      this._labelController.addEventListener('slot-content-changed', () => {
-        this.#syncFieldAriaControllerLabelId();
-      });
     }
 
     /** @protected */
@@ -548,15 +544,7 @@ export const SelectBaseMixin = (superClass) =>
      */
     _accessibleNameChanged(accessibleName) {
       this._srLabelController.setLabel(accessibleName);
-      this.#syncFieldAriaControllerLabelId();
-    }
-
-    /**
-     * @protected
-     * @override
-     */
-    _accessibleNameRefChanged() {
-      this.#syncFieldAriaControllerLabelId();
+      this.__syncFieldAriaControllerLabelId();
     }
 
     /** @private */
@@ -590,7 +578,7 @@ export const SelectBaseMixin = (superClass) =>
         delete this._selectedChanging;
       }
 
-      this.#syncFieldAriaControllerLabelId();
+      this.__syncFieldAriaControllerLabelId();
     }
 
     /** @private */
@@ -687,7 +675,8 @@ export const SelectBaseMixin = (superClass) =>
       this.__dispatchChangePending = false;
     }
 
-    #syncFieldAriaControllerLabelId() {
+    /** @override */
+    __syncFieldAriaControllerLabelId() {
       let labelId;
       if (this.accessibleNameRef) {
         labelId = this.accessibleNameRef;


### PR DESCRIPTION
This prepares for a `FieldAriaController` refactor. Instead of passing label, error and helper element ids through slot events, `FieldMixin` now recomputes them from the field state in one place when something relevant changes. Select does the same for the `aria-labelledby` ids of the value button (the label, `accessibleName` / `accessibleNameRef`, and the selected item id), which were previously computed in several places.

Part of https://github.com/vaadin/web-components/issues/11975