### PR TITLE
fix!: blur combo-box input on iOS when overlay closes

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -7,7 +7,7 @@ import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
 import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
-import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { isIOS, isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
 import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
@@ -83,6 +83,12 @@ export const ComboBoxBaseMixin = (superClass) =>
           sync: true,
           observer: '_overlayOpenedChanged',
         },
+
+        /** @private */
+        _ios: {
+          type: Boolean,
+          value: isIOS,
+        },
       };
     }
 
@@ -98,12 +104,22 @@ export const ComboBoxBaseMixin = (superClass) =>
       this._scroller;
 
       /**
-       * Used to detect if focusout should be ignored due to touch.
+       * Set while the component blurs the input itself, so that the focusout logic
+       * does not treat it as the user leaving the field.
        * Do not define in `properties` to avoid triggering updates.
        * @type {boolean}
        * @protected
        */
       this._closeOnBlurIsPrevented;
+
+      /**
+       * Set by the overlay when it suppresses the blur on the outside click that closes
+       * it, so that the input can be blurred once closed.
+       * Do not define in `properties` to avoid triggering updates.
+       * @type {boolean}
+       * @protected
+       */
+      this._outsideClickBlurPrevented;
 
       this._boundOverlaySelectedItemChanged = this._overlaySelectedItemChanged.bind(this);
       this._boundOnClearButtonMouseDown = this.__onClearButtonMouseDown.bind(this);
