### PR TITLE
fix: update virtual-list to set flex-basis auto on the host element

### DIFF
--- a/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
+++ b/packages/virtual-list/src/styles/vaadin-virtual-list-base-styles.js
@@ -16,7 +16,7 @@ export const virtualListStyles = css`
     display: block;
     height: 400px;
     overflow: auto;
-    flex: 1;
+    flex: 1 1 auto;
     align-self: stretch;
     box-sizing: border-box;
     padding: 0;

--- a/packages/virtual-list/test/virtual-list.test.js
+++ b/packages/virtual-list/test/virtual-list.test.js
@@ -30,17 +30,33 @@ describe('virtual-list', () => {
     expect(list.children.length).to.equal(0);
   });
 
-  it('should not collapse inside a flexbox', () => {
-    const flexBox = fixtureSync(`
-      <div style="display:flex">
-        <vaadin-virtual-list></vaadin-virtual-list>
-      </div>`);
-
-    expect(flexBox.firstElementChild.offsetWidth).to.equal(flexBox.offsetWidth);
-  });
-
   it('should have role="list"', () => {
     expect(list.role).to.equal('list');
+  });
+
+  describe('inside flexbox', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = document.createElement('div');
+      wrapper.style.display = 'flex';
+      list = fixtureSync('<vaadin-virtual-list></vaadin-virtual-list>', wrapper);
+    });
+
+    it('should not collapse', () => {
+      expect(list.offsetWidth).to.equal(wrapper.offsetWidth);
+    });
+
+    it('should not collapse when flex-grow and flex-shrink are reset', () => {
+      wrapper.style.width = '400px';
+
+      // Mimic CSS applied by form-layout
+      list.style.flexGrow = 0;
+      list.style.flexShrink = 0;
+      list.style.width = '100%';
+
+      expect(list.offsetWidth).to.equal(wrapper.offsetWidth);
+    });
   });
 
   describe('with items', () => {


### PR DESCRIPTION
## Description

Fixes #12358

Replaced `flex: 1` with `flex: 1 1 auto` used by other components e.g. `vaadin-grid`. 

The `flex: 1` shorthand set `flex-basis: 0%`, which takes precedence over `width` and `height` for a flex item. Inside `vaadin-form-layout`, which resets `flex-grow` and `flex-shrink` for its children, the list collapsed to zero width.

## Type of change

- Bugfix