### PR TITLE
refactor: use overlay outside click to close context menu with items

### DIFF
--- a/packages/context-menu/src/vaadin-context-menu-mixin.js
+++ b/packages/context-menu/src/vaadin-context-menu-mixin.js
@@ -206,7 +206,8 @@ export const ContextMenuMixin = (superClass) =>
           );
         }
 
-        // With items property, menu closes on item selection or items-outside-click.
+        // Clicks on items bubble to the overlay and must not close the menu
+        // (items with `keepOpen` or with children), so disable `closeOn`.
         if (this.items && this.closeOn === 'click') {
           this.closeOn = '';
         }
@@ -224,9 +225,12 @@ export const ContextMenuMixin = (superClass) =>
       }
 
       const opened = event.detail.value;
-      this._setOpened(opened);
       if (opened) {
+        this._setOpened(true);
         this.__alignOverlayPosition();
+      } else if (this.opened) {
+        // Use `close()` to also reset menu-bar button on outside click.
+        this.close();
       }
     }
 
@@ -315,7 +319,11 @@ export const ContextMenuMixin = (superClass) =>
 
     /** @private */
     _preventDefault(e) {
-      e.preventDefault();
+      // With items, `closeOn` is cleared to not close the menu on clicks bubbling
+      // from the items to the overlay, and the menu still closes on outside click.
+      if (!this.items) {
+        e.preventDefault();
+      }
     }
 
     /** @private */

--- a/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
+++ b/packages/context-menu/src/vaadin-contextmenu-items-mixin.js
@@ -87,21 +87,6 @@ export const ItemsMixin = (superClass) =>
       };
     }
 
-    constructor() {
-      super();
-
-      // Overlay's outside click listener doesn't work with modeless
-      // overlays (submenus) so we need additional logic for it
-      this.__itemsOutsideClickListener = (e) => {
-        if (this._shouldCloseOnOutsideClick(e)) {
-          this.dispatchEvent(new CustomEvent('items-outside-click'));
-        }
-      };
-      this.addEventListener('items-outside-click', () => {
-        this.items && this.close();
-      });
-    }
-
     /**
      * Tag name prefix used by overlay, list-box and items.
      * @protected
@@ -112,30 +97,9 @@ export const ItemsMixin = (superClass) =>
     }
 
     /** @protected */
-    connectedCallback() {
-      super.connectedCallback();
-      // Firefox leaks click to document on contextmenu even if prevented
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=990614
-      document.documentElement.addEventListener('click', this.__itemsOutsideClickListener);
-    }
-
-    /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
-      document.documentElement.removeEventListener('click', this.__itemsOutsideClickListener);
       this._tooltipController.setTarget(null);
-    }
-
-    /**
-     * Whether to close the overlay on outside click or not.
-     * Override this method to customize the closing logic.
-     *
-     * @param {Event} event
-     * @return {boolean}
-     * @protected
-     */
-    _shouldCloseOnOutsideClick(event) {
-      return !event.composedPath().some((el) => el.localName === `${this._tagNamePrefix}-overlay`);
     }
 
     /** @protected */
@@ -288,6 +252,11 @@ export const ItemsMixin = (superClass) =>
 
       overlay.$.backdrop.addEventListener('click', () => {
         this.close();
+      });
+
+      // TODO: deprecated, fires for backwards compatibility. Remove in Vaadin 26
+      overlay.addEventListener('vaadin-overlay-outside-click', () => {
+        this.dispatchEvent(new CustomEvent('items-outside-click'));
       });
 
       // Open a submenu on click event when a touch device is used.

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -104,7 +104,8 @@ export const MenuOverlayMixin = (superClass) =>
         return false;
       }
 
