### PR TITLE
refactor: migrate FieldMixin observers to updated lifecycle

### DIFF
--- a/packages/checkbox/src/vaadin-checkbox-mixin.js
+++ b/packages/checkbox/src/vaadin-checkbox-mixin.js
@@ -105,6 +105,15 @@ export const CheckboxMixin = (superclass) =>
       this._createPropertyObserver('checked', '_checkedChanged');
     }
 
+    updated(props) {
+      super.updated(props);
+
+      // Validate when the required constraint is removed.
+      if (props.has('required') && this.required === false) {
+        this._requestValidation();
+      }
+    }
+
     /**
      * Override method inherited from `ActiveMixin` to only set the `active`
      * attribute for clicks that actually toggle the checked state.
@@ -201,21 +210,6 @@ export const CheckboxMixin = (superclass) =>
     /** @private */
     _checkedChanged(checked, oldChecked) {
       if (checked || oldChecked) {
-        this._requestValidation();
-      }
-    }
-
-    /**
-     * Override an observer from `FieldMixin`
-     * to validate when required is removed.
-     *
-     * @protected
-     * @override
-     */
-    _requiredChanged(required) {
-      super._requiredChanged(required);
-
-      if (required === false) {
         this._requestValidation();
       }
     }

--- a/packages/custom-field/src/vaadin-custom-field-mixin.js
+++ b/packages/custom-field/src/vaadin-custom-field-mixin.js
@@ -140,6 +140,15 @@ export const CustomFieldMixin = (superClass) =>
       });
     }
 
+    updated(props) {
+      super.updated(props);
+
+      // Validate when the required constraint is removed.
+      if (props.has('required') && this.required === false) {
+        this._requestValidation();
+      }
+    }
+
     /**
      * @param {FocusOptions=} options
      * @protected
@@ -191,21 +200,6 @@ export const CustomFieldMixin = (superClass) =>
         return false;
       }
       return true;
-    }
-
-    /**
-     * Override an observer from `FieldMixin`
-     * to validate when required is removed.
-     *
-     * @protected
-     * @override
-     */
-    _requiredChanged(required) {
-      super._requiredChanged(required);
-
-      if (required === false) {
-        this._requestValidation();
-      }
     }
 
     /**

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -518,7 +518,6 @@ snapshots["vaadin-date-time-picker host error"] =
     >
     </div>
     <input
-      aria-describedby="error-message-vaadin-date-picker-5"
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-invalid="true"
@@ -554,7 +553,6 @@ snapshots["vaadin-date-time-picker host error"] =
     </div>
     <input
       aria-autocomplete="list"
-      aria-describedby="error-message-vaadin-time-picker-9"
       aria-expanded="false"
       aria-invalid="true"
       autocapitalize="off"

--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -49,12 +49,4 @@ export declare class FieldMixinClass {
   protected readonly _errorNode: HTMLElement;
 
   protected readonly _helperNode?: HTMLElement;
-
-  protected _helperTextChanged(helperText: string | null | undefined): void;
-
-  protected _ariaTargetChanged(target: HTMLElement): void;
-
-  protected _requiredChanged(required: boolean): void;
-
-  protected _invalidChanged(invalid: boolean): void;
 }

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -75,18 +75,16 @@ export const FieldMixin = (superclass) =>
       this._helperController = new HelperController(this);
       this._errorController = new ErrorController(this);
 
-      this._labelController.addEventListener('slot-content-changed', () => {
-        this.__updateFieldAriaControllerLabelledBy();
+      this._labelController.addEventListener('slot-content-changed', (event) => {
+        this.#onLabelSlotChange(event);
       });
 
       this._errorController.addEventListener('slot-content-changed', (event) => {
-        this.toggleAttribute('has-error-message', event.detail.hasContent);
-        this.__updateFieldAriaControllerErrorId();
+        this.#onErrorSlotChange(event);
       });
 
       this._helperController.addEventListener('slot-content-changed', (event) => {
-        this.toggleAttribute('has-helper', event.detail.hasContent);
-        this.__updateFieldAriaControllerHelperId();
+        this.#onHelperSlotChange(event);
       });
     }
 
@@ -166,33 +164,6 @@ export const FieldMixin = (superclass) =>
      */
     _invalidChanged(invalid) {
       this._errorController.setInvalid(invalid);
-      this.__updateFieldAriaControllerErrorId();
-    }
-
-    /** @private */
-    __updateFieldAriaControllerHelperId() {
-      if (this.hasAttribute('has-helper')) {
-        this._fieldAriaController.setHelperId(this._helperNode?.id);
-      } else {
-        this._fieldAriaController.setHelperId(null);
-      }
-    }
-
-    /** @private */
-    __updateFieldAriaControllerErrorId() {
-      // This timeout is needed to prevent NVDA from announcing the error message twice:
-      // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
-      // 2. Once linking the error ID with the ARIA target here (unwanted).
-      // Related issue: https://github.com/vaadin/web-components/issues/3061.
-      setTimeout(() => {
-        // Error message ID needs to be dynamically added / removed based on the validity
-        // Otherwise assistive technologies would announce the error, even if we hide it.
-        if (this.invalid) {
-          this._fieldAriaController.setErrorId(this._errorNode?.id);
-        } else {
-          this._fieldAriaController.setErrorId(null);
-        }
-      });
     }
 
     /** @private */
