### PR TITLE
fix: use visual viewport detection to open overlay correctly on iOS

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -16,6 +16,7 @@ export const ComboBoxOverlayMixin = (superClass) =>
       super();
 
       this.requiredVerticalSpace = 200;
+      this.limitToVisualViewport = true;
     }
 
     /**

--- a/packages/combo-box/test/overlay-position.test.js
+++ b/packages/combo-box/test/overlay-position.test.js
@@ -168,6 +168,33 @@ describe('overlay position', () => {
       expect(overlayPart.getBoundingClientRect().top).to.closeTo(inputField.getBoundingClientRect().bottom, 1);
     });
 
+    describe('visual viewport', () => {
+      // Mimics the iOS on-screen keyboard, which shrinks the visual viewport
+      // while the layout viewport keeps reporting its full height.
+      const KEYBOARD_HEIGHT = 250;
+      let visibleHeight;
+
+      beforeEach(() => {
+        visibleHeight = document.documentElement.clientHeight - KEYBOARD_HEIGHT;
+        Object.defineProperty(window.visualViewport, 'height', {
+          configurable: true,
+          get: () => visibleHeight,
+        });
+      });
+
+      afterEach(() => {
+        delete window.visualViewport.height;
+      });
+
+      it('should not extend the overlay below the visible viewport', async () => {
+        moveComboBox(xCenter, yTop, 300);
+
+        comboBox.open();
+        await aTimeout(1);
+        expect(overlayPart.getBoundingClientRect().bottom).to.be.at.most(visibleHeight);
+      });
+    });
+
     describe('lazy data provider', () => {
       beforeEach(() => {
         comboBox.items = undefined;

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -19,7 +19,10 @@ const overlayBase = css`
           override this to adjust the gap between the overlay and the viewport. */
     inset: max(env(safe-area-inset-top, 0px), var(--vaadin-overlay-viewport-inset, 8px))
       max(env(safe-area-inset-right, 0px), var(--vaadin-overlay-viewport-inset, 8px))
-      max(env(safe-area-inset-bottom, 0px), var(--vaadin-overlay-viewport-bottom))
+      calc(
+        max(env(safe-area-inset-bottom, 0px), var(--vaadin-overlay-viewport-bottom)) +
+          var(--_vaadin-overlay-viewport-occlusion, 0px)
+      )
       max(env(safe-area-inset-left, 0px), var(--vaadin-overlay-viewport-inset, 8px));
 
     /* Override native [popover] user agent styles */

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -16,13 +16,16 @@ const overlayBase = css`
           for position/sizing/alignment. The actual overlay is the overlay part. */
 
     /* Default position constraints. Themes can override this to adjust the gap between
-          the overlay and the viewport, but must keep the occlusion term on the bottom
-          side, or the overlay extends into the area hidden by the on-screen keyboard. */
-    inset: max(env(safe-area-inset-top, 0px), var(--vaadin-overlay-viewport-inset, 8px))
+          the overlay and the viewport, but must keep the occlusion terms on the vertical
+          sides, or the overlay extends into the area hidden by the on-screen keyboard. */
+    inset: calc(
+        max(env(safe-area-inset-top, 0px), var(--vaadin-overlay-viewport-inset, 8px)) +
+          var(--_vaadin-overlay-viewport-occlusion-top, 0px)
+      )
       max(env(safe-area-inset-right, 0px), var(--vaadin-overlay-viewport-inset, 8px))
       calc(
         max(env(safe-area-inset-bottom, 0px), var(--vaadin-overlay-viewport-bottom)) +
-          var(--_vaadin-overlay-viewport-occlusion, 0px)
+          var(--_vaadin-overlay-viewport-occlusion-bottom, 0px)
       )
       max(env(safe-area-inset-left, 0px), var(--vaadin-overlay-viewport-inset, 8px));
 

--- a/packages/overlay/src/styles/vaadin-overlay-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-base-styles.js
@@ -15,8 +15,9 @@ const overlayBase = css`
     /* Despite of what the names say, <vaadin-overlay> is just a container
           for position/sizing/alignment. The actual overlay is the overlay part. */
 
