### PR TITLE
test: restructure overlay unit tests for better readability (CP: 25.2)

### DIFF
--- a/packages/overlay/test/basic.test.js
+++ b/packages/overlay/test/basic.test.js
@@ -1,97 +1,10 @@
 import { expect } from '@vaadin/chai-plugins';
-import { aTimeout, fixtureSync, isIOS, nextFrame, oneEvent } from '@vaadin/testing-helpers';
+import { fixtureSync, isIOS, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
 describe('vaadin-overlay', () => {
-  describe('vaadin-overlay-open event', () => {
-    let overlay, spy;
-
-    beforeEach(() => {
-      overlay = fixtureSync('<vaadin-overlay></vaadin-overlay>');
-      overlay.renderer = (root) => {
-        root.textContent = 'overlay content';
-      };
-      spy = sinon.spy();
-      overlay.addEventListener('vaadin-overlay-open', spy);
-    });
-
-    afterEach(() => {
-      overlay.opened = false;
-    });
-
-    it('should fire when after a delay when setting opened property to true', async () => {
-      overlay.opened = true;
-      await nextFrame();
-      await aTimeout(0);
-      expect(spy).to.be.calledOnce;
-    });
-
-    it('should provide reference to the overlay in the event detail', async () => {
-      overlay.opened = true;
-      await nextFrame();
-      await aTimeout(0);
-      const event = spy.firstCall.args[0];
-      expect(event.detail.overlay).to.equal(overlay);
-    });
-
-    it('should not fire when immediately setting opened property back to false', async () => {
-      overlay.opened = true;
-      overlay.opened = false;
-      await nextFrame();
-      await aTimeout(0);
-      expect(spy).to.not.be.called;
-    });
-
-    it('should not fire when immediately disconnected after setting opened to true', async () => {
-      overlay.opened = true;
-      overlay.remove();
-
-      await nextFrame();
-      await aTimeout(0);
-
-      expect(spy).to.not.be.called;
-    });
-
-    it('should not propagate through shadow roots', async () => {
-      overlay.opened = true;
-      await nextFrame();
-      await aTimeout(0);
-
-      expect(spy.firstCall.args[0].composed).to.be.false;
-    });
-
-    describe('global', () => {
-      let globalSpy;
-
-      beforeEach(() => {
-        globalSpy = sinon.spy();
-        document.addEventListener('vaadin-overlay-open', globalSpy);
-      });
-
-      afterEach(() => {
-        document.removeEventListener('vaadin-overlay-open', globalSpy);
-      });
-
-      it('should fire a global event on the document body when opened', async () => {
-        overlay.opened = true;
-        await nextFrame();
-        await aTimeout(0);
-        expect(globalSpy).to.be.called;
-        expect(globalSpy.firstCall.args);
-      });
-
-      it('should provide reference to the overlay in the global event detail', async () => {
-        overlay.opened = true;
-        await nextFrame();
-        await aTimeout(0);
-        const event = globalSpy.firstCall.args[0];
-        expect(event.detail.overlay).to.equal(overlay);
-      });
-    });
-  });
-
   describe('popover', () => {
     let overlay;
 
@@ -170,39 +83,6 @@ describe('vaadin-overlay', () => {
 
         expect(showSpy).to.be.calledOnce;
       });
-    });
-  });
-
-  describe('pointer-events', () => {
-    let overlay;
-
-    beforeEach(async () => {
-      overlay = createOverlay('overlay content');
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-    });
-
-    afterEach(() => {
-      overlay.opened = false;
-    });
-
-    it('should not prevent clicking elements outside overlay when modeless (non-modal)', () => {
-      overlay.modeless = true;
-      expect(document.body.style.pointerEvents).to.eql('');
-    });
-
-    it('should prevent clicking elements outside overlay when modal', () => {
-      expect(document.body.style.pointerEvents).to.eql('none');
-    });
-
-    it('should not prevent clicking document elements after modal is closed', () => {
-      overlay.opened = false;
-      expect(document.body.style.pointerEvents).to.eql('');
-    });
-
-    it('should allow pointer events on the overlayPart while skipping on the host', () => {
-      expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('auto');
-      expect(getComputedStyle(overlay).pointerEvents).to.equal('none');
     });
   });
 

--- a/packages/overlay/test/escape.test.js
+++ b/packages/overlay/test/escape.test.js
@@ -1,0 +1,196 @@
+import { expect } from '@vaadin/chai-plugins';
+import { enterKeyDown, escKeyDown, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-overlay.js';
+import { createOverlay } from './helpers.js';
+
+describe('Esc', () => {
+  describe('single overlay', () => {
+    let overlay;
+
+    beforeEach(async () => {
+      overlay = createOverlay('overlay content');
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should close on Esc', () => {
+      escKeyDown(document.body);
+
+      expect(overlay.opened).to.be.false;
+    });
+
+    it('should fire the vaadin-overlay-escape-press event on Esc', () => {
+      const spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-escape-press', spy);
+
+      escKeyDown(document.body);
+
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press event on other key press', () => {
+      const spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-escape-press', spy);
+
+      enterKeyDown(document.body);
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not close on Esc if the event was prevented', () => {
+      overlay.addEventListener('vaadin-overlay-escape-press', (e) => e.preventDefault());
+
+      escKeyDown(document.body);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not close on Esc if the keydown event was prevented', () => {
+      overlay.addEventListener('keydown', (e) => e.preventDefault());
+
+      escKeyDown(overlay);
+
+      expect(overlay.opened).to.be.true;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press event if keydown was prevented', () => {
+      const spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-escape-press', spy);
+      overlay.addEventListener('keydown', (e) => e.preventDefault());
+
+      enterKeyDown(overlay);
+
+      expect(spy.called).to.be.false;
+    });
+  });
+
+  describe('multiple modal overlays', () => {
+    let parent, overlay1, overlay2, overlay3, spy;
+
+    beforeEach(async () => {
+      parent = fixtureSync('<div></div>');
+      overlay1 = createOverlay('overlay 1');
+      overlay2 = createOverlay('overlay 2');
+      overlay3 = createOverlay('overlay 3');
+      parent.append(overlay1, overlay2, overlay3);
+      await nextRender();
+
+      spy = sinon.spy();
+      overlay1.addEventListener('vaadin-overlay-escape-press', spy);
+    });
+
+    afterEach(() => {
+      overlay1.opened = false;
+      overlay2.opened = false;
+      overlay3.opened = false;
+    });
+
+    it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', () => {
+      overlay1.opened = true;
+      escKeyDown(document.body);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', () => {
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      escKeyDown(document.body);
+      expect(spy.called).to.be.false;
+    });
+  });
+
+  describe('multiple modeless overlays', () => {
+    let parent, modeless1, modeless2;
+
+    beforeEach(async () => {
+      parent = fixtureSync(`
+        <div id="parent">
+          <vaadin-overlay modeless></vaadin-overlay>
+          <vaadin-overlay modeless></vaadin-overlay>
+        </div>
+      `);
+      modeless1 = parent.children[0];
+      modeless1.renderer = (root) => {
+        if (!root.firstChild) {
+          root.textContent = 'overlay 1';
+          const input = document.createElement('input');
+          root.appendChild(input);
+        }
+      };
+      modeless2 = parent.children[1];
+      modeless2.renderer = (root) => {
+        if (!root.firstChild) {
+          root.textContent = 'overlay 2';
+          const input = document.createElement('input');
+          root.appendChild(input);
+        }
+      };
+      await nextRender();
+    });
+
+    afterEach(() => {
+      modeless1.opened = false;
+      modeless2.opened = false;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+
+      escKeyDown(document.body);
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+
+      const input = modeless1.querySelector('input');
+      input.focus();
+
+      escKeyDown(input);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+
+      modeless2.opened = true;
+      modeless1.bringToFront();
+
+      const input = modeless1.querySelector('input');
+      input.focus();
+
+      escKeyDown(input);
+      expect(spy.called).to.be.true;
+    });
+
+    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', () => {
+      const spy = sinon.spy();
+      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
+
+      modeless1.opened = true;
+      modeless2.opened = true;
+
+      const input = modeless2.querySelector('input');
+      input.focus();
+
+      escKeyDown(input);
+      expect(spy.called).to.be.false;
+    });
+  });
+});

