### PR TITLE
test: add month calendar and date cell lookup helpers

### DIFF
--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -140,6 +140,21 @@ export function getCalendars(root) {
 }
 
 /**
+ * The month calendar showing the given year and month, or `undefined` when none of the rendered
+ * calendars shows it.
+ *
+ * @param {HTMLElement} root vaadin-date-picker or vaadin-date-picker-overlay-content
+ * @param {number} year
+ * @param {number} month 0-based, like `Date#getMonth()`
+ * @return {HTMLElement | undefined}
+ */
+export function getMonthCalendar(root, year, month) {
+  return getCalendars(root).find(
+    (calendar) => calendar.month && calendar.month.getFullYear() === year && calendar.month.getMonth() === month,
+  );
+}
+
+/**
  * The date cells of a month calendar, without the empty ones padding the first and last week.
  *
  * @param {HTMLElement} calendar vaadin-month-calendar
@@ -147,6 +162,18 @@ export function getCalendars(root) {
  */
 export function getDateCells(calendar) {
   return [...calendar.shadowRoot.querySelectorAll('[part~="date"]:not(:empty)')];
+}
+
+/**
+ * The date cell of a month calendar showing the given day of the month, or `undefined` when the
+ * calendar does not show it.
+ *
+ * @param {HTMLElement} calendar vaadin-month-calendar
+ * @param {number} day
+ * @return {HTMLElement | undefined}
+ */
+export function getDateCell(calendar, day) {
+  return getDateCells(calendar).find((cell) => cell.date.getDate() === day);
 }
 
 /**

--- a/packages/date-picker/test/month-calendar.test.js
+++ b/packages/date-picker/test/month-calendar.test.js
@@ -2,7 +2,7 @@ import { expect } from '@vaadin/chai-plugins';
 import { aTimeout, fixtureSync, makeSoloTouchEvent, nextFrame, nextRender, tap } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-month-calendar.js';
-import { getDateCells, getDefaultI18n, getWeekDayCells } from './helpers.js';
+import { getDateCell, getDateCells, getDefaultI18n, getWeekDayCells } from './helpers.js';
 
 describe('vaadin-month-calendar', () => {
   let monthCalendar, valueChangedSpy;
@@ -92,7 +92,7 @@ describe('vaadin-month-calendar', () => {
   });
 
   it('should update value on tap', () => {
-    const date10 = getDateCells(monthCalendar).find((dateElement) => dateElement.date.getDate() === 10);
+    const date10 = getDateCell(monthCalendar, 10);
     tap(date10);
     expect(monthCalendar.selectedDate.getFullYear()).to.equal(2016);
     expect(monthCalendar.selectedDate.getMonth()).to.equal(1);
@@ -136,7 +136,7 @@ describe('vaadin-month-calendar', () => {
   it('should not update value on disabled-by-max date tap', async () => {
     monthCalendar.maxDate = new Date('2016-02-09');
     await nextRender();
-    const date10 = getDateCells(monthCalendar).find((dateElement) => dateElement.date.getDate() === 10);
+    const date10 = getDateCell(monthCalendar, 10);
     tap(date10);
     expect(monthCalendar.selectedDate).to.be.undefined;
   });
@@ -149,7 +149,7 @@ describe('vaadin-month-calendar', () => {
       return date.year === 2016 && date.month === 1 && date.day === 9;
     };
     await nextFrame();
-    const date9 = getDateCells(monthCalendar).find((dateElement) => dateElement.date.getDate() === 9);
+    const date9 = getDateCell(monthCalendar, 9);
     tap(date9);
     expect(monthCalendar.selectedDate).to.be.undefined;
   });


### PR DESCRIPTION
Looking up a month calendar by the month it shows, and a date cell by its day, is inlined over and over: `month-calendar.test.js` repeats the cell lookup three times, and each of the open date-metadata PRs (#12259, #12276, #12291, #12348) carries its own local copy of both. One shared copy in `helpers.js` removes the duplication, the same way #12290 did for `getCalendars` and `getDateCells`.

`getDateCell` replaces the three inlined lookups in `month-calendar.test.js`. `getMonthCalendar` gets its callers when the date-metadata PRs drop their local copies in favour of it, once this lands.

Follow-up to #12290

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
