### PR TITLE
chore: extend code review triggers

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,7 +1,8 @@
 name: Code Review
 
-# Reviews a pull request, triggered automatically when a PR is opened
-# (eligibility rules on the job condition) or by a "/code-review" PR comment.
+# Reviews a pull request, triggered automatically when a PR is opened or marked
+# ready for review (eligibility rules on the job condition), or on request by a
+# "/code-review" PR comment or a review request for vaadin-review-bot.
 # The review itself lives in the shared vaadin/github-actions/code-review
 # action (prepared review inputs, the Claude review, posting the findings as
 # one review); this workflow owns the triggers, eligibility rules, and the
@@ -11,7 +12,7 @@ on:
   issue_comment:
     types: [created]
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review, review_requested]
     branches: [main]
 
 # One review per PR at a time; a re-trigger queues instead of aborting a run
@@ -26,17 +27,22 @@ env:
 jobs:
   check:
     # Eligibility is a cheap `if` pre-filter plus an authoritative org-membership
-    # check in the job. Comment trigger: org members only. Auto trigger on opened
-    # PRs skips drafts, chore PRs, and known bots. The pre-filter allows
-    # CONTRIBUTOR because on pull_request events the author_association of a
-    # private org member is reported as CONTRIBUTOR; the org-membership API call
-    # in the job is what actually confirms access.
+    # check in the job. Requested reviews (comment, review request) only check
+    # who asked. Auto triggers (opened, ready for review) additionally skip
+    # drafts, chore PRs, and known bots. The pre-filter allows CONTRIBUTOR
+    # because on pull_request events the author_association of a private org
+    # member is reported as CONTRIBUTOR; the org-membership API call in the job
+    # is what actually confirms access.
     if: |
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        github.event.comment.body == '/code-review' &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request' &&
+       github.event.action == 'review_requested' &&
+       github.event.requested_reviewer.login == 'vaadin-review-bot') ||
+      (github.event_name == 'pull_request' &&
+       contains(fromJSON('["opened", "ready_for_review"]'), github.event.action) &&
        github.event.pull_request.draft == false &&
        !contains(fromJSON('["dependabot[bot]", "vaadin-bot"]'), github.event.pull_request.user.login) &&
        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) &&
@@ -52,9 +58,9 @@ jobs:
         id: access
         env:
           GH_TOKEN: ${{ secrets.VAADIN_REVIEW_BOT || github.token }}
-          AUTHOR: ${{ github.event.comment.user.login || github.event.pull_request.user.login }}
+          REQUESTER: ${{ github.event.sender.login }}
         run: |
-          if gh api "orgs/${{ github.repository_owner }}/members/$AUTHOR" --silent; then
+          if gh api "orgs/${{ github.repository_owner }}/members/$REQUESTER" --silent; then
             echo "eligible=true" >> "$GITHUB_OUTPUT"
           else
             echo "eligible=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Extends the triggers for the `code-review` workflow to include:
- PR is marked as ready for review
- (Re-)requesting a review from `vaadin-review-bot`
