### PR TITLE
test: await async error message link in login form snapshots

### DIFF
--- a/packages/login/test/dom/__snapshots__/login-form.test.snap.js
+++ b/packages/login/test/dom/__snapshots__/login-form.test.snap.js
@@ -137,6 +137,7 @@ snapshots["vaadin-login-form host required"] =
       spellcheck="false"
     >
       <input
+        aria-describedby="error-message-vaadin-text-field-2"
         aria-invalid="true"
         aria-labelledby="label-vaadin-text-field-0"
         autocapitalize="none"
@@ -175,6 +176,7 @@ snapshots["vaadin-login-form host required"] =
       spellcheck="false"
     >
       <input
+        aria-describedby="error-message-vaadin-password-field-5"
         aria-invalid="true"
         aria-labelledby="label-vaadin-password-field-3"
         autocapitalize="off"
@@ -475,6 +477,7 @@ snapshots["vaadin-login-form host i18n-required"] =
       spellcheck="false"
     >
       <input
+        aria-describedby="error-message-vaadin-text-field-2"
         aria-invalid="true"
         aria-labelledby="label-vaadin-text-field-0"
         autocapitalize="none"
@@ -513,6 +516,7 @@ snapshots["vaadin-login-form host i18n-required"] =
       spellcheck="false"
     >
       <input
+        aria-describedby="error-message-vaadin-password-field-5"
         aria-invalid="true"
         aria-labelledby="label-vaadin-password-field-3"
         autocapitalize="off"

--- a/packages/login/test/dom/login-form.test.js
+++ b/packages/login/test/dom/login-form.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import '../../vaadin-login-form.js';
 import { resetUniqueId } from '@vaadin/component-base/src/unique-id-utils.js';
 
@@ -38,6 +38,7 @@ describe('vaadin-login-form', () => {
       form.querySelectorAll('[required]').forEach((el) => {
         el.invalid = true;
       });
+      await aTimeout(0);
       await expect(form).dom.to.equalSnapshot();
     });
 
@@ -58,6 +59,7 @@ describe('vaadin-login-form', () => {
       form.querySelectorAll('[required]').forEach((el) => {
         el.invalid = true;
       });
+      await aTimeout(0);
       await nextUpdate(form);
       await expect(form).dom.to.equalSnapshot();
     });


### PR DESCRIPTION
The login form DOM snapshot tests set `invalid` on the fields and take the snapshot right away. However, `FieldMixin` links the error message ID to `aria-describedby` in a timeout to avoid a double announcement in NVDA, so the recorded snapshots were missing the error message association on the invalid fields. The tests now wait for that timeout before taking the snapshot.

Extracted from #12275 ([review suggestion](https://github.com/vaadin/web-components/pull/12275#discussion_r3683511442)).