### PR TITLE
fix: wait for overlay animation objects instead of animationend

### DIFF
--- a/packages/aura/src/components/item-overlay.css
+++ b/packages/aura/src/components/item-overlay.css
@@ -146,8 +146,3 @@ vaadin-popover {
     --vaadin-overlay-animation-timing-function: ease-in;
   }
 }
-
-vaadin-menu-bar-submenu,
-vaadin-context-menu {
-  --vaadin-overlay-animation-duration: 1ms;
-}

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -49,7 +49,6 @@ export const overlayAnimationStyles = css`
 
   :host(:where([opening], [closing])) {
     /* This empty animation only reports the state, the parts run the visible animation */
-    /* The state ends with it, so a theme animating a part for longer must extend the duration */
     animation-name: --no-op;
     animation-duration: var(--vaadin-overlay-animation-duration);
     animation-delay: var(--vaadin-overlay-animation-delay);

--- a/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
+++ b/packages/overlay/src/styles/vaadin-overlay-animation-base-styles.js
@@ -49,6 +49,7 @@ export const overlayAnimationStyles = css`
 
   :host(:where([opening], [closing])) {
     /* This empty animation only reports the state, the parts run the visible animation */
+    /* The state ends with it, so a theme animating a part for longer must extend the duration */
     animation-name: --no-op;
     animation-duration: var(--vaadin-overlay-animation-duration);
     animation-delay: var(--vaadin-overlay-animation-delay);

--- a/packages/overlay/src/vaadin-overlay-mixin.js
+++ b/packages/overlay/src/vaadin-overlay-mixin.js
@@ -6,7 +6,7 @@
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayFocusMixin } from './vaadin-overlay-focus-mixin.js';
 import { OverlayStackMixin } from './vaadin-overlay-stack-mixin.js';
-import { setOverlayStateAttribute, shouldAnimate } from './vaadin-overlay-utils.js';
+import { getStateAnimations, setOverlayStateAttribute } from './vaadin-overlay-utils.js';
 
 export const OverlayMixin = (superClass) =>
   class OverlayMixin extends OverlayFocusMixin(OverlayStackMixin(superClass)) {
@@ -132,11 +132,6 @@ export const OverlayMixin = (superClass) =>
       if (this.$.backdrop) {
         this.$.backdrop.addEventListener('click', () => {});
       }
-
-      this.addEventListener('animationcancel', () => {
-        this._flushAnimation('opening');
-        this._flushAnimation('closing');
-      });
     }
 
     /** @protected */
@@ -393,30 +388,35 @@ export const OverlayMixin = (superClass) =>
     }
 
     /**
-     * @return {boolean}
-     * @private
-     */
-    _shouldAnimate() {
-      return shouldAnimate(this);
-    }
-
-    /**
+     * Run the callback once every animation reporting the state has ended, or right away when
+     * there is none.
+     *
      * @param {string} type
      * @param {Function} callback
      * @private
      */
     _enqueueAnimation(type, callback) {
+      const animations = getStateAnimations(this);
+      if (animations.length === 0) {
+        callback();
+        return;
+      }
+
       const handler = `__${type}Handler`;
-      const listener = (event) => {
-        if (event && event.target !== this) {
+      const finish = () => {
+        // The phase may already have been finished by _flushAnimation(), or superseded by a
+        // later one of the same type, in which case this callback no longer applies
+        if (this[handler] !== finish) {
           return;
         }
-        callback();
-        this.removeEventListener('animationend', listener);
+        // Cleared before the callback, so that a listener reopening the overlay synchronously
+        // installs its own handler rather than having it deleted afterwards
         delete this[handler];
+        callback();
       };
-      this[handler] = listener;
-      this.addEventListener('animationend', listener);
+      this[handler] = finish;
+      // A cancelled animation rejects, which ends the phase just as finishing does
+      Promise.all(animations.map((animation) => animation.finished)).then(finish, finish);
     }
 
     /**
@@ -442,13 +442,9 @@ export const OverlayMixin = (superClass) =>
       }
       setOverlayStateAttribute(this, 'opening', true);
 
-      if (this._shouldAnimate()) {
-        this._enqueueAnimation('opening', () => {
-          this._finishOpening();
-        });
-      } else {
+      this._enqueueAnimation('opening', () => {
         this._finishOpening();
-      }
+      });
     }
 
     /** @private */
@@ -482,13 +478,9 @@ export const OverlayMixin = (superClass) =>
         setOverlayStateAttribute(this, 'closing', true);
         this.dispatchEvent(new CustomEvent('vaadin-overlay-closing'));
 
-        if (this._shouldAnimate()) {
-          this._enqueueAnimation('closing', () => {
-            this._finishClosing();
-          });
-        } else {
+        this._enqueueAnimation('closing', () => {
           this._finishClosing();
-        }
+        });
       }
     }
 

