### PR TITLE
test: cover upload behavior ahead of manager integration

### DIFF
--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -95,11 +95,25 @@ describe('adding files', () => {
       expect(upload.maxFilesReached).to.be.false;
     });
 
-    it('should upload files assigned to the files property', (done) => {
-      upload.maxFileSize = testFileSize - 1;
-      upload.addEventListener('upload-start', () => done());
-      upload.files = [files[0]];
-      upload.uploadFiles();
+    describe('uploading assigned files', () => {
+      let clock;
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it('should upload files assigned to the files property', async () => {
+        upload.maxFileSize = testFileSize - 1;
+        upload.files = [files[0]];
+        upload.uploadFiles();
+
+        await clock.tickAsync(400);
+        expect(files[0].complete).to.be.true;
+      });
     });
   });
 

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -42,6 +42,65 @@ describe('adding files', () => {
       await nextUpdate(upload);
       expect(spy.calledOnce).to.be.true;
     });
+
+    it('should not validate files assigned to the files property', async () => {
+      upload.maxFileSize = testFileSize - 1;
+      await nextUpdate(upload);
+
+      const rejectSpy = sinon.spy();
+      upload.addEventListener('file-reject', rejectSpy);
+      upload.files = files;
+      await nextUpdate(upload);
+
+      expect(rejectSpy).to.not.be.called;
+      expect(upload.files).to.have.lengthOf(2);
+    });
+
+    it('should allow files not matching the accept filter to be assigned', async () => {
+      upload.accept = 'image/*';
+      await nextUpdate(upload);
+
+      const rejectSpy = sinon.spy();
+      upload.addEventListener('file-reject', rejectSpy);
+      // Represent previously uploaded files
+      upload.files = files.map((file) => Object.assign(file, { complete: true }));
+      await nextUpdate(upload);
+
+      expect(rejectSpy).to.not.be.called;
+      expect(upload.files).to.have.lengthOf(2);
+    });
+
+    it('should allow more files than maxFiles to be assigned', async () => {
+      upload.maxFiles = 1;
+      await nextUpdate(upload);
+
+      const rejectSpy = sinon.spy();
+      upload.addEventListener('file-reject', rejectSpy);
+      upload.files = files;
+      await nextUpdate(upload);
+
+      expect(rejectSpy).to.not.be.called;
+      expect(upload.files).to.have.lengthOf(2);
+      expect(upload.maxFilesReached).to.be.true;
+    });
+
+    it('should update maxFilesReached when files are assigned', async () => {
+      upload.maxFiles = 1;
+      upload.files = [files[0]];
+      await nextUpdate(upload);
+      expect(upload.maxFilesReached).to.be.true;
+
+      upload.files = [];
+      await nextUpdate(upload);
+      expect(upload.maxFilesReached).to.be.false;
+    });
+
+    it('should upload files assigned to the files property', (done) => {
+      upload.maxFileSize = testFileSize - 1;
+      upload.addEventListener('upload-start', () => done());
+      upload.files = [files[0]];
+      upload.uploadFiles();
+    });
   });
 
   (touchDevice ? describe.skip : describe)('Dropping file', () => {

--- a/packages/upload/test/keyboard-navigation.test.js
+++ b/packages/upload/test/keyboard-navigation.test.js
@@ -124,6 +124,17 @@ describe('keyboard navigation', () => {
       expect(document.activeElement.file.name).to.equal('file-0');
     });
 
+    it('should not change focus when upload-retry is prevented', async () => {
+      uploadElement.addEventListener('upload-retry', (e) => e.preventDefault());
+
+      const retryButton = fileElements[0].shadowRoot.querySelector('[part=retry-button]');
+      retryButton.focus();
+      retryButton.click();
+      await nextFrame();
+
+      expect(fileElements[0].shadowRoot.activeElement).to.equal(retryButton);
+    });
+
     describe('retry', () => {
       let clock;
 

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { aTimeout, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
 import { addFilesViaInput, createFile, createFiles, removeFile, xhrCreator } from './helpers.js';
@@ -269,6 +269,96 @@ describe('upload', () => {
           });
         });
         upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+      });
+
+      it('should fire the `upload-success` event when retrying after a failed upload', async () => {
+        let fail = true;
+        upload._createXhr = xhrCreator({
+          size: file.size,
+          uploadTime: 200,
+          stepTime: 50,
+          serverValidation: () => (fail ? { status: 500, statusText: 'Error' } : undefined),
+        });
+
+        const errorSpy = sinon.spy();
+        upload.addEventListener('upload-error', errorSpy);
+        upload.uploadFiles(file);
+        await clock.tickAsync(400);
+        expect(errorSpy).to.be.calledOnce;
+        expect(file.error).to.be.ok;
+
+        fail = false;
+        const successSpy = sinon.spy();
+        upload.addEventListener('upload-success', successSpy);
+        upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
+        await clock.tickAsync(400);
+
+        expect(successSpy).to.be.calledOnce;
+        expect(errorSpy).to.be.calledOnce;
+        expect(file.error).to.not.be.ok;
+        expect(file.complete).to.be.true;
+      });
+
+      it('should fire the `upload-success` event when uploadFiles restarts a failed upload', async () => {
+        let fail = true;
+        upload._createXhr = xhrCreator({
+          size: file.size,
+          uploadTime: 200,
+          stepTime: 50,
+          serverValidation: () => (fail ? { status: 500, statusText: 'Error' } : undefined),
+        });
+
+        const errorSpy = sinon.spy();
+        upload.addEventListener('upload-error', errorSpy);
+        upload.uploadFiles(file);
+        await clock.tickAsync(400);
+        expect(errorSpy).to.be.calledOnce;
+        expect(file.error).to.be.ok;
+
+        fail = false;
+        const successSpy = sinon.spy();
+        upload.addEventListener('upload-success', successSpy);
+        upload.uploadFiles(file);
+        expect(file.error).to.not.be.ok;
+        await clock.tickAsync(400);
+
+        expect(successSpy).to.be.calledOnce;
+        expect(errorSpy).to.be.calledOnce;
+        expect(file.complete).to.be.true;
+      });
+
+      it('should not add files passed to uploadFiles to the files list', (done) => {
+        upload.addEventListener('upload-start', () => {
+          expect(upload.files).to.have.lengthOf(0);
+          done();
+        });
+        upload.uploadFiles(file);
+      });
+
+      it('should not count files passed to uploadFiles towards maxFiles', async () => {
+        upload.maxFiles = 1;
+        upload.uploadFiles(file);
+        await clock.tickAsync(400);
+        expect(file.complete).to.be.true;
+        expect(upload.maxFilesReached).to.be.false;
+
+        addFilesViaInput(upload, [createFile(100, 'image/jpeg')]);
+        expect(upload.files).to.have.lengthOf(1);
+      });
+
+      it('should fire files-changed only when files are added or removed', async () => {
+        const spy = sinon.spy();
+        upload.addEventListener('files-changed', spy);
+
+        addFilesViaInput(upload, [file]);
+        await clock.tickAsync(400);
+        expect(upload.files[0].complete).to.be.true;
+        expect(spy).to.be.calledOnce;
+
+        removeFile(upload);
+        await clock.tickAsync(10);
+        expect(upload.files).to.have.lengthOf(0);
+        expect(spy).to.be.calledTwice;
       });
 
       it('should propagate with-credentials to the xhr', (done) => {
@@ -626,6 +716,56 @@ describe('upload', () => {
       expect(file.remainingStr).to.equal('01:02:05');
       expect(file.loadedStr).to.equal('50 kB');
       expect(file.status).to.contain('remaining time: ');
+    });
+  });
+
+  describe('Invalid configuration', () => {
+    it('should upload using a lowercase method', (done) => {
+      const lowercaseUpload = fixtureSync(`<vaadin-upload method="put" target="/api/endpoint"></vaadin-upload>`);
+      lowercaseUpload._createXhr = xhrCreator({ size: file.size, uploadTime: 10, stepTime: 5 });
+      lowercaseUpload.addEventListener('upload-start', (e) => {
+        expect(e.detail.xhr.method).to.equal('PUT');
+        expect(e.detail.xhr.url).to.equal('/api/endpoint');
+        done();
+      });
+      lowercaseUpload.uploadFiles(file);
+    });
+
+    it('should upload using an unsupported method', async () => {
+      upload.method = 'DELETE';
+      await nextUpdate(upload);
+      upload._createXhr = xhrCreator({ size: file.size, uploadTime: 10, stepTime: 5 });
+
+      const startSpy = sinon.spy();
+      upload.addEventListener('upload-start', startSpy);
+      upload.uploadFiles(file);
+
+      expect(startSpy).to.be.calledOnce;
+      expect(startSpy.firstCall.args[0].detail.xhr.method).to.equal('DELETE');
+      expect(startSpy.firstCall.args[0].detail.xhr.url).to.equal('https://foo.com/bar');
+    });
+
+    it('should treat negative maxFiles as no limit', async () => {
+      upload.maxFiles = -1;
+      await nextUpdate(upload);
+      upload._createXhr = xhrCreator({ size: 100, uploadTime: 10, stepTime: 5 });
+
+      addFilesViaInput(upload, createFiles(2, 100, 'application/x-octet-stream'));
+      expect(upload.files).to.have.lengthOf(2);
+      expect(upload.maxFilesReached).to.be.false;
+    });
+
+    it('should pause uploads when maxConcurrentUploads is non-positive', async () => {
+      upload.maxConcurrentUploads = 0;
+      await nextUpdate(upload);
+      upload._createXhr = xhrCreator({ size: file.size, uploadTime: 10, stepTime: 5 });
+
+      const startSpy = sinon.spy();
+      upload.addEventListener('upload-start', startSpy);
+      upload.uploadFiles(file);
+      await aTimeout(50);
+
+      expect(startSpy).to.not.be.called;
     });
   });
 

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -964,6 +964,57 @@ describe('upload', () => {
     });
   });
 
