### PR TITLE
test: split context-menu items tests into separate files (CP: 25.1)

### DIFF
--- a/packages/context-menu/test/helpers.js
+++ b/packages/context-menu/test/helpers.js
@@ -38,6 +38,11 @@ export function getSubMenu(menu) {
   return menu.querySelector(':scope > vaadin-context-menu[slot="submenu"]');
 }
 
+export async function openSubMenu(menu, index = 0) {
+  await openMenu(getMenuItems(menu)[index]);
+  return getSubMenu(menu);
+}
+
 export async function openSubMenus(menu) {
   await oneEvent(menu._overlayElement, 'vaadin-overlay-open');
   const itemElement = menu.querySelector(':scope > [slot="overlay"] [aria-haspopup="true"]');

--- a/packages/context-menu/test/items-interactions.test.js
+++ b/packages/context-menu/test/items-interactions.test.js
@@ -1,0 +1,353 @@
+import { expect } from '@vaadin/chai-plugins';
+import { sendKeys } from '@vaadin/test-runner-commands';
+import { fixtureSync, nextFrame, nextRender, outsideClick } from '@vaadin/testing-helpers';
+import sinon from 'sinon';
+import '../src/vaadin-context-menu.js';
+import { getDeepActiveElement } from '@vaadin/a11y-base/src/focus-utils.js';
+import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
+import { activateItem, getMenuItems, getSubMenu, openMenu, openSubMenu } from './helpers.js';
+
+describe('items interactions', () => {
+  let rootMenu, subMenu, target, rootOverlay, subOverlay1;
+
+  const createComponent = (text) => {
+    const item = document.createElement('vaadin-context-menu-item');
+    item.textContent = text;
+    return item;
+  };
+
+  beforeEach(async () => {
+    // Firefox: when a previous test ends with focus on an overlay item
+    // that then gets removed during fixture teardown, element.focus()
+    // calls in the next test's overlay silently no-op (activeElement
+    // stays on <body>), breaking sendKeys-based arrow navigation.
+    // Adding a real focusable sibling outside the overlay helps work
+    // this around
+    const wrapper = fixtureSync(`
+      <div>
+        <input id="first-global-focusable" />
+        <vaadin-context-menu>
+          <button id="target"></button>
+        </vaadin-context-menu>
+      </div>
+    `);
+    rootMenu = wrapper.querySelector('vaadin-context-menu');
+    rootMenu.openOn = isTouch ? 'click' : 'mouseover';
+    target = rootMenu.querySelector('#target');
+    rootMenu.items = [
+      {
+        text: 'foo-0',
+        children: [{ text: 'foo-0-0' }, { text: 'foo-0-1', disabled: true }, { text: 'foo-0-2' }],
+      },
+      { text: 'foo-1' },
+      { text: 'foo-2' },
+      {
+        text: 'foo-3',
+        children: [
+          { component: createComponent('foo-3-0') },
+          { component: createComponent('foo-3-1') },
+          { component: createComponent('foo-3-2') },
+        ],
+      },
+    ];
+    await nextRender();
+  });
+
+  afterEach(() => {
+    rootMenu.close();
+
+    // Forcing dir to ltr because Safari scroll can get lost if attribute
+    // is set to `rtl` and then removed
+    document.documentElement.setAttribute('dir', 'ltr');
+  });
+
+  describe('closing on click', () => {
+    beforeEach(async () => {
+      await openMenu(target);
+      subMenu = await openSubMenu(rootMenu);
+      subOverlay1 = subMenu._overlayElement;
+    });
+
+    // On touch, the click opening the second menu closes the first one.
+    (isTouch ? it.skip : it)('should close all menus of every open menu on outside click', async () => {
+      const otherMenu = fixtureSync(`
+        <vaadin-context-menu>
+          <button></button>
+        </vaadin-context-menu>
+      `);
+      otherMenu.openOn = 'mouseover';
+      otherMenu.items = [{ text: 'bar-0' }];
+      await nextRender();
+      await openMenu(otherMenu.firstElementChild);
+      expect(rootMenu.opened).to.be.true;
+      expect(otherMenu.opened).to.be.true;
+
+      outsideClick();
+      expect(rootMenu.opened).to.be.false;
+      expect(subMenu.opened).to.be.false;
+      expect(otherMenu.opened).to.be.false;
+    });
+
+    it('should close all menus on click on the menu light DOM content', () => {
+      // Unlike a real click, a synthetic one is not blocked by the modal
+      // overlay, so on touch it would also open the menu again.
+      rootMenu.openOn = 'mouseover';
+
+      target.click();
+      expect(rootMenu.opened).to.be.false;
+      expect(subMenu.opened).to.be.false;
+    });
+
+    it('should not close on disabled item click', () => {
+      getMenuItems(subMenu)[1].click();
+      expect(subMenu.opened).to.be.true;
+    });
+
+    it('should not close on parent item click', () => {
+      getMenuItems(rootMenu)[0].click();
+      expect(rootMenu.opened).to.be.true;
+    });
+
+    it('should close on backdrop click', () => {
+      subOverlay1.$.backdrop.click();
+      expect(subMenu.opened).to.be.false;
+    });
+  });
+
+  describe('hover', () => {
+    beforeEach(async () => {
+      await openMenu(target);
+      subMenu = await openSubMenu(rootMenu);
+      rootOverlay = rootMenu._overlayElement;
+    });
+
+    it('should update the submenu when activating other parent item', () => {
+      activateItem(getMenuItems(rootMenu)[3]);
+
+      expect(subMenu.opened).to.be.true;
+
+      const items = getMenuItems(subMenu);
+      expect(items.length).to.equal(3);
+      expect(items[0].textContent).to.equal('foo-3-0');
+      expect(items[1].textContent).to.equal('foo-3-1');
+      expect(items[2].textContent).to.equal('foo-3-2');
+    });
+
+    it('should not change opened state of the submenu when activating other parent item', () => {
+      const openedChangeSpy = sinon.spy();
+      subMenu.addEventListener('opened-changed', openedChangeSpy);
+
+      activateItem(getMenuItems(rootMenu)[3]);
+
+      expect(openedChangeSpy).to.not.be.called;
+    });
+
+    it('should close the submenu on activating non-parent item', () => {
+      activateItem(getMenuItems(rootMenu)[1]);
+      expect(subMenu.opened).to.be.false;
+    });
+
+    (isTouch ? it.skip : it)('should focus closed parent item when hovering on non-parent item', () => {
+      const parent = getMenuItems(rootMenu)[0];
+      const nonParent = getMenuItems(rootMenu)[1];
+      const focusSpy = sinon.spy(parent, 'focus');
+      activateItem(nonParent);
+      expect(focusSpy).to.be.called;
+    });
+
+    (isTouch ? it.skip : it)('should focus overlay part on closing sub-menu without focused item', async () => {
+      const parent = getMenuItems(rootMenu)[3];
+      await openMenu(parent);
+      const nonParent = getMenuItems(rootMenu)[1];
+      const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
+      activateItem(nonParent);
+      expect(focusSpy).to.be.called;
+    });
+
+    (isTouch ? it.skip : it)('should not focus overlay part if the parent menu list-box has focus', () => {
+      activateItem(getMenuItems(rootMenu)[1]);
+      const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
+      activateItem(getMenuItems(rootMenu)[2]);
+      expect(focusSpy).to.not.be.called;
+    });
+  });
+
+  describe('closing with keyboard', () => {
+    beforeEach(async () => {
+      await openMenu(target);
+      subMenu = await openSubMenu(rootMenu);
+    });
+
+    it('should close the submenu on left arrow', async () => {
+      await sendKeys({ press: 'ArrowLeft' });
+      expect(subMenu.opened).to.be.false;
+      expect(getDeepActiveElement()).to.equal(getMenuItems(rootMenu)[0]);
+    });
+
+    it('should close the submenu on right arrow if RTL', async () => {
+      document.documentElement.setAttribute('dir', 'rtl');
+      await nextFrame();
+      await sendKeys({ press: 'ArrowRight' });
+      expect(subMenu.opened).to.be.false;
+      expect(getDeepActiveElement()).to.equal(getMenuItems(rootMenu)[0]);
+    });
+
+    it('should close top-most menu on esc', async () => {
+      await sendKeys({ press: 'Escape' });
+      expect(subMenu.opened).to.be.false;
+      expect(rootMenu.opened).to.be.true;
+      expect(getMenuItems(rootMenu)[0].hasAttribute('focused')).to.be.true;
+    });
+
+    it('should close all menus on Tab', async () => {
+      await sendKeys({ press: 'Tab' });
+      expect(rootMenu.opened).to.be.false;
+    });
+  });
+
+  describe('opening sub-menu with keyboard', () => {
+    beforeEach(async () => {
+      await openMenu(target);
+      subMenu = getSubMenu(rootMenu);
+      // Focus the parent item explicitly, as sendKeys sends to the browser
+      getMenuItems(rootMenu)[0].focus();
+    });
+
+    it('should open item on right arrow', async () => {
+      await sendKeys({ press: 'ArrowRight' });
+      expect(subMenu.opened).to.be.true;
+    });
+
+    it('should open item on left arrow if RTL', async () => {
+      document.documentElement.setAttribute('dir', 'rtl');
+      await nextFrame();
+      await sendKeys({ press: 'ArrowLeft' });
+      expect(subMenu.opened).to.be.true;
+    });
+
+    it('should open item on enter', async () => {
+      await sendKeys({ press: 'Enter' });
+      expect(subMenu.opened).to.be.true;
+    });
+
+    it('should open item on space', async () => {
+      await sendKeys({ press: 'Space' });
+      expect(subMenu.opened).to.be.true;
+    });
+  });
+
+  describe('focus on sub-menu open', () => {
+    beforeEach(async () => {
+      await openMenu(target);
+      subMenu = getSubMenu(rootMenu);
+      rootOverlay = rootMenu._overlayElement;
+      // Move focus from the root item to the overlay itself: a sub-menu only
+      // focuses its first item when the parent item has focus.
+      rootOverlay.$.overlay.focus();
+    });
+
+    it('should not focus item if parent item is not focused', async () => {
+      await openSubMenu(rootMenu);
+      expect(subMenu.opened).to.be.true;
+      await nextRender();
+      expect(getMenuItems(subMenu)[0].hasAttribute('focused')).to.be.false;
+    });
+
+    it('should focus first item in submenu on overlay element arrow down', async () => {
+      await openSubMenu(rootMenu);
+      await sendKeys({ press: 'ArrowDown' });
+      expect(getDeepActiveElement()).to.equal(getMenuItems(subMenu)[0]);
+    });
+
+    it('should focus last item in submenu on overlay element arrow up', async () => {
+      await openSubMenu(rootMenu);
+      const items = getMenuItems(subMenu);
+      await sendKeys({ press: 'ArrowUp' });
+      expect(getDeepActiveElement()).to.equal(items[items.length - 1]);
+    });
+
+    it('should focus first item after re-opening when using components', async () => {
+      const rootItem = getMenuItems(rootMenu)[3];
+
+      // Open the sub-menu with item components
+      await openMenu(rootItem);
+      const subMenu2 = getSubMenu(rootMenu);
+      const items = getMenuItems(subMenu2);
+
+      // Arrow Down to focus next item
+      items[0].focus();
+      await sendKeys({ press: 'ArrowDown' });
+      expect(items[1].hasAttribute('focus-ring')).to.be.true;
+
+      // Arrow Left to close the sub-menu
+      await sendKeys({ press: 'ArrowLeft' });
+      await nextFrame();
+      expect(rootItem.hasAttribute('focus-ring')).to.be.true;
+
+      // Re-open sub-menu and check focus
+      await openMenu(rootItem);
+      expect(items[0].hasAttribute('focus-ring')).to.be.true;
+    });
+
+    it('should focus first non-disabled item after re-opening when using components', async () => {
+      rootMenu.items[3].children[0].disabled = true;
+
+      const rootItem = getMenuItems(rootMenu)[3];
+
+      // Open the sub-menu with item components
+      await openMenu(rootItem);
+      const subMenu2 = getSubMenu(rootMenu);
+      const items = getMenuItems(subMenu2);
+
+      // Arrow Down to focus next item
+      items[1].focus();
+      await sendKeys({ press: 'ArrowDown' });
+      expect(items[2].hasAttribute('focus-ring')).to.be.true;
+
+      // Arrow Left to close the sub-menu
+      await sendKeys({ press: 'ArrowLeft' });
+      await nextFrame();
+      expect(rootItem.hasAttribute('focus-ring')).to.be.true;
+
+      // Re-open sub-menu and check focus
+      await openMenu(rootItem);
+      expect(items[1].hasAttribute('focus-ring')).to.be.true;
+    });
+  });
+
+  describe('expanded state', () => {
+    let items;
+
+    beforeEach(async () => {
+      await openMenu(target);
+      subMenu = await openSubMenu(rootMenu);
+      items = getMenuItems(rootMenu);
+    });
+
+    it('should have expanded attributes', async () => {
+      expect(items[0].hasAttribute('expanded')).to.be.true;
+      expect(items[0].getAttribute('aria-expanded')).to.equal('true');
+      subMenu.close();
+      await nextRender();
+      expect(items[0].hasAttribute('expanded')).to.be.false;
+      expect(items[0].getAttribute('aria-expanded')).to.equal('false');
+    });
+
+    it('should update expanded attributes when activating different parent item', async () => {
+      expect(items[0].hasAttribute('expanded')).to.be.true;
+      expect(items[0].getAttribute('aria-expanded')).to.equal('true');
+
+      await activateItem(items[3]);
+      expect(items[0].hasAttribute('expanded')).to.be.false;
+      expect(items[0].getAttribute('aria-expanded')).to.equal('false');
+      expect(items[3].hasAttribute('expanded')).to.be.true;
+      expect(items[3].getAttribute('aria-expanded')).to.equal('true');
+
+      await activateItem(items[0]);
+      expect(items[0].hasAttribute('expanded')).to.be.true;
+      expect(items[0].getAttribute('aria-expanded')).to.equal('true');
+      expect(items[3].hasAttribute('expanded')).to.be.false;
+      expect(items[3].getAttribute('aria-expanded')).to.equal('false');
+    });
+  });
+});

--- a/packages/context-menu/test/items-rendering.test.js
+++ b/packages/context-menu/test/items-rendering.test.js
@@ -1,10 +1,127 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync, nextRender } from '@vaadin/testing-helpers';
 import '../src/vaadin-context-menu.js';
