### PR TITLE
test: remove no longer needed tooltip manual test

### DIFF
--- a/packages/tooltip/test/tooltip.test.js
+++ b/packages/tooltip/test/tooltip.test.js
@@ -792,21 +792,3 @@ describe('vaadin-tooltip', () => {
     });
   });
 });
-
-describe('manual opened', () => {
-  let tooltip, overlay;
-
-  beforeEach(async () => {
-    tooltip = fixtureSync('<vaadin-tooltip text="Test" manual opened></vaadin-tooltip>');
-    await nextRender();
-    overlay = tooltip._overlayElement;
-  });
-
-  afterEach(() => {
-    tooltip.opened = false;
-  });
-
-  it('should set owner on the overlay element', () => {
-    expect(overlay.owner).to.equal(tooltip);
-  });
-});


### PR DESCRIPTION
## Description

This test was added in https://github.com/vaadin/web-components/pull/4610 and it was Polymer-specific. Later on, the corresponding logic has been removed in https://github.com/vaadin/web-components/pull/8299 so there is no point in keeping it. There's an existing test verifying that `owner` is set to the host element.

## Type of change

- Test