### PR TITLE
refactor!: remove isElementFocused helper in favor of :focus checks

### DIFF
--- a/packages/a11y-base/index.d.ts
+++ b/packages/a11y-base/index.d.ts
@@ -4,13 +4,7 @@ export { DelegateFocusMixin } from './src/delegate-focus-mixin.js';
 export { DisabledMixin } from './src/disabled-mixin.js';
 export { FieldAriaController } from './src/field-aria-controller.js';
 export { FocusMixin } from './src/focus-mixin.js';
-export {
-  getTabbableElements,
-  isElementFocusable,
-  isElementFocused,
-  isElementHidden,
-  isKeyboardActive,
-} from './src/focus-utils.js';
+export { getTabbableElements, isElementFocusable, isElementHidden, isKeyboardActive } from './src/focus-utils.js';
 export { FocusTrapController } from './src/focus-trap-controller.js';
 export { FocusRestorationController } from './src/focus-restoration-controller.js';
 export { KeyboardDirectionMixin } from './src/keyboard-direction-mixin.js';

--- a/packages/a11y-base/index.js
+++ b/packages/a11y-base/index.js
@@ -6,13 +6,7 @@ export { FieldAriaController } from './src/field-aria-controller.js';
 export { FocusMixin } from './src/focus-mixin.js';
 export { FocusTrapController } from './src/focus-trap-controller.js';
 export { FocusRestorationController } from './src/focus-restoration-controller.js';
-export {
-  getTabbableElements,
-  isElementFocusable,
-  isElementFocused,
-  isElementHidden,
-  isKeyboardActive,
-} from './src/focus-utils.js';
+export { getTabbableElements, isElementFocusable, isElementHidden, isKeyboardActive } from './src/focus-utils.js';
 export { KeyboardDirectionMixin } from './src/keyboard-direction-mixin.js';
 export { KeyboardMixin } from './src/keyboard-mixin.js';
 export { ListMixin } from './src/list-mixin.js';

--- a/packages/a11y-base/src/focus-trap-controller.js
+++ b/packages/a11y-base/src/focus-trap-controller.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { getTabbableElements, isElementFocused, isKeyboardActive } from './focus-utils.js';
+import { getTabbableElements, isKeyboardActive } from './focus-utils.js';
 
 const instances = [];
 