--- a/packages/overlay/test/events.test.js
+++ b/packages/overlay/test/events.test.js
@@ -1,0 +1,204 @@
+import { expect } from '@vaadin/chai-plugins';
+import { aTimeout, click, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-overlay.js';
+import { createOverlay } from './helpers.js';
+
+describe('events', () => {
+  describe('vaadin-overlay-open event', () => {
+    let overlay, spy;
+
+    beforeEach(() => {
+      overlay = createOverlay('overlay content');
+      spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-open', spy);
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should fire when after a delay when setting opened property to true', async () => {
+      overlay.opened = true;
+      await nextFrame();
+      await aTimeout(0);
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should provide reference to the overlay in the event detail', async () => {
+      overlay.opened = true;
+      await nextFrame();
+      await aTimeout(0);
+      const event = spy.firstCall.args[0];
+      expect(event.detail.overlay).to.equal(overlay);
+    });
+
+    it('should not fire when immediately setting opened property back to false', async () => {
+      overlay.opened = true;
+      overlay.opened = false;
+      await nextFrame();
+      await aTimeout(0);
+      expect(spy).to.not.be.called;
+    });
+
+    it('should not fire when immediately disconnected after setting opened to true', async () => {
+      overlay.opened = true;
+      overlay.remove();
+
+      await nextFrame();
+      await aTimeout(0);
+
+      expect(spy).to.not.be.called;
+    });
+
+    it('should not propagate through shadow roots', async () => {
+      overlay.opened = true;
+      await nextFrame();
+      await aTimeout(0);
+
+      expect(spy.firstCall.args[0].composed).to.be.false;
+    });
+
+    describe('global', () => {
+      let globalSpy;
+
+      beforeEach(() => {
+        globalSpy = sinon.spy();
+        document.addEventListener('vaadin-overlay-open', globalSpy);
+      });
+
+      afterEach(() => {
+        document.removeEventListener('vaadin-overlay-open', globalSpy);
+      });
+
+      it('should fire a global event on the document body when opened', async () => {
+        overlay.opened = true;
+        await nextFrame();
+        await aTimeout(0);
+        expect(globalSpy).to.be.called;
+        expect(globalSpy.firstCall.args);
+      });
+
+      it('should provide reference to the overlay in the global event detail', async () => {
+        overlay.opened = true;
+        await nextFrame();
+        await aTimeout(0);
+        const event = globalSpy.firstCall.args[0];
+        expect(event.detail.overlay).to.equal(overlay);
+      });
+    });
+  });
+
+  describe('close events', () => {
+    let parent, overlay;
+
+    beforeEach(async () => {
+      overlay = createOverlay('overlay content');
+      parent = overlay.parentElement;
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    describe('vaadin-overlay-close event', () => {
+      const preventDefaultListener = (e) => {
+        e.preventDefault();
+      };
+
+      it('should not propagate through shadow roots', () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-close', spy);
+
+        click(parent);
+
+        expect(spy.firstCall.args[0].composed).to.be.false;
+      });
+
+      it('should prevent closing the overlay if the event was prevented', async () => {
+        overlay.addEventListener('vaadin-overlay-close', preventDefaultListener);
+        click(parent);
+        await aTimeout(1);
+
+        expect(overlay.opened).to.be.true;
+      });
+
+      it('should provide reference to the overlay in the event detail', () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-close', spy);
+        click(parent);
+        const event = spy.firstCall.args[0];
+        expect(event.detail.overlay).to.equal(overlay);
+      });
+
+      describe('global', () => {
+        it('should prevent closing the overlay if the global event was prevented', async () => {
+          document.addEventListener('vaadin-overlay-close', preventDefaultListener, { once: true });
+
+          click(parent);
+          await aTimeout(1);
+
+          expect(overlay.opened).to.be.true;
+        });
+
+        it('should provide reference to the overlay in the global event detail', () => {
+          const globalSpy = sinon.spy();
+          document.addEventListener('vaadin-overlay-close', globalSpy, { once: true });
+          click(parent);
+          const event = globalSpy.firstCall.args[0];
+          expect(event.detail.overlay).to.equal(overlay);
+        });
+      });
+    });
+
+    describe('vaadin-overlay-closing event', () => {
+      it('should fire the event when the overlay is closing', async () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closing', spy);
+
+        click(parent);
+        await nextRender();
+
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('should not fire the event when preventing vaadin-overlay-close', async () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closing', spy);
+        overlay.addEventListener('vaadin-overlay-close', (e) => e.preventDefault());
+        click(parent);
+        await nextRender();
+        expect(spy.called).to.be.false;
+      });
+    });
+
+    describe('vaadin-overlay-closed event', () => {
+      it('should fire the event after the overlay has closed', async () => {
+        const closingSpy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closing', closingSpy);
+
+        const closedSpy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closed', closedSpy);
+
+        click(parent);
+        await nextRender();
+
+        expect(closedSpy.calledOnce).to.be.true;
+        expect(closedSpy.calledAfter(closingSpy)).to.be.true;
+      });
+
+      it('should not fire the event when preventing vaadin-overlay-close', async () => {
+        const spy = sinon.spy();
+        overlay.addEventListener('vaadin-overlay-closed', spy);
+        overlay.addEventListener('vaadin-overlay-close', (e) => e.preventDefault());
+
+        click(parent);
+        await nextRender();
+
+        expect(spy.called).to.be.false;
+      });
+    });
+  });
+});

--- a/packages/overlay/test/multiple.test.js
+++ b/packages/overlay/test/multiple.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { click, escKeyDown, fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
@@ -48,118 +48,6 @@ describe('multiple overlays', () => {
         expect(overlay1._last).to.be.true;
       });
     });
