### PR TITLE
test: add accessibleDescriptionRef DOM snapshot tests

### DIFF
--- a/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
+++ b/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
@@ -553,35 +553,6 @@ snapshots["vaadin-checkbox-group host error"] =
 `;
 /* end snapshot vaadin-checkbox-group host error */
 
-snapshots["vaadin-checkbox-group shadow default"] = 
-`<div class="vaadin-group-field-container">
-  <div part="label">
-    <slot name="label">
-    </slot>
-    <span
-      aria-hidden="true"
-      part="required-indicator"
-    >
-    </span>
-  </div>
-  <div part="group-field">
-    <slot>
-    </slot>
-  </div>
-  <div part="helper-text">
-    <slot name="helper">
-    </slot>
-  </div>
-  <div part="error-message">
-    <slot name="error-message">
-    </slot>
-  </div>
-</div>
-<slot name="tooltip">
-</slot>
-`;
-/* end snapshot vaadin-checkbox-group shadow default */
-
 snapshots["vaadin-checkbox-group host accessibleDescriptionRef"] = 
 `<vaadin-checkbox-group
   aria-describedby="accessible-description-ref-0"
@@ -657,4 +628,33 @@ snapshots["vaadin-checkbox-group host accessibleDescriptionRef"] =
 </vaadin-checkbox-group>
 `;
 /* end snapshot vaadin-checkbox-group host accessibleDescriptionRef */
+
+snapshots["vaadin-checkbox-group shadow default"] = 
+`<div class="vaadin-group-field-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div part="group-field">
+    <slot>
+    </slot>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+`;
+/* end snapshot vaadin-checkbox-group shadow default */
 

--- a/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
+++ b/packages/checkbox-group/test/dom/__snapshots__/checkbox-group.test.snap.js
@@ -582,3 +582,79 @@ snapshots["vaadin-checkbox-group shadow default"] =
 `;
 /* end snapshot vaadin-checkbox-group shadow default */
 
+snapshots["vaadin-checkbox-group host accessibleDescriptionRef"] = 
+`<vaadin-checkbox-group
+  aria-describedby="accessible-description-ref-0"
+  role="group"
+>
+  <vaadin-checkbox
+    has-label=""
+    has-value=""
+    label="Checkbox 1"
+    value="1"
+  >
+    <label
+      for="input-vaadin-checkbox-9"
+      id="label-vaadin-checkbox-3"
+      slot="label"
+    >
+      Checkbox 1
+    </label>
+    <div
+      hidden=""
+      id="error-message-vaadin-checkbox-5"
+      slot="error-message"
+    >
+    </div>
+    <input
+      aria-labelledby="label-vaadin-checkbox-3"
+      id="input-vaadin-checkbox-9"
+      slot="input"
+      tabindex="0"
+      type="checkbox"
+      value="1"
+    >
+  </vaadin-checkbox>
+  <vaadin-checkbox
+    has-label=""
+    has-value=""
+    label="Checkbox 2"
+    value="2"
+  >
+    <label
+      for="input-vaadin-checkbox-10"
+      id="label-vaadin-checkbox-6"
+      slot="label"
+    >
+      Checkbox 2
+    </label>
+    <div
+      hidden=""
+      id="error-message-vaadin-checkbox-8"
+      slot="error-message"
+    >
+    </div>
+    <input
+      aria-labelledby="label-vaadin-checkbox-6"
+      id="input-vaadin-checkbox-10"
+      slot="input"
+      tabindex="0"
+      type="checkbox"
+      value="2"
+    >
+  </vaadin-checkbox>
+  <label
+    id="label-vaadin-checkbox-group-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-checkbox-group-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-checkbox-group>
+`;
+/* end snapshot vaadin-checkbox-group host accessibleDescriptionRef */
+

