### PR TITLE
refactor: inline the animation check into notification

### DIFF
--- a/packages/notification/src/vaadin-notification-mixin.js
+++ b/packages/notification/src/vaadin-notification-mixin.js
@@ -7,7 +7,6 @@ import { render } from 'lit';
 import { isTemplateResult } from 'lit/directive-helpers.js';
 import { isIOS } from '@vaadin/component-base/src/browser-utils.js';
 import { OverlayClassMixin } from '@vaadin/component-base/src/overlay-class-mixin.js';
-import { shouldAnimate } from '@vaadin/overlay/src/vaadin-overlay-utils.js';
 import { ThemePropertyMixin } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 
 /**
@@ -344,6 +343,27 @@ export const NotificationMixin = (superClass) =>
     }
 
     /**
+     * Detect whether an animation runs on the card, so that its end can be awaited before the
+     * card is removed. A card that is not rendered, has no animation name, or has a zero
+     * duration does not fire `animationend`.
+     *
+     * `getStateAnimations()` cannot replace this: the card declares the same keyframes for both
+     * states, so nothing restarts when it closes right after the opening animation ended, and no
+     * animation is found. The computed style still reports the declared animation, which is what
+     * the card needs in order to stay in the DOM until its height has collapsed.
+     * @private
+     */
+    __shouldAnimateCard() {
+      const style = getComputedStyle(this._card);
+      const name = style.getPropertyValue('animation-name');
+      const hasDuration = style
+        .getPropertyValue('animation-duration')
+        .split(',')
+        .some((duration) => parseFloat(duration) > 0);
+      return style.getPropertyValue('display') !== 'none' && name && name !== 'none' && hasDuration;
+    }
+
+    /**
      * Run the callback when the animation of the card itself ends. Animations of the
      * notification content also end on the card, as the content is in its light DOM.
      * @private
@@ -365,7 +385,7 @@ export const NotificationMixin = (superClass) =>
 
         this._card.setAttribute('opening', '');
         this._appendNotificationCard();
-        if (shouldAnimate(this._card)) {
+        if (this.__shouldAnimateCard()) {
           this.__onCardAnimationEnd(() => this.__cleanUpOpeningClosingState());
         } else {
           this.__cleanUpOpeningClosingState();
@@ -428,7 +448,7 @@ export const NotificationMixin = (superClass) =>
       this.__cleanUpOpeningClosingState();
 
       this._card.setAttribute('closing', '');
-      if (shouldAnimate(this._card)) {
+      if (this.__shouldAnimateCard()) {
         this.__onCardAnimationEnd(() => {
           this._removeNotificationCard();
           this.__cleanUpOpeningClosingState();

--- a/packages/notification/test/animation-styles.test.js
+++ b/packages/notification/test/animation-styles.test.js
@@ -3,7 +3,6 @@ import { emulateMedia } from '@vaadin/test-runner-commands';
 import { fixtureSync, nextRender, oneEvent } from '@vaadin/testing-helpers';
 import sinon from 'sinon';
 import '../src/vaadin-notification.js';
-import { shouldAnimate } from '@vaadin/overlay/src/vaadin-overlay-utils.js';
 
 // Do not import `not-animated-styles.css` to verify default animations.
 
@@ -47,7 +46,7 @@ describe('notification card animation styles', () => {
     it('should animate the card', () => {
       notification.opened = true;
 
-      expect(shouldAnimate(card)).to.be.true;
+      expect(notification.__shouldAnimateCard()).to.be.true;
     });
 
     it('should run the overlay animations on the card', () => {

--- a/packages/overlay/src/vaadin-overlay-utils.d.ts
+++ b/packages/overlay/src/vaadin-overlay-utils.d.ts
@@ -13,13 +13,6 @@
 export function observeMove(element: HTMLElement, callback: () => void): () => void;
 
 /**
- * Detect whether an animation runs on the given element, so that its end can be
- * awaited before the element is hidden or removed. An element that is not rendered,
- * has no animation name, or has a zero duration does not fire `animationend`.
- */
-export function shouldAnimate(element: HTMLElement): boolean;
-
-/**
  * Collect the animations that report the state of the given element, so that their end can be
  * awaited before the element is hidden or removed. The animations are read instead of the
  * computed style, so that the decision to wait cannot disagree with what the browser actually

--- a/packages/overlay/src/vaadin-overlay-utils.js
+++ b/packages/overlay/src/vaadin-overlay-utils.js
@@ -86,24 +86,6 @@ export function observeMove(element, callback) {
 }
 
 /**
- * Detect whether an animation runs on the given element, so that its end can be
- * awaited before the element is hidden or removed. An element that is not rendered,
- * has no animation name, or has a zero duration does not fire `animationend`.
- *
- * @param {HTMLElement} element
- * @return {boolean}
- */
-export function shouldAnimate(element) {
-  const style = getComputedStyle(element);
-  const name = style.getPropertyValue('animation-name');
-  const hasDuration = style
-    .getPropertyValue('animation-duration')
-    .split(',')
-    .some((duration) => parseFloat(duration) > 0);
-  return style.getPropertyValue('display') !== 'none' && name && name !== 'none' && hasDuration;
-}
-
-/**
  * Collect the animations that report the state of the given element, so that their end can be
  * awaited before the element is hidden or removed. The animations are read instead of the
  * computed style, so that the decision to wait cannot disagree with what the browser actually

--- a/packages/overlay/test/utils.test.js
+++ b/packages/overlay/test/utils.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@vaadin/chai-plugins';
 import { fixtureSync } from '@vaadin/testing-helpers';
-import { getStateAnimations, shouldAnimate } from '../src/vaadin-overlay-utils.js';
+import { getStateAnimations } from '../src/vaadin-overlay-utils.js';
 
 const styles = document.createElement('style');
 styles.textContent = `
@@ -61,35 +61,5 @@ describe('getStateAnimations', () => {
     child.style.animation = 'utils-fade 1s';
     element.appendChild(child);
     expect(getStateAnimations(element)).to.be.empty;
-  });
-});
-
-describe('shouldAnimate', () => {
-  let element;
-
-  beforeEach(() => {
-    element = fixtureSync('<div></div>');
-  });
-
-  it('should return false when the element is not rendered', () => {
-    element.style.animation = 'utils-fade 1s';
-    element.style.display = 'none';
-    expect(shouldAnimate(element)).to.be.false;
-  });
-
-  it('should return false when the element has no animation name', () => {
-    element.style.animationDuration = '1s';
-    expect(shouldAnimate(element)).to.be.false;
-  });
-
-  it('should return false when the animation duration is zero', () => {
-    element.style.animation = 'utils-fade 0s';
-    expect(shouldAnimate(element)).to.be.false;
-  });
-
-  it('should return true when one of the animation durations is not zero', () => {
-    element.style.animationName = 'utils-fade, utils-scale';
-    element.style.animationDuration = '0s, 1s';
-    expect(shouldAnimate(element)).to.be.true;
   });
 });


### PR DESCRIPTION
Once the overlay reads animation objects, `shouldAnimate()` is left with a single caller in
notification. Inline it there as a private method, so the shared helper and its tests can go.

Notification cannot use `getStateAnimations()` in its place. The two components ask different
questions. The overlay asks whether an animation is *running*, and if none is, finishing the
state right away is correct. Notification asks whether an animation is *declared* for the state
it is entering, because its card must stay in the DOM until the closing animation has collapsed
the height — remove it earlier and the cards below jump instead of sliding up.

Animation objects cannot answer the second question at the moment the decision is made. The card
declares the same keyframes for the opening and the closing state, so when the closing state is
applied after the opening animation has ended, the resolved `animation-name` does not change,
nothing restarts, and `getAnimations()` is empty. Measured in WebKit and Firefox, where the card
takes the `max-height` fallback path: the computed style reports both keyframe names and a `0.1s`
duration while `getAnimations()` returns only a transition. The computed style still describes
what is declared, which is why reading it is the right call here.

Reading animation objects in notification becomes possible once the card uses distinct keyframes
per state. That is left for later, and the reason is recorded on the method.

Follow-up to #12404

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