--- a/packages/overlay/src/vaadin-overlay-utils.d.ts
+++ b/packages/overlay/src/vaadin-overlay-utils.d.ts
@@ -16,9 +16,6 @@ export function observeMove(element: HTMLElement, callback: () => void): () => v
  * Detect whether an animation runs on the given element, so that its end can be
  * awaited before the element is hidden or removed. An element that is not rendered,
  * has no animation name, or has a zero duration does not fire `animationend`.
- *
- * @deprecated Use `getStateAnimations()`, which reads the animations the browser created
- * rather than the computed style, so that the two cannot disagree.
  */
 export function shouldAnimate(element: HTMLElement): boolean;
 

--- a/packages/overlay/src/vaadin-overlay-utils.d.ts
+++ b/packages/overlay/src/vaadin-overlay-utils.d.ts
@@ -16,8 +16,26 @@ export function observeMove(element: HTMLElement, callback: () => void): () => v
  * Detect whether an animation runs on the given element, so that its end can be
  * awaited before the element is hidden or removed. An element that is not rendered,
  * has no animation name, or has a zero duration does not fire `animationend`.
+ *
+ * @deprecated Use `getStateAnimations()`, which reads the animations the browser created
+ * rather than the computed style, so that the two cannot disagree.
  */
 export function shouldAnimate(element: HTMLElement): boolean;
+
+/**
+ * Collect the animations that report the state of the given element, so that their end can be
+ * awaited before the element is hidden or removed. The animations are read instead of the
+ * computed style, so that the decision to wait cannot disagree with what the browser actually
+ * created: a keyframes rule that does not exist and an element that is not rendered both give
+ * an empty list.
+ *
+ * Only CSS animations count, as the transitions and the script animations that `getAnimations()`
+ * also returns do not report the state. Animations of any content are already left out, as
+ * `getAnimations()` only descends into the subtree when asked to. Animations that take no time
+ * are dropped, so that a delay on its own does not hold the state, and so are endless ones,
+ * which would hold it forever.
+ */
+export function getStateAnimations(element: HTMLElement): Animation[];
 
 /**
  * Toggle the state attribute on the overlay element and also its owner element. This allows targeting state attributes

--- a/packages/overlay/src/vaadin-overlay-utils.d.ts
+++ b/packages/overlay/src/vaadin-overlay-utils.d.ts
@@ -32,8 +32,7 @@ export function shouldAnimate(element: HTMLElement): boolean;
  * Only CSS animations count, as the transitions and the script animations that `getAnimations()`
  * also returns do not report the state. Animations of any content are already left out, as
  * `getAnimations()` only descends into the subtree when asked to. Animations that take no time
- * are dropped, so that a delay on its own does not hold the state, and so are endless ones,
- * which would hold it forever.
+ * are dropped as well, so that a delay on its own does not hold the state.
  */
 export function getStateAnimations(element: HTMLElement): Animation[];
 

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -85,11 +85,17 @@ export function observeMove(element, callback) {
   return cleanup;
 }
 
