### PR TITLE
refactor: remove no-op bringToFront call from overlay opening

### DIFF
--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -437,7 +437,6 @@ export const OverlayMixin = (superClass) =>
       }
       this._attachOverlay();
       this._appendAttachedInstance();
-      this.bringToFront();
       if (!this.modeless) {
         this._enterModalState();
       }


### PR DESCRIPTION
`_animatedOpening()` calls `bringToFront()` right after `_appendAttachedInstance()`.
That call comes from the z-index mechanism added in vaadin/vaadin-overlay#169:
back then `bringToFront()` first raised the overlay above every other attached
overlay by setting `z-index`, and only afterwards decided whether it also had to
re-append the element. Opening an overlay had to run that code to get the correct
stacking, and the method even carried a `TODO: Can be removed after switching all
overlays to be based on native popover`.

Since #9848 stacking is handled by the browser top layer, the z-index code is gone,
and `bringToFront()` now starts with:

```js
if (isLastOverlay(this)) {
  return;
}
```

At the call site the overlay is always the last one, so the call never does
anything:

- `_appendAttachedInstance()` on the line before adds the overlay to the end of
  the `attachedInstances` set.
- `isLastOverlay()` reads `getAttachedInstances()`, which skips overlays with the
  `closing` attribute, and compares against the last entry.
- The only case where the overlay could already be in the set on open is a reopen
  during a closing animation, and `_animatedOpening()` flushes that three lines
  earlier, which removes it from the set again.

Instrumenting `bringToFront()` to log whenever it gets past the `isLastOverlay()`
check while called from `_animatedOpening()` gives zero hits across the whole
overlay test suite.

Explicit `bringToFront()` calls, such as the one a modeless dialog makes when it
is clicked, are unaffected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