-      // Close on outside click also if there is a tooltip shown on top
+      // With items, overlays above the root overlay belong to the menu itself,
+      // e.g. an open sub-menu or item tooltip, so ignore the overlay stack
       if (this.owner.items) {
         return true;
       }

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -86,13 +86,7 @@ export const MenuOverlayMixin = (superClass) =>
     }
 
     /**
-     * Override method from `OverlayMixin` to close the whole menu from its
-     * root overlay: a click inside any overlay of the menu passes through
-     * the root overlay in the composed path, since all menu content is
-     * slotted through it (e.g. a click on an item with a sub-menu or with
-     * `keepOpen` set is not an outside click). Menus using the `items` API
-     * close regardless of the overlay stack, so overlays that do not belong
-     * to the menu (e.g. a tooltip shown for a menu item) do not block closing.
+     * Override method from `OverlayMixin` to close the menu from its root overlay.
      *
      * @param {Event} event
      * @return {boolean}
@@ -100,15 +94,17 @@ export const MenuOverlayMixin = (superClass) =>
      * @override
      */
     _shouldCloseOnOutsideClick(event) {
+      // Only close the menu from its root overlay
       if (this.parentOverlay) {
-        // Sub-menu overlays do not act, the root overlay closes the menu.
         return false;
       }
 
+      // Ignore clicks on nested menu items
       if (event.composedPath().includes(this)) {
         return false;
       }
 
+      // Ignore other overlays on top, e.g. an item tooltip
       if (this.owner.items) {
         return true;
       }

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -86,6 +86,37 @@ export const MenuOverlayMixin = (superClass) =>
     }
 
     /**
+     * Override method from `OverlayMixin` to close the whole menu from its
+     * root overlay: a click inside any overlay of the menu passes through
+     * the root overlay in the composed path, since all menu content is
+     * slotted through it (e.g. a click on an item with a sub-menu or with
+     * `keepOpen` set is not an outside click). Menus using the `items` API
+     * close regardless of the overlay stack, so overlays that do not belong
+     * to the menu (e.g. a tooltip shown for a menu item) do not block closing.
+     *
+     * @param {Event} event
+     * @return {boolean}
+     * @protected
+     * @override
+     */
+    _shouldCloseOnOutsideClick(event) {
+      if (this.parentOverlay) {
+        // Sub-menu overlays do not act, the root overlay closes the menu.
+        return false;
+      }
+
+      if (event.composedPath().includes(this)) {
+        return false;
+      }
+
+      if (this.owner.items) {
+        return true;
+      }
+
+      return super._shouldCloseOnOutsideClick(event);
+    }
+
+    /**
      * Returns the adjusted boundaries of the overlay.
      *
      * @returns {object}

--- a/packages/context-menu/src/vaadin-menu-overlay-mixin.js
+++ b/packages/context-menu/src/vaadin-menu-overlay-mixin.js
@@ -104,7 +104,7 @@ export const MenuOverlayMixin = (superClass) =>
         return false;
       }
 
-      // Ignore other overlays on top, e.g. an item tooltip
+      // Close on outside click also if there is a tooltip shown on top
       if (this.owner.items) {
         return true;
       }

--- a/packages/context-menu/test/items-interactions.test.js
+++ b/packages/context-menu/test/items-interactions.test.js
@@ -64,8 +64,43 @@ describe('items interactions', () => {
   describe('closing on click', () => {
     beforeEach(async () => {
       await openMenu(target);
+      rootOverlay = rootMenu._overlayElement;
       subMenu = await openSubMenu(rootMenu);
       subOverlay1 = subMenu._overlayElement;
+    });
+
+    it('should close the menu using its close() method on outside click', () => {
+      const spy = sinon.spy(rootMenu, 'close');
+
+      outsideClick();
+      expect(spy).to.be.called;
+    });
+
+    it('should only report outside click on the root overlay of the menu', () => {
+      const rootSpy = sinon.spy();
+      rootOverlay.addEventListener('vaadin-overlay-outside-click', rootSpy);
+      const subSpy = sinon.spy();
+      subOverlay1.addEventListener('vaadin-overlay-outside-click', subSpy);
+
+      outsideClick();
+      expect(rootSpy).to.be.calledOnce;
+      expect(subSpy).to.not.be.called;
+    });
+
+    it('should not close menus when the outside click event is prevented', () => {
+      rootOverlay.addEventListener('vaadin-overlay-outside-click', (event) => event.preventDefault(), { once: true });
+
+      outsideClick();
+      expect(rootMenu.opened).to.be.true;
+      expect(subMenu.opened).to.be.true;
+    });
+
+    it('should not react to outside click when closed', async () => {
+      rootMenu.close();
+      await nextRender();
+      const spy = sinon.spy(rootMenu, 'close');
+      outsideClick();
+      expect(spy).to.not.be.called;
     });
 
     // On touch, the click opening the second menu closes the first one.

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -252,6 +252,15 @@ describe('items', () => {
       expect(spy).to.be.calledOnce;
     });
 
+    it('should not fire on outside click when the menu is closed', async () => {
+      rootMenu.close();
+      await nextRender();
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      outsideClick();
+      expect(spy).to.not.be.called;
+    });
+
     it('should not fire on click inside the menu', () => {
       const spy = sinon.spy();
       rootMenu.addEventListener('items-outside-click', spy);

--- a/packages/menu-bar/src/vaadin-menu-bar-overlay.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-overlay.js
@@ -36,6 +36,25 @@ class MenuBarOverlay extends MenuOverlayMixin(
     return { ...super.lumoInjector, includeBaseStyles: true };
   }
 
+  /**
+   * Override method from `MenuOverlayMixin` to prevent closing the menu on
+   * a click on the menu-bar button that opened it: the button is the
+   * `listenOn` target of the root sub-menu, and the menu-bar click handler
+   * closes the menu on that click.
+   *
+   * @param {Event} event
+   * @return {boolean}
+   * @protected
+   * @override
+   */
+  _shouldCloseOnOutsideClick(event) {
+    if (event.composedPath().includes(this.owner.listenOn)) {
+      return false;
+    }
+
+    return super._shouldCloseOnOutsideClick(event);
+  }
+
   /** @protected */
   render() {
     return html`

--- a/packages/menu-bar/src/vaadin-menu-bar-submenu.js
+++ b/packages/menu-bar/src/vaadin-menu-bar-submenu.js
@@ -126,23 +126,6 @@ class MenuBarSubmenu extends ContextMenuMixin(ThemePropertyMixin(PolylitMixin(Li
       this.parentElement._close();
     }
   }
-
-  /**
-   * Override method from `ContextMenuMixin` to prevent closing
-   * sub-menu on the same click event that was used to open it.
-   *
-   * @param {Event} event
-   * @return {boolean}
-   * @protected
-   * @override
-   */
-  _shouldCloseOnOutsideClick(event) {
-    if (this.hasAttribute('is-root') && event.composedPath().includes(this.listenOn)) {
-      return false;
-    }
-
-    return super._shouldCloseOnOutsideClick(event);
-  }
 }
 
 defineCustomElement(MenuBarSubmenu);

--- a/packages/menu-bar/test/sub-menu.test.js
+++ b/packages/menu-bar/test/sub-menu.test.js
@@ -281,6 +281,34 @@ describe('sub-menu', () => {
     expect(subMenu.opened).to.be.false;
   });
 
+  it('should close the menu on expanded button click when a nested sub-menu is open', async () => {
+    buttons[0].click();
+    await nextRender();
+
+    const item = subMenuOverlay._contentRoot.querySelectorAll('vaadin-menu-bar-item')[1];
+    fire(item, menuOpenEvent);
+    const nestedSubMenu = subMenu._subMenu;
+    await oneEvent(nestedSubMenu._overlayElement, 'vaadin-overlay-open');
+    expect(nestedSubMenu.opened).to.be.true;
+
+    buttons[0].click();
+    await nextRender();
+    expect(subMenu.opened).to.be.false;
+    expect(nestedSubMenu.opened).to.be.false;
+  });
+
+  it('should not move focus to the button on outside click', async () => {
+    buttons[0].click();
+    await nextRender();
+
+    const spy = sinon.spy(buttons[0], 'focus');
+
+    document.body.click();
+    await nextRender();
+    expect(subMenu.opened).to.be.false;
+    expect(spy).to.not.be.called;
+  });
+
   it('should close and dispatch item-selected event on select', async () => {
     buttons[0].click();
     await nextRender();

--- a/test/integration/master-detail-layout-overlay.test.js
+++ b/test/integration/master-detail-layout-overlay.test.js
@@ -1,8 +1,9 @@
 import { expect } from '@vaadin/chai-plugins';
 import { resetMouse, sendMouse } from '@vaadin/test-runner-commands';
-import { fixtureSync, nextRender, nextResize, oneEvent } from '@vaadin/testing-helpers';
+import { fire, fixtureSync, nextRender, nextResize, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/combo-box';
+import '@vaadin/context-menu';
 import '@vaadin/date-picker';
 import '@vaadin/master-detail-layout';
 
@@ -21,6 +22,9 @@ describe('overlay in master-detail-layout', () => {
         <div slot="detail">
           <vaadin-combo-box></vaadin-combo-box>
           <vaadin-date-picker></vaadin-date-picker>
+          <vaadin-context-menu open-on="click">
+            <button>target</button>
+          </vaadin-context-menu>
         </div>
       </vaadin-master-detail-layout>
     `);