@@ -63,7 +63,7 @@ export class FocusTrapController {
    */
   get #focusedElementIndex() {
     const focusableElements = this.#focusableElements;
-    return focusableElements.indexOf(focusableElements.filter(isElementFocused).pop());
+    return focusableElements.indexOf(focusableElements.filter((element) => element.matches(':focus')).pop());
   }
 
   hostConnected() {

--- a/packages/a11y-base/src/focus-utils.d.ts
+++ b/packages/a11y-base/src/focus-utils.d.ts
@@ -45,11 +45,6 @@ export declare function isElementHidden(element: HTMLElement): boolean;
 export declare function isElementFocusable(element: HTMLElement): boolean;
 
 /**
- * Returns true if the element is focused, false otherwise.
- */
-export declare function isElementFocused(element: HTMLElement): boolean;
-
-/**
  * Returns a tab-ordered array of focusable elements for a root element.
  * The resulting array will include the root element if it is focusable.
  *

--- a/packages/a11y-base/src/focus-utils.js
+++ b/packages/a11y-base/src/focus-utils.js
@@ -195,16 +195,6 @@ export function isElementFocusable(element) {
 }
 
 /**
- * Returns true if the element is focused, false otherwise.
- *
- * @param {HTMLElement} element
- * @return {boolean}
- */
-export function isElementFocused(element) {
-  return element.getRootNode().activeElement === element;
-}
-
-/**
  * Returns the normalized element tabindex. If not focusable, returns -1.
  * It checks for the attribute "tabindex" instead of the element property
  * `tabIndex` since browsers assign different values to it.

--- a/packages/a11y-base/src/keyboard-direction-mixin.js
+++ b/packages/a11y-base/src/keyboard-direction-mixin.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2022 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isElementFocused, isElementHidden } from './focus-utils.js';
+import { isElementHidden } from './focus-utils.js';
 import { KeyboardMixin } from './keyboard-mixin.js';
 
 /**
@@ -16,7 +16,7 @@ export const KeyboardDirectionMixin = (superclass) =>
      * @protected
      */
     get focused() {
-      return (this._getItems() || []).find(isElementFocused);
+      return (this._getItems() || []).find((item) => item.matches(':focus'));
     }
 
     /**

--- a/packages/a11y-base/test/focus-utils.test.js
+++ b/packages/a11y-base/test/focus-utils.test.js
@@ -4,7 +4,6 @@ import {
   getDeepActiveElement,
   getTabbableElements,
   isElementFocusable,
-  isElementFocused,
   isElementHidden,
   isKeyboardActive,
 } from '../src/focus-utils.js';
@@ -174,24 +173,6 @@ describe('focus-utils', () => {
       const focusableElements = getTabbableElements(ancestor.querySelector('#root'));
       expect(focusableElements).to.have.lengthOf(1);
       expect(focusableElements[0].id).to.equal('root');
-    });
-  });
-
-  describe('isElementFocused', () => {
-    let input;
-
-    beforeEach(() => {
-      input = fixtureSync(`<input>`);
-    });
-
-    it('should return true for a focused element', () => {
-      input.focus();
-      expect(isElementFocused(input)).to.be.true;
-    });
-
-    it('should return false for a not focused element', () => {
-      input.focus();
-      expect(isElementFocused(document.body)).to.be.false;
     });
   });
 

--- a/packages/accordion/src/vaadin-accordion-mixin.js
+++ b/packages/accordion/src/vaadin-accordion-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2019 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { SlotObserver } from '@vaadin/component-base/src/slot-observer.js';
 
@@ -72,7 +71,7 @@ export const AccordionMixin = (superClass) =>
      * @override
      */
     get focused() {
-      return (this._getItems() || []).find((item) => isElementFocused(item.focusElement));
+      return (this._getItems() || []).find((item) => item.focusElement.matches(':focus'));
     }
 
     /**

--- a/packages/combo-box/src/vaadin-combo-box-base-mixin.js
+++ b/packages/combo-box/src/vaadin-combo-box-base-mixin.js
@@ -5,7 +5,7 @@
  */
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
-import { isElementFocused, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { setOrRemoveAttribute } from '@vaadin/component-base/src/dom-utils.js';
@@ -275,7 +275,7 @@ export const ComboBoxBaseMixin = (superClass) =>
 
     /** @protected */
     _isInputFocused() {
-      return this.inputElement && isElementFocused(this.inputElement);
+      return !!this.inputElement?.matches(':focus');
     }
 
     /** @private */

--- a/packages/date-picker/test/helpers.js
+++ b/packages/date-picker/test/helpers.js
@@ -1,5 +1,4 @@
 import { fire, makeSoloTouchEvent, nextRender } from '@vaadin/testing-helpers';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 
 export function activateScroller(scroller) {
   scroller.active = true;
@@ -204,7 +203,7 @@ export function getFocusableCell(root) {
  */
 export function getFocusedCell(root) {
   const focusableCell = getFocusableCell(root);
-  if (focusableCell && isElementFocused(focusableCell)) {
+  if (focusableCell?.matches(':focus')) {
     return focusableCell;
   }
 }

--- a/packages/field-base/src/clear-button-mixin.js
+++ b/packages/field-base/src/clear-button-mixin.js
@@ -3,7 +3,6 @@
  * Copyright (c) 2021 - 2026 Vaadin Ltd.
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardMixin } from '@vaadin/a11y-base/src/keyboard-mixin.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
 import { InputMixin } from './input-mixin.js';
@@ -117,6 +116,6 @@ export const ClearButtonMixin = (superclass) =>
      * @return {boolean}
      */
     _shouldKeepFocusOnClearMousedown() {
-      return isElementFocused(this.inputElement);
+      return this.inputElement.matches(':focus');
     }
   };

--- a/packages/grid/test/frozen-columns.test.js
+++ b/packages/grid/test/frozen-columns.test.js
@@ -4,7 +4,6 @@ import { fixtureSync, listenOnce, nextRender, nextResize } from '@vaadin/testing
 import sinon from 'sinon';
 import './grid-test-styles.js';
 import '../src/vaadin-grid.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { setNormalizedScrollLeft } from '@vaadin/component-base/src/dir-utils.js';
 import { flushGrid, getRowCells, getRows, infiniteDataProvider, isWithinParentConstraints } from './helpers.js';
 
@@ -388,9 +387,9 @@ const frozenGridFixture = (frozen, frozenToEnd) => {
           }
           const yCoordinate = boundingClientRect.y + Math.floor(boundingClientRect.height / 2);
 
-          expect(isElementFocused(grid)).to.be.false;
+          expect(grid.matches(':focus')).to.be.false;
           await sendMouse({ type: 'click', position: [xCoordinate, yCoordinate] });
-          expect(isElementFocused(grid)).to.be.true;
+          expect(grid.matches(':focus')).to.be.true;
         });
       });
     });

