### PR TITLE
test: extract overlay animation styles tests into separate file

### DIFF
--- a/packages/overlay/test/animation-styles.test.js
+++ b/packages/overlay/test/animation-styles.test.js
@@ -1,0 +1,336 @@
+import { expect } from '@vaadin/chai-plugins';
+import { emulateMedia } from '@vaadin/test-runner-commands';
+import { aTimeout, fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import './fixtures/mock-animated-overlay.js';
+
+function getAnimation(element, name) {
+  return element.getAnimations().find((animation) => animation.animationName === name);
+}
+
+/**
+ * Returns the styles of the element at the given time of the named animation. The animated
+ * value is read instead of the keyframes, because WebKit does not substitute `var()` in the
+ * keyframes returned by `getAnimations()` when a keyframe is left out of the animation.
+ */
+function stylesDuringAnimation(element, name, time) {
+  const animation = getAnimation(element, name);
+  animation.pause();
+  animation.currentTime = time;
+  return getComputedStyle(element);
+}
+
+/** Returns the value the browser computes for the given style, to compare animated values against. */
+function computedValue(property, value) {
+  const element = fixtureSync('<div></div>');
+  element.style.setProperty(property, value);
+  return getComputedStyle(element)[property];
+}
+
+describe('animation properties', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '10s');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay._flushAnimation('closing');
+    overlay.opened = false;
+  });
+
+  it('should set opening and closing attributes when animation duration is not 0s', () => {
+    overlay.opened = true;
+    expect(overlay.hasAttribute('opening')).to.be.true;
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    expect(overlay.hasAttribute('closing')).to.be.true;
+  });
+
+  // The empty keyframe animation on the host is what reports the end of the animation, so
+  // these do not flush: they verify that the attributes are cleared on their own.
+  it('should clear the opening attribute when the animation ends', async () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '50ms');
+
+    overlay.opened = true;
+    expect(overlay.hasAttribute('opening')).to.be.true;
+
+    await oneEvent(overlay, 'animationend');
+    expect(overlay.hasAttribute('opening')).to.be.false;
+  });
+
+  it('should clear the closing attribute when the animation ends', async () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-duration', '50ms');
+
+    overlay.opened = true;
+    // Let the opening animation run out, so that closing starts from a fully opened overlay
+    await aTimeout(100);
+
+    overlay.opened = false;
+    expect(overlay.hasAttribute('closing')).to.be.true;
+
+    await oneEvent(overlay, 'animationend');
+    expect(overlay.hasAttribute('closing')).to.be.false;
+  });
+
+  it('should use animation duration and delay for opening and closing animations', () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+
+    overlay.opened = true;
+    let timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
+    expect(timing.duration).to.equal(10000);
+    expect(timing.delay).to.equal(2000);
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
+    expect(timing.duration).to.equal(10000);
+    expect(timing.delay).to.equal(2000);
+  });
+
+  it('should use animation timing function for opening and closing animations', () => {
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+
+    overlay.opened = true;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
+  });
+
+  // The animations start at the closed value and end at the value of the part, because the
+  // opened state is left out of the keyframes. With a linear timing function the value in the
+  // middle of the animation is exactly between the two, which pins down both ends.
+  it('should use the closed opacity for the fade animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.opacity = '0.6';
+
+    overlay.opened = true;
+    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 0).opacity).to.equal('0.25');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 5000).opacity).to.equal('0.425');
+  });
+
+  it('should use the closed translate for the transform animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-translate-closed', '10px 20px');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.translate = '30px 40px';
+
+    overlay.opened = true;
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).translate).to.equal('10px 20px');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).translate).to.equal('20px 30px');
+  });
+
+  it('should use the closed scale for the transform animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-scale-closed', '0.5');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.scale = '1.5';
+
+    overlay.opened = true;
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).scale).to.equal('0.5');
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).scale).to.equal('1');
+  });
+
+  it('should use the closed transform for the transform animation', () => {
+    overlay.style.setProperty('--vaadin-overlay-transform-closed', 'rotate(10deg)');
+    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
+    overlay.$.overlay.style.transform = 'rotate(20deg)';
+
+    overlay.opened = true;
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).transform).to.equal(
+      computedValue('transform', 'rotate(10deg)'),
+    );
+    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).transform).to.equal(
+      computedValue('transform', 'rotate(15deg)'),
+    );
+  });
+
+  it('should reverse the animation direction while closing', () => {
+    overlay.opened = true;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('normal');
+
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('reverse');
+  });
+
+  describe('backdrop', () => {
+    beforeEach(async () => {
+      overlay.withBackdrop = true;
+      await nextRender();
+    });
+
+    it('should only run the fade animation on the backdrop', () => {
+      overlay.opened = true;
+      const names = overlay.$.backdrop.getAnimations().map((animation) => animation.animationName);
+      expect(names).to.eql(['--fade']);
+    });
+
+    it('should use linear timing function for the backdrop animation', () => {
+      overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'ease-in');
+
+      overlay.opened = true;
+      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().easing).to.equal('linear');
+    });
+
+    it('should always use zero closed opacity for the backdrop animation', () => {
+      overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
+
+      overlay.opened = true;
+      const keyframes = getAnimation(overlay.$.backdrop, '--fade').effect.getKeyframes();
+      expect(keyframes[0].opacity).to.equal('0');
+      expect(keyframes[1].opacity).to.equal('1');
+    });
+
+    it('should reverse the backdrop animation direction while closing', () => {
+      overlay.opened = true;
+      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('normal');
+
+      overlay._flushAnimation('opening');
+      overlay.opened = false;
+      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('reverse');
+    });
+  });
+
+  describe('prefers-reduced-motion', () => {
+    before(async () => {
+      await emulateMedia({ reducedMotion: 'reduce' });
+    });
+
+    after(async () => {
+      await emulateMedia({ reducedMotion: 'no-preference' });
+    });
+
+    it('should only run the fade animation on the overlay part', () => {
+      overlay.opened = true;
+      const names = overlay.$.overlay.getAnimations().map((animation) => animation.animationName);
+      expect(names).to.eql(['--fade']);
+    });
+  });
+
+  describe('fill mode', () => {
+    beforeEach(async () => {
+      overlay.setAttribute('themed-parts', '');
+      overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+      await nextRender();
+    });
+
+    it('should apply the closed value during the opening animation delay', () => {
+      overlay.opened = true;
+
+      // The backwards fill keeps the overlay at its closed opacity for the delay,
+      // instead of painting the theme value until the animation starts.
+      expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
+    });
+
+    it('should apply the value of the part during the closing animation delay', () => {
+      overlay.opened = true;
+      overlay._flushAnimation('opening');
+      overlay.opened = false;
+
+      // The closing animation is reversed, so the fill applies the opened state. That state
+      // is not declared in the keyframes, so the part keeps its own opacity and does not
+      // jump to a different value before the closing animation starts.
+      expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0.5');
+    });
+  });
+});
+
+describe('animation delay without duration', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
+    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay.opened = false;
+  });
+
+  it('should not set opening attribute when animation duration is 0s', () => {
+    overlay.opened = true;
+    expect(overlay.hasAttribute('opening')).to.be.false;
+  });
+
+  it('should not set closing attribute when animation duration is 0s', () => {
+    overlay.opened = true;
+    overlay.opened = false;
+    expect(overlay.hasAttribute('closing')).to.be.false;
+  });
+});
+
+describe('theme paint properties without an opted-in duration', () => {
+  let overlay;
+
+  // The paint properties a theme applies to the overlay parts. These must survive
+  // the opening and closing windows of a host animation that does not opt in to
+  // the overlay animation duration, e.g. a theme with its own `:host([opening])`
+  // animation. See `fixtures/mock-animated-overlay.js` for the values.
+  const themedValues = {
+    transform: 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)',
+    translate: '11px 12px',
+    scale: '0.75',
+    opacity: '0.5',
+  };
+
+  function assertThemedValues(element) {
+    const style = getComputedStyle(element);
+    expect(style.transform).to.equal(themedValues.transform);
+    expect(style.translate).to.equal(themedValues.translate);
+    expect(style.scale).to.equal(themedValues.scale);
+    expect(style.opacity).to.equal(themedValues.opacity);
+  }
+
+  beforeEach(async () => {
+    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
+    // A 5s animation on the host, while --vaadin-overlay-animation-duration stays 0s
+    overlay.setAttribute('long-animation', '');
+    overlay.setAttribute('themed-parts', '');
+    overlay.withBackdrop = true;
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay._flushAnimation('closing');
+    overlay.opened = false;
+  });
+
+  it('should not override the overlay part paint properties while opening', () => {
+    overlay.opened = true;
+
+    expect(overlay.hasAttribute('opening')).to.be.true;
+    assertThemedValues(overlay.$.overlay);
+  });
+
+  it('should not override the backdrop paint properties while opening', () => {
+    overlay.opened = true;
+
+    expect(overlay.hasAttribute('opening')).to.be.true;
+    assertThemedValues(overlay.$.backdrop);
+  });
+
+  it('should not override the overlay part paint properties while closing', () => {
+    overlay.opened = true;
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+
+    expect(overlay.hasAttribute('closing')).to.be.true;
+    assertThemedValues(overlay.$.overlay);
+  });
+
+  it('should not override the backdrop paint properties while closing', () => {
+    overlay.opened = true;
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+
+    expect(overlay.hasAttribute('closing')).to.be.true;
+    assertThemedValues(overlay.$.backdrop);
+  });
+});

