### PR TITLE
test: avoid private upload API in test cases

### DIFF
--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -3,6 +3,7 @@ import { change, fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
 import {
+  addFilesViaInput,
   createFile,
   createFiles,
   createFileSystemDirectoryEntry,
@@ -26,10 +27,10 @@ describe('adding files', () => {
   });
 
   describe('files property', () => {
-    it('should push files to `files` Array property', () => {
+    it('should prepend files to `files` Array property when adding via input', () => {
       expect(upload).to.have.property('files').that.is.an('array').that.is.empty;
 
-      files.forEach(upload._addFile.bind(upload));
+      addFilesViaInput(upload, files);
       expect(upload.files[0]).to.equal(files[1]);
       expect(upload.files[1]).to.equal(files[0]);
     });
@@ -102,7 +103,7 @@ describe('adding files', () => {
 
     it('should not have dragover-valid attribute when max files added', async () => {
       upload.maxFiles = 1;
-      upload._addFile(createFile(100, 'image/jpeg'));
+      upload.files = [createFile(100, 'image/jpeg')];
       await nextUpdate(upload);
 
       upload.dispatchEvent(createDndEvent('dragover'));
@@ -114,7 +115,7 @@ describe('adding files', () => {
 
     it('should not have dragover-valid attribute when disabled', async () => {
       upload.disabled = true;
-      upload._addFile(createFile(100, 'image/jpeg'));
+      upload.files = [createFile(100, 'image/jpeg')];
       await nextUpdate(upload);
 
       upload.dispatchEvent(createDndEvent('dragover'));
@@ -133,7 +134,7 @@ describe('adding files', () => {
 
     it('should set drop effect to none when max files reached', () => {
       upload.maxFiles = 1;
-      upload._addFile(createFile(100, 'image/jpeg'));
+      upload.files = [createFile(100, 'image/jpeg')];
 
       const event = createDndEvent('dragover');
       upload.dispatchEvent(event);
@@ -336,7 +337,7 @@ describe('adding files', () => {
       const uploadStartSpy = sinon.spy();
       upload.addEventListener('upload-start', uploadStartSpy);
 
-      files.forEach(upload._addFile.bind(upload));
+      addFilesViaInput(upload, files);
       // With queue behavior, only the first file starts uploading immediately
       expect(uploadStartSpy.calledOnce).to.be.true;
 
@@ -354,7 +355,7 @@ describe('adding files', () => {
       upload.noAuto = true;
       upload.addEventListener('upload-start', uploadStartSpy);
 
-      files.forEach(upload._addFile.bind(upload));
+      addFilesViaInput(upload, files);
       expect(uploadStartSpy.called).to.be.false;
       expect(upload.files[0].held).to.be.true;
       expect(upload.files[0].uploading).to.not.be.true;
@@ -374,7 +375,7 @@ describe('adding files', () => {
         expect(e.detail.error).to.be.ok;
         done();
       });
-      upload._addFiles([file, file]);
+      addFilesViaInput(upload, [file, file]);
     });
 
     it('should reject files with excessive size', (done) => {
@@ -383,7 +384,7 @@ describe('adding files', () => {
         expect(e.detail.error).to.be.ok;
         done();
       });
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
     });
 
     it('should reject files with incorrect contentType', (done) => {
@@ -393,59 +394,59 @@ describe('adding files', () => {
         expect(e.detail.error).to.equal('Incorrect File Type.');
         done();
       });
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
     });
 
     it('should allow files with correct extension', () => {
       upload.accept = 'image/*,.foo,video/*';
       file.name = 'bar.FOO';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files.length).to.equal(1);
     });
 
     it('should allow files with extensions containing multiple dots', () => {
       upload.accept = 'image/*,.bar.baz,video/*';
       file.name = 'foo.bar.baz';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files).to.have.lengthOf(1);
     });
 
     it('should reject files that have partial extension match', () => {
       upload.accept = 'image/*,.bar.baz,video/*';
       file.name = 'foo.baz';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files).to.have.lengthOf(0);
     });
 
     it('should allow files with correct mime type', () => {
       upload.accept = 'application/x-octet-stream';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files.length).to.equal(1);
     });
 
     it('should allow wildcards', () => {
       upload.accept = 'application/*';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files.length).to.equal(1);
     });
 
     it('should allow files matching other than the first wildcard', () => {
       upload.accept = 'text/*,application/*,image/*,video/*,audio/*';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files.length).to.equal(1);
     });
 
     it('should allow files when using regex operators in accept string', () => {
       file = createFile(testFileSize, 'image/svg+xml');
       upload.accept = 'image/svg+xml';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files.length).to.equal(1);
     });
 
     it('should reject files when accept contains regex single character wildcard and file type is not an exact match', () => {
       file = createFile(testFileSize, 'application/vndxms-excel');
       upload.accept = 'application/vnd.ms-excel';
-      upload._addFiles([file]);
+      addFilesViaInput(upload, [file]);
       expect(upload.files.length).to.equal(0);
     });
   });

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { change, fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextFrame, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
 import {
@@ -41,20 +41,6 @@ describe('adding files', () => {
       upload.files = files;
       await nextUpdate(upload);
       expect(spy.calledOnce).to.be.true;
-    });
-
-    it('should add files on input change', () => {
-      const input = upload.$.fileInput;
-
-      // We can't simply assign `files` property of input[type="file"].
-      // Tweaking __proto__ to make it assignable below.
-      Object.setPrototypeOf(input, HTMLElement.prototype);
-      input.files = files;
-
-      change(input);
-
-      expect(upload.files[0]).to.equal(files[1]);
-      expect(upload.files[1]).to.equal(files[0]);
     });
   });
 

--- a/packages/upload/test/concurrent-uploads.test.js
+++ b/packages/upload/test/concurrent-uploads.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
-import { createFiles, xhrCreator } from './helpers.js';
+import { addFilesViaInput, createFiles, xhrCreator } from './helpers.js';
 
 function assertFileUploading(file) {
   expect(file.uploading).to.be.true;
@@ -122,7 +122,7 @@ describe('concurrent uploads', () => {
       upload.noAuto = true;
       upload.maxConcurrentUploads = 2;
 
-      upload._addFiles(files);
+      addFilesViaInput(upload, files);
       await clock.tickAsync(10);
 
       files.forEach(assertFileNotStarted);
@@ -151,7 +151,7 @@ describe('concurrent uploads', () => {
       upload._createXhr.resetHistory();
 
       // Abort a queued file
-      upload._abortFileUpload(files[1]);
+      upload.dispatchEvent(new CustomEvent('file-abort', { detail: { file: files[1] } }));
       expect(upload._createXhr).to.be.not.called;
     });
 
@@ -314,7 +314,7 @@ describe('concurrent uploads', () => {
       upload._createXhr = xhrCreator({ size: 100, uploadTime: 200, stepTime: 50 });
 
       // Retry first file
-      upload._retryFileUpload(files[0]);
+      upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file: files[0] } }));
       await clock.tickAsync(10);
 
       assertFileUploading(files[0]);

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-upload.js';
 import { html, LitElement } from 'lit';
-import { createFiles, removeFile, xhrCreator } from './helpers.js';
+import { addFilesViaInput, createFiles, removeFile, xhrCreator } from './helpers.js';
 
 describe('file list', () => {
   let upload;
@@ -22,7 +22,7 @@ describe('file list', () => {
       expect(getFileListItems(upload)).to.be.empty;
 
       const files = createFiles(2);
-      files.forEach((file) => upload._addFile(file));
+      addFilesViaInput(upload, files);
       await nextFrame();
 
       const fileListItems = getFileListItems(upload);
@@ -35,7 +35,7 @@ describe('file list', () => {
 
     it('should remove files', async () => {
       const files = createFiles(2);
-      files.forEach((file) => upload._addFile(file));
+      addFilesViaInput(upload, files);
       await nextFrame();
 
       removeFile(upload, 1);
@@ -49,7 +49,7 @@ describe('file list', () => {
 
     it('should not overflow content', async () => {
       upload.style.width = '180px';
-      upload._addFile(createFiles(1)[0]);
+      upload.files = createFiles(1);
       await nextRender();
       const fileListItem = getFileListItems(upload)[0];
       expect(fileListItem.scrollWidth - fileListItem.offsetWidth).to.equal(0);
@@ -98,7 +98,7 @@ describe('file list', () => {
       expect(getFileListItems(upload)).to.be.empty;
 
       const files = createFiles(2);
-      files.forEach((file) => upload._addFile(file));
+      addFilesViaInput(upload, files);
       await nextFrame();
 
       const fileListItems = getFileListItems(upload);

--- a/packages/upload/test/helpers.js
+++ b/packages/upload/test/helpers.js
@@ -199,3 +199,17 @@ export function removeFile(upload, idx = 0) {
   const file = files[idx];
   file.shadowRoot.querySelector('[part="remove-button"]').click();
 }
+
+/**
+ * Adds files to the upload component through the file input (with validation).
+ * @param {HTMLElement} upload - The upload component
+ * @param {File[]} files - Array of files to add
+ */
+export function addFilesViaInput(upload, files) {
+  const input = upload.$.fileInput;
+  // We can't simply assign `files` property of input[type="file"].
+  // Tweaking __proto__ to make it assignable.
+  Object.setPrototypeOf(input, HTMLElement.prototype);
+  input.files = files;
+  input.dispatchEvent(new Event('change'));
+}

--- a/packages/upload/test/i18n.test.js
+++ b/packages/upload/test/i18n.test.js
@@ -3,7 +3,7 @@ import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
 import { DEFAULT_I18N } from '../src/vaadin-upload-mixin.js';
-import { createFile, xhrCreator } from './helpers.js';
+import { addFilesViaInput, createFile, xhrCreator } from './helpers.js';
 
 const CUSTOM_I18N = {
   dropFiles: {
@@ -93,7 +93,7 @@ describe('upload i18n', () => {
             ...xhrOptions,
           });
         }
-        upload._addFile(file);
+        addFilesViaInput(upload, [file]);
         await clock.tickAsync(delay);
       }
 

--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -4,8 +4,6 @@ import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-upload.js';
 import { createFile } from './helpers.js';
 
-const FAKE_FILE = createFile(100000, 'application/uknown');
-
 async function repeatTab(times) {
   for (let i = 0; i < times; i++) {
     await sendKeys({ press: 'Tab' });
@@ -29,7 +27,7 @@ describe('keyboard navigation', () => {
 
   beforeEach(async () => {
     uploadElement = fixtureSync(`<vaadin-upload></vaadin-upload>`);
-    uploadElement.files = [FAKE_FILE];
+    uploadElement.files = [createFile(100000, 'application/uknown')];
 
     await nextRender();
     uploadButton = uploadElement.querySelector('vaadin-button[slot=add-button]');
@@ -129,7 +127,7 @@ describe('keyboard navigation', () => {
       // Programmatic upload does not actually set focus, so we first navigate to the button.
       await repeatTab(1);
 
-      uploadElement._uploadFile(FAKE_FILE);
+      uploadElement.uploadFiles(uploadElement.files[0]);
 
       expect(document.activeElement).to.equal(uploadButton);
     });

--- a/packages/upload/test/slots.test.js
+++ b/packages/upload/test/slots.test.js
@@ -54,7 +54,7 @@ describe('slots', () => {
         upload.maxFiles = 1;
         expect(addButton.disabled).to.be.false;
 
-        upload._addFile(createFile(100, 'image/jpeg'));
+        upload.files = [createFile(100, 'image/jpeg')];
         await nextUpdate(upload);
         expect(addButton.disabled).to.be.true;
       });

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
-import { createFile, createFiles, removeFile, xhrCreator } from './helpers.js';
+import { addFilesViaInput, createFile, createFiles, removeFile, xhrCreator } from './helpers.js';
 
 describe('upload', () => {
   let upload, file;
@@ -56,13 +56,13 @@ describe('upload', () => {
           expect(e.detail.file.uploading).to.be.ok;
           done();
         });
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
 
       it('should fire the upload-progress event multiple times', async () => {
         const spy = sinon.spy();
         upload.addEventListener('upload-progress', spy);
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
 
         await clock.tickAsync(10);
         const e = spy.firstCall.args[0];
@@ -95,7 +95,7 @@ describe('upload', () => {
       it('should fire the upload-success', async () => {
         const spy = sinon.spy();
         upload.addEventListener('upload-success', spy);
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
 
         await clock.tickAsync(400);
         const e = spy.firstCall.args[0];
@@ -111,7 +111,7 @@ describe('upload', () => {
         const errorSpy = sinon.spy();
         upload.addEventListener('upload-error', errorSpy);
 
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
 
         await clock.tickAsync(100);
         const progressEvt = progressSpy.firstCall.args[0];
@@ -142,7 +142,7 @@ describe('upload', () => {
             done();
           };
         });
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
 
       it('should not override configurable request url if already set', (done) => {
@@ -153,7 +153,7 @@ describe('upload', () => {
           done();
         });
         file.uploadTarget = modifiedUrl;
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
 
       it('should fire the upload-before with configurable form data name in multipart mode', (done) => {
@@ -180,7 +180,7 @@ describe('upload', () => {
           };
         });
 
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
 
         window.FormData = OriginalFormData;
       });
@@ -194,14 +194,14 @@ describe('upload', () => {
         });
 
         upload.formDataName = 'attachment';
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
 
       it('should not open xhr if `upload-before` event is cancelled', () => {
         upload.addEventListener('upload-before', (e) => {
           e.preventDefault();
         });
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
         expect(file.xhr.readyState).to.equal(0);
       });
 
@@ -215,7 +215,7 @@ describe('upload', () => {
           expect(e.detail.formData).to.be.ok;
           done();
         });
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
 
       it('should not send xhr if `upload-request` listener prevents default', (done) => {
@@ -228,7 +228,7 @@ describe('upload', () => {
           });
         });
 
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
 
       it('should fail if a `upload-response` listener sets an error', async () => {
@@ -240,7 +240,7 @@ describe('upload', () => {
         const errorSpy = sinon.spy();
         upload.addEventListener('upload-error', errorSpy);
 
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
         await clock.tickAsync(250);
 
         const e = errorSpy.firstCall.args[0];
@@ -254,7 +254,7 @@ describe('upload', () => {
           e.preventDefault();
         });
 
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
         await clock.tickAsync(100);
 
         expect(file.uploading).to.be.ok;
@@ -268,7 +268,7 @@ describe('upload', () => {
             done();
           });
         });
-        upload._retryFileUpload(file);
+        upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
       });
 
       it('should propagate with-credentials to the xhr', (done) => {
@@ -278,7 +278,7 @@ describe('upload', () => {
           expect(e.detail.xhr.withCredentials).to.be.true;
           done();
         });
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
       });
     });
 
@@ -306,7 +306,7 @@ describe('upload', () => {
         const spy = sinon.spy();
         upload.addEventListener('upload-error', spy);
 
-        upload._queueFileUpload(file);
+        upload.uploadFiles(file);
         await clock.tickAsync(50);
 
         const e = spy.firstCall.args[0];
@@ -352,7 +352,7 @@ describe('upload', () => {
     });
 
     it('should be indeterminate when connecting', async () => {
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
       await clock.tickAsync(200);
       expect(file.indeterminate).to.be.ok;
       expect(file.status).to.be.equal(upload.i18n.uploading.status.connecting);
@@ -361,7 +361,7 @@ describe('upload', () => {
     it('should not be indeterminate when progressing', async () => {
       const spy = sinon.spy();
       upload.addEventListener('upload-progress', spy);
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
       await clock.tickAsync(600);
       const e = spy.firstCall.args[0];
       expect(e.detail.file.status).to.contain(upload.i18n.uploading.remainingTime.prefix);
@@ -369,7 +369,7 @@ describe('upload', () => {
     });
 
     it('should be indeterminate when server is processing the file', async () => {
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
       await clock.tickAsync(800);
       expect(file.indeterminate).to.be.ok;
       expect(file.status).to.be.equal(upload.i18n.uploading.status.processing);
@@ -394,7 +394,7 @@ describe('upload', () => {
     });
 
     it('should be stalled when progress is not updated for more than 2 sec.', async () => {
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
       await clock.tickAsync(2200);
       expect(file.status).to.be.equal(upload.i18n.uploading.status.stalled);
     });
@@ -409,7 +409,7 @@ describe('upload', () => {
     });
 
     it('should be in held status', async () => {
-      upload._addFile(file);
+      addFilesViaInput(upload, [file]);
       await nextRender();
       expect(file.uploaded).not.to.be.ok;
       expect(file.held).to.be.true;
@@ -482,20 +482,17 @@ describe('upload', () => {
       upload.uploadFiles(upload.files[0]);
     });
 
-    it('should start a file upload from the file-start event', (done) => {
-      upload._addFile(file);
+    it('should start a file upload from the file-start event', async () => {
+      addFilesViaInput(upload, [file]);
+
+      await nextRender();
 
       expect(file.uploaded).not.to.be.ok;
       expect(file.held).to.be.true;
       expect(file.status).to.be.equal(upload.i18n.uploading.status.held);
 
-      upload.addEventListener('upload-start', (e) => {
-        expect(e.detail.xhr).to.be.ok;
-        expect(e.detail.file).to.be.ok;
-        expect(e.detail.file.uploading).to.be.ok;
-
-        done();
-      });
+      const startSpy = sinon.spy();
+      upload.addEventListener('upload-start', startSpy);
 
       upload.dispatchEvent(
         new CustomEvent('file-start', {
@@ -503,6 +500,14 @@ describe('upload', () => {
           cancelable: true,
         }),
       );
+
+      await nextRender();
+      expect(startSpy.calledOnce).to.be.true;
+      const e = startSpy.firstCall.args[0];
+
+      expect(e.detail.xhr).to.be.ok;
+      expect(e.detail.file).to.be.ok;
+      expect(e.detail.file.uploading).to.be.ok;
     });
   });
 
@@ -532,7 +537,7 @@ describe('upload', () => {
       const spy = sinon.spy();
       upload.addEventListener('file-remove', spy);
 
-      upload._addFiles(files);
+      addFilesViaInput(upload, files);
       await clock.tickAsync(150);
 
       expect(spy.calledOnce).to.be.true;
@@ -541,7 +546,7 @@ describe('upload', () => {
 
     it('should remove all files', async () => {
       upload.noAuto = true;
-      upload._addFiles(files);
+      addFilesViaInput(upload, files);
       await clock.tickAsync(1);
 
       removeFile(upload, 1);
@@ -572,7 +577,7 @@ describe('upload', () => {
         expect(e.detail.formData).to.be.instanceOf(FormData);
         done();
       });
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
     });
 
     it('should send file directly for raw format', (done) => {
@@ -583,7 +588,7 @@ describe('upload', () => {
         expect(e.detail.formData).to.be.undefined;
         done();
       });
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
     });
 
     it('should set Content-Type header to file MIME type in raw format', (done) => {
@@ -594,7 +599,7 @@ describe('upload', () => {
         expect(contentType).to.equal('application/pdf');
         done();
       });
-      upload._queueFileUpload(pdfFile);
+      upload.uploadFiles(pdfFile);
     });
 
     it('should set X-Filename header in raw format', (done) => {
@@ -605,7 +610,7 @@ describe('upload', () => {
         expect(filename).to.equal(encodeURIComponent(testFile.name));
         done();
       });
-      upload._queueFileUpload(testFile);
+      upload.uploadFiles(testFile);
     });
 
     it('should encode special characters in X-Filename header in raw format', (done) => {
@@ -617,7 +622,7 @@ describe('upload', () => {
         expect(filename).to.equal('religion%20%C3%A5k4.pdf');
         done();
       });
-      upload._queueFileUpload(testFile);
+      upload.uploadFiles(testFile);
     });
 
     it('should set Content-Type to application/octet-stream when file has no type in raw format', (done) => {
@@ -634,7 +639,7 @@ describe('upload', () => {
         expect(contentType).to.equal('application/octet-stream');
         done();
       });
-      upload._queueFileUpload(unknownFile);
+      upload.uploadFiles(unknownFile);
     });
 
     it('should not set Content-Type header in multipart format', (done) => {
@@ -644,7 +649,7 @@ describe('upload', () => {
         expect(contentType).to.be.undefined;
         done();
       });
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
     });
 
     it('should not set X-Filename header in multipart format', (done) => {
@@ -654,7 +659,7 @@ describe('upload', () => {
         expect(filename).to.be.undefined;
         done();
       });
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
     });
 
     it('should ignore formDataName in raw format', (done) => {
@@ -666,7 +671,7 @@ describe('upload', () => {
         expect(e.detail.formData).to.be.undefined;
         done();
       });
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
     });
 
     it('should successfully complete upload in raw format', async () => {
@@ -674,7 +679,7 @@ describe('upload', () => {
       const successSpy = sinon.spy();
       upload.addEventListener('upload-success', successSpy);
 
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
       await clock.tickAsync(400);
 
       expect(successSpy.calledOnce).to.be.true;
@@ -691,7 +696,7 @@ describe('upload', () => {
         expect(e.detail.formData).to.be.undefined;
         done();
       });
-      upload._queueFileUpload(file);
+      upload.uploadFiles(file);
     });
   });
 


### PR DESCRIPTION
## Summary
- Upload tests called private methods (`_addFile`, `_queueFileUpload`, `_abortFileUpload`, `_retryFileUpload`), coupling them to internals that may change
- Tests now use the public API (`uploadFiles`, `files`), the documented `file-start` / `file-retry` / `file-abort` events, and a helper that adds files through the file input, so they exercise the same paths as real usage

Part of #10939

🤖 Generated with [Claude Code](https://claude.com/claude-code)