-    /* Default position constraints. Themes can
-          override this to adjust the gap between the overlay and the viewport. */
+    /* Default position constraints. Themes can override this to adjust the gap between
+          the overlay and the viewport, but must keep the occlusion term on the bottom
+          side, or the overlay extends into the area hidden by the on-screen keyboard. */
     inset: max(env(safe-area-inset-top, 0px), var(--vaadin-overlay-viewport-inset, 8px))
       max(env(safe-area-inset-right, 0px), var(--vaadin-overlay-viewport-inset, 8px))
       calc(

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -234,8 +234,14 @@ export const OverlayMixin = (superClass) =>
 
     /** @private */
     _detectIosNavbar() {
-      /* c8 ignore next 15 */
+      /* c8 ignore next 21 */
       if (!this.opened) {
+        return;
+      }
+
+      // Overlays that keep out of the area hidden by the visual viewport already reserve
+      // the space taken by the navbar, so reserving it here as well would double it.
+      if (this.limitToVisualViewport) {
         return;
       }
 

--- a/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.d.ts
@@ -64,4 +64,13 @@ export declare class PositionMixinClass {
    * @attr {number} required-vertical-space
    */
   requiredVerticalSpace: number;
+
+  /**
+   * When true, the overlay content is limited to the part of the viewport that is
+   * visible to the user, so that it shrinks instead of extending into an area that
+   * is covered by the on-screen keyboard.
+   *
+   * @attr {boolean} limit-to-visual-viewport
+   */
+  limitToVisualViewport: boolean;
 }

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -86,6 +86,17 @@ function getViewportOcclusion() {
   };
 }
 
+/**
+ * Returns the space that is available for the overlay on both sides of the target,
+ * in one dimension.
+ */
+function getSpaceForAlignments({ targetRect, viewportSize, margins, noOverlap, propNames }) {
+  return {
+    start: viewportSize - targetRect[noOverlap ? propNames.end : propNames.start] - margins[propNames.end],
+    end: targetRect[noOverlap ? propNames.start : propNames.end] - margins[propNames.start],
+  };
+}
+
 const targetResizeObserver = new ResizeObserver((entries) => {
   setTimeout(() => {
     entries.forEach((entry) => {
@@ -256,6 +267,8 @@ export const PositionMixin = (superClass) =>
         'limitToVisualViewport',
       ];
       if (positionProps.some((prop) => props.has(prop))) {
+        // The properties that changed are inputs of the alignment, so it is decided again
+        this.__resetVerticalAlignment();
         this._updatePosition();
       }
     }
@@ -319,6 +332,10 @@ export const PositionMixin = (superClass) =>
           });
         }
 
+        // Decide the side to open to from scratch, instead of keeping the one
+        // that the overlay used the last time it was open.
+        this.__resetVerticalAlignment();
+
         this._updatePosition();
         // Schedule another position update (to cover virtual keyboard opening for example)
         requestAnimationFrame(() => this._updatePosition());
@@ -350,6 +367,8 @@ export const PositionMixin = (superClass) =>
 
       this.style.removeProperty('--_vaadin-overlay-viewport-occlusion-top');
       this.style.removeProperty('--_vaadin-overlay-viewport-occlusion-bottom');
+
+      this.__resetVerticalAlignment();
 
       setOverlayStateAttribute(this, 'bottom-aligned', false);
       setOverlayStateAttribute(this, 'top-aligned', false);
@@ -451,6 +470,17 @@ export const PositionMixin = (superClass) =>
       );
     }
 
