### PR TITLE
refactor: extract field slot content change handlers

### DIFF
--- a/packages/date-time-picker/test/aria.test.js
+++ b/packages/date-time-picker/test/aria.test.js
@@ -7,7 +7,11 @@ describe('ARIA', () => {
 
   beforeEach(async () => {
     dateTimePicker = fixtureSync(
-      `<vaadin-date-time-picker helper-text="Helper text" label="Date and time"></vaadin-date-time-picker>`,
+      `<vaadin-date-time-picker
+        helper-text="Helper text"
+        label="Date and time"
+        error-message="Error message"
+      ></vaadin-date-time-picker>`,
     );
     await nextRender();
     label = dateTimePicker.querySelector(':scope > [slot=label]');

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -518,7 +518,6 @@ snapshots["vaadin-date-time-picker host error"] =
     >
     </div>
     <input
-      aria-describedby="error-message-vaadin-date-picker-5"
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-invalid="true"
@@ -554,7 +553,6 @@ snapshots["vaadin-date-time-picker host error"] =
     </div>
     <input
       aria-autocomplete="list"
-      aria-describedby="error-message-vaadin-time-picker-9"
       aria-expanded="false"
       aria-invalid="true"
       autocapitalize="off"

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -166,7 +166,6 @@ export const FieldMixin = (superclass) =>
      */
     _invalidChanged(invalid) {
       this._errorController.setInvalid(invalid);
-      this.__updateFieldAriaControllerErrorId();
     }
 
     /** @private */
@@ -185,9 +184,7 @@ export const FieldMixin = (superclass) =>
       // 2. Once linking the error ID with the ARIA target here (unwanted).
       // Related issue: https://github.com/vaadin/web-components/issues/3061.
       setTimeout(() => {
-        // Error message ID needs to be dynamically added / removed based on the validity
-        // Otherwise assistive technologies would announce the error, even if we hide it.
-        if (this.invalid) {
+        if (this.hasAttribute('has-error-message')) {
           this._fieldAriaController.setErrorId(this._errorNode?.id);
         } else {
           this._fieldAriaController.setErrorId(null);

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -75,18 +75,16 @@ export const FieldMixin = (superclass) =>
       this._helperController = new HelperController(this);
       this._errorController = new ErrorController(this);
 
-      this._labelController.addEventListener('slot-content-changed', () => {
-        this.__updateFieldAriaControllerLabelledBy();
+      this._labelController.addEventListener('slot-content-changed', (event) => {
+        this.#onLabelSlotChange(event);
       });
 
       this._errorController.addEventListener('slot-content-changed', (event) => {
-        this.toggleAttribute('has-error-message', event.detail.hasContent);
-        this.__updateFieldAriaControllerErrorId();
+        this.#onErrorSlotChange(event);
       });
 
       this._helperController.addEventListener('slot-content-changed', (event) => {
-        this.toggleAttribute('has-helper', event.detail.hasContent);
-        this.__updateFieldAriaControllerHelperId();
+        this.#onHelperSlotChange(event);
       });
     }
 
@@ -169,30 +167,6 @@ export const FieldMixin = (superclass) =>
     }
 
     /** @private */
-    __updateFieldAriaControllerHelperId() {
-      if (this.hasAttribute('has-helper')) {
-        this._fieldAriaController.setHelperId(this._helperNode?.id);
-      } else {
-        this._fieldAriaController.setHelperId(null);
-      }
-    }
-
-    /** @private */
-    __updateFieldAriaControllerErrorId() {
-      // This timeout is needed to prevent NVDA from announcing the error message twice:
-      // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
-      // 2. Once linking the error ID with the ARIA target here (unwanted).
-      // Related issue: https://github.com/vaadin/web-components/issues/3061.
-      setTimeout(() => {
-        if (this.hasAttribute('has-error-message')) {
-          this._fieldAriaController.setErrorId(this._errorNode?.id);
-        } else {
-          this._fieldAriaController.setErrorId(null);
-        }
-      });
-    }
-
-    /** @private */
     __updateFieldAriaControllerLabelledBy() {
       if (this.accessibleNameRef) {
         this._fieldAriaController.setLabelledBy(this.accessibleNameRef);
@@ -203,5 +177,39 @@ export const FieldMixin = (superclass) =>
       } else {
         this._fieldAriaController.setLabelledBy(null);
       }
+    }
+
+    #onLabelSlotChange(_event) {
+      this.__updateFieldAriaControllerLabelledBy();
+    }
+
+    #onHelperSlotChange(event) {
+      const { hasContent } = event.detail;
+
+      this.toggleAttribute('has-helper', hasContent);
+
+      if (hasContent) {
+        this._fieldAriaController.setHelperId(this._helperNode?.id);
+      } else {
+        this._fieldAriaController.setHelperId(null);
+      }
+    }
+
+    #onErrorSlotChange(event) {
+      const { hasContent } = event.detail;
+
+      this.toggleAttribute('has-error-message', hasContent);
+
+      // This timeout is needed to prevent NVDA from announcing the error message twice:
+      // 1. Once adding the `[role=alert]` attribute when updating `has-error-message` (OK).
+      // 2. Once linking the error ID with the ARIA target here (unwanted).
+      // Related issue: https://github.com/vaadin/web-components/issues/3061.
+      setTimeout(() => {
+        if (hasContent) {
+          this._fieldAriaController.setErrorId(this._errorNode?.id);
+        } else {
+          this._fieldAriaController.setErrorId(null);
+        }
+      });
     }
   };


### PR DESCRIPTION
`FieldMixin` handled `slot-content-changed` events with inline listeners that mixed attribute toggling with ARIA id updates. This PR extracts them into `#onLabelSlotChange`, `#onErrorSlotChange`, and `#onHelperSlotChange` handlers, with the helper and error id logic inlined into the handlers.

The error message ID is now linked based on whether the error element has content, instead of checking the `invalid` property. The error content is only present when the field is invalid and the message is non-empty, so the only visible change is that `aria-describedby` no longer points to an empty error element when the field is invalid but has no error message. The DateTimePicker DOM snapshot is updated accordingly, as it propagates `invalid` to its inner pickers that have no error message of their own.

Part of https://github.com/vaadin/web-components/issues/11975
