### PR TITLE
test: cover upload mixin lines missed by existing tests

### DIFF
--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -48,7 +48,8 @@ describe('adding files', () => {
     // Using dispatchEvent instead of fire in this case because
     // we have to pass the info in the dataTransfer property
     function createDndEvent(type, entries = []) {
-      const e = new Event(type);
+      // Native drag and drop events are cancelable
+      const e = new Event(type, { cancelable: true });
       const items = entries.map((entry) => ({
         webkitGetAsEntry() {
           return entry;
@@ -58,6 +59,45 @@ describe('adding files', () => {
       e.dataTransfer = { items, files };
       return e;
     }
+
+    it('should prevent default on dragover', () => {
+      const event = createDndEvent('dragover');
+      upload.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should prevent default on dragleave', () => {
+      const event = createDndEvent('dragleave');
+      upload.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should prevent default on drop', () => {
+      const event = createDndEvent('drop', [createFileSystemFileEntry(100, 'image/jpeg')]);
+      upload.dispatchEvent(event);
+      expect(event.defaultPrevented).to.be.true;
+    });
+
+    it('should reset dragover state on drop', async () => {
+      upload.dispatchEvent(createDndEvent('dragover'));
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('dragover')).to.be.true;
+
+      upload.dispatchEvent(createDndEvent('drop'));
+      await nextUpdate(upload);
+      expect(upload._dragover).to.be.false;
+      expect(upload.hasAttribute('dragover')).to.be.false;
+    });
+
+    it('should remove dragover-valid attribute on dragleave', async () => {
+      upload.dispatchEvent(createDndEvent('dragover'));
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('dragover-valid')).to.be.true;
+
+      upload.dispatchEvent(createDndEvent('dragleave'));
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('dragover-valid')).to.be.false;
+    });
 
     it('should set dragover attribute on dragover', async () => {
       expect(upload._dragover).not.to.be.ok;
@@ -364,6 +404,12 @@ describe('adding files', () => {
       addFilesViaInput(upload, [file, file]);
     });
 
+    it('should not add files over the maxFiles limit', () => {
+      upload.maxFiles = 1;
+      addFilesViaInput(upload, [file, createFile(testFileSize, 'application/x-octet-stream')]);
+      expect(upload.files.length).to.equal(1);
+    });
+
     it('should reject files with excessive size', (done) => {
       upload.maxFileSize = testFileSize - 1;
       upload.addEventListener('file-reject', (e) => {
@@ -371,6 +417,12 @@ describe('adding files', () => {
         done();
       });
       addFilesViaInput(upload, [file]);
+    });
+
+    it('should not add files with excessive size', () => {
+      upload.maxFileSize = testFileSize - 1;
+      addFilesViaInput(upload, [file]);
+      expect(upload.files.length).to.equal(0);
     });
 
     it('should reject files with incorrect contentType', (done) => {

--- a/packages/upload/test/concurrent-uploads.test.js
+++ b/packages/upload/test/concurrent-uploads.test.js
@@ -167,6 +167,49 @@ describe('concurrent uploads', () => {
       files[0].xhr.abort();
       expect(upload._createXhr).to.be.calledOnce;
     });
+
+    it('should start a queued file when removing another queued file frees capacity', () => {
+      const files = createFiles(3, 100, 'application/json');
+      upload.maxConcurrentUploads = 1;
+
+      upload.uploadFiles(files);
+
+      // Increasing the limit alone does not process the queue
+      upload.maxConcurrentUploads = 3;
+
+      // Removing a queued file processes the queue with the new limit
+      upload.dispatchEvent(new CustomEvent('file-abort', { detail: { file: files[1] } }));
+      expect(files[2].held).to.be.false;
+      expect(files[2].uploading).to.be.true;
+    });
+  });
+
+  describe('upload queue with abort and completion', () => {
+    let clock;
+
+    beforeEach(() => {
+      upload._createXhr = sinon.spy(xhrCreator({ size: 100, uploadTime: 200, stepTime: 50 }));
+      clock = sinon.useFakeTimers({
+        shouldClearNativeTimers: true,
+      });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should not upload a queued file that was aborted before starting', async () => {
+      const files = createFiles(2, 100, 'application/json');
+      upload.maxConcurrentUploads = 1;
+
+      upload.uploadFiles(files);
+      upload.dispatchEvent(new CustomEvent('file-abort', { detail: { file: files[1] } }));
+
+      // Wait for the first upload to complete
+      await clock.tickAsync(500);
+      expect(files[0].complete).to.be.true;
+      expect(upload._createXhr).to.be.calledOnce;
+    });
   });
 
   describe('upload queue with errors', () => {
@@ -352,6 +395,19 @@ describe('concurrent uploads', () => {
       // Try to upload same file again
       upload.uploadFiles(files[0]);
       expect(upload._createXhr).to.be.not.called;
+    });
+
+    it('should not restart or queue a file that is already uploading when below the limit', () => {
+      const files = createFiles(1, 100, 'application/json');
+
+      upload.uploadFiles(files[0]);
+      expect(upload._createXhr).to.be.calledOnce;
+      expect(files[0].held).to.be.false;
+
+      // Try to upload same file again while there is upload capacity left
+      upload.uploadFiles(files[0]);
+      expect(upload._createXhr).to.be.calledOnce;
+      expect(files[0].held).to.be.false;
     });
   });
 });

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -47,14 +47,18 @@ describe('file list', () => {
       expect(getFileListItems(upload).length).to.equal(0);
     });
 
-    it('should propagate disabled to the file list', async () => {
+    it('should propagate disabled to the rendered file items', async () => {
+      upload.noAuto = true;
+      addFilesViaInput(upload, createFiles(1));
+      await nextFrame();
+
       upload.disabled = true;
       await nextFrame();
-      expect(upload._fileList.disabled).to.be.true;
+      expect(getFileListItems(upload)[0].hasAttribute('disabled')).to.be.true;
 
       upload.disabled = false;
       await nextFrame();
-      expect(upload._fileList.disabled).to.be.false;
+      expect(getFileListItems(upload)[0].hasAttribute('disabled')).to.be.false;
     });
 
     it('should not overflow content', async () => {

--- a/packages/upload/test/file-list.test.js
+++ b/packages/upload/test/file-list.test.js
@@ -47,6 +47,16 @@ describe('file list', () => {
       expect(getFileListItems(upload).length).to.equal(0);
     });
 
+    it('should propagate disabled to the file list', async () => {
+      upload.disabled = true;
+      await nextFrame();
+      expect(upload._fileList.disabled).to.be.true;
+
+      upload.disabled = false;
+      await nextFrame();
+      expect(upload._fileList.disabled).to.be.false;
+    });
+
     it('should not overflow content', async () => {
       upload.style.width = '180px';
       upload.files = createFiles(1);

--- a/packages/upload/test/i18n.test.js
+++ b/packages/upload/test/i18n.test.js
@@ -64,6 +64,39 @@ const i18nConfigs = [
   { name: 'partial i18n', i18n: PARTIAL_I18N, expectedI18n: { ...DEFAULT_I18N, ...PARTIAL_I18N } },
 ];
 
+describe('custom formatters', () => {
+  let upload, clock, file;
+
+  beforeEach(async () => {
+    upload = fixtureSync('<vaadin-upload></vaadin-upload>');
+    upload.target = 'https://foo.com/bar';
+    await nextRender();
+    file = createFile(100000, 'application/octet-stream');
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('should use custom formatSize for file size strings', async () => {
+    upload.i18n = { formatSize: (bytes) => `${bytes} B!` };
+    upload._createXhr = xhrCreator({ size: file.size, uploadTime: 200, stepTime: 50 });
+    upload.uploadFiles(file);
+    await clock.tickAsync(110);
+    expect(file.totalStr).to.equal('100000 B!');
+    expect(file.loadedStr).to.equal('50000 B!');
+  });
+
+  it('should use custom formatTime for elapsed time strings', async () => {
+    upload.i18n = { formatTime: (seconds) => `${seconds} seconds` };
+    upload._createXhr = xhrCreator({ size: file.size, connectTime: 1000, uploadTime: 4000, stepTime: 2000 });
+    upload.uploadFiles(file);
+    await clock.tickAsync(3000);
+    expect(file.elapsedStr).to.equal('3 seconds');
+  });
+});
+
 describe('upload i18n', () => {
   i18nConfigs.forEach(({ name, i18n, expectedI18n }) => {
     describe(name, () => {

--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-upload.js';
-import { createFile } from './helpers.js';
+import { createFile, xhrCreator } from './helpers.js';
 
 async function repeatTab(times) {
   for (let i = 0; i < times; i++) {
@@ -121,6 +121,15 @@ describe('keyboard navigation', () => {
       await nextFrame();
 
       expect(document.activeElement.file.name).to.equal('file-0');
+    });
+
+    it('should focus the file when retrying its upload', () => {
+      uploadElement._createXhr = xhrCreator();
+      const file = uploadElement.files[0];
+
+      uploadElement.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+
+      expect(document.activeElement.file).to.equal(file);
     });
 
     it('should not change focus after upload', async () => {

--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
 import '../src/vaadin-upload.js';
 import { createFile, xhrCreator } from './helpers.js';
 
@@ -123,13 +124,27 @@ describe('keyboard navigation', () => {
       expect(document.activeElement.file.name).to.equal('file-0');
     });
 
-    it('should focus the file when retrying its upload', () => {
-      uploadElement._createXhr = xhrCreator();
-      const file = uploadElement.files[0];
+    describe('retry', () => {
+      let clock;
 
-      uploadElement.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+      beforeEach(() => {
+        clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+      });
 
-      expect(document.activeElement.file).to.equal(file);
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it('should focus the file when retrying its upload', async () => {
+        uploadElement._createXhr = xhrCreator();
+        const file = uploadElement.files[0];
+
+        uploadElement.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+        expect(document.activeElement.file).to.equal(file);
+
+        // Run the retried upload to completion so that no timers leak
+        await clock.tickAsync(500);
+      });
     });
 
     it('should not change focus after upload', async () => {

--- a/packages/upload/test/properties.test.js
+++ b/packages/upload/test/properties.test.js
@@ -64,8 +64,8 @@ describe('properties', () => {
     });
 
     it('should not be in dragover state by default', () => {
-      expect(upload._dragover).to.be.false;
-      expect(upload._dragoverValid).to.be.false;
+      expect(upload.hasAttribute('dragover')).to.be.false;
+      expect(upload.hasAttribute('dragover-valid')).to.be.false;
     });
 
     it('should not have max-files-reached attribute by default', () => {

--- a/packages/upload/test/properties.test.js
+++ b/packages/upload/test/properties.test.js
@@ -1,0 +1,178 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-upload.js';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { createFile } from './helpers.js';
+
+describe('properties', () => {
+  let upload;
+
+  describe('defaults', () => {
+    beforeEach(async () => {
+      upload = fixtureSync(`<vaadin-upload></vaadin-upload>`);
+      await nextRender();
+    });
+
+    it('should have disabled set to false by default', () => {
+      expect(upload.disabled).to.be.false;
+    });
+
+    it('should have nodrop set based on touch device support by default', () => {
+      expect(upload.nodrop).to.equal(isTouch);
+    });
+
+    it('should have target set to empty string by default', () => {
+      expect(upload.target).to.equal('');
+    });
+
+    it('should have timeout set to 0 by default', () => {
+      expect(upload.timeout).to.equal(0);
+    });
+
+    it('should have maxFiles set to Infinity by default', () => {
+      expect(upload.maxFiles).to.equal(Infinity);
+    });
+
+    it('should have maxFilesReached set to false by default', () => {
+      expect(upload.maxFilesReached).to.be.false;
+    });
+
+    it('should have maxFilesReached set to false before the element is attached', () => {
+      const element = document.createElement('vaadin-upload');
+      expect(element.maxFilesReached).to.be.false;
+    });
+
+    it('should have accept set to empty string by default', () => {
+      expect(upload.accept).to.equal('');
+    });
+
+    it('should have maxFileSize set to Infinity by default', () => {
+      expect(upload.maxFileSize).to.equal(Infinity);
+    });
+
+    it('should have noAuto set to false by default', () => {
+      expect(upload.noAuto).to.be.false;
+    });
+
+    it('should have withCredentials set to false by default', () => {
+      expect(upload.withCredentials).to.be.false;
+    });
+
+    it('should have uploadFormat set to raw by default', () => {
+      expect(upload.uploadFormat).to.equal('raw');
+    });
+
+    it('should not be in dragover state by default', () => {
+      expect(upload._dragover).to.be.false;
+      expect(upload._dragoverValid).to.be.false;
+    });
+
+    it('should not have max-files-reached attribute by default', () => {
+      expect(upload.hasAttribute('max-files-reached')).to.be.false;
+    });
+  });
+
+  describe('attributes', () => {
+    beforeEach(async () => {
+      upload = fixtureSync(`
+        <vaadin-upload
+          disabled
+          nodrop
+          no-auto
+          with-credentials
+          timeout="500"
+          max-files="5"
+          max-file-size="1000"
+          max-concurrent-uploads="2"
+          headers='{"X-Foo": "Bar"}'
+        ></vaadin-upload>
+      `);
+      await nextRender();
+    });
+
+    it('should set disabled property from attribute', () => {
+      expect(upload.disabled).to.be.true;
+    });
+
+    it('should set nodrop property from attribute', () => {
+      expect(upload.nodrop).to.be.true;
+    });
+
+    it('should set noAuto property from attribute', () => {
+      expect(upload.noAuto).to.be.true;
+    });
+
+    it('should set withCredentials property from attribute', () => {
+      expect(upload.withCredentials).to.be.true;
+    });
+
+    it('should set timeout property from attribute', () => {
+      expect(upload.timeout).to.equal(500);
+    });
+
+    it('should set maxFiles property from attribute', () => {
+      expect(upload.maxFiles).to.equal(5);
+    });
+
+    it('should set maxFileSize property from attribute', () => {
+      expect(upload.maxFileSize).to.equal(1000);
+    });
+
+    it('should set maxConcurrentUploads property from attribute', () => {
+      expect(upload.maxConcurrentUploads).to.equal(2);
+    });
+
+    it('should parse headers property from JSON string attribute', () => {
+      expect(upload.headers).to.deep.equal({ 'X-Foo': 'Bar' });
+    });
+  });
+
+  describe('reflection', () => {
+    beforeEach(async () => {
+      upload = fixtureSync(`<vaadin-upload></vaadin-upload>`);
+      await nextRender();
+    });
+
+    it('should toggle disabled attribute on disabled property change', async () => {
+      upload.disabled = true;
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('disabled')).to.be.true;
+
+      upload.disabled = false;
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('disabled')).to.be.false;
+    });
+
+    it('should toggle nodrop attribute on nodrop property change', async () => {
+      upload.nodrop = true;
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('nodrop')).to.be.true;
+
+      upload.nodrop = false;
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('nodrop')).to.be.false;
+    });
+
+    it('should toggle max-files-reached attribute when files reach maxFiles', async () => {
+      upload.maxFiles = 1;
+      upload.files = [createFile(100, 'image/jpeg')];
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('max-files-reached')).to.be.true;
+
+      upload.files = [];
+      await nextUpdate(upload);
+      expect(upload.hasAttribute('max-files-reached')).to.be.false;
+    });
+
+    it('should notify maxFilesReached property changes', async () => {
+      const spy = sinon.spy();
+      upload.addEventListener('max-files-reached-changed', spy);
+      upload.maxFiles = 1;
+      upload.files = [createFile(100, 'image/jpeg')];
+      await nextUpdate(upload);
+      expect(spy).to.be.calledOnce;
+      expect(spy.firstCall.args[0].detail.value).to.be.true;
+    });
+  });
+});

--- a/packages/upload/test/slots.test.js
+++ b/packages/upload/test/slots.test.js
@@ -89,6 +89,17 @@ describe('slots', () => {
         });
 
         runAddButtonTests('default');
+
+        it('should stop button click event from propagating to the host', () => {
+          const clickSpy = sinon.spy();
+          upload.addEventListener('click', clickSpy);
+
+          // Stub the file input click method so that only the button
+          // click event can possibly propagate to the host
+          sinon.stub(input, 'click');
+          click(addButton);
+          expect(clickSpy).to.not.be.called;
+        });
       });
     });
 
@@ -138,6 +149,12 @@ describe('slots', () => {
 
         runAddButtonTests('custom');
       });
+    });
+  });
+
+  describe('drop label icon', () => {
+    it('should create default drop label icon element', () => {
+      expect(upload.querySelector('vaadin-upload-icon[slot="drop-label-icon"]')).to.be.ok;
     });
   });
 

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -280,6 +280,170 @@ describe('upload', () => {
         });
         upload.uploadFiles(file);
       });
+
+      it('should propagate timeout to the xhr', (done) => {
+        upload.timeout = 5000;
+        upload.addEventListener('upload-request', (e) => {
+          expect(e.detail.xhr.timeout).to.equal(5000);
+          done();
+        });
+        upload.uploadFiles(file);
+      });
+
+      it('should set request headers from the headers object', (done) => {
+        upload.headers = { 'X-Foo': 'Bar' };
+        upload.addEventListener('upload-request', (e) => {
+          expect(e.detail.xhr.getRequestHeader('X-Foo')).to.equal('Bar');
+          done();
+        });
+        upload.uploadFiles(file);
+      });
+
+      it('should parse headers set as a JSON string', (done) => {
+        upload.headers = '{"X-Foo": "Bar"}';
+        upload.addEventListener('upload-request', (e) => {
+          expect(e.detail.xhr.getRequestHeader('X-Foo')).to.equal('Bar');
+          done();
+        });
+        upload.uploadFiles(file);
+      });
+
+      it('should reset headers set as an invalid JSON string', () => {
+        upload.headers = 'invalid json';
+        try {
+          upload.uploadFiles(file);
+        } catch (_) {
+          // Reset headers currently cause a TypeError when configuring the request
+        }
+        expect(upload.headers).to.be.undefined;
+      });
+
+      it('should fire a cancelable upload-request event', () => {
+        const spy = sinon.spy();
+        upload.addEventListener('upload-request', spy);
+        upload.uploadFiles(file);
+        expect(spy).to.be.calledOnce;
+        expect(spy.firstCall.args[0].cancelable).to.be.true;
+      });
+
+      it('should fire a cancelable upload-response event', async () => {
+        const spy = sinon.spy();
+        upload.addEventListener('upload-response', spy);
+        upload.uploadFiles(file);
+        await clock.tickAsync(400);
+        expect(spy).to.be.calledOnce;
+        expect(spy.firstCall.args[0].cancelable).to.be.true;
+      });
+
+      it('should not complete file if a `upload-response` listener prevents default', async () => {
+        upload.addEventListener('upload-response', (e) => e.preventDefault());
+        const successSpy = sinon.spy();
+        upload.addEventListener('upload-success', successSpy);
+
+        upload.uploadFiles(file);
+        await clock.tickAsync(400);
+
+        expect(successSpy).to.not.be.called;
+        expect(file.complete).to.not.be.ok;
+      });
+
+      it('should fire a cancelable upload-retry event with file and xhr in detail', async () => {
+        upload.uploadFiles(file);
+        await clock.tickAsync(50);
+        const xhr = file.xhr;
+
+        const spy = sinon.spy();
+        upload.addEventListener('upload-retry', spy);
+        upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+
+        expect(spy).to.be.calledOnce;
+        const e = spy.firstCall.args[0];
+        expect(e.cancelable).to.be.true;
+        expect(e.detail.file).to.equal(file);
+        expect(e.detail.xhr).to.equal(xhr);
+      });
+
+      it('should fire a cancelable upload-abort event with file and xhr in detail', async () => {
+        upload.uploadFiles(file);
+        await clock.tickAsync(50);
+        const xhr = file.xhr;
+
+        const spy = sinon.spy();
+        upload.addEventListener('upload-abort', spy);
+        upload.dispatchEvent(new CustomEvent('file-abort', { detail: { file } }));
+
+        expect(spy).to.be.calledOnce;
+        const e = spy.firstCall.args[0];
+        expect(e.cancelable).to.be.true;
+        expect(e.detail.file).to.equal(file);
+        expect(e.detail.xhr).to.equal(xhr);
+      });
+
+      it('should abort the xhr when aborting a file', async () => {
+        upload.uploadFiles(file);
+        await clock.tickAsync(50);
+
+        const abortSpy = sinon.spy(file.xhr, 'abort');
+        upload.dispatchEvent(new CustomEvent('file-abort', { detail: { file } }));
+        expect(abortSpy).to.be.calledOnce;
+      });
+
+      it('should not complete or fire upload-success for an aborted file', async () => {
+        const successSpy = sinon.spy();
+        upload.addEventListener('upload-success', successSpy);
+
+        upload.uploadFiles(file);
+        await clock.tickAsync(50);
+        upload.dispatchEvent(new CustomEvent('file-abort', { detail: { file } }));
+        await clock.tickAsync(400);
+
+        expect(successSpy).to.not.be.called;
+        expect(file.complete).to.not.be.ok;
+      });
+
+      it('should reset file status after successful upload', async () => {
+        upload.uploadFiles(file);
+        await clock.tickAsync(400);
+        expect(file.complete).to.be.true;
+        expect(file.status).to.equal('');
+      });
+
+      it('should set loadedStr to totalStr when upload progress reaches 100%', async () => {
+        upload.uploadFiles(file);
+        await clock.tickAsync(210);
+        expect(file.loadedStr).to.equal('100 kB');
+        expect(file.loadedStr).to.equal(file.totalStr);
+      });
+
+      it('should clear error and completion flags when retrying a failed upload', async () => {
+        upload._createXhr = xhrCreator({ size: file.size, serverValidation: () => ({ status: 500 }) });
+        upload.uploadFiles(file);
+        await clock.tickAsync(100);
+        expect(file.error).to.be.ok;
+
+        upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+        expect(file.error).to.be.false;
+        expect(file.complete).to.be.false;
+        expect(file.abort).to.be.false;
+      });
+
+      it('should render the file list when a file is queued', () => {
+        const renderSpy = sinon.spy(upload._fileList, 'requestContentUpdate');
+        upload.addEventListener('upload-request', (e) => e.preventDefault());
+        upload.uploadFiles(file);
+        expect(renderSpy).to.be.called;
+      });
+
+      it('should render the file list when the upload starts', () => {
+        const renderSpy = sinon.spy(upload._fileList, 'requestContentUpdate');
+        let countAtStart;
+        upload.addEventListener('upload-start', () => {
+          countAtStart = renderSpy.callCount;
+        });
+        upload.uploadFiles(file);
+        // One render right after the upload-start event
+        expect(renderSpy.callCount).to.equal(countAtStart + 1);
+      });
     });
 
     describe('Response Status', () => {
@@ -398,6 +562,75 @@ describe('upload', () => {
       await clock.tickAsync(2200);
       expect(file.status).to.be.equal(upload.i18n.uploading.status.stalled);
     });
+
+    it('should not be stalled when progress updates within 2 sec.', async () => {
+      upload._createXhr = xhrCreator({ size: file.size, uploadTime: 6000, stepTime: 1500 });
+      upload.uploadFiles(file);
+      await clock.tickAsync(2500);
+      expect(file.status).to.not.equal(upload.i18n.uploading.status.stalled);
+    });
+
+    it('should not become stalled after upload fails between progress updates', async () => {
+      // Progress updates 3 seconds apart so that no progress event occurs
+      // between the failure and the pending 2 second stalled timeout
+      upload._createXhr = xhrCreator({ size: file.size, uploadTime: 6000, stepTime: 3000 });
+      upload.uploadFiles(file);
+      await clock.tickAsync(100);
+      file.xhr.err();
+      await clock.tickAsync(2400);
+      expect(file.status).to.not.equal(upload.i18n.uploading.status.stalled);
+    });
+
+    it('should clear status and progress state on progress update after upload failed', async () => {
+      upload._createXhr = xhrCreator({ size: file.size, uploadTime: 200, stepTime: 50 });
+      upload.uploadFiles(file);
+      await clock.tickAsync(100);
+      file.xhr.err();
+      // Next progress event arrives after the upload has already failed
+      await clock.tickAsync(50);
+      expect(file.status).to.be.undefined;
+      expect(file.indeterminate).to.be.undefined;
+    });
+  });
+
+  describe('Progress time and size', () => {
+    let clock;
+
+    beforeEach(() => {
+      // Upload progressing 50% every 3000 seconds, first progress event
+      // after 725 seconds, so that elapsed and remaining time reach the
+      // hours unit: at the second progress event 3725 s (01:02:05) have
+      // elapsed and 50% of the file remains
+      upload._createXhr = xhrCreator({
+        size: file.size,
+        connectTime: 725000,
+        uploadTime: 6000000,
+        stepTime: 3000000,
+      });
+
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should show unknown remaining time before the first progress', async () => {
+      upload.uploadFiles(file);
+      await clock.tickAsync(725000);
+      expect(file.status).to.contain('unknown remaining time');
+    });
+
+    it('should update elapsed and remaining time on progress', async () => {
+      upload.uploadFiles(file);
+      await clock.tickAsync(3725000);
+      expect(file.elapsed).to.equal(3725);
+      expect(file.elapsedStr).to.equal('01:02:05');
+      expect(file.remaining).to.equal(3725);
+      expect(file.remainingStr).to.equal('01:02:05');
+      expect(file.loadedStr).to.equal('50 kB');
+      expect(file.status).to.contain('remaining time: ');
+    });
   });
 
   describe('Manual Upload', () => {
@@ -414,6 +647,22 @@ describe('upload', () => {
       expect(file.uploaded).not.to.be.ok;
       expect(file.held).to.be.true;
       expect(file.status).to.be.equal(upload.i18n.uploading.status.held);
+    });
+
+    it('should initialize loaded to zero when a file is added', async () => {
+      addFilesViaInput(upload, [file]);
+      await nextRender();
+      expect(file.loaded).to.equal(0);
+    });
+
+    it('should set held status when using a custom file list', async () => {
+      // The default file list re-computes file.status on its own, so use
+      // a custom file list element to cover the status set by the mixin
+      const customUpload = fixtureSync(`<vaadin-upload><div slot="file-list"></div></vaadin-upload>`);
+      customUpload.noAuto = true;
+      await nextRender();
+      addFilesViaInput(customUpload, [file]);
+      expect(file.status).to.equal('Queued');
     });
 
     it('should start uploading non-completed files after call to uploadFiles', (done) => {
@@ -556,6 +805,25 @@ describe('upload', () => {
       removeFile(upload, 0);
       await clock.tickAsync(1);
       expect(upload.files.length).to.equal(0);
+    });
+
+    it('should fire a bubbling composed file-remove event with file in detail', async () => {
+      upload.noAuto = true;
+      addFilesViaInput(upload, files);
+      await clock.tickAsync(1);
+
+      const spy = sinon.spy();
+      upload.addEventListener('file-remove', spy);
+
+      const removed = upload.files[0];
+      removeFile(upload, 0);
+      await clock.tickAsync(1);
+
+      expect(spy).to.be.calledOnce;
+      const e = spy.firstCall.args[0];
+      expect(e.detail.file).to.equal(removed);
+      expect(e.bubbles).to.be.true;
+      expect(e.composed).to.be.true;
     });
   });
 

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -310,11 +310,8 @@ describe('upload', () => {
 
       it('should reset headers set as an invalid JSON string', () => {
         upload.headers = 'invalid json';
-        try {
-          upload.uploadFiles(file);
-        } catch (_) {
-          // Reset headers currently cause a TypeError when configuring the request
-        }
+        // Configuring the request currently throws after headers are reset
+        expect(() => upload.uploadFiles(file)).to.throw(TypeError);
         expect(upload.headers).to.be.undefined;
       });
 
@@ -436,13 +433,12 @@ describe('upload', () => {
 
       it('should render the file list when the upload starts', () => {
         const renderSpy = sinon.spy(upload._fileList, 'requestContentUpdate');
-        let countAtStart;
         upload.addEventListener('upload-start', () => {
-          countAtStart = renderSpy.callCount;
+          renderSpy.resetHistory();
         });
         upload.uploadFiles(file);
-        // One render right after the upload-start event
-        expect(renderSpy.callCount).to.equal(countAtStart + 1);
+        // Rendered once right after the upload-start event
+        expect(renderSpy).to.be.calledOnce;
       });
     });
 


### PR DESCRIPTION
## Summary
- Line-removal mutation testing on `vaadin-upload-mixin.js` found multiple lines that could be deleted while the upload test suite stayed green
- Add tests so that removing any of those lines now makes the suite fail: property defaults, attribute parsing and reflection, upload event contracts, abort and retry behavior, stalled timer cleanup, drag and drop handling, and upload queue management
- The remaining lines that no reasonable test can cover are default-only config (for example `type: String`) or no-op calls, left for a separate cleanup

Part of #10939

🤖 Generated with [Claude Code](https://claude.com/claude-code)