### PR TITLE
fix: resolve slot state synchronously when it affects layout (CP: 25.2)

### DIFF
--- a/packages/badge/src/vaadin-badge.js
+++ b/packages/badge/src/vaadin-badge.js
@@ -123,15 +123,26 @@ class Badge extends ElementMixin(ThemableMixin(PolylitMixin(LumoInjectionMixin(L
   firstUpdated() {
     super.firstUpdated();
 
+    // Both slots use `syncInitial` because `has-content` and `has-icon` control the size of the
+    // badge. Without it, consumers that measure content synchronously, e.g. auto-width columns in
+    // vaadin-grid, would measure a badge whose content is still hidden by `display: none`.
     const slot = this.shadowRoot.querySelector('slot:not([name])');
-    this.__slotObserver = new SlotObserver(slot, ({ currentNodes }) => {
-      this.toggleAttribute('has-content', currentNodes.filter((node) => !isEmptyTextNode(node)).length > 0);
-    });
+    this.__slotObserver = new SlotObserver(
+      slot,
+      ({ currentNodes }) => {
+        this.toggleAttribute('has-content', currentNodes.filter((node) => !isEmptyTextNode(node)).length > 0);
+      },
+      { syncInitial: true },
+    );
 
     const iconSlot = this.shadowRoot.querySelector('slot[name="icon"]');
-    this.__iconSlotObserver = new SlotObserver(iconSlot, ({ currentNodes }) => {
-      this.toggleAttribute('has-icon', currentNodes.length > 0);
-    });
+    this.__iconSlotObserver = new SlotObserver(
+      iconSlot,
+      ({ currentNodes }) => {
+        this.toggleAttribute('has-icon', currentNodes.length > 0);
+      },
+      { syncInitial: true },
+    );
   }
 }
 

--- a/packages/badge/test/badge.test.ts
+++ b/packages/badge/test/badge.test.ts
@@ -112,4 +112,24 @@ describe('vaadin-badge', () => {
       expect(badge.hasAttribute('has-icon')).to.be.false;
     });
   });
+
+  describe('state attributes on connect', () => {
+    it('should set has-content attribute synchronously when connected with text content', () => {
+      const newBadge = fixtureSync<Badge>('<vaadin-badge>Text</vaadin-badge>');
+      expect(newBadge.hasAttribute('has-content')).to.be.true;
+    });
+
+    it('should set has-icon attribute synchronously when connected with icon content', () => {
+      const newBadge = fixtureSync<Badge>('<vaadin-badge><span slot="icon"></span></vaadin-badge>');
+      expect(newBadge.hasAttribute('has-icon')).to.be.true;
+    });
+
+    it('should set has-content attribute synchronously when content is set before connecting', () => {
+      const wrapper = fixtureSync('<div></div>');
+      const newBadge = document.createElement('vaadin-badge');
+      newBadge.textContent = 'Text';
+      wrapper.appendChild(newBadge);
+      expect(newBadge.hasAttribute('has-content')).to.be.true;
+    });
+  });
 });

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs-item.js
@@ -139,10 +139,13 @@ class BreadcrumbsItem extends FocusMixin(DisabledMixin(ElementMixin(PolylitMixin
   ready() {
     super.ready();
 
-    this.__slotObserver = new SlotObserver(this.shadowRoot, () => {
-      this.toggleAttribute('has-prefix', !!this.querySelector('[slot="prefix"]'));
-    });
-    this.__slotObserver.flush();
+    this.__slotObserver = new SlotObserver(
+      this.shadowRoot,
+      () => {
+        this.toggleAttribute('has-prefix', !!this.querySelector('[slot="prefix"]'));
+      },
+      { syncInitial: true },
+    );
   }
 
   /**

--- a/packages/breadcrumbs/src/vaadin-breadcrumbs.js
+++ b/packages/breadcrumbs/src/vaadin-breadcrumbs.js
@@ -180,11 +180,14 @@ class Breadcrumbs extends KeyboardDirectionMixin(
     this.$.overlay.restoreFocusNode = this.$.overflow;
 
     // Re-evaluate items on add / remove via a single shadow-root-level observer.
-    this.__slotObserver = new SlotObserver(this.shadowRoot, () => {
-      this.__updateItems();
-      this.__updateOverflow();
-    });
-    this.__slotObserver.flush();
+    this.__slotObserver = new SlotObserver(
+      this.shadowRoot,
+      () => {
+        this.__updateItems();
+        this.__updateOverflow();
+      },
+      { syncInitial: true },
+    );
 
     // Observe `path` attribute changes on items to modify the `current` state.
     this.__pathObserver = new MutationObserver(() => this.__updateItems());

--- a/packages/component-base/src/slot-observer.d.ts
+++ b/packages/component-base/src/slot-observer.d.ts
@@ -14,12 +14,18 @@
  * bubbling to it and diffs the **union** of `assignedNodes({ flatten: true })`
  * every descendant `<slot>`. Cross-slot reassignment of the same node does
  * not change the union and therefore fires no callback.
+ *
+ * The initial pass runs in a microtask by default. Use the `syncInitial` option
+ * when the callback sets state that affects the layout of the component, so that
+ * it has its final size once connected. Otherwise consumers that measure it
+ * synchronously, such as auto-width columns in `<vaadin-grid>`, would measure the
+ * component before that state is applied.
  */
 export class SlotObserver {
   constructor(
     target: HTMLSlotElement | DocumentFragment,
     callback: (info: { addedNodes: Node[]; currentNodes: Node[]; movedNodes: Node[]; removedNodes: Node[] }) => void,
-    forceInitial?: boolean,
+    options?: { forceInitial?: boolean; syncInitial?: boolean },
   );
 
   readonly target: HTMLSlotElement | DocumentFragment;

--- a/packages/component-base/src/slot-observer.js
+++ b/packages/component-base/src/slot-observer.js
@@ -14,9 +14,20 @@
  * bubbling to it and diffs the **union** of `assignedNodes({ flatten: true })`
  * across every descendant `<slot>`. Cross-slot reassignment of the same node
  * does not change the union and therefore fires no callback.
+ *
+ * The initial pass runs in a microtask by default. Use the `syncInitial` option
+ * when the callback sets state that affects the layout of the component, so that
+ * it has its final size once connected. Otherwise consumers that measure it
+ * synchronously, such as auto-width columns in `<vaadin-grid>`, would measure the
+ * component before that state is applied.
  */
 export class SlotObserver {
-  constructor(target, callback, forceInitial) {
+  /**
+   * @param {HTMLSlotElement | DocumentFragment} target
+   * @param {Function} callback
+   * @param {{ forceInitial?: boolean, syncInitial?: boolean }} options
+   */
+  constructor(target, callback, options = {}) {
     /** @type {HTMLSlotElement | DocumentFragment} */
     this.target = target;
 
@@ -24,7 +35,7 @@ export class SlotObserver {
     this.callback = callback;
 
     /** @type {boolean} */
-    this.forceInitial = forceInitial;
+    this.forceInitial = options.forceInitial;
 
     /** @type {Node[]} */
     this._storedNodes = [];
@@ -40,7 +51,12 @@ export class SlotObserver {
     };
 
     this.connect();
-    this._schedule();
+
+    if (options.syncInitial) {
+      this.flush();
+    } else {
+      this._schedule();
+    }
   }
 
   /**
@@ -69,7 +85,11 @@ export class SlotObserver {
       this._scheduled = true;
 
       queueMicrotask(() => {
-        this.flush();
+        // Skip if the nodes have already been processed by an explicit `flush()`
+        // in the meantime, to avoid running the diff a second time for nothing.
+        if (this._scheduled) {
+          this.flush();
+        }
       });
     }
   }

--- a/packages/component-base/test/slot-observer.test.js
+++ b/packages/component-base/test/slot-observer.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
+import { nextFrame } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import { SlotObserver } from '../src/slot-observer.js';
 
@@ -201,7 +202,7 @@ describe('SlotObserver', () => {
     host.innerHTML = '';
 
     spy = sinon.spy();
-    observer = new SlotObserver(slot, spy, true);
+    observer = new SlotObserver(slot, spy, { forceInitial: true });
     await Promise.resolve();
 
     expect(spy).to.be.calledOnce;
@@ -211,7 +212,7 @@ describe('SlotObserver', () => {
     host.innerHTML = '';
 
     spy = sinon.spy();
-    observer = new SlotObserver(slot, spy, true);
+    observer = new SlotObserver(slot, spy, { forceInitial: true });
     await Promise.resolve();
 
     spy.resetHistory();
@@ -219,6 +220,43 @@ describe('SlotObserver', () => {
     observer.flush();
 
     expect(spy).to.be.not.called;
+  });
+
+  it('should run callback for initial nodes synchronously with syncInitial: true', () => {
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy, { syncInitial: true });
+
+    expect(spy).to.be.calledOnce;
+    expect(spy.firstCall.args[0].addedNodes).to.have.lengthOf(3);
+  });
+
+  it('should not schedule a microtask pass with syncInitial: true', async () => {
+    // Let the slotchange from the initial assignment settle first, so that it
+    // does not schedule a pass of its own while the assertion is running.
+    await nextFrame();
+
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy, { syncInitial: true });
+
+    const processSpy = sinon.spy(observer, '_processNodes');
+    await Promise.resolve();
+
+    expect(processSpy).to.be.not.called;
+  });
+
+  it('should not process nodes again after the microtask when flushed early', async () => {
+    // Let the slotchange from the initial assignment settle first, so that it
+    // does not schedule a pass of its own while the assertion is running.
+    await nextFrame();
+
+    spy = sinon.spy();
+    observer = new SlotObserver(slot, spy);
+
+    const processSpy = sinon.spy(observer, '_processNodes');
+    observer.flush();
+    await Promise.resolve();
+
+    expect(processSpy).to.be.calledOnce;
   });
 
   describe('target mode', () => {

--- a/test/integration/grid-badge-auto-width.test.js
+++ b/test/integration/grid-badge-auto-width.test.js
@@ -1,0 +1,44 @@
+import { expect } from '@vaadin/chai-plugins';
+import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
+import '@vaadin/badge';
+import '@vaadin/grid';
+import { flushGrid, getBodyCellContent } from '@vaadin/grid/test/helpers.js';
+
+describe('badge in grid', () => {
+  let grid, column;
+
+  const items = [
+    { status: 'Confirmed' },
+    { status: 'Pending approval' },
+    { status: 'Shipped to customer' },
+    { status: 'Cancelled by administrator' },
+  ];
+
+  beforeEach(async () => {
+    grid = fixtureSync(`
+      <vaadin-grid style="width: 800px; height: 400px">
+        <vaadin-grid-column auto-width flex-grow="0"></vaadin-grid-column>
+      </vaadin-grid>
+    `);
+    column = grid.querySelector('vaadin-grid-column');
+    column.renderer = (root, _, model) => {
+      root.innerHTML = `<vaadin-badge>${model.item.status}</vaadin-badge>`;
+    };
+    grid.items = items;
+    flushGrid(grid);
+    await nextRender();
+  });
+
+  it('should not change the auto-width column width on recalculation', () => {
+    const width = column.width;
+    grid.recalculateColumnWidths();
+    expect(column.width).to.equal(width);
+  });
+
+  it('should not clip the badge in the auto-width column', () => {
+    items.forEach((_, index) => {
+      const content = getBodyCellContent(grid, index, 0);
+      expect(content.firstElementChild.offsetWidth).to.be.at.most(content.offsetWidth);
+    });
+  });
+});

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@vaadin/a11y-base": "~25.2.7",
     "@vaadin/accordion": "~25.2.7",
+    "@vaadin/badge": "~25.2.7",
     "@vaadin/button": "~25.2.7",
     "@vaadin/chai-plugins": "~25.2.7",
     "@vaadin/checkbox": "~25.2.7",


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12399 to branch 25.2.

---

> `<vaadin-badge>` in a `vaadin-grid` column with `auto-width` was measured before it had its
> final size, so the column was sized from its header text alone and the longer badges
> rendered clipped.
>
> The badge sets `has-content` and `has-icon` from a `SlotObserver`, whose initial pass runs
> in a microtask. Until those attributes are set, `[part='content']` is hidden and the badge
> collapses to its minimum width. The grid measures cell content synchronously, right after
> it runs the cell renderers, so it measured the collapsed badge. The badge is already
> defined and its shadow root already rendered at that point, so this is not about waiting
> for the custom element to upgrade — only about when those two attributes are applied.
>
> `SlotObserver` now takes a `syncInitial` option that runs the initial pass in the
> constructor. Components whose slot state affects their own size opt in, so the requirement
> is visible at the call site instead of something each new component has to rediscover.
> `vaadin-breadcrumbs` and `vaadin-breadcrumbs-item` already called `flush()` by hand right
> after the constructor for the same reason, and now use the option instead, with no change
> in behaviour.
>
> The third constructor argument becomes an options object. No component passed
> `forceInitial`, so nothing else needed updating.
>
> Separately, the microtask queued by `_schedule()` now checks whether an explicit `flush()`
> has already processed the nodes in the meantime, instead of running the whole node diff a
> second time and discarding the result. This still applies to components that flush before
> reading slot state, such as `vaadin-accordion` and `vaadin-context-menu`.
>
> Note this helps only when the badge already has its content when it is connected. Appending
> an empty badge and setting its text afterwards still measures collapsed and needs an
> explicit `grid.recalculateColumnWidths()`. The `innerHTML`, Lit and Flow renderer paths all
> set the content before attaching, so they are covered.
>
> Fixes #11891
>
> ---
>
> 🤖 Generated with Claude Code
