### PR TITLE
fix(aura): allow closing animation to finish on WebKit

### DIFF
--- a/packages/aura/src/components/item-overlay.css
+++ b/packages/aura/src/components/item-overlay.css
@@ -146,3 +146,8 @@ vaadin-popover {
     --vaadin-overlay-animation-timing-function: ease-in;
   }
 }
+
+vaadin-menu-bar-submenu,
+vaadin-context-menu {
+  --vaadin-overlay-animation-duration: 1ms;
+}


### PR DESCRIPTION
A workaround for #12363 

Chatting with Codex pointed to the following root cause:

---

For the first context-menu close, Safari therefore sees approximately:

1. Internal overlay gets [closing].
2. Its --no-op animation is created with the current duration: 0s.
3. Owner gets [closing].
4. Aura changes the inherited duration to 100ms.
5. shouldAnimate() reads the final computed duration and returns true.
6. OverlayMixin waits for animationend.
7. Safari does not restart/re-time the already-created zero-duration animation.

Dialog avoids this because step 2 starts with 160ms, not 0s. Updating it to 120ms still leaves a real running animation that produces an event.

The first forced close/reopen removes that malformed first animation. Safari’s animation state is then initialized/cached, and subsequent applications happen to be processed correctly. That explains the permanent “priming” without involving popover or visibility state.

You can verify this directly by setting the duration before the first close:

```js
contextMenu.style.setProperty('--vaadin-overlay-animation-duration', '100ms');
contextMenu.style.setProperty('--vaadin-overlay-animation-delay', '60ms');
```

Set those while the menu is still closed. If the first close now works, it confirms that the first animation was being instantiated with 0s.

The proper fix is to propagate an enabled overlay state to the owner before applying it to the internal overlay:

```js
export function setOverlayStateAttribute(overlay, name, value) {
  const enabling = typeof value === 'string' || Boolean(value);
  const elements =
    enabling && overlay.owner
      ? [overlay.owner, overlay]
      : [overlay, overlay.owner].filter(Boolean);

  // Apply or remove attribute...
}
```

That ordering ensures:

```
Enable:  owner gets variables → internal overlay starts animation
Disable: internal animation removed → owner variables removed
```

It is preferable to making Aura’s context-menu duration unconditional, because that would also enable opening animations. A timeout fallback in OverlayMixin would remain useful, but reversing the state-propagation order addresses the specific first-close cause.