@@ -206,5 +177,39 @@ export const FieldMixin = (superclass) =>
       } else {
         this._fieldAriaController.setLabelledBy(null);
       }
+    }
+
+    #onLabelSlotChange(_event) {
+      this.__updateFieldAriaControllerLabelledBy();
+    }
+
+    #onHelperSlotChange(event) {
+      const { hasContent } = event.detail;
+
+      this.toggleAttribute('has-helper', hasContent);
+
+      if (hasContent) {
+        this._fieldAriaController.setHelperId(this._helperNode?.id);
+      } else {
+        this._fieldAriaController.setHelperId(null);
+      }
+    }
+
+    #onErrorSlotChange(event) {
+      const { hasContent } = event.detail;
+
+      this.toggleAttribute('has-error-message', hasContent);
+
+      // This timeout is needed to prevent NVDA from announcing the error message twice:
+      // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
+      // 2. Once linking the error ID with the ARIA target here (unwanted).
+      // Related issue: https://github.com/vaadin/web-components/issues/3061.
+      setTimeout(() => {
+        if (hasContent) {
+          this._fieldAriaController.setErrorId(this._errorNode?.id);
+        } else {
+          this._fieldAriaController.setErrorId(null);
+        }
+      });
     }
   };

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -22,7 +22,6 @@ export const FieldMixin = (superclass) =>
          */
         ariaTarget: {
           type: Object,
-          observer: '_ariaTargetChanged',
         },
 
         /**
@@ -32,7 +31,6 @@ export const FieldMixin = (superclass) =>
          */
         errorMessage: {
           type: String,
-          observer: '_errorMessageChanged',
         },
 
         /**
@@ -41,7 +39,6 @@ export const FieldMixin = (superclass) =>
          */
         helperText: {
           type: String,
-          observer: '_helperTextChanged',
         },
 
         /**
@@ -50,7 +47,6 @@ export const FieldMixin = (superclass) =>
          */
         accessibleName: {
           type: String,
-          observer: '_accessibleNameChanged',
         },
 
         /**
@@ -59,13 +55,8 @@ export const FieldMixin = (superclass) =>
          */
         accessibleNameRef: {
           type: String,
-          observer: '_accessibleNameRefChanged',
         },
       };
-    }
-
-    static get observers() {
-      return ['_invalidChanged(invalid)', '_requiredChanged(required)'];
     }
 
     constructor() {
@@ -113,57 +104,41 @@ export const FieldMixin = (superclass) =>
       this.addController(this._errorController);
     }
 
