### PR TITLE
fix: keep virtual keyboard open when input keeps focus on overlay close

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -169,7 +169,9 @@ export const ComboBoxBaseMixin = (superClass) =>
         this.clearElement.addEventListener('mousedown', this._boundOnClearButtonMouseDown);
       }
 
-      this.addController(new VirtualKeyboardController(this));
+      // Keep the keyboard open when the input keeps focus on close (e.g. on Enter or
+      // toggle button click), so that a focused input never has a hidden keyboard.
+      this.addController(new VirtualKeyboardController(this, true));
     }
 
     /** @protected */

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -277,14 +277,23 @@ describe('interactions', () => {
   });
 
   describe('virtual keyboard', () => {
-    it('should disable virtual keyboard on close', () => {
+    it('should disable virtual keyboard on close when input is not focused', () => {
       comboBox.open();
+      input.blur();
       comboBox.close();
       expect(input.inputMode).to.equal('none');
     });
 
+    it('should keep virtual keyboard enabled on close when input is focused', () => {
+      input.focus();
+      comboBox.open();
+      comboBox.close();
+      expect(input.inputMode).to.equal('');
+    });
+
     it('should re-enable virtual keyboard on touchstart', () => {
       comboBox.open();
+      input.blur();
       comboBox.close();
       touchstart(comboBox);
       expect(input.inputMode).to.equal('');

--- a/packages/field-base/src/virtual-keyboard-controller.d.ts
+++ b/packages/field-base/src/virtual-keyboard-controller.d.ts
@@ -10,7 +10,7 @@ import type { ReactiveController } from 'lit';
  * when the field's overlay is closed.
  */
 export class VirtualKeyboardController implements ReactiveController {
-  constructor(host: HTMLElement & { inputElement?: HTMLElement; opened: boolean });
+  constructor(host: HTMLElement & { inputElement?: HTMLElement; opened: boolean }, keepWhenFocused?: boolean);
 
   /**
    * Phantom optional method to satisfy the `ReactiveController` interface

--- a/packages/field-base/src/virtual-keyboard-controller.js
+++ b/packages/field-base/src/virtual-keyboard-controller.js
@@ -3,6 +3,7 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
+import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 /**
  * A controller which prevents the virtual keyboard from showing up on mobile devices
@@ -11,12 +12,20 @@
 export class VirtualKeyboardController {
   /**
    * @param {{ inputElement?: HTMLElement; opened: boolean } & HTMLElement} host
+   * @param {boolean} keepWhenFocused
    */
-  constructor(host) {
+  constructor(host, keepWhenFocused = false) {
     this.host = host;
 
     host.addEventListener('opened-changed', () => {
       if (!host.opened) {
+        // When the input has kept focus on close, the user was typing and the keyboard
+        // is genuinely open, so it stays open instead of leaving a focused input with
+        // a hidden keyboard. Only used by hosts that do not focus the input on close.
+        if (keepWhenFocused && host.inputElement && isElementFocused(host.inputElement)) {
+          return;
+        }
+
         // Prevent opening the virtual keyboard when the input gets re-focused on dropdown close
         this.#setVirtualKeyboardEnabled(false);
       }

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -5,63 +5,105 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { VirtualKeyboardController } from '../src/virtual-keyboard-controller.js';
 
 describe('VirtualKeyboardController', () => {
-  const tag = defineLit(
-    'virtual-keyboard-controller',
-    `<slot></slot>`,
-    (Base) =>
-      class extends PolylitMixin(Base) {
-        constructor() {
-          super();
-          this.inputElement = document.createElement('input');
-          this.appendChild(this.inputElement);
-        }
+  const defineHost = (name, options) =>
+    defineLit(
+      name,
+      `<slot></slot>`,
+      (Base) =>
+        class extends PolylitMixin(Base) {
+          constructor() {
+            super();
+            this.inputElement = document.createElement('input');
+            this.appendChild(this.inputElement);
+          }
 
-        ready() {
-          super.ready();
-          this.addController(new VirtualKeyboardController(this));
-        }
+          ready() {
+            super.ready();
+            this.addController(new VirtualKeyboardController(this, options));
+          }
 
-        open() {
-          this.dispatchEvent(new CustomEvent('opened-changed', { detail: { value: true } }));
-        }
+          open() {
+            this.dispatchEvent(new CustomEvent('opened-changed', { detail: { value: true } }));
+          }
 
-        close() {
-          this.dispatchEvent(new CustomEvent('opened-changed', { detail: { value: false } }));
-        }
-      },
-  );
+          close() {
+            this.dispatchEvent(new CustomEvent('opened-changed', { detail: { value: false } }));
+          }
+        },
+    );
 
   let element, input;
 
-  beforeEach(() => {
-    element = fixtureSync(`
-      <div>
-        <${tag}></${tag}>
-        <input id="last-global-focusable" />
-      </div>
-    `).firstElementChild;
-    input = element.inputElement;
+  describe('default', () => {
+    const tag = defineHost('virtual-keyboard-controller');
+
+    beforeEach(() => {
+      element = fixtureSync(`
+        <div>
+          <${tag}></${tag}>
+          <input id="last-global-focusable" />
+        </div>
+      `).firstElementChild;
+      input = element.inputElement;
+    });
+
+    it('should disable virtual keyboard on close', () => {
+      element.open();
+      element.close();
+      expect(input.inputMode).to.equal('none');
+    });
+
+    it('should re-enable virtual keyboard on touchstart', () => {
+      element.open();
+      element.close();
+      touchstart(element);
+      expect(input.inputMode).to.equal('');
+    });
+
+    it('should re-enable virtual keyboard on blur', async () => {
+      element.open();
+      element.close();
+      element.tabIndex = 1;
+      element.focus();
+      await sendKeys({ press: 'Tab' });
+      expect(input.inputMode).to.equal('');
+    });
+
+    it('should disable virtual keyboard on close when input is focused', () => {
+      input.focus();
+      element.open();
+      element.close();
+      expect(input.inputMode).to.equal('none');
+    });
   });
 
-  it('should disable virtual keyboard on close', () => {
-    element.open();
-    element.close();
-    expect(input.inputMode).to.equal('none');
-  });
+  describe('keepWhenFocused', () => {
+    const keepTag = defineHost('virtual-keyboard-controller-keep', true);
 
-  it('should re-enable virtual keyboard on touchstart', () => {
-    element.open();
-    element.close();
-    touchstart(element);
-    expect(input.inputMode).to.equal('');
-  });
+    beforeEach(() => {
+      element = fixtureSync(`<${keepTag}></${keepTag}>`);
+      input = element.inputElement;
+    });
 
-  it('should re-enable virtual keyboard on blur', async () => {
-    element.open();
-    element.close();
-    element.tabIndex = 1;
-    element.focus();
-    await sendKeys({ press: 'Tab' });
-    expect(input.inputMode).to.equal('');
+    it('should not disable virtual keyboard on close when input is focused', () => {
+      input.focus();
+      element.open();
+      element.close();
+      expect(input.inputMode).to.equal('');
+    });
+
+    it('should disable virtual keyboard on close when input is not focused', () => {
+      element.open();
+      element.close();
+      expect(input.inputMode).to.equal('none');
+    });
+
+    it('should disable virtual keyboard on close after input has lost focus', () => {
+      input.focus();
+      element.open();
+      input.blur();
+      element.close();
+      expect(input.inputMode).to.equal('none');
+    });
   });
 });

--- a/packages/field-base/test/virtual-keyboard-controller.test.js
+++ b/packages/field-base/test/virtual-keyboard-controller.test.js
@@ -5,7 +5,7 @@ import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
 import { VirtualKeyboardController } from '../src/virtual-keyboard-controller.js';
 
 describe('VirtualKeyboardController', () => {
-  const defineHost = (name, options) =>
+  const defineHost = (name, keepWhenFocused) =>
     defineLit(
       name,
       `<slot></slot>`,
@@ -19,7 +19,7 @@ describe('VirtualKeyboardController', () => {
 
           ready() {
             super.ready();
-            this.addController(new VirtualKeyboardController(this, options));
+            this.addController(new VirtualKeyboardController(this, keepWhenFocused));
           }
 
           open() {


### PR DESCRIPTION
## Description

Fixes #12037
Fixes #12036

On iOS, the on-screen keyboard is hidden when the combo-box overlay closes while the input keeps focus — on an outside tap, a toggle button tap, or <kbd>return</kbd> on the on-screen keyboard. `VirtualKeyboardController` sets `inputMode="none"` on every close, so the field ends up focused with a hidden keyboard. Tapping such an input again fires no focus event, and iOS scrolls a field into the visual viewport only on a focus event. The input then stays where it was, and the keyboard opens on top of it.

## How to test

1. On iOS, open a page with a combo-box near the bottom, e.g. `dev/combo-box.html` with `<div style="height: 200vh"></div>` before the field.
2. Scroll down and tap the input. The keyboard opens and the input is visible above it.
3. Tap the page background to close the overlay.
4. Tap the input again — it stays hidden behind the keyboard.

## Changes

`VirtualKeyboardController` gets a `keepWhenFocused` option: the keyboard is only disabled on close when the input is not focused. A focused input then always has a visible keyboard, so no close action can produce the state where the next tap needs a scroll that never happens.

The option is enabled for combo-box (whose base mixin is also used by multi-select-combo-box and time-picker) and not for date-picker: date-picker focuses the input before closing on date selection, and relies on the disable to keep the keyboard hidden after picking a date.

### Behavior per close action, on touch devices

| Close action | Before | After |
| --- | --- | --- |
| Outside tap | Keyboard hides, input keeps focus; the next tap opens the keyboard over the input | Keyboard stays open, input stays visible above it |
| Toggle button tap | Keyboard hides, input keeps focus; same problem on the next tap | Keyboard stays open |
| <kbd>return</kbd> on the on-screen keyboard | Keyboard hides, input keeps focus; same problem on the next tap | Keyboard stays open |
| Tapping an item | Input is blurred on touch inside the overlay, keyboard hides | Unchanged; the next tap is a real focus event that iOS scrolls on |
| Focus moving away | Keyboard hides on blur | Unchanged |

Verified on iOS Simulator: the keyboard stays open when closing with <kbd>return</kbd>, an outside tap, and a toggle button tap. On desktop, `inputMode` has no effect, so nothing changes.

Keeping the keyboard open on <kbd>return</kbd> roughly matches native behavior: a single-line input without `enterkeyhint="done"` does not dismiss the keyboard on <kbd>return</kbd> either.

> [!NOTE]
> On touch devices (Android included), closing the overlay no longer hides the keyboard while the input keeps focus. Dismissing everything from an open overlay now takes two taps outside: the first closes the overlay, the second blurs the input and hides the keyboard.

### Alternative PRs

Earlier attempts at the same issue, closed in favor of this fix:

- #12324 scrolled the input into the visual viewport from component code on overlay open. Closed because the manual scroll approach is fragile and relies on timings that are not possible to test reliably;
- #12329 blurred the input on iOS when closing on outside tap, so that the next tap fires a real focus event. Closed because it only covered that one close action — closing with <kbd>return</kbd> or the toggle button still left a focused input with a hidden keyboard — and because the new `focusout` on outside tap stopped editing in wrappers such as Grid Pro.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

