### PR TITLE
docs: remove outdated aria-labelledby mention

### DIFF
--- a/packages/a11y-base/src/field-aria-controller.d.ts
+++ b/packages/a11y-base/src/field-aria-controller.d.ts
@@ -44,18 +44,14 @@ export class FieldAriaController {
   setLabelId(labelId: string | null, fromUser: boolean | null): void;
 
   /**
-   * Links the target element with a slotted error element via the target's attribute:
-   * - `aria-labelledby` if the target is the host component (e.g a field group).
-   * - `aria-describedby` otherwise.
+   * Links the target element with a slotted error element via `aria-describedby` attribute.
    *
    * To unlink the previous slotted error element, pass `null` as `errorId`.
    */
   setErrorId(errorId: string | null): void;
 
   /**
-   * Links the target element with a slotted helper element via the target's attribute:
-   * - `aria-labelledby` if the target is the host component (e.g a field group).
-   * - `aria-describedby` otherwise.
+   * Links the target element with a slotted helper element via `aria-describedby` attribute.
    *
    * To unlink the previous slotted helper element, pass `null` as `helperId`.
    */

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -96,9 +96,7 @@ export class FieldAriaController {
   }
 
   /**
-   * Links the target element with a slotted error element via the target's attribute:
-   * - `aria-labelledby` if the target is the host component (e.g a field group).
-   * - `aria-describedby` otherwise.
+   * Links the target element with a slotted error element via `aria-describedby` attribute.
    *
    * To unlink the previous slotted error element, pass `null` as `errorId`.
    *
@@ -110,9 +108,7 @@ export class FieldAriaController {
   }
 
   /**
-   * Links the target element with a slotted helper element via the target's attribute:
-   * - `aria-labelledby` if the target is the host component (e.g a field group).
-   * - `aria-describedby` otherwise.
+   * Links the target element with a slotted helper element via `aria-describedby` attribute.
    *
    * To unlink the previous slotted helper element, pass `null` as `helperId`.
    *


### PR DESCRIPTION
The JSDoc for `setErrorId` and `setHelperId` still describes the old behavior where the error and helper elements were linked via `aria-labelledby` when the target is the host component (a field group). That behavior was removed in #5818, which made both methods always use `aria-describedby`, but the comments were left unchanged in both the implementation and the type definitions.

Part of https://github.com/vaadin/web-components/issues/11975