### PR TITLE
fix: update time-picker dropdown selection when items change

### DIFF
--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -108,7 +108,7 @@ export const TimePickerMixin = (superClass) =>
     static get observers() {
       return [
         '_openedOrItemsChanged(opened, _dropdownItems)',
-        '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme)',
+        '_updateScroller(opened, _dropdownItems, _focusedIndex, _theme, _comboBoxValue)',
         '__updateAriaAttributes(_dropdownItems, opened, inputElement)',
         '__updateDropdownItems(__effectiveI18n, min, max, step)',
       ];
@@ -225,16 +225,6 @@ export const TimePickerMixin = (superClass) =>
       this.addController(this._tooltipController);
     }
 
-    /** @protected */
-    updated(props) {
-      super.updated(props);
-
-      // Update selected item in the scroller
-      if (props.has('_comboBoxValue') && this._dropdownItems) {
-        this._scroller.selectedItem = this._dropdownItems.find((item) => item.value === this._comboBoxValue);
-      }
-    }
-
     /**
      * Returns true if the current input value satisfies all constraints (if any).
      * You can override this method for custom validations.
@@ -259,7 +249,7 @@ export const TimePickerMixin = (superClass) =>
     }
 
     /** @private */
-    _updateScroller(opened, items, focusedIndex, theme) {
+    _updateScroller(opened, items, focusedIndex, theme, comboBoxValue) {
       if (opened) {
         this._scroller.style.maxHeight =
           getComputedStyle(this).getPropertyValue(`--${this._tagNamePrefix}-overlay-max-height`) || '65vh';
@@ -272,6 +262,7 @@ export const TimePickerMixin = (superClass) =>
         opened,
         focusedIndex,
         theme,
+        selectedItem: items && items.find((item) => item.value === comboBoxValue),
       });
     }
 

--- a/packages/time-picker/src/vaadin-time-picker-mixin.js
+++ b/packages/time-picker/src/vaadin-time-picker-mixin.js
@@ -262,7 +262,7 @@ export const TimePickerMixin = (superClass) =>
         opened,
         focusedIndex,
         theme,
-        selectedItem: items && items.find((item) => item.value === comboBoxValue),
+        selectedItem: items?.find((item) => item.value === comboBoxValue),
       });
     }
 

--- a/packages/time-picker/test/dropdown-items.test.js
+++ b/packages/time-picker/test/dropdown-items.test.js
@@ -70,6 +70,33 @@ describe('dropdown items', () => {
     expect(timePicker.value).to.be.equal('01:00:00.000');
     timePicker.step = 3600;
     expect(timePicker.value).to.be.equal('01:00');
-    expect(timePicker._scroller.selectedItem).to.deep.equal(timePicker._dropdownItems[1]);
+    expect(timePicker._scroller.selectedItem).to.equal(timePicker._dropdownItems[1]);
+  });
+
+  ['min', 'max'].forEach((constraint) => {
+    it(`should keep the matching item selected after regenerating items on ${constraint} change`, () => {
+      timePicker.value = '10:00';
+      timePicker[constraint] = constraint === 'min' ? '01:00' : '23:00';
+      expect(timePicker._dropdownItems).to.include(timePicker._scroller.selectedItem);
+    });
+  });
+});
+
+describe('value set before attach', () => {
+  let picker;
+
+  beforeEach(() => {
+    picker = document.createElement('vaadin-time-picker');
+  });
+
+  afterEach(() => {
+    picker.remove();
+  });
+
+  it('should set value to the input when added to the DOM', async () => {
+    picker.value = '10:00';
+    document.body.appendChild(picker);
+    await nextRender();
+    expect(picker._scroller.selectedItem).to.equal(picker._dropdownItems[10]);
   });
 });

--- a/packages/time-picker/test/dropdown-items.test.js
+++ b/packages/time-picker/test/dropdown-items.test.js
@@ -93,7 +93,7 @@ describe('value set before attach', () => {
     picker.remove();
   });
 
-  it('should set value to the input when added to the DOM', async () => {
+  it('should select the matching dropdown item when added to the DOM', async () => {
     picker.value = '10:00';
     document.body.appendChild(picker);
     await nextRender();


### PR DESCRIPTION
## Description

Fixes vaadin/flow-components#9842

Selecting the dropdown item was done in `updated()` and required both `_comboBoxValue` and `_dropdownItems` to be observed in the same update cycle. On the first cycle they never are: setting `_comboBoxValue` from the `value` observer flushes a nested synchronous update before the `__updateDropdownItems` complex observer has generated the items, and the later cycle that assigns the items no longer reports `_comboBoxValue` as changed. As a result, a value assigned before the element was attached was never marked as selected.

Resolving the selected item in `_updateScroller` also fixes losing the selection when `min`, `max` or `i18n` change: the items are recreated as new objects, and the scroller compares them by identity because `itemIdPath` is not set.

## Type of change

- Bugfix