### PR TITLE
fix: do not validate or commit on internal blur from overlay touch

### DIFF
--- a/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
+++ b/packages/multi-select-combo-box/src/vaadin-multi-select-combo-box-mixin.js
@@ -574,7 +574,11 @@ export const MultiSelectComboBoxMixin = (superClass) =>
      * @protected
      */
     _setFocused(focused) {
-      if (!focused) {
+      // Do not validate, commit or close on internal blur triggered
+      // on overlay touch action needed to hide the virtual keyboard.
+      const blurred = !focused && !this._closeOnBlurIsPrevented;
+
+      if (blurred) {
         this._ignoreCommitValue = true;
       }
 
@@ -582,12 +586,12 @@ export const MultiSelectComboBoxMixin = (superClass) =>
 
       // Do not validate when focusout is caused by document
       // losing focus, which happens on browser tab switch.
-      if (!focused && document.hasFocus()) {
+      if (blurred && document.hasFocus()) {
         this._focusedChipIndex = -1;
         this._requestValidation();
       }
 
-      if (!focused && this.readonly && !this._closeOnBlurIsPrevented) {
+      if (blurred && this.readonly) {
         this.close();
       }
     }

--- a/packages/multi-select-combo-box/test/selecting-items.test.js
+++ b/packages/multi-select-combo-box/test/selecting-items.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendKeys, sendMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
-import { fixtureSync, keyboardEventFor, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, keyboardEventFor, nextRender, oneEvent, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
 import { getAllItems, getDataProvider, getFirstItem } from './helpers.js';
@@ -67,6 +67,17 @@ describe('selecting items', () => {
       await sendKeys({ type: 'orange' });
       await sendKeys({ down: 'Enter' });
       expect(comboBox.selectedItems).to.deep.equal(['orange']);
+    });
+
+    it('should select item on Enter after internal blur on overlay touch action', async () => {
+      comboBox.open();
+      touchend(comboBox.$.overlay);
+
+      inputElement.focus();
+      await sendKeys({ type: 'apple' });
+      await sendKeys({ press: 'Enter' });
+
+      expect(comboBox.selectedItems).to.deep.equal(['apple']);
     });
 
     it('should update has-value attribute on selected items change', () => {

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { sendKeys } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender, outsideClick, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-multi-select-combo-box.js';
 
@@ -111,6 +111,30 @@ describe('validation', () => {
       comboBox.selectedItems = ['apple'];
       expect(comboBox.checkValidity()).to.be.true;
     });
+  });
+
+  describe('blur', () => {
+    let validateSpy;
+
+    beforeEach(async () => {
+      comboBox = fixtureSync(`<vaadin-multi-select-combo-box required></vaadin-multi-select-combo-box>`);
+      comboBox.items = ['apple', 'banana'];
+      await nextRender();
+
+      validateSpy = sinon.spy(comboBox, 'validate');
+      comboBox.inputElement.focus();
+    });
+
+    describe('opened', () => {
+      it('should not validate on overlay touch action causing internal blur', () => {
+        comboBox.open();
+
+        touchend(comboBox.$.overlay);
+
+        expect(validateSpy).to.be.not.called;
+        expect(comboBox.invalid).to.be.false;
+      });
+    });
 
     describe('document losing focus', () => {
       beforeEach(() => {
@@ -122,10 +146,9 @@ describe('validation', () => {
       });
 
       it('should not validate on blur when document does not have focus', () => {
-        const spy = sinon.spy(comboBox, 'validate');
-        comboBox.inputElement.focus();
         comboBox.inputElement.blur();
-        expect(spy.called).to.be.false;
+        expect(validateSpy).to.be.not.called;
+        expect(comboBox.invalid).to.be.false;
       });
     });
   });

--- a/packages/multi-select-combo-box/test/validation.test.js
+++ b/packages/multi-select-combo-box/test/validation.test.js
@@ -89,6 +89,33 @@ describe('validation', () => {
       comboBox.required = false;
       expect(validateSpy.called).to.be.false;
     });
+
+    describe('opened', () => {
+      it('should not validate on overlay touch action causing internal blur', () => {
+        comboBox.inputElement.focus();
+        comboBox.open();
+
+        touchend(comboBox.$.overlay);
+
+        expect(validateSpy).to.be.not.called;
+      });
+    });
+
+    describe('document losing focus', () => {
+      beforeEach(() => {
+        sinon.stub(document, 'hasFocus').returns(false);
+      });
+
+      afterEach(() => {
+        document.hasFocus.restore();
+      });
+
+      it('should not validate on blur when document does not have focus', () => {
+        comboBox.inputElement.focus();
+        comboBox.inputElement.blur();
+        expect(validateSpy).to.be.not.called;
+      });
+    });
   });
 
   describe('required', () => {
@@ -110,46 +137,6 @@ describe('validation', () => {
     it('should pass validation when selectedItems is not empty', () => {
       comboBox.selectedItems = ['apple'];
       expect(comboBox.checkValidity()).to.be.true;
-    });
-  });
-
-  describe('blur', () => {
-    let validateSpy;
-
-    beforeEach(async () => {
-      comboBox = fixtureSync(`<vaadin-multi-select-combo-box required></vaadin-multi-select-combo-box>`);
-      comboBox.items = ['apple', 'banana'];
-      await nextRender();
-
-      validateSpy = sinon.spy(comboBox, 'validate');
-      comboBox.inputElement.focus();
-    });
-
-    describe('opened', () => {
-      it('should not validate on overlay touch action causing internal blur', () => {
-        comboBox.open();
-
-        touchend(comboBox.$.overlay);
-
-        expect(validateSpy).to.be.not.called;
-        expect(comboBox.invalid).to.be.false;
-      });
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        comboBox.inputElement.blur();
-        expect(validateSpy).to.be.not.called;
-        expect(comboBox.invalid).to.be.false;
-      });
     });
   });
 });

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -367,7 +367,7 @@ export const TimePickerMixin = (superClass) =>
     _setFocused(focused) {
       super._setFocused(focused);
 
-      if (!focused) {
+      if (!focused && !this._closeOnBlurIsPrevented) {
         // Do not validate when focusout is caused by document
         // losing focus, which happens on browser tab switch.
         if (document.hasFocus()) {

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { enter, fixtureSync, nextFrame, nextRender } from '@vaadin/testing-helpers';
+import { enter, fixtureSync, nextFrame, nextRender, touchend } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-time-picker.js';
 import { setInputValue } from './helpers.js';
@@ -263,6 +263,45 @@ describe('validation', () => {
       timePicker.value = '20:00';
       expect(timePicker.validate()).to.equal(true);
       expect(timePicker.invalid).to.equal(false);
+    });
+  });
+
+  describe('blur', () => {
+    let validateSpy;
+
+    beforeEach(async () => {
+      timePicker = fixtureSync(`<vaadin-time-picker required></vaadin-time-picker>`);
+      await nextRender();
+
+      validateSpy = sinon.spy(timePicker, 'validate');
+      timePicker.inputElement.focus();
+    });
+
+    describe('opened', () => {
+      it('should not validate on overlay touch action causing internal blur', () => {
+        timePicker.open();
+
+        touchend(timePicker.$.overlay);
+
+        expect(validateSpy).to.be.not.called;
+        expect(timePicker.invalid).to.be.false;
+      });
+    });
+
+    describe('document losing focus', () => {
+      beforeEach(() => {
+        sinon.stub(document, 'hasFocus').returns(false);
+      });
+
+      afterEach(() => {
+        document.hasFocus.restore();
+      });
+
+      it('should not validate on blur when document does not have focus', () => {
+        timePicker.inputElement.blur();
+        expect(validateSpy).to.be.not.called;
+        expect(timePicker.invalid).to.be.false;
+      });
     });
   });
 

--- a/packages/time-picker/test/validation.test.js
+++ b/packages/time-picker/test/validation.test.js
@@ -130,6 +130,35 @@ describe('validation', () => {
       const event = validatedSpy.firstCall.args[0];
       expect(event.detail.valid).to.be.false;
     });
+
+    describe('opened', () => {
+      it('should not validate on overlay touch action causing internal blur', () => {
+        timePicker.inputElement.focus();
+        timePicker.open();
+
+        touchend(timePicker.$.overlay);
+
+        expect(validateSpy).to.be.not.called;
+        expect(timePicker.invalid).to.be.false;
+      });
+    });
+
+    describe('document losing focus', () => {
+      beforeEach(() => {
+        sinon.stub(document, 'hasFocus').returns(false);
+      });
+
+      afterEach(() => {
+        document.hasFocus.restore();
+      });
+
+      it('should not validate on blur when document does not have focus', () => {
+        timePicker.inputElement.focus();
+        timePicker.inputElement.blur();
+        expect(validateSpy).to.be.not.called;
+        expect(timePicker.invalid).to.be.false;
+      });
+    });
   });
 
   describe('input value', () => {
@@ -263,45 +292,6 @@ describe('validation', () => {
       timePicker.value = '20:00';
       expect(timePicker.validate()).to.equal(true);
       expect(timePicker.invalid).to.equal(false);
-    });
-  });
-
-  describe('blur', () => {
-    let validateSpy;
-
-    beforeEach(async () => {
-      timePicker = fixtureSync(`<vaadin-time-picker required></vaadin-time-picker>`);
-      await nextRender();
-
-      validateSpy = sinon.spy(timePicker, 'validate');
-      timePicker.inputElement.focus();
-    });
-
-    describe('opened', () => {
-      it('should not validate on overlay touch action causing internal blur', () => {
-        timePicker.open();
-
-        touchend(timePicker.$.overlay);
-
-        expect(validateSpy).to.be.not.called;
-        expect(timePicker.invalid).to.be.false;
-      });
-    });
-
-    describe('document losing focus', () => {
-      beforeEach(() => {
-        sinon.stub(document, 'hasFocus').returns(false);
-      });
-
-      afterEach(() => {
-        document.hasFocus.restore();
-      });
-
-      it('should not validate on blur when document does not have focus', () => {
-        timePicker.inputElement.blur();
-        expect(validateSpy).to.be.not.called;
-        expect(timePicker.invalid).to.be.false;
-      });
     });
   });
 


### PR DESCRIPTION
## Description

On a touch device, a touch inside the overlay blurs the input to hide the virtual keyboard. Since the user has not left the field, `_onOverlayTouchAction()` sets `_closeOnBlurIsPrevented` around that blur, so that the `focusout` is not treated as the user leaving.

`multi-select-combo-box` and `time-picker` validate on blur in their own `_setFocused()` overrides, and `multi-select-combo-box` also marks the value to be ignored there. Neither checks the flag, so both run on a blur that the component caused itself.

As a result, on a touch device:

- A required empty field is shown as invalid after merely opening the overlay and scrolling the list.
- In `multi-select-combo-box`, `_ignoreCommitValue` is left `true`, so the next value the user commits is dropped.

## How to test

On a touch device, or with touch emulation:

1. Focus a required, empty `vaadin-multi-select-combo-box` and open the overlay.
2. Scroll the list by touch — the field is shown as invalid.
3. Type `apple` and press <kbd>Enter</kbd> — nothing is selected.

Same first two steps for a required, empty `vaadin-time-picker`.

## Changes

Both overrides now check `_closeOnBlurIsPrevented`, so the flag covers every side effect of a blur, not only the ones in `ComboBoxBaseMixin`.

### What the flag guards

| Blur side effect | Before | After |
| --- | --- | --- |
| `ComboBoxBaseMixin._setFocused()` → `_handleFocusOut()`, which commits the value and closes | Skipped | Unchanged |
| `MultiSelectComboBoxMixin._setFocused()` → `close()` when readonly | Skipped | Unchanged |
| `MultiSelectComboBoxMixin._setFocused()` → `_ignoreCommitValue = true` | Runs | Skipped |
| `MultiSelectComboBoxMixin._setFocused()` → `_requestValidation()` | Runs | Skipped |
| `TimePickerMixin._setFocused()` → `_requestValidation()` | Runs | Skipped |

The `focused` attribute still follows the blur in all cases, so the field stops looking focused while the virtual keyboard is hidden.

Related to #12329, which adds a second reason for the component to blur the input itself and needs the same guards. The bug is reproducible without it, so it is fixed separately here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