+// Notification still uses `shouldAnimate()`: its card cancels and restarts a same-named
+// animation when it moves between the opening and closing state, which leaves the animation
+// objects briefly unobservable.
+
 /**
  * Detect whether an animation runs on the given element, so that its end can be
  * awaited before the element is hidden or removed. An element that is not rendered,
  * has no animation name, or has a zero duration does not fire `animationend`.
  *
+ * @deprecated Use `getStateAnimations()`, which reads the animations the browser created
+ * rather than the computed style, so that the two cannot disagree.
  * @param {HTMLElement} element
  * @return {boolean}
  */
@@ -101,6 +107,29 @@ export function shouldAnimate(element) {
     .split(',')
     .some((duration) => parseFloat(duration) > 0);
   return style.getPropertyValue('display') !== 'none' && name && name !== 'none' && hasDuration;
+}
+
+/**
+ * Collect the animations that report the state of the given element, so that their end can be
+ * awaited before the element is hidden or removed. The animations are read instead of the
+ * computed style, so that the decision to wait cannot disagree with what the browser actually
+ * created: a keyframes rule that does not exist and an element that is not rendered both give
+ * an empty list.
+ *
+ * Only CSS animations count, as the transitions and the script animations that `getAnimations()`
+ * also returns do not report the state. Animations of any content are already left out, as
+ * `getAnimations()` only descends into the subtree when asked to. Animations that take no time
+ * are dropped, so that a delay on its own does not hold the state, and so are endless ones,
+ * which would hold it forever.
+ *
+ * @param {HTMLElement} element
+ * @return {!Array<!Animation>}
+ */
+export function getStateAnimations(element) {
+  return element.getAnimations().filter((animation) => {
+    const { activeDuration } = animation.effect.getComputedTiming();
+    return animation instanceof CSSAnimation && activeDuration > 0 && Number.isFinite(activeDuration);
+  });
 }
 
 /**

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -119,17 +119,17 @@ export function shouldAnimate(element) {
  * Only CSS animations count, as the transitions and the script animations that `getAnimations()`
  * also returns do not report the state. Animations of any content are already left out, as
  * `getAnimations()` only descends into the subtree when asked to. Animations that take no time
- * are dropped, so that a delay on its own does not hold the state, and so are endless ones,
- * which would hold it forever.
+ * are dropped as well, so that a delay on its own does not hold the state.
  *
  * @param {HTMLElement} element
  * @return {!Array<!Animation>}
  */
 export function getStateAnimations(element) {
-  return element.getAnimations().filter((animation) => {
-    const { activeDuration } = animation.effect.getComputedTiming();
-    return animation instanceof CSSAnimation && activeDuration > 0 && Number.isFinite(activeDuration);
-  });
+  return element
+    .getAnimations()
+    .filter(
+      (animation) => animation instanceof CSSAnimation && animation.effect.getComputedTiming().activeDuration > 0,
+    );
 }
 
 /**

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -94,8 +94,6 @@ export function observeMove(element, callback) {
  * awaited before the element is hidden or removed. An element that is not rendered,
  * has no animation name, or has a zero duration does not fire `animationend`.
  *
- * @deprecated Use `getStateAnimations()`, which reads the animations the browser created
- * rather than the computed style, so that the two cannot disagree.
  * @param {HTMLElement} element
  * @return {boolean}
  */

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -85,10 +85,6 @@ export function observeMove(element, callback) {
   return cleanup;
 }
 