-
-    describe('vaadin-overlay-escape-press', () => {
-      let spy;
-
-      beforeEach(() => {
-        spy = sinon.spy();
-        overlay1.addEventListener('vaadin-overlay-escape-press', spy);
-      });
-
-      it('should fire the vaadin-overlay-escape-press if it is the only overlay opened', () => {
-        overlay1.opened = true;
-        escKeyDown(document.body);
-        expect(spy.called).to.be.true;
-      });
-
-      it('should not fire the vaadin-overlay-escape-press if there is a recent overlay opened', () => {
-        overlay1.opened = true;
-
-        overlay2.opened = true;
-
-        escKeyDown(document.body);
-        expect(spy.called).to.be.false;
-      });
-    });
-
-    describe('vaadin-overlay-outside-click', () => {
-      let spy;
-
-      beforeEach(() => {
-        spy = sinon.spy();
-        overlay1.addEventListener('vaadin-overlay-outside-click', spy);
-      });
-
-      it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', () => {
-        overlay1.opened = true;
-        click(parent);
-        expect(spy.calledOnce).to.be.true;
-      });
-
-      it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', () => {
-        overlay1.opened = true;
-
-        overlay2.opened = true;
-
-        click(parent);
-        expect(spy.called).to.be.false;
-      });
-    });
-
-    describe('pointer-events', () => {
-      it('should restore pointer-events correctly when overlays are not closed in order', () => {
-        overlay1.opened = true;
-
-        overlay2.opened = true;
-        expect(document.body.style.pointerEvents).to.eql('none');
-
-        overlay1.opened = false;
-
-        overlay2.opened = false;
-        expect(document.body.style.pointerEvents).to.eql('');
-      });
-
-      it('should disable pointer-events in first overlay when second opens', () => {
-        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-        overlay1.opened = true;
-
-        overlay2.opened = true;
-
-        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
-      });
-
-      it('should restore pointer-events in first overlay when second closes', () => {
-        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-        overlay1.opened = true;
-
-        overlay2.opened = true;
-
-        overlay2.opened = false;
-        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
-      });
-
-      it('should restore pointer-events in second overlay when third closes', () => {
-        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-        const overlay2Part = overlay2.shadowRoot.querySelector('[part="overlay"]');
-        overlay1.opened = true;
-
-        overlay2.opened = true;
-
-        overlay3.opened = true;
-
-        overlay3.opened = false;
-
-        expect(getComputedStyle(overlay2Part).pointerEvents).to.equal('auto');
-        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('none');
-      });
-
-      it('should clear pointer events after closing overlays', () => {
-        const overlay1Part = overlay1.shadowRoot.querySelector('[part="overlay"]');
-        // Step 1: Opening overlay 1 so it's physically moved under the body
-        overlay1.opened = true;
-        // Step 2: As overlay2 is modal, it will set overlay 1's pointer events to none
-        overlay2.opened = true;
-        // Step 3: Closing overlay 1 so it's physically moved back from under the body
-        overlay1.opened = false;
-        // Step 4: Closing overlay 2 restores pointer-events of an overlay it
-        // finds under the body node, but overlay 1 is no longer there.
-        overlay2.opened = false;
-        // The fix: Clear pointer-events whenever an overlay is closed
-        // (in this case overlay 1 at step 3)
-        expect(getComputedStyle(overlay1Part).pointerEvents).to.equal('auto');
-      });
-    });
   });
 
   describe('modeless', () => {
@@ -174,28 +62,12 @@ describe('multiple overlays', () => {
     };
 
     beforeEach(async () => {
-      parent = fixtureSync(`
-        <div id="parent">
-          <vaadin-overlay modeless></vaadin-overlay>
-          <vaadin-overlay modeless></vaadin-overlay>
-        </div>
-      `);
-      modeless1 = parent.children[0];
-      modeless1.renderer = (root) => {
-        if (!root.firstChild) {
-          root.textContent = 'overlay 1';
-          const input = document.createElement('input');
-          root.appendChild(input);
-        }
-      };
-      modeless2 = parent.children[1];
-      modeless2.renderer = (root) => {
-        if (!root.firstChild) {
-          root.textContent = 'overlay 2';
-          const input = document.createElement('input');
-          root.appendChild(input);
-        }
-      };
+      parent = fixtureSync('<div></div>');
+      modeless1 = createOverlay('overlay 1');
+      modeless2 = createOverlay('overlay 2');
+      modeless1.modeless = true;
+      modeless2.modeless = true;
+      parent.append(modeless1, modeless2);
       await nextRender();
     });
 
@@ -267,59 +139,6 @@ describe('multiple overlays', () => {
       expect(showSpy2).to.be.not.called;
 
       expect(modeless2._last).to.be.true;
-    });
-
-    it('should not fire the vaadin-overlay-escape-press if the overlay does not contain focus', () => {
-      const spy = sinon.spy();
-      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
-
-      modeless1.opened = true;
-
-      escKeyDown(document.body);
-      expect(spy.called).to.be.false;
-    });
-
-    it('should not fire the vaadin-overlay-escape-press if the overlay contains focus', () => {
-      const spy = sinon.spy();
-      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
-
-      modeless1.opened = true;
-
-      const input = modeless1.querySelector('input');
-      input.focus();
-
-      escKeyDown(input);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should fire the vaadin-overlay-escape-press if the overlay is the frontmost one', () => {
-      const spy = sinon.spy();
-      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
-
-      modeless1.opened = true;
-
-      modeless2.opened = true;
-      modeless1.bringToFront();
-
-      const input = modeless1.querySelector('input');
-      input.focus();
-
-      escKeyDown(input);
-      expect(spy.called).to.be.true;
-    });
-
-    it('should not fire the vaadin-overlay-escape-press if the overlay is not the frontmost', () => {
-      const spy = sinon.spy();
-      modeless1.addEventListener('vaadin-overlay-escape-press', spy);
-
-      modeless1.opened = true;
-      modeless2.opened = true;
-
-      const input = modeless2.querySelector('input');
-      input.focus();
-
-      escKeyDown(input);
-      expect(spy.called).to.be.false;
     });
   });
 });