+  describe('Custom file list', () => {
+    let clock;
+
+    beforeEach(async () => {
+      // A custom file list does not compute file status strings on its own,
+      // so these tests cover the statuses maintained by the upload mixin for
+      // files added to the list
+      upload = fixtureSync(`<vaadin-upload><div slot="file-list"></div></vaadin-upload>`);
+      upload.target = 'https://foo.com/bar';
+      await nextRender();
+      upload._createXhr = xhrCreator({
+        size: file.size,
+        connectTime: 500,
+        uploadTime: 200,
+        stepTime: 100,
+        serverTime: 500,
+      });
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should set connecting status on the file when upload starts', async () => {
+      addFilesViaInput(upload, [file]);
+      await clock.tickAsync(200);
+      expect(file.status).to.equal('Connecting...');
+    });
+
+    it('should set remaining time status on the file on progress', async () => {
+      addFilesViaInput(upload, [file]);
+      await clock.tickAsync(650);
+      expect(file.status).to.contain('remaining time: ');
+    });
+
+    it('should clear the file status after successful upload', async () => {
+      addFilesViaInput(upload, [file]);
+      await clock.tickAsync(2000);
+      expect(file.complete).to.be.true;
+      expect(file.status).to.equal('');
+    });
+
+    it('should set translated error message on the file on failure', async () => {
+      upload._createXhr = xhrCreator({ size: file.size, serverValidation: () => ({ status: 403 }) });
+      addFilesViaInput(upload, [file]);
+      await clock.tickAsync(100);
+      expect(file.error).to.equal('Upload forbidden');
+    });
+  });
+
   describe('theme', () => {
     it('should propagate theme to file list', async () => {
       upload.setAttribute('theme', 'thumbnails');

--- a/packages/upload/test/upload.test.js
+++ b/packages/upload/test/upload.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, nextUpdate } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-upload.js';
 import { addFilesViaInput, createFile, createFiles, removeFile, xhrCreator } from './helpers.js';
@@ -42,7 +42,7 @@ describe('upload', () => {
       let clock;
 
       beforeEach(() => {
-        clock = sinon.useFakeTimers();
+        clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
       });
 
       afterEach(() => {
@@ -271,13 +271,19 @@ describe('upload', () => {
         upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
       });
 
-      it('should fire the `upload-success` event when retrying after a failed upload', async () => {
+      // Uploads the file against a server that rejects the first request and
+      // accepts the following ones, and waits for the upload to fail
+      async function uploadWithServerError() {
         let fail = true;
         upload._createXhr = xhrCreator({
           size: file.size,
           uploadTime: 200,
           stepTime: 50,
-          serverValidation: () => (fail ? { status: 500, statusText: 'Error' } : undefined),
+          serverValidation: () => {
+            const error = fail ? { status: 500, statusText: 'Error' } : undefined;
+            fail = false;
+            return error;
+          },
         });
 
         const errorSpy = sinon.spy();
@@ -286,8 +292,12 @@ describe('upload', () => {
         await clock.tickAsync(400);
         expect(errorSpy).to.be.calledOnce;
         expect(file.error).to.be.ok;
+        return errorSpy;
+      }
 
-        fail = false;
+      it('should fire the `upload-success` event when retrying after a failed upload', async () => {
+        const errorSpy = await uploadWithServerError();
+
         const successSpy = sinon.spy();
         upload.addEventListener('upload-success', successSpy);
         upload.dispatchEvent(new CustomEvent('file-retry', { detail: { file } }));
@@ -300,22 +310,8 @@ describe('upload', () => {
       });
 
       it('should fire the `upload-success` event when uploadFiles restarts a failed upload', async () => {
-        let fail = true;
-        upload._createXhr = xhrCreator({
-          size: file.size,
-          uploadTime: 200,
-          stepTime: 50,
-          serverValidation: () => (fail ? { status: 500, statusText: 'Error' } : undefined),
-        });
+        const errorSpy = await uploadWithServerError();
 
-        const errorSpy = sinon.spy();
-        upload.addEventListener('upload-error', errorSpy);
-        upload.uploadFiles(file);
-        await clock.tickAsync(400);
-        expect(errorSpy).to.be.calledOnce;
-        expect(file.error).to.be.ok;
-
-        fail = false;
         const successSpy = sinon.spy();
         upload.addEventListener('upload-success', successSpy);
         upload.uploadFiles(file);
@@ -536,7 +532,7 @@ describe('upload', () => {
       let clock;
 
       beforeEach(() => {
-        clock = sinon.useFakeTimers();
+        clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
       });
 
       afterEach(() => {
@@ -594,7 +590,7 @@ describe('upload', () => {
         serverTime: 500,
       });
 
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
     });
 
     afterEach(() => {
@@ -636,7 +632,7 @@ describe('upload', () => {
         stepTime: 2500,
       });
 
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
     });
 
     afterEach(() => {
@@ -694,7 +690,7 @@ describe('upload', () => {
         stepTime: 3000000,
       });
 
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
     });
 
     afterEach(() => {
@@ -720,15 +716,38 @@ describe('upload', () => {
   });
 
   describe('Invalid configuration', () => {
-    it('should upload using a lowercase method', (done) => {
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should upload using a lowercase method', async () => {
       const lowercaseUpload = fixtureSync(`<vaadin-upload method="put" target="/api/endpoint"></vaadin-upload>`);
       lowercaseUpload._createXhr = xhrCreator({ size: file.size, uploadTime: 10, stepTime: 5 });
-      lowercaseUpload.addEventListener('upload-start', (e) => {
-        expect(e.detail.xhr.method).to.equal('PUT');
-        expect(e.detail.xhr.url).to.equal('/api/endpoint');
-        done();
+
+      // Capture the method that the component passes to the request
+      let requestMethod;
+      lowercaseUpload.addEventListener('upload-before', (e) => {
+        const originalOpen = e.detail.xhr.open;
+        e.detail.xhr.open = function (method, ...args) {
+          requestMethod = method;
+          return originalOpen.call(this, method, ...args);
+        };
       });
+
+      const startSpy = sinon.spy();
+      lowercaseUpload.addEventListener('upload-start', startSpy);
       lowercaseUpload.uploadFiles(file);
+      await clock.tickAsync(50);
+
+      expect(startSpy).to.be.calledOnce;
+      expect(requestMethod).to.equal('put');
+      expect(startSpy.firstCall.args[0].detail.xhr.url).to.equal('/api/endpoint');
     });
 
     it('should upload using an unsupported method', async () => {
@@ -743,6 +762,7 @@ describe('upload', () => {
       expect(startSpy).to.be.calledOnce;
       expect(startSpy.firstCall.args[0].detail.xhr.method).to.equal('DELETE');
       expect(startSpy.firstCall.args[0].detail.xhr.url).to.equal('https://foo.com/bar');
+      await clock.tickAsync(50);
     });
 
     it('should treat negative maxFiles as no limit', async () => {
@@ -753,6 +773,7 @@ describe('upload', () => {
       addFilesViaInput(upload, createFiles(2, 100, 'application/x-octet-stream'));
       expect(upload.files).to.have.lengthOf(2);
       expect(upload.maxFilesReached).to.be.false;
+      await clock.tickAsync(50);
     });
 
     it('should pause uploads when maxConcurrentUploads is non-positive', async () => {
@@ -763,7 +784,7 @@ describe('upload', () => {
       const startSpy = sinon.spy();
       upload.addEventListener('upload-start', startSpy);
       upload.uploadFiles(file);
-      await aTimeout(50);
+      await clock.tickAsync(50);
 
       expect(startSpy).to.not.be.called;
     });
@@ -968,7 +989,7 @@ describe('upload', () => {
 
     beforeEach(() => {
       upload._createXhr = xhrCreator({ size: file.size, uploadTime: 200, stepTime: 50 });
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
     });
 
     afterEach(() => {
@@ -1121,7 +1142,7 @@ describe('upload', () => {
         stepTime: 100,
         serverTime: 500,
       });
-      clock = sinon.useFakeTimers();
+      clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
     });
 
     afterEach(() => {
@@ -1148,10 +1169,11 @@ describe('upload', () => {
     });
 
     it('should set translated error message on the file on failure', async () => {
+      upload.i18n = { uploading: { error: { forbidden: 'Hochladen verboten' } } };
       upload._createXhr = xhrCreator({ size: file.size, serverValidation: () => ({ status: 403 }) });
       addFilesViaInput(upload, [file]);
       await clock.tickAsync(100);
-      expect(file.error).to.equal('Upload forbidden');
+      expect(file.error).to.equal('Hochladen verboten');
     });
   });
 


### PR DESCRIPTION
## Summary
- The upcoming UploadManager integration (`refactor/integrate-upload-manager`) rewrites how `vaadin-upload` handles files, statuses, and configuration, so the current behavior needs test coverage before the refactor lands to make any behavior change visible in that PR
- Cover file status and error updates that the mixin maintains when a custom file list is used, since the default file list computes these on its own and hides regressions
- Adopt the behavior tests written on the refactor branch that already pass against main: no validation for directly assigned files, `files-changed` timing, retry and restart of failed uploads, `uploadFiles` with files outside the list, and invalid configuration handling

Part of #10939

🤖 Generated with [Claude Code](https://claude.com/claude-code)