### PR TITLE
feat: add accessibleDescriptionRef property to field components

### DIFF
--- a/packages/a11y-base/src/field-aria-controller.d.ts
+++ b/packages/a11y-base/src/field-aria-controller.d.ts
@@ -43,6 +43,14 @@ export class FieldAriaController {
   setLabelledBy(labelledBy: string | null): void;
 
   /**
+   * Links the target element to one or more elements via the `aria-describedby` attribute.
+   *
+   * @param describedBy the space-delimited list of IDs,
+   * or `null` to remove the previously linked IDs
+   */
+  setDescribedBy(describedBy: string | null): void;
+
+  /**
    * Links the target element to a slotted error element via the `aria-describedby` attribute.
    *
    * Pass the ID of the error element, or `null` to remove the previously linked ID.

--- a/packages/a11y-base/src/field-aria-controller.js
+++ b/packages/a11y-base/src/field-aria-controller.js
@@ -27,6 +27,9 @@ export class FieldAriaController {
   #labelledBy;
 
   /** @type {string | null | undefined} */
+  #describedBy;
+
+  /** @type {string | null | undefined} */
   #errorId;
 
   /** @type {string | null | undefined} */
@@ -91,6 +94,17 @@ export class FieldAriaController {
   }
 
   /**
+   * Links the target element to one or more elements via the `aria-describedby` attribute.
+   *
+   * @param {string | null} describedBy the space-delimited list of IDs,
+   * or `null` to remove the previously linked IDs
+   */
+  setDescribedBy(describedBy) {
+    this.#describedBy = describedBy;
+    this.#updateAriaDescribedByAttribute();
+  }
+
+  /**
    * Links the target element to a slotted error element via the `aria-describedby` attribute.
    *
    * @param {string | null} errorId the ID of the error element,
@@ -139,7 +153,7 @@ export class FieldAriaController {
 
     removeValuesFromAttribute(this.#target, 'aria-describedby', this.#ariaDescribedByAttributeIds);
 
-    this.#ariaDescribedByAttributeIds = [this.#helperId, this.#errorId];
+    this.#ariaDescribedByAttributeIds = [this.#describedBy, this.#helperId, this.#errorId];
 
     addValuesToAttribute(this.#target, 'aria-describedby', this.#ariaDescribedByAttributeIds);
   }

--- a/packages/a11y-base/test/field-aria-controller.test.js
+++ b/packages/a11y-base/test/field-aria-controller.test.js
@@ -71,10 +71,10 @@ describe('FieldAriaController', () => {
     });
 
     describe('set before target', () => {
-      it('should add label id to aria-labelledby attribute', () => {
-        controller.setLabelledBy('label-id');
+      it('should add label ids to aria-labelledby attribute', () => {
+        controller.setLabelledBy('label-id-0 label-id-1');
         controller.setTarget(input);
-        expect(input.getAttribute('aria-labelledby')).to.equal('custom-id label-id');
+        expect(input.getAttribute('aria-labelledby')).to.equal('custom-id label-id-0 label-id-1');
       });
 
       it('should add error id to aria-describedby attribute', () => {
@@ -88,6 +88,12 @@ describe('FieldAriaController', () => {
         controller.setTarget(input);
         expect(input.getAttribute('aria-describedby')).to.equal('custom-id helper-id');
       });
+
+      it('should add description ids to aria-describedby attribute', () => {
+        controller.setDescribedBy('description-id-0 description-id-1');
+        controller.setTarget(input);
+        expect(input.getAttribute('aria-describedby')).to.equal('custom-id description-id-0 description-id-1');
+      });
     });
 
     describe('set after target', () => {
@@ -95,9 +101,9 @@ describe('FieldAriaController', () => {
         controller.setTarget(input);
       });
 
-      it('should set label id to aria-labelledby attribute', () => {
-        controller.setLabelledBy('label-id');
-        expect(input.getAttribute('aria-labelledby')).to.equal('custom-id label-id');
+      it('should set label ids to aria-labelledby attribute', () => {
+        controller.setLabelledBy('label-id-0 label-id-1');
+        expect(input.getAttribute('aria-labelledby')).to.equal('custom-id label-id-0 label-id-1');
         controller.setLabelledBy(null);
         expect(input.getAttribute('aria-labelledby')).to.equal('custom-id');
       });
@@ -113,6 +119,13 @@ describe('FieldAriaController', () => {
         controller.setHelperId('helper-id');
         expect(input.getAttribute('aria-describedby')).to.equal('custom-id helper-id');
         controller.setHelperId(null);
+        expect(input.getAttribute('aria-describedby')).to.equal('custom-id');
+      });
+
+      it('should set description ids to aria-describedby attribute', () => {
+        controller.setDescribedBy('description-id-0 description-id-1');
+        expect(input.getAttribute('aria-describedby')).to.equal('custom-id description-id-0 description-id-1');
+        controller.setDescribedBy(null);
         expect(input.getAttribute('aria-describedby')).to.equal('custom-id');
       });
     });

--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -30,16 +30,27 @@ export declare class FieldMixinClass {
   errorMessage: string | null | undefined;
 
   /**
-   * String used to label the component to screen reader users.
+   * String used to label the component for screen reader users.
+   *
    * @attr {string} accessible-name
    */
   accessibleName: string | null | undefined;
 
   /**
-   * Id of the element used as label of the component to screen reader users.
+   * A space-separated list of IDs referencing the elements that
+   * label the component for screen reader users.
+   *
    * @attr {string} accessible-name-ref
    */
   accessibleNameRef: string | null | undefined;
+
+  /**
+   * A space-separated list of IDs referencing the elements that
+   * describe the component for screen reader users.
+   *
+   * @attr {string} accessible-description-ref
+   */
+  accessibleDescriptionRef: string | null | undefined;
 
   /**
    * A target element to which ARIA attributes are set.

--- a/packages/field-base/src/field-mixin.d.ts
+++ b/packages/field-base/src/field-mixin.d.ts
@@ -46,7 +46,9 @@ export declare class FieldMixinClass {
 
   /**
    * A space-separated list of IDs referencing the elements that
-   * describe the component for screen reader users.
+   * describe the component for screen reader users. The referenced
+   * elements are announced in addition to the helper text and
+   * the error message.
    *
    * @attr {string} accessible-description-ref
    */

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -42,7 +42,8 @@ export const FieldMixin = (superclass) =>
         },
 
         /**
-         * String used to label the component to screen reader users.
+         * String used to label the component for screen reader users.
+         *
          * @attr {string} accessible-name
          */
         accessibleName: {
@@ -50,10 +51,22 @@ export const FieldMixin = (superclass) =>
         },
 
         /**
-         * Id of the element used as label of the component to screen reader users.
+         * A space-separated list of IDs referencing the elements that
+         * label the component for screen reader users.
+         *
          * @attr {string} accessible-name-ref
          */
         accessibleNameRef: {
+          type: String,
+        },
+
+        /**
+         * A space-separated list of IDs referencing the elements that
+         * describe the component for screen reader users.
+         *
+         * @attr {string} accessible-description-ref
+         */
+        accessibleDescriptionRef: {
           type: String,
         },
       };
