### PR TITLE
docs: clarify not moving focus from disabled date on overlay opening

### DIFF
--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -157,13 +157,15 @@ re-validation below reporting the value invalid.
 
 ## What the overlay focuses when it opens
 
-Opening focuses the value, `initialPosition`, or today, and the provider may then report that date disabled.
-The focus stays on it: a disabled date is focusable, so it renders as disabled, `Enter` does nothing, and the
-user moves to another date. Opening on a date that can be selected is what `initialPosition` is for.
+Opening focuses the value when there is one, otherwise `initialPosition`, otherwise today. A date the
+developer named is used as it is: neither a value nor an explicit `initialPosition` is checked against
+anything that might disable it. Only the fallback to today is, and `min`, `max` and `isDateDisabled` can send
+it to the closest of `min` and `max` instead.
 
-`isDateDisabled` leaves a disabled initial date focused in the same way. `_getInitialPosition` steps off such
-a date only when `min` or `max` rules it out, and it honors an explicit `initialPosition` even when something
-else disables that date.
+The provider takes no part in that choice. Those checks are synchronous, while the answer for the month may
+still be on its way, so a date the provider goes on to report disabled ends up focused — and stays focused. A
+disabled date is focusable, so it renders as disabled, `Enter` does nothing, and the user moves to another
+date. Opening on a date that can be selected is what `initialPosition` is for.
 
 Moving the focus would have to find somewhere to move it to, and a search can only trust the months already
 loaded. Since an unanswered date counts as selectable, the search stops at the first date nothing is known

--- a/packages/date-picker/ARCHITECTURE.md
+++ b/packages/date-picker/ARCHITECTURE.md
@@ -155,6 +155,23 @@ never answers. The window is narrow: reaching a pending month means navigating i
 been loaded yet and clicking before it answers. Such a commit is corrected once the month resolves, by the
 re-validation below reporting the value invalid.
 
+## What the overlay focuses when it opens
+
+Opening focuses the value, `initialPosition`, or today, and the provider may then report that date disabled.
+The focus stays on it: a disabled date is focusable, so it renders as disabled, `Enter` does nothing, and the
+user moves to another date. Opening on a date that can be selected is what `initialPosition` is for.
+
+`isDateDisabled` leaves a disabled initial date focused in the same way. `_getInitialPosition` steps off such
+a date only when `min` or `max` rules it out, and it honors an explicit `initialPosition` even when something
+else disables that date.
+
+Moving the focus would have to find somewhere to move it to, and a search can only trust the months already
+loaded. Since an unanswered date counts as selectable, the search stops at the first date nothing is known
+about; revealing that date asks the provider about it, and the answer can be that it is disabled too — so the
+focus has travelled, possibly months, and still ends up on a disabled date. Treating unanswered dates as
+unselectable instead would keep the search inside the loaded months, and contradict the predicate every other
+caller reads. Either way the focus moves on its own, some time after the user opened the dropdown.
+
 ## When a value counts as valid
 
 Validity reads the same predicate, so what the calendar refuses to select is what the field reports as

--- a/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.d.ts
@@ -307,6 +307,9 @@ export declare class DatePickerMixinClass {
    * marks it disabled. That decides what the calendar renders as disabled, what can be selected, and
    * whether the field is valid.
    *
+   * The date focused when the overlay opens is not moved if the provider reports it disabled. Use
+   * `initialPosition` to open on a date that can be selected.
+   *
    * A value is checked against the provider even if the overlay is never opened, which loads the
    * month holding it. Until that month answers the value is valid, and it is re-validated once the
    * answer arrives, so `checkValidity()` can report a value as valid and then invalid.

--- a/packages/date-picker/src/vaadin-date-picker-mixin.js
+++ b/packages/date-picker/src/vaadin-date-picker-mixin.js
@@ -236,6 +236,9 @@ export const DatePickerMixin = (subclass) =>
          * metadata marks it disabled. That decides what the calendar renders as disabled, what can be
          * selected, and whether the field is valid.
          *
+         * The date focused when the overlay opens is not moved if the provider reports it disabled.
+         * Use `initialPosition` to open on a date that can be selected.
+         *
          * A value is checked against the provider even if the overlay is never opened, which loads the
          * month holding it. Until that month answers the value is valid, and it is re-validated once
          * the answer arrives, so `checkValidity()` can report a value as valid and then invalid.


### PR DESCRIPTION
## Description

Based on the suggestion from https://github.com/vaadin/web-components/pull/12348#issuecomment-5240795197

Updated JSDoc to clarify that the date focused on open is not moved when the provider reports it disabled.
Suggested to use `initialPosition` instead. This replaces https://github.com/vaadin/web-components/pull/12348 which added way too much complexity. 

## Type of change

- Documentation