### PR TITLE
fix: scroll combo-box input into visual viewport on iOS refocus

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -7,7 +7,7 @@ import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
-import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { isIOS, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
 import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
@@ -218,6 +218,9 @@ export const ComboBoxBaseMixin = (superClass) =>
         this._onOverlayClosed();
       });
 
+      // Restore the input into the visual viewport on iOS after the overlay is open
+      overlay.addEventListener('vaadin-overlay-open', () => this.__onOverlayOpen());
+
       this._overlayElement = overlay;
     }
 
@@ -319,6 +322,15 @@ export const ComboBoxBaseMixin = (superClass) =>
         }
 
         this._onClosed();
+
+        // Stop any in-flight viewport correction from a previous open.
+        this.__stopViewportCorrection();
+
+        // On iOS, the input can keep focus while the overlay closes, e.g. on an outside
+        // click (`_mouseDownListener` in vaadin-combo-box-overlay-mixin.js, added in
+        // #7846). Remember it so the next overlay open can scroll the input back into
+        // the visual viewport, which iOS only does on a fresh focus event.
+        this.__inputFocusRetained = isIOS && this._isInputFocused();
       }
 
       const input = this.inputElement;
@@ -386,6 +398,59 @@ export const ComboBoxBaseMixin = (superClass) =>
       if (!this.autoOpenDisabled) {
         event.preventDefault();
         this.open();
+      }
+    }
+
+    /**
+     * The input keeps focus when closing on outside click. Subsequent click does not
+     * fire focus event and iOS skips its automatic scrolling into view logic, so the
+     * input can end up behind the virtual keyboard. Scroll it into view manually.
+     * @private
+     */
+    __onOverlayOpen() {
+      if (!this.__inputFocusRetained) {
+        return;
+      }
+      this.__inputFocusRetained = false;
+      this.__scrollInputIntoViewport();
+    }
+
+    /**
+     * Scrolls the input into the visual viewport if the virtual keyboard covers it.
+     * @private
+     */
+    __scrollInputIntoViewport() {
+      const viewport = window.visualViewport;
+      const scrollIfCovered = () => {
+        // Client rectangles are relative to the visual viewport on iOS, so the visible
+        // area starts at 0 and ends at its height. Adding the visual viewport offset
+        // here would count the shift that the keyboard causes a second time.
+        const rect = this.inputElement.getBoundingClientRect();
+        if (rect.bottom > viewport.height || rect.top < 0) {
+          this.inputElement.scrollIntoView({ block: 'center' });
+        }
+      };
+
+      // Virtual keyboard can close on the outside click and reopen on re-tap, so its final
+      // geometry is not known yet at open time. Check right away in case the keyboard stayed
+      // open, keep correcting on every visual viewport resize while it settles, then stop so
+      // later user scrolling is not overridden.
+      this.__stopViewportCorrection();
+      scrollIfCovered();
+      viewport.addEventListener('resize', scrollIfCovered);
+      this.__viewportCorrectionCleanup = () => viewport.removeEventListener('resize', scrollIfCovered);
+      this.__viewportCorrectionTimeout = setTimeout(() => this.__stopViewportCorrection(), 500);
+    }
+
+    /** @private */
+    __stopViewportCorrection() {
+      if (this.__viewportCorrectionCleanup) {
+        this.__viewportCorrectionCleanup();
+        this.__viewportCorrectionCleanup = null;
+      }
+      if (this.__viewportCorrectionTimeout) {
+        clearTimeout(this.__viewportCorrectionTimeout);
+        this.__viewportCorrectionTimeout = null;
       }
     }
 
