### PR TITLE
fix: remove virtual keyboard suppression from combo-box

### DIFF
--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -9,7 +9,6 @@ import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { InputMixin } from '@vaadin/field-base/src/input-mixin.js';
-import { VirtualKeyboardController } from '@vaadin/field-base/src/virtual-keyboard-controller.js';
 import { ComboBoxPlaceholder } from './vaadin-combo-box-placeholder.js';
 
 export const ComboBoxBaseMixin = (superClass) =>
@@ -168,8 +167,6 @@ export const ComboBoxBaseMixin = (superClass) =>
       if (this.clearElement) {
         this.clearElement.addEventListener('mousedown', this._boundOnClearButtonMouseDown);
       }
-
-      this.addController(new VirtualKeyboardController(this));
     }
 
     /** @protected */

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -1,7 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
-import { resetMouse, sendKeys, sendMouseToElement } from '@vaadin/test-runner-commands';
+import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import {
-  aTimeout,
   click,
   escKeyDown,
   fire,
@@ -13,7 +12,6 @@ import {
   outsideClick,
   tabKeyDown,
   tap,
-  touchstart,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-combo-box.js';
@@ -277,25 +275,17 @@ describe('interactions', () => {
   });
 
   describe('virtual keyboard', () => {
-    it('should disable virtual keyboard on close', () => {
+    it('should not set inputmode on close when input is focused', () => {
+      input.focus();
       comboBox.open();
       comboBox.close();
-      expect(input.inputMode).to.equal('none');
-    });
-
-    it('should re-enable virtual keyboard on touchstart', () => {
-      comboBox.open();
-      comboBox.close();
-      touchstart(comboBox);
       expect(input.inputMode).to.equal('');
     });
 
-    it('should re-enable virtual keyboard on blur', async () => {
-      comboBox.focus();
+    it('should not set inputmode on close when input is not focused', () => {
       comboBox.open();
+      input.blur();
       comboBox.close();
-      await aTimeout(0);
-      await sendKeys({ press: 'Tab' });
       expect(input.inputMode).to.equal('');
     });
   });

--- a/packages/combo-box/test/interactions.test.js
+++ b/packages/combo-box/test/interactions.test.js
@@ -274,22 +274,6 @@ describe('interactions', () => {
     });
   });
 
-  describe('virtual keyboard', () => {
-    it('should not set inputmode on close when input is focused', () => {
-      input.focus();
-      comboBox.open();
-      comboBox.close();
-      expect(input.inputMode).to.equal('');
-    });
-
-    it('should not set inputmode on close when input is not focused', () => {
-      comboBox.open();
-      input.blur();
-      comboBox.close();
-      expect(input.inputMode).to.equal('');
-    });
-  });
-
   describe('clear button', () => {
     let clearButton;
 


### PR DESCRIPTION
## Description

Fixes #12037
Fixes #12036

On iOS, the combo-box input can end up behind the on-screen keyboard when tapped a second time (#12037). The precondition is a state that native iOS never produces: a focused input with a hidden keyboard. `VirtualKeyboardController` creates that state by setting `inputMode="none"` on every overlay close, including closes where the input keeps focus — an outside tap, a toggle button tap, or <kbd>return</kbd> on the on-screen keyboard. Re-tapping the still-focused input fires no focus event, and iOS scrolls a field into the visual viewport only on a focus event, so the input stays where it was while the keyboard opens on top of it.

## Why the controller is no longer needed in combo-box

The suppression was added in #3253 for #3191, which describes a combo-box that automatically re-focused its input on dropdown close — the suppression existed so that this internal refocus would not pop the keyboard back open after selecting an item.

That refocus no longer exists. In the current combo-box, no code focuses the input on close: the only `focus()` calls are on open (non-touch only), in the clear button `mousedown` handler, and in `_shouldRemoveFocus()` when focus moves to the overlay element itself. The overlay does not use `restoreFocusOnClose`, and `multi-select-combo-box` and `time-picker` add no refocus of their own.

With the internal refocus gone, the only remaining effect of the suppression was hiding the keyboard when the input is focused programmatically after a close — and a programmatic `focus()` is expected to show the keyboard, as it does for any other input. So instead of configuring the controller, combo-box stops using it: the keyboard simply follows focus, which is the native behavior.

`date-picker` is different: it focuses the input **before** closing on date selection (`_focus(); this.close()`) and relies on the suppression to keep the keyboard hidden after picking a date. It keeps the controller unchanged.

## How to test

1. On iOS, open a page with a combo-box near the bottom, e.g. `dev/combo-box.html` with `<div style="height: 200vh"></div>` before the field.
2. Scroll down and tap the input. The keyboard opens and the input is visible above it.
3. Tap the page background to close the overlay.
4. Tap the input again — it stays hidden behind the keyboard.

### Behavior per close action, on touch devices

| Close action | Before | After |
| --- | --- | --- |
| Outside tap | Keyboard hides, input keeps focus; the next tap opens the keyboard over the input | Keyboard stays open, input stays visible above it |
| Toggle button tap | Keyboard hides, input keeps focus; same problem on the next tap | Keyboard stays open |
| <kbd>return</kbd> on the on-screen keyboard | Keyboard hides, input keeps focus; same problem on the next tap | Keyboard stays open |
| Tapping an item | Input is blurred on touch inside the overlay, keyboard hides | Unchanged; the next tap is a real focus event that iOS scrolls on |
| Focus moving away | Keyboard hides on blur | Unchanged |
| Programmatic `focus()` after close | Keyboard stays hidden until the next touch | Keyboard opens, like for any focused input |

Keeping the keyboard open on <kbd>return</kbd> roughly matches native behavior: a single-line input without `enterkeyhint="done"` does not dismiss the keyboard on <kbd>return</kbd> either. On desktop, `inputMode` had no effect, so nothing changes there.

> [!NOTE]
> On touch devices (Android included), closing the overlay no longer hides the keyboard while the input keeps focus. Dismissing everything from an open overlay now takes two taps outside: the first closes the overlay, the second blurs the input and hides the keyboard.

Alternative to #12334, which keeps the controller in combo-box and skips the suppression while the input is focused. Removing the controller covers the same close actions and also lets a programmatic `focus()` show the keyboard, with no new option in `VirtualKeyboardController`.

Earlier attempts at the same issue, closed:

- #12324 scrolled the input into the visual viewport from component code on overlay open. Closed because the manual scroll was fragile: it had to wait out the scrolling that iOS does on its own.
- #12329 blurred the input on iOS when closing on outside tap, so that the next tap fires a real focus event. Closed because it only covered that one close action, and because the new `focusout` on outside tap stopped editing in wrappers such as Grid Pro.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