-    /** @protected */
-    _accessibleNameChanged(accessibleName) {
-      this._fieldAriaController.setLabel(accessibleName);
-      this.__updateFieldAriaControllerLabelledBy();
-    }
+    updated(props) {
+      super.updated(props);
 
-    /** @protected */
-    _accessibleNameRefChanged() {
-      this.__updateFieldAriaControllerLabelledBy();
-    }
+      if (props.has('invalid')) {
+        this._errorController.setInvalid(this.invalid);
+      }
 
-    /**
-     * @param {string | null | undefined} errorMessage
-     * @protected
-     */
-    _errorMessageChanged(errorMessage) {
-      this._errorController.setErrorMessage(errorMessage);
-    }
+      if (props.has('errorMessage')) {
+        this._errorController.setErrorMessage(this.errorMessage);
+      }
 
-    /**
-     * @param {string} helperText
-     * @protected
-     */
-    _helperTextChanged(helperText) {
-      this._helperController.setHelperText(helperText);
-    }
+      if (props.has('helperText')) {
+        this._helperController.setHelperText(this.helperText);
+      }
 
-    /**
-     * @param {HTMLElement | null | undefined} target
-     * @protected
-     */
-    _ariaTargetChanged(target) {
-      if (target) {
-        this._fieldAriaController.setTarget(target);
+      if (props.has('ariaTarget')) {
+        this._fieldAriaController.setTarget(this.ariaTarget);
+      }
+
+      if (props.has('required')) {
+        this._fieldAriaController.setRequired(this.required);
+      }
+
+      if (props.has('accessibleName')) {
+        this.__updateFieldAriaControllerLabel();
+      }
+
+      if (props.has('accessibleName') || props.has('accessibleNameRef')) {
+        this.__updateFieldAriaControllerLabelledBy();
       }
     }
 
-    /**
-     * @param {boolean} required
-     * @protected
-     */
-    _requiredChanged(required) {
-      this._fieldAriaController.setRequired(required);
-    }
-
-    /**
-     * @param {boolean} invalid
-     * @protected
-     */
-    _invalidChanged(invalid) {
-      this._errorController.setInvalid(invalid);
+    /** @private */
+    __updateFieldAriaControllerLabel() {
+      this._fieldAriaController.setLabel(this.accessibleName);
     }
 
     /** @private */

--- a/packages/radio-group/src/vaadin-radio-group-mixin.js
+++ b/packages/radio-group/src/vaadin-radio-group-mixin.js
@@ -137,6 +137,18 @@ export const RadioGroupMixin = (superclass) =>
       this.addController(this._tooltipController);
     }
 
+    updated(props) {
+      super.updated(props);
+
+      if (props.has('invalid')) {
+        if (this.invalid) {
+          this.setAttribute('aria-invalid', 'true');
+        } else {
+          this.removeAttribute('aria-invalid');
+        }
+      }
+    }
+
     /**
      * @param {!Array<!Node>} nodes
      * @return {!Array<!RadioButton>}
@@ -170,23 +182,6 @@ export const RadioGroupMixin = (superclass) =>
       if (['ArrowRight', 'ArrowDown'].includes(event.key)) {
         event.preventDefault();
         this.__selectPrevRadioButton(radioButton);
-      }
-    }
-
-    /**
-     * Override an observer from `FieldMixin`.
-     *
-     * @param {boolean} invalid
-     * @protected
-     * @override
-     */
-    _invalidChanged(invalid) {
-      super._invalidChanged(invalid);
-
-      if (invalid) {
-        this.setAttribute('aria-invalid', 'true');
-      } else {
-        this.removeAttribute('aria-invalid');
       }
     }
 

--- a/packages/select/src/vaadin-select-base-mixin.js
+++ b/packages/select/src/vaadin-select-base-mixin.js
@@ -231,6 +231,15 @@ export const SelectBaseMixin = (superClass) =>
           this.__lastMenuElement = null;
         }
       }
+
+      if (props.has('accessibleName')) {
+        this._srLabelController.setLabel(this.accessibleName);
+      }
+
+      // Validate when the required constraint is removed.
+      if (props.has('required') && this.required === false) {
+        this._requestValidation();
+      }
     }
 
     /**
@@ -247,21 +256,6 @@ export const SelectBaseMixin = (superClass) =>
       }
 
       this._overlayElement.requestContentUpdate();
-    }
-
-    /**
-     * Override an observer from `FieldMixin`
-     * to validate when required is removed.
-     *
-     * @protected
-     * @override
-     */
-    _requiredChanged(required) {
-      super._requiredChanged(required);
-
-      if (required === false) {
-        this._requestValidation();
-      }
     }
 
     /**
@@ -537,16 +531,6 @@ export const SelectBaseMixin = (superClass) =>
       itemElement.setAttribute('id', this._itemId);
     }
 
-    /**
-     * @param {string} accessibleName
-     * @protected
-     * @override
-     */
-    _accessibleNameChanged(accessibleName) {
-      this._srLabelController.setLabel(accessibleName);
-      this.__updateFieldAriaControllerLabelledBy();
-    }
-
     /** @private */
     __updateValueButton() {
       const valueButton = this.focusElement;
@@ -673,6 +657,11 @@ export const SelectBaseMixin = (superClass) =>
       this._requestValidation();
       this.dispatchEvent(new CustomEvent('change', { bubbles: true }));
       this.__dispatchChangePending = false;
+    }
+
+    /** @override */
+    __updateFieldAriaControllerLabel() {
+      // NO-OP
     }
 
     /** @override */


### PR DESCRIPTION
`FieldMixin` used Polymer-style observers to sync its properties to the label, helper, and error controllers. This PR moves that logic into the Lit `updated()` callback and removes the protected `_*Changed` observer hooks. Checkbox, CustomField, Select, and RadioGroup overrode some of these hooks, so they now handle `accessibleName`, `invalid`, and `required` in their own `updated()` callbacks.

Part of https://github.com/vaadin/web-components/issues/11975