### PR TITLE
fix: skip empty tokens when deserializing attribute value

### DIFF
--- a/packages/component-base/src/dom-utils.js
+++ b/packages/component-base/src/dom-utils.js
@@ -84,7 +84,7 @@ export function getClosestElement(selector, node) {
  * @return {Set<string>}
  */
 export function deserializeAttributeValue(value) {
-  return new Set(value ? value.split(' ') : []);
+  return new Set(value ? value.split(' ').filter(Boolean) : []);
 }
 
 /**

--- a/packages/component-base/test/dom-utils.test.js
+++ b/packages/component-base/test/dom-utils.test.js
@@ -128,6 +128,11 @@ describe('dom-utils', () => {
       addValuesToAttribute(element, 'aria-labelledby', []);
       expect(element.hasAttribute('aria-labelledby')).to.be.false;
     });
+
+    it('should ignore empty tokens produced by extra whitespace', () => {
+      addValuesToAttribute(element, 'aria-labelledby', '  label-id   error-id  ');
+      expect(element.getAttribute('aria-labelledby')).to.equal('label-id error-id');
+    });
   });
 
   describe('removeValuesFromAttribute', () => {
@@ -155,6 +160,12 @@ describe('dom-utils', () => {
 
     it('should remove the attribute when no values remain', () => {
       removeValuesFromAttribute(element, 'aria-labelledby', ['label-id', 'error-id helper-id']);
+      expect(element.hasAttribute('aria-labelledby')).to.be.false;
+    });
+
+    it('should remove the attribute when only whitespace remains', () => {
+      element.setAttribute('aria-labelledby', ' label-id  error-id ');
+      removeValuesFromAttribute(element, 'aria-labelledby', ['label-id', 'error-id']);
       expect(element.hasAttribute('aria-labelledby')).to.be.false;
     });
   });


### PR DESCRIPTION
`deserializeAttributeValue` splits the attribute value on a single space, so repeated or leading/trailing spaces produce empty strings that end up in the resulting Set. As a result, `addValuesToAttribute` can write attribute values with stray spaces, and `removeValuesFromAttribute` can leave an empty attribute behind instead of removing it (the leftover empty token keeps the Set non-empty). Filtering out empty tokens after the split fixes both cases.


Part of https://github.com/vaadin/web-components/issues/11975