### PR TITLE
refactor: support adding and removing multiple attribute values

### DIFF
--- a/packages/a11y-base/src/aria-id-reference.js
+++ b/packages/a11y-base/src/aria-id-reference.js
@@ -4,10 +4,9 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import {
-  addValueToAttribute,
+  addValuesToAttribute,
   deserializeAttributeValue,
-  removeValueFromAttribute,
-  serializeAttributeValue,
+  removeValuesFromAttribute,
 } from '@vaadin/component-base/src/dom-utils.js';
 
 const attributeToTargets = new Map();
@@ -74,7 +73,7 @@ export function restoreGeneratedAriaIDReference(target, attr) {
   if (!values || values.size === 0) {
     target.removeAttribute(attr);
   } else {
-    addValueToAttribute(target, attr, serializeAttributeValue(values));
+    addValuesToAttribute(target, attr, [...values]);
   }
   attributeMap.delete(target);
 }
@@ -133,11 +132,12 @@ export function setAriaIDReference(target, attr, config = { newId: null, oldId: 
     cleanAriaIDReference(target, attr);
   }
 
-  removeValueFromAttribute(target, attr, oldId);
+  removeValuesFromAttribute(target, attr, oldId);
 
-  const attributeValue = !newId ? serializeAttributeValue(storedValues) : newId;
-  if (attributeValue) {
-    addValueToAttribute(target, attr, attributeValue);
+  if (newId) {
+    addValuesToAttribute(target, attr, newId);
+  } else if (storedValues) {
+    addValuesToAttribute(target, attr, [...storedValues]);
   }
 }
 

--- a/packages/component-base/src/dom-utils.d.ts
+++ b/packages/component-base/src/dom-utils.d.ts
@@ -37,15 +37,16 @@ export function deserializeAttributeValue(value: string): Set<string>;
 export function serializeAttributeValue(values: Set<string>): string;
 
 /**
- * Adds a value to an attribute containing space-delimited values.
+ * Adds one or more values to an attribute containing space-delimited values.
+ * If no values remain, the whole attribute is removed.
  */
-export function addValueToAttribute(element: HTMLElement, attr: string, value: string): void;
+export function addValuesToAttribute(element: HTMLElement, attr: string, valuesToAdd: string | string[]): void;
 
 /**
- * Removes a value from an attribute containing space-delimited values.
- * If the value is the last one, the whole attribute is removed.
+ * Removes one or more values from an attribute containing space-delimited values.
+ * If no values remain, the whole attribute is removed.
  */
-export function removeValueFromAttribute(element: HTMLElement, attr: string, value: string): void;
+export function removeValuesFromAttribute(element: HTMLElement, attr: string, valuesToRemove: string | string[]): void;
 
 /**
  * Returns true if the given node is an empty text node, false otherwise.

--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -84,11 +84,7 @@ export function getClosestElement(selector, node) {
  * @return {Set<string>}
  */
 export function deserializeAttributeValue(value) {
-  if (!value) {
-    return new Set();
-  }
-
-  return new Set(value.split(' '));
+  return new Set(value ? value.split(' ') : []);
 }
 
 /**
@@ -102,34 +98,65 @@ export function serializeAttributeValue(values) {
 }
 
 /**
- * Adds a value to an attribute containing space-delimited values.
+ * Normalizes values passed to `addValuesToAttribute` and `removeValuesFromAttribute`
+ * into a set of values. Both a single string and every array entry may contain
+ * multiple values separated by space.
  *
- * @param {HTMLElement} element
- * @param {string} attr
- * @param {string} value
+ * @param {string | string[] | null | undefined} values
+ * @return {Set<string>}
  */
-export function addValueToAttribute(element, attr, value) {
-  const values = deserializeAttributeValue(element.getAttribute(attr));
-  values.add(value);
-  element.setAttribute(attr, serializeAttributeValue(values));
+function normalizeAttributeValues(values) {
+  return deserializeAttributeValue(Array.isArray(values) ? values.join(' ') : values);
 }
 
 /**
- * Removes a value from an attribute containing space-delimited values.
- * If the value is the last one, the whole attribute is removed.
+ * Sets the attribute to the given set of values. If the set is empty,
+ * the whole attribute is removed.
  *
  * @param {HTMLElement} element
  * @param {string} attr
- * @param {string} value
+ * @param {Set<string>} values
  */
-export function removeValueFromAttribute(element, attr, value) {
-  const values = deserializeAttributeValue(element.getAttribute(attr));
-  values.delete(value);
+function setAttributeValues(element, attr, values) {
   if (values.size === 0) {
     element.removeAttribute(attr);
-    return;
+  } else {
+    element.setAttribute(attr, serializeAttributeValue(values));
   }
-  element.setAttribute(attr, serializeAttributeValue(values));
+}
+
+/**
+ * Adds one or more values to an attribute containing space-delimited values.
+ * If no values remain, the whole attribute is removed.
+ *
+ * @param {HTMLElement} element
+ * @param {string} attr
+ * @param {string | string[]} valuesToAdd a string or an array of strings with values separated by space
+ */
+export function addValuesToAttribute(element, attr, valuesToAdd) {
+  valuesToAdd = normalizeAttributeValues(valuesToAdd);
+
+  const values = deserializeAttributeValue(element.getAttribute(attr));
+  valuesToAdd.forEach((value) => values.add(value));
+
+  setAttributeValues(element, attr, values);
+}
+
+/**
+ * Removes one or more values from an attribute containing space-delimited values.
+ * If no values remain, the whole attribute is removed.
+ *
+ * @param {HTMLElement} element
+ * @param {string} attr
+ * @param {string | string[]} valuesToRemove a string or an array of strings with values separated by space
+ */
+export function removeValuesFromAttribute(element, attr, valuesToRemove) {
+  valuesToRemove = normalizeAttributeValues(valuesToRemove);
+
+  const values = deserializeAttributeValue(element.getAttribute(attr));
+  valuesToRemove.forEach((value) => values.delete(value));
+
+  setAttributeValues(element, attr, values);
 }
 
 /**

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -1,12 +1,12 @@
 import { expect } from '@vaadin/chai-plugins';
 import { defineCE, fixtureSync } from '@vaadin/testing-helpers';
 import {
-  addValueToAttribute,
+  addValuesToAttribute,
   getAncestorRootNodes,
   getClosestElement,
   getFlattenedElements,
   isEmptyTextNode,
-  removeValueFromAttribute,
+  removeValuesFromAttribute,
 } from '../src/dom-utils.js';
 
 describe('dom-utils', () => {
@@ -93,41 +93,68 @@ describe('dom-utils', () => {
     });
   });
 
-  describe('addValueToAttribute', () => {
+  describe('addValuesToAttribute', () => {
     let element;
 
     beforeEach(() => {
       element = document.createElement('div');
     });
 
-    it('should add a value to an attribute', () => {
-      addValueToAttribute(element, 'aria-labelledby', 'label-id');
+    it('should add a single value to an attribute', () => {
+      addValuesToAttribute(element, 'aria-labelledby', 'label-id');
       expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
 
-      addValueToAttribute(element, 'aria-labelledby', 'error-id');
+      addValuesToAttribute(element, 'aria-labelledby', 'error-id');
       expect(element.getAttribute('aria-labelledby')).to.equal('label-id error-id');
     });
 
+    it('should add a string of space-delimited values to an attribute', () => {
+      addValuesToAttribute(element, 'aria-labelledby', 'label-id error-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id error-id');
+    });
+
+    it('should add an array of values to an attribute', () => {
+      addValuesToAttribute(element, 'aria-labelledby', ['label-id', 'error-id helper-id']);
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id error-id helper-id');
+    });
+
     it('should not duplicate values in the attribute', () => {
-      addValueToAttribute(element, 'aria-labelledby', 'label-id');
-      addValueToAttribute(element, 'aria-labelledby', 'label-id');
-      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+      addValuesToAttribute(element, 'aria-labelledby', ['label-id', 'error-id']);
+      addValuesToAttribute(element, 'aria-labelledby', 'label-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id error-id');
+    });
+
+    it('should not set the attribute when there are no values to add', () => {
+      addValuesToAttribute(element, 'aria-labelledby', []);
+      expect(element.hasAttribute('aria-labelledby')).to.be.false;
     });
   });
 
-  describe('removeValueFromAttribute', () => {
+  describe('removeValuesFromAttribute', () => {
     let element;
 
     beforeEach(() => {
       element = document.createElement('div');
-      element.setAttribute('aria-labelledby', 'label-id error-id');
+      element.setAttribute('aria-labelledby', 'label-id error-id helper-id');
     });
 
-    it('should remove a value from an attribute', () => {
-      removeValueFromAttribute(element, 'aria-labelledby', 'error-id');
-      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+    it('should remove a single value from an attribute', () => {
+      removeValuesFromAttribute(element, 'aria-labelledby', 'error-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id helper-id');
+    });
 
-      removeValueFromAttribute(element, 'aria-labelledby', 'label-id');
+    it('should remove a string of space-delimited values from an attribute', () => {
+      removeValuesFromAttribute(element, 'aria-labelledby', 'error-id helper-id');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+    });
+
+    it('should remove an array of values from an attribute', () => {
+      removeValuesFromAttribute(element, 'aria-labelledby', ['error-id', 'helper-id']);
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id');
+    });
+
+    it('should remove the attribute when no values remain', () => {
+      removeValuesFromAttribute(element, 'aria-labelledby', ['label-id', 'error-id helper-id']);
       expect(element.hasAttribute('aria-labelledby')).to.be.false;
     });
   });

--- a/packages/form-layout/src/vaadin-form-item-mixin.js
+++ b/packages/form-layout/src/vaadin-form-item-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2017 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
+import { addValuesToAttribute, removeValuesFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 import { generateUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 import { issueWarning } from '@vaadin/component-base/src/warnings.js';
 
@@ -70,7 +70,7 @@ export const FormItemMixin = (superClass) =>
      * @private
      */
     __linkLabelToField(field) {
-      addValueToAttribute(this._getFieldAriaTarget(field), 'aria-labelledby', this.__labelId);
+      addValuesToAttribute(this._getFieldAriaTarget(field), 'aria-labelledby', this.__labelId);
     }
 
     /**
@@ -81,7 +81,7 @@ export const FormItemMixin = (superClass) =>
      * @private
      */
     __unlinkLabelFromField(field) {
-      removeValueFromAttribute(this._getFieldAriaTarget(field), 'aria-labelledby', this.__labelId);
+      removeValuesFromAttribute(this._getFieldAriaTarget(field), 'aria-labelledby', this.__labelId);
     }
 
     /** @private */

--- a/packages/tooltip/src/vaadin-tooltip-aria-mixin.js
+++ b/packages/tooltip/src/vaadin-tooltip-aria-mixin.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { addAriaElementReference, removeAriaElementReference } from '@vaadin/a11y-base/src/aria-element-reference.js';
-import { addValueToAttribute, removeValueFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
+import { addValuesToAttribute, removeValuesFromAttribute } from '@vaadin/component-base/src/dom-utils.js';
 
 /**
  * A mixin providing linking of the tooltip content to the tooltip target
@@ -92,7 +92,7 @@ export const TooltipAriaMixin = (superClass) =>
         if (byReference) {
           addAriaElementReference(target, mode, contentNode);
         } else {
-          addValueToAttribute(target, mode, contentNode.id);
+          addValuesToAttribute(target, mode, contentNode.id);
         }
 
         this.#ariaReferences.push({ target, mode, byReference });
@@ -106,7 +106,7 @@ export const TooltipAriaMixin = (superClass) =>
         if (byReference) {
           removeAriaElementReference(target, mode, contentNode);
         } else {
-          removeValueFromAttribute(target, mode, contentNode.id);
+          removeValuesFromAttribute(target, mode, contentNode.id);
         }
       });
       this.#ariaReferences = [];


### PR DESCRIPTION
The dom-utils helpers for attributes with space-delimited values could only add or remove one value at a time. This replaces `addValueToAttribute` and `removeValueFromAttribute` with `addValuesToAttribute` and `removeValuesFromAttribute`, which accept either a string or an array of strings, where each string can hold multiple values separated by space. When no values remain after an update, the whole attribute is removed, so an empty attribute is not left behind.

Part of https://github.com/vaadin/web-components/issues/11975
