### PR TITLE
test: extract shared calendar query helpers

### DIFF
--- a/packages/date-picker/test/basic.test.js
+++ b/packages/date-picker/test/basic.test.js
@@ -4,7 +4,7 @@ import { click, fixtureSync, keyboardEventFor, nextRender, oneEvent, tap } from 
 import sinon from 'sinon';
 import '../src/vaadin-date-picker.js';
 import { parseDate } from '../src/vaadin-date-picker-helper.js';
-import { open, touchTap, untilOverlayRendered } from './helpers.js';
+import { getCalendars, getWeekDayCells, open, touchTap, untilOverlayRendered } from './helpers.js';
 
 describe('basic features', () => {
   let datePicker, input, overlay;
@@ -217,9 +217,8 @@ describe('basic features', () => {
     });
 
     it('should notify i18n mutation to children', () => {
-      const monthCalendar = overlayContent.querySelector('vaadin-month-calendar');
-      const weekdays = monthCalendar.$.monthGrid.querySelectorAll('[part="weekday"]:not(:empty)');
-      const weekdayTitles = Array.prototype.map.call(weekdays, (weekday) => weekday.textContent.trim());
+      const [monthCalendar] = getCalendars(overlayContent);
+      const weekdayTitles = getWeekDayCells(monthCalendar).map((weekday) => weekday.textContent.trim());
       expect(weekdayTitles).to.eql(['ma', 'ti', 'ke', 'to', 'pe', 'la', 'su']);
     });
 

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -127,11 +127,43 @@ export function getFirstVisibleItem(scroller, bufferOffset = 0) {
 }
 
 /**
+ * The month calendars the overlay content currently holds. The month scroller keeps a fixed pool of
+ * them and reassigns which month each one shows, so the list includes calendars that are scrolled out
+ * of view, and ones with no `month` assigned yet. Filter by `month` to get the rendered ones.
+ *
+ * @param {HTMLElement} root vaadin-date-picker or vaadin-date-picker-overlay-content
+ * @return {HTMLElement[]}
+ */
+export function getCalendars(root) {
+  const overlayContent = root._overlayContent ?? root;
+  return [...overlayContent.querySelectorAll('vaadin-month-calendar')];
+}
+
+/**
+ * The date cells of a month calendar, without the empty ones padding the first and last week.
+ *
+ * @param {HTMLElement} calendar vaadin-month-calendar
+ * @return {HTMLElement[]}
+ */
+export function getDateCells(calendar) {
+  return [...calendar.shadowRoot.querySelectorAll('[part~="date"]:not(:empty)')];
+}
+
+/**
+ * The weekday header cells of a month calendar, without the empty one above the week numbers.
+ *
+ * @param {HTMLElement} calendar vaadin-month-calendar
+ * @return {HTMLElement[]}
+ */
+export function getWeekDayCells(calendar) {
+  return [...calendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)')];
+}
+
+/**
  * @param {HTMLElement} root vaadin-date-picker or vaadin-date-picker-overlay-content
  */
 export function getFocusableCell(root) {
-  const overlayContent = root._overlayContent ?? root;
-  const focusableMonth = [...overlayContent.querySelectorAll('vaadin-month-calendar')].find((month) => {
+  const focusableMonth = getCalendars(root).find((month) => {
     return !!month.shadowRoot.querySelector('[tabindex="0"]');
   });
 

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -2,18 +2,10 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, makeSoloTouchEvent, nextFrame, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-month-calendar.js';
-import { getDefaultI18n } from './helpers.js';
+import { getDateCells, getDefaultI18n, getWeekDayCells } from './helpers.js';
 
 describe('vaadin-month-calendar', () => {
   let monthCalendar, valueChangedSpy;
-
-  function getDateCells(calendar) {
-    return [...calendar.shadowRoot.querySelectorAll('[part~="date"]:not(:empty)')];
-  }
-
-  function getWeekDayCells(calendar) {
-    return [...calendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)')];
-  }
 
   beforeEach(async () => {
     monthCalendar = fixtureSync('<vaadin-month-calendar></vaadin-month-calendar>');

--- a/packages/date-picker/test/wai-aria.test.js
+++ b/packages/date-picker/test/wai-aria.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-date-picker.js';
-import { activateScroller, getDefaultI18n, open } from './helpers.js';
+import { activateScroller, getCalendars, getDefaultI18n, open } from './helpers.js';
 
 describe('WAI-ARIA', () => {
   describe('date picker', () => {
@@ -71,7 +71,8 @@ describe('WAI-ARIA', () => {
     it('should set aria-hidden on all calendars except focusable one', async () => {
       await open(datePicker);
       await nextRender();
-      const calendars = datePicker._overlayContent.querySelectorAll('vaadin-month-calendar');
+      const calendars = getCalendars(datePicker);
+      expect(calendars).to.not.be.empty;
       calendars.forEach((calendar) => {
         const focusable = calendar.shadowRoot.querySelector('[tabindex="0"]');
         expect(calendar.getAttribute('aria-hidden')).to.equal(focusable ? null : 'true');


### PR DESCRIPTION
The same calendar queries are written out in test file after test file: `querySelectorAll('vaadin-month-calendar')` in five places, and the date cell and weekday cell queries redefined locally wherever they are needed. The date metadata tests added more copies, so this extracts them first instead of adding to the pile.

### Changes

- **`getCalendars(root)`**, taking either a date-picker or an overlay content, like the other helpers in the file. Its JSDoc records that the month scroller keeps a fixed pool, so the list includes calendars that are scrolled out of view and ones with no `month` assigned yet — a caller that wants the rendered ones has to filter by `month`.
- **`getDateCells(calendar)`** and **`getWeekDayCells(calendar)`**, both dropping the empty cells: the ones padding the first and last week, and the one above the week numbers.
- `getFocusableCell` now uses `getCalendars`, so the calendar query has a single definition rather than one more copy inside `helpers.js` itself.
- `basic.test.js` scoped its weekday query to `$.monthGrid` rather than the shadow root. Every `[part="weekday"]` is inside that table, so the helper matches the same cells.
- Added `expect(calendars).to.not.be.empty` to the `aria-hidden` test in `wai-aria.test.js`, which iterates the calendars and asserts per calendar — so it passed whether or not the query found anything. The neighbouring year-separator test already guards itself the same way.

The three helpers were each checked by stubbing them to return `[]`: 80 tests fail, so none of them is decoration. Before and after, the group is 478 passing.

Related to #12259

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