-// Notification still uses `shouldAnimate()`: its card cancels and restarts a same-named
-// animation when it moves between the opening and closing state, which leaves the animation
-// objects briefly unobservable.
-
 /**
  * Detect whether an animation runs on the given element, so that its end can be
  * awaited before the element is hidden or removed. An element that is not rendered,

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -487,35 +487,6 @@ describe('animation objects', () => {
       overlay.style.animationDuration = '10s';
     });
 
-    it('should report an animation in the computed style but create none', () => {
-      overlay.opened = true;
-
-      const style = getComputedStyle(overlay);
-      expect(style.animationName).to.equal('does-not-exist');
-      expect(parseFloat(style.animationDuration)).to.be.above(0);
-      expect(overlay.getAnimations()).to.be.empty;
-    });
-
-    it('should not wait for the opening animation', () => {
-      overlay.opened = true;
-
-      expect(overlay.hasAttribute('opening')).to.be.false;
-    });
-
-    it('should not wait for the closing animation', () => {
-      overlay.opened = true;
-      overlay.opened = false;
-
-      expect(overlay.hasAttribute('closing')).to.be.false;
-      expect(overlay.matches(':popover-open')).to.be.false;
-    });
-  });
-
-  describe('animation that never ends', () => {
-    beforeEach(() => {
-      overlay.setAttribute('endless-animation', '');
-    });
-
     it('should not wait for the opening animation', () => {
       overlay.opened = true;
 

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -481,27 +481,6 @@ describe('animation objects', () => {
     overlay._flushAnimation('closing');
   });
 
-  describe('keyframes that do not exist', () => {
-    beforeEach(() => {
-      overlay.style.animationName = 'does-not-exist';
-      overlay.style.animationDuration = '10s';
-    });
-
-    it('should not wait for the opening animation', () => {
-      overlay.opened = true;
-
-      expect(overlay.hasAttribute('opening')).to.be.false;
-    });
-
-    it('should not wait for the closing animation', () => {
-      overlay.opened = true;
-      overlay.opened = false;
-
-      expect(overlay.hasAttribute('closing')).to.be.false;
-      expect(overlay.matches(':popover-open')).to.be.false;
-    });
-  });
-
   describe('animations that do not report the state', () => {
     it('should not wait for a transition on the overlay', () => {
       overlay.setAttribute('theme-transition', '');
@@ -557,6 +536,16 @@ describe('animation objects', () => {
   describe('short animation', () => {
     beforeEach(() => {
       overlay.setAttribute('animate', '');
+    });
+
+    it('should not get stuck when closed right after the opening animation ended', async () => {
+      overlay.opened = true;
+      await oneEvent(overlay, 'animationend');
+
+      overlay.opened = false;
+
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(overlay.matches(':popover-open')).to.be.false;
     });
 
     it('should not fire closed again when the flushed closing animation settles', async () => {

--- a/packages/overlay/test/animations.test.js
+++ b/packages/overlay/test/animations.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@vaadin/chai-plugins';
-import { escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
+import { aTimeout, escKeyDown, fixtureSync, nextFrame, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import './fixtures/mock-animated-overlay.js';
 
@@ -191,19 +191,6 @@ function afterOverlayClosingFinished(overlay, callback) {
 
         expect(overlay.hasAttribute('closing')).to.be.false;
         expect(owner.hasAttribute('closing')).to.be.false;
-      });
-
-      it('should remove the animationend listener after the animation has finished', async () => {
-        overlay.opened = true;
-
-        await new Promise((resolve) => {
-          afterOverlayOpeningFinished(overlay, resolve);
-        });
-
-        const spy = sinon.spy(overlay, '_finishOpening');
-        overlay.dispatchEvent(new AnimationEvent('animationend'));
-
-        expect(spy).to.be.not.called;
       });
 
       it('should not run the animation callback again after the animation has finished', async () => {
@@ -477,5 +464,159 @@ describe('zero-duration animation', () => {
     expect(finishClosing).to.be.calledOnce;
     expect(overlay.hasAttribute('closing')).to.be.false;
     expect(owner.hasAttribute('closing')).to.be.false;
+  });
+});
+
+describe('animation objects', () => {
+  let overlay;
+
+  beforeEach(async () => {
+    overlay = fixtureSync('<mock-animated-overlay>overlay content</mock-animated-overlay>');
+    await nextRender();
+  });
+
+  afterEach(() => {
+    overlay._flushAnimation('opening');
+    overlay.opened = false;
+    overlay._flushAnimation('closing');
+  });
+
+  describe('keyframes that do not exist', () => {
+    beforeEach(() => {
+      overlay.style.animationName = 'does-not-exist';
+      overlay.style.animationDuration = '10s';
+    });
+
+    it('should report an animation in the computed style but create none', () => {
+      overlay.opened = true;
+
+      const style = getComputedStyle(overlay);
+      expect(style.animationName).to.equal('does-not-exist');
+      expect(parseFloat(style.animationDuration)).to.be.above(0);
+      expect(overlay.getAnimations()).to.be.empty;
+    });
+
+    it('should not wait for the opening animation', () => {
+      overlay.opened = true;
+
+      expect(overlay.hasAttribute('opening')).to.be.false;
+    });
+
+    it('should not wait for the closing animation', () => {
+      overlay.opened = true;
+      overlay.opened = false;
+
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(overlay.matches(':popover-open')).to.be.false;
+    });
+  });
+
+  describe('animation that never ends', () => {
+    beforeEach(() => {
+      overlay.setAttribute('endless-animation', '');
+    });
+
+    it('should not wait for the opening animation', () => {
+      overlay.opened = true;
+
+      expect(overlay.hasAttribute('opening')).to.be.false;
+    });
+
+    it('should not wait for the closing animation', () => {
+      overlay.opened = true;
+      overlay.opened = false;
+
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(overlay.matches(':popover-open')).to.be.false;
+    });
+  });
+
+  describe('animations that do not report the state', () => {
+    it('should not wait for a transition on the overlay', () => {
+      overlay.setAttribute('theme-transition', '');
+      expect(getComputedStyle(overlay).transitionDuration).to.equal('5s');
+
+      overlay.opened = true;
+
+      expect(overlay.hasAttribute('opening')).to.be.false;
+    });
+
+    it('should not wait for a content animation that outlives the overlay animation', async () => {
+      overlay.setAttribute('animate', '');
+
+      const div = document.createElement('div');
+      div.classList.add('slow-content');
+      overlay.appendChild(div);
+
+      overlay.opened = true;
+      expect(div.getAnimations()).to.have.lengthOf(1);
+
+      await oneEvent(overlay, 'animationend');
+      await nextFrame();
+
+      expect(div.getAnimations()).to.have.lengthOf(1);
+      expect(overlay.hasAttribute('opening')).to.be.false;
+    });
+  });
+
+  describe('long animation', () => {
+    beforeEach(() => {
+      overlay.setAttribute('long-animation', '');
+    });
+
+    it('should wait for the closing animation when closed while opening', () => {
+      overlay.opened = true;
+      overlay.opened = false;
+
+      expect(overlay.hasAttribute('closing')).to.be.true;
+    });
+
+    it('should stay open when reopened while the closing animation runs', async () => {
+      overlay.opened = true;
+      overlay._flushAnimation('opening');
+      overlay.opened = false;
+      overlay.opened = true;
+      await aTimeout(100);
+
+      expect(overlay.hasAttribute('closing')).to.be.false;
+      expect(overlay.matches(':popover-open')).to.be.true;
+    });
+  });
+
+  describe('short animation', () => {
+    beforeEach(() => {
+      overlay.setAttribute('animate', '');
+    });
+
+    it('should not fire closed again when the flushed closing animation settles', async () => {
+      overlay.opened = true;
+      overlay._flushAnimation('opening');
+      overlay.opened = false;
+      overlay._flushAnimation('closing');
+
+      const spy = sinon.spy();
+      overlay.addEventListener('vaadin-overlay-closed', spy);
+      // Longer than the animation, so its promise has settled either way
+      await aTimeout(100);
+
+      expect(spy).to.be.not.called;
+    });
+  });
+
+  describe('multiple animations', () => {
+    beforeEach(() => {
+      overlay.setAttribute('multiple-animations', '');
+    });
+
+    it('should wait for the longest animation', async () => {
+      overlay.opened = true;
+      expect(overlay.getAnimations()).to.have.lengthOf(2);
+
+      // The 50ms animation ends first, while the 5s one is still running
+      await oneEvent(overlay, 'animationend');
+      await nextFrame();
+
+      expect(overlay.hasAttribute('opening')).to.be.true;
+    });
   });
 });

--- a/packages/overlay/test/fixtures/mock-animated-overlay.js
+++ b/packages/overlay/test/fixtures/mock-animated-overlay.js
@@ -43,12 +43,6 @@ class MockAnimatedOverlay extends MockOverlay {
             5s content-dummy-animation;
         }
 
-        /* An animation that never ends, so the state can never wait for it */
-        :host([endless-animation][opening]),
-        :host([endless-animation][closing]) {
-          animation: 50ms infinite overlay-dummy-animation;
-        }
-
         /* A transition applied by a theme, which does not report the state of the overlay */
         :host([theme-transition]) {
           transition: opacity 5s;

--- a/packages/overlay/test/fixtures/mock-animated-overlay.js
+++ b/packages/overlay/test/fixtures/mock-animated-overlay.js
@@ -35,9 +35,43 @@ class MockAnimatedOverlay extends MockOverlay {
           opacity: 0.5;
         }
 
+        /* Two animations of different lengths, the state ends with the longest */
+        :host([multiple-animations][opening]),
+        :host([multiple-animations][closing]) {
+          animation:
+            50ms overlay-dummy-animation,
+            5s content-dummy-animation;
+        }
+
+        /* An animation that never ends, so the state can never wait for it */
+        :host([endless-animation][opening]),
+        :host([endless-animation][closing]) {
+          animation: 50ms infinite overlay-dummy-animation;
+        }
+
+        /* A transition applied by a theme, which does not report the state of the overlay */
+        :host([theme-transition]) {
+          transition: opacity 5s;
+        }
+
+        :host([theme-transition][opening]) {
+          opacity: 0.9;
+        }
+
+        /* Content that keeps animating for longer than the overlay itself */
+        ::slotted(.slow-content) {
+          animation: 5s content-dummy-animation;
+        }
+
         @keyframes overlay-dummy-animation {
           to {
             opacity: 1 !important; /* stylelint-disable-line keyframe-declaration-no-important */
+          }
+        }
+
+        @keyframes content-dummy-animation {
+          to {
+            opacity: 0.5;
           }
         }
       `,

--- a/packages/overlay/test/utils.test.js
+++ b/packages/overlay/test/utils.test.js
@@ -1,6 +1,76 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { shouldAnimate } from '../src/vaadin-overlay-utils.js';
+import { getStateAnimations, shouldAnimate } from '../src/vaadin-overlay-utils.js';
+
+const styles = document.createElement('style');
+styles.textContent = `
+  @keyframes utils-fade { to { opacity: 0.5; } }
+  @keyframes utils-scale { to { scale: 0.5; } }
+`;
+document.head.appendChild(styles);
+
+describe('getStateAnimations', () => {
+  let element;
+
+  beforeEach(() => {
+    element = fixtureSync('<div>content</div>');
+  });
+
+  it('should return an empty list when the element is not rendered', () => {
+    element.style.animation = 'utils-fade 1s';
+    element.style.display = 'none';
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+
+  it('should return an empty list when the element has no animation name', () => {
+    element.style.animationDuration = '1s';
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+
+  it('should return an empty list when the animation duration is zero', () => {
+    element.style.animation = 'utils-fade 0s';
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+
+  it('should return an empty list when the keyframes do not exist', () => {
+    element.style.animation = 'utils-does-not-exist 1s';
+    expect(getComputedStyle(element).animationName).to.equal('utils-does-not-exist');
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+
+  it('should return the animations that take time', () => {
+    element.style.animationName = 'utils-fade, utils-scale';
+    element.style.animationDuration = '0s, 1s';
+
+    const animations = getStateAnimations(element);
+    expect(animations.map((animation) => animation.animationName)).to.eql(['utils-scale']);
+  });
+
+  it('should return an empty list for an animation that never ends', () => {
+    element.style.animation = 'utils-fade 1s infinite';
+
+    const [animation] = element.getAnimations();
+    expect(animation.effect.getComputedTiming().activeDuration).to.equal(Infinity);
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+
+  it('should return an empty list for a transition', () => {
+    element.style.transition = 'opacity 1s';
+    // The transition only starts from a value the browser has already resolved
+    expect(getComputedStyle(element).opacity).to.equal('1');
+    element.style.opacity = '0.5';
+
+    expect(element.getAnimations()).to.have.lengthOf(1);
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+
+  it('should leave out the animations of the content', () => {
+    const child = document.createElement('div');
+    child.style.animation = 'utils-fade 1s';
+    element.appendChild(child);
+    expect(getStateAnimations(element)).to.be.empty;
+  });
+});
 
 describe('shouldAnimate', () => {
   let element;
@@ -10,7 +80,7 @@ describe('shouldAnimate', () => {
   });
 
   it('should return false when the element is not rendered', () => {
-    element.style.animation = 'foo 1s';
+    element.style.animation = 'utils-fade 1s';
     element.style.display = 'none';
     expect(shouldAnimate(element)).to.be.false;
   });
@@ -21,12 +91,12 @@ describe('shouldAnimate', () => {
   });
 
   it('should return false when the animation duration is zero', () => {
-    element.style.animation = 'foo 0s';
+    element.style.animation = 'utils-fade 0s';
     expect(shouldAnimate(element)).to.be.false;
   });
 
   it('should return true when one of the animation durations is not zero', () => {
-    element.style.animationName = 'foo, bar';
+    element.style.animationName = 'utils-fade, utils-scale';
     element.style.animationDuration = '0s, 1s';
     expect(shouldAnimate(element)).to.be.true;
   });

--- a/packages/overlay/test/utils.test.js
+++ b/packages/overlay/test/utils.test.js
@@ -46,14 +46,6 @@ describe('getStateAnimations', () => {
     expect(animations.map((animation) => animation.animationName)).to.eql(['utils-scale']);
   });
 
-  it('should return an empty list for an animation that never ends', () => {
-    element.style.animation = 'utils-fade 1s infinite';
-
-    const [animation] = element.getAnimations();
-    expect(animation.effect.getComputedTiming().activeDuration).to.equal(Infinity);
-    expect(getStateAnimations(element)).to.be.empty;
-  });
-
   it('should return an empty list for a transition', () => {
     element.style.transition = 'opacity 1s';
     // The transition only starts from a value the browser has already resolved


### PR DESCRIPTION
## Description

Fixes #12363 
Reverts #12364

The overlay decided whether to wait for an animation by reading the computed style, and then
waited for an `animationend` event. Those two can disagree: when the style reports an animation
the browser never created, the event never arrives and the overlay keeps the `opening` or
`closing` attribute for good.

That is what #12363 hits on Safari. The computed style reported the 100ms closing duration that
Aura sets, while the animation the engine had actually created had a zero duration, so the
context menu and the menu bar did not close on the first outside click.

A keyframes rule that does not exist puts the overlay in the same state in every browser:

```js
overlay.style.animationName = 'does-not-exist';
overlay.style.animationDuration = '10s';

overlay.opened = true;
// `animation-name` and `animation-duration` both resolve in the computed style,
// no animation runs, and the `opening` attribute is never removed
```

## Changes

A new `getStateAnimations()` helper reads the animations from `getAnimations()`, and
`_enqueueAnimation()` waits for their `finished` promises. The decision and the wait now come
from the same objects, so they cannot disagree. The case above is covered by a test.

Only CSS animations of the overlay itself that take a finite time count. This leaves out
transitions, animations started from script, animations of the content, and endless ones. An
endless animation used to hang the overlay in every browser, as its `finished` never settles.

Two observable differences:

- A phase ends once every animation reporting the state has ended, where the listener ended on
  the first `animationend`. An overlay with several animations of different lengths now holds
  the state until the longest one is done.
- The `animationcancel` listener is gone. It had no target check, so a cancel coming from a
  content animation used to end both phases. The rejection of the awaited promises only ends the
  phase whose own animations were cancelled.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
