### PR TITLE
refactor: rename FieldAriaController label methods

### DIFF
--- a/packages/a11y-base/src/field-aria-controller.d.ts
+++ b/packages/a11y-base/src/field-aria-controller.d.ts
@@ -33,27 +33,26 @@ export class FieldAriaController {
    *
    * To remove the attribute, pass `null` as `label`.
    */
-  setAriaLabel(label: string | null): void;
+  setLabel(label: string | null): void;
 
   /**
-   * Links the target element with a slotted label element
-   * via the target's attribute `aria-labelledby`.
+   * Links the target element to one or more elements via the `aria-labelledby` attribute.
    *
-   * To unlink the previous slotted label element, pass `null` as `labelId`.
+   * Pass a space-delimited list of IDs, or `null` to remove the previously linked IDs.
    */
-  setLabelId(labelId: string | null, fromUser: boolean | null): void;
+  setLabelledBy(labelledBy: string | null): void;
 
   /**
-   * Links the target element with a slotted error element via `aria-describedby` attribute.
+   * Links the target element to a slotted error element via the `aria-describedby` attribute.
    *
-   * To unlink the previous slotted error element, pass `null` as `errorId`.
+   * Pass the ID of the error element, or `null` to remove the previously linked ID.
    */
   setErrorId(errorId: string | null): void;
 
   /**
-   * Links the target element with a slotted helper element via `aria-describedby` attribute.
+   * Links the target element to a slotted helper element via the `aria-describedby` attribute.
    *
-   * To unlink the previous slotted helper element, pass `null` as `helperId`.
+   * Pass the ID of the helper element, or `null` to remove the previously linked ID.
    */
   setHelperId(helperId: string | null): void;
 }

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -20,7 +20,7 @@ export class FieldAriaController {
   #label;
 
   /** @type {string | null | undefined} */
-  #labelId;
+  #labelledBy;
 
   /** @type {string | null | undefined} */
   #errorId;
@@ -29,10 +29,10 @@ export class FieldAriaController {
   #helperId;
 
   /** @type {string[]} */
-  #ariaLabelledByIds = [];
+  #ariaLabelledByAttributeIds = [];
 
   /** @type {string[]} */
-  #ariaDescribedByIds = [];
+  #ariaDescribedByAttributeIds = [];
 
   constructor(host) {
     this.host = host;
@@ -70,30 +70,27 @@ export class FieldAriaController {
    *
    * @param {string | null | undefined} label
    */
-  setAriaLabel(label) {
+  setLabel(label) {
     this.#label = label;
     this.#updateAriaLabelAttribute();
   }
 
   /**
-   * Links the target element with a slotted label element
-   * via the target's attribute `aria-labelledby`.
+   * Links the target element to one or more elements via the `aria-labelledby` attribute.
    *
-   * To unlink the previous slotted label element, pass `null` as `labelId`.
-   *
-   * @param {string | null} labelId
+   * @param {string | null} labelledBy the space-delimited list of IDs,
+   * or `null` to remove the previously linked IDs
    */
-  setLabelId(labelId) {
-    this.#labelId = labelId;
+  setLabelledBy(labelledBy) {
+    this.#labelledBy = labelledBy;
     this.#updateAriaLabelledByAttribute();
   }
 
   /**
-   * Links the target element with a slotted error element via `aria-describedby` attribute.
+   * Links the target element to a slotted error element via the `aria-describedby` attribute.
    *
-   * To unlink the previous slotted error element, pass `null` as `errorId`.
-   *
-   * @param {string | null} errorId
+   * @param {string | null} errorId the ID of the error element,
+   * or `null` to remove the previously linked ID
    */
   setErrorId(errorId) {
     this.#errorId = errorId;
@@ -101,11 +98,10 @@ export class FieldAriaController {
   }
 
   /**
-   * Links the target element with a slotted helper element via `aria-describedby` attribute.
+   * Links the target element to a slotted helper element via the `aria-describedby` attribute.
    *
-   * To unlink the previous slotted helper element, pass `null` as `helperId`.
-   *
-   * @param {string | null} helperId
+   * @param {string | null} helperId the ID of the helper element,
+   * or `null` to remove the previously linked ID
    */
   setHelperId(helperId) {
     this.#helperId = helperId;
@@ -129,11 +125,11 @@ export class FieldAriaController {
       return;
     }
 
-    removeValuesFromAttribute(this.#target, 'aria-labelledby', this.#ariaLabelledByIds);
+    removeValuesFromAttribute(this.#target, 'aria-labelledby', this.#ariaLabelledByAttributeIds);
 
-    this.#ariaLabelledByIds = [this.#labelId];
+    this.#ariaLabelledByAttributeIds = [this.#labelledBy];
 
-    addValuesToAttribute(this.#target, 'aria-labelledby', this.#ariaLabelledByIds);
+    addValuesToAttribute(this.#target, 'aria-labelledby', this.#ariaLabelledByAttributeIds);
   }
 
   #updateAriaDescribedByAttribute() {
@@ -141,11 +137,11 @@ export class FieldAriaController {
       return;
     }
 
-    removeValuesFromAttribute(this.#target, 'aria-describedby', this.#ariaDescribedByIds);
+    removeValuesFromAttribute(this.#target, 'aria-describedby', this.#ariaDescribedByAttributeIds);
 
-    this.#ariaDescribedByIds = [this.#helperId, this.#errorId];
+    this.#ariaDescribedByAttributeIds = [this.#helperId, this.#errorId];
 
-    addValuesToAttribute(this.#target, 'aria-describedby', this.#ariaDescribedByIds);
+    addValuesToAttribute(this.#target, 'aria-describedby', this.#ariaDescribedByAttributeIds);
   }
 
   #updateAriaRequiredAttribute() {

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -44,7 +44,7 @@ describe('FieldAriaController', () => {
 
     describe('label id', () => {
       beforeEach(() => {
-        controller.setLabelId('label-id');
+        controller.setLabelledBy('label-id');
         controller.setTarget(input);
       });
 
@@ -101,9 +101,9 @@ describe('FieldAriaController', () => {
       });
 
       it('should set label id to aria-labelledby attribute', () => {
-        controller.setLabelId('label-id');
+        controller.setLabelledBy('label-id');
         expect(input.getAttribute('aria-labelledby')).equal('custom-id label-id');
-        controller.setLabelId(null);
+        controller.setLabelledBy(null);
         expect(input.getAttribute('aria-labelledby')).equal('custom-id');
       });
 
@@ -138,7 +138,7 @@ describe('FieldAriaController', () => {
 
     describe('label id', () => {
       beforeEach(() => {
-        controller.setLabelId('label-id');
+        controller.setLabelledBy('label-id');
         controller.setTarget(element);
       });
 
@@ -187,9 +187,9 @@ describe('FieldAriaController', () => {
       });
 
       it('should set label id to aria-labelledby attribute', () => {
-        controller.setLabelId('label-id');
+        controller.setLabelledBy('label-id');
         expect(element.getAttribute('aria-labelledby')).equal('custom-id label-id');
-        controller.setLabelId(null);
+        controller.setLabelledBy(null);
         expect(element.getAttribute('aria-labelledby')).equal('custom-id');
       });
 

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -76,17 +76,17 @@ export const FieldMixin = (superclass) =>
       this._errorController = new ErrorController(this);
 
       this._labelController.addEventListener('slot-content-changed', () => {
-        this.__syncFieldAriaControllerLabelId();
+        this.__updateFieldAriaControllerLabelledBy();
       });
 
       this._errorController.addEventListener('slot-content-changed', (event) => {
         this.toggleAttribute('has-error-message', event.detail.hasContent);
-        this.__syncFieldAriaControllerErrorId();
+        this.__updateFieldAriaControllerErrorId();
       });
 
       this._helperController.addEventListener('slot-content-changed', (event) => {
         this.toggleAttribute('has-helper', event.detail.hasContent);
-        this.__syncFieldAriaControllerHelperId();
+        this.__updateFieldAriaControllerHelperId();
       });
     }
 
@@ -117,13 +117,13 @@ export const FieldMixin = (superclass) =>
 
     /** @protected */
     _accessibleNameChanged(accessibleName) {
-      this._fieldAriaController.setAriaLabel(accessibleName);
-      this.__syncFieldAriaControllerLabelId();
+      this._fieldAriaController.setLabel(accessibleName);
+      this.__updateFieldAriaControllerLabelledBy();
     }
 
     /** @protected */
     _accessibleNameRefChanged() {
-      this.__syncFieldAriaControllerLabelId();
+      this.__updateFieldAriaControllerLabelledBy();
     }
 
     /**
@@ -166,11 +166,11 @@ export const FieldMixin = (superclass) =>
      */
     _invalidChanged(invalid) {
       this._errorController.setInvalid(invalid);
-      this.__syncFieldAriaControllerErrorId();
+      this.__updateFieldAriaControllerErrorId();
     }
 
     /** @private */
-    __syncFieldAriaControllerHelperId() {
+    __updateFieldAriaControllerHelperId() {
       if (this.hasAttribute('has-helper')) {
         this._fieldAriaController.setHelperId(this._helperNode?.id);
       } else {
@@ -179,7 +179,7 @@ export const FieldMixin = (superclass) =>
     }
 
     /** @private */
-    __syncFieldAriaControllerErrorId() {
+    __updateFieldAriaControllerErrorId() {
       // This timeout is needed to prevent NVDA from announcing the error message twice:
       // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
       // 2. Once linking the error ID with the ARIA target here (unwanted).
@@ -196,15 +196,15 @@ export const FieldMixin = (superclass) =>
     }
 
     /** @private */
-    __syncFieldAriaControllerLabelId() {
+    __updateFieldAriaControllerLabelledBy() {
       if (this.accessibleNameRef) {
-        this._fieldAriaController.setLabelId(this.accessibleNameRef);
+        this._fieldAriaController.setLabelledBy(this.accessibleNameRef);
       } else if (this.hasAttribute('has-label') && !this.accessibleName) {
         // Label ID should be only added when the label content is present
         // and not overridden by `accessible-name` which sets `aria-label`.
-        this._fieldAriaController.setLabelId(this._labelNode?.id);
+        this._fieldAriaController.setLabelledBy(this._labelNode?.id);
       } else {
-        this._fieldAriaController.setLabelId(null);
+        this._fieldAriaController.setLabelledBy(null);
       }
     }
   };

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -544,7 +544,7 @@ export const SelectBaseMixin = (superClass) =>
      */
     _accessibleNameChanged(accessibleName) {
       this._srLabelController.setLabel(accessibleName);
-      this.__syncFieldAriaControllerLabelId();
+      this.__updateFieldAriaControllerLabelledBy();
     }
 
     /** @private */
@@ -578,7 +578,7 @@ export const SelectBaseMixin = (superClass) =>
         delete this._selectedChanging;
       }
 
-      this.__syncFieldAriaControllerLabelId();
+      this.__updateFieldAriaControllerLabelledBy();
     }
 
     /** @private */
@@ -676,7 +676,7 @@ export const SelectBaseMixin = (superClass) =>
     }
 
     /** @override */
-    __syncFieldAriaControllerLabelId() {
+    __updateFieldAriaControllerLabelledBy() {
       let labelId;
       if (this.accessibleNameRef) {
         labelId = this.accessibleNameRef;
@@ -691,9 +691,9 @@ export const SelectBaseMixin = (superClass) =>
 
       const ids = [labelId, itemId].filter(Boolean);
       if (ids.length > 0) {
-        this._fieldAriaController.setLabelId(ids.join(' '));
+        this._fieldAriaController.setLabelledBy(ids.join(' '));
       } else {
-        this._fieldAriaController.setLabelId(null);
+        this._fieldAriaController.setLabelledBy(null);
       }
     }
   };


### PR DESCRIPTION
`FieldAriaController.setLabelId` accepts a space-delimited list of IDs rather than a single label element ID (for example, Select passes several IDs at once), so the name is misleading. This PR renames it to `setLabelledBy` after the attribute it manages, and renames `setAriaLabel` to `setLabel` to match. The `__syncFieldAriaController*` helpers in `FieldMixin` and Select are renamed to `__updateFieldAriaController*` accordingly.

The TypeScript definition of `setLabelId` also still declared a `fromUser` parameter that the implementation no longer accepts since #12286. The renamed signature drops it.

Part of https://github.com/vaadin/web-components/issues/11975