--- a/packages/checkbox-group/test/dom/checkbox-group.test.js
+++ b/packages/checkbox-group/test/dom/checkbox-group.test.js
@@ -56,6 +56,12 @@ describe('vaadin-checkbox-group', () => {
       await aTimeout(0);
       await expect(group).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      group.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(group);
+      await expect(group).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
+++ b/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
@@ -237,6 +237,32 @@ snapshots["vaadin-checkbox host error"] =
 `;
 /* end snapshot vaadin-checkbox host error */
 
+snapshots["vaadin-checkbox host accessibleDescriptionRef"] = 
+`<vaadin-checkbox has-value="">
+  <label
+    for="input-vaadin-checkbox-3"
+    id="label-vaadin-checkbox-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-checkbox-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-checkbox-3"
+    slot="input"
+    tabindex="0"
+    type="checkbox"
+    value="on"
+  >
+</vaadin-checkbox>
+`;
+/* end snapshot vaadin-checkbox host accessibleDescriptionRef */
+
 snapshots["vaadin-checkbox shadow default"] = 
 `<div class="vaadin-checkbox-container">
   <div
@@ -265,30 +291,4 @@ snapshots["vaadin-checkbox shadow default"] =
 </slot>
 `;
 /* end snapshot vaadin-checkbox shadow default */
-
-snapshots["vaadin-checkbox host accessibleDescriptionRef"] = 
-`<vaadin-checkbox has-value="">
-  <label
-    for="input-vaadin-checkbox-3"
-    id="label-vaadin-checkbox-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-checkbox-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    id="input-vaadin-checkbox-3"
-    slot="input"
-    tabindex="0"
-    type="checkbox"
-    value="on"
-  >
-</vaadin-checkbox>
-`;
-/* end snapshot vaadin-checkbox host accessibleDescriptionRef */
 

--- a/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
+++ b/packages/checkbox/test/dom/__snapshots__/checkbox.test.snap.js
@@ -266,3 +266,29 @@ snapshots["vaadin-checkbox shadow default"] =
 `;
 /* end snapshot vaadin-checkbox shadow default */
 
+snapshots["vaadin-checkbox host accessibleDescriptionRef"] = 
+`<vaadin-checkbox has-value="">
+  <label
+    for="input-vaadin-checkbox-3"
+    id="label-vaadin-checkbox-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-checkbox-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-checkbox-3"
+    slot="input"
+    tabindex="0"
+    type="checkbox"
+    value="on"
+  >
+</vaadin-checkbox>
+`;
+/* end snapshot vaadin-checkbox host accessibleDescriptionRef */
+

--- a/packages/checkbox/test/dom/checkbox.test.js
+++ b/packages/checkbox/test/dom/checkbox.test.js
@@ -56,6 +56,12 @@ describe('vaadin-checkbox', () => {
       await aTimeout(0);
       await expect(checkbox).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      checkbox.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(checkbox);
+      await expect(checkbox).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -796,3 +796,40 @@ snapshots["vaadin-combo-box shadow theme"] =
 `;
 /* end snapshot vaadin-combo-box shadow theme */
 
+snapshots["vaadin-combo-box host accessibleDescriptionRef"] = 
+`<vaadin-combo-box>
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host accessibleDescriptionRef */
+

--- a/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
+++ b/packages/combo-box/test/dom/__snapshots__/combo-box.test.snap.js
@@ -349,6 +349,43 @@ snapshots["vaadin-combo-box host error"] =
 `;
 /* end snapshot vaadin-combo-box host error */
 
+snapshots["vaadin-combo-box host accessibleDescriptionRef"] = 
+`<vaadin-combo-box>
+  <vaadin-combo-box-scroller
+    id="vaadin-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-combo-box-scroller>
+  <label
+    for="input-vaadin-combo-box-4"
+    id="label-vaadin-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-combo-box>
+`;
+/* end snapshot vaadin-combo-box host accessibleDescriptionRef */
+
 snapshots["vaadin-combo-box host value"] = 
 `<vaadin-combo-box has-value="">
   <vaadin-combo-box-scroller
@@ -795,41 +832,4 @@ snapshots["vaadin-combo-box shadow theme"] =
 </vaadin-combo-box-overlay>
 `;
 /* end snapshot vaadin-combo-box shadow theme */
-
-snapshots["vaadin-combo-box host accessibleDescriptionRef"] = 
-`<vaadin-combo-box>
-  <vaadin-combo-box-scroller
-    id="vaadin-combo-box-scroller-3"
-    role="listbox"
-    slot="overlay"
-    tabindex="-1"
-  >
-  </vaadin-combo-box-scroller>
-  <label
-    for="input-vaadin-combo-box-4"
-    id="label-vaadin-combo-box-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-combo-box-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-autocomplete="list"
-    aria-describedby="accessible-description-ref-0"
-    aria-expanded="false"
-    autocapitalize="off"
-    autocomplete="off"
-    autocorrect="off"
-    id="input-vaadin-combo-box-4"
-    role="combobox"
-    slot="input"
-    spellcheck="false"
-  >
-</vaadin-combo-box>
-`;
-/* end snapshot vaadin-combo-box host accessibleDescriptionRef */
 

--- a/packages/combo-box/test/dom/combo-box.test.js
+++ b/packages/combo-box/test/dom/combo-box.test.js
@@ -63,6 +63,12 @@ describe('vaadin-combo-box', () => {
       await expect(comboBox).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      comboBox.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(comboBox);
+      await expect(comboBox).dom.to.equalSnapshot();
+    });
+
     it('value', async () => {
       comboBox.allowCustomValue = true;
       comboBox.value = 'value';

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -142,3 +142,23 @@ snapshots["vaadin-custom-field shadow default"] =
 `;
 /* end snapshot vaadin-custom-field shadow default */
 
+snapshots["vaadin-custom-field host accessibleDescriptionRef"] = 
+`<vaadin-custom-field
+  aria-describedby="accessible-description-ref-0"
+  role="group"
+>
+  <label
+    id="label-vaadin-custom-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-custom-field-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-custom-field>
+`;
+/* end snapshot vaadin-custom-field host accessibleDescriptionRef */
+

--- a/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
+++ b/packages/custom-field/test/dom/__snapshots__/custom-field.test.snap.js
@@ -110,6 +110,26 @@ snapshots["vaadin-custom-field host error"] =
 `;
 /* end snapshot vaadin-custom-field host error */
 
+snapshots["vaadin-custom-field host accessibleDescriptionRef"] = 
+`<vaadin-custom-field
+  aria-describedby="accessible-description-ref-0"
+  role="group"
+>
+  <label
+    id="label-vaadin-custom-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-custom-field-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-custom-field>
+`;
+/* end snapshot vaadin-custom-field host accessibleDescriptionRef */
+
 snapshots["vaadin-custom-field shadow default"] = 
 `<div class="vaadin-custom-field-container">
   <div part="label">
@@ -141,24 +161,4 @@ snapshots["vaadin-custom-field shadow default"] =
 </slot>
 `;
 /* end snapshot vaadin-custom-field shadow default */
-
-snapshots["vaadin-custom-field host accessibleDescriptionRef"] = 
-`<vaadin-custom-field
-  aria-describedby="accessible-description-ref-0"
-  role="group"
->
-  <label
-    id="label-vaadin-custom-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-custom-field-2"
-    slot="error-message"
-  >
-  </div>
-</vaadin-custom-field>
-`;
-/* end snapshot vaadin-custom-field host accessibleDescriptionRef */
 

--- a/packages/custom-field/test/dom/custom-field.test.js
+++ b/packages/custom-field/test/dom/custom-field.test.js
@@ -39,6 +39,12 @@ describe('vaadin-custom-field', () => {
       await aTimeout(0);
       await expect(field).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      field.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -232,6 +232,33 @@ snapshots["vaadin-date-picker host error"] =
 `;
 /* end snapshot vaadin-date-picker host error */
 
+snapshots["vaadin-date-picker host accessibleDescriptionRef"] = 
+`<vaadin-date-picker>
+  <label
+    for="search-input-vaadin-date-picker-3"
+    id="label-vaadin-date-picker-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-date-picker-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    aria-haspopup="dialog"
+    autocomplete="off"
+    id="search-input-vaadin-date-picker-3"
+    role="combobox"
+    slot="input"
+  >
+</vaadin-date-picker>
+`;
+/* end snapshot vaadin-date-picker host accessibleDescriptionRef */
+
 snapshots["vaadin-date-picker host name"] = 
 `<vaadin-date-picker name="Field Name">
   <label
@@ -824,31 +851,4 @@ snapshots["vaadin-date-picker shadow theme"] =
 </vaadin-date-picker-overlay>
 `;
 /* end snapshot vaadin-date-picker shadow theme */
-
-snapshots["vaadin-date-picker host accessibleDescriptionRef"] = 
-`<vaadin-date-picker>
-  <label
-    for="search-input-vaadin-date-picker-3"
-    id="label-vaadin-date-picker-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-date-picker-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    aria-expanded="false"
-    aria-haspopup="dialog"
-    autocomplete="off"
-    id="search-input-vaadin-date-picker-3"
-    role="combobox"
-    slot="input"
-  >
-</vaadin-date-picker>
-`;
-/* end snapshot vaadin-date-picker host accessibleDescriptionRef */
 

--- a/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
+++ b/packages/date-picker/test/dom/__snapshots__/date-picker.test.snap.js
@@ -825,3 +825,30 @@ snapshots["vaadin-date-picker shadow theme"] =
 `;
 /* end snapshot vaadin-date-picker shadow theme */
 
+snapshots["vaadin-date-picker host accessibleDescriptionRef"] = 
+`<vaadin-date-picker>
+  <label
+    for="search-input-vaadin-date-picker-3"
+    id="label-vaadin-date-picker-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-date-picker-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    aria-haspopup="dialog"
+    autocomplete="off"
+    id="search-input-vaadin-date-picker-3"
+    role="combobox"
+    slot="input"
+  >
+</vaadin-date-picker>
+`;
+/* end snapshot vaadin-date-picker host accessibleDescriptionRef */
+

--- a/packages/date-picker/test/dom/date-picker.test.js
+++ b/packages/date-picker/test/dom/date-picker.test.js
@@ -58,6 +58,12 @@ describe('vaadin-date-picker', () => {
       await expect(datePicker).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      datePicker.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(datePicker);
+      await expect(datePicker).dom.to.equalSnapshot();
+    });
+
     it('name', async () => {
       datePicker.name = 'Field Name';
       await nextUpdate(datePicker);

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -608,3 +608,77 @@ snapshots["vaadin-date-time-picker shadow default"] =
 `;
 /* end snapshot vaadin-date-time-picker shadow default */
 
+snapshots["vaadin-date-time-picker host accessibleDescriptionRef"] = 
+`<vaadin-date-time-picker
+  aria-describedby="accessible-description-ref-0"
+  role="group"
+>
+  <label
+    id="label-vaadin-date-time-picker-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-date-time-picker-2"
+    slot="error-message"
+  >
+  </div>
+  <vaadin-date-picker slot="date-picker">
+    <label
+      for="search-input-vaadin-date-picker-6"
+      id="label-vaadin-date-picker-3"
+      slot="label"
+    >
+    </label>
+    <div
+      hidden=""
+      id="error-message-vaadin-date-picker-5"
+      slot="error-message"
+    >
+    </div>
+    <input
+      aria-expanded="false"
+      aria-haspopup="dialog"
+      autocomplete="off"
+      id="search-input-vaadin-date-picker-6"
+      role="combobox"
+      slot="input"
+    >
+  </vaadin-date-picker>
+  <vaadin-time-picker slot="time-picker">
+    <vaadin-time-picker-scroller
+      id="vaadin-time-picker-scroller-10"
+      role="listbox"
+      slot="overlay"
+      tabindex="-1"
+    >
+    </vaadin-time-picker-scroller>
+    <label
+      for="search-input-vaadin-time-picker-11"
+      id="label-vaadin-time-picker-7"
+      slot="label"
+    >
+    </label>
+    <div
+      hidden=""
+      id="error-message-vaadin-time-picker-9"
+      slot="error-message"
+    >
+    </div>
+    <input
+      aria-autocomplete="list"
+      aria-expanded="false"
+      autocapitalize="off"
+      autocomplete="off"
+      autocorrect="off"
+      id="search-input-vaadin-time-picker-11"
+      role="combobox"
+      slot="input"
+      spellcheck="false"
+    >
+  </vaadin-time-picker>
+</vaadin-date-time-picker>
+`;
+/* end snapshot vaadin-date-time-picker host accessibleDescriptionRef */
+

--- a/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
+++ b/packages/date-time-picker/test/dom/__snapshots__/date-time-picker.test.snap.js
@@ -571,43 +571,6 @@ snapshots["vaadin-date-time-picker host error"] =
 `;
 /* end snapshot vaadin-date-time-picker host error */
 
-snapshots["vaadin-date-time-picker shadow default"] = 
-`<div class="vaadin-date-time-picker-container">
-  <div part="label">
-    <slot name="label">
-    </slot>
-    <span
-      aria-hidden="true"
-      part="required-indicator"
-    >
-    </span>
-  </div>
-  <div part="input-fields">
-    <slot
-      id="dateSlot"
-      name="date-picker"
-    >
-    </slot>
-    <slot
-      id="timeSlot"
-      name="time-picker"
-    >
-    </slot>
-  </div>
-  <div part="helper-text">
-    <slot name="helper">
-    </slot>
-  </div>
-  <div part="error-message">
-    <slot name="error-message">
-    </slot>
-  </div>
-</div>
-<slot name="tooltip">
-</slot>
-`;
-/* end snapshot vaadin-date-time-picker shadow default */
-
 snapshots["vaadin-date-time-picker host accessibleDescriptionRef"] = 
 `<vaadin-date-time-picker
   aria-describedby="accessible-description-ref-0"
@@ -681,4 +644,41 @@ snapshots["vaadin-date-time-picker host accessibleDescriptionRef"] =
 </vaadin-date-time-picker>
 `;
 /* end snapshot vaadin-date-time-picker host accessibleDescriptionRef */
+
+snapshots["vaadin-date-time-picker shadow default"] = 
+`<div class="vaadin-date-time-picker-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div part="input-fields">
+    <slot
+      id="dateSlot"
+      name="date-picker"
+    >
+    </slot>
+    <slot
+      id="timeSlot"
+      name="time-picker"
+    >
+    </slot>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+`;
+/* end snapshot vaadin-date-time-picker shadow default */
 

--- a/packages/date-time-picker/test/dom/date-time-picker.test.js
+++ b/packages/date-time-picker/test/dom/date-time-picker.test.js
@@ -51,6 +51,12 @@ describe('vaadin-date-time-picker', () => {
       await aTimeout(0);
       await expect(dateTimePicker).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      dateTimePicker.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(dateTimePicker);
+      await expect(dateTimePicker).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -86,6 +86,31 @@ snapshots["vaadin-email-field host error"] =
 `;
 /* end snapshot vaadin-email-field host error */
 
+snapshots["vaadin-email-field host accessibleDescriptionRef"] = 
+`<vaadin-email-field>
+  <label
+    for="input-vaadin-email-field-3"
+    id="label-vaadin-email-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-email-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    autocapitalize="off"
+    id="input-vaadin-email-field-3"
+    slot="input"
+    type="email"
+  >
+</vaadin-email-field>
+`;
+/* end snapshot vaadin-email-field host accessibleDescriptionRef */
+
 snapshots["vaadin-email-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -327,29 +352,4 @@ snapshots["vaadin-email-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-email-field shadow theme */
-
-snapshots["vaadin-email-field host accessibleDescriptionRef"] = 
-`<vaadin-email-field>
-  <label
-    for="input-vaadin-email-field-3"
-    id="label-vaadin-email-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-email-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    autocapitalize="off"
-    id="input-vaadin-email-field-3"
-    slot="input"
-    type="email"
-  >
-</vaadin-email-field>
-`;
-/* end snapshot vaadin-email-field host accessibleDescriptionRef */
 

--- a/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
+++ b/packages/email-field/test/dom/__snapshots__/email-field.test.snap.js
@@ -328,3 +328,28 @@ snapshots["vaadin-email-field shadow theme"] =
 `;
 /* end snapshot vaadin-email-field shadow theme */
 
+snapshots["vaadin-email-field host accessibleDescriptionRef"] = 
+`<vaadin-email-field>
+  <label
+    for="input-vaadin-email-field-3"
+    id="label-vaadin-email-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-email-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    autocapitalize="off"
+    id="input-vaadin-email-field-3"
+    slot="input"
+    type="email"
+  >
+</vaadin-email-field>
+`;
+/* end snapshot vaadin-email-field host accessibleDescriptionRef */
+

--- a/packages/email-field/test/dom/email-field.test.js
+++ b/packages/email-field/test/dom/email-field.test.js
@@ -35,6 +35,12 @@ describe('vaadin-email-field', () => {
       await aTimeout(0);
       await expect(field).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
     });
+
+    it('accessibleDescriptionRef', async () => {
+      field.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot(SNAPSHOT_CONFIG);
+    });
   });
 
   describe('shadow', () => {

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -92,6 +92,33 @@ snapshots["vaadin-integer-field host error"] =
 `;
 /* end snapshot vaadin-integer-field host error */
 
+snapshots["vaadin-integer-field host accessibleDescriptionRef"] = 
+`<vaadin-integer-field>
+  <label
+    for="input-vaadin-integer-field-3"
+    id="label-vaadin-integer-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-integer-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-integer-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-integer-field>
+`;
+/* end snapshot vaadin-integer-field host accessibleDescriptionRef */
+
 snapshots["vaadin-integer-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -461,31 +488,4 @@ snapshots["vaadin-integer-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-integer-field shadow theme */
-
-snapshots["vaadin-integer-field host accessibleDescriptionRef"] = 
-`<vaadin-integer-field>
-  <label
-    for="input-vaadin-integer-field-3"
-    id="label-vaadin-integer-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-integer-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    id="input-vaadin-integer-field-3"
-    max="undefined"
-    min="undefined"
-    slot="input"
-    step="any"
-    type="number"
-  >
-</vaadin-integer-field>
-`;
-/* end snapshot vaadin-integer-field host accessibleDescriptionRef */
 

--- a/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
+++ b/packages/integer-field/test/dom/__snapshots__/integer-field.test.snap.js
@@ -462,3 +462,30 @@ snapshots["vaadin-integer-field shadow theme"] =
 `;
 /* end snapshot vaadin-integer-field shadow theme */
 
+snapshots["vaadin-integer-field host accessibleDescriptionRef"] = 
+`<vaadin-integer-field>
+  <label
+    for="input-vaadin-integer-field-3"
+    id="label-vaadin-integer-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-integer-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-integer-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-integer-field>
+`;
+/* end snapshot vaadin-integer-field host accessibleDescriptionRef */
+

--- a/packages/integer-field/test/dom/integer-field.test.js
+++ b/packages/integer-field/test/dom/integer-field.test.js
@@ -29,6 +29,12 @@ describe('vaadin-integer-field', () => {
       await aTimeout(0);
       await expect(field).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      field.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -192,6 +192,51 @@ snapshots["vaadin-multi-select-combo-box host error"] =
 `;
 /* end snapshot vaadin-multi-select-combo-box host error */
 
+snapshots["vaadin-multi-select-combo-box host accessibleDescriptionRef"] = 
+`<vaadin-multi-select-combo-box>
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
+  <label
+    for="input-vaadin-multi-select-combo-box-4"
+    id="label-vaadin-multi-select-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-multi-select-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-multi-select-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+  <vaadin-multi-select-combo-box-chip
+    count="0"
+    hidden=""
+    slot="overflow"
+    title=""
+  >
+  </vaadin-multi-select-combo-box-chip>
+</vaadin-multi-select-combo-box>
+`;
+/* end snapshot vaadin-multi-select-combo-box host accessibleDescriptionRef */
+
 snapshots["vaadin-multi-select-combo-box host required"] = 
 `<vaadin-multi-select-combo-box required="">
   <vaadin-multi-select-combo-box-scroller
@@ -707,49 +752,4 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
 </vaadin-multi-select-combo-box-overlay>
 `;
 /* end snapshot vaadin-multi-select-combo-box shadow invalid */
-
-snapshots["vaadin-multi-select-combo-box host accessibleDescriptionRef"] = 
-`<vaadin-multi-select-combo-box>
-  <vaadin-multi-select-combo-box-scroller
-    aria-multiselectable="true"
-    id="vaadin-multi-select-combo-box-scroller-3"
-    role="listbox"
-    slot="overlay"
-    tabindex="-1"
-  >
-  </vaadin-multi-select-combo-box-scroller>
-  <label
-    for="input-vaadin-multi-select-combo-box-4"
-    id="label-vaadin-multi-select-combo-box-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-multi-select-combo-box-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-autocomplete="list"
-    aria-describedby="accessible-description-ref-0"
-    aria-expanded="false"
-    autocapitalize="off"
-    autocomplete="off"
-    autocorrect="off"
-    id="input-vaadin-multi-select-combo-box-4"
-    role="combobox"
-    slot="input"
-    spellcheck="false"
-  >
-  <vaadin-multi-select-combo-box-chip
-    count="0"
-    hidden=""
-    slot="overflow"
-    title=""
-  >
-  </vaadin-multi-select-combo-box-chip>
-</vaadin-multi-select-combo-box>
-`;
-/* end snapshot vaadin-multi-select-combo-box host accessibleDescriptionRef */
 

--- a/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
+++ b/packages/multi-select-combo-box/test/dom/__snapshots__/multi-select-combo-box.test.snap.js
@@ -708,3 +708,48 @@ snapshots["vaadin-multi-select-combo-box shadow invalid"] =
 `;
 /* end snapshot vaadin-multi-select-combo-box shadow invalid */
 
+snapshots["vaadin-multi-select-combo-box host accessibleDescriptionRef"] = 
+`<vaadin-multi-select-combo-box>
+  <vaadin-multi-select-combo-box-scroller
+    aria-multiselectable="true"
+    id="vaadin-multi-select-combo-box-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-multi-select-combo-box-scroller>
+  <label
+    for="input-vaadin-multi-select-combo-box-4"
+    id="label-vaadin-multi-select-combo-box-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-multi-select-combo-box-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="input-vaadin-multi-select-combo-box-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+  <vaadin-multi-select-combo-box-chip
+    count="0"
+    hidden=""
+    slot="overflow"
+    title=""
+  >
+  </vaadin-multi-select-combo-box-chip>
+</vaadin-multi-select-combo-box>
+`;
+/* end snapshot vaadin-multi-select-combo-box host accessibleDescriptionRef */
+

--- a/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
+++ b/packages/multi-select-combo-box/test/dom/multi-select-combo-box.test.js
@@ -36,6 +36,12 @@ describe('vaadin-multi-select-combo-box', () => {
       await expect(multiSelectComboBox).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      multiSelectComboBox.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(multiSelectComboBox);
+      await expect(multiSelectComboBox).dom.to.equalSnapshot();
+    });
+
     it('required', async () => {
       multiSelectComboBox.required = true;
       await expect(multiSelectComboBox).dom.to.equalSnapshot();

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -92,6 +92,33 @@ snapshots["vaadin-number-field host error"] =
 `;
 /* end snapshot vaadin-number-field host error */
 
+snapshots["vaadin-number-field host accessibleDescriptionRef"] = 
+`<vaadin-number-field>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-number-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host accessibleDescriptionRef */
+
 snapshots["vaadin-number-field host min"] = 
 `<vaadin-number-field>
   <label
@@ -539,31 +566,4 @@ snapshots["vaadin-number-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-number-field shadow theme */
-
-snapshots["vaadin-number-field host accessibleDescriptionRef"] = 
-`<vaadin-number-field>
-  <label
-    for="input-vaadin-number-field-3"
-    id="label-vaadin-number-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-number-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    id="input-vaadin-number-field-3"
-    max="undefined"
-    min="undefined"
-    slot="input"
-    step="any"
-    type="number"
-  >
-</vaadin-number-field>
-`;
-/* end snapshot vaadin-number-field host accessibleDescriptionRef */
 

--- a/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
+++ b/packages/number-field/test/dom/__snapshots__/number-field.test.snap.js
@@ -540,3 +540,30 @@ snapshots["vaadin-number-field shadow theme"] =
 `;
 /* end snapshot vaadin-number-field shadow theme */
 
+snapshots["vaadin-number-field host accessibleDescriptionRef"] = 
+`<vaadin-number-field>
+  <label
+    for="input-vaadin-number-field-3"
+    id="label-vaadin-number-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-number-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-number-field-3"
+    max="undefined"
+    min="undefined"
+    slot="input"
+    step="any"
+    type="number"
+  >
+</vaadin-number-field>
+`;
+/* end snapshot vaadin-number-field host accessibleDescriptionRef */
+

--- a/packages/number-field/test/dom/number-field.test.js
+++ b/packages/number-field/test/dom/number-field.test.js
@@ -30,6 +30,12 @@ describe('vaadin-number-field', () => {
       await expect(field).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      field.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
+
     it('min', async () => {
       field.min = 2;
       await nextUpdate(field);

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -110,6 +110,39 @@ snapshots["vaadin-password-field host error"] =
 `;
 /* end snapshot vaadin-password-field host error */
 
+snapshots["vaadin-password-field host accessibleDescriptionRef"] = 
+`<vaadin-password-field>
+  <label
+    for="input-vaadin-password-field-3"
+    id="label-vaadin-password-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-password-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    autocapitalize="off"
+    id="input-vaadin-password-field-3"
+    slot="input"
+    type="password"
+  >
+  <vaadin-password-field-button
+    aria-label="Show password"
+    aria-pressed="false"
+    role="button"
+    slot="reveal"
+    tabindex="0"
+  >
+  </vaadin-password-field-button>
+</vaadin-password-field>
+`;
+/* end snapshot vaadin-password-field host accessibleDescriptionRef */
+
 snapshots["vaadin-password-field shadow default"] = 
 `<div class="vaadin-field-container">
   <div part="label">
@@ -386,37 +419,4 @@ snapshots["vaadin-password-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-password-field shadow theme */
-
-snapshots["vaadin-password-field host accessibleDescriptionRef"] = 
-`<vaadin-password-field>
-  <label
-    for="input-vaadin-password-field-3"
-    id="label-vaadin-password-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-password-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    autocapitalize="off"
-    id="input-vaadin-password-field-3"
-    slot="input"
-    type="password"
-  >
-  <vaadin-password-field-button
-    aria-label="Show password"
-    aria-pressed="false"
-    role="button"
-    slot="reveal"
-    tabindex="0"
-  >
-  </vaadin-password-field-button>
-</vaadin-password-field>
-`;
-/* end snapshot vaadin-password-field host accessibleDescriptionRef */
 

--- a/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
+++ b/packages/password-field/test/dom/__snapshots__/password-field.test.snap.js
@@ -387,3 +387,36 @@ snapshots["vaadin-password-field shadow theme"] =
 `;
 /* end snapshot vaadin-password-field shadow theme */
 
+snapshots["vaadin-password-field host accessibleDescriptionRef"] = 
+`<vaadin-password-field>
+  <label
+    for="input-vaadin-password-field-3"
+    id="label-vaadin-password-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-password-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    autocapitalize="off"
+    id="input-vaadin-password-field-3"
+    slot="input"
+    type="password"
+  >
+  <vaadin-password-field-button
+    aria-label="Show password"
+    aria-pressed="false"
+    role="button"
+    slot="reveal"
+    tabindex="0"
+  >
+  </vaadin-password-field-button>
+</vaadin-password-field>
+`;
+/* end snapshot vaadin-password-field host accessibleDescriptionRef */
+

--- a/packages/password-field/test/dom/password-field.test.js
+++ b/packages/password-field/test/dom/password-field.test.js
@@ -29,6 +29,12 @@ describe('vaadin-password-field', () => {
       await aTimeout(0);
       await expect(field).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      field.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -431,3 +431,67 @@ snapshots["vaadin-radio-group shadow default"] =
 `;
 /* end snapshot vaadin-radio-group shadow default */
 
+snapshots["vaadin-radio-group host accessibleDescriptionRef"] = 
+`<vaadin-radio-group
+  aria-describedby="accessible-description-ref-0"
+  role="radiogroup"
+>
+  <vaadin-radio-button
+    has-label=""
+    has-value=""
+    label="Radio 1"
+    value="1"
+  >
+    <label
+      for="input-vaadin-radio-button-6"
+      id="label-vaadin-radio-button-3"
+      slot="label"
+    >
+      Radio 1
+    </label>
+    <input
+      id="input-vaadin-radio-button-6"
+      name="vaadin-radio-group-5"
+      slot="input"
+      tabindex="0"
+      type="radio"
+      value="1"
+    >
+  </vaadin-radio-button>
+  <vaadin-radio-button
+    has-label=""
+    has-value=""
+    label="Radio 2"
+    value="2"
+  >
+    <label
+      for="input-vaadin-radio-button-7"
+      id="label-vaadin-radio-button-4"
+      slot="label"
+    >
+      Radio 2
+    </label>
+    <input
+      id="input-vaadin-radio-button-7"
+      name="vaadin-radio-group-5"
+      slot="input"
+      tabindex="0"
+      type="radio"
+      value="2"
+    >
+  </vaadin-radio-button>
+  <label
+    id="label-vaadin-radio-group-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-radio-group-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-radio-group>
+`;
+/* end snapshot vaadin-radio-group host accessibleDescriptionRef */
+

--- a/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
+++ b/packages/radio-group/test/dom/__snapshots__/radio-group.test.snap.js
@@ -402,35 +402,6 @@ snapshots["vaadin-radio-group host error"] =
 `;
 /* end snapshot vaadin-radio-group host error */
 
-snapshots["vaadin-radio-group shadow default"] = 
-`<div class="vaadin-group-field-container">
-  <div part="label">
-    <slot name="label">
-    </slot>
-    <span
-      aria-hidden="true"
-      part="required-indicator"
-    >
-    </span>
-  </div>
-  <div part="group-field">
-    <slot>
-    </slot>
-  </div>
-  <div part="helper-text">
-    <slot name="helper">
-    </slot>
-  </div>
-  <div part="error-message">
-    <slot name="error-message">
-    </slot>
-  </div>
-</div>
-<slot name="tooltip">
-</slot>
-`;
-/* end snapshot vaadin-radio-group shadow default */
-
 snapshots["vaadin-radio-group host accessibleDescriptionRef"] = 
 `<vaadin-radio-group
   aria-describedby="accessible-description-ref-0"
@@ -494,4 +465,33 @@ snapshots["vaadin-radio-group host accessibleDescriptionRef"] =
 </vaadin-radio-group>
 `;
 /* end snapshot vaadin-radio-group host accessibleDescriptionRef */
+
+snapshots["vaadin-radio-group shadow default"] = 
+`<div class="vaadin-group-field-container">
+  <div part="label">
+    <slot name="label">
+    </slot>
+    <span
+      aria-hidden="true"
+      part="required-indicator"
+    >
+    </span>
+  </div>
+  <div part="group-field">
+    <slot>
+    </slot>
+  </div>
+  <div part="helper-text">
+    <slot name="helper">
+    </slot>
+  </div>
+  <div part="error-message">
+    <slot name="error-message">
+    </slot>
+  </div>
+</div>
+<slot name="tooltip">
+</slot>
+`;
+/* end snapshot vaadin-radio-group shadow default */
 

--- a/packages/radio-group/test/dom/radio-group.test.js
+++ b/packages/radio-group/test/dom/radio-group.test.js
@@ -50,6 +50,12 @@ describe('vaadin-radio-group', () => {
       await aTimeout(0);
       await expect(group).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      group.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(group);
+      await expect(group).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -498,6 +498,58 @@ snapshots["vaadin-select host error"] =
 `;
 /* end snapshot vaadin-select host error */
 
+snapshots["vaadin-select host accessibleDescriptionRef"] = 
+`<vaadin-select>
+  <div slot="overlay">
+    <vaadin-select-list-box
+      aria-orientation="vertical"
+      role="listbox"
+    >
+      <vaadin-select-item
+        aria-selected="false"
+        role="option"
+        tabindex="0"
+      >
+        Option 1
+      </vaadin-select-item>
+      <vaadin-select-item
+        aria-selected="false"
+        role="option"
+        tabindex="-1"
+      >
+        Option 2
+      </vaadin-select-item>
+    </vaadin-select-list-box>
+  </div>
+  <label
+    id="label-vaadin-select-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-select-2"
+    slot="error-message"
+  >
+  </div>
+  <vaadin-select-value-button
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    role="button"
+    slot="value"
+    tabindex="0"
+  >
+  </vaadin-select-value-button>
+  <label
+    id="label-vaadin-select-4"
+    slot="sr-label"
+  >
+  </label>
+</vaadin-select>
+`;
+/* end snapshot vaadin-select host accessibleDescriptionRef */
+
 snapshots["vaadin-select host opened default"] = 
 `<vaadin-select
   opened=""
@@ -841,56 +893,4 @@ snapshots["vaadin-select shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-select shadow theme */
-
-snapshots["vaadin-select host accessibleDescriptionRef"] = 
-`<vaadin-select>
-  <div slot="overlay">
-    <vaadin-select-list-box
-      aria-orientation="vertical"
-      role="listbox"
-    >
-      <vaadin-select-item
-        aria-selected="false"
-        role="option"
-        tabindex="0"
-      >
-        Option 1
-      </vaadin-select-item>
-      <vaadin-select-item
-        aria-selected="false"
-        role="option"
-        tabindex="-1"
-      >
-        Option 2
-      </vaadin-select-item>
-    </vaadin-select-list-box>
-  </div>
-  <label
-    id="label-vaadin-select-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-select-2"
-    slot="error-message"
-  >
-  </div>
-  <vaadin-select-value-button
-    aria-describedby="accessible-description-ref-0"
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    role="button"
-    slot="value"
-    tabindex="0"
-  >
-  </vaadin-select-value-button>
-  <label
-    id="label-vaadin-select-4"
-    slot="sr-label"
-  >
-  </label>
-</vaadin-select>
-`;
-/* end snapshot vaadin-select host accessibleDescriptionRef */
 

--- a/packages/select/test/dom/__snapshots__/select.test.snap.js
+++ b/packages/select/test/dom/__snapshots__/select.test.snap.js
@@ -842,3 +842,55 @@ snapshots["vaadin-select shadow theme"] =
 `;
 /* end snapshot vaadin-select shadow theme */
 
+snapshots["vaadin-select host accessibleDescriptionRef"] = 
+`<vaadin-select>
+  <div slot="overlay">
+    <vaadin-select-list-box
+      aria-orientation="vertical"
+      role="listbox"
+    >
+      <vaadin-select-item
+        aria-selected="false"
+        role="option"
+        tabindex="0"
+      >
+        Option 1
+      </vaadin-select-item>
+      <vaadin-select-item
+        aria-selected="false"
+        role="option"
+        tabindex="-1"
+      >
+        Option 2
+      </vaadin-select-item>
+    </vaadin-select-list-box>
+  </div>
+  <label
+    id="label-vaadin-select-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-select-2"
+    slot="error-message"
+  >
+  </div>
+  <vaadin-select-value-button
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    role="button"
+    slot="value"
+    tabindex="0"
+  >
+  </vaadin-select-value-button>
+  <label
+    id="label-vaadin-select-4"
+    slot="sr-label"
+  >
+  </label>
+</vaadin-select>
+`;
+/* end snapshot vaadin-select host accessibleDescriptionRef */
+

--- a/packages/select/test/dom/select.test.js
+++ b/packages/select/test/dom/select.test.js
@@ -67,6 +67,12 @@ describe('vaadin-select', () => {
       await expect(select).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      select.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(select);
+      await expect(select).dom.to.equalSnapshot();
+    });
+
     describe('opened', () => {
       let overlay;
 

--- a/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
@@ -1279,3 +1279,52 @@ snapshots["vaadin-range-slider shadow max < min"] =
 `;
 /* end snapshot vaadin-range-slider shadow max < min */
 
+snapshots["vaadin-range-slider host accessibleDescriptionRef"] = 
+`<vaadin-range-slider aria-describedby="accessible-description-ref-0">
+  <input
+    aria-label="min"
+    id="slider-3"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <input
+    aria-label="max"
+    id="slider-4"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <vaadin-slider-bubble
+    modeless=""
+    slot="bubble"
+  >
+    0
+  </vaadin-slider-bubble>
+  <vaadin-slider-bubble
+    modeless=""
+    slot="bubble"
+  >
+    100
+  </vaadin-slider-bubble>
+  <label
+    id="label-vaadin-range-slider-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-range-slider-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-range-slider>
+`;
+/* end snapshot vaadin-range-slider host accessibleDescriptionRef */
+

--- a/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/range-slider.test.snap.js
@@ -614,6 +614,55 @@ snapshots["vaadin-range-slider host error"] =
 `;
 /* end snapshot vaadin-range-slider host error */
 
+snapshots["vaadin-range-slider host accessibleDescriptionRef"] = 
+`<vaadin-range-slider aria-describedby="accessible-description-ref-0">
+  <input
+    aria-label="min"
+    id="slider-3"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <input
+    aria-label="max"
+    id="slider-4"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <vaadin-slider-bubble
+    modeless=""
+    slot="bubble"
+  >
+    0
+  </vaadin-slider-bubble>
+  <vaadin-slider-bubble
+    modeless=""
+    slot="bubble"
+  >
+    100
+  </vaadin-slider-bubble>
+  <label
+    id="label-vaadin-range-slider-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-range-slider-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-range-slider>
+`;
+/* end snapshot vaadin-range-slider host accessibleDescriptionRef */
+
 snapshots["vaadin-range-slider host value always visible"] = 
 `<vaadin-range-slider>
   <input
@@ -1278,53 +1327,4 @@ snapshots["vaadin-range-slider shadow max < min"] =
 </div>
 `;
 /* end snapshot vaadin-range-slider shadow max < min */
-
-snapshots["vaadin-range-slider host accessibleDescriptionRef"] = 
-`<vaadin-range-slider aria-describedby="accessible-description-ref-0">
-  <input
-    aria-label="min"
-    id="slider-3"
-    max="100"
-    min="0"
-    slot="input"
-    step="1"
-    tabindex="0"
-    type="range"
-  >
-  <input
-    aria-label="max"
-    id="slider-4"
-    max="100"
-    min="0"
-    slot="input"
-    step="1"
-    tabindex="0"
-    type="range"
-  >
-  <vaadin-slider-bubble
-    modeless=""
-    slot="bubble"
-  >
-    0
-  </vaadin-slider-bubble>
-  <vaadin-slider-bubble
-    modeless=""
-    slot="bubble"
-  >
-    100
-  </vaadin-slider-bubble>
-  <label
-    id="label-vaadin-range-slider-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-range-slider-2"
-    slot="error-message"
-  >
-  </div>
-</vaadin-range-slider>
-`;
-/* end snapshot vaadin-range-slider host accessibleDescriptionRef */
 

--- a/packages/slider/test/dom/__snapshots__/slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider.test.snap.js
@@ -956,3 +956,37 @@ snapshots["vaadin-slider shadow max < min"] =
 `;
 /* end snapshot vaadin-slider shadow max < min */
 
+snapshots["vaadin-slider host accessibleDescriptionRef"] = 
+`<vaadin-slider>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="slider-3"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <vaadin-slider-bubble
+    modeless=""
+    slot="bubble"
+  >
+    0
+  </vaadin-slider-bubble>
+  <label
+    for="slider-3"
+    id="label-vaadin-slider-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-slider-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-slider>
+`;
+/* end snapshot vaadin-slider host accessibleDescriptionRef */
+

--- a/packages/slider/test/dom/__snapshots__/slider.test.snap.js
+++ b/packages/slider/test/dom/__snapshots__/slider.test.snap.js
@@ -348,6 +348,40 @@ snapshots["vaadin-slider host error"] =
 `;
 /* end snapshot vaadin-slider host error */
 
+snapshots["vaadin-slider host accessibleDescriptionRef"] = 
+`<vaadin-slider>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="slider-3"
+    max="100"
+    min="0"
+    slot="input"
+    step="1"
+    tabindex="0"
+    type="range"
+  >
+  <vaadin-slider-bubble
+    modeless=""
+    slot="bubble"
+  >
+    0
+  </vaadin-slider-bubble>
+  <label
+    for="slider-3"
+    id="label-vaadin-slider-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-slider-2"
+    slot="error-message"
+  >
+  </div>
+</vaadin-slider>
+`;
+/* end snapshot vaadin-slider host accessibleDescriptionRef */
+
 snapshots["vaadin-slider host value always visible"] = 
 `<vaadin-slider>
   <input
@@ -955,38 +989,4 @@ snapshots["vaadin-slider shadow max < min"] =
 </div>
 `;
 /* end snapshot vaadin-slider shadow max < min */
-
-snapshots["vaadin-slider host accessibleDescriptionRef"] = 
-`<vaadin-slider>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    id="slider-3"
-    max="100"
-    min="0"
-    slot="input"
-    step="1"
-    tabindex="0"
-    type="range"
-  >
-  <vaadin-slider-bubble
-    modeless=""
-    slot="bubble"
-  >
-    0
-  </vaadin-slider-bubble>
-  <label
-    for="slider-3"
-    id="label-vaadin-slider-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-slider-2"
-    slot="error-message"
-  >
-  </div>
-</vaadin-slider>
-`;
-/* end snapshot vaadin-slider host accessibleDescriptionRef */
 

--- a/packages/slider/test/dom/range-slider.test.ts
+++ b/packages/slider/test/dom/range-slider.test.ts
@@ -86,6 +86,12 @@ describe('vaadin-range-slider', () => {
       await expect(slider).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      slider.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(slider);
+      await expect(slider).dom.to.equalSnapshot();
+    });
+
     it('value always visible', async () => {
       slider.valueAlwaysVisible = true;
       await nextUpdate(slider);

--- a/packages/slider/test/dom/slider.test.ts
+++ b/packages/slider/test/dom/slider.test.ts
@@ -74,6 +74,12 @@ describe('vaadin-slider', () => {
       await expect(slider).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      slider.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(slider);
+      await expect(slider).dom.to.equalSnapshot();
+    });
+
     it('value always visible', async () => {
       slider.valueAlwaysVisible = true;
       await nextUpdate(slider);

--- a/packages/switch/test/dom/__snapshots__/switch.test.snap.js
+++ b/packages/switch/test/dom/__snapshots__/switch.test.snap.js
@@ -181,3 +181,30 @@ snapshots["vaadin-switch shadow default"] =
 `;
 /* end snapshot vaadin-switch shadow default */
 
+snapshots["vaadin-switch host accessibleDescriptionRef"] = 
+`<vaadin-switch has-value="">
+  <label
+    for="input-vaadin-switch-3"
+    id="label-vaadin-switch-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-switch-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-switch-3"
+    role="switch"
+    slot="input"
+    tabindex="0"
+    type="checkbox"
+    value="on"
+  >
+</vaadin-switch>
+`;
+/* end snapshot vaadin-switch host accessibleDescriptionRef */
+

--- a/packages/switch/test/dom/__snapshots__/switch.test.snap.js
+++ b/packages/switch/test/dom/__snapshots__/switch.test.snap.js
@@ -150,6 +150,33 @@ snapshots["vaadin-switch host invalid"] =
 `;
 /* end snapshot vaadin-switch host invalid */
 
+snapshots["vaadin-switch host accessibleDescriptionRef"] = 
+`<vaadin-switch has-value="">
+  <label
+    for="input-vaadin-switch-3"
+    id="label-vaadin-switch-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-switch-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-switch-3"
+    role="switch"
+    slot="input"
+    tabindex="0"
+    type="checkbox"
+    value="on"
+  >
+</vaadin-switch>
+`;
+/* end snapshot vaadin-switch host accessibleDescriptionRef */
+
 snapshots["vaadin-switch shadow default"] = 
 `<div class="vaadin-switch-container">
   <div
@@ -180,31 +207,4 @@ snapshots["vaadin-switch shadow default"] =
 </slot>
 `;
 /* end snapshot vaadin-switch shadow default */
-
-snapshots["vaadin-switch host accessibleDescriptionRef"] = 
-`<vaadin-switch has-value="">
-  <label
-    for="input-vaadin-switch-3"
-    id="label-vaadin-switch-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-switch-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    id="input-vaadin-switch-3"
-    role="switch"
-    slot="input"
-    tabindex="0"
-    type="checkbox"
-    value="on"
-  >
-</vaadin-switch>
-`;
-/* end snapshot vaadin-switch host accessibleDescriptionRef */
 

--- a/packages/switch/test/dom/switch.test.ts
+++ b/packages/switch/test/dom/switch.test.ts
@@ -46,6 +46,12 @@ describe('vaadin-switch', () => {
       await aTimeout(0);
       await expect(element).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      element.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(element);
+      await expect(element).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -328,3 +328,28 @@ snapshots["vaadin-text-area shadow theme"] =
 `;
 /* end snapshot vaadin-text-area shadow theme */
 
+snapshots["vaadin-text-area host accessibleDescriptionRef"] = 
+`<vaadin-text-area>
+  <label
+    for="textarea-vaadin-text-area-3"
+    id="label-vaadin-text-area-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-area-2"
+    slot="error-message"
+  >
+  </div>
+  <textarea
+    aria-describedby="accessible-description-ref-0"
+    id="textarea-vaadin-text-area-3"
+    rows="2"
+    slot="textarea"
+  >
+  </textarea>
+</vaadin-text-area>
+`;
+/* end snapshot vaadin-text-area host accessibleDescriptionRef */
+

--- a/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
+++ b/packages/text-area/test/dom/__snapshots__/text-area.test.snap.js
@@ -86,6 +86,31 @@ snapshots["vaadin-text-area host error"] =
 `;
 /* end snapshot vaadin-text-area host error */
 
+snapshots["vaadin-text-area host accessibleDescriptionRef"] = 
+`<vaadin-text-area>
+  <label
+    for="textarea-vaadin-text-area-3"
+    id="label-vaadin-text-area-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-area-2"
+    slot="error-message"
+  >
+  </div>
+  <textarea
+    aria-describedby="accessible-description-ref-0"
+    id="textarea-vaadin-text-area-3"
+    rows="2"
+    slot="textarea"
+  >
+  </textarea>
+</vaadin-text-area>
+`;
+/* end snapshot vaadin-text-area host accessibleDescriptionRef */
+
 snapshots["vaadin-text-area shadow default"] = 
 `<div class="vaadin-text-area-container">
   <div part="label">
@@ -327,29 +352,4 @@ snapshots["vaadin-text-area shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-text-area shadow theme */
-
-snapshots["vaadin-text-area host accessibleDescriptionRef"] = 
-`<vaadin-text-area>
-  <label
-    for="textarea-vaadin-text-area-3"
-    id="label-vaadin-text-area-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-text-area-2"
-    slot="error-message"
-  >
-  </div>
-  <textarea
-    aria-describedby="accessible-description-ref-0"
-    id="textarea-vaadin-text-area-3"
-    rows="2"
-    slot="textarea"
-  >
-  </textarea>
-</vaadin-text-area>
-`;
-/* end snapshot vaadin-text-area host accessibleDescriptionRef */
 

--- a/packages/text-area/test/dom/text-area.test.js
+++ b/packages/text-area/test/dom/text-area.test.js
@@ -28,6 +28,12 @@ describe('vaadin-text-area', () => {
       await aTimeout(0);
       await expect(textArea).dom.to.equalSnapshot();
     });
+
+    it('accessibleDescriptionRef', async () => {
+      textArea.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(textArea);
+      await expect(textArea).dom.to.equalSnapshot();
+    });
   });
 
   describe('shadow', () => {

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -108,6 +108,30 @@ snapshots["vaadin-text-field host error"] =
 `;
 /* end snapshot vaadin-text-field host error */
 
+snapshots["vaadin-text-field host accessibleDescriptionRef"] = 
+`<vaadin-text-field>
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-text-field-3"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host accessibleDescriptionRef */
+
 snapshots["vaadin-text-field host inputMode property"] = 
 `<vaadin-text-field>
   <label
@@ -397,28 +421,4 @@ snapshots["vaadin-text-field shadow theme"] =
 </div>
 `;
 /* end snapshot vaadin-text-field shadow theme */
-
-snapshots["vaadin-text-field host accessibleDescriptionRef"] = 
-`<vaadin-text-field>
-  <label
-    for="input-vaadin-text-field-3"
-    id="label-vaadin-text-field-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-text-field-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-describedby="accessible-description-ref-0"
-    id="input-vaadin-text-field-3"
-    slot="input"
-    type="text"
-  >
-</vaadin-text-field>
-`;
-/* end snapshot vaadin-text-field host accessibleDescriptionRef */
 

--- a/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
+++ b/packages/text-field/test/dom/__snapshots__/text-field.test.snap.js
@@ -398,3 +398,27 @@ snapshots["vaadin-text-field shadow theme"] =
 `;
 /* end snapshot vaadin-text-field shadow theme */
 
+snapshots["vaadin-text-field host accessibleDescriptionRef"] = 
+`<vaadin-text-field>
+  <label
+    for="input-vaadin-text-field-3"
+    id="label-vaadin-text-field-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-text-field-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-describedby="accessible-description-ref-0"
+    id="input-vaadin-text-field-3"
+    slot="input"
+    type="text"
+  >
+</vaadin-text-field>
+`;
+/* end snapshot vaadin-text-field host accessibleDescriptionRef */
+

--- a/packages/text-field/test/dom/text-field.test.js
+++ b/packages/text-field/test/dom/text-field.test.js
@@ -35,6 +35,12 @@ describe('vaadin-text-field', () => {
       await expect(field).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      field.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(field);
+      await expect(field).dom.to.equalSnapshot();
+    });
+
     it('inputMode property', async () => {
       field.inputMode = 'search';
       await nextUpdate(field);

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -160,6 +160,43 @@ snapshots["vaadin-time-picker host error"] =
 `;
 /* end snapshot vaadin-time-picker host error */
 
+snapshots["vaadin-time-picker host accessibleDescriptionRef"] = 
+`<vaadin-time-picker>
+  <vaadin-time-picker-scroller
+    id="vaadin-time-picker-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-time-picker-scroller>
+  <label
+    for="search-input-vaadin-time-picker-4"
+    id="label-vaadin-time-picker-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-time-picker-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="search-input-vaadin-time-picker-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host accessibleDescriptionRef */
+
 snapshots["vaadin-time-picker host required"] = 
 `<vaadin-time-picker required="">
   <vaadin-time-picker-scroller
@@ -934,41 +971,4 @@ snapshots["vaadin-time-picker shadow theme"] =
 </vaadin-time-picker-overlay>
 `;
 /* end snapshot vaadin-time-picker shadow theme */
-
-snapshots["vaadin-time-picker host accessibleDescriptionRef"] = 
-`<vaadin-time-picker>
-  <vaadin-time-picker-scroller
-    id="vaadin-time-picker-scroller-3"
-    role="listbox"
-    slot="overlay"
-    tabindex="-1"
-  >
-  </vaadin-time-picker-scroller>
-  <label
-    for="search-input-vaadin-time-picker-4"
-    id="label-vaadin-time-picker-0"
-    slot="label"
-  >
-  </label>
-  <div
-    hidden=""
-    id="error-message-vaadin-time-picker-2"
-    slot="error-message"
-  >
-  </div>
-  <input
-    aria-autocomplete="list"
-    aria-describedby="accessible-description-ref-0"
-    aria-expanded="false"
-    autocapitalize="off"
-    autocomplete="off"
-    autocorrect="off"
-    id="search-input-vaadin-time-picker-4"
-    role="combobox"
-    slot="input"
-    spellcheck="false"
-  >
-</vaadin-time-picker>
-`;
-/* end snapshot vaadin-time-picker host accessibleDescriptionRef */
 

--- a/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
+++ b/packages/time-picker/test/dom/__snapshots__/time-picker.test.snap.js
@@ -935,3 +935,40 @@ snapshots["vaadin-time-picker shadow theme"] =
 `;
 /* end snapshot vaadin-time-picker shadow theme */
 
+snapshots["vaadin-time-picker host accessibleDescriptionRef"] = 
+`<vaadin-time-picker>
+  <vaadin-time-picker-scroller
+    id="vaadin-time-picker-scroller-3"
+    role="listbox"
+    slot="overlay"
+    tabindex="-1"
+  >
+  </vaadin-time-picker-scroller>
+  <label
+    for="search-input-vaadin-time-picker-4"
+    id="label-vaadin-time-picker-0"
+    slot="label"
+  >
+  </label>
+  <div
+    hidden=""
+    id="error-message-vaadin-time-picker-2"
+    slot="error-message"
+  >
+  </div>
+  <input
+    aria-autocomplete="list"
+    aria-describedby="accessible-description-ref-0"
+    aria-expanded="false"
+    autocapitalize="off"
+    autocomplete="off"
+    autocorrect="off"
+    id="search-input-vaadin-time-picker-4"
+    role="combobox"
+    slot="input"
+    spellcheck="false"
+  >
+</vaadin-time-picker>
+`;
+/* end snapshot vaadin-time-picker host accessibleDescriptionRef */
+

--- a/packages/time-picker/test/dom/time-picker.test.js
+++ b/packages/time-picker/test/dom/time-picker.test.js
@@ -35,6 +35,12 @@ describe('vaadin-time-picker', () => {
       await expect(timePicker).dom.to.equalSnapshot();
     });
 
+    it('accessibleDescriptionRef', async () => {
+      timePicker.accessibleDescriptionRef = 'accessible-description-ref-0';
+      await nextUpdate(timePicker);
+      await expect(timePicker).dom.to.equalSnapshot();
+    });
+
     it('required', async () => {
       timePicker.required = true;
       await expect(timePicker).dom.to.equalSnapshot();


### PR DESCRIPTION
The PR smoke tests the new `accessibleDescriptionRef` property across all components that use `FieldMixin`. 

Part of https://github.com/vaadin/web-components/issues/11975
