### PR TITLE
feat(details): add summary-suffix slot

### DIFF
--- a/packages/details/src/vaadin-details.d.ts
+++ b/packages/details/src/vaadin-details.d.ts
@@ -35,9 +35,10 @@ export type DetailsEventMap = DetailsCustomEventMap & HTMLElementEventMap;
  *
  * The following shadow DOM parts are exposed for styling:
  *
- * Part name        | Description
- * -----------------|----------------
- * `content`        | The wrapper for the collapsible details content.
+ * Part name          | Description
+ * -------------------|----------------
+ * `content`          | The wrapper for the collapsible details content.
+ * `summary-wrapper`  | The wrapper for the summary and summary-suffix slots.
  *
  * The following state attributes are available for styling:
  *

--- a/packages/details/src/vaadin-details.js
+++ b/packages/details/src/vaadin-details.js
@@ -29,9 +29,10 @@ import { DetailsBaseMixin } from './vaadin-details-base-mixin.js';
  *
  * The following shadow DOM parts are exposed for styling:
  *
- * Part name        | Description
- * -----------------|----------------
- * `content`        | The wrapper for the collapsible details content.
+ * Part name          | Description
+ * -------------------|----------------
+ * `content`          | The wrapper for the collapsible details content.
+ * `summary-wrapper`  | The wrapper for the summary and summary-suffix slots.
  *
  * The following state attributes are available for styling:
  *
@@ -66,6 +67,19 @@ class Details extends DetailsBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(L
       :host(:not([opened])) [part='content'] {
         display: none !important;
       }
+
+      [part='summary-wrapper'] {
+        display: flex;
+        align-items: center;
+      }
+
+      [part='summary-wrapper'] > slot[name='summary'] {
+        flex: 1;
+      }
+
+      [part='summary-wrapper'] > slot[name='summary-suffix'] {
+        flex: none;
+      }
     `;
   }
 
@@ -76,7 +90,10 @@ class Details extends DetailsBaseMixin(ElementMixin(ThemableMixin(PolylitMixin(L
   /** @protected */
   render() {
     return html`
-      <slot name="summary"></slot>
+      <div part="summary-wrapper">
+        <slot name="summary"></slot>
+        <slot name="summary-suffix"></slot>
+      </div>
 
       <div part="content">
         <slot></slot>

--- a/packages/details/test/details.test.js
+++ b/packages/details/test/details.test.js
@@ -280,4 +280,46 @@ describe('vaadin-details', () => {
       expect(details.opened).to.be.false;
     });
   });
+
+  describe('summary-suffix slot', () => {
+    let suffix;
+
+    beforeEach(async () => {
+      details = fixtureSync(`
+        <vaadin-details summary="Summary">
+          <div slot="summary-suffix">Suffix</div>
+          <div>Content</div>
+        </vaadin-details>
+      `);
+      await nextRender();
+      suffix = details.querySelector('[slot="summary-suffix"]');
+    });
+
+    it('should render a summary-wrapper part in the shadow DOM', () => {
+      const wrapper = details.shadowRoot.querySelector('[part="summary-wrapper"]');
+      expect(wrapper).to.be.ok;
+    });
+
+    it('should render a summary-suffix slot in the shadow DOM', () => {
+      const slot = details.shadowRoot.querySelector('slot[name="summary-suffix"]');
+      expect(slot).to.be.ok;
+    });
+
+    it('should assign the suffix element to the summary-suffix slot', () => {
+      const slot = details.shadowRoot.querySelector('slot[name="summary-suffix"]');
+      expect(slot.assignedNodes()).to.include(suffix);
+    });
+
+    it('should not toggle opened on summary-suffix click', () => {
+      suffix.click();
+      expect(details.opened).to.be.false;
+    });
+
+    it('should still toggle opened on summary click', async () => {
+      const summary = details.querySelector('[slot="summary"]');
+      summary.click();
+      await nextUpdate(details);
+      expect(details.opened).to.be.true;
+    });
+  });
 });

--- a/packages/details/test/dom/__snapshots__/details.test.snap.js
+++ b/packages/details/test/dom/__snapshots__/details.test.snap.js
@@ -93,9 +93,13 @@ snapshots["vaadin-details host theme"] =
 `;
 /* end snapshot vaadin-details host theme */
 
-snapshots["vaadin-details shadow default"] = 
-`<slot name="summary">
-</slot>
+snapshots["vaadin-details shadow default"] =
+`<div part="summary-wrapper">
+  <slot name="summary">
+  </slot>
+  <slot name="summary-suffix">
+  </slot>
+</div>
 <div part="content">
   <slot>
   </slot>
@@ -105,9 +109,13 @@ snapshots["vaadin-details shadow default"] =
 `;
 /* end snapshot vaadin-details shadow default */
 
-snapshots["vaadin-details shadow opened"] = 
-`<slot name="summary">
-</slot>
+snapshots["vaadin-details shadow opened"] =
+`<div part="summary-wrapper">
+  <slot name="summary">
+  </slot>
+  <slot name="summary-suffix">
+  </slot>
+</div>
 <div part="content">
   <slot>
   </slot>


### PR DESCRIPTION
## Summary

Add a `summary-suffix` slot to `<vaadin-details>` so action buttons can be placed on the right side of the summary, visible in both open and closed states, without triggering the toggle behavior.

### Changes
- Wrapped the `summary` slot and a new `summary-suffix` slot in a `<div part="summary-wrapper">` with flex layout
- Summary takes `flex: 1`, suffix takes `flex: none` (sits on the right)
- Added tests for the new slot

### Why
Currently there is no way to add action buttons (edit, delete, etc.) next to the summary without them also toggling the panel open/close. The `summary-suffix` slot provides a dedicated area for such buttons.

Closes vaadin/web-components#12440

#### Test plan
- [x] `summary-wrapper` part renders in shadow DOM
- [x] `summary-suffix` slot renders in shadow DOM
- [x] Suffix element is assigned to the slot
- [x] Clicking suffix does NOT toggle the panel

https://github.com/user-attachments/assets/b47f4ae9-20b8-4d5c-b7d2-e5d198e30cef