### PR TITLE
refactor: remove virtualizer-element-focused event

### DIFF
--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -78,8 +78,6 @@ export class IronListAdapter {
     });
     attachObserver.observe(this.scrollTarget);
 
-    // The focusin event bubbles through the flat tree, so it also fires for
-    // focus on slotted light DOM content, e.g. grid cell content.
     this.elementsContainer.addEventListener('focusin', () => this.__onElementFocused());
 
     if (this.reorderElements) {

--- a/packages/component-base/src/virtualizer-iron-list-adapter.js
+++ b/packages/component-base/src/virtualizer-iron-list-adapter.js
@@ -78,12 +78,9 @@ export class IronListAdapter {
     });
     attachObserver.observe(this.scrollTarget);
 
-    this.scrollTarget.addEventListener('virtualizer-element-focused', (e) => this.__onElementFocused(e));
-    this.elementsContainer.addEventListener('focusin', () => {
-      this.scrollTarget.dispatchEvent(
-        new CustomEvent('virtualizer-element-focused', { detail: { element: this.__getFocusedElement() } }),
-      );
-    });
+    // The focusin event bubbles through the flat tree, so it also fires for
+    // focus on slotted light DOM content, e.g. grid cell content.
+    this.elementsContainer.addEventListener('focusin', () => this.__onElementFocused());
 
     if (this.reorderElements) {
       // Reordering the physical elements cancels the user's grab of the scroll bar handle on Safari.
@@ -558,12 +555,12 @@ export class IronListAdapter {
   }
 
   /** @private */
-  __onElementFocused(e) {
+  __onElementFocused() {
     if (!this.reorderElements) {
       return;
     }
 
-    const focusedElement = e.detail.element;
+    const focusedElement = this.__getFocusedElement();
     if (!focusedElement) {
       return;
     }

--- a/packages/grid/src/vaadin-grid-scroll-mixin.js
+++ b/packages/grid/src/vaadin-grid-scroll-mixin.js
@@ -136,12 +136,6 @@ export const ScrollMixin = (superClass) =>
 
             this.__scrollIntoViewport(scrollTarget);
           }
-
-          if (!this.$.table.contains(e.relatedTarget)) {
-            // Virtualizer can't catch the event because if orginates from the light DOM.
-            // Dispatch a virtualizer-element-focused event for virtualizer to catch.
-            this.$.table.dispatchEvent(new CustomEvent('virtualizer-element-focused', { detail: { element: row } }));
-          }
         }
       });
 


### PR DESCRIPTION
On `focusin`, the virtualizer dispatched a `virtualizer-element-focused` event to itself. Grid dispatched the same event when focus landed on slotted cell content, because at the time (#7119) the virtualizer could not find the focused row when focus was in the light DOM.

Since #11653, the focused element detection walks the flat tree through `assignedSlot`, so it finds the row in the light DOM case as well. The `focusin` event itself already bubbles through slots to the elements container, so the `focusin` listener alone is enough. This removes the event and resolves the focused element directly in the listener. It also avoids running the focus handler twice when focus enters the grid body.