--- a/packages/overlay/test/outside-click.test.js
+++ b/packages/overlay/test/outside-click.test.js
@@ -1,98 +1,17 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
-import {
-  aTimeout,
-  click,
-  enterKeyDown,
-  escKeyDown,
-  fixtureSync,
-  mousedown,
-  mouseup,
-  nextRender,
-  oneEvent,
-} from '@vaadin/testing-helpers';
+import { click, fixtureSync, mousedown, mouseup, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-overlay.js';
 import { createOverlay } from './helpers.js';
 
-describe('interactions', () => {
-  describe('Esc', () => {
-    let overlay;
-
-    beforeEach(async () => {
-      overlay = createOverlay('overlay content');
-      overlay.opened = true;
-      await oneEvent(overlay, 'vaadin-overlay-open');
-    });
-
-    afterEach(() => {
-      overlay.opened = false;
-    });
-
-    it('should close on Esc', () => {
-      escKeyDown(document.body);
-
-      expect(overlay.opened).to.be.false;
-    });
-
-    it('should fire the vaadin-overlay-escape-press event on Esc', () => {
-      const spy = sinon.spy();
-      overlay.addEventListener('vaadin-overlay-escape-press', spy);
-
-      escKeyDown(document.body);
-
-      expect(spy.calledOnce).to.be.true;
-    });
-
-    it('should not fire the vaadin-overlay-escape-press event on other key press', () => {
-      const spy = sinon.spy();
-      overlay.addEventListener('vaadin-overlay-escape-press', spy);
-
-      enterKeyDown(document.body);
-
-      expect(spy.called).to.be.false;
-    });
-
-    it('should not close on Esc if the event was prevented', () => {
-      overlay.addEventListener('vaadin-overlay-escape-press', (e) => e.preventDefault());
-
-      escKeyDown(document.body);
-
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should not close on Esc if the keydown event was prevented', () => {
-      overlay.addEventListener('keydown', (e) => e.preventDefault());
-
-      escKeyDown(overlay);
-
-      expect(overlay.opened).to.be.true;
-    });
-
-    it('should not fire the vaadin-overlay-escape-press event if keydown was prevented', () => {
-      const spy = sinon.spy();
-      overlay.addEventListener('vaadin-overlay-escape-press', spy);
-      overlay.addEventListener('keydown', (e) => e.preventDefault());
-
-      enterKeyDown(overlay);
-
-      expect(spy.called).to.be.false;
-    });
-  });
-
-  describe('click', () => {
+describe('outside click', () => {
+  describe('single overlay', () => {
     let parent, overlay, overlayPart, backdrop;
 
     beforeEach(async () => {
-      parent = document.createElement('div');
-      overlay = fixtureSync('<vaadin-overlay></vaadin-overlay>', parent);
-      overlay.renderer = (root) => {
-        if (!root.firstChild) {
-          const div = document.createElement('div');
-          div.textContent = 'overlay content';
-          root.appendChild(div);
-        }
-      };
+      overlay = createOverlay('overlay content');
+      parent = overlay.parentElement;
       overlay.opened = true;
       await oneEvent(overlay, 'vaadin-overlay-open');
       overlayPart = overlay.$.overlay;
@@ -202,104 +121,6 @@ describe('interactions', () => {
       });
     });
 
-    describe('vaadin-overlay-close event', () => {
-      const preventDefaultListener = (e) => {
-        e.preventDefault();
-      };
-
-      it('should not propagate through shadow roots', () => {
-        const spy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-close', spy);
-
-        click(parent);
-
-        expect(spy.firstCall.args[0].composed).to.be.false;
-      });
-
-      it('should prevent closing the overlay if the event was prevented', async () => {
-        overlay.addEventListener('vaadin-overlay-close', preventDefaultListener);
-        click(parent);
-        await aTimeout(1);
-
-        expect(overlay.opened).to.be.true;
-      });
-
-      it('should provide reference to the overlay in the event detail', () => {
-        const spy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-close', spy);
-        click(parent);
-        const event = spy.firstCall.args[0];
-        expect(event.detail.overlay).to.equal(overlay);
-      });
-
-      describe('global', () => {
-        it('should prevent closing the overlay if the global event was prevented', async () => {
-          document.addEventListener('vaadin-overlay-close', preventDefaultListener, { once: true });
-
-          click(parent);
-          await aTimeout(1);
-
-          expect(overlay.opened).to.be.true;
-        });
-
-        it('should provide reference to the overlay in the global event detail', () => {
-          const globalSpy = sinon.spy();
-          document.addEventListener('vaadin-overlay-close', globalSpy, { once: true });
-          click(parent);
-          const event = globalSpy.firstCall.args[0];
-          expect(event.detail.overlay).to.equal(overlay);
-        });
-      });
-    });
-
-    describe('vaadin-overlay-closing event', () => {
-      it('should fire the event when the overlay is closing', async () => {
-        const spy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-closing', spy);
-
-        click(parent);
-        await nextRender();
-
-        expect(spy.calledOnce).to.be.true;
-      });
-
-      it('should not fire the event when preventing vaadin-overlay-close', async () => {
-        const spy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-closing', spy);
-        overlay.addEventListener('vaadin-overlay-close', (e) => e.preventDefault());
-        click(parent);
-        await nextRender();
-        expect(spy.called).to.be.false;
-      });
-    });
-
-    describe('vaadin-overlay-closed event', () => {
-      it('should fire the event after the overlay has closed', async () => {
-        const closingSpy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-closing', closingSpy);
-
-        const closedSpy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-closed', closedSpy);
-
-        click(parent);
-        await nextRender();
-
-        expect(closedSpy.calledOnce).to.be.true;
-        expect(closedSpy.calledAfter(closingSpy)).to.be.true;
-      });
-
-      it('should not fire the event when preventing vaadin-overlay-close', async () => {
-        const spy = sinon.spy();
-        overlay.addEventListener('vaadin-overlay-closed', spy);
-        overlay.addEventListener('vaadin-overlay-close', (e) => e.preventDefault());
-
-        click(parent);
-        await nextRender();
-
-        expect(spy.called).to.be.false;
-      });
-    });
-
     describe('moving mouse pointer during click', () => {
       it('should close if both mousedown and mouseup outside', () => {
         mousedown(parent);
@@ -403,6 +224,43 @@ describe('interactions', () => {
 
         expect(document.activeElement).to.be.equal(document.body);
       });
+    });
+  });
+
+  describe('multiple modal overlays', () => {
+    let parent, overlay1, overlay2, overlay3, spy;
+
+    beforeEach(async () => {
+      parent = fixtureSync('<div></div>');
+      overlay1 = createOverlay('overlay 1');
+      overlay2 = createOverlay('overlay 2');
+      overlay3 = createOverlay('overlay 3');
+      parent.append(overlay1, overlay2, overlay3);
+      await nextRender();
+
+      spy = sinon.spy();
+      overlay1.addEventListener('vaadin-overlay-outside-click', spy);
+    });
+
+    afterEach(() => {
+      overlay1.opened = false;
+      overlay2.opened = false;
+      overlay3.opened = false;
+    });
+
+    it('should fire the vaadin-overlay-outside-click if it is the only overlay opened', () => {
+      overlay1.opened = true;
+      click(parent);
+      expect(spy.calledOnce).to.be.true;
+    });
+
+    it('should not fire the vaadin-overlay-outside-click if there is a recent overlay opened', () => {
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      click(parent);
+      expect(spy.called).to.be.false;
     });
   });
 });

--- a/packages/overlay/test/pointer-events.test.js
+++ b/packages/overlay/test/pointer-events.test.js
@@ -1,0 +1,115 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import '../src/vaadin-overlay.js';
+import { createOverlay } from './helpers.js';
+
+describe('pointer-events', () => {
+  describe('single overlay', () => {
+    let overlay;
+
+    beforeEach(async () => {
+      overlay = createOverlay('overlay content');
+      overlay.opened = true;
+      await oneEvent(overlay, 'vaadin-overlay-open');
+    });
+
+    afterEach(() => {
+      overlay.opened = false;
+    });
+
+    it('should not prevent clicking elements outside overlay when modeless (non-modal)', () => {
+      overlay.modeless = true;
+      expect(document.body.style.pointerEvents).to.eql('');
+    });
+
+    it('should prevent clicking elements outside overlay when modal', () => {
+      expect(document.body.style.pointerEvents).to.eql('none');
+    });
+
+    it('should not prevent clicking document elements after modal is closed', () => {
+      overlay.opened = false;
+      expect(document.body.style.pointerEvents).to.eql('');
+    });
+
+    it('should allow pointer events on the overlayPart while skipping on the host', () => {
+      expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('auto');
+      expect(getComputedStyle(overlay).pointerEvents).to.equal('none');
+    });
+  });
+
+  describe('multiple modal overlays', () => {
+    let parent, overlay1, overlay2, overlay3;
+
+    beforeEach(async () => {
+      parent = fixtureSync('<div></div>');
+      overlay1 = createOverlay('overlay 1');
+      overlay2 = createOverlay('overlay 2');
+      overlay3 = createOverlay('overlay 3');
+      parent.append(overlay1, overlay2, overlay3);
+      await nextRender();
+    });
+
+    afterEach(() => {
+      overlay1.opened = false;
+      overlay2.opened = false;
+      overlay3.opened = false;
+    });
+
+    it('should restore pointer-events correctly when overlays are not closed in order', () => {
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+      expect(document.body.style.pointerEvents).to.eql('none');
+
+      overlay1.opened = false;
+
+      overlay2.opened = false;
+      expect(document.body.style.pointerEvents).to.eql('');
+    });
+
+    it('should disable pointer-events in first overlay when second opens', () => {
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      expect(getComputedStyle(overlay1.$.overlay).pointerEvents).to.equal('none');
+    });
+
+    it('should restore pointer-events in first overlay when second closes', () => {
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      overlay2.opened = false;
+      expect(getComputedStyle(overlay1.$.overlay).pointerEvents).to.equal('auto');
+    });
+
+    it('should restore pointer-events in second overlay when third closes', () => {
+      overlay1.opened = true;
+
+      overlay2.opened = true;
+
+      overlay3.opened = true;
+
+      overlay3.opened = false;
+
+      expect(getComputedStyle(overlay2.$.overlay).pointerEvents).to.equal('auto');
+      expect(getComputedStyle(overlay1.$.overlay).pointerEvents).to.equal('none');
+    });
+
+    it('should clear pointer events after closing overlays', () => {
+      // Step 1: Opening overlay 1 so it's physically moved under the body
+      overlay1.opened = true;
+      // Step 2: As overlay2 is modal, it will set overlay 1's pointer events to none
+      overlay2.opened = true;
+      // Step 3: Closing overlay 1 so it's physically moved back from under the body
+      overlay1.opened = false;
+      // Step 4: Closing overlay 2 restores pointer-events of an overlay it
+      // finds under the body node, but overlay 1 is no longer there.
+      overlay2.opened = false;
+      // The fix: Clear pointer-events whenever an overlay is closed
+      // (in this case overlay 1 at step 3)
+      expect(getComputedStyle(overlay1.$.overlay).pointerEvents).to.equal('auto');
+    });
+  });
+});


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12368 to branch 25.2.

---

> ## Description
>
> - Restructured unit tests in `packages/overlay` to not cover <kbd>Esc</kbd> / outside click in 2 files each
> - Removed `interactions.test.js` - covered by `escape.test.js` / `outside-click.test.js`
> - Simplified `beforeEach` to reuse `createOverlay()` where rendering `<input>` isn't needed
> - Replaced `querySelector('[part="overlay"]')` with `$.overlay` to align with other tests
>
> First 4 commits only move tests, actual tests (including titles) are unchanged.
>
> ## Type of change
>
> - Test