### PR TITLE
refactor: use :focus-within to detect focus in grid cell content

### DIFF
--- a/packages/grid/src/vaadin-grid-active-item-mixin.js
+++ b/packages/grid/src/vaadin-grid-active-item-mixin.js
@@ -76,7 +76,7 @@ export const ActiveItemMixin = (superClass) =>
         // Cell is the empty state cell
         cell === this.$.emptystatecell ||
         // Cell content is focused
-        cell._content.contains(this.getRootNode().activeElement) ||
+        cell._content.matches(':focus-within') ||
         // Clicked on a focusable element
         this._isFocusable(e.target) ||
         // Clicked on a label element

--- a/packages/grid/src/vaadin-grid-column-reordering-mixin.js
+++ b/packages/grid/src/vaadin-grid-column-reordering-mixin.js
@@ -116,7 +116,7 @@ export const ColumnReorderingMixin = (superClass) =>
           return;
         }
 
-        if (headerCell._content.contains(this.getRootNode().activeElement)) {
+        if (headerCell._content.matches(':focus-within')) {
           // Something was focused inside the cell
           return;
         }

--- a/packages/grid/src/vaadin-grid-sorter-mixin.js
+++ b/packages/grid/src/vaadin-grid-sorter-mixin.js
@@ -131,8 +131,7 @@ export const GridSorterMixin = (superClass) =>
         return;
       }
 
-      const activeElement = this.getRootNode().activeElement;
-      if (this !== activeElement && this.contains(activeElement)) {
+      if (this.matches(':focus-within') && !this.matches(':focus')) {
         // Some focusable content inside the sorter was clicked, do nothing.
         return;
       }


### PR DESCRIPTION
Grid checks in a few places whether focus is inside a cell's content or a sorter by comparing against `this.getRootNode().activeElement`. The `:focus-within` selector answers the same question directly: it matches an element when the element itself or any of its flat-tree descendants has focus. In the sorter's click handler, `:focus-within` combined with `:focus` replaces the "focus is inside the sorter but not on the sorter itself" check.