### PR TITLE
fix: keep clicked input focused when AI popover closes

### DIFF
--- a/packages/field-highlighter/src/vaadin-ai-field-marker.js
+++ b/packages/field-highlighter/src/vaadin-ai-field-marker.js
@@ -7,7 +7,7 @@ import '@vaadin/popover/src/vaadin-popover.js';
 import '@vaadin/tooltip/src/vaadin-tooltip.js';
 import { html, LitElement, nothing } from 'lit';
 import { announce } from '@vaadin/a11y-base/src/announce.js';
-import { getTabbableElements, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
+import { getDeepActiveElement, getTabbableElements, isKeyboardActive } from '@vaadin/a11y-base/src/focus-utils.js';
 import { registerCSSProperty } from '@vaadin/component-base/src/css-utils.js';
 import { defineCustomElement } from '@vaadin/component-base/src/define.js';
 import { DirMixin } from '@vaadin/component-base/src/dir-mixin.js';
@@ -320,9 +320,22 @@ class AiFieldMarker extends SlotStylesMixin(I18nMixin(DirMixin(PolylitMixin(LitE
     // never happens — would otherwise leave it open, and popovers of several
     // marked fields could pile up. A null relatedTarget is left alone so that
     // the window losing focus does not close the popover.
+    //
+    // The popover is closed only once the focus transition has settled: while
+    // it is still in progress the document has no focused element, which the
+    // popover overlay reads as focus not having left it, and so it restores
+    // focus to the badge (see OverlayFocusMixin._shouldRestoreFocus). That
+    // restore is itself deferred, so it would land on the badge after the
+    // browser has focused the element the user clicked — clicking a field
+    // input would close the popover but leave the badge focused.
     this.addEventListener('focusout', (event) => {
       if (event.relatedTarget && !this.contains(event.relatedTarget)) {
-        this.#closePopover();
+        setTimeout(() => {
+          // Focus may have moved back into the marker in the meantime.
+          if (!this.contains(getDeepActiveElement())) {
+            this.#closePopover();
+          }
+        });
       }
     });
   }

--- a/packages/field-highlighter/src/vaadin-ai-field-marker.js
+++ b/packages/field-highlighter/src/vaadin-ai-field-marker.js
@@ -314,29 +314,20 @@ class AiFieldMarker extends SlotStylesMixin(I18nMixin(DirMixin(PolylitMixin(LitE
     // before this bubble-phase listener.
     this.addEventListener('click', (event) => event.stopPropagation());
 
-    // Close the popover when focus moves on, e.g. to the next field. A
-    // click-triggered popover only closes itself on outside pointer
-    // interaction or Esc, so keyboard navigation — where an outside click
-    // never happens — would otherwise leave it open, and popovers of several
-    // marked fields could pile up. A null relatedTarget is left alone so that
-    // the window losing focus does not close the popover.
-    //
-    // The popover is closed only once the focus transition has settled: while
-    // it is still in progress the document has no focused element, which the
-    // popover overlay reads as focus not having left it, and so it restores
-    // focus to the badge (see OverlayFocusMixin._shouldRestoreFocus). That
-    // restore is itself deferred, so it would land on the badge after the
-    // browser has focused the element the user clicked — clicking a field
-    // input would close the popover but leave the badge focused.
-    this.addEventListener('focusout', (event) => {
-      if (event.relatedTarget && !this.contains(event.relatedTarget)) {
-        setTimeout(() => {
-          // Focus may have moved back into the marker in the meantime.
-          if (!this.contains(getDeepActiveElement())) {
-            this.#closePopover();
-          }
-        });
-      }
+    // Close the popover when focus moves on, e.g. by tabbing to the next
+    // field: a click-triggered popover only closes itself on outside pointer
+    // interaction or Esc, so popovers of several marked fields could pile up.
+    // Where focus ended up is read only once the transition has settled — mid
+    // transition the document has no focused element, which the popover
+    // overlay reads as focus not having left it (see
+    // OverlayFocusMixin._shouldRestoreFocus) and restores focus to the badge,
+    // stealing it from the input the user clicked.
+    this.addEventListener('focusout', () => {
+      setTimeout(() => {
+        if (!this.contains(getDeepActiveElement())) {
+          this.#closePopover();
+        }
+      });
     });
   }
 

--- a/packages/field-highlighter/test/ai-field-marker.test.ts
+++ b/packages/field-highlighter/test/ai-field-marker.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { resetMouse, sendMouseToElement } from '@vaadin/test-runner-commands';
 import { aTimeout, fixtureSync, nextRender, nextUpdate, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '@vaadin/custom-field/src/vaadin-custom-field.js';
@@ -321,6 +322,43 @@ describe('ai field marker', () => {
       await nextRender();
 
       expect(popover.opened).to.be.true;
+    });
+
+    describe('click outside the popover', () => {
+      let otherField: TextField;
+
+      beforeEach(async () => {
+        otherField = fixtureSync(`<vaadin-text-field label="Other"></vaadin-text-field>`);
+        await nextRender();
+
+        const overlay = popover.shadowRoot!.querySelector('vaadin-popover-overlay')!;
+        const opened = oneEvent(overlay, 'vaadin-overlay-open');
+        marker.querySelector<HTMLButtonElement>('.badge')!.click();
+        await opened;
+      });
+
+      afterEach(async () => {
+        await resetMouse();
+      });
+
+      it('should focus the field input clicked while the popover is open', async () => {
+        await sendMouseToElement({ type: 'click', element: field.inputElement });
+        await nextRender();
+        // The popover overlay defers restoring focus to the badge.
+        await aTimeout(0);
+
+        expect(popover.opened).to.be.false;
+        expect(field.inputElement.matches(':focus')).to.be.true;
+      });
+
+      it('should focus another field input clicked while the popover is open', async () => {
+        await sendMouseToElement({ type: 'click', element: otherField.inputElement });
+        await nextRender();
+        await aTimeout(0);
+
+        expect(popover.opened).to.be.false;
+        expect(otherField.inputElement.matches(':focus')).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Clicking a field input while the AI field marker popover was open closed the popover but left focus on the badge, so the click never put the cursor in the field. Clicking another field's input had the same result.
- The marker closed the popover in the middle of the focus transition, when the document has no focused element. The popover overlay reads that state as focus not having left it, and restores focus to the badge — landing after the browser has focused the clicked input. The marker now decides once the transition has settled and reads where focus actually went.
- Reading the active element also covers focus staying within the marker and the window losing focus, so the `relatedTarget` guards it replaces are removed.


Before:

https://github.com/user-attachments/assets/2866994b-65e0-4fd1-aa0e-e80b8efb60cd




🤖 Generated with [Claude Code](https://claude.com/claude-code)