### PR TITLE
fix: collapse empty drawer on app-layout init

### DIFF
--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -154,6 +154,12 @@ export const AppLayoutMixin = (superclass) =>
       this.addController(this.__focusTrapController);
       this.__setAriaExpanded();
 
+      // The `drawer` slot's `slotchange` handler updates the drawer size, but
+      // `slotchange` does not fire for a slot that never receives assigned nodes.
+      // Update the drawer size once on init so that a layout that is empty from
+      // the start collapses the drawer instead of reserving space for it.
+      this.__updateDrawerSize();
+
       this.$.drawer.addEventListener('transitionstart', () => {
         this.__isDrawerAnimating = true;
       });

--- a/packages/app-layout/src/vaadin-app-layout-mixin.js
+++ b/packages/app-layout/src/vaadin-app-layout-mixin.js
@@ -154,10 +154,6 @@ export const AppLayoutMixin = (superclass) =>
       this.addController(this.__focusTrapController);
       this.__setAriaExpanded();
 
-      // The `drawer` slot's `slotchange` handler updates the drawer size, but
-      // `slotchange` does not fire for a slot that never receives assigned nodes.
-      // Update the drawer size once on init so that a layout that is empty from
-      // the start collapses the drawer instead of reserving space for it.
       this.__updateDrawerSize();
 
       this.$.drawer.addEventListener('transitionstart', () => {

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -254,22 +254,6 @@ describe('vaadin-app-layout', () => {
         expect(getComputedStyle(layout).paddingInlineStart).to.be.equal(initialPadding);
       });
 
-      it('should hide the drawer when rendered without drawer content', async () => {
-        const emptyLayout = fixtureSync(`
-          <vaadin-app-layout style="--vaadin-app-layout-transition-duration: 0s;">
-            <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
-            <main>Page content</main>
-          </vaadin-app-layout>
-        `);
-        await nextRender();
-        await nextResize(emptyLayout);
-        await nextFrame();
-
-        const emptyDrawer = emptyLayout.shadowRoot.querySelector('[part=drawer]');
-        expect(emptyDrawer.hasAttribute('hidden')).to.be.true;
-        expect(getComputedStyle(emptyLayout).paddingInlineStart).to.be.equal('0px');
-      });
-
       it('should not close the drawer on navigation event', () => {
         window.dispatchEvent(new CustomEvent('vaadin-router-location-changed'));
         expect(layout.drawerOpened).to.be.true;

--- a/packages/app-layout/test/app-layout.test.js
+++ b/packages/app-layout/test/app-layout.test.js
@@ -254,6 +254,22 @@ describe('vaadin-app-layout', () => {
         expect(getComputedStyle(layout).paddingInlineStart).to.be.equal(initialPadding);
       });
 
+      it('should hide the drawer when rendered without drawer content', async () => {
+        const emptyLayout = fixtureSync(`
+          <vaadin-app-layout style="--vaadin-app-layout-transition-duration: 0s;">
+            <vaadin-drawer-toggle slot="navbar"></vaadin-drawer-toggle>
+            <main>Page content</main>
+          </vaadin-app-layout>
+        `);
+        await nextRender();
+        await nextResize(emptyLayout);
+        await nextFrame();
+
+        const emptyDrawer = emptyLayout.shadowRoot.querySelector('[part=drawer]');
+        expect(emptyDrawer.hasAttribute('hidden')).to.be.true;
+        expect(getComputedStyle(emptyLayout).paddingInlineStart).to.be.equal('0px');
+      });
+
       it('should not close the drawer on navigation event', () => {
         window.dispatchEvent(new CustomEvent('vaadin-router-location-changed'));
         expect(layout.drawerOpened).to.be.true;

--- a/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
@@ -40,7 +40,7 @@ snapshots["vaadin-app-layout host with navbar"] =
 `;
 /* end snapshot vaadin-app-layout host with navbar */
 
-snapshots["vaadin-app-layout shadow desktop layout default"] = 
+snapshots["vaadin-app-layout shadow drawer content desktop layout default"] = 
 `<div
   id="navbarTop"
   part="navbar navbar-top"
@@ -80,9 +80,9 @@ snapshots["vaadin-app-layout shadow desktop layout default"] =
   </slot>
 </div>
 `;
-/* end snapshot vaadin-app-layout shadow desktop layout default */
+/* end snapshot vaadin-app-layout shadow drawer content desktop layout default */
 
-snapshots["vaadin-app-layout shadow desktop layout drawer closed"] = 
+snapshots["vaadin-app-layout shadow drawer content desktop layout drawer closed"] = 
 `<div
   id="navbarTop"
   part="navbar navbar-top"
@@ -122,9 +122,9 @@ snapshots["vaadin-app-layout shadow desktop layout drawer closed"] =
   </slot>
 </div>
 `;
-/* end snapshot vaadin-app-layout shadow desktop layout drawer closed */
+/* end snapshot vaadin-app-layout shadow drawer content desktop layout drawer closed */
 
-snapshots["vaadin-app-layout shadow mobile layout default"] = 
+snapshots["vaadin-app-layout shadow drawer content mobile layout default"] = 
 `<div
   id="navbarTop"
   part="navbar navbar-top"
@@ -167,9 +167,9 @@ snapshots["vaadin-app-layout shadow mobile layout default"] =
   </slot>
 </div>
 `;
-/* end snapshot vaadin-app-layout shadow mobile layout default */
+/* end snapshot vaadin-app-layout shadow drawer content mobile layout default */
 
-snapshots["vaadin-app-layout shadow mobile layout drawer opened"] = 
+snapshots["vaadin-app-layout shadow drawer content mobile layout drawer opened"] = 
 `<div
   id="navbarTop"
   part="navbar navbar-top"
@@ -212,5 +212,94 @@ snapshots["vaadin-app-layout shadow mobile layout drawer opened"] =
   </slot>
 </div>
 `;
-/* end snapshot vaadin-app-layout shadow mobile layout drawer opened */
+/* end snapshot vaadin-app-layout shadow drawer content mobile layout drawer opened */
+
+snapshots["vaadin-app-layout shadow empty desktop layout default"] = 
+`<div
+  id="navbarTop"
+  part="navbar navbar-top"
+>
+  <slot name="navbar">
+  </slot>
+</div>
+<div part="backdrop">
+</div>
+<div
+  hidden=""
+  id="drawer"
+  part="drawer"
+>
+  <slot
+    id="drawerSlot"
+    name="drawer"
+  >
+  </slot>
+</div>
+<div part="content">
+  <slot>
+  </slot>
+</div>
+<div
+  hidden=""
+  id="navbarBottom"
+  part="navbar navbar-bottom"
+>
+  <slot name="navbar-bottom">
+  </slot>
+</div>
+<div hidden="">
+  <slot
+    id="touchSlot"
+    name="navbar touch-optimized"
+  >
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-app-layout shadow empty desktop layout default */
+
+snapshots["vaadin-app-layout shadow empty mobile layout default"] = 
+`<div
+  id="navbarTop"
+  part="navbar navbar-top"
+>
+  <slot name="navbar">
+  </slot>
+</div>
+<div part="backdrop">
+</div>
+<div
+  aria-label="Drawer"
+  aria-modal="true"
+  hidden=""
+  id="drawer"
+  part="drawer"
+  role="dialog"
+>
+  <slot
+    id="drawerSlot"
+    name="drawer"
+  >
+  </slot>
+</div>
+<div part="content">
+  <slot>
+  </slot>
+</div>
+<div
+  hidden=""
+  id="navbarBottom"
+  part="navbar navbar-bottom"
+>
+  <slot name="navbar-bottom">
+  </slot>
+</div>
+<div hidden="">
+  <slot
+    id="touchSlot"
+    name="navbar touch-optimized"
+  >
+  </slot>
+</div>
+`;
+/* end snapshot vaadin-app-layout shadow empty mobile layout default */
 

--- a/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
+++ b/packages/app-layout/test/dom/__snapshots__/app-layout.test.snap.js
@@ -6,7 +6,7 @@ snapshots["vaadin-app-layout host default"] =
   no-anim=""
   overlay=""
   primary-section="navbar"
-  style="--_vaadin-app-layout-drawer-offset-size: 320px; --_vaadin-app-layout-navbar-offset-size: 16px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
+  style="--_vaadin-app-layout-drawer-width: 0; --_vaadin-app-layout-drawer-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size: 16px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
 >
 </vaadin-app-layout>
 `;
@@ -31,7 +31,7 @@ snapshots["vaadin-app-layout host with navbar"] =
   has-navbar=""
   overlay=""
   primary-section="navbar"
-  style="--_vaadin-app-layout-drawer-offset-size: 320px; --_vaadin-app-layout-navbar-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
+  style="--_vaadin-app-layout-drawer-width: 0; --_vaadin-app-layout-drawer-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size: 0px; --_vaadin-app-layout-navbar-offset-size-bottom: 0px;"
 >
   <div slot="navbar">
     Navbar Content

--- a/packages/app-layout/test/dom/app-layout.test.js
+++ b/packages/app-layout/test/dom/app-layout.test.js
@@ -42,49 +42,86 @@ describe('vaadin-app-layout', () => {
   });
 
   describe('shadow', () => {
-    beforeEach(async () => {
-      layout = fixtureSync(`
-        <vaadin-app-layout>
-          <vaadin-drawer-toggle id="toggle" slot="navbar">
-            Drawer Toggle
-          </vaadin-drawer-toggle>
-          <section slot="drawer">
-            Drawer Content
-          </section>
-          <main>Page Content</main>
-        </vaadin-app-layout>
-      `);
-      await nextResize(layout);
-      await nextFrame();
+    describe('drawer content', () => {
+      beforeEach(async () => {
+        layout = fixtureSync(`
+          <vaadin-app-layout>
+            <vaadin-drawer-toggle id="toggle" slot="navbar">
+              Drawer Toggle
+            </vaadin-drawer-toggle>
+            <section slot="drawer">
+              Drawer Content
+            </section>
+            <main>Page Content</main>
+          </vaadin-app-layout>
+        `);
+        await nextResize(layout);
+        await nextFrame();
+      });
+
+      describe('desktop layout', () => {
+        before(async () => {
+          await setViewport({ width: 1000, height: 1000 });
+        });
+
+        it('default', async () => {
+          await expect(layout).shadowDom.to.equalSnapshot();
+        });
+
+        it('drawer closed', async () => {
+          layout.drawerOpened = false;
+          await expect(layout).shadowDom.to.equalSnapshot();
+        });
+      });
+
+      describe('mobile layout', () => {
+        before(async () => {
+          await setViewport({ width: 500, height: 500 });
+        });
+
+        it('default', async () => {
+          await expect(layout).shadowDom.to.equalSnapshot();
+        });
+
+        it('drawer opened', async () => {
+          layout.drawerOpened = true;
+          await expect(layout).shadowDom.to.equalSnapshot();
+        });
+      });
     });
 
-    describe('desktop layout', () => {
-      before(async () => {
-        await setViewport({ width: 1000, height: 1000 });
+    describe('empty', () => {
+      beforeEach(async () => {
+        layout = fixtureSync(`
+          <vaadin-app-layout>
+            <vaadin-drawer-toggle id="toggle" slot="navbar">
+              Drawer Toggle
+            </vaadin-drawer-toggle>
+            <main>Page Content</main>
+          </vaadin-app-layout>
+        `);
+        await nextResize(layout);
+        await nextFrame();
       });
 
-      it('default', async () => {
-        await expect(layout).shadowDom.to.equalSnapshot();
+      describe('desktop layout', () => {
+        before(async () => {
+          await setViewport({ width: 1000, height: 1000 });
+        });
+
+        it('default', async () => {
+          await expect(layout).shadowDom.to.equalSnapshot();
+        });
       });
 
-      it('drawer closed', async () => {
-        layout.drawerOpened = false;
-        await expect(layout).shadowDom.to.equalSnapshot();
-      });
-    });
+      describe('mobile layout', () => {
+        before(async () => {
+          await setViewport({ width: 500, height: 500 });
+        });
 
-    describe('mobile layout', () => {
-      before(async () => {
-        await setViewport({ width: 500, height: 500 });
-      });
-
-      it('default', async () => {
-        await expect(layout).shadowDom.to.equalSnapshot();
-      });
-
-      it('drawer opened', async () => {
-        layout.drawerOpened = true;
-        await expect(layout).shadowDom.to.equalSnapshot();
+        it('default', async () => {
+          await expect(layout).shadowDom.to.equalSnapshot();
+        });
       });
     });
   });


### PR DESCRIPTION
When `vaadin-app-layout` has no drawer content at all, it still reserved space for the drawer and pushed the content area right (256px with Lumo).

`__updateDrawerSize()` only ran from the drawer slot's `slotchange` handler, but `slotchange` never fires for a slot that stays empty from the start, so the empty case was never handled on first render. A regression from #11493.

The fix calls `__updateDrawerSize()` once in `ready()` to restore the pre-#11493 behavior, without reintroducing forced style recalculations.

Fixes #12405

Generated with [Claude Code](https://claude.ai/code)