### PR TITLE
fix: do not fire backdrop-click when click closes a modal overlay

### DIFF
--- a/packages/master-detail-layout/src/vaadin-master-detail-layout.js
+++ b/packages/master-detail-layout/src/vaadin-master-detail-layout.js
@@ -489,7 +489,11 @@ class MasterDetailLayout extends ElementMixin(ThemableMixin(PolylitMixin(LitElem
   }
 
   /** @private */
-  __onBackdropClick() {
+  __onBackdropClick(event) {
+    if (event.defaultPrevented) {
+      return;
+    }
+
     this.dispatchEvent(new CustomEvent('backdrop-click'));
   }
 

--- a/packages/master-detail-layout/test/events.test.js
+++ b/packages/master-detail-layout/test/events.test.js
@@ -46,6 +46,14 @@ describe('events', () => {
         await sendMouse({ type: 'click', position: [bounds.x + 10, bounds.y + 10] });
         expect(spy).to.not.be.called;
       });
+
+      it('should not fire backdrop-click event on backdrop click if the event was prevented', async () => {
+        const backdrop = layout.shadowRoot.querySelector('[part="backdrop"]');
+        const bounds = backdrop.getBoundingClientRect();
+        backdrop.addEventListener('click', (event) => event.preventDefault(), { capture: true });
+        await sendMouse({ type: 'click', position: [bounds.x + 10, bounds.y + 10] });
+        expect(spy).to.not.be.called;
+      });
     });
 
     describe('Escape press', () => {

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -545,6 +545,11 @@ export const OverlayMixin = (superClass) =>
 
       if (this.opened && !evt.defaultPrevented) {
         this.close(event);
+
+        // Only for modal overlays which make underlying content non-interactive.
+        if (!this.opened && !this.modeless) {
+          event.preventDefault();
+        }
       }
     }
 

--- a/packages/overlay/test/outside-click.test.js
+++ b/packages/overlay/test/outside-click.test.js
@@ -49,6 +49,40 @@ describe('outside click', () => {
       });
     });
 
+    describe('click prevention', () => {
+      it('should prevent default on outside click by default', () => {
+        expect(click(parent).defaultPrevented).to.be.true;
+      });
+
+      it('should not prevent default on inside click', () => {
+        expect(click(overlayPart).defaultPrevented).to.be.false;
+      });
+
+      it('should not prevent default on outside click when modeless', () => {
+        // Mimic vaadin-popover, which adds the outside click listener also when modeless
+        overlay._shouldAddGlobalListeners = () => true;
+        overlay.modeless = true;
+
+        const event = click(parent);
+
+        expect(overlay.opened).to.be.false;
+        expect(event.defaultPrevented).to.be.false;
+      });
+
+      it('should not prevent default if vaadin-overlay-outside-click was prevented', () => {
+        overlay.addEventListener('vaadin-overlay-outside-click', (e) => e.preventDefault());
+
+        expect(click(parent).defaultPrevented).to.be.false;
+      });
+
+      it('should not prevent default if vaadin-overlay-close was prevented', () => {
+        overlay.addEventListener('vaadin-overlay-close', (e) => e.preventDefault());
+
+        expect(click(parent).defaultPrevented).to.be.false;
+        expect(overlay.opened).to.be.true;
+      });
+    });
+
     describe('vaadin-overlay-outside-click event', () => {
       it('should fire the event on outside click', () => {
         const spy = sinon.spy();

--- a/test/integration/master-detail-layout-overlay.test.js
+++ b/test/integration/master-detail-layout-overlay.test.js
@@ -1,0 +1,67 @@
+import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendMouse } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextRender, nextResize, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '@vaadin/combo-box';
+import '@vaadin/date-picker';
+import '@vaadin/master-detail-layout';
+
+describe('overlay in master-detail-layout', () => {
+  let layout, backdrop, spy;
+
+  async function clickBackdrop() {
+    const { x, y } = backdrop.getBoundingClientRect();
+    await sendMouse({ type: 'click', position: [Math.round(x + 10), Math.round(y + 10)] });
+  }
+
+  beforeEach(async () => {
+    layout = fixtureSync(`
+      <vaadin-master-detail-layout no-animation master-size="300px" detail-size="300px" style="width: 400px; height: 300px;">
+        <div>Master</div>
+        <div slot="detail">
+          <vaadin-combo-box></vaadin-combo-box>
+          <vaadin-date-picker></vaadin-date-picker>
+        </div>
+      </vaadin-master-detail-layout>
+    `);
+    await nextResize(layout);
+    await nextRender();
+
+    backdrop = layout.shadowRoot.querySelector('[part="backdrop"]');
+    layout.querySelector('vaadin-combo-box').items = ['foo', 'bar'];
+
+    spy = sinon.spy();
+    layout.addEventListener('backdrop-click', spy);
+  });
+
+  afterEach(async () => {
+    await resetMouse();
+  });
+
+  ['combo-box', 'date-picker'].forEach((component) => {
+    describe(component, () => {
+      let field;
+
+      beforeEach(async () => {
+        field = layout.querySelector(`vaadin-${component}`);
+        field.open();
+        await oneEvent(field.$.overlay, 'vaadin-overlay-open');
+      });
+
+      it(`should not fire backdrop-click when the click closes the ${component} overlay`, async () => {
+        await clickBackdrop();
+
+        expect(field.opened).to.be.false;
+        expect(spy).to.not.be.called;
+        expect(layout.hasAttribute('has-detail')).to.be.true;
+      });
+
+      it(`should fire backdrop-click on click after the ${component} overlay is closed`, async () => {
+        await clickBackdrop();
+        await clickBackdrop();
+
+        expect(spy).to.be.calledOnce;
+      });
+    });
+  });
+});

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -27,6 +27,7 @@
     "@vaadin/icon": "25.3.0-alpha9",
     "@vaadin/integer-field": "25.3.0-alpha9",
     "@vaadin/list-box": "25.3.0-alpha9",
+    "@vaadin/master-detail-layout": "25.3.0-alpha9",
     "@vaadin/menu-bar": "25.3.0-alpha9",
     "@vaadin/message-input": "25.3.0-alpha9",
     "@vaadin/multi-select-combo-box": "25.3.0-alpha9",


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/flow-components/issues/9822

A click that closed a field overlay in the detail area also reached the backdrop, so applications closed the detail from that same click. Updated the overlay to call `preventDefault()` when closed on click and MDL to ignore `defaultPrevented`.

## Type of change

- Bugfix