+    /**
+     * Forgets the side that the overlay is aligned to, so that the next position update
+     * decides it from scratch instead of keeping the current one.
+     * @private
+     */
+    __resetVerticalAlignment() {
+      this.__alignedStartVertically = undefined;
+      this.__alignedSpaceVertically = undefined;
+      this.__alignedContentHeight = undefined;
+    }
+
     __shouldAlignStartVertically(targetRect) {
       // Using previous size to fix a case where window resize may cause the overlay to be squeezed
       // smaller than its current space before the fit-calculations.
@@ -459,9 +489,29 @@ export const PositionMixin = (superClass) =>
       this.__oldContentHeight = this.$.overlay.offsetHeight;
 
       const viewportHeight = getVisibleViewportHeight();
+      const space = getSpaceForAlignments({
+        targetRect,
+        viewportSize: viewportHeight,
+        margins: this.__margins,
+        noOverlap: this.noVerticalOverlap,
+        propNames: PROP_NAMES_VERTICAL,
+      });
+
+      // Keep the side that the overlay is on as long as it did not get less space, and
+      // the content did not get taller, than when that side was chosen. Only the space
+      // on the other side depends on the height of the visible area, so closing the
+      // on-screen keyboard would otherwise move the overlay to that side, which happens
+      // while the user scrolls the overlay.
+      if (this.__alignedStartVertically !== undefined) {
+        const currentSpace = this.__alignedStartVertically ? space.start : space.end;
+        if (currentSpace >= this.__alignedSpaceVertically - 1 && contentHeight <= this.__alignedContentHeight + 1) {
+          return this.__alignedStartVertically;
+        }
+      }
+
       const defaultAlignTop = this.verticalAlign === 'top';
 
-      return this.__shouldAlignStart(
+      const alignStart = this.__shouldAlignStart(
         targetRect,
         contentHeight,
         viewportHeight,
@@ -470,13 +520,23 @@ export const PositionMixin = (superClass) =>
         this.noVerticalOverlap,
         PROP_NAMES_VERTICAL,
       );
+
+      this.__alignedStartVertically = alignStart;
+      this.__alignedSpaceVertically = alignStart ? space.start : space.end;
+      this.__alignedContentHeight = contentHeight;
+
+      return alignStart;
     }
 
     // eslint-disable-next-line @typescript-eslint/max-params
     __shouldAlignStart(targetRect, contentSize, viewportSize, margins, defaultAlignStart, noOverlap, propNames) {
-      const spaceForStartAlignment =
-        viewportSize - targetRect[noOverlap ? propNames.end : propNames.start] - margins[propNames.end];
-      const spaceForEndAlignment = targetRect[noOverlap ? propNames.start : propNames.end] - margins[propNames.start];
+      const { start: spaceForStartAlignment, end: spaceForEndAlignment } = getSpaceForAlignments({
+        targetRect,
+        viewportSize,
+        margins,
+        noOverlap,
+        propNames,
+      });
 
       const spaceForDefaultAlignment = defaultAlignStart ? spaceForStartAlignment : spaceForEndAlignment;
       const spaceForOtherAlignment = defaultAlignStart ? spaceForEndAlignment : spaceForStartAlignment;

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -33,6 +33,15 @@ function getLayoutViewportHeight() {
 }
 
 /**
+ * Returns whether the page is pinch-zoomed. The browser shrinks the visual viewport when
+ * zooming in as well, but the area outside of it is only panned away instead of being
+ * hidden, so the overlay should keep using the layout viewport in that case.
+ */
+function isPinchZoomed() {
+  return window.visualViewport.scale > 1;
+}
+
+/**
  * Returns the height of the area that is visible to the user, in the same coordinate
  * space as the values returned by `getBoundingClientRect()`.
  *
@@ -45,6 +54,10 @@ function getLayoutViewportHeight() {
  * account for the shift, so adding it would cancel out the shrinking again.
  */
 function getVisibleViewportHeight() {
+  if (isPinchZoomed()) {
+    return getLayoutViewportHeight();
+  }
+
   return Math.min(getLayoutViewportHeight(), window.visualViewport.height);
 }
 
@@ -60,6 +73,10 @@ function getVisibleViewportHeight() {
  * covered by the keyboard.
  */
 function getViewportOcclusion() {
+  if (isPinchZoomed()) {
+    return { top: 0, bottom: 0 };
+  }
+
   const { height, offsetTop } = window.visualViewport;
   return {
     top: Math.max(0, offsetTop),

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -16,6 +16,38 @@ const PROP_NAMES_HORIZONTAL = {
   end: 'right',
 };
 
+/**
+ * Returns the width of the layout viewport, which is the containing block used
+ * for resolving the `left` and `right` CSS properties of the fixed positioned overlay.
+ */
+function getLayoutViewportWidth() {
+  return Math.min(window.innerWidth, document.documentElement.clientWidth);
+}
+
+/**
+ * Returns the height of the layout viewport, which is the containing block used
+ * for resolving the `top` and `bottom` CSS properties of the fixed positioned overlay.
+ */
+function getLayoutViewportHeight() {
+  return Math.min(window.innerHeight, document.documentElement.clientHeight);
+}
+
+/**
+ * Returns the height of the area that is visible to the user, in the same coordinate
+ * space as the values returned by `getBoundingClientRect()`.
+ *
+ * On iOS Safari, the on-screen keyboard shifts the page up and shrinks the visual
+ * viewport, while the layout viewport keeps its full height. Both `window.innerHeight`
+ * and `document.documentElement.clientHeight` then describe an area that reaches below
+ * the keyboard, so measuring against them treats the space behind the keyboard as free.
+ *
+ * The visual viewport offset is deliberately not added: client rectangles already
+ * account for the shift, so adding it would cancel out the shrinking again.
+ */
+function getVisibleViewportHeight() {
+  return Math.min(getLayoutViewportHeight(), window.visualViewport.height);
+}
+
 const targetResizeObserver = new ResizeObserver((entries) => {
   setTimeout(() => {
     entries.forEach((entry) => {
@@ -330,7 +362,7 @@ export const PositionMixin = (superClass) =>
       const contentWidth = Math.max(this.__oldContentWidth || 0, this.$.overlay.offsetWidth);
       this.__oldContentWidth = this.$.overlay.offsetWidth;
 
-      const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
+      const viewportWidth = getLayoutViewportWidth();
       const defaultAlignLeft = (!rtl && this.horizontalAlign === 'start') || (rtl && this.horizontalAlign === 'end');
 
       return this.__shouldAlignStart(
@@ -351,7 +383,7 @@ export const PositionMixin = (superClass) =>
         this.requiredVerticalSpace || Math.max(this.__oldContentHeight || 0, this.$.overlay.offsetHeight);
       this.__oldContentHeight = this.$.overlay.offsetHeight;
 
-      const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
+      const viewportHeight = getVisibleViewportHeight();
       const defaultAlignTop = this.verticalAlign === 'top';
 
       return this.__shouldAlignStart(
@@ -390,9 +422,11 @@ export const PositionMixin = (superClass) =>
       let adjustedProp;
 
       if (cssPropNameToSet === propNames.end) {
-        // Adjust horizontally
+        // Adjust vertically
         if (propNames.end === PROP_NAMES_VERTICAL.end) {
-          const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
+          // The `bottom` property is resolved against the layout viewport, so the
+          // adjustment must only compensate for changes of the layout viewport.
+          const viewportHeight = getLayoutViewportHeight();
 
           if (currentValue > viewportHeight && this.__oldViewportHeight) {
             const heightDiff = this.__oldViewportHeight - viewportHeight;
@@ -402,9 +436,9 @@ export const PositionMixin = (superClass) =>
           this.__oldViewportHeight = viewportHeight;
         }
 
-        // Adjust vertically
+        // Adjust horizontally
         if (propNames.end === PROP_NAMES_HORIZONTAL.end) {
-          const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
+          const viewportWidth = getLayoutViewportWidth();
 
           if (currentValue > viewportWidth && this.__oldViewportWidth) {
             const widthDiff = this.__oldViewportWidth - viewportWidth;

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -48,6 +48,20 @@ function getVisibleViewportHeight() {
   return Math.min(getLayoutViewportHeight(), window.visualViewport.height);
 }
 
+/**
+ * Returns the height of the area that is not visible to the user at the bottom of the
+ * layout viewport, e.g. covered by the on-screen keyboard, measured in the coordinate
+ * space of the layout viewport.
+ *
+ * Unlike `getVisibleViewportHeight`, this includes the visual viewport offset: iOS Safari
+ * shifts the page to reveal the focused field, but leaves the layout viewport in place,
+ * so the offset is the distance between the two coordinate spaces.
+ */
+function getViewportOcclusionHeight() {
+  const { height, offsetTop } = window.visualViewport;
+  return Math.max(0, document.documentElement.clientHeight - (height + offsetTop));
+}
+
 const targetResizeObserver = new ResizeObserver((entries) => {
   setTimeout(() => {
     entries.forEach((entry) => {
@@ -142,6 +156,19 @@ export const PositionMixin = (superClass) =>
           value: 0,
           sync: true,
         },
+
+        /**
+         * When true, the overlay content is limited to the part of the viewport that is
+         * visible to the user, so that it shrinks instead of extending into an area that
+         * is covered by the on-screen keyboard.
+         *
+         * @attr {boolean} limit-to-visual-viewport
+         */
+        limitToVisualViewport: {
+          type: Boolean,
+          value: false,
+          sync: true,
+        },
       };
     }
 
@@ -202,6 +229,7 @@ export const PositionMixin = (superClass) =>
         'noHorizontalOverlap',
         'noVerticalOverlap',
         'requiredVerticalSpace',
+        'limitToVisualViewport',
       ];
       if (positionProps.some((prop) => props.has(prop))) {
         this._updatePosition();
@@ -296,10 +324,25 @@ export const PositionMixin = (superClass) =>
         right: '',
       });
 
+      this.style.removeProperty('--_vaadin-overlay-viewport-occlusion');
+
       setOverlayStateAttribute(this, 'bottom-aligned', false);
       setOverlayStateAttribute(this, 'top-aligned', false);
       setOverlayStateAttribute(this, 'end-aligned', false);
       setOverlayStateAttribute(this, 'start-aligned', false);
+    }
+
+    /**
+     * Reduces the space available to the overlay by the height of the area that is not
+     * visible to the user, so that the content shrinks instead of extending into it.
+     * @private
+     */
+    __updateViewportOcclusion() {
+      if (this.limitToVisualViewport) {
+        this.style.setProperty('--_vaadin-overlay-viewport-occlusion', `${getViewportOcclusionHeight()}px`);
+      } else {
+        this.style.removeProperty('--_vaadin-overlay-viewport-occlusion');
+      }
     }
 
     _updatePosition() {
@@ -313,6 +356,10 @@ export const PositionMixin = (superClass) =>
         this.opened = false;
         return;
       }
+
+      // Apply the constraint before measuring, so that the content is measured
+      // with the height it will actually get.
+      this.__updateViewportOcclusion();
 
       // Detect the desired alignment and update the layout accordingly
       const shouldAlignStartVertically = this.__shouldAlignStartVertically(targetRect);

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -77,6 +77,8 @@ function getViewportOcclusion() {
     return { top: 0, bottom: 0 };
   }
 
+  // Measured against `clientHeight` rather than `getLayoutViewportHeight()`: iOS Safari
+  // reduces `innerHeight` to the visible area, which would cancel out the occlusion.
   const { height, offsetTop } = window.visualViewport;
   return {
     top: Math.max(0, offsetTop),

--- a/packages/overlay/src/vaadin-overlay-position-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-position-mixin.js
@@ -49,17 +49,22 @@ function getVisibleViewportHeight() {
 }
 
 /**
- * Returns the height of the area that is not visible to the user at the bottom of the
- * layout viewport, e.g. covered by the on-screen keyboard, measured in the coordinate
+ * Returns the heights of the areas that are not visible to the user above and below the
+ * visual viewport, e.g. covered by the on-screen keyboard, measured in the coordinate
  * space of the layout viewport.
  *
- * Unlike `getVisibleViewportHeight`, this includes the visual viewport offset: iOS Safari
- * shifts the page to reveal the focused field, but leaves the layout viewport in place,
- * so the offset is the distance between the two coordinate spaces.
+ * Unlike `getVisibleViewportHeight`, these take the visual viewport offset into account:
+ * iOS Safari shifts the page to reveal the focused field, but leaves the layout viewport
+ * in place, so the offset is the distance between the two coordinate spaces. The area
+ * above the offset is scrolled out of view, and the one below the visual viewport is
+ * covered by the keyboard.
  */
-function getViewportOcclusionHeight() {
+function getViewportOcclusion() {
   const { height, offsetTop } = window.visualViewport;
-  return Math.max(0, document.documentElement.clientHeight - (height + offsetTop));
+  return {
+    top: Math.max(0, offsetTop),
+    bottom: Math.max(0, document.documentElement.clientHeight - (height + offsetTop)),
+  };
 }
 
 const targetResizeObserver = new ResizeObserver((entries) => {
@@ -324,7 +329,8 @@ export const PositionMixin = (superClass) =>
         right: '',
       });
 
-      this.style.removeProperty('--_vaadin-overlay-viewport-occlusion');
+      this.style.removeProperty('--_vaadin-overlay-viewport-occlusion-top');
+      this.style.removeProperty('--_vaadin-overlay-viewport-occlusion-bottom');
 
       setOverlayStateAttribute(this, 'bottom-aligned', false);
       setOverlayStateAttribute(this, 'top-aligned', false);
@@ -339,9 +345,12 @@ export const PositionMixin = (superClass) =>
      */
     __updateViewportOcclusion() {
       if (this.limitToVisualViewport) {
-        this.style.setProperty('--_vaadin-overlay-viewport-occlusion', `${getViewportOcclusionHeight()}px`);
+        const { top, bottom } = getViewportOcclusion();
+        this.style.setProperty('--_vaadin-overlay-viewport-occlusion-top', `${top}px`);
+        this.style.setProperty('--_vaadin-overlay-viewport-occlusion-bottom', `${bottom}px`);
       } else {
-        this.style.removeProperty('--_vaadin-overlay-viewport-occlusion');
+        this.style.removeProperty('--_vaadin-overlay-viewport-occlusion-top');
+        this.style.removeProperty('--_vaadin-overlay-viewport-occlusion-bottom');
       }
     }
 

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -482,9 +482,9 @@ describe('position mixin', () => {
         expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);
       });
 
-      it('should not constrain the overlay when the visual viewport is only shifted', () => {
+      it('should not constrain the bottom when the visual viewport is only shifted', () => {
         // The bottom of the layout viewport is visible, only the top is out of view,
-        // so there is nothing to constrain even though the visual viewport is smaller.
+        // so there is nothing to constrain at the bottom side.
         Object.defineProperty(window.visualViewport, 'offsetTop', {
           configurable: true,
           get: () => KEYBOARD_HEIGHT,
@@ -502,6 +502,32 @@ describe('position mixin', () => {
         visibleHeight = document.documentElement.clientHeight;
         updatePosition();
         expect(overlayContent.getBoundingClientRect().bottom).to.be.closeTo(visibleHeight - margin, 1);
+      });
+
+      describe('flipped to the other side', () => {
+        beforeEach(() => {
+          // The page is shifted up, so that the top of the layout viewport is out of view
+          Object.defineProperty(window.visualViewport, 'offsetTop', {
+            configurable: true,
+            get: () => KEYBOARD_HEIGHT,
+          });
+
+          // Move the target down, so that the overlay flips and grows upwards
+          target.style.top = `${visibleHeight - 30}px`;
+        });
+
+        it('should not extend the overlay above the visible viewport', () => {
+          overlay.limitToVisualViewport = true;
+          updatePosition();
+          expect(overlay.hasAttribute('bottom-aligned')).to.be.true;
+          expect(overlayContent.getBoundingClientRect().top).to.be.at.least(KEYBOARD_HEIGHT + margin - 1);
+        });
+
+        it('should extend the overlay above the visible viewport when not constrained', () => {
+          updatePosition();
+          expect(overlay.hasAttribute('bottom-aligned')).to.be.true;
+          expect(overlayContent.getBoundingClientRect().top).to.be.below(KEYBOARD_HEIGHT + margin - 1);
+        });
       });
     });
 

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -464,6 +464,47 @@ describe('position mixin', () => {
       expectEdgesAligned(TOP, TOP);
     });
 
+    describe('limit to visual viewport', () => {
+      beforeEach(() => {
+        // Content taller than the whole viewport, so that it has to shrink
+        overlay.querySelector('#overlay-child').style.height = `${document.documentElement.clientHeight}px`;
+        target.style.top = '0px';
+      });
+
+      it('should not extend the overlay below the visible viewport', () => {
+        overlay.limitToVisualViewport = true;
+        updatePosition();
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.at.most(visibleHeight - margin + 1);
+      });
+
+      it('should extend the overlay below the visible viewport when not constrained', () => {
+        updatePosition();
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);
+      });
+
+      it('should not constrain the overlay when the visual viewport is only shifted', () => {
+        // The bottom of the layout viewport is visible, only the top is out of view,
+        // so there is nothing to constrain even though the visual viewport is smaller.
+        Object.defineProperty(window.visualViewport, 'offsetTop', {
+          configurable: true,
+          get: () => KEYBOARD_HEIGHT,
+        });
+
+        overlay.limitToVisualViewport = true;
+        updatePosition();
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);
+      });
+
+      it('should release the constraint when the visual viewport grows again', () => {
+        overlay.limitToVisualViewport = true;
+        updatePosition();
+
+        visibleHeight = document.documentElement.clientHeight;
+        updatePosition();
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.closeTo(visibleHeight - margin, 1);
+      });
+    });
+
     it('should not add the visual viewport offset to the available space', () => {
       // The on-screen keyboard also shifts the page up, which is already reflected
       // by the client rectangles, so the offset must not be added to the height.

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -414,6 +414,70 @@ describe('position mixin', () => {
     });
   });
 
+  describe('visual viewport', () => {
+    // Mimics the iOS on-screen keyboard: the layout viewport keeps reporting the full
+    // window height, while the visual viewport shrinks to the area above the keyboard.
+    const KEYBOARD_HEIGHT = 200;
+    let visibleHeight;
+
+    beforeEach(() => {
+      visibleHeight = document.documentElement.clientHeight - KEYBOARD_HEIGHT;
+      Object.defineProperty(window.visualViewport, 'height', {
+        configurable: true,
+        get: () => visibleHeight,
+      });
+
+      margin = parseInt(getComputedStyle(overlay).bottom, 10);
+      targetPositionToFlipOverlay = visibleHeight - overlayContent.offsetHeight - margin;
+    });
+
+    afterEach(() => {
+      delete window.visualViewport.height;
+      delete window.visualViewport.offsetTop;
+    });
+
+    it('should flip to align bottom when out of space in the visual viewport', () => {
+      target.style.top = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+
+    it('should flip to align bottom when out of required vertical space', () => {
+      overlay.requiredVerticalSpace = 200;
+      target.style.top = `${targetPositionToFlipOverlay - 100}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+
+    it('should flip back to default when the visual viewport grows again', () => {
+      target.style.top = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+
+      visibleHeight = document.documentElement.clientHeight;
+      updatePosition();
+      expectEdgesAligned(TOP, TOP);
+    });
+
+    it('should not flip when there is enough space in the visual viewport', () => {
+      target.style.top = `${targetPositionToFlipOverlay - 3}px`;
+      updatePosition();
+      expectEdgesAligned(TOP, TOP);
+    });
+
+    it('should not add the visual viewport offset to the available space', () => {
+      // The on-screen keyboard also shifts the page up, which is already reflected
+      // by the client rectangles, so the offset must not be added to the height.
+      Object.defineProperty(window.visualViewport, 'offsetTop', {
+        configurable: true,
+        get: () => KEYBOARD_HEIGHT,
+      });
+
+      target.style.top = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+  });
+
   describe('horizontal align start', () => {
     beforeEach(() => {
       overlay.horizontalAlign = START;

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -462,6 +462,7 @@ describe('position mixin', () => {
     it('should flip back to default when the visual viewport grows again', () => {
       target.style.top = `${targetPositionToFlipOverlay + 3}px`;
       updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
 
       visibleHeight = document.documentElement.clientHeight;
       updatePosition();
@@ -533,6 +534,7 @@ describe('position mixin', () => {
       it('should release the constraint when the visual viewport grows again', () => {
         overlay.limitToVisualViewport = true;
         updatePosition();
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.at.most(visibleHeight - margin + 1);
 
         visibleHeight = document.documentElement.clientHeight;
         updatePosition();

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -434,7 +434,17 @@ describe('position mixin', () => {
     afterEach(() => {
       delete window.visualViewport.height;
       delete window.visualViewport.offsetTop;
+      delete window.visualViewport.scale;
     });
+
+    // The browser also shrinks the visual viewport when the page is pinch-zoomed,
+    // which only pans the rest of the page away instead of hiding it.
+    function pinchZoom() {
+      Object.defineProperty(window.visualViewport, 'scale', {
+        configurable: true,
+        get: () => 2,
+      });
+    }
 
     it('should flip to align bottom when out of space in the visual viewport', () => {
       target.style.top = `${targetPositionToFlipOverlay + 3}px`;
@@ -460,6 +470,13 @@ describe('position mixin', () => {
 
     it('should not flip when there is enough space in the visual viewport', () => {
       target.style.top = `${targetPositionToFlipOverlay - 3}px`;
+      updatePosition();
+      expectEdgesAligned(TOP, TOP);
+    });
+
+    it('should not flip based on the visual viewport when pinch-zoomed', () => {
+      pinchZoom();
+      target.style.top = `${targetPositionToFlipOverlay + 3}px`;
       updatePosition();
       expectEdgesAligned(TOP, TOP);
     });
@@ -490,6 +507,13 @@ describe('position mixin', () => {
           get: () => KEYBOARD_HEIGHT,
         });
 
+        overlay.limitToVisualViewport = true;
+        updatePosition();
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);
+      });
+
+      it('should not constrain the overlay when pinch-zoomed', () => {
+        pinchZoom();
         overlay.limitToVisualViewport = true;
         updatePosition();
         expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -499,6 +499,17 @@ describe('position mixin', () => {
         expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);
       });
 
+      it('should update position when setting limitToVisualViewport', () => {
+        overlay.limitToVisualViewport = true;
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.at.most(visibleHeight - margin + 1);
+      });
+
+      it('should release the constraint when unsetting limitToVisualViewport', () => {
+        overlay.limitToVisualViewport = true;
+        overlay.limitToVisualViewport = false;
+        expect(overlayContent.getBoundingClientRect().bottom).to.be.above(visibleHeight - margin + 1);
+      });
+
       it('should not constrain the bottom when the visual viewport is only shifted', () => {
         // The bottom of the layout viewport is visible, only the top is out of view,
         // so there is nothing to constrain at the bottom side.

--- a/packages/overlay/test/position-mixin.test.js
+++ b/packages/overlay/test/position-mixin.test.js
@@ -459,12 +459,40 @@ describe('position mixin', () => {
       expectEdgesAligned(BOTTOM, BOTTOM);
     });
 
-    it('should flip back to default when the visual viewport grows again', () => {
+    it('should keep the alignment when the visual viewport grows again', () => {
       target.style.top = `${targetPositionToFlipOverlay + 3}px`;
       updatePosition();
       expectEdgesAligned(BOTTOM, BOTTOM);
 
       visibleHeight = document.documentElement.clientHeight;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+
+    it('should keep the alignment on further updates after the visual viewport grows', () => {
+      target.style.top = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+
+      visibleHeight = document.documentElement.clientHeight;
+      updatePosition();
+
+      // Scrolling the overlay causes further updates, which must not change the side
+      updatePosition();
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+    });
+
+    it('should flip back to default when the target moves after the viewport grows', () => {
+      target.style.top = `${targetPositionToFlipOverlay + 3}px`;
+      updatePosition();
+      expectEdgesAligned(BOTTOM, BOTTOM);
+
+      visibleHeight = document.documentElement.clientHeight;
+      updatePosition();
+
+      // Moving the target is not a change of the visible area, so the side is decided again
+      target.style.top = `${targetPositionToFlipOverlay}px`;
       updatePosition();
       expectEdgesAligned(TOP, TOP);
     });

--- a/packages/overlay/test/typings/overlay.types.ts
+++ b/packages/overlay/test/typings/overlay.types.ts
@@ -65,3 +65,4 @@ assertType<'end' | 'start'>(customOverlay.horizontalAlign);
 assertType<'bottom' | 'top'>(customOverlay.verticalAlign);
 assertType<HTMLElement>(customOverlay.positionTarget);
 assertType<number>(customOverlay.requiredVerticalSpace);
+assertType<boolean>(customOverlay.limitToVisualViewport);

--- a/packages/vaadin-lumo-styles/src/mixins/overlay.css
+++ b/packages/vaadin-lumo-styles/src/mixins/overlay.css
@@ -40,10 +40,12 @@
 
     --_vaadin-overlay-inset: var(--vaadin-overlay-viewport-inset, var(--lumo-space-m));
 
-    /* The bottom side also keeps out of the area that is not visible to the user,
+    /* The vertical sides also keep out of the areas that are not visible to the user,
        e.g. the one covered by the on-screen keyboard. */
-    inset: var(--_vaadin-overlay-inset) var(--_vaadin-overlay-inset)
-      calc(var(--_vaadin-overlay-inset) + var(--_vaadin-overlay-viewport-occlusion, 0px)) var(--_vaadin-overlay-inset);
+    inset: calc(var(--_vaadin-overlay-inset) + var(--_vaadin-overlay-viewport-occlusion-top, 0px))
+      var(--_vaadin-overlay-inset)
+      calc(var(--_vaadin-overlay-inset) + var(--_vaadin-overlay-viewport-occlusion-bottom, 0px))
+      var(--_vaadin-overlay-inset);
     /* Workaround for Edge issue (only on Surface), where an overflowing vaadin-list-box inside vaadin-select-overlay makes the overlay transparent */
     /* stylelint-disable-next-line */
     outline: 0px solid transparent;

--- a/packages/vaadin-lumo-styles/src/mixins/overlay.css
+++ b/packages/vaadin-lumo-styles/src/mixins/overlay.css
@@ -38,7 +38,12 @@
     /* CSS API for host */
     --vaadin-overlay-viewport-bottom: 0px;
 
-    inset: var(--vaadin-overlay-viewport-inset, var(--lumo-space-m));
+    --_vaadin-overlay-inset: var(--vaadin-overlay-viewport-inset, var(--lumo-space-m));
+
+    /* The bottom side also keeps out of the area that is not visible to the user,
+       e.g. the one covered by the on-screen keyboard. */
+    inset: var(--_vaadin-overlay-inset) var(--_vaadin-overlay-inset)
+      calc(var(--_vaadin-overlay-inset) + var(--_vaadin-overlay-viewport-occlusion, 0px)) var(--_vaadin-overlay-inset);
     /* Workaround for Edge issue (only on Surface), where an overflowing vaadin-list-box inside vaadin-select-overlay makes the overlay transparent */
     /* stylelint-disable-next-line */
     outline: 0px solid transparent;


### PR DESCRIPTION
## Description

Fixes #12036

On iOS Safari the on-screen keyboard shifts the page up and shrinks the visual viewport, while the layout viewport keeps its full height. Both `window.innerHeight` and `document.documentElement.clientHeight` then describe an area that reaches below the keyboard, so the overlay incorrectly treated the space behind the keyboard as available.

Using `visualViewport` was not enough. Another part of the fix is adding `limitToVisualViewport` logic to combo-box overlay (+ time-picker & MSCB). When it is on, the overlay effectively treats the top edge of the on-screen keyboard as the bottom of the available space - set as `--_vaadin-overlay-viewport-occlusion` custom property. 

## Type of change

- Bugfix

## How to test

Add `margin-top: 200px` to `dev/combo-box.html` and open the page on iOS Safari.

#### Before
https://github.com/user-attachments/assets/d7e19182-5ae9-4f78-b6ce-bed10b41b095

#### After

https://github.com/user-attachments/assets/15990c94-13d6-441b-b89e-4a6c91f8e306

## Note

Tested manually on iOS Simulator 18.3, needs verification on real iOS device before approval.