@@ -62,6 +66,39 @@ describe('overlay in master-detail-layout', () => {
 
         expect(spy).to.be.calledOnce;
       });
+    });
+  });
+
+  describe('context-menu', () => {
+    let menu;
+
+    beforeEach(async () => {
+      menu = layout.querySelector('vaadin-context-menu');
+      menu.items = [{ text: 'Item 0', children: [{ text: 'Item 0-0' }] }, { text: 'Item 1' }];
+      await nextRender();
+
+      menu.querySelector('button').click();
+      await oneEvent(menu._overlayElement, 'vaadin-overlay-open');
+    });
+
+    it('should not fire backdrop-click when the click closes the context menu', async () => {
+      await clickBackdrop();
+
+      expect(menu.opened).to.be.false;
+      expect(spy).to.not.be.called;
+    });
+
+    it('should not fire backdrop-click when the click closes the menu with a sub-menu open', async () => {
+      const item = menu.querySelector('vaadin-context-menu-item');
+      fire(item, 'mouseover');
+      const subMenu = menu.querySelector('vaadin-context-menu');
+      await oneEvent(subMenu._overlayElement, 'vaadin-overlay-open');
+
+      await clickBackdrop();
+
+      expect(menu.opened).to.be.false;
+      expect(subMenu.opened).to.be.false;
+      expect(spy).to.not.be.called;
     });
   });
 });


