### PR TITLE
test: fix stale overlay detach assertions and cover animation cleanup

### DIFF
--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -192,6 +192,32 @@ function afterOverlayClosingFinished(overlay, callback) {
         expect(overlay.hasAttribute('closing')).to.be.false;
         expect(owner.hasAttribute('closing')).to.be.false;
       });
+
+      it('should remove the animationend listener after the animation has finished', async () => {
+        overlay.opened = true;
+
+        await new Promise((resolve) => {
+          afterOverlayOpeningFinished(overlay, resolve);
+        });
+
+        const spy = sinon.spy(overlay, '_finishOpening');
+        overlay.dispatchEvent(new AnimationEvent('animationend'));
+
+        expect(spy).to.be.not.called;
+      });
+
+      it('should not run the animation callback again after the animation has finished', async () => {
+        overlay.opened = true;
+
+        await new Promise((resolve) => {
+          afterOverlayOpeningFinished(overlay, resolve);
+        });
+
+        const spy = sinon.spy(overlay, '_finishOpening');
+        overlay._flushAnimation('opening');
+
+        expect(spy).to.be.not.called;
+      });
     }
 
     it('should flush closing overlay when re-opened while closing animation is in progress', () => {
@@ -224,7 +250,7 @@ function afterOverlayClosingFinished(overlay, callback) {
       overlay.opened = false;
       overlay._flushAnimation('closing');
 
-      expect(overlay.parentNode).not.to.equal(document.body);
+      expect(overlay.matches(':popover-open')).to.be.false;
     });
 
     it('should not animate closing if the overlay is explicitly hidden', () => {
@@ -234,7 +260,8 @@ function afterOverlayClosingFinished(overlay, callback) {
 
       overlay.opened = false;
 
-      expect(overlay.parentNode).not.to.equal(document.body);
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(overlay.matches(':popover-open')).to.be.false;
     });
 
     it('should close the overlay if hidden is set while closing', () => {
@@ -244,7 +271,8 @@ function afterOverlayClosingFinished(overlay, callback) {
 
       overlay.hidden = true;
 
-      expect(overlay.parentNode).not.to.equal(document.body);
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(overlay.matches(':popover-open')).to.be.false;
     });
 
     it('should close the overlay when ESC pressed while opening', () => {
@@ -376,7 +404,7 @@ function afterOverlayClosingFinished(overlay, callback) {
       });
     });
 
-    it('should not remove pointer events on last opened overlay', (done) => {
+    it('should not remove pointer events on last opened overlay with animated content', (done) => {
       afterOverlayOpeningFinished(overlays[1], () => {
         expect(overlays[0].$.overlay.style.pointerEvents).to.equal('none');
         expect(overlays[1].$.overlay.style.pointerEvents).to.equal('');
@@ -385,6 +413,34 @@ function afterOverlayClosingFinished(overlay, callback) {
       overlays[0].opened = true;
       overlays[1].opened = true;
     });
+  });
+});
+
+describe('content animation', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = fixtureSync(`
+      <mock-animated-overlay long-animation>
+        <animated-div>Fancy content</animated-div>
+      </mock-animated-overlay>
+    `);
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+  });
+
+  it('should not finish the overlay animation when the content animation ends', async () => {
+    overlay.opened = true;
+
+    // The content animation is much shorter than the overlay animation, so the first
+    // `animationend` bubbling to the overlay is the one from the content
+    await oneEvent(overlay, 'animationend');
+
+    expect(overlay.hasAttribute('opening')).to.be.true;
   });
 });
 


### PR DESCRIPTION
The three `parentNode` assertions in `animations.test.js` were written when the
overlay moved itself into `<body>` while open, so
`expect(overlay.parentNode).not.to.equal(document.body)` checked that it had
been moved back. Since #9848 the overlay uses the native popover API and never
changes parent, so these assertions can no longer fail: deleting
`hidePopover()` from `OverlayMixin` keeps the whole file green.

Two of them were also the only tests written for behavior that nothing else in
the overlay suite covers.

## Changes

- Check the popover state instead, the same way `basic.test.js` already does.
- Add a `content animation` suite that pairs a long overlay animation with a
  short content animation, to cover the `event.target !== this` check in
  `_enqueueAnimation()`.
- Add two tests for the `animationend` listener cleanup, so a leftover handler
  cannot run the animation callback a second time.
- Give the animated content pointer-events test a unique name.

Every line below could be deleted without any test failing. Each is now covered
by one test:

| deleted line | failing test |
| --- | --- |
| `_flushAnimation('closing')` in `_hiddenChanged()` | should close the overlay if hidden is set while closing |
| `return` in the `animationend` check | should not finish the overlay animation when the content animation ends |
| `removeEventListener('animationend', ...)` | should remove the animationend listener after the animation has finished |
| `delete this[handler]` | should not run the animation callback again after the animation has finished |
| `hidePopover()` | the three updated tests, in both arms |

> [!NOTE]
> Not addressed here: `bringToFront()` in `_animatedOpening()` never gets past
> its `isLastOverlay()` check, because `_appendAttachedInstance()` on the line
> before already makes the overlay the last one. No test in the suite reaches
> it, so it looks like dead code worth a separate look.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