@@ -741,6 +806,9 @@ export const ComboBoxBaseMixin = (superClass) =>
 
       if (!focused) {
         this.__autoselectPending = false;
+        // A genuine blur (e.g. the keyboard Done key) makes the next tap a fresh focus
+        // that iOS scrolls into view itself, so drop the retained-focus flag.
+        this.__inputFocusRetained = false;
       }
 
       if (!focused && !this.readonly && !this._closeOnBlurIsPrevented) {

--- a/packages/combo-box/test/scroll-into-viewport.test.js
+++ b/packages/combo-box/test/scroll-into-viewport.test.js
@@ -113,19 +113,6 @@ describe('scrolling input into the visual viewport', () => {
       await open();
       expect(scrollIntoView).to.be.calledOnce;
     });
-
-    it('should skip the correction when the overlay open event fires after close', async () => {
-      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
-
-      // The overlay dispatches `vaadin-overlay-open` from a timeout that closing
-      // does not cancel, so the event can arrive while the combo-box is closed
-      comboBox.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-open'));
-      expect(scrollIntoView).to.not.be.called;
-
-      // The retained focus state must survive for the next real open
-      await open();
-      expect(scrollIntoView).to.be.calledOnce;
-    });
   });
 
   it('should not scroll the input on open when focus was not retained', async () => {

--- a/packages/combo-box/test/scroll-into-viewport.test.js
+++ b/packages/combo-box/test/scroll-into-viewport.test.js
@@ -1,0 +1,136 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, focusout, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-combo-box.js';
+
+describe('scrolling input into the visual viewport', () => {
+  let comboBox, input, scrollIntoView;
+
+  function setVisualViewportHeight(height) {
+    Object.defineProperty(window.visualViewport, 'height', {
+      configurable: true,
+      get: () => height,
+    });
+  }
+
+  async function open() {
+    comboBox.open();
+    await oneEvent(comboBox.$.overlay, 'vaadin-overlay-open');
+  }
+
+  beforeEach(async () => {
+    comboBox = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+    comboBox.items = ['foo', 'bar'];
+    await nextRender();
+    input = comboBox.inputElement;
+    scrollIntoView = sinon.stub(input, 'scrollIntoView');
+  });
+
+  afterEach(() => {
+    // Remove the stubbed getter to restore the native accessor
+    delete window.visualViewport.height;
+    comboBox.opened = false;
+  });
+
+  describe('input focus retained on outside click', () => {
+    beforeEach(() => {
+      // The flag is only set on iOS (see `_openedChanged`), so drive it directly
+      comboBox.__inputFocusRetained = true;
+    });
+
+    it('should scroll the input into view on open when the on-screen keyboard covers it', async () => {
+      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+      await open();
+      expect(scrollIntoView).to.be.calledOnceWithExactly({ block: 'center' });
+    });
+
+    it('should not scroll the input on open when it is inside the visible area', async () => {
+      await open();
+      expect(scrollIntoView).to.not.be.called;
+    });
+
+    it('should scroll the input when the visual viewport shrinks over it after open', async () => {
+      await open();
+      expect(scrollIntoView).to.not.be.called;
+
+      // The on-screen keyboard finishes opening: the visible area ends above the input
+      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+      window.visualViewport.dispatchEvent(new Event('resize'));
+      expect(scrollIntoView).to.be.calledOnce;
+    });
+
+    it('should stop correcting on viewport resize once the overlay is closed', async () => {
+      await open();
+      comboBox.close();
+
+      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+      window.visualViewport.dispatchEvent(new Event('resize'));
+      expect(scrollIntoView).to.not.be.called;
+    });
+
+    describe('correction timeout', () => {
+      let clock;
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it('should stop correcting on viewport resize after the timeout', async () => {
+        comboBox.open();
+        // Fire the overlay rAF + setTimeout chain dispatching `vaadin-overlay-open`
+        await clock.tickAsync(100);
+        // Expire the correction window
+        await clock.tickAsync(500);
+
+        setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+        window.visualViewport.dispatchEvent(new Event('resize'));
+        expect(scrollIntoView).to.not.be.called;
+      });
+    });
+
+    it('should not scroll the input on open after the input loses focus', async () => {
+      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+      focusout(comboBox);
+      await open();
+      expect(scrollIntoView).to.not.be.called;
+    });
+
+    it('should reset the retained focus state on close', async () => {
+      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+      await open();
+      expect(scrollIntoView).to.be.calledOnce;
+
+      // Close recomputes the flag from the actual environment (non-iOS here),
+      // so retention forced while open must not survive into the next open.
+      comboBox.__inputFocusRetained = true;
+      comboBox.close();
+      await nextRender();
+
+      await open();
+      expect(scrollIntoView).to.be.calledOnce;
+    });
+
+    it('should skip the correction when the overlay open event fires after close', async () => {
+      setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+
+      // The overlay dispatches `vaadin-overlay-open` from a timeout that closing
+      // does not cancel, so the event can arrive while the combo-box is closed
+      comboBox.$.overlay.dispatchEvent(new CustomEvent('vaadin-overlay-open'));
+      expect(scrollIntoView).to.not.be.called;
+
+      // The retained focus state must survive for the next real open
+      await open();
+      expect(scrollIntoView).to.be.calledOnce;
+    });
+  });
+
+  it('should not scroll the input on open when focus was not retained', async () => {
+    setVisualViewportHeight(input.getBoundingClientRect().top - 10);
+    await open();
+    expect(scrollIntoView).to.not.be.called;
+  });
+});


### PR DESCRIPTION
## Description

Fixes #12037

On iOS the input keeps focus when the overlay is closed on an outside click (#7846), so re-tapping it fires no fresh focus event and iOS skips its native scroll-into-view. The input can then stay hidden behind the on-screen keyboard. Scroll it into the visual viewport manually after the overlay opens, correcting while the keyboard geometry settles.

## Type of change

- Bugfix

## Note

#### Before


https://github.com/user-attachments/assets/05b352b1-0fd0-4166-beb1-71a2e8d2754f


#### After


https://github.com/user-attachments/assets/d24e346d-c50a-4ef6-a88c-41b068b7c1be