@@ -135,6 +148,10 @@ export const FieldMixin = (superclass) =>
       if (props.has('accessibleName') || props.has('accessibleNameRef')) {
         this.__updateFieldAriaControllerLabelledBy();
       }
+
+      if (props.has('accessibleDescriptionRef')) {
+        this.__updateFieldAriaControllerDescribedBy();
+      }
     }
 
     /** @private */
@@ -155,6 +172,15 @@ export const FieldMixin = (superclass) =>
       }
 
       this._fieldAriaController.setLabelledBy(id);
+    }
+
+    /** @private */
+    __updateFieldAriaControllerDescribedBy() {
+      if (this.accessibleDescriptionRef) {
+        this._fieldAriaController.setDescribedBy(this.accessibleDescriptionRef);
+      } else {
+        this._fieldAriaController.setDescribedBy(null);
+      }
     }
 
     #onLabelSlotContentChange(_event) {

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -62,7 +62,9 @@ export const FieldMixin = (superclass) =>
 
         /**
          * A space-separated list of IDs referencing the elements that
-         * describe the component for screen reader users.
+         * describe the component for screen reader users. The referenced
+         * elements are announced in addition to the helper text and
+         * the error message.
          *
          * @attr {string} accessible-description-ref
          */

--- a/packages/field-base/src/field-mixin.js
+++ b/packages/field-base/src/field-mixin.js
@@ -176,11 +176,7 @@ export const FieldMixin = (superclass) =>
 
     /** @private */
     __updateFieldAriaControllerDescribedBy() {
-      if (this.accessibleDescriptionRef) {
-        this._fieldAriaController.setDescribedBy(this.accessibleDescriptionRef);
-      } else {
-        this._fieldAriaController.setDescribedBy(null);
-      }
+      this._fieldAriaController.setDescribedBy(this.accessibleDescriptionRef);
     }
 
     #onLabelSlotContentChange(_event) {

