### PR TITLE
fix: align time-picker assigning items with combo-box

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -265,8 +265,10 @@ export const TimePickerMixin = (superClass) =>
           getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
       }
 
+      const isClosing = this.hasAttribute('closing');
+
       this._scroller.setProperties({
-        items: opened ? items : [],
+        items: opened || isClosing ? items : [],
         opened,
         focusedIndex,
         theme,


### PR DESCRIPTION
## Description

Same as https://github.com/vaadin/web-components/pull/12115 but for `vaadin-time-picker`.

## Type of change

- Bugfix