--- a/packages/overlay/test/animation-styles.test.js
+++ b/packages/overlay/test/animation-styles.test.js
@@ -212,14 +212,14 @@ describe('animation properties', () => {
     });
   });
 
-  describe('fill mode', () => {
+  describe('fill during the animation delay', () => {
     beforeEach(async () => {
       overlay.setAttribute('themed-parts', '');
       overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
       await nextRender();
     });
 
-    it('should apply the closed value during the opening animation delay', () => {
+    it('should apply the closed value while opening', () => {
       overlay.opened = true;
 
       // The backwards fill keeps the overlay at its closed opacity for the delay,
@@ -227,7 +227,7 @@ describe('animation properties', () => {
       expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
     });
 
-    it('should apply the value of the part during the closing animation delay', () => {
+    it('should apply the value of the part while closing', () => {
       overlay.opened = true;
       overlay._flushAnimation('opening');
       overlay.opened = false;
@@ -265,26 +265,30 @@ describe('animation delay without duration', () => {
   });
 });
 
-describe('theme paint properties without an opted-in duration', () => {
+/**
+ * The `[opening]` and `[closing]` attributes follow the animation on the host, which is defined
+ * separately from the overlay animation properties and can therefore outlast the part animations.
+ * These cover `animation-fill-mode: backwards`: filling forwards would pin the parts on their
+ * last keyframe for the rest of that window, covering the styles set on them, and while closing
+ * that keyframe is the closed one, so the overlay would vanish instead of fading out.
+ */
+describe('theme animation on the host', () => {
   let overlay;
 
-  // The paint properties a theme applies to the overlay parts. These must survive
-  // the opening and closing windows of a host animation that does not opt in to
-  // the overlay animation duration, e.g. a theme with its own `:host([opening])`
-  // animation. See `fixtures/mock-animated-overlay.js` for the values.
-  const themedValues = {
+  // The styles the theme applies to the parts, see `fixtures/mock-animated-overlay.js`
+  const themeStyles = {
     transform: 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)',
     translate: '11px 12px',
     scale: '0.75',
     opacity: '0.5',
   };
 
-  function assertThemedValues(element) {
+  function expectThemeStyles(element) {
     const style = getComputedStyle(element);
-    expect(style.transform).to.equal(themedValues.transform);
-    expect(style.translate).to.equal(themedValues.translate);
-    expect(style.scale).to.equal(themedValues.scale);
-    expect(style.opacity).to.equal(themedValues.opacity);
+    expect(style.transform).to.equal(themeStyles.transform);
+    expect(style.translate).to.equal(themeStyles.translate);
+    expect(style.scale).to.equal(themeStyles.scale);
+    expect(style.opacity).to.equal(themeStyles.opacity);
   }
 
   beforeEach(async () => {
@@ -302,35 +306,35 @@ describe('theme paint properties without an opted-in duration', () => {
     overlay.opened = false;
   });
 
-  it('should not override the overlay part paint properties while opening', () => {
+  it('should keep the theme styles on the overlay part while opening', () => {
     overlay.opened = true;
 
     expect(overlay.hasAttribute('opening')).to.be.true;
-    assertThemedValues(overlay.$.overlay);
+    expectThemeStyles(overlay.$.overlay);
   });
 
-  it('should not override the backdrop paint properties while opening', () => {
+  it('should keep the theme styles on the backdrop while opening', () => {
     overlay.opened = true;
 
     expect(overlay.hasAttribute('opening')).to.be.true;
-    assertThemedValues(overlay.$.backdrop);
+    expectThemeStyles(overlay.$.backdrop);
   });
 
-  it('should not override the overlay part paint properties while closing', () => {
+  it('should keep the theme styles on the overlay part while closing', () => {
     overlay.opened = true;
     overlay._flushAnimation('opening');
     overlay.opened = false;
 
     expect(overlay.hasAttribute('closing')).to.be.true;
-    assertThemedValues(overlay.$.overlay);
+    expectThemeStyles(overlay.$.overlay);
   });
 
-  it('should not override the backdrop paint properties while closing', () => {
+  it('should keep the theme styles on the backdrop while closing', () => {
     overlay.opened = true;
     overlay._flushAnimation('opening');
     overlay.opened = false;
 
     expect(overlay.hasAttribute('closing')).to.be.true;
-    assertThemedValues(overlay.$.backdrop);
+    expectThemeStyles(overlay.$.backdrop);
   });
 });

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { emulateMedia, resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
-import { aTimeout, escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './fixtures/mock-animated-overlay.js';
 
@@ -88,42 +87,6 @@ function afterOverlayClosingFinished(overlay, callback) {
   });
   observer.observe(overlay, { attributes: true, attributeFilter: ['closing'] });
 }
-
-describe('overlay with zero-duration animation', () => {
-  let overlay, owner;
-
-  beforeEach(async () => {
-    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
-    owner = fixtureSync('<div></div>');
-    overlay.owner = owner;
-    overlay.setAttribute('zero-duration-animation', '');
-    await nextRender();
-  });
-
-  afterEach(() => {
-    overlay.opened = false;
-    sinon.restore();
-  });
-
-  it('should finish opening and closing synchronously', () => {
-    const finishOpening = sinon.spy(overlay, '_finishOpening');
-    const finishClosing = sinon.spy(overlay, '_finishClosing');
-
-    expect(getComputedStyle(overlay).animationName).to.equal('overlay-dummy-animation');
-
-    overlay.opened = true;
-
-    expect(finishOpening).to.be.calledOnce;
-    expect(overlay.hasAttribute('opening')).to.be.false;
-    expect(owner.hasAttribute('opening')).to.be.false;
-
-    overlay.opened = false;
-
-    expect(finishClosing).to.be.calledOnce;
-    expect(overlay.hasAttribute('closing')).to.be.false;
-    expect(owner.hasAttribute('closing')).to.be.false;
-  });
-});
 
 [false, true].forEach((withAnimation) => {
   const titleSuffix = withAnimation ? ' (animated)' : '';
@@ -425,380 +388,38 @@ describe('overlay with zero-duration animation', () => {
   });
 });
 
-describe('interaction while closing', () => {
-  let overlay, content, spy;
-
-  beforeEach(async () => {
-    overlay = fixtureSync('<mock-animated-overlay><button>Overlay content</button></mock-animated-overlay>');
-    overlay.setAttribute('long-animation', '');
-    await nextRender();
-
-    overlay.opened = true;
-    await nextRender();
-    overlay._flushAnimation('opening');
-
-    content = overlay.querySelector('button');
-    spy = sinon.spy();
-    content.addEventListener('click', spy);
-  });
-
-  afterEach(async () => {
-    overlay._flushAnimation('closing');
-    await resetMouse();
-  });
-
-  it('should not allow pointer events on the overlay part while closing', () => {
-    overlay.opened = false;
-
-    expect(overlay.hasAttribute('closing')).to.be.true;
-    expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('none');
-  });
-
-  it('should not dispatch click on the overlay content while closing', async () => {
-    overlay.opened = false;
-
-    await sendMouseToElement({ type: 'click', element: content });
-
-    expect(spy).to.be.not.called;
-  });
-
-  it('should restore pointer events on the overlay part after closing', () => {
-    overlay.opened = false;
-    overlay._flushAnimation('closing');
-
-    expect(overlay.hasAttribute('closing')).to.be.false;
-    expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('auto');
-  });
-});
-
-function getAnimation(element, name) {
-  return element.getAnimations().find((animation) => animation.animationName === name);
-}
-
-/**
- * Returns the styles of the element at the given time of the named animation. The animated
- * value is read instead of the keyframes, because WebKit does not substitute `var()` in the
- * keyframes returned by `getAnimations()` when a keyframe is left out of the animation.
- */
-function stylesDuringAnimation(element, name, time) {
-  const animation = getAnimation(element, name);
-  animation.pause();
-  animation.currentTime = time;
-  return getComputedStyle(element);
-}
-
-/** Returns the value the browser computes for the given style, to compare animated values against. */
-function computedValue(property, value) {
-  const element = fixtureSync('<div></div>');
-  element.style.setProperty(property, value);
-  return getComputedStyle(element)[property];
-}
-
-describe('animation properties', () => {
-  let overlay;
+describe('zero-duration animation', () => {
+  let overlay, owner;
 
   beforeEach(async () => {
     overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
-    overlay.style.setProperty('--vaadin-overlay-animation-duration', '10s');
+    owner = fixtureSync('<div></div>');
+    overlay.owner = owner;
+    overlay.setAttribute('zero-duration-animation', '');
     await nextRender();
   });
 
   afterEach(() => {
-    overlay._flushAnimation('opening');
-    overlay._flushAnimation('closing');
     overlay.opened = false;
+    sinon.restore();
   });
 
-  it('should set opening and closing attributes when animation duration is not 0s', () => {
-    overlay.opened = true;
-    expect(overlay.hasAttribute('opening')).to.be.true;
+  it('should finish opening and closing synchronously', () => {
+    const finishOpening = sinon.spy(overlay, '_finishOpening');
+    const finishClosing = sinon.spy(overlay, '_finishClosing');
 
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-    expect(overlay.hasAttribute('closing')).to.be.true;
-  });
-
-  // The empty keyframe animation on the host is what reports the end of the animation, so
-  // these do not flush: they verify that the attributes are cleared on their own.
-  it('should clear the opening attribute when the animation ends', async () => {
-    overlay.style.setProperty('--vaadin-overlay-animation-duration', '50ms');
+    expect(getComputedStyle(overlay).animationName).to.equal('overlay-dummy-animation');
 
     overlay.opened = true;
-    expect(overlay.hasAttribute('opening')).to.be.true;
 
-    await oneEvent(overlay, 'animationend');
+    expect(finishOpening).to.be.calledOnce;
     expect(overlay.hasAttribute('opening')).to.be.false;
-  });
-
-  it('should clear the closing attribute when the animation ends', async () => {
-    overlay.style.setProperty('--vaadin-overlay-animation-duration', '50ms');
-
-    overlay.opened = true;
-    // Let the opening animation run out, so that closing starts from a fully opened overlay
-    await aTimeout(100);
+    expect(owner.hasAttribute('opening')).to.be.false;
 
     overlay.opened = false;
-    expect(overlay.hasAttribute('closing')).to.be.true;
 
-    await oneEvent(overlay, 'animationend');
+    expect(finishClosing).to.be.calledOnce;
     expect(overlay.hasAttribute('closing')).to.be.false;
-  });
-
-  it('should use animation duration and delay for opening and closing animations', () => {
-    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
-
-    overlay.opened = true;
-    let timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
-    expect(timing.duration).to.equal(10000);
-    expect(timing.delay).to.equal(2000);
-
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-    timing = getAnimation(overlay.$.overlay, '--fade').effect.getTiming();
-    expect(timing.duration).to.equal(10000);
-    expect(timing.delay).to.equal(2000);
-  });
-
-  it('should use animation timing function for opening and closing animations', () => {
-    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
-
-    overlay.opened = true;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
-
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().easing).to.equal('linear');
-  });
-
-  // The animations start at the closed value and end at the value of the part, because the
-  // opened state is left out of the keyframes. With a linear timing function the value in the
-  // middle of the animation is exactly between the two, which pins down both ends.
-  it('should use the closed opacity for the fade animation', () => {
-    overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
-    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
-    overlay.$.overlay.style.opacity = '0.6';
-
-    overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 0).opacity).to.equal('0.25');
-    expect(stylesDuringAnimation(overlay.$.overlay, '--fade', 5000).opacity).to.equal('0.425');
-  });
-
-  it('should use the closed translate for the transform animation', () => {
-    overlay.style.setProperty('--vaadin-overlay-translate-closed', '10px 20px');
-    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
-    overlay.$.overlay.style.translate = '30px 40px';
-
-    overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).translate).to.equal('10px 20px');
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).translate).to.equal('20px 30px');
-  });
-
-  it('should use the closed scale for the transform animation', () => {
-    overlay.style.setProperty('--vaadin-overlay-scale-closed', '0.5');
-    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
-    overlay.$.overlay.style.scale = '1.5';
-
-    overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).scale).to.equal('0.5');
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).scale).to.equal('1');
-  });
-
-  it('should use the closed transform for the transform animation', () => {
-    overlay.style.setProperty('--vaadin-overlay-transform-closed', 'rotate(10deg)');
-    overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'linear');
-    overlay.$.overlay.style.transform = 'rotate(20deg)';
-
-    overlay.opened = true;
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 0).transform).to.equal(
-      computedValue('transform', 'rotate(10deg)'),
-    );
-    expect(stylesDuringAnimation(overlay.$.overlay, '--transform', 5000).transform).to.equal(
-      computedValue('transform', 'rotate(15deg)'),
-    );
-  });
-
-  it('should reverse the animation direction while closing', () => {
-    overlay.opened = true;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('normal');
-
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-    expect(getAnimation(overlay.$.overlay, '--fade').effect.getTiming().direction).to.equal('reverse');
-  });
-
-  describe('backdrop', () => {
-    beforeEach(async () => {
-      overlay.withBackdrop = true;
-      await nextRender();
-    });
-
-    it('should only run the fade animation on the backdrop', () => {
-      overlay.opened = true;
-      const names = overlay.$.backdrop.getAnimations().map((animation) => animation.animationName);
-      expect(names).to.eql(['--fade']);
-    });
-
-    it('should use linear timing function for the backdrop animation', () => {
-      overlay.style.setProperty('--vaadin-overlay-animation-timing-function', 'ease-in');
-
-      overlay.opened = true;
-      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().easing).to.equal('linear');
-    });
-
-    it('should always use zero closed opacity for the backdrop animation', () => {
-      overlay.style.setProperty('--vaadin-overlay-opacity-closed', '0.25');
-
-      overlay.opened = true;
-      const keyframes = getAnimation(overlay.$.backdrop, '--fade').effect.getKeyframes();
-      expect(keyframes[0].opacity).to.equal('0');
-      expect(keyframes[1].opacity).to.equal('1');
-    });
-
-    it('should reverse the backdrop animation direction while closing', () => {
-      overlay.opened = true;
-      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('normal');
-
-      overlay._flushAnimation('opening');
-      overlay.opened = false;
-      expect(getAnimation(overlay.$.backdrop, '--fade').effect.getTiming().direction).to.equal('reverse');
-    });
-  });
-
-  describe('prefers-reduced-motion', () => {
-    before(async () => {
-      await emulateMedia({ reducedMotion: 'reduce' });
-    });
-
-    after(async () => {
-      await emulateMedia({ reducedMotion: 'no-preference' });
-    });
-
-    it('should only run the fade animation on the overlay part', () => {
-      overlay.opened = true;
-      const names = overlay.$.overlay.getAnimations().map((animation) => animation.animationName);
-      expect(names).to.eql(['--fade']);
-    });
-  });
-
-  describe('fill mode', () => {
-    beforeEach(async () => {
-      overlay.setAttribute('themed-parts', '');
-      overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
-      await nextRender();
-    });
-
-    it('should apply the closed value during the opening animation delay', () => {
-      overlay.opened = true;
-
-      // The backwards fill keeps the overlay at its closed opacity for the delay,
-      // instead of painting the theme value until the animation starts.
-      expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0');
-    });
-
-    it('should apply the value of the part during the closing animation delay', () => {
-      overlay.opened = true;
-      overlay._flushAnimation('opening');
-      overlay.opened = false;
-
-      // The closing animation is reversed, so the fill applies the opened state. That state
-      // is not declared in the keyframes, so the part keeps its own opacity and does not
-      // jump to a different value before the closing animation starts.
-      expect(getComputedStyle(overlay.$.overlay).opacity).to.equal('0.5');
-    });
-  });
-});
-
-describe('animation delay without duration', () => {
-  let overlay;
-
-  beforeEach(async () => {
-    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
-    overlay.style.setProperty('--vaadin-overlay-animation-delay', '2s');
-    await nextRender();
-  });
-
-  afterEach(() => {
-    overlay.opened = false;
-  });
-
-  it('should not set opening attribute when animation duration is 0s', () => {
-    overlay.opened = true;
-    expect(overlay.hasAttribute('opening')).to.be.false;
-  });
-
-  it('should not set closing attribute when animation duration is 0s', () => {
-    overlay.opened = true;
-    overlay.opened = false;
-    expect(overlay.hasAttribute('closing')).to.be.false;
-  });
-});
-
-describe('theme paint properties without an opted-in duration', () => {
-  let overlay;
-
-  // The paint properties a theme applies to the overlay parts. These must survive
-  // the opening and closing windows of a host animation that does not opt in to
-  // the overlay animation duration, e.g. a theme with its own `:host([opening])`
-  // animation. See `animated-styles.js` for the values.
-  const themedValues = {
-    transform: 'matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)',
-    translate: '11px 12px',
-    scale: '0.75',
-    opacity: '0.5',
-  };
-
-  function assertThemedValues(element) {
-    const style = getComputedStyle(element);
-    expect(style.transform).to.equal(themedValues.transform);
-    expect(style.translate).to.equal(themedValues.translate);
-    expect(style.scale).to.equal(themedValues.scale);
-    expect(style.opacity).to.equal(themedValues.opacity);
-  }
-
-  beforeEach(async () => {
-    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
-    // A 5s animation on the host, while --vaadin-overlay-animation-duration stays 0s
-    overlay.setAttribute('long-animation', '');
-    overlay.setAttribute('themed-parts', '');
-    overlay.withBackdrop = true;
-    await nextRender();
-  });
-
-  afterEach(() => {
-    overlay._flushAnimation('opening');
-    overlay._flushAnimation('closing');
-    overlay.opened = false;
-  });
-
-  it('should not override the overlay part paint properties while opening', () => {
-    overlay.opened = true;
-
-    expect(overlay.hasAttribute('opening')).to.be.true;
-    assertThemedValues(overlay.$.overlay);
-  });
-
-  it('should not override the backdrop paint properties while opening', () => {
-    overlay.opened = true;
-
-    expect(overlay.hasAttribute('opening')).to.be.true;
-    assertThemedValues(overlay.$.backdrop);
-  });
-
-  it('should not override the overlay part paint properties while closing', () => {
-    overlay.opened = true;
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-
-    expect(overlay.hasAttribute('closing')).to.be.true;
-    assertThemedValues(overlay.$.overlay);
-  });
-
-  it('should not override the backdrop paint properties while closing', () => {
-    overlay.opened = true;
-    overlay._flushAnimation('opening');
-    overlay.opened = false;
-
-    expect(overlay.hasAttribute('closing')).to.be.true;
-    assertThemedValues(overlay.$.backdrop);
+    expect(owner.hasAttribute('closing')).to.be.false;
   });
 });

--- a/packages/overlay/test/pointer-events.test.js
+++ b/packages/overlay/test/pointer-events.test.js
@@ -1,5 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import './fixtures/mock-animated-overlay.js';
 import './fixtures/mock-overlay.js';
 
 describe('pointer-events', () => {
@@ -112,6 +114,50 @@ describe('pointer-events', () => {
       // The fix: Clear pointer-events whenever an overlay is closed
       // (in this case overlay 1 at step 3)
       expect(getComputedStyle(overlay1.$.overlay).pointerEvents).to.equal('auto');
+    });
+  });
+
+  describe('animated closing', () => {
+    let overlay, content, spy;
+
+    beforeEach(async () => {
+      overlay = fixtureSync('<mock-animated-overlay><button>Overlay content</button></mock-animated-overlay>');
+      overlay.setAttribute('long-animation', '');
+      await nextRender();
+
+      overlay.opened = true;
+      await nextRender();
+      overlay._flushAnimation('opening');
+
+      content = overlay.querySelector('button');
+      spy = sinon.spy();
+      content.addEventListener('click', spy);
+    });
+
+    afterEach(async () => {
+      overlay._flushAnimation('closing');
+    });
+
+    it('should not allow pointer events on the overlay part while closing', () => {
+      overlay.opened = false;
+
+      expect(overlay.hasAttribute('closing')).to.be.true;
+      expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('none');
+    });
+
+    it('should not dispatch click on the overlay content while closing', async () => {
+      overlay.opened = false;
+
+      content = overlay.querySelector('button');
+      expect(getComputedStyle(content).pointerEvents).to.equal('none');
+    });
+
+    it('should restore pointer events on the overlay part after closing', () => {
+      overlay.opened = false;
+      overlay._flushAnimation('closing');
+
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('auto');
     });
   });
 });

--- a/packages/overlay/test/pointer-events.test.js
+++ b/packages/overlay/test/pointer-events.test.js
@@ -1,6 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
-import sinon from 'sinon';
 import './fixtures/mock-animated-overlay.js';
 import './fixtures/mock-overlay.js';
 
@@ -118,7 +117,7 @@ describe('pointer-events', () => {
   });
 
   describe('animated closing', () => {
-    let overlay, content, spy;
+    let overlay;
 
     beforeEach(async () => {
       overlay = fixtureSync('<mock-animated-overlay><button>Overlay content</button></mock-animated-overlay>');
@@ -128,13 +127,9 @@ describe('pointer-events', () => {
       overlay.opened = true;
       await nextRender();
       overlay._flushAnimation('opening');
-
-      content = overlay.querySelector('button');
-      spy = sinon.spy();
-      content.addEventListener('click', spy);
     });
 
-    afterEach(async () => {
+    afterEach(() => {
       overlay._flushAnimation('closing');
     });
 
@@ -145,11 +140,11 @@ describe('pointer-events', () => {
       expect(getComputedStyle(overlay.$.overlay).pointerEvents).to.equal('none');
     });
 
-    it('should not dispatch click on the overlay content while closing', async () => {
+    it('should not allow pointer events on the overlay content while closing', () => {
       overlay.opened = false;
 
-      content = overlay.querySelector('button');
-      expect(getComputedStyle(content).pointerEvents).to.equal('none');
+      const button = overlay.querySelector('button');
+      expect(getComputedStyle(button).pointerEvents).to.equal('none');
     });
 
     it('should restore pointer events on the overlay part after closing', () => {


### PR DESCRIPTION
## Description

- Extracted CSS assertions to `animated-styles.test.js` to align with notification test structure
- Moved "interactions while closing" test suite to `pointer-events.test.js` where it fits naturally
- Updated comment that referenced `animated-styles.js` to point to `mock-animated-overlay`

## Type of change

- Test