### PR TITLE
test: cover outside click closing of context menu with items

### DIFF
--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -148,7 +148,7 @@ describe('items', () => {
     it('should not fire on click inside the menu', () => {
       const spy = sinon.spy();
       rootMenu.addEventListener('items-outside-click', spy);
-      getMenuItems(subMenu)[3].click();
+      getMenuItems(subMenu)[4].click();
       expect(spy).to.not.be.called;
     });
   });
@@ -360,7 +360,7 @@ describe('items', () => {
   });
 
   it('should not close the menu if sub menu item has keep open', () => {
-    getMenuItems(subMenu)[3].click();
+    getMenuItems(subMenu)[4].click();
     expect(rootMenu.opened).to.be.true;
     expect(subMenu.opened).to.be.true;
   });

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -10,6 +10,7 @@ import {
   fixtureSync,
   nextFrame,
   nextRender,
+  outsideClick,
   spaceKeyDown,
   tabKeyDown,
 } from '@vaadin/testing-helpers';
@@ -93,11 +94,63 @@ describe('items', () => {
     expect(subMenu.opened).to.be.false;
   });
 
+  // On touch, the click opening the second menu closes the first one.
+  (isTouch ? it.skip : it)('should close all menus of every open menu on outside click', async () => {
+    const otherMenu = fixtureSync(`
+      <vaadin-context-menu>
+        <button></button>
+      </vaadin-context-menu>
+    `);
+    otherMenu.openOn = 'mouseover';
+    otherMenu.items = [{ text: 'bar-0' }];
+    await nextRender();
+    await openMenu(otherMenu.firstElementChild);
+    expect(rootMenu.opened).to.be.true;
+    expect(otherMenu.opened).to.be.true;
+
+    outsideClick();
+    expect(rootMenu.opened).to.be.false;
+    expect(subMenu.opened).to.be.false;
+    expect(otherMenu.opened).to.be.false;
+  });
+
+  it('should close all menus on click on the menu light DOM content', () => {
+    target.click();
+    expect(rootMenu.opened).to.be.false;
+    expect(subMenu.opened).to.be.false;
+  });
+
   it('should remove close listener', () => {
     rootMenu.parentNode.removeChild(rootMenu);
     const spy = sinon.spy(rootMenu, 'close');
     fire(document.documentElement, 'click');
     expect(spy.called).to.be.false;
+  });
+
+  // TODO: remove when the deprecated event is removed in Vaadin 26
+  describe('items-outside-click event', () => {
+    it('should fire on outside click when a sub-menu is open', () => {
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      outsideClick();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire on outside click when only the root menu is open', async () => {
+      subMenu.close();
+      await nextRender();
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      outsideClick();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should not fire on click inside the menu', () => {
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      getMenuItems(subMenu)[3].click();
+      expect(spy).to.not.be.called;
+    });
   });
 
   (isTouch ? it.skip : it)('should open the subMenu on the right side', () => {

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -115,6 +115,10 @@ describe('items', () => {
   });
 
   it('should close all menus on click on the menu light DOM content', () => {
+    // Unlike a real click, a synthetic one is not blocked by the modal
+    // overlay, so on touch it would also open the menu again.
+    rootMenu.openOn = 'mouseover';
+
     target.click();
     expect(rootMenu.opened).to.be.false;
     expect(subMenu.opened).to.be.false;

--- a/packages/context-menu/test/overlay.test.js
+++ b/packages/context-menu/test/overlay.test.js
@@ -386,12 +386,21 @@ describe('overlay', () => {
       expect(menu.opened).to.eql(false);
     });
 
-    it('should disable close on empty `closeOn`', () => {
+    it('should not close on overlay click with empty `closeOn`', () => {
       menu.closeOn = '';
 
       overlay.dispatchEvent(new CustomEvent('click'));
 
       expect(menu.opened).to.eql(true);
+    });
+
+    it('should not close on outside click with empty `closeOn`', async () => {
+      menu.closeOn = '';
+
+      fire(document.body, 'click');
+      await nextRender();
+
+      expect(menu.opened).to.be.true;
     });
 
     it('should dispatch closed event when the overlay is closed', async () => {


### PR DESCRIPTION
Outside click closing of the menu with the `items` API has little test coverage. Nothing pinned that two menus open at the same time both close on one outside click, that a click on the light DOM content inside the menu closes it, or when the deprecated `items-outside-click` event fires. Empty `closeOn` was only tested with a click on the overlay, never with an outside click, even though it disables that as well.

#12384 changes how this closing works. Adding the tests first makes it possible to see that the change keeps the current behavior: every test added here passes both on `main` and with that change applied.

The renamed test now says what it checks. It dispatches a click on the overlay, while the old name suggested `closeOn` only affects clicks inside the menu.

Part of #12367

---

🤖 Generated with Claude Code
