### PR TITLE
refactor: do not add empty error message to aria-describedby

### DIFF
--- a/packages/date-time-picker/test/aria.test.js
+++ b/packages/date-time-picker/test/aria.test.js
@@ -7,7 +7,11 @@ describe('ARIA', () => {
 
   beforeEach(async () => {
     dateTimePicker = fixtureSync(
-      `<vaadin-date-time-picker helper-text="Helper text" label="Date and time"></vaadin-date-time-picker>`,
+      `<vaadin-date-time-picker
+        helper-text="Helper text"
+        label="Date and time"
+        error-message="Error message"
+      ></vaadin-date-time-picker>`,
     );
     await nextRender();
     label = dateTimePicker.querySelector(':scope > [slot=label]');

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -518,7 +518,6 @@ snapshots["vaadin-date-time-picker host error"] =
     >
     </div>
     <input
-      aria-describedby="error-message-vaadin-date-picker-5"
       aria-expanded="false"
       aria-haspopup="dialog"
       aria-invalid="true"
@@ -554,7 +553,6 @@ snapshots["vaadin-date-time-picker host error"] =
     </div>
     <input
       aria-autocomplete="list"
-      aria-describedby="error-message-vaadin-time-picker-9"
       aria-expanded="false"
       aria-invalid="true"
       autocapitalize="off"

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -166,7 +166,6 @@ export const FieldMixin = (superclass) =>
      */
     _invalidChanged(invalid) {
       this._errorController.setInvalid(invalid);
-      this.__updateFieldAriaControllerErrorId();
     }
 
     /** @private */
@@ -185,9 +184,7 @@ export const FieldMixin = (superclass) =>
       // 2. Once linking the error ID with the ARIA target here (unwanted).
       // Related issue: https://github.com/vaadin/web-components/issues/3061.
       setTimeout(() => {
-        // Error message ID needs to be dynamically added / removed based on the validity
-        // Otherwise assistive technologies would announce the error, even if we hide it.
-        if (this.invalid) {
+        if (this.hasAttribute('has-error-message')) {
           this._fieldAriaController.setErrorId(this._errorNode?.id);
         } else {
           this._fieldAriaController.setErrorId(null);


### PR DESCRIPTION
`FieldMixin` computed the error message ID reference for `aria-describedby` from the `invalid` property, while the helper ID is computed from the `has-helper` attribute. This PR aligns the error ID with the helper ID by computing it from the `has-error-message` attribute, decoupling it from `invalid`. With that, `_invalidChanged` no longer needs to trigger the error ID update: toggling `invalid` changes the error element's content, which already updates the attribute and the ID through the `slot-content-changed` listener.

As a result, `aria-describedby` no longer points to an empty error element when the field is invalid but has no error message. The DateTimePicker ARIA test and DOM snapshot are updated accordingly: the test now sets an error message on the host, and the inner pickers (which get `invalid` propagated from the host but have no error message of their own) no longer reference their empty error elements.

Part of https://github.com/vaadin/web-components/issues/11975