### PR TITLE
fix: keep _removeFile a no-op when called without a file

### DIFF
--- a/packages/upload/src/vaadin-upload-mixin.js
+++ b/packages/upload/src/vaadin-upload-mixin.js
@@ -787,10 +787,16 @@ export const UploadMixin = (superClass) =>
 
     /**
      * Remove file from upload list. Called internally if file upload was canceled.
+     * Does nothing when called without a file.
      * @param {!UploadFile} file File to remove
      * @protected
      */
     _removeFile(file) {
+      // Tolerate a missing file to keep the historical no-op behavior,
+      // which e.g. UploadElement.removeFile(index) in Flow relies on
+      if (!file) {
+        return;
+      }
       this._manager.removeFile(file);
     }
 

--- a/packages/upload/test/adding-files.test.js
+++ b/packages/upload/test/adding-files.test.js
@@ -122,6 +122,18 @@ describe('adding files', () => {
       expect(upload.files).to.have.lengthOf(0);
     });
 
+    it('should not throw when calling the protected _removeFile method without a file', async () => {
+      upload.noAuto = true;
+      addFilesViaInput(upload, [files[0]]);
+      await nextUpdate(upload);
+
+      // Calls the protected method directly, like UploadElement in flow-components
+      // does: its removeFile(index) evaluates `_removeFile(files[index])`, which
+      // passes undefined when there is no file with the given index
+      expect(() => upload._removeFile()).to.not.throw();
+      expect(upload.files).to.have.lengthOf(1);
+    });
+
     describe('uploading assigned files', () => {
       let clock;
 


### PR DESCRIPTION
## Summary
- #12354 moved the `<vaadin-upload>` upload logic into `UploadManager`, which dereferences the given file unconditionally, so the protected `_removeFile()` now throws a `TypeError` when called without a file — historically it was a no-op
- Flow's TestBench `UploadElement.removeFile(index)` relies on the old behavior (it passes `files[index]`, which is `undefined` for an out-of-range index and is documented to do nothing), and Flow's `UploadIT` [started failing](https://github.com/vaadin/flow-components/blob/352fd4fbc3871d492c0b03a5cbb7c117c6f3c090/vaadin-upload-flow-parent/vaadin-upload-flow-integration-tests/src/test/java/com/vaadin/flow/component/upload/tests/UploadIT.java#L177) on this
- Restores the tolerance in the component's `_removeFile` delegation only, keeping `UploadManager` itself strict for the new public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)