@@ -311,15 +327,28 @@ export const ComboBoxBaseMixin = (superClass) =>
           }
         }
       } else {
-        if (this.autoselect) {
-          // When the dropdown closes, the input remains focused. Mark that the next
-          // host click should re-trigger autoselect, since the normal focus event
-          // won't fire again.
+        // By default, overlay keeps focus by preventing `mousedown` event for the outside
+        // click. On touch devices, blur input programmatically in this case: iOS scrolls
+        // the input into the  viewport only on focus event, so tapping again with focus
+        // preserved would result with the input placed behind the on-screen keyboard.
+        const shouldBlur = this._ios && this._outsideClickBlurPrevented && this._isInputFocused();
+
+        if (this.autoselect && !shouldBlur) {
+          // When the dropdown closes and input remains focused, the next host click
+          // should re-trigger autoselect, since the normal focus event won't fire.
           this.__autoselectPending = true;
         }
 
         this._onClosed();
+
+        // On iOS, blur the input after the overlay is closed and the value is committed.
+        if (shouldBlur) {
+          this.__blurWithoutClosing();
+        }
       }
+
+      // The flag only applies to the close caused by that outside click.
+      this._outsideClickBlurPrevented = false;
 
       const input = this.inputElement;
       if (input) {
@@ -335,8 +364,17 @@ export const ComboBoxBaseMixin = (superClass) =>
 
     /** @private */
     _onOverlayTouchAction() {
-      // On touch devices, blur the input on touch start inside the overlay, in order to hide
-      // the virtual keyboard. But don't close the overlay on this blur.
+      // On touch devices, blur the input on touch start inside the overlay,
+      // in order to hide the virtual keyboard.
+      this.__blurWithoutClosing();
+    }
+
+    /**
+     * Blurs the input without the focusout logic closing the overlay
+     * or committing the value.
+     * @private
+     */
+    __blurWithoutClosing() {
       this._closeOnBlurIsPrevented = true;
       this.inputElement.blur();
       this._closeOnBlurIsPrevented = false;

--- a/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-overlay-mixin.js
@@ -40,9 +40,14 @@ export const ComboBoxOverlayMixin = (superClass) =>
 
       // Prevent global mousedown event to avoid losing focus on outside click,
       // unless the clicked element is also focusable (e.g. in date-time-picker).
-      if (this._shouldCloseOnOutsideClick(event) && !isElementFocusable(event.composedPath()[0])) {
+      const preventBlur = this._shouldCloseOnOutsideClick(event) && !isElementFocusable(event.composedPath()[0]);
+      if (preventBlur) {
         event.preventDefault();
       }
+
+      // Let the owner know whether it needs to blur the input itself once closed.
+      // Assigned on every mousedown, so that a click inside also clears it.
+      this.owner._outsideClickBlurPrevented = preventBlur;
     }
 
     /** @protected */

--- a/packages/combo-box/test/blur.test.js
+++ b/packages/combo-box/test/blur.test.js
@@ -1,0 +1,271 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
+import {
+  aTimeout,
+  escKeyDown,
+  fire,
+  fixtureSync,
+  focusout,
+  nextRender,
+  tabKeyDown,
+  touchstart,
+} from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-combo-box.js';
+import { getFirstItem, setInputValue } from './helpers.js';
+
+describe('blur', () => {
+  let comboBox, overlay, input;
+
+  beforeEach(async () => {
+    comboBox = fixtureSync(
+      `<div>
+        <vaadin-combo-box label="Label"></vaadin-combo-box>
+        <input id="last-global-focusable" />
+      </div>`,
+    ).firstElementChild;
+
+    await nextRender();
+    comboBox.items = ['foo', 'bar', 'baz'];
+    input = comboBox.inputElement;
+    overlay = comboBox.$.overlay;
+  });
+
+  describe('blur method', () => {
+    it('should blur the input with the blur method', () => {
+      comboBox.focus();
+      comboBox.blur();
+
+      expect(comboBox.hasAttribute('focused')).to.be.false;
+      expect(document.activeElement).to.not.equal(input);
+    });
+  });
+
+  describe('focus retention', () => {
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should restore focus to the input on outside click', async () => {
+      comboBox.focus();
+      comboBox.open();
+      await sendMouseToElement({ type: 'click', element: document.body });
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('should keep focus in the input on toggle button click', async () => {
+      comboBox.focus();
+      comboBox.open();
+      await sendMouseToElement({ type: 'click', element: comboBox._toggleElement });
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('should keep focus-ring attribute after closing with outside click', async () => {
+      comboBox.focus();
+      comboBox.setAttribute('focus-ring', '');
+      comboBox.open();
+      await sendMouseToElement({ type: 'click', element: document.body });
+      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should keep focus-ring attribute after closing with Escape', () => {
+      comboBox.focus();
+      comboBox.setAttribute('focus-ring', '');
+      comboBox.open();
+      escKeyDown(input);
+      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should keep the input focused when closing on Enter', async () => {
+      input.focus();
+      comboBox.open();
+      await nextRender();
+      await sendKeys({ type: 'foo' });
+      await sendKeys({ press: 'Enter' });
+
+      expect(comboBox.opened).to.be.false;
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('should not remove the focused attribute when focusing the scroll bar', () => {
+      comboBox.focus();
+      comboBox.open();
+      focusout(input, overlay);
+      expect(comboBox.hasAttribute('focused')).to.be.true;
+    });
+  });
+
+  describe('close on focus loss', () => {
+    beforeEach(() => {
+      comboBox.open();
+    });
+
+    it('should close when focus is lost from keyboard', () => {
+      tabKeyDown(input);
+      focusout(input);
+
+      expect(comboBox.opened).to.be.false;
+    });
+
+    it('should not close when focus is moved to item', () => {
+      const item = getFirstItem(comboBox);
+      focusout(input, item);
+
+      expect(comboBox.opened).to.be.true;
+    });
+
+    it('should not close when focus is moved to overlay', () => {
+      focusout(input, overlay);
+
+      expect(comboBox.opened).to.be.true;
+    });
+  });
+
+  describe('overlay touch', () => {
+    it('should not blur the input on overlay touchstart', () => {
+      comboBox.focus();
+      comboBox.open();
+
+      const spy = sinon.spy(input, 'blur');
+      overlay.dispatchEvent(new CustomEvent('touchstart'));
+      expect(spy).to.be.not.called;
+    });
+
+    it('should blur the input on overlay touchend', () => {
+      comboBox.focus();
+      comboBox.open();
+
+      const spy = sinon.spy(input, 'blur');
+      overlay.dispatchEvent(new CustomEvent('touchend'));
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should blur the input on overlay touchmove', () => {
+      comboBox.focus();
+      comboBox.open();
+
+      const spy = sinon.spy(input, 'blur');
+      overlay.dispatchEvent(new CustomEvent('touchmove'));
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should prevent default on overlay mousedown', () => {
+      const event = fire(overlay, 'mousedown');
+      expect(event.defaultPrevented).to.be.true;
+    });
+  });
+
+  describe('virtual keyboard', () => {
+    it('should disable virtual keyboard on close', () => {
+      comboBox.open();
+      comboBox.close();
+      expect(input.inputMode).to.equal('none');
+    });
+
+    it('should re-enable virtual keyboard on touchstart', () => {
+      comboBox.open();
+      comboBox.close();
+      touchstart(comboBox);
+      expect(input.inputMode).to.equal('');
+    });
+
+    it('should re-enable virtual keyboard on blur', async () => {
+      comboBox.focus();
+      comboBox.open();
+      comboBox.close();
+      await aTimeout(0);
+      await sendKeys({ press: 'Tab' });
+      expect(input.inputMode).to.equal('');
+    });
+  });
+
+  describe('iOS', () => {
+    beforeEach(() => {
+      // Mimic iOS so that the real blur-on-close condition is used
+      comboBox._ios = true;
+    });
+
+    afterEach(async () => {
+      await resetMouse();
+    });
+
+    it('should blur the input when closing on outside click', async () => {
+      input.focus();
+      comboBox.open();
+      await nextRender();
+
+      // The outside click alone does not blur: the overlay prevents the mousedown
+      // to keep the input focused (see the `_mouseDownListener` override)
+      await sendMouseToElement({ type: 'click', element: document.body });
+      expect(document.activeElement).to.not.equal(input);
+    });
+
+    it('should commit a typed value before the input is blurred', async () => {
+      let focusedOnChange;
+      comboBox.addEventListener('change', () => {
+        focusedOnChange = document.activeElement === input;
+      });
+
+      input.focus();
+      comboBox.open();
+      await nextRender();
+      setInputValue(comboBox, 'foo');
+
+      await sendMouseToElement({ type: 'click', element: document.body });
+      expect(comboBox.value).to.equal('foo');
+      // Wrappers reacting to focusout, such as Grid Pro editors, must see the
+      // committed value, so the commit has to happen before the input is blurred
+      expect(focusedOnChange).to.be.true;
+      expect(document.activeElement).to.not.equal(input);
+    });
+
+    it('should not blur the input when it lost focus before the close', async () => {
+      const blurSpy = sinon.spy(input, 'blur');
+
+      input.focus();
+      comboBox.open();
+      await nextRender();
+
+      // Mimic the overlay touch action blurring the input before the close
+      comboBox._onOverlayTouchAction();
+      blurSpy.resetHistory();
+
+      await sendMouseToElement({ type: 'click', element: document.body });
+      expect(blurSpy).to.be.not.called;
+    });
+
+    it('should not blur the input when closing on toggle button click', async () => {
+      input.focus();
+      comboBox.open();
+      await nextRender();
+
+      // Blurring would end editing in wrappers such as Grid Pro, where the
+      // toggle button is a part of the editor
+      await sendMouseToElement({ type: 'click', element: comboBox._toggleElement });
+      expect(comboBox.opened).to.be.false;
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('should not set the pending autoselect state when blurring', async () => {
+      comboBox.autoselect = true;
+      input.focus();
+      comboBox.open();
+      await nextRender();
+
+      await sendMouseToElement({ type: 'click', element: document.body });
+      // Autoselect is triggered by the next focus event instead
+      expect(comboBox.__autoselectPending).to.not.be.true;
+    });
+
+    it('should not commit the value on close while loading', async () => {
+      comboBox.loading = true;
+      input.focus();
+      comboBox.open();
+      await nextRender();
+      setInputValue(comboBox, 'foo');
+
+      await sendMouseToElement({ type: 'click', element: document.body });
+      expect(comboBox.value).to.equal('');
+    });
+  });
+});

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -1,19 +1,14 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { sendMouseToElement } from '@vaadin/test-runner-commands';
 import {
-  aTimeout,
   click,
-  escKeyDown,
-  fire,
   fixtureSync,
   focusout,
   nextRender,
   nextUpdate,
   oneEvent,
   outsideClick,
-  tabKeyDown,
   tap,
-  touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-combo-box.js';
@@ -65,26 +60,6 @@ describe('interactions', () => {
       tap(comboBox._toggleElement);
 
       expect(comboBox.opened).to.be.false;
-    });
-
-    it('should close when focus is lost from keyboard', () => {
-      tabKeyDown(input);
-      focusout(input);
-
-      expect(comboBox.opened).to.be.false;
-    });
-
-    it('should not close when focus is moved to item', () => {
-      const item = getFirstItem(comboBox);
-      focusout(input, item);
-
-      expect(comboBox.opened).to.be.true;
-    });
-
-    it('should not close when focus is moved to overlay', () => {
-      focusout(input, overlay);
-
-      expect(comboBox.opened).to.be.true;
     });
 
     it('should close the overlay on entering non-existent value', () => {
@@ -159,52 +134,12 @@ describe('interactions', () => {
       expect(comboBox.hasAttribute('focused')).to.be.true;
     });
 
-    it('should blur the input with the blur method', () => {
-      comboBox.focus();
-      comboBox.blur();
-
-      expect(comboBox.hasAttribute('focused')).to.be.false;
-      expect(document.activeElement).to.not.equal(input);
-    });
-
     it('should focus the input on required indicator click', () => {
       comboBox.required = true;
       comboBox.shadowRoot.querySelector('[part="required-indicator"]').click();
 
       expect(comboBox.hasAttribute('focused')).to.be.true;
       expect(document.activeElement).to.equal(input);
-    });
-
-    it('should not blur the input on overlay touchstart', () => {
-      comboBox.focus();
-      comboBox.open();
-
-      const spy = sinon.spy(input, 'blur');
-      overlay.dispatchEvent(new CustomEvent('touchstart'));
-      expect(spy.callCount).to.eql(0);
-    });
-
-    it('should blur the input on overlay touchend', () => {
-      comboBox.focus();
-      comboBox.open();
-
-      const spy = sinon.spy(input, 'blur');
-      overlay.dispatchEvent(new CustomEvent('touchend'));
-      expect(spy.callCount).to.eql(1);
-    });
-
-    it('should blur the input on overlay touchmove', () => {
-      comboBox.focus();
-      comboBox.open();
-
-      const spy = sinon.spy(input, 'blur');
-      overlay.dispatchEvent(new CustomEvent('touchmove'));
-      expect(spy.callCount).to.eql(1);
-    });
-
-    it('should prevent default on overlay mousedown', () => {
-      const event = fire(overlay, 'mousedown');
-      expect(event.defaultPrevented).to.be.true;
     });
 
     // NOTE: WebKit incorrectly detects touch environment
@@ -230,73 +165,6 @@ describe('interactions', () => {
       tap(comboBox._toggleElement);
 
       expect(spy).to.be.not.called;
-    });
-
-    it('should not remove the focused attribute when focusing the scroll bar', () => {
-      comboBox.focus();
-      comboBox.open();
-      focusout(input, overlay);
-      expect(comboBox.hasAttribute('focused')).to.be.true;
-    });
-
-    it('should keep focus-ring attribute after closing with Escape', () => {
-      comboBox.focus();
-      comboBox.setAttribute('focus-ring', '');
-      comboBox.open();
-      escKeyDown(input);
-      expect(comboBox.hasAttribute('focus-ring')).to.be.true;
-    });
-
-    describe('close on click', () => {
-      afterEach(async () => {
-        await resetMouse();
-      });
-
-      it('should restore focus to the input on outside click', async () => {
-        comboBox.focus();
-        comboBox.open();
-        await sendMouseToElement({ type: 'click', element: document.body });
-        expect(document.activeElement).to.equal(input);
-      });
-
-      it('should keep focus in the input on toggle button click', async () => {
-        comboBox.focus();
-        comboBox.open();
-        await sendMouseToElement({ type: 'click', element: comboBox._toggleElement });
-        expect(document.activeElement).to.equal(input);
-      });
-
-      it('should keep focus-ring attribute after closing with outside click', async () => {
-        comboBox.focus();
-        comboBox.setAttribute('focus-ring', '');
-        comboBox.open();
-        await sendMouseToElement({ type: 'click', element: document.body });
-        expect(comboBox.hasAttribute('focus-ring')).to.be.true;
-      });
-    });
-  });
-
-  describe('virtual keyboard', () => {
-    it('should disable virtual keyboard on close', () => {
-      comboBox.open();
-      comboBox.close();
-      expect(input.inputMode).to.equal('none');
-    });
-
-    it('should re-enable virtual keyboard on touchstart', () => {
-      comboBox.open();
-      comboBox.close();
-      touchstart(comboBox);
-      expect(input.inputMode).to.equal('');
-    });
-
-    it('should re-enable virtual keyboard on blur', async () => {
-      comboBox.focus();
-      comboBox.open();
-      comboBox.close();
-      await aTimeout(0);
-      await sendKeys({ press: 'Tab' });
-      expect(input.inputMode).to.equal('');
     });
   });
 

--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -574,9 +574,10 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      * @protected
      */
     _setFocused(focused) {
-      // Do not validate, commit or close on internal blur triggered
-      // on overlay touch action needed to hide the virtual keyboard.
-      const blurred = !focused && !this._closeOnBlurIsPrevented;
+      // An internal blur, triggered by the component itself to hide the virtual keyboard,
+      // does not mean the user left the field, so it must not affect the value or close.
+      const internalBlur = !focused && this._closeOnBlurIsPrevented;
+      const blurred = !focused && !internalBlur;
 
       if (blurred) {
         this._ignoreCommitValue = true;
@@ -584,9 +585,11 @@ export const MultiSelectComboBoxMixin = (superClass) =>
 
       super._setFocused(focused);
 
-      // Do not validate when focusout is caused by document
-      // losing focus, which happens on browser tab switch.
-      if (blurred && document.hasFocus()) {
+      // The input is focused again after an internal blur that keeps the overlay open,
+      // so validation waits for the focusout that follows when the user leaves.
+      // Also do not validate when focusout is caused by document losing focus,
+      // which happens on browser tab switch.
+      if (!focused && !(internalBlur && this.opened) && document.hasFocus()) {
         this._focusedChipIndex = -1;
         this._requestValidation();
       }

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { sendKeys } from '@vaadin/test-runner-commands';
+import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, outsideClick, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
@@ -91,6 +91,10 @@ describe('validation', () => {
     });
 
     describe('opened', () => {
+      afterEach(async () => {
+        await resetMouse();
+      });
+
       it('should not validate on overlay touch action causing internal blur', () => {
         comboBox.inputElement.focus();
         comboBox.open();
@@ -98,6 +102,19 @@ describe('validation', () => {
         touchend(comboBox.$.overlay);
 
         expect(validateSpy).to.be.not.called;
+      });
+
+      it('should validate on internal blur caused by closing on outside click', async () => {
+        // Mimic iOS, where the input is blurred once the overlay is closed
+        comboBox._ios = true;
+        comboBox.inputElement.focus();
+        comboBox.open();
+        await nextRender();
+
+        await sendMouseToElement({ type: 'click', element: document.body });
+
+        // The input is no longer focused, so no other focusout follows
+        expect(validateSpy).to.be.calledOnce;
       });
     });
 

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -367,7 +367,9 @@ export const TimePickerMixin = (superClass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      if (!focused && !this._closeOnBlurIsPrevented) {
+      // The input is focused again after an internal blur that keeps the overlay open,
+      // so validation waits for the focusout that follows when the user leaves.
+      if (!focused && !(this._closeOnBlurIsPrevented && this.opened)) {
         // Do not validate when focusout is caused by document
         // losing focus, which happens on browser tab switch.
         if (document.hasFocus()) {

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { enter, fixtureSync, nextFrame, nextRender, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-time-picker.js';
@@ -132,6 +133,10 @@ describe('validation', () => {
     });
 
     describe('opened', () => {
+      afterEach(async () => {
+        await resetMouse();
+      });
+
       it('should not validate on overlay touch action causing internal blur', () => {
         timePicker.inputElement.focus();
         timePicker.open();
@@ -140,6 +145,19 @@ describe('validation', () => {
 
         expect(validateSpy).to.be.not.called;
         expect(timePicker.invalid).to.be.false;
+      });
+
+      it('should validate on internal blur caused by closing on outside click', async () => {
+        // Mimic iOS, where the input is blurred once the overlay is closed
+        timePicker._ios = true;
+        timePicker.inputElement.focus();
+        timePicker.open();
+        await nextRender();
+
+        await sendMouseToElement({ type: 'click', element: document.body });
+
+        // The input is no longer focused, so no other focusout follows
+        expect(validateSpy).to.be.calledOnce;
       });
     });
 


### PR DESCRIPTION
## Description

Fixes #12037

On iOS, the combo-box input keeps focus when the overlay is closed on an outside tap. This was done on purpose in #7846, so that no `focusout` is fired before the value is committed. The side effect is that re-tapping the input fires no focus event, and iOS only scrolls a field into the visual viewport when it receives one. The input then stays where it was while the on-screen keyboard covers it.

## How to test

1. On iOS, open a page with a combo-box near the bottom, e.g. `dev/combo-box.html` with `<div style="height: 200vh"></div>` before the field.
2. Scroll down and tap the input. The keyboard opens and the input is visible above it.
3. Tap the page background to close the overlay.
4. Tap the input again — it stays hidden behind the keyboard.

## Changes

The input is blurred after the overlay closes, so that the next tap is a fresh focus event that iOS scrolls into view on its own. The blur runs after `_onClosed()`, so wrappers that react to `focusout`, such as Grid Pro editors, still read the committed value (#7796). Because the same value would otherwise be committed twice, the blur suppresses the `focusout` logic, reusing the existing `_closeOnBlurIsPrevented` flag that `_onOverlayTouchAction` already uses.

The blur only undoes a focus retention that the overlay performed itself: `_mouseDownListener()` marks the outside click where it suppresses the blur, and only then is the input blurred once closed. Closing in any other way keeps the input focused — on <kbd>Enter</kbd> or <kbd>Escape</kbd> to continue typing or <kbd>Tab</kbd> onwards, and on a toggle button click to not interrupt editing in wrappers such as Grid Pro, where the toggle button is a part of the editor.

`multi-select-combo-box` and `time-picker` validate on blur, and `multi-select-combo-box` also marks the value to be ignored, in their own `_setFocused()` overrides. These now check `_closeOnBlurIsPrevented` as well, so that a blur the component causes itself neither validates nor drops the next committed value.

### Behavior per scenario, on iOS

| Scenario | Before | After |
| --- | --- | --- |
| Close on outside tap | Input keeps focus, stays behind the keyboard on the next tap | Input is blurred, the next tap scrolls it into view |
| Close on toggle button tap | Input keeps focus | Unchanged |
| Close by tapping an item | Input is already blurred on `touchend` | Unchanged |
| Close on <kbd>return</kbd> on the on-screen keyboard | Input keeps focus, keyboard stays open | Unchanged |
| Close on <kbd>Enter</kbd> on a hardware keyboard | Input keeps focus | Unchanged |
| Close on <kbd>Escape</kbd> | Input keeps focus | Unchanged |
| Close on <kbd>Tab</kbd> | Input has already lost focus | Unchanged |
| Any close on desktop and Android | Input keeps focus | Unchanged |

Closing on <kbd>return</kbd> needs no blur: `_onEnter()` calls `preventDefault()` while the overlay is open, so no form is submitted and the keyboard stays open. The visible area does not change, so the input remains where iOS put it.

The blur and focus retention tests are moved from `interactions.test.js` into a single `blur.test.js` suite.

> [!NOTE]
> On iOS, closing the overlay on an outside tap now fires a real `focusout`. Listeners for focus and blur run at that point instead of staying silent until the user leaves the field.
>
> On all touch devices, `multi-select-combo-box` and `time-picker` no longer validate when the input is blurred to hide the keyboard on a touch inside the overlay.

Alternative to #12324, which corrects the scroll position from the component instead of letting iOS do it. Only one of the two is needed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
