### PR TITLE
refactor: make UploadI18n extend UploadFileListI18n

### DIFF
--- a/packages/upload/src/vaadin-upload-file-list-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-file-list-mixin.d.ts
@@ -33,6 +33,7 @@ export interface UploadFileListI18n {
       serverUnavailable?: string;
       unexpectedServerError?: string;
       forbidden?: string;
+      fileTooLarge?: string;
     };
   };
   units?: {

--- a/packages/upload/src/vaadin-upload-mixin.d.ts
+++ b/packages/upload/src/vaadin-upload-mixin.d.ts
@@ -5,6 +5,7 @@
  */
 import type { Constructor } from '@open-wc/dedupe-mixin';
 import type { I18nMixinClass } from '@vaadin/component-base/src/i18n-mixin.js';
+import type { UploadFileListI18n } from './vaadin-upload-file-list-mixin.js';
 
 export interface UploadFile extends File {
   uploadTarget: string;
@@ -25,7 +26,7 @@ export interface UploadFile extends File {
   uploading?: boolean;
 }
 
-export interface UploadI18n {
+export interface UploadI18n extends UploadFileListI18n {
   dropFiles?: {
     one?: string;
     many?: string;
@@ -34,37 +35,6 @@ export interface UploadI18n {
     one?: string;
     many?: string;
   };
-  error?: {
-    tooManyFiles?: string;
-    fileIsTooBig?: string;
-    incorrectFileType?: string;
-  };
-  uploading?: {
-    status?: {
-      connecting?: string;
-      stalled?: string;
-      processing?: string;
-      held?: string;
-    };
-    remainingTime?: {
-      prefix?: string;
-      unknown?: string;
-    };
-    error?: {
-      serverUnavailable?: string;
-      unexpectedServerError?: string;
-      forbidden?: string;
-      fileTooLarge?: string;
-    };
-  };
-  units?: {
-    size?: string[];
-    sizeBase?: number;
-  };
-
-  formatSize?(bytes: number): string;
-
-  formatTime?(seconds: number, units: number[]): string;
 }
 
 export type UploadMethod = 'POST' | 'PUT';


### PR DESCRIPTION
`UploadI18n` re-declared the whole `UploadFileListI18n` shape instead of extending it, and the two copies had already drifted: the file list type was missing the `fileTooLarge` error message that its own documented default includes, and the upload type never declared the `file` key that the runtime default provides.

Extending `UploadFileListI18n` leaves only the upload-specific `dropFiles` and `addFiles` keys declared in `UploadI18n`, so the shared part is maintained in one place.

Related to #12354

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)