--- a/packages/field-base/test/field-mixin.test.js
+++ b/packages/field-base/test/field-mixin.test.js
@@ -860,6 +860,63 @@ describe('FieldMixin', () => {
         expect(input.getAttribute('aria-labelledby')).to.be.equal('accessible-name-ref-0');
       });
     });
+
+    describe('accessibleDescriptionRef', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`<${tag} label="Label" helper-text="Helper"></${tag}>`);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+        helper = element.querySelector('[slot=helper]');
+      });
+
+      it('should not change aria-describedby by default', () => {
+        expect(input.getAttribute('aria-describedby')).to.be.equal(helper.id);
+      });
+
+      it('should update aria-describedby when the property changes', async () => {
+        element.accessibleDescriptionRef = 'accessible-description-ref-0';
+        await nextUpdate(element);
+        let aria = input.getAttribute('aria-describedby');
+        expect(aria).to.include('accessible-description-ref-0');
+        expect(aria).to.include(helper.id);
+
+        element.accessibleDescriptionRef = 'accessible-description-ref-1 accessible-description-ref-2';
+        await nextUpdate(element);
+        aria = input.getAttribute('aria-describedby');
+        expect(aria).to.include('accessible-description-ref-1');
+        expect(aria).to.include('accessible-description-ref-2');
+        expect(aria).to.not.include('accessible-description-ref-0');
+      });
+
+      it('should restore original aria-describedby when the property is cleared', async () => {
+        element.accessibleDescriptionRef = 'accessible-description-ref-0';
+        await nextUpdate(element);
+        element.accessibleDescriptionRef = null;
+        await nextUpdate(element);
+        expect(input.getAttribute('aria-describedby')).to.be.equal(helper.id);
+      });
+    });
+
+    describe('accessibleDescriptionRef is set initially', () => {
+      beforeEach(async () => {
+        element = fixtureSync(`
+          <${tag}
+            label="Label"
+            helper-text="Helper"
+            accessible-description-ref="accessible-description-ref-0"
+          ></${tag}>
+        `);
+        await nextRender();
+        input = element.querySelector('[slot=input]');
+        helper = element.querySelector('[slot=helper]');
+      });
+
+      it('should include the property value in aria-describedby', () => {
+        const aria = input.getAttribute('aria-describedby');
+        expect(aria).to.include('accessible-description-ref-0');
+        expect(aria).to.include(helper.id);
+      });
+    });
   });
 
   describe('slotted label', () => {


### PR DESCRIPTION
The PR adds the `accessibleDescriptionRef` property to let developers provide external elements that describe the field for screen readers. The references are prepended to the internal helper text and error message references, so they are announced first.

Part of https://github.com/vaadin/web-components/issues/11975