### PR DESCRIPTION
`<vaadin-context-menu>` with the `items` API did not use the overlay's outside click logic. It closed through its own `document` click listener, which ran in the bubble phase — after every other click handler on the page — so components that react to the same click acted before the menu closed. In particular, the master-detail-layout backdrop fired `backdrop-click` on the click that dismissed the menu, because the `preventDefault()` signal added in #12366 only works when the menu closes through the overlay. The listener was also registered for every menu and sub-menu instance while connected and ran on every document click, even when the menu was closed. Finally, the closing decision lived in two places: `_shouldCloseOnOutsideClick` existed both on the menu element and on the overlay, with the same name but a different meaning.

This change removes the document click listener and lets the root menu overlay close the whole menu through the overlay logic instead.

Non-obvious parts:

- Only the root overlay of a menu acts on outside click. A click inside any overlay of the menu passes through the root overlay in the composed path, since all menu content (including sub-menus) is slotted through it. Sub-menu overlays stay out of the decision and register no document listeners.
- The root overlay closes itself through the regular `OverlayMixin` path, so `preventDefault()` from #12366 is called on the closing click and the master-detail-layout backdrop ignores it — covered by new integration tests. Canceling `vaadin-overlay-outside-click` also works for menus with `items` now.
- Menus with `items` close regardless of the overlay stack, same as before: an item tooltip overlay on top of the stack must not block closing. Menus using a renderer keep the default rule of only closing when their overlay is the last one in the stack.
- Setting `closeOn` to `''` still disables closing on outside click for menus with a renderer or a slotted list-box. The listener that cancels the outside click event now skips menus with `items`, where the empty `closeOn` is set internally as the default.
- The `items-outside-click` event (deprecated in #12388) now fires on the menu only when an outside click happens while it is open, and dispatching it manually no longer closes the menu.
- The protected `_shouldCloseOnOutsideClick(event)` hook is removed from the menu element; the replacement with the same name lives on the menu overlay (`MenuOverlayMixin`).

> [!WARNING]
> Behavior changes to the deprecated `items-outside-click` event and two edge cases:
>
> - `items-outside-click` fires only when an outside click happens on an open menu, no longer on every document click while the menu element is connected, and dispatching it manually no longer closes the menu.
> - A click inside another open overlay-based component (e.g. another context menu) now closes the menu, and pressing the mouse down inside the menu and releasing it outside no longer closes it — both now match how other overlay-based components behave.
> - Subclasses overriding the removed element-level `_shouldCloseOnOutsideClick(event)` need to override it on the overlay instead.

Fixes #12367

---

🤖 Generated with Claude Code
