### PR TITLE
fix(aura): always recompute item highlight color based on current accent color

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -13,11 +13,6 @@
 
   --aura-app-background: var(--aura-background-color);
 
-  --_aura-highlight-color: light-dark(
-    oklch(from var(--aura-accent-color-light) min(0.9, l) c h / max(0.05, l / 4)),
-    oklch(from var(--aura-accent-color-dark) max(0.6, l) c h / max(0.2, l / 4))
-  );
-
   --vaadin-focus-ring-color: light-dark(
     oklch(from var(--aura-accent-color-light) min(l, 0.62) c h),
     oklch(from var(--aura-accent-color-dark) max(l, 0.62) c h)
@@ -202,6 +197,10 @@ vaadin-upload-file,
     transparent
   );
   accent-color: var(--aura-accent-color);
+  --_aura-highlight-color: light-dark(
+    oklch(from var(--aura-accent-color-light) min(0.9, l) c h / max(0.05, l / 4)),
+    oklch(from var(--aura-accent-color-dark) max(0.6, l) c h / max(0.2, l / 4))
+  );
 }
 
 :where(h1, h2, h3, h4, h5, h6) {


### PR DESCRIPTION
Fixes a regression caused by #11730.