--- a/packages/menu-bar/src/vaadin-menu-bar-mixin.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-mixin.js
@@ -8,7 +8,7 @@ import { Directive, directive } from 'lit/directive.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { DisabledMixin } from '@vaadin/a11y-base/src/disabled-mixin.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
-import { isElementFocused, isElementHidden, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isElementHidden, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { KeyboardDirectionMixin } from '@vaadin/a11y-base/src/keyboard-direction-mixin.js';
 import { microTask } from '@vaadin/component-base/src/async.js';
 import { Debouncer } from '@vaadin/component-base/src/debounce.js';
@@ -237,7 +237,7 @@ export const MenuBarMixin = (superClass) =>
      * @override
      */
     get focused() {
-      return (this._getItems() || []).find(isElementFocused) || this._expandedButton;
+      return (this._getItems() || []).find((item) => item.matches(':focus')) || this._expandedButton;
     }
 
     /**
@@ -759,7 +759,7 @@ export const MenuBarMixin = (superClass) =>
     /** @private */
     __getFocusTarget() {
       // First, check if focus is moving to a visible button
-      let target = this._buttons.find((btn) => isElementFocused(btn));
+      let target = this._buttons.find((btn) => btn.matches(':focus'));
 
       if (!target) {
         const selector = this.tabNavigation ? '[focused]' : '[tabindex="0"]';

--- a/packages/overlay/src/vaadin-overlay-focus-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-focus-mixin.js
@@ -8,7 +8,6 @@ import { FocusTrapController } from '@vaadin/a11y-base/src/focus-trap-controller
 import {
   getDeepActiveElement,
   getTabbableElements,
-  isElementFocused,
   isElementHidden,
   isKeyboardActive,
 } from '@vaadin/a11y-base/src/focus-utils.js';
@@ -140,7 +139,7 @@ export const OverlayFocusMixin = (superClass) =>
 
       if (this.autofocus) {
         const tabbables = getTabbableElements(this._focusRoot);
-        if (!tabbables.some(isElementFocused)) {
+        if (!tabbables.some((element) => element.matches(':focus'))) {
           tabbables[0]?.focus({ focusVisible: isKeyboardActive() });
         }
       }

--- a/packages/overlay/test/focus.test.js
+++ b/packages/overlay/test/focus.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender, oneEvent, tabKeyDown } from '@vaadin/testing-helpers';
 import './fixtures/mock-overlay.js';
-import { getDeepActiveElement, getTabbableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, getTabbableElements } from '@vaadin/a11y-base/src/focus-utils.js';
 
 describe('autofocus', () => {
   let overlay;
@@ -30,7 +30,7 @@ describe('autofocus', () => {
 
   it('should focus the overlay part when opened', async () => {
     await open();
-    expect(isElementFocused(overlay.$.overlay)).to.be.true;
+    expect(overlay.$.overlay.matches(':focus')).to.be.true;
   });
 
   it('should not focus any element when autofocus is false', async () => {
@@ -54,7 +54,7 @@ describe('autofocus', () => {
       root.querySelectorAll('button')[1].focus();
     };
     await open();
-    expect(isElementFocused(overlay.querySelectorAll('button')[1])).to.be.true;
+    expect(overlay.querySelectorAll('button')[1].matches(':focus')).to.be.true;
   });
 });
 
@@ -62,7 +62,7 @@ describe('focus-trap', () => {
   let overlay, overlayPart, focusableElements;
 
   function getFocusedElementIndex() {
-    return focusableElements.findIndex(isElementFocused);
+    return focusableElements.findIndex((element) => element.matches(':focus'));
   }
 
   describe('focusable elements', () => {

--- a/packages/popover/src/vaadin-popover-focus-controller.js
+++ b/packages/popover/src/vaadin-popover-focus-controller.js
@@ -4,7 +4,7 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { getActiveTrappingNode } from '@vaadin/a11y-base/src/focus-trap-controller.js';
-import { getDeepActiveElement, getTabbableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, getTabbableElements } from '@vaadin/a11y-base/src/focus-utils.js';
 
 /**
  * Controller that routes Tab and Shift+Tab when a non-modal popover is opened.
@@ -38,7 +38,7 @@ export class PopoverFocusController {
     const host = this.host;
     const targetFocusable = this.__getTargetFocusable();
 
-    if (targetFocusable && isElementFocused(targetFocusable)) {
+    if (targetFocusable && targetFocusable.matches(':focus')) {
       event.preventDefault();
       if (host.noTabFocus) {
         this.__moveLogicalNext(event, targetFocusable);
@@ -49,7 +49,7 @@ export class PopoverFocusController {
     }
 
     const lastPopoverFocusable = this.__getLastPopoverFocusable();
-    if (isElementFocused(lastPopoverFocusable)) {
+    if (lastPopoverFocusable.matches(':focus')) {
       // With noTabFocus the popover isn't in the logical list, so the target
       // becomes the reference for "next after the popover".
       this.__moveLogicalNext(event, host.noTabFocus ? targetFocusable : host);
@@ -75,11 +75,11 @@ export class PopoverFocusController {
     // through to the redirect logic: when the popover is DOM-prev of the target,
     // case 5 steers focus away from it instead of letting the browser land on
     // the popover host or its content.
-    if (targetFocusable && isElementFocused(targetFocusable) && host.__shouldRestoreFocus) {
+    if (targetFocusable && targetFocusable.matches(':focus') && host.__shouldRestoreFocus) {
       host.__shouldRestoreFocus = false;
     }
 
-    if (isElementFocused(host)) {
+    if (host.matches(':focus')) {
       event.preventDefault();
       targetFocusable.focus();
       return;

--- a/packages/popover/src/vaadin-popover-overlay.js
+++ b/packages/popover/src/vaadin-popover-overlay.js
@@ -4,7 +4,6 @@
  * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
  */
 import { html, LitElement } from 'lit';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -53,7 +52,7 @@ class PopoverOverlay extends PopoverOverlayMixin(
 
     if (props.has('restoreFocusNode') && this.opened) {
       // Save focus to be restored when target is set while opened
-      if (this.restoreFocusNode && isElementFocused(this.restoreFocusNode.focusElement || this.restoreFocusNode)) {
+      if (this.restoreFocusNode && (this.restoreFocusNode.focusElement || this.restoreFocusNode).matches(':focus')) {
         this.__focusRestorationController.saveFocus();
       } else if (!this.restoreFocusNode) {
         // Do not restore focus when target is cleared while opened

--- a/packages/slider/src/vaadin-range-slider.js
+++ b/packages/slider/src/vaadin-range-slider.js
@@ -8,7 +8,6 @@ import { css, html, LitElement, render } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { FocusMixin } from '@vaadin/a11y-base/src/focus-mixin.js';
-import { isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { ElementMixin } from '@vaadin/component-base/src/element-mixin.js';
 import { PolylitMixin } from '@vaadin/component-base/src/polylit-mixin.js';
@@ -514,7 +513,7 @@ class RangeSlider extends FieldMixin(
    */
   blur() {
     if (this._inputElements) {
-      const focusedInput = this._inputElements.find((input) => isElementFocused(input));
+      const focusedInput = this._inputElements.find((input) => input.matches(':focus'));
       if (focusedInput) {
         focusedInput.blur();
       }
@@ -532,8 +531,8 @@ class RangeSlider extends FieldMixin(
   _setFocused(focused) {
     super._setFocused(focused);
 
-    this.__startFocused = isElementFocused(this._inputElements[0]);
-    this.__endFocused = isElementFocused(this._inputElements[1]);
+    this.__startFocused = this._inputElements[0].matches(':focus');
+    this.__endFocused = this._inputElements[1].matches(':focus');
   }
 
   /** @private */

--- a/test/integration/overlay-focus-trap.test.js
+++ b/test/integration/overlay-focus-trap.test.js
@@ -6,14 +6,14 @@ import '@vaadin/grid';
 import '@vaadin/radio-group';
 import '@vaadin/text-field';
 import '@vaadin/overlay/test/fixtures/mock-overlay.js';
-import { getTabbableElements, isElementFocused } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getTabbableElements } from '@vaadin/a11y-base/src/focus-utils.js';
 import { flushGrid } from '@vaadin/grid/test/helpers.js';
 
 describe('overlay focus-trap', () => {
   let overlay, focusableElements;
 
   function getFocusedElementIndex() {
-    return focusableElements.findIndex(isElementFocused);
+    return focusableElements.findIndex((element) => element.matches(':focus'));
   }
 
   describe('elements in light DOM', () => {


### PR DESCRIPTION
The `isElementFocused(element)` helper compared `element.getRootNode().activeElement` to the element. The native `:focus` selector answers the same question, so `element.matches(':focus')`  is now used instead.

The two are equivalent also when the element is a shadow host, which some components rely on (menu-bar buttons, the popover host, `isElementFocused(grid)` in grid tests):

- Focus inside the host's shadow root: `activeElement` never returns nodes from inside a nested shadow tree. It returns the closest ancestor that lives in the same tree, which is the host itself. So the old check was true for the host. `:focus` also matches a shadow host that contains the focused element, so it is true as well.
- Focus on slotted content: the slotted element is a light DOM child of the host, so `activeElement` returns the slotted element itself. The old check was false for the host. `:focus` does not match the host here either (only `:focus-within` does), so it is false as well.

> [!WARNING]
> `isElementFocused` is removed from the `@vaadin/a11y-base` package exports. Use `element.matches(':focus')` instead.