-import '@vaadin/item/src/vaadin-item.js';
-import '@vaadin/list-box/src/vaadin-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { getMenuItems, getSubMenu, openMenu } from './helpers.js';
+import { getMenuItems, openMenu, openSubMenu } from './helpers.js';
+
+describe('items rendering', () => {
+  let rootMenu, subMenu, target;
+
+  beforeEach(async () => {
+    rootMenu = fixtureSync(`
+      <vaadin-context-menu>
+        <button id="target"></button>
+      </vaadin-context-menu>
+    `);
+    rootMenu.openOn = isTouch ? 'click' : 'mouseover';
+    target = rootMenu.firstElementChild;
+    rootMenu.items = [
+      {
+        text: 'foo-0',
+        children: [
+          { text: 'foo-0-0', checked: true },
+          { text: 'foo-0-1', disabled: true },
+        ],
+      },
+      { text: 'foo-1' },
+    ];
+    await nextRender();
+  });
+
+  afterEach(() => {
+    rootMenu.close();
+  });
+
+  async function openRoot() {
+    await openMenu(target);
+  }
+
+  describe('item content', () => {
+    beforeEach(async () => {
+      await openRoot();
+      subMenu = await openSubMenu(rootMenu);
+    });
+
+    it('should render root level items', () => {
+      expect(getMenuItems(rootMenu)[0].textContent).to.equal('foo-0');
+    });
+
+    it('should render sub-menu items', () => {
+      expect(getMenuItems(subMenu)[0].textContent).to.equal('foo-0-0');
+    });
+  });
+
+  describe('item elements', () => {
+    it('should have default item type', async () => {
+      await openRoot();
+      expect(getMenuItems(rootMenu)[0].localName).to.equal('vaadin-context-menu-item');
+    });
+
+    it('should accept component items', async () => {
+      const component = document.createElement('button');
+      rootMenu.items = [{ component }];
+      await openRoot();
+      expect(getMenuItems(rootMenu)[0]).to.equal(component);
+    });
+
+    it('should accept custom tags', async () => {
+      rootMenu.items = [{ component: 'button' }];
+      await openRoot();
+      expect(getMenuItems(rootMenu)[0].localName).to.equal('button');
+    });
+
+    it('should not remove the component attributes', async () => {
+      const button = document.createElement('button');
+      button.setAttribute('disabled', '');
+      button.setAttribute('menu-item-checked', '');
+      rootMenu.items[0].component = button;
+      await openRoot();
+      expect(button.hasAttribute('disabled')).to.be.true;
+      expect(button.hasAttribute('menu-item-checked')).to.be.true;
+    });
+  });
+
+  describe('item state attributes', () => {
+    it('should have menuitem role attribute', async () => {
+      await openRoot();
+      expect(getMenuItems(rootMenu)[0].getAttribute('role')).to.equal('menuitem');
+    });
+
+    it('should set aria-haspopup on an item with children', async () => {
+      await openRoot();
+      expect(getMenuItems(rootMenu)[0].getAttribute('aria-haspopup')).to.equal('true');
+    });
+
+    it('should unset aria-haspopup on an item without children', async () => {
+      const button = document.createElement('button');
+      rootMenu.items[0].component = button;
+      await openRoot();
+      rootMenu.close();
+      rootMenu.items[0].children = [];
+      await openRoot();
+      expect(getMenuItems(rootMenu)[0].getAttribute('aria-haspopup')).to.equal('false');
+    });
+
+    it('should have a checked item', async () => {
+      await openRoot();
+      subMenu = await openSubMenu(rootMenu);
+      expect(getMenuItems(subMenu)[0].hasAttribute('menu-item-checked')).to.be.true;
+    });
+
+    it('should not have a checked item', async () => {
+      rootMenu.items[0].children[0].checked = false;
+      await openRoot();
+      subMenu = await openSubMenu(rootMenu);
+      expect(getMenuItems(subMenu)[0].hasAttribute('menu-item-checked')).to.be.false;
+    });
+
+    it('should have a disabled item', async () => {
+      await openRoot();
+      subMenu = await openSubMenu(rootMenu);
+      expect(getMenuItems(subMenu)[1].disabled).to.be.true;
+    });
+  });
+});
 
 describe('items theme', () => {
   let rootMenu, subMenu, subMenu2, target;
@@ -44,10 +161,8 @@ describe('items theme', () => {
     ];
     await nextRender();
     await openMenu(target);
-    await openMenu(getMenuItems(rootMenu)[0]);
-    subMenu = getSubMenu(rootMenu);
-    await openMenu(getMenuItems(subMenu)[1]);
-    subMenu2 = getSubMenu(subMenu);
+    subMenu = await openSubMenu(rootMenu);
+    subMenu2 = await openSubMenu(subMenu, 1);
   });
 
   afterEach(() => {
@@ -82,8 +197,8 @@ describe('items theme', () => {
     // Should wait until submenus will be opened again.
     await nextRender();
     await openMenu(target);
-    await openMenu(getMenuItems(rootMenu)[0]);
-    await openMenu(getMenuItems(subMenu)[1]);
+    await openSubMenu(rootMenu);
+    await openSubMenu(subMenu, 1);
 
     [rootMenu, subMenu, subMenu2].forEach((subMenu) => {
       const overlay = subMenu._overlayElement;
@@ -103,8 +218,7 @@ describe('items theme', () => {
     rootMenu.items[0].children[0].theme = 'bar-0-0';
     await updateItemsAndReopen();
 
-    await openMenu(getMenuItems(rootMenu)[0]);
-    subMenu = getSubMenu(rootMenu);
+    subMenu = await openSubMenu(rootMenu);
 
     const rootItems = getMenuItems(rootMenu);
     const subItems = getMenuItems(subMenu);
@@ -163,7 +277,7 @@ describe('items theme', () => {
     subMenu.close();
     subMenu.items = [...subMenu.items];
 
-    await openMenu(getMenuItems(rootMenu)[0]);
+    await openSubMenu(rootMenu);
 
     const item = getMenuItems(subMenu)[2];
 

--- a/packages/context-menu/test/items.test.js
+++ b/packages/context-menu/test/items.test.js
@@ -1,33 +1,20 @@
 import { expect } from '@vaadin/chai-plugins';
 import {
-  arrowDownKeyDown,
-  arrowLeftKeyDown,
-  arrowRightKeyDown,
-  arrowUpKeyDown,
+  aTimeout,
   enterKeyDown,
-  escKeyDown,
   fire,
   fixtureSync,
   nextFrame,
   nextRender,
-  spaceKeyDown,
-  tabKeyDown,
+  outsideClick,
 } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-context-menu.js';
-import '@vaadin/item/src/vaadin-item.js';
-import '@vaadin/list-box/src/vaadin-list-box.js';
 import { isTouch } from '@vaadin/component-base/src/browser-utils.js';
-import { activateItem, getMenuItems, getSubMenu, openMenu } from './helpers.js';
+import { getMenuItems, getSubMenu, openMenu, openSubMenu } from './helpers.js';
 
 describe('items', () => {
   let rootMenu, subMenu, target, rootOverlay, subOverlay1;
-
-  const createComponent = (text) => {
-    const item = document.createElement('vaadin-context-menu-item');
-    item.textContent = text;
-    return item;
-  };
 
   beforeEach(async () => {
     rootMenu = fixtureSync(`
@@ -41,8 +28,8 @@ describe('items', () => {
       {
         text: 'foo-0',
         children: [
-          { text: 'foo-0-0', checked: true },
-          { text: 'foo-0-1', disabled: true },
+          { text: 'foo-0-0' },
+          { text: 'foo-0-1' },
           { text: 'foo-0-2', children: [{ text: 'foo-0-2-0', keepOpen: true }] },
           { component: 'hr' },
           { text: 'foo-0-3', keepOpen: true },
@@ -52,536 +39,279 @@ describe('items', () => {
       { text: 'foo-2', keepOpen: true },
       {
         text: 'foo-3',
-        children: [
-          { component: createComponent('foo-3-0') },
-          { component: createComponent('foo-3-1') },
-          { component: createComponent('foo-3-2') },
-        ],
+        children: [{ text: 'foo-3-0' }, { text: 'foo-3-1' }, { text: 'foo-3-2' }],
       },
     ];
     await nextRender();
-    await openMenu(target);
-    rootOverlay = rootMenu._overlayElement;
-    await openMenu(getMenuItems(rootMenu)[0]);
-    subMenu = getSubMenu(rootMenu);
-    subOverlay1 = subMenu._overlayElement;
   });
 
   afterEach(() => {
     rootMenu.close();
-
-    // Forcing dir to ltr because Safari scroll can get lost if attribute
-    // is set to `rtl` and then removed
-    document.documentElement.setAttribute('dir', 'ltr');
   });
 
-  it('should render root level items', () => {
-    expect(getMenuItems(rootMenu)[0].textContent).to.equal('foo-0');
-  });
-
-  it('should have menuitem role attribute', () => {
-    expect(getMenuItems(rootMenu)[0].getAttribute('role')).to.equal('menuitem');
-  });
-
-  it('should render sub-menu items', () => {
-    expect(getMenuItems(subMenu)[0].textContent).to.equal('foo-0-0');
-  });
-
-  it('should close all menus', () => {
-    fire(document.documentElement, 'click');
-    expect(rootMenu.opened).to.be.false;
-    expect(subMenu.opened).to.be.false;
-  });
-
-  it('should remove close listener', () => {
-    rootMenu.parentNode.removeChild(rootMenu);
-    const spy = sinon.spy(rootMenu, 'close');
-    fire(document.documentElement, 'click');
-    expect(spy.called).to.be.false;
-  });
-
-  (isTouch ? it.skip : it)('should open the subMenu on the right side', () => {
-    const rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
-    const subItemRect = getMenuItems(subMenu)[0].getBoundingClientRect();
-    expect(subItemRect.left).to.be.at.least(rootItemRect.right);
-  });
-
-  (isTouch ? it.skip : it)('should open the subMenu on the left side', async () => {
-    subMenu.close();
-    let rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
-    rootOverlay.style.left = `${window.innerWidth - rootItemRect.width * 1.5}px`;
-    await openMenu(getMenuItems(rootMenu)[0]);
-    rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
-    const subItemRect = getMenuItems(subMenu)[0].getBoundingClientRect();
-    expect(subItemRect.right).to.be.at.most(rootItemRect.left);
-  });
-
-  (isTouch ? it.skip : it)('should open the subMenu on the top if root menu is bottom-aligned', async () => {
-    subMenu.close();
-    rootOverlay.style.removeProperty('top');
-    rootOverlay.style.bottom = '0px';
-    rootOverlay.setAttribute('bottom-aligned', '');
-    await openMenu(getMenuItems(rootMenu)[0]);
-    const rootMenuRect = rootOverlay.getBoundingClientRect();
-    const subMenuRect = subOverlay1.getBoundingClientRect();
-    expect(subMenuRect.bottom).to.be.at.most(rootMenuRect.bottom);
-  });
-
-  (isTouch ? it.skip : it)('should open the subMenu on the left if root menu is end-aligned', async () => {
-    subMenu.close();
-    await nextRender();
-    const rootItem = getMenuItems(rootMenu)[0];
-    const rootItemRect = rootItem.getBoundingClientRect();
-    rootOverlay.style.removeProperty('left');
-    rootOverlay.style.right = `${rootItemRect.width}px`;
-    rootOverlay.setAttribute('end-aligned', '');
-    await openMenu(rootItem);
-    expect(subOverlay1.hasAttribute('end-aligned')).to.be.true;
-    const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
-    const subMenuRect = subOverlay1.$.content.getBoundingClientRect();
-    expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left, 2);
-  });
-
-  // TODO: Previously this test was relying on iframe which had fixed size of WCT.
-  // Consider changing it so that it no longer depends on the browser window size.
-  it.skip('should open the second subMenu on the right again if not enough space', async () => {
-    let padding;
-    subMenu.close();
-    await nextRender();
-    rootMenu.items[0].children[2].text = 'foo-0-2-longer';
-
-    const rootItem = getMenuItems(rootMenu)[0];
-    const rootItemRect = rootItem.getBoundingClientRect();
-    rootOverlay.style.removeProperty('left');
-    rootOverlay.style.right = `${rootItemRect.width}px`;
-    rootOverlay.setAttribute('end-aligned', '');
-    padding = parseFloat(getComputedStyle(rootOverlay.$.content).paddingLeft) * 2;
-
-    /* First sub-menu end-aligned */
-    await openMenu(rootItem);
-    expect(subOverlay1.hasAttribute('end-aligned')).to.be.true;
-    const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
-    const subMenuRect = subOverlay1.$.content.getBoundingClientRect();
-    expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left, 1);
-
-    /* Second sub-menu left-aligned */
-    const nestedItem = getMenuItems(subMenu)[2];
-    const nestedItemRect = nestedItem.getBoundingClientRect();
-    padding = parseFloat(getComputedStyle(subOverlay1.$.content).paddingLeft) * 2;
-    await openMenu(nestedItem);
-    const subMenu2 = getSubMenu(subMenu);
-    expect(subMenu2._overlayElement.hasAttribute('end-aligned')).to.be.false;
-    const subMenu2Rect = subMenu2._overlayElement.$.content.getBoundingClientRect();
-    expect(subMenu2Rect.left).to.be.closeTo(nestedItemRect.right + padding / 2, 1);
-  });
-
-  it('should clean up the old content on reopen', async () => {
-    rootMenu.close();
+  async function openRoot() {
     await openMenu(target);
-    expect(getMenuItems(rootMenu).length).to.equal(rootMenu.items.length);
+    rootOverlay = rootMenu._overlayElement;
+    subMenu = getSubMenu(rootMenu);
+    subOverlay1 = subMenu._overlayElement;
+  }
+
+  describe('reopening', () => {
+    beforeEach(async () => {
+      await openRoot();
+      await openSubMenu(rootMenu);
+    });
+
+    it('should clean up the old content on reopen', async () => {
+      rootMenu.close();
+      await openMenu(target);
+      expect(getMenuItems(rootMenu).length).to.equal(rootMenu.items.length);
+    });
+
+    it('should clear selections on reopen', async () => {
+      getMenuItems(subMenu)[0].click();
+      await openMenu(target);
+      await openSubMenu(rootMenu);
+      expect(getMenuItems(subMenu)[0].selected).to.be.false;
+    });
   });
 
-  it('should clear selections on reopen', async () => {
-    getMenuItems(subMenu)[0].click();
-    await openMenu(target);
-    await openMenu(getMenuItems(rootMenu)[0]);
-    expect(getMenuItems(subMenu)[0].selected).to.be.false;
+  describe('keepOpen', () => {
+    beforeEach(async () => {
+      await openRoot();
+      await openSubMenu(rootMenu);
+    });
+
+    it('should have a checked root item after click if keep open', async () => {
+      rootMenu.items[2].checked = true;
+      getMenuItems(rootMenu)[2].click();
+      await nextRender();
+      expect(getMenuItems(rootMenu)[2].hasAttribute('menu-item-checked')).to.be.true;
+    });
+
+    it('should have a focused root item after click if keep open', async () => {
+      rootMenu.items[2].checked = true;
+      getMenuItems(rootMenu)[2].click();
+      await nextRender();
+      expect(getMenuItems(rootMenu)[2].hasAttribute('focused')).to.be.true;
+    });
+
+    it('should have a checked sub menu item after click if keep open', async () => {
+      subMenu.items[4].checked = true;
+      getMenuItems(subMenu)[4].click();
+      await nextRender();
+      expect(getMenuItems(subMenu)[4].hasAttribute('menu-item-checked')).to.be.true;
+    });
+
+    it('should have a focused sub menu item after click if keep open', async () => {
+      subMenu.items[4].checked = true;
+      getMenuItems(subMenu)[4].click();
+      await nextRender();
+      expect(getMenuItems(subMenu)[4].hasAttribute('focused')).to.be.true;
+    });
+
+    it('should not close the menu if root item has keep open', () => {
+      getMenuItems(rootMenu)[2].click();
+      expect(rootMenu.opened).to.be.true;
+    });
+
+    it('should not close the menu if sub menu item has keep open', () => {
+      getMenuItems(subMenu)[4].click();
+      expect(rootMenu.opened).to.be.true;
+      expect(subMenu.opened).to.be.true;
+    });
   });
 
-  it('should have default item type', () => {
-    expect(getMenuItems(rootMenu)[0].localName).to.equal('vaadin-context-menu-item');
+  describe('sub-menu positioning', () => {
+    beforeEach(async () => {
+      await openRoot();
+    });
+
+    (isTouch ? it.skip : it)('should open the subMenu on the right side', async () => {
+      await openSubMenu(rootMenu);
+      const rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
+      const subItemRect = getMenuItems(subMenu)[0].getBoundingClientRect();
+      expect(subItemRect.left).to.be.at.least(rootItemRect.right);
+    });
+
+    (isTouch ? it.skip : it)('should open the subMenu on the left side', async () => {
+      let rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
+      rootOverlay.style.left = `${window.innerWidth - rootItemRect.width * 1.5}px`;
+      await openSubMenu(rootMenu);
+      rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
+      const subItemRect = getMenuItems(subMenu)[0].getBoundingClientRect();
+      expect(subItemRect.right).to.be.at.most(rootItemRect.left);
+    });
+
+    (isTouch ? it.skip : it)('should open the subMenu on the top if root menu is bottom-aligned', async () => {
+      rootOverlay.style.removeProperty('top');
+      rootOverlay.style.bottom = '0px';
+      rootOverlay.setAttribute('bottom-aligned', '');
+      await openSubMenu(rootMenu);
+      const rootMenuRect = rootOverlay.getBoundingClientRect();
+      const subMenuRect = subOverlay1.getBoundingClientRect();
+      expect(subMenuRect.bottom).to.be.at.most(rootMenuRect.bottom);
+    });
+
+    (isTouch ? it.skip : it)('should open the subMenu on the left if root menu is end-aligned', async () => {
+      const rootItem = getMenuItems(rootMenu)[0];
+      const rootItemRect = rootItem.getBoundingClientRect();
+      rootOverlay.style.removeProperty('left');
+      rootOverlay.style.right = `${rootItemRect.width}px`;
+      rootOverlay.setAttribute('end-aligned', '');
+      await openMenu(rootItem);
+      expect(subOverlay1.hasAttribute('end-aligned')).to.be.true;
+      const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
+      const subMenuRect = subOverlay1.$.content.getBoundingClientRect();
+      expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left, 2);
+    });
+
+    // TODO: Previously this test was relying on iframe which had fixed size of WCT.
+    // Consider changing it so that it no longer depends on the browser window size.
+    it.skip('should open the second subMenu on the right again if not enough space', async () => {
+      let padding;
+      rootMenu.items[0].children[2].text = 'foo-0-2-longer';
+
+      const rootItem = getMenuItems(rootMenu)[0];
+      const rootItemRect = rootItem.getBoundingClientRect();
+      rootOverlay.style.removeProperty('left');
+      rootOverlay.style.right = `${rootItemRect.width}px`;
+      rootOverlay.setAttribute('end-aligned', '');
+      padding = parseFloat(getComputedStyle(rootOverlay.$.content).paddingLeft) * 2;
+
+      /* First sub-menu end-aligned */
+      await openMenu(rootItem);
+      expect(subOverlay1.hasAttribute('end-aligned')).to.be.true;
+      const rootMenuRect = rootOverlay.$.content.getBoundingClientRect();
+      const subMenuRect = subOverlay1.$.content.getBoundingClientRect();
+      expect(subMenuRect.right).to.be.closeTo(rootMenuRect.left, 1);
+
+      /* Second sub-menu left-aligned */
+      const nestedItem = getMenuItems(subMenu)[2];
+      const nestedItemRect = nestedItem.getBoundingClientRect();
+      padding = parseFloat(getComputedStyle(subOverlay1.$.content).paddingLeft) * 2;
+      await openMenu(nestedItem);
+      const subMenu2 = getSubMenu(subMenu);
+      expect(subMenu2._overlayElement.hasAttribute('end-aligned')).to.be.false;
+      const subMenu2Rect = subMenu2._overlayElement.$.content.getBoundingClientRect();
+      expect(subMenu2Rect.left).to.be.closeTo(nestedItemRect.right + padding / 2, 1);
+    });
+
+    it('should have modeless sub menus', async () => {
+      await openSubMenu(rootMenu);
+      const rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
+      const border = parseInt(getComputedStyle(rootOverlay.$.overlay).borderWidth);
+      const element = document.elementFromPoint(rootItemRect.left + border, rootItemRect.top + border);
+      expect(element).not.to.equal(document.documentElement);
+    });
   });
 
-  it('should accept component items', async () => {
-    rootMenu.close();
-    const component = document.createElement('button');
-    rootMenu.items = [{ component }];
-    await openMenu(target);
-    expect(getMenuItems(rootMenu)[0]).to.equal(component);
+  describe('item-selected event', () => {
+    beforeEach(async () => {
+      await openRoot();
+      await openSubMenu(rootMenu);
+    });
+
+    it('should fire an event for item selection', async () => {
+      const eventSpy = sinon.spy();
+      rootMenu.addEventListener('item-selected', eventSpy);
+      getMenuItems(subMenu)[0].click();
+      await nextRender();
+      expect(eventSpy).to.be.calledOnce;
+      expect(eventSpy.firstCall.args[0].detail.value).to.equal(rootMenu.items[0].children[0]);
+    });
+
+    it('should not fire an event for parent item selection', () => {
+      const eventSpy = sinon.spy();
+      rootMenu.addEventListener('item-selected', eventSpy);
+      getMenuItems(rootMenu)[0].click();
+      expect(eventSpy).to.not.be.called;
+    });
   });
 
-  it('should accept custom tags', async () => {
-    rootMenu.close();
-    rootMenu.items = [{ component: 'button' }];
-    await openMenu(target);
-    expect(getMenuItems(rootMenu)[0].localName).to.equal('button');
+  // TODO: remove when the deprecated event is removed in Vaadin 26
+  describe('items-outside-click event', () => {
+    beforeEach(async () => {
+      await openRoot();
+      await openSubMenu(rootMenu);
+    });
+
+    it('should fire on outside click when a sub-menu is open', () => {
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      outsideClick();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should fire on outside click when only the root menu is open', async () => {
+      subMenu.close();
+      await nextRender();
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      outsideClick();
+      expect(spy).to.be.calledOnce;
+    });
+
+    it('should not fire on click inside the menu', () => {
+      const spy = sinon.spy();
+      rootMenu.addEventListener('items-outside-click', spy);
+      getMenuItems(subMenu)[4].click();
+      expect(spy).to.not.be.called;
+    });
   });
 
-  it('should have a checked item', () => {
-    expect(getMenuItems(subMenu)[0].hasAttribute('menu-item-checked')).to.be.true;
+  describe('lifecycle', () => {
+    beforeEach(async () => {
+      await openRoot();
+      await openSubMenu(rootMenu);
+    });
+
+    it('should not react to outside click when disconnected', async () => {
+      rootMenu.remove();
+      // Closing on disconnect is deferred, so that moving the menu in the DOM
+      // does not close it
+      await aTimeout(0);
+
+      const spy = sinon.spy(rootMenu, 'close');
+      outsideClick();
+      expect(spy).to.not.be.called;
+    });
+
+    it('should close submenus', async () => {
+      rootMenu.close();
+      await nextRender();
+      expect(subMenu.opened).to.be.false;
+    });
   });
 
-  it('should have a checked root item after click if keep open', async () => {
-    rootMenu.items[2].checked = true;
-    getMenuItems(rootMenu)[2].click();
-    await nextRender();
-    expect(getMenuItems(rootMenu)[2].hasAttribute('menu-item-checked')).to.be.true;
-  });
+  describe('API', () => {
+    it('should throw with renderer', () => {
+      expect(() => {
+        rootMenu.renderer = () => {};
+      }).to.throw(Error);
+    });
 
-  it('should have a focused root item after click if keep open', async () => {
-    rootMenu.items[2].checked = true;
-    getMenuItems(rootMenu)[2].click();
-    await nextRender();
-    expect(getMenuItems(rootMenu)[2].hasAttribute('focused')).to.be.true;
-  });
+    it('should call requestContentUpdate on the overlay', async () => {
+      await openRoot();
+      const spy = sinon.spy(rootOverlay, 'requestContentUpdate');
+      rootMenu.requestContentUpdate();
+      expect(spy).to.be.called;
+    });
 
-  it('should have a checked sub menu item after click if keep open', async () => {
-    subMenu.items[4].checked = true;
-    getMenuItems(subMenu)[4].click();
-    await nextRender();
-    expect(getMenuItems(subMenu)[4].hasAttribute('menu-item-checked')).to.be.true;
-  });
-
-  it('should have a focused sub menu item after click if keep open', async () => {
-    subMenu.items[4].checked = true;
-    getMenuItems(subMenu)[4].click();
-    await nextRender();
-    expect(getMenuItems(subMenu)[4].hasAttribute('focused')).to.be.true;
-  });
-
-  it('should not have a checked item', async () => {
-    rootMenu.items[0].children[0].checked = false;
-    subMenu.close();
-    await nextRender();
-    await openMenu(getMenuItems(rootMenu)[0]);
-    expect(getMenuItems(subMenu)[0].hasAttribute('menu-item-checked')).to.be.false;
-  });
-
-  it('should have a disabled item', () => {
-    expect(getMenuItems(subMenu)[1].disabled).to.be.true;
-  });
-
-  it('should update the submenu when activating other parent item', () => {
-    activateItem(getMenuItems(rootMenu)[3]);
-
-    expect(subMenu.opened).to.be.true;
-
-    const items = getMenuItems(subMenu);
-    expect(items.length).to.equal(3);
-    expect(items[0].textContent).to.equal('foo-3-0');
-    expect(items[1].textContent).to.equal('foo-3-1');
-    expect(items[2].textContent).to.equal('foo-3-2');
-  });
-
-  it('should not change opened state of the submenu when activating other parent item', () => {
-    const openedChangeSpy = sinon.spy();
-    subMenu.addEventListener('opened-changed', openedChangeSpy);
-
-    activateItem(getMenuItems(rootMenu)[3]);
-
-    expect(openedChangeSpy.called).to.be.false;
-  });
-
-  it('should close the submenu on activating non-parent item', () => {
-    activateItem(getMenuItems(rootMenu)[1]);
-    expect(subMenu.opened).to.be.false;
-  });
-
-  (isTouch ? it.skip : it)('should focus closed parent item when hovering on non-parent item', () => {
-    const parent = getMenuItems(rootMenu)[0];
-    const nonParent = getMenuItems(rootMenu)[1];
-    const focusSpy = sinon.spy(parent, 'focus');
-    activateItem(nonParent);
-    expect(focusSpy.called).to.be.true;
-  });
-
-  (isTouch ? it.skip : it)('should focus overlay part on closing sub-menu without focused item', async () => {
-    const parent = getMenuItems(rootMenu)[3];
-    await openMenu(parent);
-    const nonParent = getMenuItems(rootMenu)[1];
-    const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
-    activateItem(nonParent);
-    expect(focusSpy.called).to.be.true;
-  });
-
-  (isTouch ? it.skip : it)('should not focus overlay part if the parent menu list-box has focus', () => {
-    activateItem(getMenuItems(rootMenu)[1]);
-    const focusSpy = sinon.spy(rootOverlay.$.overlay, 'focus');
-    activateItem(getMenuItems(rootMenu)[2]);
-    expect(focusSpy.called).to.be.false;
-  });
-
-  it('should not close the menu if root item has keep open', () => {
-    getMenuItems(rootMenu)[2].click();
-    expect(rootMenu.opened).to.be.true;
-  });
-
-  it('should not close the menu if sub menu item has keep open', () => {
-    getMenuItems(subMenu)[3].click();
-    expect(rootMenu.opened).to.be.true;
-    expect(subMenu.opened).to.be.true;
-  });
-
-  it('should close the submenu on left arrow', () => {
-    const focusSpy = sinon.spy(getMenuItems(rootMenu)[0], 'focus');
-    arrowLeftKeyDown(getMenuItems(subMenu)[0]);
-    expect(subMenu.opened).to.be.false;
-    expect(focusSpy.called).to.be.true;
-  });
-
-  it('should close the submenu on right arrow if RTL', async () => {
-    document.documentElement.setAttribute('dir', 'rtl');
-    await nextFrame();
-    const focusSpy = sinon.spy(getMenuItems(rootMenu)[0], 'focus');
-    arrowRightKeyDown(getMenuItems(subMenu)[0]);
-    expect(subMenu.opened).to.be.false;
-    expect(focusSpy.called).to.be.true;
-    document.documentElement.setAttribute('dir', 'ltr');
-  });
-
-  it('should close top-most menu on esc', () => {
-    escKeyDown(getMenuItems(subMenu)[0]);
-    expect(subMenu.opened).to.be.false;
-    expect(rootMenu.opened).to.be.true;
-    expect(getMenuItems(rootMenu)[0].hasAttribute('focused')).to.be.true;
-  });
-
-  it('should close all menus on Tab', () => {
-    tabKeyDown(getMenuItems(subMenu)[0]);
-    expect(rootMenu.opened).to.be.false;
-  });
-
-  it('should not close on disabled item click', () => {
-    getMenuItems(subMenu)[1].click();
-    expect(subMenu.opened).to.be.true;
-  });
-
-  it('should not close on parent item click', () => {
-    getMenuItems(rootMenu)[0].click();
-    expect(rootMenu.opened).to.be.true;
-  });
-
-  it('should close on backdrop click', () => {
-    subOverlay1.$.backdrop.click();
-    expect(subMenu.opened).to.be.false;
-  });
-
-  it('should have be a parent item', () => {
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-haspopup')).to.equal('true');
-  });
-
-  it('should not have be a parent item', async () => {
-    const button = document.createElement('button');
-    rootMenu.close();
-    rootMenu.items[0].component = button;
-    await openMenu(target);
-    rootMenu.close();
-    rootMenu.items[0].children = [];
-    await openMenu(target);
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-haspopup')).to.equal('false');
-  });
-
-  it('should open item on right arrow', async () => {
-    subMenu.close();
-    await nextRender();
-    arrowRightKeyDown(getMenuItems(rootMenu)[0]);
-    expect(subMenu.opened).to.be.true;
-  });
-
-  it('should open item on left arrow if RTL', async () => {
-    document.documentElement.setAttribute('dir', 'rtl');
-    await nextFrame();
-    subMenu.close();
-    await nextRender();
-    arrowLeftKeyDown(getMenuItems(rootMenu)[0]);
-    expect(subMenu.opened).to.be.true;
-    document.documentElement.setAttribute('dir', 'ltr');
-  });
-
-  it('should open item on enter', async () => {
-    subMenu.close();
-    await nextRender();
-    enterKeyDown(getMenuItems(rootMenu)[0]);
-    expect(subMenu.opened).to.be.true;
-  });
-
-  it('should open item on space', async () => {
-    subMenu.close();
-    await nextRender();
-    spaceKeyDown(getMenuItems(rootMenu)[0]);
-    expect(subMenu.opened).to.be.true;
-  });
-
-  it('should not focus item if parent item is not focused', async () => {
-    subMenu.close();
-    await nextRender();
-    rootOverlay.focus();
-    await openMenu(getMenuItems(rootMenu)[0]);
-    expect(subMenu.opened).to.be.true;
-    await nextRender();
-    expect(getMenuItems(subMenu)[0].hasAttribute('focused')).to.be.false;
-  });
-
-  it('should focus first item in submenu on overlay element arrow down', async () => {
-    subMenu.close();
-    await nextRender();
-    rootOverlay.focus();
-    await openMenu(getMenuItems(rootMenu)[0]);
-    const item = getMenuItems(subMenu)[0];
-    const spy = sinon.spy(item, 'focus');
-    arrowDownKeyDown(subOverlay1.$.overlay);
-    expect(spy.calledOnce).to.be.true;
-  });
-
-  it('should focus last item in submenu on overlay element arrow up', async () => {
-    subMenu.close();
-    await nextRender();
-    rootOverlay.focus();
-    await openMenu(getMenuItems(rootMenu)[0]);
-    const items = getMenuItems(subMenu);
-    const item = items[items.length - 1];
-    const spy = sinon.spy(item, 'focus');
-    arrowUpKeyDown(subOverlay1.$.overlay);
-    expect(spy.calledOnce).to.be.true;
-  });
-
-  it('should focus first item after re-opening when using components', async () => {
-    subMenu.close();
-    await nextRender();
-    rootOverlay.focus();
-
-    const rootItem = getMenuItems(rootMenu)[3];
-
-    // Open the sub-menu with item components
-    await openMenu(rootItem);
-    const subMenu2 = getSubMenu(rootMenu);
-    const items = getMenuItems(subMenu2);
-
-    // Arrow Down to focus next item
-    items[0].focus();
-    arrowDownKeyDown(items[0]);
-    expect(items[1].hasAttribute('focus-ring')).to.be.true;
-
-    // Arrow Left to close the sub-menu
-    arrowLeftKeyDown(items[1]);
-    await nextFrame();
-    expect(rootItem.hasAttribute('focus-ring')).to.be.true;
-
-    // Re-open sub-menu and check focus
-    await openMenu(rootItem);
-    expect(items[0].hasAttribute('focus-ring')).to.be.true;
-  });
-
-  it('should focus first non-disabled item after re-opening when using components', async () => {
-    subMenu.close();
-    await nextRender();
-    rootOverlay.focus();
-
-    rootMenu.items[3].children[0].disabled = true;
-
-    const rootItem = getMenuItems(rootMenu)[3];
-
-    // Open the sub-menu with item components
-    await openMenu(rootItem);
-    const subMenu2 = getSubMenu(rootMenu);
-    const items = getMenuItems(subMenu2);
-
-    // Arrow Down to focus next item
-    items[1].focus();
-    arrowDownKeyDown(items[1]);
-    expect(items[2].hasAttribute('focus-ring')).to.be.true;
-
-    // Arrow Left to close the sub-menu
-    arrowLeftKeyDown(items[2]);
-    await nextFrame();
-    expect(rootItem.hasAttribute('focus-ring')).to.be.true;
-
-    // Re-open sub-menu and check focus
-    await openMenu(rootItem);
-    expect(items[1].hasAttribute('focus-ring')).to.be.true;
-  });
-
-  it('should have modeless sub menus', () => {
-    const rootItemRect = getMenuItems(rootMenu)[0].getBoundingClientRect();
-    const border = parseInt(getComputedStyle(rootOverlay.$.overlay).borderWidth);
-    const element = document.elementFromPoint(rootItemRect.left + border, rootItemRect.top + border);
-    expect(element).not.to.equal(document.documentElement);
-  });
-
-  it('should close submenus', async () => {
-    rootMenu.close();
-    await nextRender();
-    expect(subMenu.opened).to.be.false;
-  });
-
-  it('should fire an event for item selection', async () => {
-    const eventSpy = sinon.spy();
-    rootMenu.addEventListener('item-selected', eventSpy);
-    getMenuItems(subMenu)[0].click();
-    await nextRender();
-    expect(eventSpy.getCall(0).args[0].detail.value).to.equal(rootMenu.items[0].children[0]);
-  });
-
-  it('should not fire an event for parent item selection', () => {
-    const eventSpy = sinon.spy();
-    rootMenu.addEventListener('item-selected', eventSpy);
-    getMenuItems(rootMenu)[0].click();
-    expect(eventSpy.called).to.be.false;
-  });
-
-  it('should throw with renderer', () => {
-    expect(() => {
-      rootMenu.renderer = () => {};
-    }).to.throw(Error);
-  });
-
-  it('should call requestContentUpdate on the overlay', () => {
-    const spy = sinon.spy(rootOverlay, 'requestContentUpdate');
-    rootMenu.requestContentUpdate();
-    expect(spy.called).to.be.true;
-  });
-
-  it('should not remove the component attributes', async () => {
-    rootMenu.close();
-    const button = document.createElement('button');
-    button.setAttribute('disabled', '');
-    button.setAttribute('menu-item-checked', '');
-    rootMenu.items[0].component = button;
-    await openMenu(target);
-    expect(button.hasAttribute('disabled')).to.be.true;
-    expect(button.hasAttribute('menu-item-checked')).to.be.true;
-  });
-
-  it('should propagate closeOn', async () => {
-    rootMenu.close();
-    rootMenu.closeOn = 'keydown';
-    await openMenu(target);
-    await openMenu(getMenuItems(rootMenu)[0]);
-    fire(getMenuItems(subMenu)[0], 'keydown', {}, { keyCode: 65, key: 'a' });
-    expect(subMenu.opened).to.be.false;
-  });
-
-  it('should have expanded attributes', async () => {
-    expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.true;
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('true');
-    subMenu.close();
-    await nextRender();
-    expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.false;
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('false');
-  });
-
-  it('should update expanded attributes when activating different parent items', async () => {
-    expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.true;
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('true');
-
-    await activateItem(getMenuItems(rootMenu)[3]);
-    expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.false;
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('false');
-    expect(getMenuItems(rootMenu)[3].hasAttribute('expanded')).to.be.true;
-    expect(getMenuItems(rootMenu)[3].getAttribute('aria-expanded')).to.equal('true');
-
-    await activateItem(getMenuItems(rootMenu)[0]);
-    expect(getMenuItems(rootMenu)[0].hasAttribute('expanded')).to.be.true;
-    expect(getMenuItems(rootMenu)[0].getAttribute('aria-expanded')).to.equal('true');
-    expect(getMenuItems(rootMenu)[3].hasAttribute('expanded')).to.be.false;
-    expect(getMenuItems(rootMenu)[3].getAttribute('aria-expanded')).to.equal('false');
+    it('should propagate closeOn', async () => {
+      rootMenu.closeOn = 'keydown';
+      await openRoot();
+      await openSubMenu(rootMenu);
+      fire(getMenuItems(subMenu)[0], 'keydown', {}, { keyCode: 65, key: 'a' });
+      expect(subMenu.opened).to.be.false;
+    });
   });
 
   (isTouch ? describe.skip : describe)('scrolling', () => {
-    let rootOverlay, subOverlay1, subOverlay2, scrollElm;
+    let subOverlay2, scrollElm, testStyle;
 
     beforeEach(async () => {
-      const testStyle = document.createElement('style');
+      testStyle = document.createElement('style');
       testStyle.innerHTML = `
         html {
           overflow:scroll;
@@ -596,16 +326,23 @@ describe('items', () => {
 
       scrollElm = window.document.scrollingElement || window.document.querySelector('html');
 
-      rootOverlay = rootMenu._overlayElement;
-      subOverlay1 = subMenu._overlayElement;
+      await openRoot();
+      await openSubMenu(rootMenu);
 
-      await openMenu(getMenuItems(subMenu)[2]);
-      const subMenu2 = getSubMenu(subMenu);
+      const subMenu2 = await openSubMenu(subMenu, 2);
       subOverlay2 = subMenu2._overlayElement;
       await nextFrame();
     });
 
-    it('Should properly move overlays on scrolling distance within y axis', async () => {
+    afterEach(() => {
+      // The style and the scroll position are set on elements outside the
+      // fixture, so they would otherwise leak into the following tests
+      testStyle.remove();
+      scrollElm.scrollTop = 0;
+      scrollElm.scrollLeft = 0;
+    });
+
+    it('should properly move overlays on scrolling distance within y axis', async () => {
       const scrollDistance = 150;
 
       // Default indentation is 16
@@ -620,7 +357,7 @@ describe('items', () => {
       expect(subOverlay2.getBoundingClientRect().top).to.be.closeTo(subBRCTop2 - scrollDistance, 1);
     });
 
-    it('Should properly move overlays on scrolling distance within x axis', async () => {
+    it('should properly move overlays on scrolling distance within x axis', async () => {
       const scrollDistance = 150;
 
       // Default indentation is 16
@@ -637,6 +374,11 @@ describe('items', () => {
   });
 
   describe('updating while opened', () => {
+    beforeEach(async () => {
+      await openRoot();
+      await openSubMenu(rootMenu);
+    });
+
     it('should update items when calling requestContentUpdate while opened', async () => {
       rootMenu.items = [{ text: 'foo-1' }, { text: 'foo-2' }];
       rootMenu.requestContentUpdate();
@@ -673,7 +415,7 @@ describe('items', () => {
 
     it('should close submenu from item-selected event and focus parent item after calling requestContentUpdate while opened', async () => {
       // Open nested sub-menu
-      await openMenu(getMenuItems(subMenu)[2]);
+      const subMenu2 = await openSubMenu(subMenu, 2);
 
       rootMenu.addEventListener('item-selected', () => {
         rootMenu.items = [
@@ -689,7 +431,6 @@ describe('items', () => {
         rootMenu.requestContentUpdate();
       });
 
-      const subMenu2 = getSubMenu(subMenu);
       const item = getMenuItems(subMenu2)[0];
       item.focus();
       enterKeyDown(item);


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #12400 to branch 25.1.

The conflict came from #12396, which is not on 25.1. That PR added the outside click tests and the `items-outside-click` event tests that #12400 moves around, and fixed the item index in `should not close the menu if sub menu item has keep open` (it was clicking the `hr` separator). Since the `items` mixin behaves the same on both branches, those tests are included here, so the context-menu test files stay identical to `main`. Verified on Chromium, Firefox and WebKit.

---

> `items.test.js` had grown to 790 lines with around 60 tests in one flat list, covering rendering, positioning, keyboard and pointer interaction, theming, events and the `items` API together.
>
> The shared `beforeEach` opened both the menu and a sub-menu, which 25 of those tests had to undo before they could set up what they actually needed. That also hid a real dependency: in the focus tests, closing the sub-menu again is what moves focus off the parent item, which is the condition the tests are about.
>
> Changes:
>
> - Interaction tests move to `items-interactions.test.js`, grouped by what triggers them: closing on click, hover, closing with keyboard, opening a sub-menu with keyboard, focus on sub-menu open, and expanded state.
> - Rendering tests move to `items-rendering.test.js`, which also takes over `items-theme.test.js`, since both cover how item data becomes DOM.
> - The remaining tests are grouped into nested suites: reopening, `keepOpen`, sub-menu positioning, `item-selected` event, `items-outside-click` event, lifecycle, API, scrolling, and updating while opened.
> - Each suite opens only what it needs, through a new `openSubMenu()` helper that opens the sub-menu of a given item and returns it. It replaces the `openMenu(getMenuItems(menu)[index])` calls.
> - Each file declares only the items its own tests use. The rendering tests, for example, no longer carry item components or a separator.
> - The interaction tests use `sendKeys` instead of the synthetic keydown helpers, as `CONVENTIONS.md` requires, so they also cover the browser behavior the component relies on. Where a real key press makes it redundant, spying on `focus()` is replaced with asserting the focused element.
> - The `scrolling` suite added a style element setting `overflow: scroll` on `html` and a 2000px body, and scrolled the document, without restoring either. Both leaked into every later test in the same browser page.
>
> One test is removed: `should close all menus` duplicated the outside click test next to it and `overlay.test.js`. Test counts are otherwise unchanged, verified per browser.
>
> ---
>
> 🤖 Generated with Claude Code
