### PR TITLE
fix: make AI field marker controls tabbable in Safari

### DIFF
--- a/packages/field-highlighter/src/vaadin-ai-field-marker.js
+++ b/packages/field-highlighter/src/vaadin-ai-field-marker.js
@@ -502,8 +502,13 @@ class AiFieldMarker extends SlotStylesMixin(I18nMixin(DirMixin(PolylitMixin(LitE
     }
 
     const { message, revert, badgeLabel, badgeTooltip } = this.__effectiveI18n;
+    // Both buttons set `tabindex` although they are natively focusable: with the
+    // macOS keyboard navigation setting off — the default — Safari leaves buttons
+    // out of the tab order, unless they set a tabindex of their own. Without it,
+    // neither the badge nor the revert control could be reached with the keyboard
+    // there.
     return html`
-      <button id="${this.#badgeId}" class="badge" type="button" aria-label="${badgeLabel}"></button>
+      <button id="${this.#badgeId}" class="badge" type="button" tabindex="0" aria-label="${badgeLabel}"></button>
       <vaadin-tooltip for="${this.#badgeId}" text="${badgeTooltip}"></vaadin-tooltip>
       <vaadin-popover
         for="${this.#badgeId}"
@@ -516,7 +521,7 @@ class AiFieldMarker extends SlotStylesMixin(I18nMixin(DirMixin(PolylitMixin(LitE
       >
         <p class="message">${message}</p>
         <div class="actions">
-          <button type="button" @click="${this.#onRevert}">${revert}</button>
+          <button type="button" tabindex="0" @click="${this.#onRevert}">${revert}</button>
         </div>
       </vaadin-popover>
     `;

--- a/packages/field-highlighter/src/vaadin-ai-field-marker.js
+++ b/packages/field-highlighter/src/vaadin-ai-field-marker.js
@@ -502,11 +502,7 @@ class AiFieldMarker extends SlotStylesMixin(I18nMixin(DirMixin(PolylitMixin(LitE
     }
 
     const { message, revert, badgeLabel, badgeTooltip } = this.__effectiveI18n;
-    // Both buttons set `tabindex` although they are natively focusable: with the
-    // macOS keyboard navigation setting off — the default — Safari leaves buttons
-    // out of the tab order, unless they set a tabindex of their own. Without it,
-    // neither the badge nor the revert control could be reached with the keyboard
-    // there.
+    // Safari leaves buttons out of the tab order unless they set a tabindex.
     return html`
       <button id="${this.#badgeId}" class="badge" type="button" tabindex="0" aria-label="${badgeLabel}"></button>
       <vaadin-tooltip for="${this.#badgeId}" text="${badgeTooltip}"></vaadin-tooltip>

--- a/packages/field-highlighter/test/dom/__snapshots__/ai-field-marker.test.snap.js
+++ b/packages/field-highlighter/test/dom/__snapshots__/ai-field-marker.test.snap.js
@@ -17,6 +17,7 @@ snapshots["vaadin-ai-field-marker host default"] =
     aria-label="AI-provided value"
     class="badge"
     id="vaadin-ai-field-marker-4"
+    tabindex="0"
     type="button"
   >
   </button>
@@ -50,7 +51,10 @@ Click for details
       This field value was modified by AI.
     </p>
     <div class="actions">
-      <button type="button">
+      <button
+        tabindex="0"
+        type="button"
+      >
         Revert Value
       </button>
     </div>


### PR DESCRIPTION
## Summary
- With the macOS keyboard navigation setting off — the default — Safari leaves buttons out of the tab order, so neither the marker badge nor the revert control in its popover could be reached with the keyboard. The popover explaining the AI fill was therefore mouse-only.
- Safari skips that restriction for a button that sets a tabindex of its own, so both buttons now set `tabindex="0"`.
- Note that no browser in CI reproduces this: the restriction comes from the macOS setting, and both Chromium and Playwright's WebKit tab to buttons regardless, so the DOM snapshot is the only test affected.

Before:

https://github.com/user-attachments/assets/8ac20e4b-8498-472a-83c3-28965dd82ac7

🤖 Generated with [Claude Code](https://claude.com/claude-code)