### PR TITLE
fix: remove has-error-message with custom error element when valid

### DIFF
--- a/packages/component-base/src/slot-child-observe-controller.d.ts
+++ b/packages/component-base/src/slot-child-observe-controller.d.ts
@@ -27,6 +27,12 @@ export class SlotChildObserveController extends SlotController {
   protected updateDefaultNode(node: Node): void;
 
   /**
+   * Returns true if a node is an HTML element with children,
+   * or is a defined custom element, or has non-empty text.
+   */
+  protected _hasContent(node: Node): boolean;
+
+  /**
    * Fire an event to notify the controller host about node changes.
    */
   protected _notifyChange(node: Node): void;

--- a/packages/component-base/src/slot-child-observe-controller.js
+++ b/packages/component-base/src/slot-child-observe-controller.js
@@ -136,8 +136,9 @@ export class SlotChildObserveController extends SlotController {
    *
    * @param {Node} node
    * @return {boolean}
+   * @protected
    */
-  #hasContent(node) {
+  _hasContent(node) {
     if (!node) {
       return false;
     }
@@ -157,7 +158,7 @@ export class SlotChildObserveController extends SlotController {
   _notifyChange(node) {
     this.dispatchEvent(
       new CustomEvent('slot-content-changed', {
-        detail: { hasContent: this.#hasContent(node), node },
+        detail: { hasContent: this._hasContent(node), node },
       }),
     );
   }

--- a/packages/field-base/src/error-controller.js
+++ b/packages/field-base/src/error-controller.js
@@ -102,21 +102,37 @@ export class ErrorController extends SlotChildObserveController {
    * @override
    */
   updateDefaultNode(errorNode) {
-    const { errorMessage, invalid } = this;
-    const hasError = Boolean(invalid && errorMessage && errorMessage.trim() !== '');
+    const hasError = this.#hasError;
 
     if (errorNode) {
-      errorNode.textContent = hasError ? errorMessage : '';
+      errorNode.textContent = hasError ? this.errorMessage : '';
       errorNode.hidden = !hasError;
 
       if (hasError) {
         // Assertive mode ensures VoiceOver reads
         // the error message on commit with Enter.
-        announce(errorMessage, { mode: 'assertive' });
+        announce(this.errorMessage, { mode: 'assertive' });
       }
     }
 
     // Notify the host after update.
     super.updateDefaultNode(errorNode);
+  }
+
+  /**
+   * Override method inherited from `SlotChildObserveController`
+   * to report content based on whether the error is shown, since
+   * the controller clears and hides the error element when the
+   * field is valid, regardless of the node type.
+   *
+   * @override
+   */
+  _hasContent(_node) {
+    return this.#hasError;
+  }
+
+  get #hasError() {
+    const { errorMessage, invalid } = this;
+    return Boolean(invalid && errorMessage && errorMessage.trim() !== '');
   }
 }

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -67,6 +67,8 @@ describe('FieldMixin', () => {
       },
   );
 
+  customElements.define('custom-error-message', class extends HTMLElement {});
+
   let element, label, error, helper, input;
 
   describe('error message', () => {
@@ -246,6 +248,32 @@ describe('FieldMixin', () => {
         element.errorMessage = 'This field is required';
         await nextUpdate(element);
         expect(error.textContent).to.equal('This field is required');
+      });
+    });
+
+    describe('slotted custom element', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`
+          <${tag}>
+            <custom-error-message slot="error-message">Required field</custom-error-message>
+          </${tag}>
+        `);
+        await nextRender();
+        error = element.querySelector('[slot=error-message]');
+      });
+
+      it('should not set has-error-message attribute when the field is valid', () => {
+        expect(element.hasAttribute('has-error-message')).to.be.false;
+      });
+
+      it('should toggle has-error-message attribute on invalid property change', async () => {
+        element.invalid = true;
+        await nextUpdate(element);
+        expect(element.hasAttribute('has-error-message')).to.be.true;
+
+        element.invalid = false;
+        await nextUpdate(element);
+        expect(element.hasAttribute('has-error-message')).to.be.false;
       });
     });
   });
@@ -745,6 +773,32 @@ describe('FieldMixin', () => {
           expect(aria).to.include(error.id);
           expect(aria).to.not.include(label.id);
         });
+      });
+    });
+
+    describe('custom element error message', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`
+          <${tag}>
+            <custom-error-message slot="error-message">Required field</custom-error-message>
+          </${tag}>
+        `);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+        error = element.querySelector('[slot=error-message]');
+      });
+
+      it('should not contain error id in aria-describedby when the field is valid', async () => {
+        await aTimeout(0);
+        const aria = input.getAttribute('aria-describedby') || '';
+        expect(aria).to.not.include(error.id);
+      });
+
+      it('should add error id to aria-describedby when the field becomes invalid', async () => {
+        element.invalid = true;
+        await nextUpdate(element);
+        await aTimeout(0);
+        expect(input.getAttribute('aria-describedby')).to.include(error.id);
       });
     });
 


### PR DESCRIPTION
`FieldMixin` sets the `has-error-message` attribute from the `slot-content-changed` event, whose `hasContent` reports `true` for any registered custom element regardless of its content. When the field becomes valid, `ErrorController` clears and hides the error element, but with a custom element in the error slot the attribute was never removed.

The custom element check was originally added for helper components that render their content in shadow DOM (#4823), where the element has no light DOM text but still counts as content. That assumption does not fit the error slot, where the controller itself manages the content and visibility of the element.

`ErrorController` now overrides the content check to report whether the error is shown (invalid and non-empty message), which is the same condition it already uses to update the error element. With that, `has-error-message` follows its contract for custom error elements too: set when the error is shown, removed when the field is valid or the message is empty.

Part of https://github.com/vaadin/web-components/issues/11975