### PR TITLE
fix(aura): recompute colors defined from current accent color on vaadin-select-item

### DIFF
--- a/packages/aura/src/color.css
+++ b/packages/aura/src/color.css
@@ -80,6 +80,7 @@ vaadin-notification-card::part(overlay),
 vaadin-checkbox::part(checkbox),
 vaadin-radio-button::part(radio),
 vaadin-side-nav-item::part(content),
+vaadin-select-item,
 vaadin-tab,
 vaadin-upload-file,
 :where(


### PR DESCRIPTION
Fixes a regression caused by `<vaadin-select>` rendering `<vaadin-select-item>`'s instead of `<vaadin-item>`'s.